### PR TITLE
Set X-Frame-Options to ALLOWALL

### DIFF
--- a/app/controllers/govuk_publishing_components/application_controller.rb
+++ b/app/controllers/govuk_publishing_components/application_controller.rb
@@ -5,11 +5,16 @@ module GovukPublishingComponents
     include Slimmer::Headers
     protect_from_forgery with: :exception
     before_action :set_custom_slimmer_headers
+    before_action :set_x_frame_options_header
 
   private
 
     def set_custom_slimmer_headers
       set_slimmer_headers(report_a_problem: 'false', remove_search: true)
+    end
+
+    def set_x_frame_options_header
+      response.headers["X-Frame-Options"] = "ALLOWALL"
     end
   end
 end

--- a/spec/component_guide/component_guide_spec.rb
+++ b/spec/component_guide/component_guide_spec.rb
@@ -10,6 +10,11 @@ describe 'Component guide' do
     expect(page).to have_title 'GOV.UK Component Guide'
   end
 
+  it 'sets X-Frame-Options to allow inclusion in iFrames' do
+    visit '/component-guide'
+    expect(page.response_headers["X-Frame-Options"]).to eq('ALLOWALL')
+  end
+
   it 'loads a component guide' do
     visit '/component-guide'
     expect(page).to have_title 'GOV.UK Component Guide'


### PR DESCRIPTION
To enable our visual diff tool to work, we need to set X-Frame-Options to ALLOWALL so that the component guide can be embedded into an iframe.