### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.0
+
+* Add support for components which accept a block (PR #117)
+
 # 3.0.3
 
 * Sort components by name in the component list (PR #114)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '3.0.3'.freeze
+  VERSION = '3.1.0'.freeze
 end


### PR DESCRIPTION
Bump version because https://github.com/alphagov/govuk_publishing_components/pull/117