### PR TITLE
Allow asset compilation in production mode and add assets clobber

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,13 +18,18 @@ end
 
 namespace :assets do
   desc "Test precompiling assets through dummy application"
-
   task :precompile do
     Rake::Task['app:assets:precompile'].invoke
   end
 
+  desc "Test cleaning assets through dummy application"
   task :clean do
     Rake::Task['app:assets:clean'].invoke
+  end
+
+  desc "Test clobbering assets through dummy application"
+  task :clobber do
+    Rake::Task['app:assets:clobber'].invoke
   end
 end
 

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara", "~> 2.14.4"
   s.add_development_dependency "poltergeist", "~> 1.16.0"
   s.add_development_dependency "jasmine", "~> 2.4.0"
+  s.add_development_dependency "uglifier", ">= 1.3.0"
 
   # Needed to load slimmer test helpers
   # https://github.com/alphagov/slimmer/issues/201


### PR DESCRIPTION
For: https://trello.com/c/QtpGwa2A/288-improve-feedback-on-github-for-changes-to-govuk-content-schemas

Mostly this is to support the changes to `buildProject` proposed in https://github.com/alphagov/govuk-puppet/pull/6821 although the changes should be generally useful.