### PR TITLE
Remove component guide hover styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.10.0
 
 * Add visual diff tool (PR #61)
+* Disable duplicate ID aXe rule (PR #80)
 
 # 1.9.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -127,13 +127,6 @@ $border-color: #ccc;
     color: $black;
     font-weight: bold;
   }
-
-  div[class^="govuk-"] {
-    &:hover {
-      outline: 1px solid $border-color;
-      box-shadow: 0 0 10px $border-color;
-    }
-  }
 }
 
 .component-guide-preview--simple {


### PR DESCRIPTION
This would flash a box around the component on hover. Box shadows look
out of place and the effect can be confusing, especially with
components that have a solid background.

The `govuk-` namespace is deprecated.

## Removes

![screen shot 2017-09-22 at 08 56 51](https://user-images.githubusercontent.com/319055/30734661-0a6d2f5c-9f74-11e7-9016-1ce3502a1a38.png)
