### PR TITLE
Fix task list appearance

### DIFF
--- a/app/assets/stylesheets/components/_task-list-print.scss
+++ b/app/assets/stylesheets/components/_task-list-print.scss
@@ -1,9 +1,15 @@
 // scss-lint:disable SelectorFormat
 
+.gem-c-task-list__circle,
 .gem-c-task-list__controls,
 .gem-c-task-list__toggle-link,
 .gem-c-task-list__help {
   display: none;
+}
+
+.gem-c-task-list__step,
+.gem-c-task-list__paragraph {
+  padding-bottom: 1em;
 }
 
 .gem-c-task-list__title {
@@ -24,8 +30,7 @@
 }
 
 .gem-c-task-list__links {
-  padding-left: 0;
-  list-style: none;
+  list-style: disc;
 }
 
 .gem-c-task-list__links--choice {

--- a/app/assets/stylesheets/components/_task-list.scss
+++ b/app/assets/stylesheets/components/_task-list.scss
@@ -28,7 +28,6 @@ $top-border: solid 2px $grey-3;
 
 .gem-c-task-list {
   margin-bottom: $gutter-half;
-  overflow: hidden;
 }
 
 .gem-c-task-list__controls {
@@ -106,7 +105,10 @@ $top-border: solid 2px $grey-3;
 
   .gem-c-task-list__step:last-child {
     &:after {
+      // scss-lint:disable DuplicateProperty
+      height: -webkit-calc(100% - #{$gutter-half}); // fallback
       height: calc(100% - #{$gutter-half});
+      // scss-lint:enable DuplicateProperty
     }
 
     .gem-c-task-list__help:after {
@@ -224,15 +226,21 @@ $top-border: solid 2px $grey-3;
   }
 }
 
-// to make the numbers readable for users zooming the text only in Firefox
+// makes sure logic text expands to the left if text size is zoomed, preventing overlap
 .gem-c-task-list__circle-inner {
   float: right;
   min-width: 100%;
 }
 
 .gem-c-task-list__circle-background {
-  background: $white;
-  border-radius: 100px;
+  $shadow-offset: 0.1em;
+  $shadow-colour: $white;
+
+  // to make numbers readable for users zooming text only in browsers such as Firefox
+  text-shadow: 0 -#{$shadow-offset} 0 $shadow-colour,
+              $shadow-offset 0 0 $shadow-colour,
+              0 $shadow-offset 0 $shadow-colour,
+              -#{$shadow-offset} 0 0 $shadow-colour;
 }
 
 .gem-c-task-list__header {

--- a/app/assets/stylesheets/components/_task-list.scss
+++ b/app/assets/stylesheets/components/_task-list.scss
@@ -41,6 +41,7 @@ $top-border: solid 2px $grey-3;
   cursor: pointer;
   background: none;
   border: 0;
+  margin: 0;
 }
 
 // removes extra dotted outline from buttons in Firefox


### PR DESCRIPTION
A few visual-related changes:

- iphone was having difficulty with the white background on the inner element of the numbers (added so numbers are still legible when text only is zoomed) where it was overflowing slightly and corrupting the outer circle. This white background has now been replaced with a similar effect achieved with text shadow.
- overflow hidden removed from overall component to prevent clipping of beginning of logic text ('or', 'and') in some steps, which is aligned to grow to the left when text only is zoomed, to prevent overlap onto the step titles.
- overflow hidden was previously added to solve a problem with iphone 4 where the final part of the line down the side of the task list 'escaped' the component (it was ignoring the calc'ed height). Now overflow hidden is removed, have added a second height declaration as a fallback for older iphones to fix this escaping line issue.
- miscellaneous print style improvements, spacing, list styling