### PR TITLE
Make it clear when aXe has failed, succeeded or found errors

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+++ b/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
@@ -21,14 +21,14 @@
       }
 
       var violations = (typeof results === 'undefined') ? [] : results.violations
-      var incompleteWarnings = (typeof results === 'undefined') ? [] : results.incomplete
-
-      if (violations.length === 0 && incompleteWarnings.length === 0) {
-        return callback('No accessibility issues found')
-      }
-
-      var incompleteWarningsObj = _processIncompleteWarnings(incompleteWarnings)
       var errorText = _processViolations(violations, results.url)
+
+      var incompleteWarnings = (typeof results === 'undefined') ? [] : results.incomplete
+      var incompleteWarningsObj = _processIncompleteWarnings(incompleteWarnings)
+
+      var bodyClass = violations.length === 0 ? "test-a11y-success" : "test-a11y-failed"
+      document.body.classList.add(bodyClass);
+      document.body.classList.add("test-a11y-finished");
 
       callback(undefined, errorText, incompleteWarningsObj)
     })
@@ -51,33 +51,36 @@
           ].join('\n\n\n')
         }).join('\n\n- - -\n\n')
       )
-    }
-    else {
-      console.info("aXe: No accessibility errors found")
+    } else {
+      return false
     }
   }
 
   var _processIncompleteWarnings = function(incompleteWarnings) {
-    return (
-      incompleteWarnings.map(function (incomplete) {
-        var help = incomplete.help
-        var helpUrl = _formatHelpUrl(incomplete.helpUrl)
-        var cssSelector = incomplete.nodes.map(function (node) {
+    if (incompleteWarnings.length !== 0) {
+      return (
+        incompleteWarnings.map(function (incomplete) {
+          var help = incomplete.help
+          var helpUrl = _formatHelpUrl(incomplete.helpUrl)
+          var cssSelector = incomplete.nodes.map(function (node) {
+            return {
+              'selector': node.target,
+              'reason': node.any.map(function(item) {
+                return item.message
+              })
+            }
+          })
+
           return {
-            'selector': node.target,
-            'reason': node.any.map(function(item) {
-              return item.message
-            })
+            'summary': help,
+            'selectors': cssSelector,
+            'url': helpUrl
           }
         })
-
-        return {
-          'summary': help,
-          'selectors': cssSelector,
-          'url': helpUrl
-        }
-      })
-    )
+      )
+    } else {
+      return false
+    }
   }
 
   var _formatHelpUrl = function (helpUrl) {

--- a/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+++ b/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
@@ -7,7 +7,7 @@
     }
 
     if (!document.querySelector(selector)) {
-      return callback('No selector "' + selector + '" found')
+      return callback()
     }
 
     var axeOptions = {

--- a/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+++ b/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
@@ -17,16 +17,17 @@
 
     axe.run(selector, axeOptions, function (err, results) {
       if (err) {
-        callback('aXe Error: ' + err)
+        return callback('aXe Error: ' + err)
       }
 
-      var violations = (typeof results === 'undefined') ? [] : results.violations
-      var errorText = _processViolations(violations, results.url)
+      if (typeof results === "undefined") {
+        return callback('aXe Error: Expected results but none returned')
+      }
 
-      var incompleteWarnings = (typeof results === 'undefined') ? [] : results.incomplete
-      var incompleteWarningsObj = _processIncompleteWarnings(incompleteWarnings)
+      var errorText = _processViolations(results.violations, results.url)
+      var incompleteWarningsObj = _processIncompleteWarnings(results.incomplete)
 
-      var bodyClass = violations.length === 0 ? "test-a11y-success" : "test-a11y-failed"
+      var bodyClass = results.violations.length === 0 ? "test-a11y-success" : "test-a11y-failed"
       document.body.classList.add(bodyClass);
       document.body.classList.add("test-a11y-finished");
 

--- a/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+++ b/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
@@ -15,6 +15,12 @@
       include: [selector]
     }
 
+    // TODO: Remove when aXe core patched
+    // https://github.com/dequelabs/axe-core/issues/525
+    if (document.querySelector('svg') && !(document.querySelector('svg').children instanceof HTMLCollection)) {
+      delete axeOptions['restoreScroll']
+    }
+
     axe.run(selector, axeOptions, function (err, results) {
       if (err) {
         return callback('aXe Error: ' + err)

--- a/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+++ b/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
@@ -33,9 +33,9 @@
       var errorText = _processViolations(results.violations, results.url)
       var incompleteWarningsObj = _processIncompleteWarnings(results.incomplete)
 
-      var bodyClass = results.violations.length === 0 ? "test-a11y-success" : "test-a11y-failed"
+      var bodyClass = results.violations.length === 0 ? "js-test-a11y-success" : "js-test-a11y-failed"
       document.body.classList.add(bodyClass);
-      document.body.classList.add("test-a11y-finished");
+      document.body.classList.add("js-test-a11y-finished");
 
       callback(undefined, errorText, incompleteWarningsObj)
     })

--- a/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+++ b/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
@@ -153,7 +153,7 @@
     document.addEventListener('DOMContentLoaded', function () {
       AccessibilityTest('[data-module="test-a11y"]', function (err, violations, incompleteWarnings) {
         if (err) {
-          return
+          _throwUncaughtError(err)
         }
         if (incompleteWarnings) _renderIncompleteWarnings(incompleteWarnings)
         if (violations) _throwUncaughtError(violations)

--- a/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
+++ b/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
@@ -90,7 +90,7 @@ describe('AccessibilityTest', function () {
     addToDom('<div>text</div>')
 
     AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
-      expect(document.body.classList.contains('test-a11y-finished')).toBe(true)
+      expect(document.body.classList.contains('js-test-a11y-finished')).toBe(true)
       done()
     })
   })
@@ -99,7 +99,7 @@ describe('AccessibilityTest', function () {
     addToDom('<div>text</div>')
 
     AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
-      expect(document.body.classList.contains('test-a11y-success')).toBe(true)
+      expect(document.body.classList.contains('js-test-a11y-success')).toBe(true)
       done()
     })
   })
@@ -136,8 +136,8 @@ describe('AccessibilityTest', function () {
       })
 
       expect(violations).toBe(errorMessage)
-      expect(document.body.classList.contains('test-a11y-finished')).toBe(true)
-      expect(document.body.classList.contains('test-a11y-failed')).toBe(true)
+      expect(document.body.classList.contains('js-test-a11y-finished')).toBe(true)
+      expect(document.body.classList.contains('js-test-a11y-failed')).toBe(true)
       done()
     })
   })

--- a/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
+++ b/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
@@ -47,6 +47,7 @@ function renderErrorMessage (option) {
 describe('AccessibilityTest', function () {
   afterEach(function () {
     removeFromDom(TEST_SELECTOR)
+    document.body.className = '';
   })
 
   it('should do nothing if no callback is specified', function () {
@@ -58,6 +59,24 @@ describe('AccessibilityTest', function () {
       expect(violations).toBe(undefined)
       expect(incompleteWarnings).toBe(undefined)
       expect(err).toBe('No selector "' + TEST_SELECTOR + '" found')
+      done()
+    })
+  })
+
+  it('should add a class to the body when it finishes', function (done) {
+    addToDom('<div>text</div>')
+
+    AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
+      expect(document.body.classList.contains('test-a11y-finished')).toBe(true)
+      done()
+    })
+  })
+
+  it('should add a class to the body when it finds no violations', function (done) {
+    addToDom('<div>text</div>')
+
+    AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
+      expect(document.body.classList.contains('test-a11y-success')).toBe(true)
       done()
     })
   })
@@ -94,7 +113,8 @@ describe('AccessibilityTest', function () {
       })
 
       expect(violations).toBe(errorMessage)
-
+      expect(document.body.classList.contains('test-a11y-finished')).toBe(true)
+      expect(document.body.classList.contains('test-a11y-failed')).toBe(true)
       done()
     })
   })

--- a/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
+++ b/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
@@ -54,11 +54,14 @@ describe('AccessibilityTest', function () {
     AccessibilityTest(TEST_SELECTOR)
   })
 
-  it('should error if no selector is found', function (done) {
+  it('should not run axe if no selector is found', function (done) {
+    spyOn(window.axe, 'run').and.callThrough()
+
     AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
+      expect(window.axe.run).not.toHaveBeenCalled()
+      expect(err).toBe(undefined)
       expect(violations).toBe(undefined)
       expect(incompleteWarnings).toBe(undefined)
-      expect(err).toBe('No selector "' + TEST_SELECTOR + '" found')
       done()
     })
   })
@@ -66,7 +69,7 @@ describe('AccessibilityTest', function () {
   // TODO: Remove when aXe core patched
   // https://github.com/dequelabs/axe-core/issues/525
   it('should prevent aXe from erroring when SVG is present by disabling restoreScroll', function (done) {
-    spyOn(window.axe, 'run').and.callThrough();
+    spyOn(window.axe, 'run').and.callThrough()
     addToDom('<div style="height: 1000px; width: 100px;"></div><svg class="svg" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">\
                 <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>\
               </svg>')

--- a/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
+++ b/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
@@ -63,6 +63,26 @@ describe('AccessibilityTest', function () {
     })
   })
 
+  // TODO: Remove when aXe core patched
+  // https://github.com/dequelabs/axe-core/issues/525
+  it('should prevent aXe from erroring when SVG is present by disabling restoreScroll', function (done) {
+    spyOn(window.axe, 'run').and.callThrough();
+    addToDom('<div style="height: 1000px; width: 100px;"></div><svg class="svg" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">\
+                <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>\
+              </svg>')
+
+    AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
+      expect(err).toBe(undefined)
+
+      // Protect against test failing if PhantomJS updated
+      if (!(document.querySelector('svg').children instanceof HTMLCollection)) {
+        axeOptions = window.axe.run.calls.argsFor(0)
+        expect(axeOptions['restoreScroll']).toBe(undefined)
+      }
+      done()
+    })
+  })
+
   it('should add a class to the body when it finishes', function (done) {
     addToDom('<div>text</div>')
 


### PR DESCRIPTION
Easiest to review with `?w=1` to ignore whitespace changes.

Our integration tests in government-frontend couldn't easily check that aXe was present and running on each page. If aXe itself had an error we swallowed the error and CI would report that as "no accessibility errors".

Refactoring to fix this unveiled one of these false positives: a problem with restoreScroll on pages with SVGs – a bug in aXe itself. Added a tweak to prevent this from erroring in the future. See: https://github.com/dequelabs/axe-core/issues/525

Use body class to indicate accessibility tests have run and their state.  Classes can be used in integration tests to confirm tests are running.

See: https://github.com/alphagov/government-frontend/compare/assert-axe-runs
