### PR TITLE
Improve task list component print styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Remove unneeded CSS from component guide (PR #126)
 * Add heading element into task list component and change get help link behaviour (PR #113)
+* Improve task list print styles (PR #125)
 
 # 3.1.0
 

--- a/app/assets/stylesheets/components/_task-list-print.scss
+++ b/app/assets/stylesheets/components/_task-list-print.scss
@@ -1,28 +1,99 @@
 // scss-lint:disable SelectorFormat
 
-.gem-c-task-list__circle,
+$grey-2: #bfc1c3;
+$white: #ffffff;
+$number-circle-size: 35px;
+$stroke-width: 3px;
+
+.gem-c-task-list:not(.gem-c-task-list--large),
 .gem-c-task-list__controls,
 .gem-c-task-list__toggle-link,
 .gem-c-task-list__help {
   display: none;
 }
 
+.gem-c-task-list {
+  position: relative;
+
+  &:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: $number-circle-size / 2;
+    width: 3px;
+    height: 100%;
+    margin-left: -1.5px;
+    border-left: solid $stroke-width $grey-2;
+  }
+
+  &:after {
+    content: "";
+    position: absolute;
+    z-index: 6;
+    bottom: 0;
+    left: 0;
+    margin-left: $number-circle-size / 4;
+    width: $number-circle-size / 2;
+    height: 0;
+    border-bottom: solid $stroke-width $grey-2;
+  }
+}
+
+.gem-c-task-list__group {
+  position: relative;
+}
+
+.gem-c-task-list__groups {
+  padding: 0;
+  list-style: none;
+}
+
+.gem-c-task-list__circle {
+  @include _core-font-generator(19px, 16px, 19px, 30px, 23px, false, bold);
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: $number-circle-size;
+  height: $number-circle-size;
+  background: $white;
+  border-radius: 100px;
+  text-align: center;
+}
+
+.gem-c-task-list__circle--number {
+  border: solid 3px $grey-2;
+}
+
 .gem-c-task-list__step,
-.gem-c-task-list__paragraph {
+.gem-c-task-list__paragraph,
+.gem-c-task-list__links {
+  @include core-16;
   padding-bottom: 1em;
 }
 
+.gem-c-task-list__step {
+  position: relative;
+  padding-left: 60px;
+}
+
 .gem-c-task-list__title {
-  margin: 0;
+  @include bold-19;
+  margin: 0 0 0.5em 0;
   padding: 0;
 }
 
 .gem-c-task-list__button--title {
   @include bold-19;
-
   padding: 0;
   border: 0;
   background: none;
+}
+
+.gem-c-task-list__context {
+  &:before {
+    content: " \2013  ";
+  }
 }
 
 .gem-c-task-list__panel-link--active {
@@ -30,11 +101,17 @@
 }
 
 .gem-c-task-list__links {
-  list-style: disc;
+  padding-left: 0;
+  list-style: none;
 }
 
 .gem-c-task-list__links--choice {
+  padding-left: 30px;
   list-style: disc;
+}
+
+.gem-c-task-list__link {
+  margin-bottom: 0.3em;
 }
 
 // scss-lint:enable SelectorFormat

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -10,7 +10,7 @@
     <% end %>
     <%= yield :title %><% if content_for(:title) %> - <% end %><%= GovukPublishingComponents::Config.component_guide_title %>
   </title>
-  <%= stylesheet_link_tag "govuk_publishing_components/application", media: "all" %>
+  <%= stylesheet_link_tag "govuk_publishing_components/application", media: "screen" %>
   <%= stylesheet_link_tag "govuk_publishing_components/print", media: "print" %>
   <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_stylesheet}" %>
   <%= javascript_include_tag "govuk_publishing_components/application" %>


### PR DESCRIPTION
Update print styles so the task list looks better when printed.

Specifically, add in spacing and lines and number circles to print stylesheet so that printed version more closely (but not exactly) resembles screen version, for consistency.

Also change component guide so main stylesheet is delivered to screen, not 'all' (was causing problems when showing both screen and print stylesheets).

Looks like this in print view:

![screen shot 2018-01-05 at 09 29 42](https://user-images.githubusercontent.com/861310/34603232-082fa8a8-f1fb-11e7-88db-c2c143ebfbb4.png)

Trello card: https://trello.com/c/9CD3dY7r/409-add-task-list-print-styles-to-apps

  