### PR TITLE
Move form components into gem

### DIFF
--- a/app/assets/stylesheets/components/_fieldset.scss
+++ b/app/assets/stylesheets/components/_fieldset.scss
@@ -1,0 +1,30 @@
+@import "helpers/variables";
+@import "helpers/clearfix";
+
+.gem-c-fieldset {
+  margin: 0 0 $gem-spacing-scale-4;
+
+  @include media(tablet) {
+    margin-bottom: $gem-spacing-scale-5;
+  }
+
+  padding: 0;
+  border: 0;
+  @include gem-h-clearfix;
+}
+
+.gem-c-fieldset__legend {
+  // Fix legend text wrapping in Edge and IE
+  // 1. IE9-11 & Edge 12-13
+  // 2. IE8-11
+  box-sizing: border-box; // 1
+  display: table;         // 2
+  max-width: 100%;        // 1
+  padding: 0;
+  // Hack to let legends or elements within legends have margins in webkit browsers
+  overflow: hidden;
+
+  color: $gem-text-colour;
+  white-space: normal;    // 1
+  @include core-19;
+}

--- a/app/assets/stylesheets/components/_label.scss
+++ b/app/assets/stylesheets/components/_label.scss
@@ -1,0 +1,18 @@
+@import "helpers/variables";
+
+.gem-c-label {
+  display: block;
+  color: $gem-text-colour;
+  @include core-19;
+}
+
+.gem-c-label--bold {
+  font-weight: 700;
+}
+
+// Hint text sits inside a label, to be read by AT
+.gem-c-label__hint {
+  display: block;
+  color: $gem-secondary-text-colour;
+  font-weight: 400;
+}

--- a/app/assets/stylesheets/components/_radio.scss
+++ b/app/assets/stylesheets/components/_radio.scss
@@ -1,0 +1,130 @@
+@import "helpers/variables";
+@import "helpers/px-to-em";
+
+.gem-c-radio {
+  display: block;
+
+  position: relative;
+
+  margin-bottom: $gem-spacing-scale-2;
+  padding: 0 0 0 em(40px, 19px);
+
+  clear: left;
+
+  @include core-19;
+}
+
+.gem-c-radio:last-child,
+.gem-c-radio:last-of-type {
+  margin-bottom: 0;
+}
+
+.gem-c-radio--inline {
+  margin-right: $gem-spacing-scale-4;
+  float: left;
+  clear: none;
+}
+
+.gem-c-radio__input {
+  position: absolute;
+
+  z-index: 1;
+  top: 0;
+  left: 0;
+
+  width: em(40px, 19px);
+  height: em(40px, 19px);
+
+  cursor: pointer;
+
+  // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there. Double colons get ommited by IE8.
+  @if ($is-ie == false) or ($ie-version == 9) {
+    margin: 0;
+    opacity: 0;
+  }
+}
+
+.gem-c-radio__label {
+  display: block;
+  border: 2px solid transparent;
+}
+
+.gem-c-radio__label__text {
+  cursor: pointer;
+  // remove 300ms pause on mobile
+  -ms-touch-action: manipulation;
+  touch-action: manipulation;
+
+  display: block;
+  padding-top: em(8px, 19px);
+  padding-bottom: em($gem-spacing-scale-1, 19px);
+}
+
+.gem-c-radio__label__text,
+.gem-c-radio__label__hint {
+  padding-left: em($gem-spacing-scale-3, 19px);
+  padding-right: em($gem-spacing-scale-3, 19px);
+}
+
+.gem-c-radio__input + .gem-c-radio__label::before {
+  content: "";
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  width: em(40px, 19px);
+  height: em(40px, 19px);
+
+  border: $gem-border-width-form-element solid;
+  border-radius: 50%;
+  background: transparent;
+}
+
+.gem-c-radio__input + .gem-c-radio__label::after {
+  content: "";
+
+  position: absolute;
+  top: em($gem-spacing-scale-2, 19px);
+  left: em($gem-spacing-scale-2, 19px);
+
+  width: 0;
+  height: 0;
+
+  border: em($gem-spacing-scale-2, 19px) solid;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0;
+}
+
+// Focused state
+.gem-c-radio__input:focus + .gem-c-radio__label::before {
+  box-shadow: 0 0 0 4px $gem-focus-colour;
+}
+
+// Selected state
+.gem-c-radio__input:checked + .gem-c-radio__label::after {
+  opacity: 1;
+}
+
+// Disabled state
+.gem-c-radio__input:disabled,
+.gem-c-radio__input:disabled + .gem-c-radio__label__text {
+  cursor: default;
+}
+
+.gem-c-radio__input:disabled + .gem-c-radio__label {
+  opacity: .5;
+}
+
+// TODO: Can be replaced by spacing + typography helpers from GOV.UK Frontend
+.gem-c-radio--margin-bottom-0 {
+  margin-bottom: $gem-spacing-scale-0 !important;
+}
+
+// TODO: Can be replaced by spacing + typography helpers from GOV.UK Frontend
+.gem-c-radio__block-text {
+  display: block;
+  @include core-19;
+  margin-bottom: $gem-spacing-scale-3;
+}

--- a/app/assets/stylesheets/components/helpers/_clearfix.scss
+++ b/app/assets/stylesheets/components/helpers/_clearfix.scss
@@ -1,0 +1,12 @@
+// Mixin to clear floats
+@mixin gem-h-clearfix {
+  &:after {
+    content: "";
+    display: block;
+    clear: both;
+  }
+
+  @include ie-lte(7) {
+    zoom: 1;
+  }
+}

--- a/app/assets/stylesheets/components/helpers/_px-to-em.scss
+++ b/app/assets/stylesheets/components/helpers/_px-to-em.scss
@@ -1,0 +1,10 @@
+// Convert pixels to em
+@function em($value, $gem-context-font-size) {
+  @if (unitless($value)) {
+    $value: $value * 1px;
+  }
+  @if (unitless($gem-context-font-size)) {
+    $gem-context-font-size: $gem-context-font-size * 1px;
+  }
+  @return $value / $gem-context-font-size * 1em;
+}

--- a/app/assets/stylesheets/components/helpers/_variables.scss
+++ b/app/assets/stylesheets/components/helpers/_variables.scss
@@ -1,0 +1,25 @@
+// Forked from GOV.UK Frontend, namespace changed to ensure no conflicts.
+
+$gem-spacing-scale-0: 0;
+$gem-spacing-scale-1: 5px;
+$gem-spacing-scale-2: 10px;
+$gem-spacing-scale-3: 15px;
+$gem-spacing-scale-4: 20px;
+$gem-spacing-scale-5: 30px;
+$gem-spacing-scale-6: 40px;
+$gem-spacing-scale-7: 50px;
+$gem-spacing-scale-8: 60px;
+
+$gem-text-colour: $text-colour;
+$gem-secondary-text-colour: $grey-1;
+
+// Border widths
+$gem-border-width-mobile: 4px;
+$gem-border-width-tablet: 5px;
+$gem-border-width-form-element: 2px;
+
+// Focus
+$gem-focus-width: 3px;
+$gem-focus-colour: $focus-colour;
+
+$gem-error-colour: $red;

--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -5,6 +5,7 @@
 @import "colours";
 
 @import "../components/label";
+@import "../components/radio";
 @import "../components/task-list";
 @import "../components/task-list-header";
 @import "../components/task-list-related";

--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -3,6 +3,8 @@
 @import "grid_layout";
 @import "typography";
 @import "colours";
+
+@import "../components/label";
 @import "../components/task-list";
 @import "../components/task-list-header";
 @import "../components/task-list-related";

--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -4,6 +4,7 @@
 @import "typography";
 @import "colours";
 
+@import "../components/fieldset";
 @import "../components/label";
 @import "../components/radio";
 @import "../components/task-list";

--- a/app/views/components/_fieldset.html.erb
+++ b/app/views/components/_fieldset.html.erb
@@ -1,0 +1,7 @@
+<% text = text || yield %>
+<fieldset class="gem-c-fieldset">
+  <legend class="gem-c-fieldset__legend">
+    <%= legend_text %>
+  </legend>
+  <%= text %>
+</fieldset>

--- a/app/views/components/_label.html.erb
+++ b/app/views/components/_label.html.erb
@@ -1,0 +1,40 @@
+<%
+  classes ||= ''
+  text_classes ||= ''
+  hint_text_classes ||= ''
+  html_for ||= ''
+  hint_text ||= ''
+  bold ||= false
+%>
+
+
+<div
+  class="
+    gem-c-label
+    <%= "gem-c-label--bold" if bold %>
+    <%= classes if classes %>
+  "
+>
+  <label
+    class="
+      gem-c-label__text
+      <%= text_classes if text_classes %>
+    "
+    <% if html_for %>
+      for="<%= html_for %>"
+    <% end %>
+  >
+    <%= text %>
+  </label>
+  <% if hint_text.present? %>
+    <span
+      class="
+        gem-c-label__hint
+        <%= hint_text_classes if hint_text_classes %>
+      "
+      id="<%= hint_id %>"
+    >
+      <%= hint_text %>
+    </span>
+  <% end %>
+</div>

--- a/app/views/components/_radio.html.erb
+++ b/app/views/components/_radio.html.erb
@@ -1,0 +1,45 @@
+<%
+  id_prefix ||= "radio-#{SecureRandom.hex(4)}"
+  items ||= []
+%>
+<% items.each_with_index do |item, index| %>
+  <% if item === :or %>
+    <span class="gem-c-radio__block-text">
+      <%= t('components.radio.or') %>
+    </span>
+  <% else %>
+    <%
+      item_next = items[index + 1] unless index === items.size - 1
+      label_id = item[:id] ? item[:id] : "#{id_prefix}-#{index}"
+      label_hint_id = "label-hint-#{SecureRandom.hex(4)}" if item[:hint_text].present?
+    %>
+    <div
+      class="
+        gem-c-radio
+        <%= 'gem-c-radio--margin-bottom-0' if item_next === :or && item[:hint_text].present? %>
+      "
+    >
+      <input
+        class="gem-c-radio__input"
+        id="<%= label_id %>"
+        name="<%= name %>"
+        type="radio"
+        value="<%= item[:value] %>"
+        <%= "checked" if item[:checked] %>
+        <% if label_hint_id %>
+          aria-describedby="<%= label_hint_id %>"
+        <% end %>
+      >
+      <%= render "components/label", {
+        hint_id: label_hint_id,
+        html_for: label_id,
+        classes: 'gem-c-radio__label',
+        text_classes: 'gem-c-radio__label__text',
+        hint_text_classes: 'gem-c-radio__label__hint',
+        hint_text: item[:hint_text],
+        text: item[:text],
+        bold: item[:bold]
+      } %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/components/docs/fieldset.yml
+++ b/app/views/components/docs/fieldset.yml
@@ -1,0 +1,34 @@
+name: Form fieldset
+description: The fieldset element is used to group several controls within a web form. The legend element represents a caption for the content of its parent fieldset.
+body: |
+  [Using the fieldset and legend elements](https://accessibility.blog.gov.uk/2016/07/22/using-the-fieldset-and-legend-elements/)
+
+  You can use the 'text' property or pass 'text' as a block.
+accessibility_criteria: |
+  - must give inputs within the fieldset context with legend text
+examples:
+  default:
+    data:
+      legend_text: 'Do you have a passport?'
+      text: |
+        <!-- Use the radio component, this is hardcoded only for this example -->
+        <input type="radio" id="default-yes" name="default"t>
+        <label for="default-yes">Yes</label>
+
+        <input type="radio" id="default-no" name="default"t>
+        <label for="default-no">No</label>
+  with_html_legend:
+    description: 'If you only have one fieldset on the page you might want to include the title of the page as the legend text. Used with a [captured](http://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-capture) [title](http://govuk-static.herokuapp.com/component-guide/title)'
+    data:
+      legend_text: |
+        <!-- Use the title component, this is hardcoded only for this example -->
+        <h1 style="font-size: 48px; line-height: 1.0416666667; font-weight: bold; margin-bottom: 30px;">
+          Do you have a passport?
+        </h1>
+      text: |
+        <!-- Use the radio component, this is hardcoded only for this example -->
+        <input type="radio" id="html-legend-yes" name="html-legend">
+        <label for="html-legend-yes">Yes</label>
+
+        <input type="radio" id="html-legend-no" name="html-legend">
+        <label for="html-legend-no">No</label>

--- a/app/views/components/docs/label.yml
+++ b/app/views/components/docs/label.yml
@@ -1,0 +1,25 @@
+name: Form label
+description: Use labels for all form fields.
+body: |
+  For use with other form inputs e.g. [Radio buttons](/component-guide/radio)
+
+  Forked from the upcoming [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend), when GOV.UK Frontend release we can replace these source files.
+accessibility_criteria: |
+  - have a text contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+  - have visible text
+  - `hint_id` is matched with an `aria-describedby` property on the input your label is associated with.
+examples:
+  default:
+    data:
+      text: "National Insurance number"
+  with_hint:
+    data:
+      text: "National Insurance number"
+      hint_id: "should-match-aria-describedby-input"
+      hint_text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+  bold_with_hint:
+    data:
+      bold: true
+      text: "National Insurance number"
+      hint_id: "should-match-aria-describedby-input-bold"
+      hint_text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."

--- a/app/views/components/docs/radio.yml
+++ b/app/views/components/docs/radio.yml
@@ -1,0 +1,119 @@
+name: Radio button
+description: A radio button is a GOV.UK element that allows users to answer a question by selecting an option. If you have a question with more than one option you should stack radio buttons.
+body: |
+  Forked from the upcoming [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend), when GOV.UK Frontend release we can replace these source files.
+
+  You can also use 'or' as an item to [break up radios](https://www.gov.uk/service-manual/design/writing-for-user-interfaces#ask-questions-that-users-can-understand)
+accessibility_criteria: |
+  Radio buttons should
+
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - indicate when they have focus
+  - change in appearance when touched (in the touch-down state)
+  - be usable with touch
+  - have label with a touch area similar to the input
+  - be usable with [voice commands](https://www.w3.org/WAI/perspectives/voice.html)
+  - have visible text
+  - have a meaningful accessible name
+  - be usable when interacting with the label
+  - additional information in hint text should be read out found when focusing inputs
+  - should always be used nested in a fieldset so that it has proper context, useful for users of assistive technologies.
+
+  [Keyboard interaction](https://www.w3.org/TR/wai-aria-practices-1.1/#radiobutton)
+
+  - when a radio group receives focus:
+    - if a radio button is checked, focus is set on the checked button.
+    - if none of the radio buttons are checked, focus is set on the first radio button in the group.
+  - Space: checks the focused radio button if it is not already checked.
+  - Right Arrow and Down Arrow: move focus to the next radio button in the group, uncheck the previously focused button, and check the newly focused button. If focus is on the last button, focus moves to the first button.
+  - Left Arrow and Up Arrow: move focus to the previous radio button in the group, uncheck the previously focused button, and check the newly focused button. If focus is on the first button, focus moves to the last button.
+
+accessibility_excluded_rules:
+- radiogroup # Since this is in isolation we don't want to wrap a fieldset here.
+examples:
+  default:
+    data:
+      name: "radio-group"
+      items:
+      - value: "government-gateway"
+        text: "Use Government Gateway"
+      - value: "govuk-verify"
+        text: "Use GOV.UK Verify"
+  with_bold:
+    description: 'Used to provide better contrast between long labels and hint text, Note that the `:or` option [is documented as a string due to a bug](https://github.com/alphagov/govuk_publishing_components/issues/102)'
+    data:
+      name: "radio-group-bold"
+      items:
+      - value: "government-gateway"
+        text: "Use Government Gateway"
+        hint_text: "You'll have a user ID if you've signed up to do things like sign up Self Assessment tax return online."
+        bold: true
+      - value: "govuk-verify"
+        text: "Use GOV.UK Verify"
+        hint_text: "You'll have an account if you've already proved your identity with a certified company, such as the Post Office."
+        bold: true
+  with_hint_text:
+    data:
+      name: "radio-group-hint-text"
+      items:
+      - value: "government-gateway"
+        hint_text: "You'll have a user ID if you've signed up to do things like sign up Self Assessment tax return online."
+        text: "Use Government Gateway"
+      - value: "govuk-verify"
+        hint_text: "You'll have an account if you've already proved your identity with a certified company, such as the Post Office."
+        text: "Use GOV.UK Verify"
+  with_checked_option:
+    data:
+      name: "radio-group-checked"
+      items:
+      - value: "government-gateway"
+        text: "Use Government Gateway"
+      - value: "govuk-verify"
+        text: "Use GOV.UK Verify"
+        checked: true
+  with_custom_id_prefix:
+    data:
+      id_prefix: 'custom'
+      name: "radio-custom-id-prefix"
+      items:
+      - value: "government-gateway"
+        text: "Use Government Gateway"
+      - value: "govuk-verify"
+        text: "Use GOV.UK Verify"
+  with_or_divider:
+    description: "See [related service manual gudiance for this pattern](https://www.gov.uk/service-manual/design/writing-for-user-interfaces#ask-questions-that-users-can-understand)"
+    data:
+      name: "radio-group-or-divider"
+      items:
+      - value: "government-gateway"
+        text: "Use Government Gateway"
+      - value: "govuk-verify"
+        text: "Use GOV.UK Verify"
+      - :or
+      - value: "create-an-account"
+        text: "Create an account"
+  extreme:
+    description: 'Note that the `:or` option [is documented as a string due to a bug](https://github.com/alphagov/govuk_publishing_components/issues/102)'
+    data:
+      id_prefix: 'extreme'
+      name: "radio-custom-extreme"
+      items:
+      - value: "extreme-value-1"
+        hint_text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sapien justo, lobortis elementum tortor in, luctus interdum turpis. Nam sit amet nulla nec arcu condimentum dapibus quis varius metus. Suspendisse cursus tristique diam et vestibulum. Proin nec lacinia tortor. Morbi at nisi id lorem aliquam ullamcorper. Pellentesque laoreet sit amet leo sodales ultricies. Suspendisse maximus efficitur odio in tristique."
+        text: "Quisque tincidunt venenatis bibendum. Morbi volutpat magna euismod ipsum consequat cursus. Etiam bibendum interdum ultricies."
+        bold: true
+      - value: "extreme-value-2"
+        hint_text: "Cras mi neque, porttitor mattis ultricies id, fringilla non ipsum. Etiam non elit ac magna tincidunt ultrices. Morbi eu quam sed justo scelerisque efficitur sed ut risus. Integer commodo, lectus et venenatis maximus, augue erat egestas nulla, eget fermentum augue lacus tempor nulla. Aenean ultricies suscipit erat, vitae hendrerit neque varius nec. Etiam ac euismod massa. Ut at erat id sapien mollis posuere."
+        text: "Aliquam rutrum lobortis blandit. Praesent sit amet lacinia libero. Morbi nulla tellus, euismod et ipsum id, porta volutpat enim. Ut mauris libero"
+        bold: true
+      - :or
+      - value: "extreme-value-3"
+        hint_text: "Nullam congue neque et tempor tincidunt. In ornare lacus ac arcu maximus ultricies. Quisque et ultrices nulla. Suspendisse potenti. Nunc imperdiet ornare leo ut ultrices. Praesent in quam in tellus dictum lacinia vitae vitae lacus. Nulla hendrerit feugiat urna eu gravida. Nam a molestie nisi, at semper neque. Quisque tincidunt venenatis bibendum. Morbi volutpat magna euismod ipsum consequat cursus. Etiam bibendum interdum ultricies."
+        text: "Duis tempus est metus, in varius enim lobortis non. Nunc laoreet nisi vel lectus consequat, sed venenatis tellus dictum. Nunc ut nibh blandit ipsum bibendum dictum."
+        bold: true
+      - value: "extreme-value-4"
+        hint_text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sapien justo, lobortis elementum tortor in, luctus interdum turpis. Nam sit amet nulla nec arcu condimentum dapibus quis varius metus. Suspendisse cursus tristique diam et vestibulum. Proin nec lacinia tortor. Morbi at nisi id lorem aliquam ullamcorper. Pellentesque laoreet sit amet leo sodales ultricies. Suspendisse maximus efficitur odio in tristique."
+        text: "Quisque tincidunt venenatis bibendum. Morbi volutpat magna euismod ipsum consequat cursus. Etiam bibendum interdum ultricies."
+        bold: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,25 @@
+# Files in the config/locales directory are used for internationalization
+# and are automatically loaded by Rails. If you want to use locales other
+# than English, add the necessary files in this directory.
+#
+# To use the locales, use `I18n.t`:
+#
+#     I18n.t 'hello'
+#
+# In views, this is aliased to just `t`:
+#
+#     <%= t('hello') %>
+#
+# To use a different locale, set it with `I18n.locale`:
+#
+#     I18n.locale = :es
+#
+# This would use the information in config/locales/es.yml.
+#
+# To learn more, please read the Rails Internationalization guide
+# available at http://guides.rubyonrails.org/i18n.html.
+
+en:
+  components:
+    radio:
+      or: 'or'

--- a/spec/components/fieldset_test_spec.rb
+++ b/spec/components/fieldset_test_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe "Fieldset", type: :view do
+  def render_component(locals)
+    render file: "components/_fieldset", locals: locals
+  end
+
+  it "fails to render when no data is given" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  it "renders a fieldset correctly" do
+    render_component(
+      legend_text: 'Do you have a passport?',
+      text: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vel ad neque, maxime est ea laudantium totam fuga!'
+    )
+
+    assert_select ".gem-c-fieldset__legend", text: 'Do you have a passport?'
+    assert_select ".gem-c-fieldset", text: /Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vel ad neque, maxime est ea laudantium totam fuga!/
+  end
+end

--- a/spec/components/label_test_spec.rb
+++ b/spec/components/label_test_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe "Label", type: :view do
+  def render_component(locals)
+    render file: "components/_label", locals: locals
+  end
+
+  it "does not render label when no data is given" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  it "renders label with text" do
+    render_component(text: "National Insurance number")
+
+    assert_select ".gem-c-label__text", text: "National Insurance number"
+  end
+
+  it "renders label with text and hint text" do
+    render_component(
+      text: "National Insurance number",
+      hint_id: "should-match-aria-describedby-input",
+      hint_text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    )
+
+    assert_select ".gem-c-label__text", text: "National Insurance number"
+    assert_select ".gem-c-label__hint", text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    assert_select ".gem-c-label__hint[id=should-match-aria-describedby-input]"
+  end
+
+  it "renders label with bold text" do
+    render_component(text: "National Insurance number", bold: true)
+
+    assert_select ".gem-c-label__text", text: "National Insurance number"
+    assert_select ".gem-c-label--bold"
+  end
+end

--- a/spec/components/radio_test_spec.rb
+++ b/spec/components/radio_test_spec.rb
@@ -1,0 +1,207 @@
+require 'spec_helper'
+
+describe "Radio", type: :view do
+  def render_component(locals)
+    render file: "components/_radio", locals: locals
+  end
+
+  it "does not render anything if no data is passed" do
+    assert_empty render_component({})
+  end
+
+  it "throws an error if items are passed but no name is passed" do
+    assert_raises do
+      render_component(items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        }
+      ])
+    end
+  end
+
+  it "renders radio-group with one item" do
+    render_component(
+      name: "radio-group-one-item",
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        }
+      ]
+    )
+
+    assert_select ".gem-c-radio__input[name=radio-group-one-item]"
+    assert_select ".gem-c-radio:first-child .gem-c-radio__label__text", text: "Use Government Gateway"
+  end
+
+  it "renders radio-group with multiple items" do
+    render_component(
+      name: "radio-group-multiple-items",
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        },
+        {
+          value: "govuk-verify",
+          text: "Use GOV.UK Verify"
+        }
+      ]
+    )
+
+    assert_select ".gem-c-radio__input[name=radio-group-multiple-items]"
+    assert_select ".gem-c-radio:first-child .gem-c-radio__label__text", text: "Use Government Gateway"
+    assert_select ".gem-c-radio:last-child .gem-c-radio__label__text", text: "Use GOV.UK Verify"
+  end
+
+  it "renders radio-group with bold labels" do
+    render_component(
+      name: "radio-group-bold-labels",
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway",
+          bold: true
+        },
+        {
+          value: "govuk-verify",
+          text: "Use GOV.UK Verify",
+          bold: true
+        }
+      ]
+    )
+
+    assert_select ".gem-c-radio__input[name=radio-group-bold-labels]"
+    assert_select ".gem-c-radio .gem-c-label--bold"
+  end
+
+  it "renders radio-group with hint text" do
+    render_component(
+      name: "radio-group-hint-text",
+      items: [
+        {
+          value: "government-gateway",
+          hint_text: "You'll have a user ID if you've signed up to do things like sign up Self Assessment tax return online.",
+          text: "Use Government Gateway"
+        },
+        {
+          value: "govuk-verify",
+          hint_text: "You'll have an account if you've already proved your identity with a certified company, such as the Post Office.",
+          text: "Use GOV.UK Verify"
+        }
+      ]
+    )
+
+    assert_select ".gem-c-radio__input[name=radio-group-hint-text]"
+    assert_select ".gem-c-radio:first-child .gem-c-radio__label__text", text: "Use Government Gateway"
+    assert_select ".gem-c-radio:first-child .gem-c-label__hint", text: "You'll have a user ID if you've signed up to do things like sign up Self Assessment tax return online."
+    assert_select ".gem-c-radio:last-child .gem-c-radio__label__text", text: "Use GOV.UK Verify"
+    assert_select ".gem-c-radio:last-child .gem-c-label__hint", text: "You'll have an account if you've already proved your identity with a certified company, such as the Post Office."
+  end
+
+  it "renders radio-group with checked option" do
+    render_component(
+      name: "radio-group-checked-option",
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        },
+        {
+          value: "govuk-verify",
+          text: "Use GOV.UK Verify",
+          checked: true
+        }
+      ]
+    )
+
+    assert_select ".gem-c-radio__input[name=radio-group-checked-option]"
+    assert_select ".gem-c-radio__input[checked]", value: "govuk-verify"
+  end
+
+  it "renders radio-group with custom id prefix" do
+    render_component(
+      id_prefix: 'custom',
+      name: "radio-group-custom-id-prefix",
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        },
+        {
+          value: "govuk-verify",
+          text: "Use GOV.UK Verify"
+        }
+      ]
+    )
+
+    assert_select ".gem-c-radio__input[name=radio-group-custom-id-prefix]"
+    assert_select ".gem-c-radio__input[id=custom-0]", value: "government-gateway"
+    assert_select ".gem-c-radio__label__text[for=custom-0]", text: "Use Government Gateway"
+    assert_select ".gem-c-radio__input[id=custom-1]", value: "govuk-verify"
+    assert_select ".gem-c-radio__label__text[for=custom-1]", text: "Use GOV.UK Verify"
+  end
+
+  it "renders radio-group with or divider" do
+    render_component(
+      name: "radio-group-or-divider",
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        },
+        :or,
+        {
+          value: "govuk-verify",
+          text: "Use GOV.UK Verify"
+        }
+      ]
+    )
+
+    assert_select ".gem-c-radio__input[name=radio-group-or-divider]"
+    assert_select ".gem-c-radio:first-child .gem-c-radio__label__text", text: "Use Government Gateway"
+    assert_select ".gem-c-radio__block-text", text: "or"
+    assert_select ".gem-c-radio:last-child .gem-c-radio__label__text", text: "Use GOV.UK Verify"
+  end
+end
+
+# This component can be interacted with, so use integration tests for these cases.
+describe 'Radio (integration)' do
+  def input_visible
+    false # our inputs are hidden with CSS, and rely on the label.
+  end
+
+  it "radio can choose an option" do
+    visit '/component-guide/radio/default/preview'
+
+    within '.component-guide-preview' do
+      assert_text 'Use GOV.UK Verify'
+      assert_text 'Use Government Gateway'
+
+      expect(page).to_not have_selector("[@class='gem-c-radio__input'][@checked='checked']", visible: input_visible)
+
+      page.choose(option: 'govuk-verify', allow_label_click: true)
+
+      expect(page).to_not have_selector("[@class='gem-c-radio__input'][@value='government-gateway'][@checked='checked']", visible: input_visible)
+      expect(page).to have_selector("[@class='gem-c-radio__input'][@value='govuk-verify'][@checked='checked']", visible: input_visible)
+    end
+  end
+
+  it "radio can choose an option when already has one checked" do
+    visit '/component-guide/radio/with_checked_option/preview'
+
+    within '.component-guide-preview' do
+      assert_text 'Use Government Gateway'
+      assert_text 'Use GOV.UK Verify'
+
+      expect(page).to have_selector("[@class='gem-c-radio__input'][@value='govuk-verify'][@checked='checked']", visible: input_visible)
+      expect(page).to_not have_selector("[@class='gem-c-radio__input'][@value='government-gateway'][@checked='checked']", visible: input_visible)
+
+      page.choose(option: 'government-gateway', allow_label_click: true)
+
+      expect(page).to have_selector("[@class='gem-c-radio__input'][@value='government-gateway'][@checked='checked']", visible: input_visible)
+      expect(page).to_not have_selector("[@class='gem-c-radio__input'][@value='govuk-verify'][@checked='checked']", visible: input_visible)
+    end
+  end
+end


### PR DESCRIPTION
Moves form related components needed in [email-alert-frontend](https://github.com/alphagov/email-alert-frontend) into the gem so they can be used across applications.

We're avoiding [static](https://github.com/alphagov/static) here since these pages need strong integration tests within the applications they are used in, and `static` mocks components.

These were originally implemented in the following pull requests to `government-frontend`

- [Radio and label](https://github.com/alphagov/government-frontend/pull/552)
- [Fieldset](https://github.com/alphagov/government-frontend/pull/561)

We'll move the error related components later to make the PR smaller.

We will do a follow up PR to remove these components from `government-frontend`

As part of https://trello.com/c/HSre7K10/453-style-the-mvp-email-collection-page-needed-by-jan
  
  
  
  