### PR TITLE
Relax slimmer requirements

### DIFF
--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENCE.md", "Rakefile", "README.md"]
 
   s.add_dependency "rails", "~> 5.0.0", ">= 5.0.0.1"
-  s.add_dependency "slimmer", "~> 10.1.3"
+  s.add_dependency "slimmer"
   s.add_dependency "sass-rails", "~> 5.0.4"
   s.add_dependency "govuk_frontend_toolkit"
   s.add_dependency "govspeak", "~> 5.0.3"


### PR DESCRIPTION
We can’t upgrade slimmer on government-frontend to v11 without first relaxing the versions this gem needs.