### PR TITLE
Link to principles, conventions in component guide

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -12,6 +12,8 @@ $border-color: #ccc;
 }
 
 .component-list {
+  margin-left: 20px;
+
   li {
     @include core-19;
     margin-bottom: $gutter-half;

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -1,5 +1,17 @@
 <%= render 'govuk_component/title', title: GovukPublishingComponents::Config.component_guide_title %>
 
+<div class="govuk-govspeak">
+  <p>Components are packages of template, style, behaviour and documentation that live in your application.</p>
+  <p>A component must:</p>
+  <ul>
+    <li><a href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_principles.md">meet the component principles</a></li>
+    <li><a href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_conventions.md">follow component conventions</a></li>
+  </ul>
+  <p>See the <a href="https://github.com/alphagov/govuk_publishing_components">govuk_publishing_components gem</a> for further details, or <a href="https://docs.publishing.service.gov.uk/manual/components.html#component-guides">a list of all component guides</a>.</p>
+</div>
+
+<h2 class="component-doc-h2">Components</h2>
+
 <ul class="component-list">
   <% @component_docs.each do |component_doc| %>
     <li>


### PR DESCRIPTION
- adds links to component guide homepage linking to conventions and principles

![screen shot 2017-09-07 at 13 41 17](https://user-images.githubusercontent.com/861310/30163812-48d4a200-93d2-11e7-9c3a-c75263c50f3b.png)

https://trello.com/c/iVZWGnZA/131-1-link-to-principles-and-conventions-from-the-component-guide