### PR TITLE
Fix for removal of cookie/survey banner in guide

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -215,6 +215,14 @@ html {
   }
 }
 
+// Hide survey and cookie banners
+// scss-lint:disable IdSelector
+#user-satisfaction-survey-container,
+#global-cookie-message {
+  display: none;
+}
+// scss-lint:enable IdSelector
+
 // Rouge syntax highlighting
 // Based on https://github.com/alphagov/tech-docs-template/blob/master/template/source/stylesheets/palette/_syntax-highlighting.scss
 

--- a/app/controllers/govuk_publishing_components/application_controller.rb
+++ b/app/controllers/govuk_publishing_components/application_controller.rb
@@ -6,7 +6,6 @@ module GovukPublishingComponents
     protect_from_forgery with: :exception
     before_action :set_custom_slimmer_headers
     before_action :set_x_frame_options_header
-    before_action :set_no_banner_cookie
 
   private
 
@@ -16,20 +15,6 @@ module GovukPublishingComponents
 
     def set_x_frame_options_header
       response.headers["X-Frame-Options"] = "ALLOWALL"
-    end
-
-    def set_no_banner_cookie
-      cookies['govuk_takenUserSatisfactionSurvey'] = {
-        value: 'yes',
-        domain: 'localhost',
-        path: '/component-guide'
-      }
-
-      cookies['seen_cookie_message'] = {
-        value: 'yes',
-        domain: 'localhost',
-        path: '/component-guide'
-      }
     end
   end
 end

--- a/spec/component_guide/component_guide_spec.rb
+++ b/spec/component_guide/component_guide_spec.rb
@@ -21,16 +21,6 @@ describe 'Component guide' do
     expect(page.response_headers["X-Frame-Options"]).to eq('ALLOWALL')
   end
 
-  it 'sets cookie to hide survey banner' do
-    visit '/component-guide'
-    expect(page.response_headers["Set-Cookie"]).to include('govuk_takenUserSatisfactionSurvey=yes')
-  end
-
-  it 'sets cookie to hide cookies banner' do
-    visit '/component-guide'
-    expect(page.response_headers["Set-Cookie"]).to include('seen_cookie_message=yes')
-  end
-
   it 'loads a component guide' do
     visit '/component-guide'
     expect(page).to have_title 'GOV.UK Component Guide'


### PR DESCRIPTION
Cookies set in #65 to remove cookie/survey banners in the guide are not always being applied. It may be easier to hide the banners using CSS.