### PR TITLE
Allow components to use application view helpers

### DIFF
--- a/app/controllers/govuk_publishing_components/application_controller.rb
+++ b/app/controllers/govuk_publishing_components/application_controller.rb
@@ -1,5 +1,6 @@
 module GovukPublishingComponents
   class ApplicationController < ActionController::Base
+    helper ::Rails.application.helpers
     include Slimmer::GovukComponents
     include Slimmer::Headers
     protect_from_forgery with: :exception

--- a/spec/component_guide/component_guide_spec.rb
+++ b/spec/component_guide/component_guide_spec.rb
@@ -72,4 +72,10 @@ describe 'Component guide' do
     expect(body).to include('test_component_parameter: &quot;A different value&quot;')
     expect(page).to have_selector('.component-guide-preview .test-component-with-params', text: 'A different value')
   end
+
+  it 'handles components that use application helpers' do
+    visit '/component-guide/test-component-with-helper'
+    expect(body).to include('A test component that uses a helper in the host application')
+    expect(page).to have_selector('.component-guide-preview .test-component-with-helper', text: 'This thing has been modified by a helper')
+  end
 end

--- a/test/dummy/app/helpers/example_helper.rb
+++ b/test/dummy/app/helpers/example_helper.rb
@@ -1,0 +1,5 @@
+module ExampleHelper
+  def example_helper(str)
+    "#{str} has been modified by a helper"
+  end
+end

--- a/test/dummy/app/views/components/_test-component-with-helper.html.erb
+++ b/test/dummy/app/views/components/_test-component-with-helper.html.erb
@@ -1,0 +1,3 @@
+<div class="test-component-with-helper">
+  <%= example_helper(string) %>
+</div>

--- a/test/dummy/app/views/components/docs/test-component-with-helper.yml
+++ b/test/dummy/app/views/components/docs/test-component-with-helper.yml
@@ -1,0 +1,5 @@
+name: Test component with helper
+description: A test component that uses a helper in the host application
+fixtures:
+  default:
+    string: 'This thing'


### PR DESCRIPTION
Previously a component that used it’s own app’s view helpers would error on the component guide with: `undefined method`

* Add example of component using a helper
* Write test against component
* Include Rails.application.helpers in ApplicationController to make those helper methods available when rendering the component through this Engine. https://stackoverflow.com/questions/9232175/#comment44856151_19453140

Note this does the opposite of a conventional gem: It needs things from the application to render views, rather than providing methods to an app.