### PR TITLE
Fix radio component not including welsh translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix radio component not including welsh translation (Patch)
+
 # 3.2.0
 
 * Remove unneeded CSS from component guide (PR #126)

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1,0 +1,4 @@
+cy:
+  components:
+    radio:
+      or: 'neu'

--- a/spec/components/radio_test_spec.rb
+++ b/spec/components/radio_test_spec.rb
@@ -5,6 +5,10 @@ describe "Radio", type: :view do
     render file: "components/_radio", locals: locals
   end
 
+  before(:each) do
+    I18n.default_locale = :en
+  end
+
   it "does not render anything if no data is passed" do
     assert_empty render_component({})
   end
@@ -163,6 +167,26 @@ describe "Radio", type: :view do
     assert_select ".gem-c-radio:first-child .gem-c-radio__label__text", text: "Use Government Gateway"
     assert_select ".gem-c-radio__block-text", text: "or"
     assert_select ".gem-c-radio:last-child .gem-c-radio__label__text", text: "Use GOV.UK Verify"
+  end
+
+  it "renders radio-group with welsh translated 'or'" do
+    I18n.default_locale = :cy
+
+    render_component(
+      name: "radio-welsh-or",
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        },
+        :or,
+        {
+          value: "govuk-verify",
+          text: "Use GOV.UK Verify"
+        }
+      ]
+    )
+    assert_select ".gem-c-radio__block-text", text: "neu"
   end
 end
 


### PR DESCRIPTION
This was missed when moving this component upstream from `government-frontend`

See https://github.com/alphagov/government-frontend/pull/671#discussion_r159884811