### PR TITLE
Allow excluded rules to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ class ComponentGuideTest < ActionDispatch::IntegrationTest
 end
 ```
 
+### Exclude accessibility rules
+
+Sometimes you will have a component that will throw an error due to it being in isolation, for example radio buttons not being in a fieldset.
+
+For this case you can add `accessibility_excluded_rules` to your components' documentation yml file with the rules you want to exclude. These rules can be found in brackets in the error messages displayed.
+
+For an example of this check [test/.../docs/test-component-with-duplicate-ids.yml](test/dummy/app/views/components/docs/test-component-with-duplicate-ids.yml)
+
+
 ## Component generator
 
 The gem includes a component generator to stub the minimal files required for a component.

--- a/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
+++ b/app/assets/javascripts/govuk_publishing_components/accessibility-test.js
@@ -6,18 +6,25 @@
       return
     }
 
-    if (!document.querySelector(selector)) {
+    var element = document.querySelector(selector)
+
+    if (!element) {
       return callback()
     }
+
+    var dataDisabledRules = element.getAttribute('data-excluded-rules')
+    var disabledRules = dataDisabledRules ? JSON.parse(dataDisabledRules) : []
+
+    var axeRules = {}
+
+    disabledRules.forEach(function (rule) {
+      axeRules[rule] = { enabled: false }
+    })
 
     var axeOptions = {
       restoreScroll: true,
       include: [selector],
-      rules: {
-        "duplicate-id": {
-          enabled: false
-        }
-      }
+      rules: axeRules
     }
 
     // TODO: Remove when aXe core patched
@@ -50,7 +57,7 @@
         '\n' + 'Accessibility issues at ' +
         url + '\n\n' +
         violations.map(function (violation) {
-          var help = 'Problem: ' + violation.help
+          var help = 'Problem: ' + violation.help + ' (' + violation.id + ')'
           var helpUrl = 'Try fixing it with this help: ' + _formatHelpUrl(violation.helpUrl)
           var htmlAndTarget = violation.nodes.map(_renderNode).join('\n\n')
 
@@ -84,6 +91,7 @@
                           }
                         })
       return {
+        'id': result.id,
         'summary': result.help,
         'selectors': cssSelector,
         'url': _formatHelpUrl(result.helpUrl)
@@ -125,7 +133,7 @@
         var wrapper = activeElParent.querySelector(resultContainerSelector)
 
         if (wrapper) {
-          var resultHTML = '<h3>' + result.summary + ' <a href="' + result.url + '">(see guidance)</a></h3>' +
+          var resultHTML = '<h3>(' + result.id + ') ' + result.summary + ' <a href="' + result.url + '">(see guidance)</a></h3>' +
           '<p>' + selectorObj.reasons.join('<br />') + '</p>' +
           '<p>Element can be found using the selector:<br /><span class="selector">' +
           selectorObj.selector +

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -5,14 +5,24 @@ module GovukPublishingComponents
                 :description,
                 :body,
                 :accessibility_criteria,
+                :accessibility_excluded_rules,
                 :examples
 
-    def initialize(id, name, description, body, accessibility_criteria, examples)
+    def initialize(
+      id,
+      name,
+      description,
+      body,
+      accessibility_criteria,
+      accessibility_excluded_rules,
+      examples
+    )
       @id = id
       @name = name
       @description = description
       @body = body
       @accessibility_criteria = accessibility_criteria
+      @accessibility_excluded_rules = accessibility_excluded_rules
       @examples = examples
     end
 

--- a/app/models/govuk_publishing_components/component_doc_resolver.rb
+++ b/app/models/govuk_publishing_components/component_doc_resolver.rb
@@ -17,12 +17,15 @@ module GovukPublishingComponents
         ComponentExample.new(id.to_s, example["data"], example["context"], example["description"])
       }
 
-      ComponentDoc.new(component[:id],
-                       component[:name],
-                       component[:description],
-                       component[:body],
-                       combined_accessibility_criteria(component),
-                       examples)
+      ComponentDoc.new(
+        component[:id],
+        component[:name],
+        component[:description],
+        component[:body],
+        combined_accessibility_criteria(component),
+        component[:accessibility_excluded_rules],
+        examples
+      )
     end
 
     def combined_accessibility_criteria(component)

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
@@ -1,4 +1,4 @@
-<div data-module="test-a11y">
+<div data-module="test-a11y" data-excluded-rules="<%= @component_doc.accessibility_excluded_rules %>">
   <%= render "govuk_publishing_components/component_guide/component_doc/component", component_doc: @component_doc, example: example, preview_page: false %>
   <div class="component-guide-preview component-guide-preview--violation" data-module="test-a11y-violation" data-content="Accessibility Issues"></div>
   <div class="component-guide-preview component-guide-preview--warning" data-module="test-a11y-warning" data-content="Potential accessibility issues: need manual check"></div>

--- a/app/views/govuk_publishing_components/component_guide/preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/preview.html.erb
@@ -3,7 +3,7 @@
     <% if @component_examples.length > 1 %>
       <h2 class="preview-title"><a href="<%= component_example_path(@component_doc.id, example.id) %>"><%= example.name %></a></h2>
     <% end %>
-    <div data-module="test-a11y">
+    <div data-module="test-a11y" data-excluded-rules="<%= @component_doc.accessibility_excluded_rules %>">
       <%= render "govuk_publishing_components/component_guide/component_doc/component", component_doc: @component_doc, example: example, preview_page: true %>
     </div>
   </div>

--- a/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
+++ b/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
@@ -30,7 +30,7 @@ function renderErrorMessage (option) {
     message += '\nAccessibility issues at ' + url + '\n\n'
   }
   message += (
-    'Problem: ' + option.problem + '\n' +
+    'Problem: ' + option.problem + ' (' + option.id + ')' + '\n' +
     '\n' +
     '\n' +
     ' Check the HTML:\n' +
@@ -129,6 +129,7 @@ describe('AccessibilityTest', function () {
       }
 
       var errorMessage = renderErrorMessage({
+        id: 'color-contrast',
         problem: 'Elements must have sufficient color contrast',
         html: '<a href="#" style="">Low contrast</a>',
         selector: TEST_SELECTOR + ' > a',
@@ -151,6 +152,7 @@ describe('AccessibilityTest', function () {
       }
 
       var errorMessage = renderErrorMessage({
+        id: 'image-alt',
         problem: 'Images must have alternate text',
         html: '<img src="">',
         selector: TEST_SELECTOR + ' > img',
@@ -197,6 +199,7 @@ describe('AccessibilityTest', function () {
 
       var errorMessage = (
         renderErrorMessage({
+          id: 'color-contrast',
           problem: 'Elements must have sufficient color contrast',
           html: '<a href="#" style="">Low contrast</a>',
           selector: TEST_SELECTOR + ' > a',
@@ -204,6 +207,7 @@ describe('AccessibilityTest', function () {
         }) +
         '\n\n- - -\n\n' +
         renderErrorMessage({
+          id: 'image-alt',
           skipHeader: true,
           problem: 'Images must have alternate text',
           html: '<img src="">',

--- a/test/dummy/app/views/components/_test-component-with-duplicate-ids.html.erb
+++ b/test/dummy/app/views/components/_test-component-with-duplicate-ids.html.erb
@@ -1,4 +1,5 @@
 <div class="test-component-with-duplicate-ids">
   <div id="blah"></div>
   <div id="blah"></div>
+  <img src="">
 </div>

--- a/test/dummy/app/views/components/docs/test-component-with-duplicate-ids.yml
+++ b/test/dummy/app/views/components/docs/test-component-with-duplicate-ids.yml
@@ -1,4 +1,7 @@
-name: Test invalid component with duplicate IDs
+name: Test invalid component with an invalid image and duplicate IDs
+accessibility_excluded_rules:
+- 'duplicate-id'
+- 'image-alt'
 examples:
   default:
     data: {}


### PR DESCRIPTION
When trying to add a radio button component to government-frontend I was hitting a rule since they're not in a fieldset, I want to be able to remove this.

I've made it so you can see the id you need to use in the error/frontend, and allowed you to use that id to exclude rules.

Adds to the original test that was making sure the `duplicate-id` rule doesnt throw an error.

https://trello.com/c/yo9dWRM8/242-create-a-radio-button-component