### PR TITLE
Bump gem to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# Unreleased
+# 3.2.0
 
 * Remove unneeded CSS from component guide (PR #126)
 * Add heading element into task list component and change get help link behaviour (PR #113)
 * Improve task list print styles (PR #125)
+* Move form components into gem (PR #116)
 
 # 3.1.0
 

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '3.1.0'.freeze
+  VERSION = '3.2.0'.freeze
 end


### PR DESCRIPTION
* Remove unneeded CSS from component guide (PR #126)
* Add heading element into task list component and change get help link behaviour (PR #113)
* Improve task list print styles (PR #125)
* Move form components into gem (PR #116)