### PR TITLE
Explicitly extend namespaced controller

### DIFF
--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -1,5 +1,5 @@
 module GovukPublishingComponents
-  class ComponentGuideController < ApplicationController
+  class ComponentGuideController < GovukPublishingComponents::ApplicationController
     append_view_path File.join(Rails.root, "app", "views", "components")
 
     def index

--- a/spec/component_guide/component_guide_spec.rb
+++ b/spec/component_guide/component_guide_spec.rb
@@ -1,6 +1,15 @@
 require "spec_helper"
 
 describe 'Component guide' do
+  # Load ordering test can only fail if run as the first test in suite
+  # https://github.com/rails/rails/issues/12168
+  it 'renders using gem layout not app layout after viewing a page on the application' do
+    visit '/'
+    expect(page).to have_title 'Dummy'
+    visit '/component-guide'
+    expect(page).to have_title 'GOV.UK Component Guide'
+  end
+
   it 'loads a component guide' do
     visit '/component-guide'
     expect(page).to have_title 'GOV.UK Component Guide'

--- a/test/dummy/app/controllers/welcome_controller.rb
+++ b/test/dummy/app/controllers/welcome_controller.rb
@@ -1,0 +1,2 @@
+class WelcomeController < ApplicationController
+end

--- a/test/dummy/app/views/welcome/index.html.erb
+++ b/test/dummy/app/views/welcome/index.html.erb
@@ -1,0 +1,1 @@
+<h1>A page in the dummy app</h1>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   mount GovukPublishingComponents::Engine, at: "/component-guide"
+  root to: 'welcome#index'
 end


### PR DESCRIPTION
Depending on load ordering the value of “ApplicationController” can vary.
See: https://github.com/rails/rails/issues/12168

If you visited an application page before visiting the component guide, the guide would render within the host application’s layout rather than the gem’s.

* Be explicit about which ApplicationController we want to use
* Include what was a failing test to demonstrate fix

Hat-tip to @h-lame for pointing me in the right direction.