### PR TITLE
Extract the back_link component to govuk_publishing_components

### DIFF
--- a/app/assets/stylesheets/components/_back-link.scss
+++ b/app/assets/stylesheets/components/_back-link.scss
@@ -1,0 +1,33 @@
+@import "helpers/variables";
+
+.gem-c-back-link {
+  position: relative;
+  display: inline-block;
+  margin-top: $gem-spacing-scale-3;
+  margin-bottom: $gem-spacing-scale-3;
+  font-size: 16px;
+  line-height: 1.25;
+
+  text-decoration: none;
+  border-bottom: 1px solid currentColor;
+
+  &:link,
+  &:link:focus,
+  &:visited,
+  &:active {
+    color: currentColor;
+  }
+
+  &:hover {
+    color: $link-colour;
+  }
+
+  &::before {
+    content: "";
+    display: inline-block;
+    margin-right: .3em;
+    border-top: 0.3125em solid transparent;
+    border-right: 0.375em solid currentColor;
+    border-bottom: 0.3125em solid transparent;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -4,6 +4,7 @@
 @import "typography";
 @import "colours";
 
+@import "../components/back-link";
 @import "../components/fieldset";
 @import "../components/label";
 @import "../components/radio";

--- a/app/views/components/_back_link.html.erb
+++ b/app/views/components/_back_link.html.erb
@@ -1,0 +1,6 @@
+<a
+  class="gem-c-back-link"
+  href="<%= href %>"
+>
+  <%= t('components.back_link.back') %>
+</a>

--- a/app/views/components/docs/back_link.yml
+++ b/app/views/components/docs/back_link.yml
@@ -1,0 +1,10 @@
+name: Back link
+description: A link used to help users get back, useful when not using other navigation such as breadcrumbs
+accessibility_criteria: |
+  - has a touch area easy for users to touch
+shared_accessibility_criteria:
+- link
+examples:
+  default:
+    data:
+      href: '#'

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -2,3 +2,5 @@ cy:
   components:
     radio:
       or: 'neu'
+    back_link:
+      back: "Yn ôl"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,3 +23,5 @@ en:
   components:
     radio:
       or: 'or'
+    back_link:
+      back: 'Back'

--- a/spec/components/back_link_spec.rb
+++ b/spec/components/back_link_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe "Back Link", type: :view do
+  def render_component(locals)
+    render file: "components/_back_link", locals: locals
+  end
+
+  it "fails to render a back link when no href is given" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  it "renders a back link correctly" do
+    render_component(href: '/back-me')
+    assert_select ".gem-c-back-link[href=\"/back-me\"]", text: "Back"
+  end
+
+  it "can render in welsh" do
+    I18n.with_locale(:cy) { render_component(href: '/back-me') }
+    assert_select ".gem-c-back-link[href=\"/back-me\"]", text: "Yn ôl"
+  end
+end

--- a/spec/components/radio_test_spec.rb
+++ b/spec/components/radio_test_spec.rb
@@ -5,10 +5,6 @@ describe "Radio", type: :view do
     render file: "components/_radio", locals: locals
   end
 
-  before(:each) do
-    I18n.default_locale = :en
-  end
-
   it "does not render anything if no data is passed" do
     assert_empty render_component({})
   end
@@ -170,22 +166,23 @@ describe "Radio", type: :view do
   end
 
   it "renders radio-group with welsh translated 'or'" do
-    I18n.default_locale = :cy
+    I18n.with_locale(:cy) do
+      render_component(
+        name: "radio-welsh-or",
+        items: [
+          {
+            value: "government-gateway",
+            text: "Use Government Gateway"
+          },
+          :or,
+          {
+            value: "govuk-verify",
+            text: "Use GOV.UK Verify"
+          }
+        ]
+      )
+    end
 
-    render_component(
-      name: "radio-welsh-or",
-      items: [
-        {
-          value: "government-gateway",
-          text: "Use Government Gateway"
-        },
-        :or,
-        {
-          value: "govuk-verify",
-          text: "Use GOV.UK Verify"
-        }
-      ]
-    )
     assert_select ".gem-c-radio__block-text", text: "neu"
   end
 end


### PR DESCRIPTION
https://trello.com/c/HSre7K10/453-style-the-mvp-email-collection-page-needed-by-jan

Add Back Link component

Moved from government-frontend for use in email-alert-frontend

Also renames the namespace to `gem`

Originally implemented in alphagov/government-frontend#568