### PR TITLE
Add integration test helpers for component guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ https://government-frontend.herokuapp.com/component-guide
 
 The guide includes your application’s `application.scss` and `application.js` files by default. This is [configurable](#configuration).
 
+## Test the component guide
+
+The gem [includes integration tests](lib/govuk_publishing_components/minitest/component_guide_test.rb) to check that your component guide and examples are error free and that they meet basic accessibility needs.
+
+Automated accessibility tests use [aXe](https://github.com/dequelabs/axe-core). Using our `AccessibilityTest` wrapper the gem runs the aXe suite against each example and throws JavaScript errors for any violations. These JavaScript errors can be used to fail a build in CI.
+
+### Minitest
+
+```ruby
+# component_guide_test.rb
+require 'govuk_publishing_components/minitest/component_guide_test'
+
+class ComponentGuideTest < ActionDispatch::IntegrationTest
+  include GovukPublishingComponents::Minitest::ComponentGuideTest
+end
+```
+
 ### Install gem
 
 Add this line to your application's Gemfile in the [development and test groups](http://bundler.io/v1.12/groups.html#grouping-your-dependencies):

--- a/lib/govuk_publishing_components/minitest/component_guide_test.rb
+++ b/lib/govuk_publishing_components/minitest/component_guide_test.rb
@@ -1,0 +1,23 @@
+module GovukPublishingComponents
+  module Minitest
+    module ComponentGuideTest
+      extend ActiveSupport::Concern
+
+      included do
+        test "renders all component guide preview pages without erroring" do
+          visit '/component-guide'
+
+          # Confirm accessibility JS test is available
+          assert_equal 'function', evaluate_script('typeof window.GOVUK.AccessibilityTest'), "AccessibilityTest JavaScript isn’t available"
+          assert_equal 'string', evaluate_script('typeof window.axe.version'), "aXe accessibility test library isn’t available"
+
+          all(:css, '.component-list a').map { |el| "#{el[:href]}/preview" }.each do |component|
+            visit component
+            assert page.has_css?(".js-test-a11y-finished"), "Accessibility test did not run on #{component}"
+            assert page.has_css?(".js-test-a11y-success"), "Accessibility test found violations on #{component}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow apps to include a component guide integration test that checks:

* all component examples render without error
* there are no accessibility errors on any of the previews

It asserts that the tests are available and have run. Any violations will throw a JS error.

Reviewers note: I wanted to include a test for the minitest test helpers. However, we have an intentionally failing test – a component with known accessibility errors, which I can't easily mock, stub or expect. That work is saved in a gist here: https://gist.github.com/fofr/ea3b60362f1cdf200c3090f6df98bc88