### PR TITLE
Remove cookie and survey banners from guide

### DIFF
--- a/app/controllers/govuk_publishing_components/application_controller.rb
+++ b/app/controllers/govuk_publishing_components/application_controller.rb
@@ -6,6 +6,7 @@ module GovukPublishingComponents
     protect_from_forgery with: :exception
     before_action :set_custom_slimmer_headers
     before_action :set_x_frame_options_header
+    before_action :set_no_banner_cookie
 
   private
 
@@ -15,6 +16,20 @@ module GovukPublishingComponents
 
     def set_x_frame_options_header
       response.headers["X-Frame-Options"] = "ALLOWALL"
+    end
+
+    def set_no_banner_cookie
+      cookies['govuk_takenUserSatisfactionSurvey'] = {
+        value: 'yes',
+        domain: 'localhost',
+        path: '/component-guide'
+      }
+
+      cookies['seen_cookie_message'] = {
+        value: 'yes',
+        domain: 'localhost',
+        path: '/component-guide'
+      }
     end
   end
 end

--- a/spec/component_guide/component_guide_spec.rb
+++ b/spec/component_guide/component_guide_spec.rb
@@ -21,6 +21,16 @@ describe 'Component guide' do
     expect(page.response_headers["X-Frame-Options"]).to eq('ALLOWALL')
   end
 
+  it 'sets cookie to hide survey banner' do
+    visit '/component-guide'
+    expect(page.response_headers["Set-Cookie"]).to include('govuk_takenUserSatisfactionSurvey=yes')
+  end
+
+  it 'sets cookie to hide cookies banner' do
+    visit '/component-guide'
+    expect(page.response_headers["Set-Cookie"]).to include('seen_cookie_message=yes')
+  end
+
   it 'loads a component guide' do
     visit '/component-guide'
     expect(page).to have_title 'GOV.UK Component Guide'


### PR DESCRIPTION
I have split this into a separate PR to https://github.com/alphagov/govuk_publishing_components/pull/61 so the Visual Diff Tool can be properly tested once this is merged.

This will allow the visual diff tool to correctly compare component guide pages without the banners adding noise to diff. We've set the path to '/component-guide' so the cookie only applies on routes on or below /component-guide.