### PR TITLE
Display incomplete warnings from aXe in component guide

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+++ b/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
@@ -27,26 +27,21 @@
         return callback('No accessibility issues found')
       }
 
-      var incompleteWarningsObj = (
-        incompleteWarnings.map(function (incomplete) {
-          var help = incomplete.help
-          var helpUrl = _formatHelpUrl(incomplete.helpUrl)
-          var cssSelector = incomplete.nodes.map(function (node) {
-            return node.target
-          })
+      // We don't want to display incomplete warnings on preview pages
+      if (!document.querySelector(selector).parentNode.className.includes('preview')) {
+        var incompleteWarningsObj = _processIncompleteWarnings(incompleteWarnings)
+      }
+      var errorText = _processViolations(violations, results.url)
 
-          return {
-            'summary': help,
-            'selectors': cssSelector,
-            'url': helpUrl
-          }
-        })
-      )
+      callback(undefined, errorText, incompleteWarningsObj)
+    })
+  }
 
-      if (violations.length !== 0) {
-      var errorText = (
+  var _processViolations = function(violations, url) {
+    if (violations.length !== 0) {
+      return (
         '\n' + 'Accessibility issues at ' +
-        results.url + '\n\n' +
+        url + '\n\n' +
         violations.map(function (violation) {
           var help = 'Problem: ' + violation.help
           var helpUrl = 'Try fixing it with this help: ' + _formatHelpUrl(violation.helpUrl)
@@ -63,9 +58,24 @@
     else {
       console.info("aXe: No accessibility errors found")
     }
+  }
 
-      callback(undefined, errorText, incompleteWarningsObj)
-    })
+  var _processIncompleteWarnings = function(incompleteWarnings) {
+    return (
+      incompleteWarnings.map(function (incomplete) {
+        var help = incomplete.help
+        var helpUrl = _formatHelpUrl(incomplete.helpUrl)
+        var cssSelector = incomplete.nodes.map(function (node) {
+          return node.target
+        })
+
+        return {
+          'summary': help,
+          'selectors': cssSelector,
+          'url': helpUrl
+        }
+      })
+    )
   }
 
   var _formatHelpUrl = function (helpUrl) {
@@ -99,7 +109,7 @@
         }
 
         // Add warning to warnings box
-        warningsHTML = '<h3>' + warning.summary + ' <a href="' + warning.url + '">(see guidance)</a></h3>' +
+        var warningsHTML = '<h3>' + warning.summary + ' <a href="' + warning.url + '">(see guidance)</a></h3>' +
                         '<p>Element can be found using the following CSS selector: <span class="axe-incomplete-selector">' +
                           selector +
                         '</span></p>'
@@ -126,7 +136,7 @@
         if (err) {
           return
         }
-        _renderIncompleteWarnings(incompleteWarnings)
+        if (incompleteWarnings) _renderIncompleteWarnings(incompleteWarnings)
         if (violations) _throwUncaughtError(violations)
       })
     })

--- a/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+++ b/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
@@ -23,14 +23,14 @@
       var violations = (typeof results === 'undefined') ? [] : results.violations
       var incompleteWarnings = (typeof results === 'undefined') ? [] : results.incomplete
 
-      /*if (violations.length === 0) {
+      if (violations.length === 0 && incompleteWarnings.length === 0) {
         return callback('No accessibility issues found')
-      }*/
+      }
 
       var incompleteWarningsObj = (
         incompleteWarnings.map(function (incomplete) {
           var help = incomplete.help
-          var helpUrl = incomplete.helpUrl
+          var helpUrl = _formatHelpUrl(incomplete.helpUrl)
           var cssSelector = incomplete.nodes.map(function (node) {
             return node.target
           })
@@ -43,6 +43,7 @@
         })
       )
 
+      if (violations.length !== 0) {
       var errorText = (
         '\n' + 'Accessibility issues at ' +
         results.url + '\n\n' +
@@ -58,6 +59,11 @@
           ].join('\n\n\n')
         }).join('\n\n- - -\n\n')
       )
+    }
+    else {
+      console.info("aXe: No accessibility errors found")
+    }
+
       callback(undefined, errorText, incompleteWarningsObj)
     })
   }
@@ -121,7 +127,7 @@
           return
         }
         _renderIncompleteWarnings(incompleteWarnings)
-        _throwUncaughtError(violations)
+        if (violations) _throwUncaughtError(violations)
       })
     })
   }

--- a/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+++ b/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
@@ -111,7 +111,7 @@
       warning.selectors.forEach(function (selectorObj) {
         var activeEl = document.querySelector(selectorObj.selector)
         var activeElParent = _findParent(activeEl, '[data-module="test-a11y"]')
-        var warningWrapper = activeElParent.querySelector('.component-guide-preview--warning')
+        var warningWrapper = activeElParent.querySelector('[data-module="test-a11y-warning"]')
 
         if (warningWrapper) {
           // Add warning to warnings box

--- a/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+++ b/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
@@ -27,10 +27,7 @@
         return callback('No accessibility issues found')
       }
 
-      // We don't want to display incomplete warnings on preview pages
-      if ($(selector).closest('[data-type="preview"]').data('type') !== 'preview') {
-        var incompleteWarningsObj = _processIncompleteWarnings(incompleteWarnings)
-      }
+      var incompleteWarningsObj = _processIncompleteWarnings(incompleteWarnings)
       var errorText = _processViolations(violations, results.url)
 
       callback(undefined, errorText, incompleteWarningsObj)
@@ -100,19 +97,32 @@
     )
   }
 
+  var _findParent = function (element, selector) {
+    while (element.tagName !== 'HTML') {
+      if (element.matches(selector)) {
+        return element
+      }
+      element = element.parentNode
+    }
+  }
+
   var _renderIncompleteWarnings = function (incompleteWarnings) {
     incompleteWarnings.forEach(function (warning) {
       warning.selectors.forEach(function (selectorObj) {
-        var warningWrapper = window.$(selectorObj.selector.toString()).closest('[data-module="test-a11y"]').next('[data-module="test-a11y-warning"]')[0]
+        var activeEl = document.querySelector(selectorObj.selector)
+        var activeElParent = _findParent(activeEl, '[data-module="test-a11y"]')
+        var warningWrapper = activeElParent.querySelector('.component-guide-preview--warning')
 
-        // Add warning to warnings box
-        var warningsHTML = '<h3>' + warning.summary + ' <a href="' + warning.url + '">(see guidance)</a></h3>' +
-                        '<p>Reason: ' + selectorObj.reason + '</p>' +
-                        '<p>Element can be found using the following CSS selector: <span class="selector">' +
-                        selectorObj.selector +
-                        '</span></p>'
+        if (warningWrapper) {
+          // Add warning to warnings box
+          var warningsHTML = '<h3>' + warning.summary + ' <a href="' + warning.url + '">(see guidance)</a></h3>' +
+          '<p>Reason: ' + selectorObj.reason + '</p>' +
+          '<p>Element can be found using the following CSS selector: <span class="selector">' +
+          selectorObj.selector +
+          '</span></p>'
 
-        warningWrapper.insertAdjacentHTML('beforeend', warningsHTML)
+          warningWrapper.insertAdjacentHTML('beforeend', warningsHTML)
+        }
       })
     })
   }

--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -134,6 +134,31 @@ $border-color: #ccc;
   }
 }
 
+.component-guide-preview--warning {
+  margin-top: $gutter-half;
+  border-color: $yellow;
+
+  &:empty {
+    display: none;
+  }
+
+  &:before {
+    background-color: $yellow;
+  }
+
+  h3 {
+    @include bold-16;
+  }
+
+  h3:not(:first-child) {
+    margin-top: $gutter;
+  }
+
+  .selector {
+    font-style: italic;
+  }
+}
+
 .examples {
   .component-example {
     margin: 0 0 $gutter * 1.5;
@@ -176,27 +201,5 @@ html {
     a {
       color: $black;
     }
-  }
-}
-
-// aXe Accessibility Testing Styling
-.axe-incomplete {
-  margin-top: $gutter-half;
-  border-color: $yellow;
-
-  &:before {
-    background-color: $yellow;
-  }
-
-  h3 {
-    @include bold-16;
-  }
-
-  &-selector {
-    font-style: italic;
-  }
-
-  p:not(:last-child) {
-    margin-bottom: $gutter;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -134,6 +134,15 @@ $border-color: #ccc;
   }
 }
 
+.component-guide-preview--simple {
+  border: 0;
+  padding: 0;
+
+  &:before {
+    display: none;
+  }
+}
+
 .component-guide-preview--warning {
   margin-top: $gutter-half;
   border-color: $yellow;

--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -116,13 +116,14 @@ $border-color: #ccc;
 
   &:before {
     @include core-14;
-    content: "EXAMPLE";
+    content: attr(data-content);
     position: absolute;
     top: 0;
     left: 0;
     padding: 0.21053em 0.78947em;
     background: $border-colour;
-    color: $white;
+    color: $black;
+    font-weight: bold;
   }
 
   div[class^="govuk-"] {
@@ -175,5 +176,27 @@ html {
     a {
       color: $black;
     }
+  }
+}
+
+// aXe Accessibility Testing Styling
+.axe-incomplete {
+  margin-top: $gutter-half;
+  border-color: $yellow;
+
+  &:before {
+    background-color: $yellow;
+  }
+
+  h3 {
+    @include bold-16;
+  }
+
+  &-selector {
+    font-style: italic;
+  }
+
+  p:not(:last-child) {
+    margin-bottom: $gutter;
   }
 }

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
@@ -1,0 +1,5 @@
+<div class="component-guide-preview
+            <% if example.right_to_left? %>direction-rtl<% end %>
+            <% if preview_page %>component-guide-preview--simple<% end %>" data-content="EXAMPLE">
+  <%= render component_doc.partial_path, example.html_safe_data %>
+</div>

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
@@ -1,4 +1,4 @@
-<div data-module="test-a11y" class="component-guide-preview <% if example.right_to_left? %>direction-rtl<% end %>" data-content="EXAMPLE">
-  <%= render component_doc.partial_path, example.html_safe_data %>
+<div data-module="test-a11y">
+  <%= render "govuk_publishing_components/component_guide/component_doc/component", component_doc: @component_doc, example: example, preview_page: false %>
+  <div class="component-guide-preview component-guide-preview--warning" data-module="test-a11y-warning" data-content="Potential Accessibility Issues: Need Manual Check"></div>
 </div>
-<div class="component-guide-preview component-guide-preview--warning" data-module="test-a11y-warning" data-content="Potential Accessibility Issues: Need Manual Check"></div>

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
@@ -1,3 +1,4 @@
 <div data-module="test-a11y" class="component-guide-preview <% if example.right_to_left? %>direction-rtl<% end %>" data-content="EXAMPLE">
   <%= render component_doc.partial_path, example.html_safe_data %>
 </div>
+<div class="component-guide-preview component-guide-preview--warning" data-module="test-a11y-warning" data-content="Potential Accessibility Issues: Need Manual Check"></div>

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
@@ -1,3 +1,3 @@
-<div data-module="test-a11y" class="component-guide-preview <% if example.right_to_left? %>direction-rtl<% end %>">
+<div data-module="test-a11y" class="component-guide-preview <% if example.right_to_left? %>direction-rtl<% end %>" data-content="EXAMPLE">
   <%= render component_doc.partial_path, example.html_safe_data %>
 </div>

--- a/app/views/govuk_publishing_components/component_guide/preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/preview.html.erb
@@ -1,5 +1,5 @@
 <% @component_examples.each do |example| %>
-  <div class="component-guide-preview-page">
+  <div class="component-guide-preview-page" data-type="preview">
     <% if @component_examples.length > 1 %>
       <h2 class="preview-title" data-content="EXAMPLE"><a href="<%= component_example_path(@component_doc.id, example.id) %>"><%= example.name %></a></h2>
     <% end %>

--- a/app/views/govuk_publishing_components/component_guide/preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/preview.html.erb
@@ -1,7 +1,7 @@
 <% @component_examples.each do |example| %>
   <div class="component-guide-preview-page">
     <% if @component_examples.length > 1 %>
-      <h2 class="preview-title"><a href="<%= component_example_path(@component_doc.id, example.id) %>"><%= example.name %></a></h2>
+      <h2 class="preview-title" data-content="EXAMPLE"><a href="<%= component_example_path(@component_doc.id, example.id) %>"><%= example.name %></a></h2>
     <% end %>
     <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, example: example %>
   </div>

--- a/app/views/govuk_publishing_components/component_guide/preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/preview.html.erb
@@ -1,8 +1,10 @@
 <% @component_examples.each do |example| %>
-  <div class="component-guide-preview-page" data-type="preview">
+  <div class="component-guide-preview-page">
     <% if @component_examples.length > 1 %>
-      <h2 class="preview-title" data-content="EXAMPLE"><a href="<%= component_example_path(@component_doc.id, example.id) %>"><%= example.name %></a></h2>
+      <h2 class="preview-title"><a href="<%= component_example_path(@component_doc.id, example.id) %>"><%= example.name %></a></h2>
     <% end %>
-    <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, example: example %>
+    <div data-module="test-a11y">
+      <%= render "govuk_publishing_components/component_guide/component_doc/component", component_doc: @component_doc, example: example, preview_page: true %>
+    </div>
   </div>
 <% end %>

--- a/spec/component_guide/component_guide_spec.rb
+++ b/spec/component_guide/component_guide_spec.rb
@@ -123,7 +123,7 @@ describe 'Component guide' do
 
   it 'has accessibility testing hooks' do
     visit '/component-guide/test-component'
-    expect(page).to have_selector('.component-guide-preview[data-module="test-a11y"]')
+    expect(page).to have_selector('[data-module="test-a11y"]')
   end
 
   it 'displays the accessibility acceptance criteria of a component as html using static’s govspeak component' do

--- a/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
+++ b/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
@@ -54,8 +54,9 @@ describe('AccessibilityTest', function () {
   })
 
   it('should error if no selector is found', function (done) {
-    AccessibilityTest(TEST_SELECTOR, function (err, result) {
-      expect(result).toBe(undefined)
+    AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
+      expect(violations).toBe(undefined)
+      expect(incompleteWarnings).toBe(undefined)
       expect(err).toBe('No selector "' + TEST_SELECTOR + '" found')
       done()
     })
@@ -80,7 +81,7 @@ describe('AccessibilityTest', function () {
   it('should throw if there\'s a contrast issue', function (done) {
     addToDom('<a href="#">Low contrast</a>', 'a { background: white; color: #ddd }')
 
-    AccessibilityTest(TEST_SELECTOR, function (err, result) {
+    AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
       if (err) {
         throw err
       }
@@ -92,7 +93,7 @@ describe('AccessibilityTest', function () {
         helpUrl: 'https://dequeuniversity.com/rules/axe/2.3/color-contrast?application=axeAPI'
       })
 
-      expect(result).toBe(errorMessage)
+      expect(violations).toBe(errorMessage)
 
       done()
     })
@@ -101,7 +102,7 @@ describe('AccessibilityTest', function () {
   it('should throw if there\'s a alt tag issue', function (done) {
     addToDom('<img src="">')
 
-    AccessibilityTest(TEST_SELECTOR, function (err, result) {
+    AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
       if (err) {
         throw err
       }
@@ -113,8 +114,25 @@ describe('AccessibilityTest', function () {
         helpUrl: 'https://dequeuniversity.com/rules/axe/2.3/image-alt?application=axeAPI'
       })
 
-      expect(result).toBe(errorMessage)
+      expect(violations).toBe(errorMessage)
 
+      done()
+    })
+  })
+
+  it('process incomplete warnings into object for rendering in guide', function (done) {
+    addToDom('<a href="#">Link</a>', 'a { background-image: url("/"); }')
+
+    AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
+      if (err) {
+        throw err
+      }
+
+      console.log(incompleteWarnings)
+
+      expect(incompleteWarnings[0].summary).toBe("Elements must have sufficient color contrast")
+      expect(incompleteWarnings[0].url).toBe("https://dequeuniversity.com/rules/axe/2.3/color-contrast?application=axeAPI")
+      expect(incompleteWarnings[0].selectors[0][0]).toBe('.js-test-a11y > a')
       done()
     })
   })
@@ -122,7 +140,7 @@ describe('AccessibilityTest', function () {
   it('should throw on multiple issues', function (done) {
     addToDom('<img src=""><a href="#">Low contrast</a>', 'a { background: white; color: #ddd }')
 
-    AccessibilityTest(TEST_SELECTOR, function (err, result) {
+    AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
       if (err) {
         throw err
       }
@@ -144,7 +162,7 @@ describe('AccessibilityTest', function () {
         })
       )
 
-      expect(result).toBe(errorMessage)
+      expect(violations).toBe(errorMessage)
 
       done()
     })

--- a/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
+++ b/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
@@ -128,11 +128,9 @@ describe('AccessibilityTest', function () {
         throw err
       }
 
-      console.log(incompleteWarnings)
-
       expect(incompleteWarnings[0].summary).toBe("Elements must have sufficient color contrast")
       expect(incompleteWarnings[0].url).toBe("https://dequeuniversity.com/rules/axe/2.3/color-contrast?application=axeAPI")
-      expect(incompleteWarnings[0].selectors[0][0]).toBe('.js-test-a11y > a')
+      expect(incompleteWarnings[0].selectors[0].selector[0]).toBe('.js-test-a11y > a')
       done()
     })
   })


### PR DESCRIPTION
In some cases, aXe is unable to definitely say whether there has been an accessibility error/violation. In these cases, it reports the potential error as 'incomplete', meaning it requires a manual check [(see more info here)](https://www.deque.com/blog/introducing-axe-2-1-7/). We want to show these underneath the relevant component so that developers are aware of what might require a manual check.

<img width="984" alt="screen shot 2017-08-29 at 13 53 52" src="https://user-images.githubusercontent.com/29889908/29821916-8707e72a-8cc1-11e7-87cd-819fdc708e50.png">
