### PR TITLE
Add a Procfile so we can run as a govuk::app in puppet

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec rackup spec/dummy/config.ru -p $PORT

--- a/README.md
+++ b/README.md
@@ -40,6 +40,27 @@ And then execute:
 $ bundle
 ```
 
+### Running as a standalone app
+
+If you want to work on this gem directly, without having to add it to another
+application, you can run it in the development vm:
+
+```
+$ cd /var/govuk/govuk-puppet/development-vm
+$ bowl publishing-components
+```
+
+Then visit [publishing-components.dev.gov.uk/component-guide](http://publishing-components.dev.gov.uk/component-guide).
+
+If you don't want to run it in the development vm, you can start the app with:
+
+```
+$ gem install foreman
+$ PLEK_SERVICE_STATIC_URI=assets.publishing.service.gov.uk foreman start
+```
+
+Then visit [localhost:5000/component-guide](http://localhost:5000/component-guide).
+
 #### Integration with Heroku
 
 To make the best use of the component guide we use Heroku to serve the current `master` build and whenever a [pull request is added](https://devcenter.heroku.com/articles/github-integration-review-apps)


### PR DESCRIPTION
https://trello.com/c/HSre7K10/453-style-the-mvp-email-collection-page-needed-by-jan

The #publishing-frontend team want to be able to work on the gem without
having to mount it into another Rails application first. We can use the
dummy Rails app the test suite uses to achieve this.
  
Other PR: https://github.com/alphagov/govuk-puppet/pull/7014
  