### PR TITLE
Remove ApplicationRecord file

### DIFF
--- a/app/models/govuk_publishing_components/application_record.rb
+++ b/app/models/govuk_publishing_components/application_record.rb
@@ -1,5 +1,0 @@
-module GovukPublishingComponents
-  class ApplicationRecord < ActiveRecord::Base
-    self.abstract_class = true
-  end
-end

--- a/test/dummy/app/models/application_record.rb
+++ b/test/dummy/app/models/application_record.rb
@@ -1,3 +1,0 @@
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-end


### PR DESCRIPTION
govuk_publishing_components doesn’t use ActiveRecord
This file was included as boilerplate when the gem was generated.

Without this fix the govuk_publishing_components gem doesn't run on Heroku when used with government-frontend (https://github.com/alphagov/government-frontend/pull/416):

> 2017-07-28T14:08:21.579099+00:00 app[web.1]: /app/vendor/bundle/ruby/2.3.0/gems/govuk_publishing_components-0.3.0/app/models/govuk_publishing_components/application_record.rb:2:in '<module:GovukPublishingComponents>': uninitialized constant GovukPublishingComponents::ActiveRecord (NameError)
2017-07-28T14:08:21.579101+00:00 app[web.1]: 	from /app/vendor/bundle/ruby/2.3.0/gems/govuk_publishing_components-0.3.0/app/models/govuk_publishing_components/application_record.rb:1:in `<top (required)>'