### PR TITLE
Render accessibility violations in component guide

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+++ b/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
@@ -121,22 +121,22 @@
     }
   }
 
-  var _renderIncompleteWarnings = function (incompleteWarnings) {
-    incompleteWarnings.forEach(function (warning) {
-      warning.selectors.forEach(function (selectorObj) {
+  var _renderAxeResultsInGuide = function (resultsGroup, resultContainerSelector) {
+    resultsGroup.forEach(function (result) {
+      result.selectors.forEach(function (selectorObj) {
         var activeEl = document.querySelector(selectorObj.selector)
         var activeElParent = _findParent(activeEl, '[data-module="test-a11y"]')
-        var warningWrapper = activeElParent.querySelector('[data-module="test-a11y-warning"]')
+        var wrapper = activeElParent.querySelector(resultContainerSelector)
 
-        if (warningWrapper) {
+        if (wrapper) {
           // Add warning to warnings box
-          var warningsHTML = '<h3>' + warning.summary + ' <a href="' + warning.url + '">(see guidance)</a></h3>' +
+          var resultHTML = '<h3>' + result.summary + ' <a href="' + result.url + '">(see guidance)</a></h3>' +
           '<p>Reason: ' + selectorObj.reason + '</p>' +
           '<p>Element can be found using the following CSS selector: <span class="selector">' +
           selectorObj.selector +
           '</span></p>'
 
-          warningWrapper.insertAdjacentHTML('beforeend', warningsHTML)
+          wrapper.insertAdjacentHTML('beforeend', resultHTML)
         }
       })
     })
@@ -160,7 +160,7 @@
         if (err) {
           _throwUncaughtError(err)
         }
-        if (incompleteWarnings) _renderIncompleteWarnings(incompleteWarnings)
+        if (incompleteWarnings) _renderAxeResultsInGuide(incompleteWarnings, '[data-module="test-a11y-warning"]')
         if (violations) _throwUncaughtError(violations)
       })
     })

--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -145,20 +145,22 @@ $border-color: #ccc;
   }
 }
 
+.component-guide-preview--violation,
 .component-guide-preview--warning {
   margin-top: $gutter-half;
-  border-color: $yellow;
+  @include core-19;
 
   &:empty {
     display: none;
   }
 
-  &:before {
-    background-color: $yellow;
+  h3 {
+    @include bold-19;
   }
 
+  p,
   h3 {
-    @include bold-16;
+    margin-bottom: $gutter / 2;
   }
 
   h3:not(:first-child) {
@@ -167,6 +169,23 @@ $border-color: #ccc;
 
   .selector {
     font-style: italic;
+  }
+}
+
+.component-guide-preview--warning {
+  border-color: $yellow;
+
+  &:before {
+    background-color: $yellow;
+  }
+}
+
+.component-guide-preview--violation {
+  border-color: $red;
+
+  &:before {
+    background-color: $red;
+    color: $white;
   }
 }
 

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
@@ -1,4 +1,5 @@
 <div data-module="test-a11y">
   <%= render "govuk_publishing_components/component_guide/component_doc/component", component_doc: @component_doc, example: example, preview_page: false %>
-  <div class="component-guide-preview component-guide-preview--warning" data-module="test-a11y-warning" data-content="Potential Accessibility Issues: Need Manual Check"></div>
+  <div class="component-guide-preview component-guide-preview--violation" data-module="test-a11y-violation" data-content="Accessibility Issues"></div>
+  <div class="component-guide-preview component-guide-preview--warning" data-module="test-a11y-warning" data-content="Potential accessibility issues: need manual check"></div>
 </div>

--- a/spec/component_guide/component_example_accessibility_testing_spec.rb
+++ b/spec/component_guide/component_example_accessibility_testing_spec.rb
@@ -35,4 +35,18 @@ describe 'Component example with automated testing' do
   it 'does not throw JavaScript errors if there are duplicate IDs' do
     visit '/component-guide/test-component-with-duplicate-ids'
   end
+
+  it 'shows incomplete accessibility warnings on the page' do
+    visit '/component-guide/test-component-with-a11y-incomplete-warning'
+    expect(page).to have_selector('.js-test-a11y-success.js-test-a11y-finished')
+
+    selector_with_error = page.first('.selector').text
+    expect(page).to have_selector(selector_with_error)
+
+    within '.component-guide-preview--warning' do
+      expect(page).to have_selector('h3', text: 'Elements must have sufficient color contrast')
+      expect(page).to have_selector('h3 a[href*="https://dequeuniversity.com"]', text: '(see guidance)')
+      expect(page).to have_text('Element\'s background color could not be determined due to a background image')
+    end
+  end
 end

--- a/spec/component_guide/component_example_accessibility_testing_spec.rb
+++ b/spec/component_guide/component_example_accessibility_testing_spec.rb
@@ -16,6 +16,22 @@ describe 'Component example with automated testing' do
       .to raise_error(Capybara::Poltergeist::JavascriptError)
   end
 
+  it 'shows accessibility violations on the page' do
+    expect { visit '/component-guide/test-component-with-a11y-issue' }
+      .to raise_error(Capybara::Poltergeist::JavascriptError)
+
+    expect(page).to have_selector('.js-test-a11y-failed.js-test-a11y-finished')
+
+    selector_with_error = page.first('.selector').text
+    expect(page).to have_selector(selector_with_error)
+
+    within '.component-guide-preview--violation' do
+      expect(page).to have_selector('h3', text: 'Images must have alternate text')
+      expect(page).to have_selector('h3 a[href*="https://dequeuniversity.com"]', text: '(see guidance)')
+      expect(page).to have_text('Element does not have an alt attribute')
+    end
+  end
+
   it 'does not throw JavaScript errors if there are duplicate IDs' do
     visit '/component-guide/test-component-with-duplicate-ids'
   end

--- a/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
+++ b/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
@@ -166,14 +166,23 @@ describe('AccessibilityTest', function () {
   it('process incomplete warnings into object for rendering in guide', function (done) {
     addToDom('<a href="#">Link</a>', 'a { background-image: url("/"); }')
 
-    AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
-      if (err) {
-        throw err
-      }
+    AccessibilityTest(TEST_SELECTOR, function (err, violations, pageResults) {
+      expect(pageResults.incompleteWarnings[0].summary).toBe("Elements must have sufficient color contrast")
+      expect(pageResults.incompleteWarnings[0].url).toBe("https://dequeuniversity.com/rules/axe/2.3/color-contrast?application=axeAPI")
+      expect(pageResults.incompleteWarnings[0].selectors[0].selector[0]).toBe('.js-test-a11y > a')
+      expect(pageResults.incompleteWarnings[0].selectors[0].reasons[0]).toBe('Element\'s background color could not be determined due to a background image')
+      done()
+    })
+  })
 
-      expect(incompleteWarnings[0].summary).toBe("Elements must have sufficient color contrast")
-      expect(incompleteWarnings[0].url).toBe("https://dequeuniversity.com/rules/axe/2.3/color-contrast?application=axeAPI")
-      expect(incompleteWarnings[0].selectors[0].selector[0]).toBe('.js-test-a11y > a')
+  it('process violations into object for rendering in guide', function (done) {
+    addToDom('<img src=""><a href="#">Low contrast</a>', 'a { background: white; color: #ddd }')
+
+    AccessibilityTest(TEST_SELECTOR, function (err, violations, pageResults) {
+      expect(pageResults.violations[0].summary).toBe("Elements must have sufficient color contrast")
+      expect(pageResults.violations[0].url).toBe("https://dequeuniversity.com/rules/axe/2.3/color-contrast?application=axeAPI")
+      expect(pageResults.violations[0].selectors[0].selector[0]).toBe('.js-test-a11y > a')
+      expect(pageResults.violations[0].selectors[0].reasons[0]).toBe('Element has insufficient color contrast of 1.35 (foreground color: #dddddd, background color: #ffffff, font size: 12.0pt, font weight: normal)')
       done()
     })
   })

--- a/test/dummy/app/views/components/_test-component-with-a11y-incomplete-warning.html.erb
+++ b/test/dummy/app/views/components/_test-component-with-a11y-incomplete-warning.html.erb
@@ -1,0 +1,3 @@
+<div class="test-component-with-a11y-incomplete-warning">
+  <a href="#" style="background-image: url('data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=')">Link</a>
+</div>

--- a/test/dummy/app/views/components/docs/test-component-with-a11y-incomplete-warning.yml
+++ b/test/dummy/app/views/components/docs/test-component-with-a11y-incomplete-warning.yml
@@ -1,0 +1,5 @@
+name: Test component with an incomplete accessibility warning
+description: Component link has a background image (a black pixel) meaning aXe can’t determine the colour contrast
+examples:
+  default:
+    data: {}


### PR DESCRIPTION
* Refactor incomplete warnings JS to work with both incomplete and violations
* Improve typography of HTML output - large text and increased spacing between text
* Update to cope better with multiple reasons (eg an image without an alt tag can have many possible solutions)
* Add integration tests for both warnings and violations

![screen shot 2017-09-22 at 11 09 06](https://user-images.githubusercontent.com/319055/30739792-8322c8a0-9f86-11e7-8d78-6a1010b79617.png)
