### PR TITLE
Fix task list active link

### DIFF
--- a/app/assets/stylesheets/components/_task-list.scss
+++ b/app/assets/stylesheets/components/_task-list.scss
@@ -377,6 +377,10 @@ $top-border: solid 2px $grey-3;
     color: $black;
   }
 
+  &:focus {
+    outline: 0;
+  }
+
   &:before {
     @include box-sizing(border-box);
     content: "";

--- a/app/assets/stylesheets/components/_task-list.scss
+++ b/app/assets/stylesheets/components/_task-list.scss
@@ -337,8 +337,22 @@ $top-border: solid 2px $grey-3;
 }
 
 .gem-c-task-list__links--choice {
-  margin-left: 20px;
+  $links-margin: 20px;
+
+  margin-left: $links-margin;
   list-style: disc;
+
+  .gem-c-task-list__link-item--active:before {
+    left: -($gutter + $gutter-half) - $links-margin;
+  }
+
+  .gem-c-task-list--large & {
+    @include media(tablet) {
+      .gem-c-task-list__link-item--active:before {
+        left: -($gutter * 2) - $links-margin;
+      }
+    }
+  }
 }
 
 .gem-c-task-list__link {

--- a/app/views/components/docs/task_list.yml
+++ b/app/views/components/docs/task_list.yml
@@ -250,12 +250,14 @@ examples:
                 contents: [
                   {
                     href: '/component-guide/task_list/',
-                    text: 'Leave school at sixteen'
+                    text: 'Leave school at sixteen',
+                    active: true
                   },
                   {
                     href: '/component-guide/task_list/',
                     text: 'Continue into higher education',
-                    context: '&pound;9,500'
+                    context: '&pound;9,500',
+                    active: true
                   }
                 ]
               }


### PR DESCRIPTION
Fix active styles for choice lists (no before image but the big dot wasn't on the line):

<img width="631" alt="screen shot 2017-12-18 at 16 11 29" src="https://user-images.githubusercontent.com/861310/34115858-acdf246e-e40e-11e7-8c01-741178e2fbfc.png">

Fix outline styles for Firefox, before:

![screen shot 2017-12-18 at 16 12 35](https://user-images.githubusercontent.com/861310/34115888-c13767dc-e40e-11e7-8e48-fb1117d871f8.png)

After:

<img width="480" alt="screen shot 2017-12-18 at 16 25 34" src="https://user-images.githubusercontent.com/861310/34116297-18f6ccaa-e410-11e7-92d6-1867c77f265c.png">

Tested in IE8+, Edge 14+, latest Chrome, latest Firefox.
