### PR TITLE
Add context param to aXe so that options are passed correctly

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+++ b/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
@@ -15,7 +15,7 @@
       include: [selector]
     }
 
-    axe.run(axeOptions, function (err, results) {
+    axe.run(selector, axeOptions, function (err, results) {
       if (err) {
         callback('aXe Error: ' + err)
       }

--- a/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
+++ b/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
@@ -61,6 +61,22 @@ describe('AccessibilityTest', function () {
     })
   })
 
+  it('should not scroll the page', function (done) {
+    var bigElement = '<div style="height: 1000px; width: 100px;"></div>'
+
+    addToDom(
+      bigElement + '<a href="#">Low contrast</a>' + bigElement,
+      'a { background: white; color: #ddd }'
+    )
+
+    expect(window.scrollY).toBe(0, 'should start at top of the page')
+
+    AccessibilityTest(TEST_SELECTOR, function () {
+      expect(window.scrollY).toBe(0, 'should end at top of the page')
+      done()
+    })
+  })
+
   it('should throw if there\'s a contrast issue', function (done) {
     addToDom('<a href="#">Low contrast</a>', 'a { background: white; color: #ddd }')
 


### PR DESCRIPTION
The restoreScroll option was not being passed properly, I think this may
be an axe bug but this work around fixes the issue by double specifying where
axe should run.