### PR TITLE
[DO NOT MERGE] Add universal accessibility criteria

### DIFF
--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -5,14 +5,16 @@ module GovukPublishingComponents
                 :description,
                 :body,
                 :accessibility_criteria,
+                :universal_accessibility_criteria,
                 :examples
 
-    def initialize(id, name, description, body, accessibility_criteria, examples)
+    def initialize(id, name, description, body, accessibility_criteria, universal_accessibility_criteria, examples)
       @id = id
       @name = name
       @description = description
       @body = body
       @accessibility_criteria = accessibility_criteria
+      @universal_accessibility_criteria = universal_accessibility_criteria
       @examples = examples
     end
 
@@ -30,6 +32,11 @@ module GovukPublishingComponents
 
     def html_accessibility_criteria
       govspeak_to_html(accessibility_criteria) if accessibility_criteria.present?
+    end
+
+    def html_universal_accessibility_criteria
+      #govspeak_to_html(universal_accessibility_criteria) if universal_accessibility_criteria.present?
+      "universal"
     end
 
     def partial_path

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -13,8 +13,8 @@ module GovukPublishingComponents
       @name = name
       @description = description
       @body = body
-      @accessibility_criteria = accessibility_criteria
       @universal_accessibility_criteria = universal_accessibility_criteria
+      @accessibility_criteria = "#{accessibility_criteria}\n#{check_for_universal_accessibility_criteria}"
       @examples = examples
     end
 
@@ -34,11 +34,6 @@ module GovukPublishingComponents
       govspeak_to_html(accessibility_criteria) if accessibility_criteria.present?
     end
 
-    def html_universal_accessibility_criteria
-      #govspeak_to_html(universal_accessibility_criteria) if universal_accessibility_criteria.present?
-      "universal"
-    end
-
     def partial_path
       "#{GovukPublishingComponents::Config.component_directory_name}/#{id}"
     end
@@ -47,6 +42,27 @@ module GovukPublishingComponents
 
     def govspeak_to_html(govspeak)
       Govspeak::Document.new(govspeak).to_html
+    end
+
+    def check_for_universal_accessibility_criteria
+      fetch_component_docs.map { |criteria| match_universal_accessibility_criteria(criteria) }.join("\n") if universal_accessibility_criteria.present?
+    end
+
+    def match_universal_accessibility_criteria(criteria)
+      criteria["accessibility_criteria"] if universal_accessibility_criteria.include? criteria["id"]
+    end
+
+    def fetch_component_docs
+      doc_files = Rails.root.join(documentation_directory, "*.yml")
+      Dir[doc_files].sort.map { |file| parse_documentation(file) }
+    end
+
+    def parse_documentation(file)
+      { id: File.basename(file, ".yml") }.merge(YAML::load_file(file)).with_indifferent_access
+    end
+
+    def documentation_directory
+      File.join(File.dirname(File.expand_path(__FILE__)), '../../views/govuk_publishing_components/component_guide/docs')
     end
   end
 end

--- a/app/models/govuk_publishing_components/component_doc_resolver.rb
+++ b/app/models/govuk_publishing_components/component_doc_resolver.rb
@@ -22,6 +22,7 @@ module GovukPublishingComponents
                        component[:description],
                        component[:body],
                        component[:accessibility_criteria],
+                       component[:universal_accessibility_criteria],
                        examples)
     end
 

--- a/app/views/govuk_publishing_components/component_guide/docs/link.yml
+++ b/app/views/govuk_publishing_components/component_guide/docs/link.yml
@@ -1,6 +1,6 @@
 name: Link
 accessibility_criteria: |
-  The link must:
+  Links in the component must:
 
   - accept focus
   - be focusable with a keyboard

--- a/app/views/govuk_publishing_components/component_guide/docs/link.yml
+++ b/app/views/govuk_publishing_components/component_guide/docs/link.yml
@@ -1,0 +1,13 @@
+name: Link
+accessibility_criteria: |
+  The link must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - indicate when it has focus
+  - change in appearance when touched (in the touch-down state)
+  - change in appearance when hovered
+  - be usable with touch
+  - be usable with [voice commands](https://www.w3.org/WAI/perspectives/voice.html)
+  - have visible text

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -33,6 +33,11 @@
     </div>
   <% end %>
 
+  <% if @component_doc.universal_accessibility_criteria.present? %>
+    <p>Universal</p>
+    <%= render 'govuk_component/govspeak', content: @component_doc.html_universal_accessibility_criteria %>
+  <% end %>
+
   <% if @component_doc.other_examples.any? %>
     <div class="examples">
       <h2 class="component-doc-h2">Other examples

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -33,11 +33,6 @@
     </div>
   <% end %>
 
-  <% if @component_doc.universal_accessibility_criteria.present? %>
-    <p>Universal</p>
-    <%= render 'govuk_component/govspeak', content: @component_doc.html_universal_accessibility_criteria %>
-  <% end %>
-
   <% if @component_doc.other_examples.any? %>
     <div class="examples">
       <h2 class="component-doc-h2">Other examples

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -46,12 +46,15 @@ name: Name of component
 description: Short description of component
 body: |
   Optional markdown providing further detail about the component
-acceptance_criteria: |
+accessibility_criteria: |
   Markdown listing what this component must do to be accessible. For example:
 
-  The link must:
+  The banner must:
 
-  * be keyboard focusable
+  - be visually distinct from other content on the page
+  - have an accessible name that describes the banner as a notice
+universal_accessibility_criteria:
+  - link
 examples:
   default:
     data:
@@ -64,6 +67,14 @@ examples:
     data:
       some_parameter: 'A different parameter value'
 ```
+
+#### Accessibility Criteria
+
+Markdown listing what this component must do to be accessible.
+
+Universal accessibility criteria can be included in a list as shown. They are pre-written accessibility criteria that can apply to more than one component, created to avoid duplication. For example, links within components should all accept focus, be focusable with a keyboard, etc.
+
+A component can have accessibility criteria, universal accessibility criteria, or both.
 
 #### Description
 

--- a/spec/component_guide/component_guide_spec.rb
+++ b/spec/component_guide/component_guide_spec.rb
@@ -1,6 +1,12 @@
 require "spec_helper"
 
 describe 'Component guide' do
+  before(:each) do
+    GovukPublishingComponents.configure do |config|
+      config.static = false
+    end
+  end
+
   # Load ordering test can only fail if run as the first test in suite
   # https://github.com/rails/rails/issues/12168
   it 'renders using gem layout not app layout after viewing a page on the application' do
@@ -183,6 +189,28 @@ describe 'Component guide' do
     expect(body).to include('render <span class="token string">\'govuk_component/test-static-component\'</span>')
     within '.component-guide-preview' do
       expect(page).to have_selector('.a-test-static-component')
+    end
+  end
+
+  it 'shows universal accessibility criteria' do
+    visit '/component-guide/test-component-with-universal-accessibility-criteria'
+
+    within '.component-accessibility-criteria' do
+      within(shared_component_selector("govspeak")) do
+        content = JSON.parse(page.text).fetch("content").squish
+        expect(content).to eq('<ul> <li>This is some criteria in a list</li> </ul> <p>Links in the component must:</p> <ul> <li>accept focus</li> <li>be focusable with a keyboard</li> <li>be usable with a keyboard</li> <li>indicate when it has focus</li> <li>change in appearance when touched (in the touch-down state)</li> <li>change in appearance when hovered</li> <li>be usable with touch</li> <li>be usable with <a rel="external" href="https://www.w3.org/WAI/perspectives/voice.html">voice commands</a> </li> <li>have visible text</li> </ul>')
+      end
+    end
+  end
+
+  it 'shows universal accessibility criteria when no other accessibility criteria are included' do
+    visit '/component-guide/test-component-with-universal-accessibility-criteria-only'
+
+    within '.component-accessibility-criteria' do
+      within(shared_component_selector("govspeak")) do
+        content = JSON.parse(page.text).fetch("content").squish
+        expect(content).to eq('<p>Links in the component must:</p> <ul> <li>accept focus</li> <li>be focusable with a keyboard</li> <li>be usable with a keyboard</li> <li>indicate when it has focus</li> <li>change in appearance when touched (in the touch-down state)</li> <li>change in appearance when hovered</li> <li>be usable with touch</li> <li>be usable with <a rel="external" href="https://www.w3.org/WAI/perspectives/voice.html">voice commands</a> </li> <li>have visible text</li> </ul>')
+      end
     end
   end
 end

--- a/test/dummy/app/views/components/_test-component-with-universal-accessibility-criteria-only.html.erb
+++ b/test/dummy/app/views/components/_test-component-with-universal-accessibility-criteria-only.html.erb
@@ -1,0 +1,3 @@
+<div class="a-test-component">
+  <h1 class="something-inside-test-component">Test component with only universal accessibility criteria</h1>
+</div>

--- a/test/dummy/app/views/components/_test-component-with-universal-accessibility-criteria.html.erb
+++ b/test/dummy/app/views/components/_test-component-with-universal-accessibility-criteria.html.erb
@@ -1,0 +1,3 @@
+<div class="a-test-component">
+  <h1 class="something-inside-test-component">Test component with universal accessibility criteria</h1>
+</div>

--- a/test/dummy/app/views/components/docs/test-component-with-universal-accessibility-criteria-only.yml
+++ b/test/dummy/app/views/components/docs/test-component-with-universal-accessibility-criteria-only.yml
@@ -1,0 +1,8 @@
+name: Test component with only universal accessibility criteria
+description: A test component with only universal accessibility criteria
+universal_accessibility_criteria:
+  - link
+  - notvalid
+examples:
+  default:
+    data: {}

--- a/test/dummy/app/views/components/docs/test-component-with-universal-accessibility-criteria.yml
+++ b/test/dummy/app/views/components/docs/test-component-with-universal-accessibility-criteria.yml
@@ -1,0 +1,10 @@
+name: Test component with universal accessibility criteria
+description: A test component with universal accessibility criteria
+accessibility_criteria: |
+  * This is some criteria in a list
+universal_accessibility_criteria:
+  - link
+  - notvalid
+examples:
+  default:
+    data: {}


### PR DESCRIPTION
- common accessibility criteria defined in yml in the gem can be referenced in yml in components to save copying and pasting and reduce duplication
- universal_accessibility_criteria is a list
- only one defined at the moment, 'link'
- components can include accessibility_criteria, universal_accessibility_criteria, or both

![screen shot 2017-09-11 at 12 18 40](https://user-images.githubusercontent.com/861310/30272228-60b419d4-96eb-11e7-8172-a380418781d5.png)

![screen shot 2017-09-11 at 12 20 50](https://user-images.githubusercontent.com/861310/30272287-b3f3c46e-96eb-11e7-9784-7ad62a88882f.png)

https://trello.com/c/qS1pfVle/132-2-accessibility-criteria-universal-criteria-for-all-components
