### PR TITLE
Warn if components exist without docs

### DIFF
--- a/lib/tasks/govuk_publishing_components_tasks.rake
+++ b/lib/tasks/govuk_publishing_components_tasks.rake
@@ -1,4 +1,22 @@
-# desc "Explaining what the task does"
-# task :govuk_publishing_components do
-#   # Task goes here
-# end
+desc 'warns if component view files exist without corresponding documentation'
+task :validate_component_documentation do
+  components_missing_docs = []
+  component_views = Dir["app/views/#{GovukPublishingComponents::Config.component_directory_name}/**/*.html.erb"]
+
+  component_views.each do |partial|
+    expected_component_docs_file = partial.split('/')[-1].gsub('html.erb', 'yml')
+    expected_component_docs_file.sub!(/^_/, '')
+
+    expected_component_docs_path = "app/views/#{GovukPublishingComponents::Config.component_directory_name}/docs/#{expected_component_docs_file}"
+    components_missing_docs << partial unless File.exist?(expected_component_docs_path)
+  end
+
+  if components_missing_docs.any?
+    error = "You have components which are missing documentation. These components will not be displayed in the component guide:\n"
+    components_missing_docs.each { |component| error += "\t" + component + "\n" }
+    error += "\n"
+    raise NotImplementedError, error
+  end
+end
+
+Rake::Task["validate_component_documentation"].invoke


### PR DESCRIPTION
When running bundle exec rake, if an app uses the govuk_publishing_components gem, it will warn if component files exist (html.erb) without corresponding docs (.yml)

**Example:**
<img width="819" alt="screen shot 2017-09-26 at 11 30 00" src="https://user-images.githubusercontent.com/29889908/30855999-dee03ed6-a2ae-11e7-96c6-715fdcd30b5d.png">
