### PR TITLE
Add dark background context to gem

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -110,6 +110,10 @@ $border-color: #ccc;
     text-align: start;
   }
 
+  &.dark-background {
+    background-color: $govuk-blue;
+  }
+
   padding: ($gutter * 1.5) $gutter $gutter;
   border: 1px solid $border-colour;
   position: relative;

--- a/app/models/govuk_publishing_components/component_example.rb
+++ b/app/models/govuk_publishing_components/component_example.rb
@@ -51,6 +51,10 @@ module GovukPublishingComponents
       !!context['right_to_left']
     end
 
+    def dark_background?
+      !!context['dark_background']
+    end
+
     def html_description
       govspeak_to_html(description) if description.present?
     end

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
@@ -1,5 +1,6 @@
 <div class="component-guide-preview
             <% if example.right_to_left? %>direction-rtl<% end %>
+            <% if example.dark_background? %>dark-background<% end %>
             <% if preview_page %>component-guide-preview--simple<% end %>" data-content="EXAMPLE">
   <%= render component_doc.partial_path, example.html_safe_data %>
 </div>


### PR DESCRIPTION
Allow components to be viewed on a govuk-blue background

For example:
<img width="979" alt="screen shot 2017-09-06 at 13 18 26" src="https://user-images.githubusercontent.com/29889908/30111527-e70c7128-9305-11e7-8158-0579b6fef5ec.png">
