### PR TITLE
Mark fixture data as HTML safe

### DIFF
--- a/app/models/govuk_publishing_components/component_fixture.rb
+++ b/app/models/govuk_publishing_components/component_fixture.rb
@@ -19,5 +19,28 @@ module GovukPublishingComponents
     def data?
       data.any?
     end
+
+    def html_safe_data
+      html_safe_strings(data.dup)
+    end
+
+    # Iterate through data object and recursively mark
+    # any found string as html_safe
+    #
+    # Safe HTML can be passed to components, simulate
+    # by marking any string that comes from YAML as safe
+    def html_safe_strings(obj)
+      if obj.is_a?(String)
+        obj.html_safe
+      elsif obj.is_a?(Hash)
+        obj.each do |key, value|
+          obj[key] = html_safe_strings(value)
+        end
+      elsif obj.is_a?(Array)
+        obj.map! { |e| html_safe_strings(e) }
+      else
+        obj
+      end
+    end
   end
 end

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
@@ -1,3 +1,3 @@
 <div class="component-guide-preview">
-  <%= render @component_doc.partial_path, fixture.data %>
+  <%= render @component_doc.partial_path, fixture.html_safe_data %>
 </div>

--- a/app/views/govuk_publishing_components/component_guide/preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/preview.html.erb
@@ -3,6 +3,6 @@
     <% if @component_fixtures.length > 1 %>
       <h2 class="preview-title"><a href="<%= component_fixture_path(@component_doc.id, fixture.id) %>"><%= fixture.name %></a></h2>
     <% end %>
-    <%= render @component_doc.partial_path, fixture.data %>
+    <%= render @component_doc.partial_path, fixture.html_safe_data %>
   </div>
 <% end %>

--- a/spec/component_guide/component_guide_spec.rb
+++ b/spec/component_guide/component_guide_spec.rb
@@ -73,6 +73,16 @@ describe 'Component guide' do
     expect(page).to have_selector('.component-guide-preview .test-component-with-params', text: 'A different value')
   end
 
+  it 'marks strings in fixtures as html_safe' do
+    visit '/component-guide/test-component-with-html-params'
+    within ".test-component-with-html-params" do
+      7.times do |i|
+        count = i + 1
+        expect(page).to have_selector(".param-#{count}", text: count)
+      end
+    end
+  end
+
   it 'creates a page for each fixture' do
     visit '/component-guide/test-component-with-params/another_fixture'
     expect(body).to include('How to call this example')

--- a/test/dummy/app/views/components/_test-component-with-html-params.html.erb
+++ b/test/dummy/app/views/components/_test-component-with-html-params.html.erb
@@ -1,0 +1,14 @@
+<div class="test-component-with-html-params">
+  <%= first %>
+  <%= nested[:second] %>
+  <%= nested[:deeper][:third] %>
+  <% list.each do |item| %>
+    <% if item.is_a?(Array) %>
+      <% item.each do |nested_item| %>
+        <%= nested_item %>
+      <% end %>
+    <% else %>
+      <%= item %>
+    <% end %>
+  <% end %>
+</div>

--- a/test/dummy/app/views/components/docs/test-component-with-html-params.yml
+++ b/test/dummy/app/views/components/docs/test-component-with-html-params.yml
@@ -1,0 +1,15 @@
+name: Test component with HTML parameters
+description: A test component that takes parameters containing HTML
+fixtures:
+  default:
+    first: '<span class="param-1">1</span>'
+    nested:
+      second: '<span class="param-2">2</span>'
+      deeper:
+        third: '<span class="param-3">3</span>'
+    list:
+      - '<span class="param-4">4</span>'
+      - '<span class="param-5">5</span>'
+      -
+        - '<span class="param-6">6</span>'
+        - '<span class="param-7">7</span>'


### PR DESCRIPTION
Allow HTML strings to be written in YAML and rendered in the component guide as examples.

It is preferable to mark our trusted YAML strings as html_safe than to require `.html_safe` be included within each component. Safe HTML blocks are acceptable arguments to a component.