### PR TITLE
Support components accepting blocks

### DIFF
--- a/app/models/govuk_publishing_components/component_example.rb
+++ b/app/models/govuk_publishing_components/component_example.rb
@@ -5,13 +5,15 @@ module GovukPublishingComponents
     attr_reader :id,
                 :data,
                 :context,
-                :description
+                :description,
+                :block
 
     def initialize(id, data, context, description)
       @id = id
       @data = data || {}
       @context = context || {}
       @description = description || false
+      @block = @data.delete(:block) || false
     end
 
     def name
@@ -65,6 +67,10 @@ module GovukPublishingComponents
 
     def html_description
       govspeak_to_html(description) if description.present?
+    end
+
+    def has_block?
+      !!block
     end
 
   private

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_call.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_call.html.erb
@@ -1,3 +1,12 @@
 <div class="component-call component-highlight" contenteditable>
-  <pre><code><%= example.highlight_code("\<%= render \"#{@component_doc.partial_path}\", #{example.pretty_data} %\>") %></code></pre>
+  <% if example.has_block? %>
+    <%
+      code = "<%= render \"#{@component_doc.partial_path}\", #{example.pretty_data} do %\>\n"
+      code += "  #{example.block.html_safe}"
+      code += "<% end %\>"
+    -%>
+    <pre><code><%= example.highlight_code(code) %></code></pre>
+  <% else %>
+    <pre><code><%= example.highlight_code("\<%= render \"#{@component_doc.partial_path}\", #{example.pretty_data} %\>") %></code></pre>
+<% end %>
 </div>

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
@@ -2,5 +2,12 @@
             <% if example.right_to_left? %>direction-rtl<% end %>
             <% if example.dark_background? %>dark-background<% end %>
             <% if preview_page %>component-guide-preview--simple<% end %>" data-content="EXAMPLE">
-  <%= render component_doc.partial_path, example.html_safe_data %>
+
+  <% if example.has_block? %>
+    <%= render component_doc.partial_path, example.html_safe_data do %>
+      <%= example.block.html_safe %>
+    <% end %>
+  <% else %>
+    <%= render component_doc.partial_path, example.html_safe_data %>
+  <% end %>
 </div>

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -69,6 +69,29 @@ examples:
       some_parameter: 'A different parameter value'
 ```
 
+#### Yaml configuration for a component which accepts a block
+
+Some components can accept a block as an argument.
+eg.
+
+```ruby
+<%= render "my-accepts-block-component", { param: value }, do %>
+  <span>Some text</span>
+<% end %>
+```
+
+To configure the block in the component yaml file you should specify
+a `block` key in the example data:
+
+```yaml
+examples:
+  default:
+    data:
+      some_parameter: 'The parameter value'
+      block: |
+        <span>Some text</span>
+```
+
 #### [Accessibility Acceptance Criteria](accessibility_acceptance_criteria.md)
 
 Markdown listing what this component must do to be accessible.

--- a/spec/component_guide/component_example_spec.rb
+++ b/spec/component_guide/component_example_spec.rb
@@ -35,6 +35,14 @@ describe 'Component example' do
     expect(page).to have_selector('.component-guide-preview .test-component-with-params', text: 'A different value')
   end
 
+  it 'yields a block in component examples' do
+    visit '/component-guide/test-component-with-block'
+
+    expect(page).to have_selector('.component-guide-preview .test-component-with-block', text: 'Here\'s a block')
+
+    expect(page).to have_content(%(<%= render "components/test-component-with-block", {\n} do %>\n<div class="test-block">Here's a block</div>\n<% end %>))
+  end
+
   it 'marks strings in examples as html_safe' do
     visit '/component-guide/test-component-with-html-params'
     within ".test-component-with-html-params" do

--- a/spec/dummy/app/views/components/_test-component-with-block.html.erb
+++ b/spec/dummy/app/views/components/_test-component-with-block.html.erb
@@ -1,0 +1,3 @@
+<div class="test-component-with-block">
+  <%= yield %>
+</div>

--- a/spec/dummy/app/views/components/docs/test-component-with-block.yml
+++ b/spec/dummy/app/views/components/docs/test-component-with-block.yml
@@ -1,0 +1,7 @@
+name: Test component with block
+description: A test component that takes a block
+examples:
+  default:
+    data:
+      block: |
+        <div class="test-block">Here's a block</div>


### PR DESCRIPTION
ERB's render method accepts a block, which is useful for components which
embed multiple components for a specific purpose (eg. a content list with
a back-to-top link).
The component guide should be able to render the docs for this type of component
so this PR adds the ability to configure the component guide with a specific example data key:

```yaml
examples:
  default:
    data:
      block: |
         <div><%= some_local_thing %></div>
```
  