### PR TITLE
Add Element#matches polyfill

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/vendor/matches-polyfill.min.js
+++ b/app/assets/javascripts/govuk_publishing_components/vendor/matches-polyfill.min.js
@@ -1,0 +1,1 @@
+if(window.Element&&!window.Element.prototype.matches){var proto=window.Element.prototype;proto.matches=proto.matchesSelector||proto.mozMatchesSelector||proto.msMatchesSelector||proto.oMatchesSelector||proto.webkitMatchesSelector};


### PR DESCRIPTION
This is not something that upsets government-frontend but static throws errors around
not having matches in CI.