### PR TITLE
Remove unneeded component guide styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Remove unneeded CSS from component guide (PR #126)
 * Add heading element into task list component and change get help link behaviour (PR #113)
 
 # 3.1.0

--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -36,15 +36,6 @@ $border-color: #ccc;
   .component-doc-h2:first-child {
     margin-top: 0;
   }
-
-  p {
-    margin: $gutter-half 0;
-  }
-
-  ol,
-  ul {
-    margin: 0 0 0 $gutter;
-  }
 }
 
 .component-violation {

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_call.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_call.html.erb
@@ -8,5 +8,5 @@
     <pre><code><%= example.highlight_code(code) %></code></pre>
   <% else %>
     <pre><code><%= example.highlight_code("\<%= render \"#{@component_doc.partial_path}\", #{example.pretty_data} %\>") %></code></pre>
-<% end %>
+  <% end %>
 </div>


### PR DESCRIPTION
Styles for p and list tags inside the component-doc class were not needed and causing layout of component examples to break in some circumstances.

These styles were used inside the wrapping element for the opening text and 'How to call this example' and 'How it looks' sections of the component guide, for example on the [preview page](https://government-frontend.herokuapp.com/component-guide/task_list/or_then) and [main component detail page](http://collections.dev.gov.uk/component-guide/task_list).

Example of the problem these styles were causing, this is the task list...

![screen shot 2018-01-05 at 10 28 54](https://user-images.githubusercontent.com/861310/34605520-d9afe228-f203-11e7-8ce7-7bf0ef29c230.png)

Should look like this...

![screen shot 2018-01-05 at 10 29 10](https://user-images.githubusercontent.com/861310/34605531-e0a3c414-f203-11e7-90c4-c6afd67117de.png)

Fixes #106   