### PR TITLE
Sort components by name

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/visual-regression.js
+++ b/app/assets/javascripts/govuk_publishing_components/visual-regression.js
@@ -2,7 +2,7 @@
   window.GOVUK = window.GOVUK || {}
 
   window.GOVUK.VisualDiffTool = function (currentWindowLocation) {
-    const visualDiffSelector = 'visual-diff';
+    var visualDiffSelector = 'visual-diff';
     var existingIframe = document.getElementById(visualDiffSelector);
     var windowLocation = currentWindowLocation || window.location;
 

--- a/app/models/govuk_publishing_components/component_doc_resolver.rb
+++ b/app/models/govuk_publishing_components/component_doc_resolver.rb
@@ -10,7 +10,7 @@ module GovukPublishingComponents
     end
 
     def all
-      fetch_component_docs.map { |component| build(component) }
+      fetch_component_docs.map { |component| build(component) }.sort_by(&:name)
     end
 
   private


### PR DESCRIPTION
Components were being ordered by their filename but displayed their name in the component list. For some components such as “Form label”
(label.html.erb), the component wasn’t appearing where expected.

* Always sort the list of components by name

## Before

![screen shot 2018-01-03 at 11 35 17](https://user-images.githubusercontent.com/319055/34519048-3667f7b6-f07a-11e7-82c6-31735d6ec804.png)

## After

![screen shot 2018-01-03 at 11 35 05](https://user-images.githubusercontent.com/319055/34519053-3973dd44-f07a-11e7-98f1-ae6acc3bbc00.png)
