### PR TITLE
Add descriptions to component examples

### DIFF
--- a/app/models/govuk_publishing_components/component_doc_resolver.rb
+++ b/app/models/govuk_publishing_components/component_doc_resolver.rb
@@ -14,7 +14,7 @@ module GovukPublishingComponents
     def build(component)
       examples = component[:examples].map { |id, example|
         example = example || {}
-        ComponentExample.new(id.to_s, example["data"], example["context"])
+        ComponentExample.new(id.to_s, example["data"], example["context"], example["description"])
       }
 
       ComponentDoc.new(component[:id],

--- a/app/models/govuk_publishing_components/component_example.rb
+++ b/app/models/govuk_publishing_components/component_example.rb
@@ -2,12 +2,14 @@ module GovukPublishingComponents
   class ComponentExample
     attr_reader :id,
                 :data,
-                :context
+                :context,
+                :description
 
-    def initialize(id, data, context)
+    def initialize(id, data, context, description)
       @id = id
       @data = data || {}
       @context = context || {}
+      @description = description || false
     end
 
     def name
@@ -47,6 +49,16 @@ module GovukPublishingComponents
 
     def right_to_left?
       !!context['right_to_left']
+    end
+
+    def html_description
+      govspeak_to_html(description) if description.present?
+    end
+
+  private
+
+    def govspeak_to_html(govspeak)
+      Govspeak::Document.new(govspeak).to_html
     end
   end
 end

--- a/app/views/govuk_publishing_components/component_guide/example.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/example.html.erb
@@ -3,6 +3,7 @@
 
 <div class="component-show">
   <div class="component-doc">
+    <%= render "govuk_component/govspeak", content: @component_example.html_description %>
     <h2 class="component-doc-h2">How to call this example</h2>
     <%= render partial: "govuk_publishing_components/component_guide/component_doc/call", locals: { component_doc: @component_doc, example: @component_example } %>
 

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -44,6 +44,7 @@
             <a href="<%= component_example_path(@component_doc.id, example.id) %>"><%= example.name %></a>
             <small>(<a href="<%= component_preview_path(@component_doc.id, example.id) %>">preview</a>)</small>
           </h3>
+          <%= render "govuk_component/govspeak", content: example.html_description %>
           <%= render "govuk_publishing_components/component_guide/component_doc/call", component_doc: @component_doc, example: example %>
           <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, example: example %>
         </div>

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -56,10 +56,18 @@ examples:
   default:
     data:
       some_parameter: 'The parameter value'
+    description: |
+      This component is used in the following contexts:
+
+      - [the GOV.UK homepage](https://www.gov.uk)
   another_example:
     data:
       some_parameter: 'A different parameter value'
 ```
+
+#### Description
+
+An example can have an optional description. This is a govspeak markdown block.
 
 #### Right to left examples
 

--- a/spec/component_guide/component_guide_spec.rb
+++ b/spec/component_guide/component_guide_spec.rb
@@ -162,6 +162,17 @@ describe 'Component guide' do
     expect(page).to have_selector('.component-guide-preview-page [data-module="test-a11y"]')
   end
 
+  it 'shows an example description if one is present' do
+    visit '/component-guide/test-component-with-example-description'
+
+    within ".component-example" do
+      within(shared_component_selector("govspeak")) do
+        content = JSON.parse(page.text).fetch("content").squish
+        expect(content).to include('<p>This is the description of this example. It has a list in it, containing:</p>')
+      end
+    end
+  end
+
   it 'loads a static component with correct component directory when configured' do
     GovukPublishingComponents.configure do |config|
       config.static = true

--- a/test/dummy/app/views/components/_test-component-with-example-description.html.erb
+++ b/test/dummy/app/views/components/_test-component-with-example-description.html.erb
@@ -1,0 +1,6 @@
+<% test_component_parameter ||= false %>
+<div class="test-component-with-example-description">
+  <% if test_component_parameter %>
+    <%= test_component_parameter %>
+  <% end %>
+</div>

--- a/test/dummy/app/views/components/docs/test-component-with-example-description.yml
+++ b/test/dummy/app/views/components/docs/test-component-with-example-description.yml
@@ -1,0 +1,11 @@
+name: Test component with example description
+description: A test component that contains examples with descriptions
+examples:
+  default:
+    data: {}
+  another_example:
+    description: |
+      This is the description of this example. It has a list in it, containing:
+
+      - the first item
+      - the second item


### PR DESCRIPTION
- 'description' can be added to yml files at the same point as 'data' and 'context'
- description is output using govspeak in the same way as main description and accessibility_criteria

![screen shot 2017-09-05 at 15 44 40](https://user-images.githubusercontent.com/861310/30066895-3152ea4c-9251-11e7-9ed3-4ec0841e40c4.png)

https://trello.com/c/2M84sEvg/133-improve-description-of-components-examples-1
