### PR TITLE
Add an optional print stylesheet to component guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ if defined?(GovukPublishingComponents)
   GovukPublishingComponents.configure do |c|
     c.component_guide_title = "My component guide"
 
-    c.application_stylesheet = "custom_stylesheet" # defaults to "application"
-    c.application_javascript = "custom_javascript" # default to "application"
+    c.application_stylesheet = "custom_stylesheet" # Defaults to "application"
+    c.application_print_stylesheet = "print" # Not included by default
+    c.application_javascript = "custom_javascript" # Defaults to "application"
   end
 end
 ```

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -6,6 +6,9 @@
   </title>
   <%= stylesheet_link_tag "govuk_publishing_components/application", media: "all" %>
   <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_stylesheet}" %>
+  <% if GovukPublishingComponents::Config.application_print_stylesheet %>
+    <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_print_stylesheet}", media: "print" %>
+  <% end %>
 
   <%= javascript_include_tag "govuk_publishing_components/application" %>
   <%= javascript_include_tag "#{GovukPublishingComponents::Config.application_javascript}" %>

--- a/lib/govuk_publishing_components/config.rb
+++ b/lib/govuk_publishing_components/config.rb
@@ -10,6 +10,9 @@ module GovukPublishingComponents
     mattr_accessor :application_stylesheet
     self.application_stylesheet = "application"
 
+    mattr_accessor :application_print_stylesheet
+    self.application_print_stylesheet = nil
+
     mattr_accessor :application_javascript
     self.application_javascript = "application"
   end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -6,11 +6,13 @@ describe GovukPublishingComponents::Config do
       GovukPublishingComponents.configure do |config|
         config.component_guide_title = "My component guide"
         config.application_stylesheet = "custom_stylesheet"
+        config.application_print_stylesheet = "custom_print_stylesheet"
         config.application_javascript = "custom_javascript"
       end
 
       expect(GovukPublishingComponents::Config.component_guide_title).to eql("My component guide")
       expect(GovukPublishingComponents::Config.application_stylesheet).to eql("custom_stylesheet")
+      expect(GovukPublishingComponents::Config.application_print_stylesheet).to eql("custom_print_stylesheet")
       expect(GovukPublishingComponents::Config.application_javascript).to eql("custom_javascript")
     end
   end


### PR DESCRIPTION
Some components require print styles to render correctly.

Add an option to include print styles in the component guide. Apps handle print stylesheets differently – make this a configuration option without a default.