### PR TITLE
Split ComponentDoc into ComponentDoc and ComponentDocResolver

### DIFF
--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -3,16 +3,16 @@ module GovukPublishingComponents
     append_view_path File.join(Rails.root, "app", "views", "components")
 
     def index
-      @component_docs = ComponentDoc.all
+      @component_docs = component_documentation_resolver.all
     end
 
     def show
-      @component_doc = ComponentDoc.get(params[:component])
+      @component_doc = component_documentation_resolver.get(params[:component])
       @guide_breadcrumbs = [index_breadcrumb, component_breadcrumb(@component_doc)]
     end
 
     def fixture
-      @component_doc = ComponentDoc.get(params[:component])
+      @component_doc = component_documentation_resolver.get(params[:component])
       @component_fixture = @component_doc.fixtures.find { |f| f.id == params[:fixture] }
       @guide_breadcrumbs = [
                              index_breadcrumb,
@@ -25,7 +25,7 @@ module GovukPublishingComponents
 
     def preview
       @component_fixtures = []
-      @component_doc = ComponentDoc.get(params[:component])
+      @component_doc = component_documentation_resolver.get(params[:component])
       @preview = true
 
       if params[:fixture].present?
@@ -36,6 +36,10 @@ module GovukPublishingComponents
     end
 
   private
+
+    def component_documentation_resolver
+      @component_documentation_resolver ||= ComponentDocResolver.new
+    end
 
     def index_breadcrumb
       {

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -32,6 +32,10 @@ module GovukPublishingComponents
       govspeak_to_html(accessibility_criteria) if accessibility_criteria.present?
     end
 
+    def partial_path
+      "components/#{id}"
+    end
+
   private
 
     def govspeak_to_html(govspeak)

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -1,25 +1,19 @@
 module GovukPublishingComponents
-  ComponentDoc = Struct.new(:id, :name, :description, :body, :accessibility_criteria, :fixtures) do
-    def self.get(id)
-      component = fetch_component_doc(id)
-      self.build(component)
-    end
+  class ComponentDoc
+    attr_reader :id,
+                :name,
+                :description,
+                :body,
+                :accessibility_criteria,
+                :fixtures
 
-    def self.all
-      fetch_component_docs.map { |component| build(component) }
-    end
-
-    def self.build(component)
-      fixtures = component[:fixtures].map { |id, data|
-        GovukPublishingComponents::ComponentFixture.new(id.to_s, data)
-      }
-
-      self.new(component[:id],
-               component[:name],
-               component[:description],
-               component[:body],
-               component[:accessibility_criteria],
-               fixtures)
+    def initialize(id, name, description, body, accessibility_criteria, fixtures)
+      @id = id
+      @name = name
+      @description = description
+      @body = body
+      @accessibility_criteria = accessibility_criteria
+      @fixtures = fixtures
     end
 
     def fixture
@@ -28,20 +22,6 @@ module GovukPublishingComponents
 
     def other_fixtures
       fixtures.slice(1..-1)
-    end
-
-    def self.fetch_component_docs
-      doc_files = Rails.root.join("app", "views", "components", "docs", "*.yml")
-      Dir[doc_files].sort.map { |file| parse_documentation(file) }
-    end
-
-    def self.fetch_component_doc(id)
-      file = Rails.root.join("app", "views", "components", "docs", "#{id}.yml")
-      parse_documentation(file)
-    end
-
-    def self.parse_documentation(file)
-      { id: File.basename(file, ".yml") }.merge(YAML::load_file(file)).with_indifferent_access
     end
 
     def html_body

--- a/app/models/govuk_publishing_components/component_doc_resolver.rb
+++ b/app/models/govuk_publishing_components/component_doc_resolver.rb
@@ -1,0 +1,41 @@
+module GovukPublishingComponents
+  class ComponentDocResolver
+    def get(id)
+      component = fetch_component_doc(id)
+      build(component)
+    end
+
+    def all
+      fetch_component_docs.map { |component| build(component) }
+    end
+
+  private
+
+    def build(component)
+      fixtures = component[:fixtures].map { |id, data|
+        ComponentFixture.new(id.to_s, data)
+      }
+
+      ComponentDoc.new(component[:id],
+                       component[:name],
+                       component[:description],
+                       component[:body],
+                       component[:accessibility_criteria],
+                       fixtures)
+    end
+
+    def fetch_component_docs
+      doc_files = Rails.root.join("app", "views", "components", "docs", "*.yml")
+      Dir[doc_files].sort.map { |file| parse_documentation(file) }
+    end
+
+    def fetch_component_doc(id)
+      file = Rails.root.join("app", "views", "components", "docs", "#{id}.yml")
+      parse_documentation(file)
+    end
+
+    def parse_documentation(file)
+      { id: File.basename(file, ".yml") }.merge(YAML::load_file(file)).with_indifferent_access
+    end
+  end
+end

--- a/app/models/govuk_publishing_components/component_fixture.rb
+++ b/app/models/govuk_publishing_components/component_fixture.rb
@@ -1,5 +1,13 @@
 module GovukPublishingComponents
-  ComponentFixture = Struct.new(:id, :data) do
+  class ComponentFixture
+    attr_reader :id,
+                :data
+
+    def initialize(id, data)
+      @id = id
+      @data = data
+    end
+
     def name
       id.humanize
     end

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_call.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_call.html.erb
@@ -1,3 +1,3 @@
 <div class="component-call code-block" contenteditable>
-  <pre class="language-ruby"><code>&lt;%= render 'components/<%= component_doc.id %>'<% if fixture.data? %>, <%= fixture.pretty_data %><% end %> %&gt;</code></pre>
+  <pre class="language-ruby"><code>&lt;%= render '<%= @component_doc.partial_path %>'<% if fixture.data? %>, <%= fixture.pretty_data %><% end %> %&gt;</code></pre>
 </div>

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
@@ -1,3 +1,3 @@
 <div class="component-guide-preview">
-  <%= render "components/#{@component_doc[:id]}", fixture.data %>
+  <%= render "components/#{@component_doc.id}", fixture.data %>
 </div>

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
@@ -1,3 +1,3 @@
 <div class="component-guide-preview">
-  <%= render "components/#{@component_doc.id}", fixture.data %>
+  <%= render @component_doc.partial_path, fixture.data %>
 </div>

--- a/app/views/govuk_publishing_components/component_guide/preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/preview.html.erb
@@ -3,6 +3,6 @@
     <% if @component_fixtures.length > 1 %>
       <h2 class="preview-title"><a href="<%= component_fixture_path(@component_doc.id, fixture.id) %>"><%= fixture.name %></a></h2>
     <% end %>
-    <%= render "components/#{@component_doc.id}", fixture.data %>
+    <%= render @component_doc.partial_path, fixture.data %>
   </div>
 <% end %>

--- a/app/views/govuk_publishing_components/component_guide/preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/preview.html.erb
@@ -3,6 +3,6 @@
     <% if @component_fixtures.length > 1 %>
       <h2 class="preview-title"><a href="<%= component_fixture_path(@component_doc.id, fixture.id) %>"><%= fixture.name %></a></h2>
     <% end %>
-    <%= render "components/#{@component_doc[:id]}", fixture.data %>
+    <%= render "components/#{@component_doc.id}", fixture.data %>
   </div>
 <% end %>


### PR DESCRIPTION
A small refactor to switch from structs to classes.

Specifically:
* split ComponentDoc model into ComponentDoc and ComponentDocResolver
* makes monkey patching the gem from an app easier (eg govuk-component-guide WIP: https://github.com/alphagov/govuk-component-guide/compare/component-gem#diff-bb6adab3eaf25dfc303b4f34455f5be9)

Addresses some of @alecgibson’s original review comments in https://github.com/alphagov/govuk_publishing_components/pull/1#discussion_r128566361