### PR TITLE
Fix height problem with code snippet examples

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/component_guide.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/component_guide.scss
@@ -65,7 +65,6 @@ $border-color: #ccc;
 .code-block {
   margin: 30px 0;
   @extend %outdent-to-full-width;
-  max-height: 300px;
 
   // Match Prism styles to avoid a flash as it renders
   background: $prism-background;
@@ -83,6 +82,7 @@ $border-color: #ccc;
 
   pre[class*=language-] {
     padding: $gutter;
+    max-height: 300px;
   }
 
   code {


### PR DESCRIPTION
- some code examples were taller than 300px, caused overflow problem
- moving max height from container to pre fixes

Changes this:

<img width="953" alt="screen shot 2017-08-04 at 15 51 21" src="https://user-images.githubusercontent.com/861310/28974003-d6b17f46-792c-11e7-835d-857f01b0ebab.png">

to this:

<img width="953" alt="screen shot 2017-08-04 at 15 51 35" src="https://user-images.githubusercontent.com/861310/28974013-de91b87a-792c-11e7-8475-d51d72f95dfd.png">
