### PR TITLE
Rework get help link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add heading element into task list component and change get help link behaviour (PR #113)
+
 # 3.1.0
 
 * Add support for components which accept a block (PR #117)

--- a/app/assets/stylesheets/components/_task-list.scss
+++ b/app/assets/stylesheets/components/_task-list.scss
@@ -447,6 +447,7 @@ $top-border: solid 2px $grey-3;
 
 .gem-c-task-list__help-link {
   text-decoration: none;
+  font-weight: bold;
 
   &:hover {
     text-decoration: underline;

--- a/app/assets/stylesheets/components/_task-list.scss
+++ b/app/assets/stylesheets/components/_task-list.scss
@@ -297,7 +297,8 @@ $top-border: solid 2px $grey-3;
 
 // contents of the task list, such as paragraphs and links
 
-.gem-c-task-list__paragraph {
+.gem-c-task-list__paragraph,
+.gem-c-task-list__heading {
   padding-bottom: $gutter-half;
   margin: 0;
   font-size: inherit;
@@ -317,6 +318,10 @@ $top-border: solid 2px $grey-3;
       padding-bottom: $gutter;
     }
   }
+}
+
+.gem-c-task-list__heading {
+  font-weight: bold;
 }
 
 .gem-c-task-list__links {

--- a/app/views/components/_task_list.html.erb
+++ b/app/views/components/_task_list.html.erb
@@ -69,6 +69,9 @@
                   <% if element[:type] == 'paragraph' %>
                     <p class="gem-c-task-list__paragraph"><%= element[:text] %></p>
 
+                  <% elsif element[:type] == 'heading' %>
+                    <%= content_tag("h#{heading_level + 1}", element[:text], class: 'gem-c-task-list__heading') %>
+
                   <% elsif element[:type] == 'list' %>
                     <%
                       list_style = ''

--- a/app/views/components/_task_list.html.erb
+++ b/app/views/components/_task_list.html.erb
@@ -130,7 +130,7 @@
                   </div>
                 <% end %>
 
-                <% if task_list_url %>
+                <% if task_list_url && step[:show_help_link] %>
                   <div class="gem-c-task-list__help">
                     <a href="<%= task_list_url %>#<%= id %>" class="gem-c-task-list__help-link js-link" data-position="get-help"><%= task_list_url_link_text %></a>
                   </div>

--- a/app/views/components/docs/task_list.yml
+++ b/app/views/components/docs/task_list.yml
@@ -612,9 +612,11 @@ examples:
           }
         ]
       ]
-  with_links_to_more_information:
+  get_help_links:
     description: |
       Where task lists are long, content can be substituted with a link back to the main task list page. This link will open the main task list page with that step shown. The link text defaults to "Get help completing this step" but can be overridden.
+
+      Get help links will only appear if the task_list_url global parameter is set and the step itself has the optional show_help_link parameter set to true.
 
       Note that this option does not remove any content - it is left to developers to simply pass less content to the component in this situation.
     data:
@@ -625,6 +627,7 @@ examples:
         [
           {
             title: "A link back to the main task list",
+            show_help_link: true,
             contents: [
               {
                 type: 'list',
@@ -644,7 +647,7 @@ examples:
         ],
         [
           {
-            title: "Another link back to the main task list",
+            title: "No help link here",
             contents: [
               {
                 type: 'list',

--- a/app/views/components/docs/task_list.yml
+++ b/app/views/components/docs/task_list.yml
@@ -316,8 +316,21 @@ examples:
                 text: 'Get help completing this step'
               },
               {
-                type: 'paragraph',
-                text: 'More help is available on the GOV.UK website.'
+                type: 'list',
+                contents: [
+                  {
+                    href: '#',
+                    text: 'Apply online'
+                  },
+                  {
+                    href: '#',
+                    text: 'Talk to one of our advisers'
+                  },
+                  {
+                    href: '#',
+                    text: 'Search our website'
+                  }
+                ]
               }
             ]
           }
@@ -761,6 +774,10 @@ examples:
                 optional: true
               },
               {
+                type: 'heading',
+                text: 'Optional steps'
+              },
+              {
                 type: 'paragraph',
                 text: 'These steps are not required.'
               },
@@ -785,6 +802,7 @@ examples:
         [
           {
             title: 'Join and configure the standup',
+            show_help_link: true,
             contents: [
               {
                 type: 'paragraph',
@@ -961,6 +979,10 @@ examples:
                 optional: true
               },
               {
+                type: 'heading',
+                text: 'Optional steps'
+              },
+              {
                 type: 'paragraph',
                 text: 'These steps are not required.'
               },
@@ -985,6 +1007,7 @@ examples:
         [
           {
             title: 'Join and configure the standup.',
+            show_help_link: true,
             contents: [
               {
                 type: 'paragraph',

--- a/app/views/components/docs/task_list.yml
+++ b/app/views/components/docs/task_list.yml
@@ -293,6 +293,36 @@ examples:
           }
         ]
       ]
+  with_headings:
+    description: Headings can be included to break up complex content within steps. Headings are intended to be used to highlight 'Get help completing this step' information, but can be used in other contexts. The heading level is automatically determined based on the heading level of the step titles.
+    data:
+      show_step: 1
+      heading_level: 3
+      groups: [
+        [
+          {
+            title: "Do something complicated",
+            contents: [
+              {
+                type: 'paragraph',
+                text: 'This is an example of a step containing a heading. A section has been used with the heading to demonstrate the intended appearance of a Get Help section.'
+              },
+              {
+                type: 'substep',
+                optional: true
+              },
+              {
+                type: 'heading',
+                text: 'Get help completing this step'
+              },
+              {
+                type: 'paragraph',
+                text: 'More help is available on the GOV.UK website.'
+              }
+            ]
+          }
+        ]
+      ]
   or_then:
     description: Some of the more complex things in a task list require an option for laying out links in a clear structure. If a link in a list is not given a href, only the text is displayed, allowing for structures like the one shown below.
     data:

--- a/spec/components/task_list_spec.rb
+++ b/spec/components/task_list_spec.rb
@@ -10,6 +10,7 @@ describe "Task List", type: :view do
       [
         {
           title: 'Group 1 step 1',
+          show_help_link: true,
           optional: true,
           contents: [
             {
@@ -206,7 +207,7 @@ describe "Task List", type: :view do
     render_component(groups: tasklist, task_list_url: "/learn-to-drive", task_list_url_link_text: "Get help")
 
     assert_select group1step1 + " .gem-c-task-list__help-link[href='/learn-to-drive#group-1-step-1']", text: "Get help"
-    assert_select group2step1 + " .gem-c-task-list__help-link[href='/learn-to-drive#group-2-step-1']", text: "Get help"
+    assert_select group2step1 + " .gem-c-task-list__help-link[href='/learn-to-drive#group-2-step-1']", false
   end
 
   it "displays group numbering and step logic correctly" do

--- a/spec/components/task_list_spec.rb
+++ b/spec/components/task_list_spec.rb
@@ -108,6 +108,10 @@ describe "Task List", type: :view do
                   text: 'Link 6'
                 }
               ]
+            },
+            {
+              type: 'heading',
+              text: 'This is a heading'
             }
           ]
         }
@@ -140,11 +144,23 @@ describe "Task List", type: :view do
     assert_select group2step1 + " .gem-c-task-list__paragraph", text: "Group 2 step 1 paragraph"
   end
 
+  it "renders headings" do
+    render_component(groups: tasklist)
+
+    assert_select group2step2 + " h3.gem-c-task-list__heading", text: "This is a heading"
+  end
+
   it "renders a tasklist with different heading levels" do
     render_component(groups: tasklist, heading_level: 4)
 
     assert_select group1step1 + " h4.gem-c-task-list__title", text: "Group 1 step 1"
     assert_select group2step1 + " h4.gem-c-task-list__title", text: "Group 2 step 1"
+  end
+
+  it "renders headings correctly if the heading level is changed" do
+    render_component(groups: tasklist, heading_level: 4)
+
+    assert_select group2step2 + " h5.gem-c-task-list__heading", text: "This is a heading"
   end
 
   it "opens a step by default" do


### PR DESCRIPTION
Change how the 'get help with this step' link works, specifically:

- restyle the link to be bold so it stands out more (users missed it in lab)
- add a 'heading' element into the task list content, works like a paragraph but outputs a heading (needed for 'get help' section in main task lists)
- change get help link functionality to be a per-step option, not a global (all steps) option, necessary because only some steps need a get help link

Get help section (showing new heading element):

![screen shot 2018-01-03 at 09 29 31](https://user-images.githubusercontent.com/861310/34515137-a93242e0-f068-11e7-99fb-8fbb5c9957cf.png)

Get help link (now bold):

![screen shot 2018-01-03 at 09 30 29](https://user-images.githubusercontent.com/861310/34515174-c61e3cc4-f068-11e7-8bfc-e6d45de8a47e.png)

- [Trello card](https://trello.com/c/0z6EzxSr/403-add-the-get-help-link-to-the-small-task-list-component-and-the-task-list-page)
  
  
  