### PR TITLE
Add visual diff JS tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ if !Rails.env.production? || ENV['HEROKU_APP_NAME'].present?
 end
 ```
 
+## Automated Testing
+### Visual Diff Tool
+The component guide includes a visual diff tool that should make it easier to spot when you are introducing visual regressions in your components.
+
+It can be run on a locally running version of the component guide, to compare it to the heroku master deploy. For example: [government-frontend.dev.gov.uk/component-guide](government-frontend.dev.gov.uk/component-guide) will be compared to [government-frontend.herokuapp.com/component-guide](government-frontend.herokuapp.com/component-guide).
+
+The tool can be run via the console using the following command:
+```js
+  window.GOVUK.VisualDiffTool()`
+```
+
 ## Licence
 
 [MIT Licence](LICENCE.md)

--- a/app/assets/javascripts/govuk_publishing_components/visual-regression.js
+++ b/app/assets/javascripts/govuk_publishing_components/visual-regression.js
@@ -19,9 +19,9 @@
         'position': 'absolute',
         'top': '0',
         'pointer-events': 'none',
-        'border': '0',
-        'z-index': '999 !important'
+        'border': '0'
       });
+      iframe.style.setProperty('z-index', '999','important');
 
       // For browsers that support it, do mix-blend-mode diff
       if ('mix-blend-mode' in document.body.style) {

--- a/app/assets/javascripts/govuk_publishing_components/visual-regression.js
+++ b/app/assets/javascripts/govuk_publishing_components/visual-regression.js
@@ -1,0 +1,75 @@
+(function (window, document) {
+  window.GOVUK = window.GOVUK || {}
+
+  window.GOVUK.VisualDiffTool = function (currentWindowLocation) {
+    const visualDiffSelector = 'visual-diff';
+    var existingIframe = document.getElementById(visualDiffSelector);
+    var windowLocation = currentWindowLocation || window.location;
+
+    if (existingIframe) {
+      existingIframe.parentNode.removeChild(existingIframe);
+      document.body.style.filter = null;
+    } else {
+      var iframe = document.createElement('iframe');
+      iframe.id =  visualDiffSelector;
+      iframe.setAttribute('scrolling', 'no');
+      _setElementStyles(iframe, {
+        'width': '100%',
+        'height': document.body.scrollHeight + 'px',
+        'position': 'absolute',
+        'top': '0',
+        'pointer-events': 'none',
+        'border': '0',
+        'z-index': '999 !important'
+      });
+
+      // For browsers that support it, do mix-blend-mode diff
+      if ('mix-blend-mode' in document.body.style) {
+        _setElementStyles(iframe, {'mix-blend-mode': 'difference'});
+        document.body.style.filter = 'invert(100%)';
+      } else {
+        // Else do a simple overlay of the live page for comparison (IE and Edge)
+        _setElementStyles(iframe, {'opacity': '0.7'});
+      }
+
+      iframe.src = _processComparisonURL(windowLocation);
+
+      if (iframe.src) {
+        document.body.appendChild(iframe);
+        console.log("comparing to " + iframe.src);
+      }
+    }
+  };
+
+  var _processComparisonURL = function (url) {
+    var href = url.href;
+    var host = url.host;
+
+    if (href.includes('dev.gov.uk/component-guide')) {
+      var appName = host.split('.')[0];
+
+      if (appName === 'static') {
+        appName = 'govuk-static';
+      }
+
+      return _forceHTTPS(href.replace(host, appName + '.herokuapp.com'));
+    } else if (href.includes('dev.gov.uk')) {
+      return _forceHTTPS(href.replace(host, 'www.gov.uk'));
+    } else if (href.includes('-pr-')) {
+      var appName = host.split('-pr')[0];
+      return _forceHTTPS(href.replace(host, appName + '.herokuapp.com'));
+    } else {
+      throw new Error('Visual Diff Tool: You need to run this tool against a page running on your local dev environment');
+    }
+  };
+
+  var _forceHTTPS = function(href) {
+    return href.replace('http://', 'https://');
+  }
+
+  var _setElementStyles = function(element, styles) {
+    for (var style in styles) {
+      element.style[style] = styles[style];
+    }
+  };
+})(window, document);

--- a/spec/javascripts/govuk_publishing_components/VisualRegressionSpec.js
+++ b/spec/javascripts/govuk_publishing_components/VisualRegressionSpec.js
@@ -1,0 +1,69 @@
+/* global describe, afterEach, it, expect */
+
+var VisualDiffTool = window.GOVUK.VisualDiffTool;
+var windowLocation;
+
+describe('VisualDiffTool', function () {
+
+  describe('throws errors', function () {
+    it('throws error if not running on local page', function () {
+      expect(VisualDiffTool).toThrow();
+    });
+  });
+
+  describe('URL processing', function() {
+    beforeEach(function() {
+      spyOn(console, 'log').and.callThrough();
+    });
+
+    afterEach(function() {
+      // We need to call this again to 'turn off' the diff tool that's running from each test
+      VisualDiffTool();
+      windowLocation = null;
+    });
+
+    it('compares dev.gov.uk to gov.uk', function() {
+      windowLocation = {
+        href: 'http://government-frontend.dev.gov.uk',
+        host: 'government-frontend.dev.gov.uk'
+      };
+
+      VisualDiffTool(windowLocation);
+
+      expect(console.log.calls.mostRecent().args[0]).toContain("https://www.gov.uk");
+    });
+
+    it('compares local component guide to heroku deploy', function() {
+      windowLocation = {
+        href: 'http://government-frontend.dev.gov.uk/component-guide',
+        host: 'government-frontend.dev.gov.uk'
+      };
+
+      VisualDiffTool(windowLocation);
+
+      expect(console.log.calls.mostRecent().args[0]).toContain("https://government-frontend.herokuapp.com/component-guide");
+    });
+
+    it('compares pr heroku app to master heroku deploy', function() {
+      windowLocation = {
+        href: 'https://government-frontend-pr-100.herokuapp.com',
+        host: 'government-frontend-pr-100.herokuapp.com'
+      };
+
+      VisualDiffTool(windowLocation);
+
+      expect(console.log.calls.mostRecent().args[0]).toContain("https://government-frontend.herokuapp.com");
+    });
+
+    it('compares local static url to live static deploy', function() {
+      windowLocation = {
+        href: 'https://static.dev.gov.uk/component-guide/title',
+        host: 'static.dev.gov.uk'
+      };
+
+      VisualDiffTool(windowLocation);
+
+      expect(console.log.calls.mostRecent().args[0]).toContain("https://govuk-static.herokuapp.com/component-guide/title");
+    });
+  });
+});

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -13,6 +13,7 @@
 src_files:
   - app/assets/javascripts/govuk_publishing_components/vendor/*.js
   - app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+  - app/assets/javascripts/govuk_publishing_components/visual-regression.js
   - app/assets/javascripts/govuk_publishing_components/application.js
 
 # stylesheets


### PR DESCRIPTION
Add a JS/CSS visual diff tool which allows developers to compare local dev pages to live for visual regressions.
<img width="1325" alt="screen shot 2017-09-12 at 12 20 56" src="https://user-images.githubusercontent.com/29889908/30323373-e2f3b5d4-97b4-11e7-8f32-b0a9326aefae.png">

The tool relies on mix-blend-mode and filters which aren't supported in IE or Edge. In these cases, the tool simply overlays the live page onto the local page:

<img width="350" alt="screen shot 2017-09-18 at 16 12 46" src="https://user-images.githubusercontent.com/29889908/30549271-3ee17d3c-9c8c-11e7-962d-a059104410dd.png">

**Note: the tool relies on X-Frame-Options being set to ALLOWALL on live pages. Therefore the tool may not be able to be run on all GOV.UK pages.**