### PR TITLE
Override default styling of cookie banner to hide

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -219,7 +219,7 @@ html {
 // scss-lint:disable IdSelector
 #user-satisfaction-survey-container,
 #global-cookie-message {
-  display: none;
+  display: none !important;
 }
 // scss-lint:enable IdSelector
 


### PR DESCRIPTION
The cookie/survey banners have a display: none styling on which overrides the styling in the gem.
Need to add !important flag to force this styling.