### PR TITLE
Use lead paragraph component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -19,12 +19,6 @@ $border-color: #ccc;
   }
 }
 
-.component-description {
-  @include core-24;
-  max-width: 30em;
-  margin-bottom: $gutter * 1.5;
-}
-
 .component-body {
   margin-bottom: $gutter * 1.5;
 }

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -10,9 +10,7 @@
           <p><a class="component-violation__link" href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/accessibility_acceptance_criteria.md">Please define accessibility acceptance criteria for this component.</a></p>
         </div>
       <% end %>
-      <p class="component-description">
-        <%= @component_doc.description %>
-      </p>
+      <%= render 'govuk_component/lead_paragraph', text: @component_doc.description %>
       <% if @component_doc.body.present? %>
         <div class="component-body">
           <%= render 'govuk_component/govspeak', content: @component_doc.html_body %>

--- a/test/dummy/app/views/govuk_component/lead_paragraph.raw.html.erb
+++ b/test/dummy/app/views/govuk_component/lead_paragraph.raw.html.erb
@@ -1,0 +1,3 @@
+<p class="stubbed-lead-paragraph">
+  Stubbed lead paragraph component representative of static component.
+</p>


### PR DESCRIPTION
- Replace code that renders first paragraph in examples
- Remove redundant CSS
- Stub lead_paragraph for testing

![screen shot 2017-10-18 at 09 00 33](https://user-images.githubusercontent.com/31649453/31711710-e8b97d34-b3f0-11e7-8ab7-5e4750d7ee1f.png)
