### PR TITLE
Render accessibility criteria and body on component page

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,15 @@ The `.yml` file must have:
 #### Example documentation
 
 ```yaml
-name: Withdrawal notice
-description: A banner that displays when content is withdrawn
+name: Name of component
+description: Short description of component
+body: |
+  Optional markdown providing further detail about the component
+acceptance_criteria: |
+  Markdown listing what this component must do to be accessible
 fixtures:
   default:
-    title: 'This consultation was withdrawn on 20 April 2017'
-    explanation_html: '<p>A supporting paragraph</p>'
+    some_parameter: 'The parameter value'
 ```
 
 ### Configuration

--- a/app/assets/stylesheets/govuk_publishing_components/component_guide.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/component_guide.scss
@@ -2,7 +2,7 @@ $prism-background: #f5f2f0;
 $border-color: #ccc;
 
 .govuk-component-guide-wrapper {
-  padding-bottom: $gutter * 2;
+  padding-bottom: $gutter * 1.5;
 }
 
 .component-list {
@@ -15,10 +15,19 @@ $border-color: #ccc;
 .component-description {
   @include core-24;
   max-width: 30em;
+  margin-bottom: $gutter * 1.5;
+}
+
+.component-body {
+  margin-bottom: $gutter * 1.5;
 }
 
 .component-doc {
   @include core-16;
+
+  .component-doc-h2:first-child {
+    margin-top: 0;
+  }
 
   p {
     margin: $gutter-half 0;
@@ -28,11 +37,16 @@ $border-color: #ccc;
   ul {
     margin: 0 0 0 $gutter;
   }
+}
 
-  h3 {
-    margin: $gutter 0 $gutter-half;
-    @include bold-19;
-  }
+.component-doc-h2 {
+  @include bold-27;
+  margin: ($gutter * 1.5) 0 $gutter;
+}
+
+.component-doc-h3 {
+  margin: $gutter 0 $gutter-half;
+  @include bold-19;
 }
 
 .component-guide-preview {
@@ -93,19 +107,8 @@ $border-color: #ccc;
 }
 
 .fixtures {
-  margin-top: $gutter * 2;
-
-  .fixtures-title {
-    @include bold-27;
-    margin: $gutter 0;
-
-    small {
-      @include bold-16;
-    }
-  }
-
   .component-fixture {
-    margin: 0 0 $gutter * 2;
+    margin: 0 0 $gutter * 1.5;
 
     .fixture-title {
       @include bold-24;

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -1,5 +1,5 @@
 module GovukPublishingComponents
-  ComponentDoc = Struct.new(:id, :name, :description, :body, :fixtures) do
+  ComponentDoc = Struct.new(:id, :name, :description, :body, :accessibility_criteria, :fixtures) do
     def self.get(id)
       component = fetch_component_doc(id)
       self.build(component)
@@ -14,7 +14,12 @@ module GovukPublishingComponents
         GovukPublishingComponents::ComponentFixture.new(id.to_s, data)
       }
 
-      self.new(component[:id], component[:name], component[:description], component[:body], fixtures)
+      self.new(component[:id],
+               component[:name],
+               component[:description],
+               component[:body],
+               component[:accessibility_criteria],
+               fixtures)
     end
 
     def fixture
@@ -38,6 +43,19 @@ module GovukPublishingComponents
     def self.parse_documentation(file)
       { id: File.basename(file, ".yml") }.merge(YAML::load_file(file)).with_indifferent_access
     end
+
+    def html_body
+      govspeak_to_html(body) if body.present?
+    end
+
+    def html_accessibility_criteria
+      govspeak_to_html(accessibility_criteria) if accessibility_criteria.present?
+    end
+
+  private
+
+    def govspeak_to_html(govspeak)
+      Govspeak::Document.new(govspeak).to_html
     end
   end
 end

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -1,7 +1,8 @@
 module GovukPublishingComponents
   ComponentDoc = Struct.new(:id, :name, :description, :body, :fixtures) do
     def self.get(id)
-      all.find { |component| component.id == id }
+      component = fetch_component_doc(id)
+      self.build(component)
     end
 
     def self.all
@@ -26,9 +27,17 @@ module GovukPublishingComponents
 
     def self.fetch_component_docs
       doc_files = Rails.root.join("app", "views", "components", "docs", "*.yml")
-      Dir[doc_files].sort.map do |file|
-        { id: File.basename(file, ".yml") }.merge(YAML::load_file(file)).with_indifferent_access
-      end
+      Dir[doc_files].sort.map { |file| parse_documentation(file) }
+    end
+
+    def self.fetch_component_doc(id)
+      file = Rails.root.join("app", "views", "components", "docs", "#{id}.yml")
+      parse_documentation(file)
+    end
+
+    def self.parse_documentation(file)
+      { id: File.basename(file, ".yml") }.merge(YAML::load_file(file)).with_indifferent_access
+    end
     end
   end
 end

--- a/app/views/govuk_publishing_components/component_guide/fixture.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/fixture.html.erb
@@ -3,10 +3,10 @@
 
 <div class="component-show">
   <div class="component-doc">
-    <h3>How to call this example</h3>
+    <h2 class="component-doc-h2">How to call this example</h2>
     <%= render partial: "govuk_publishing_components/component_guide/component_doc/call", locals: { component_doc: @component_doc, fixture: @component_fixture } %>
 
-    <h3>How it looks</h3>
+    <h2 class="component-doc-h2">How it looks</h2>
     <%= render partial: "govuk_publishing_components/component_guide/component_doc/preview", locals: { component_doc: @component_doc, fixture: @component_fixture } %>
   </div>
 </div>

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -1,30 +1,48 @@
 <% content_for :title, "#{@component_doc.name} component" %>
 <%= render 'govuk_component/title', title: @component_doc.name, context: 'Component' %>
 
-<p class="component-description">
-  <%= @component_doc.description %>
-</p>
-
 <div class="component-show">
-  <div class="component-doc">
-    <h3>How to call this component</h3>
-    <%= render partial: "govuk_publishing_components/component_guide/component_doc/call", locals: { component_doc: @component_doc, fixture: @component_doc.fixture } %>
-
-    <h3>How it looks</h3>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <p class="component-description">
+        <%= @component_doc.description %>
+      </p>
+      <% if @component_doc.body.present? %>
+        <div class="component-body">
+          <%= render 'govuk_component/govspeak', content: @component_doc.html_body %>
+        </div>
+      <% end %>
+    </div>
   </div>
 
-  <%= render partial: "govuk_publishing_components/component_guide/component_doc/preview", locals: { component_doc: @component_doc, fixture: @component_doc.fixture } %>
+  <div class="component-doc">
+    <h2 class="component-doc-h2">How to call this component</h2>
+    <%= render "govuk_publishing_components/component_guide/component_doc/call", component_doc: @component_doc, fixture: @component_doc.fixture %>
+
+    <h2 class="component-doc-h2">How it looks</h2>
+  </div>
+
+  <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, fixture: @component_doc.fixture %>
+
+  <% if @component_doc.accessibility_criteria.present? %>
+    <div class="grid-row component-accessibility-criteria">
+      <div class="column-two-thirds">
+        <h2 class="component-doc-h2">Accessibility acceptance criteria</h2>
+        <%= render 'govuk_component/govspeak', content: @component_doc.html_accessibility_criteria %>
+      </div>
+    </div>
+  <% end %>
 
   <% if @component_doc.other_fixtures.any? %>
     <div class="fixtures">
-      <h2 class="fixtures-title">Other examples</h2>
+      <h2 class="component-doc-h2">Other examples</h2>
       <% @component_doc.other_fixtures.each do |fixture| %>
         <div class="component-fixture">
           <h3 class="fixture-title">
             <a href="<%= component_fixture_path(@component_doc.id, fixture.id) %>"><%= fixture.name %></a>
           </h3>
-          <%= render partial: "govuk_publishing_components/component_guide/component_doc/call", locals: { component_doc: @component_doc, fixture: fixture } %>
-          <%= render partial: "govuk_publishing_components/component_guide/component_doc/preview", locals: { component_doc: @component_doc, fixture: fixture } %>
+          <%= render "govuk_publishing_components/component_guide/component_doc/call", component_doc: @component_doc, fixture: fixture %>
+          <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, fixture: fixture %>
         </div>
       <% end %>
     </div>

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "slimmer", "~> 10.1.3"
   s.add_dependency "sass-rails", "~> 5.0.4"
   s.add_dependency "govuk_frontend_toolkit"
+  s.add_dependency "govspeak", "~> 5.0.3"
 
   s.add_development_dependency "govuk-lint", "~> 2.1.0"
   s.add_development_dependency "rspec", "~> 3.6"

--- a/lib/govuk_publishing_components/engine.rb
+++ b/lib/govuk_publishing_components/engine.rb
@@ -2,5 +2,6 @@ module GovukPublishingComponents
   class Engine < ::Rails::Engine
     isolate_namespace GovukPublishingComponents
     require 'govuk_frontend_toolkit'
+    require 'govspeak'
   end
 end

--- a/spec/component_guide/component_guide_spec.rb
+++ b/spec/component_guide/component_guide_spec.rb
@@ -87,4 +87,28 @@ describe 'Component guide' do
     expect(body).to include('A test component that uses a helper in the host application')
     expect(page).to have_selector('.component-guide-preview .test-component-with-helper', text: 'This thing has been modified by a helper')
   end
+
+  it 'displays the body of a component as html using static’s govspeak component' do
+    visit '/component-guide/test-component'
+    within ".component-body" do
+      within(shared_component_selector("govspeak")) do
+        content = JSON.parse(page.text).fetch("content").squish
+        expect(content).to include('An example body with <a href="/component-guide">markdown in it</a>')
+        expect(content).to include('<p>This is a list:</p>')
+        expect(content).to include('<li>list item one</li>')
+      end
+    end
+  end
+
+  it 'displays the accessibility acceptance criteria of a component as html using static’s govspeak component' do
+    visit '/component-guide/test-component'
+    within ".component-accessibility-criteria" do
+      expect(page).to have_selector('h2', text: 'Accessibility acceptance criteria')
+
+      within(shared_component_selector("govspeak")) do
+        content = JSON.parse(page.text).fetch("content").squish
+        expect(content).to include('<li>This is some criteria in a list</li>')
+      end
+    end
+  end
 end

--- a/test/dummy/app/views/components/docs/test-component.yml
+++ b/test/dummy/app/views/components/docs/test-component.yml
@@ -1,4 +1,13 @@
 name: Test component
 description: A test component for the dummy app
+body: |
+  An example body with [markdown in it](/component-guide).
+
+  This is a list:
+
+  * list item one
+  * list item two
+accessibility_criteria: |
+  * This is some criteria in a list
 fixtures:
   default: {}


### PR DESCRIPTION
* Don't process all components every pageload
* Use govspeak to turn markdown into HTML
* Use govspeak (static) component to render HTML
* Style headings based on class not with default styles to avoid risk of affecting component partials and to make re-use easier

https://trello.com/c/qIwQRSai/35-1-gem-render-body-markdown-as-html
https://trello.com/c/gCTvBkD1/36-1-gem-render-accessibility-acceptance-criteria-and-update-documentation

![description component - gov uk component guide 20170726](https://user-images.githubusercontent.com/319055/28615258-64be0ba4-71f0-11e7-974a-4f92b4289b96.png)