### PR TITLE
Add shared accessibility criteria

### DIFF
--- a/app/models/govuk_publishing_components/component_doc_resolver.rb
+++ b/app/models/govuk_publishing_components/component_doc_resolver.rb
@@ -21,8 +21,19 @@ module GovukPublishingComponents
                        component[:name],
                        component[:description],
                        component[:body],
-                       component[:accessibility_criteria],
+                       combined_accessibility_criteria(component),
                        examples)
+    end
+
+    def combined_accessibility_criteria(component)
+      shared_accessibility_criteria = []
+
+      if component[:shared_accessibility_criteria].present?
+        component[:shared_accessibility_criteria].each do |criteria|
+          shared_accessibility_criteria << SharedAccessibilityCriteria.send(criteria) if SharedAccessibilityCriteria.respond_to? criteria
+        end
+      end
+      "#{component[:accessibility_criteria]}\n#{shared_accessibility_criteria.join("\n")}"
     end
 
     def fetch_component_docs

--- a/app/models/govuk_publishing_components/shared_accessibility_criteria.rb
+++ b/app/models/govuk_publishing_components/shared_accessibility_criteria.rb
@@ -1,0 +1,19 @@
+module GovukPublishingComponents
+  module SharedAccessibilityCriteria
+    def self.link
+      "
+Links in the component must:
+
+- accept focus
+- be focusable with a keyboard
+- be usable with a keyboard
+- indicate when it has focus
+- change in appearance when touched (in the touch-down state)
+- change in appearance when hovered
+- be usable with touch
+- be usable with [voice commands](https://www.w3.org/WAI/perspectives/voice.html)
+- have visible text
+      "
+    end
+  end
+end

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -46,12 +46,15 @@ name: Name of component
 description: Short description of component
 body: |
   Optional markdown providing further detail about the component
-acceptance_criteria: |
+accessibility_criteria: |
   Markdown listing what this component must do to be accessible. For example:
 
-  The link must:
+  The banner must:
 
-  * be keyboard focusable
+  - be visually distinct from other content on the page
+  - have an accessible name that describes the banner as a notice
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data:
@@ -64,6 +67,14 @@ examples:
     data:
       some_parameter: 'A different parameter value'
 ```
+
+#### Accessibility Criteria
+
+Markdown listing what this component must do to be accessible.
+
+[Shared accessibility criteria](https://github.com/alphagov/govuk_publishing_components/blob/master/app/models/govuk_publishing_components/shared_accessibility_criteria.rb) can be included in a list as shown. They are pre-written accessibility criteria that can apply to more than one component, created to avoid duplication. For example, links within components should all accept focus, be focusable with a keyboard, etc.
+
+A component can have accessibility criteria, shared accessibility criteria, or both.
 
 #### Description
 

--- a/spec/component_guide/component_guide_spec.rb
+++ b/spec/component_guide/component_guide_spec.rb
@@ -1,6 +1,12 @@
 require "spec_helper"
 
 describe 'Component guide' do
+  before(:each) do
+    GovukPublishingComponents.configure do |config|
+      config.static = false
+    end
+  end
+
   # Load ordering test can only fail if run as the first test in suite
   # https://github.com/rails/rails/issues/12168
   it 'renders using gem layout not app layout after viewing a page on the application' do
@@ -183,6 +189,28 @@ describe 'Component guide' do
     expect(body).to include('render <span class="token string">\'govuk_component/test-static-component\'</span>')
     within '.component-guide-preview' do
       expect(page).to have_selector('.a-test-static-component')
+    end
+  end
+
+  it 'shows shared accessibility criteria' do
+    visit '/component-guide/test-component-with-shared-accessibility-criteria'
+
+    within '.component-accessibility-criteria' do
+      within(shared_component_selector("govspeak")) do
+        content = JSON.parse(page.text).fetch("content").squish
+        expect(content).to eq('<ul> <li>This is some criteria in a list</li> </ul> <p>Links in the component must:</p> <ul> <li>accept focus</li> <li>be focusable with a keyboard</li> <li>be usable with a keyboard</li> <li>indicate when it has focus</li> <li>change in appearance when touched (in the touch-down state)</li> <li>change in appearance when hovered</li> <li>be usable with touch</li> <li>be usable with <a rel="external" href="https://www.w3.org/WAI/perspectives/voice.html">voice commands</a> </li> <li>have visible text</li> </ul>')
+      end
+    end
+  end
+
+  it 'shows shared accessibility criteria when no other accessibility criteria are included' do
+    visit '/component-guide/test-component-with-shared-accessibility-criteria-only'
+
+    within '.component-accessibility-criteria' do
+      within(shared_component_selector("govspeak")) do
+        content = JSON.parse(page.text).fetch("content").squish
+        expect(content).to eq('<p>Links in the component must:</p> <ul> <li>accept focus</li> <li>be focusable with a keyboard</li> <li>be usable with a keyboard</li> <li>indicate when it has focus</li> <li>change in appearance when touched (in the touch-down state)</li> <li>change in appearance when hovered</li> <li>be usable with touch</li> <li>be usable with <a rel="external" href="https://www.w3.org/WAI/perspectives/voice.html">voice commands</a> </li> <li>have visible text</li> </ul>')
+      end
     end
   end
 end

--- a/test/dummy/app/views/components/_test-component-with-shared-accessibility-criteria-only.html.erb
+++ b/test/dummy/app/views/components/_test-component-with-shared-accessibility-criteria-only.html.erb
@@ -1,0 +1,3 @@
+<div class="a-test-component">
+  <h1 class="something-inside-test-component">Test component with only shared accessibility criteria</h1>
+</div>

--- a/test/dummy/app/views/components/_test-component-with-shared-accessibility-criteria.html.erb
+++ b/test/dummy/app/views/components/_test-component-with-shared-accessibility-criteria.html.erb
@@ -1,0 +1,3 @@
+<div class="a-test-component">
+  <h1 class="something-inside-test-component">Test component with shared accessibility criteria</h1>
+</div>

--- a/test/dummy/app/views/components/docs/test-component-with-shared-accessibility-criteria-only.yml
+++ b/test/dummy/app/views/components/docs/test-component-with-shared-accessibility-criteria-only.yml
@@ -1,0 +1,8 @@
+name: Test component with only shared accessibility criteria
+description: A test component with only shared accessibility criteria
+shared_accessibility_criteria:
+  - link
+  - notvalid
+examples:
+  default:
+    data: {}

--- a/test/dummy/app/views/components/docs/test-component-with-shared-accessibility-criteria.yml
+++ b/test/dummy/app/views/components/docs/test-component-with-shared-accessibility-criteria.yml
@@ -1,0 +1,10 @@
+name: Test component with shared accessibility criteria
+description: A test component with shared accessibility criteria
+accessibility_criteria: |
+  * This is some criteria in a list
+shared_accessibility_criteria:
+  - link
+  - notvalid
+examples:
+  default:
+    data: {}


### PR DESCRIPTION
- common accessibility criteria defined in the gem can be referenced in yml in components to save copying and pasting and reduce duplication
- shared_accessibility_criteria is a list
- only one defined at the moment, 'link'
- components can include accessibility_criteria, shared_accessibility_criteria, or both

![screen shot 2017-09-11 at 12 18 40](https://user-images.githubusercontent.com/861310/30272228-60b419d4-96eb-11e7-8172-a380418781d5.png)

![screen shot 2017-09-12 at 14 59 18](https://user-images.githubusercontent.com/861310/30329711-0023caca-97cb-11e7-8f15-afe016269ced.png)

https://trello.com/c/qS1pfVle/132-2-accessibility-criteria-universal-criteria-for-all-components
