### PR TITLE
Disable duplicate ID rule in axe tests

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+++ b/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
@@ -12,7 +12,12 @@
 
     var axeOptions = {
       restoreScroll: true,
-      include: [selector]
+      include: [selector],
+      rules: {
+        "duplicate-id": {
+          enabled: false
+        }
+      }
     }
 
     // TODO: Remove when aXe core patched

--- a/spec/component_guide/component_example_accessibility_testing_spec.rb
+++ b/spec/component_guide/component_example_accessibility_testing_spec.rb
@@ -6,8 +6,17 @@ describe 'Component example with automated testing' do
     expect(page).to have_selector('[data-module="test-a11y"]')
   end
 
+  it 'runs automated accessibility testing tools' do
+    visit '/component-guide/test-component'
+    expect(page).to have_selector('.js-test-a11y-success.js-test-a11y-finished')
+  end
+
   it 'throws JavaScript errors if a component has an accessibility issue' do
     expect { visit '/component-guide/test-component-with-a11y-issue' }
       .to raise_error(Capybara::Poltergeist::JavascriptError)
+  end
+
+  it 'does not throw JavaScript errors if there are duplicate IDs' do
+    visit '/component-guide/test-component-with-duplicate-ids'
   end
 end

--- a/test/dummy/app/views/components/_test-component-with-duplicate-ids.html.erb
+++ b/test/dummy/app/views/components/_test-component-with-duplicate-ids.html.erb
@@ -1,0 +1,4 @@
+<div class="test-component-with-duplicate-ids">
+  <div id="blah"></div>
+  <div id="blah"></div>
+</div>

--- a/test/dummy/app/views/components/docs/test-component-with-duplicate-ids.yml
+++ b/test/dummy/app/views/components/docs/test-component-with-duplicate-ids.yml
@@ -1,0 +1,4 @@
+name: Test invalid component with duplicate IDs
+examples:
+  default:
+    data: {}

--- a/test/dummy/config/initializers/new_framework_defaults.rb
+++ b/test/dummy/config/initializers/new_framework_defaults.rb
@@ -14,8 +14,5 @@ Rails.application.config.action_controller.forgery_protection_origin_check = tru
 # Previous versions had false.
 ActiveSupport.to_time_preserves_timezone = true
 
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = false
-
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }


### PR DESCRIPTION
Components sometimes contain IDs. These get repeated on the component
guide page. This repetition is not representative of actual usage,
leading to a false positive accessibility failure.

This specifically affects the document_footer component in static where
we rely on a specific component ID to link to from elsewhere in the
page – so it can’t be dynamic and unique with each use.