### PR TITLE
Add startup script to match frontend apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,32 +40,6 @@ And then execute:
 $ bundle
 ```
 
-### Running as a standalone app
-
-If you want to work on this gem directly, without having to add it to another
-application, you can run it in the development vm:
-
-```
-$ cd /var/govuk/govuk_publishing_components
-$ bundle
-
-$ cd /var/govuk/govuk-puppet/development-vm
-$ bowl publishing-components
-```
-
-Then visit [publishing-components.dev.gov.uk/component-guide](http://publishing-components.dev.gov.uk/component-guide).
-
-If you don't want to run it in the development vm, you can start the app with:
-
-```
-$ cd /var/govuk/govuk_publishing_components
-$ bundle
-
-$ PLEK_SERVICE_STATIC_URI=assets.publishing.service.gov.uk bundle exec foreman start
-```
-
-Then visit [localhost:5000/component-guide](http://localhost:5000/component-guide).
-
 #### Integration with Heroku
 
 To make the best use of the component guide we use Heroku to serve the current `master` build and whenever a [pull request is added](https://devcenter.heroku.com/articles/github-integration-review-apps)
@@ -120,6 +94,48 @@ if defined?(GovukPublishingComponents)
   end
 end
 ```
+
+### Running the gem as a standalone app
+
+If you want to work on this gem directly, without having to add it to another
+application, you can run it in the development vm:
+
+```
+./startup.sh
+```
+
+The app should start on http://localhost:3212 or http://publishing-components.dev.gov.uk/component-guide on GOV.UK development machines.
+
+```
+./startup.sh --live
+```
+
+This will run the app and point it at the production `static` instance.
+
+#### Running with bowl on the VM
+
+```
+$ cd /var/govuk/govuk_publishing_components
+$ bundle
+
+$ cd /var/govuk/govuk-puppet/development-vm
+$ bowl publishing-components
+```
+
+Then visit [publishing-components.dev.gov.uk/component-guide](http://publishing-components.dev.gov.uk/component-guide).
+
+#### Running locally
+
+If you don't want to run it in the development vm, you can start the app with:
+
+```
+$ cd /var/govuk/govuk_publishing_components
+$ bundle
+
+$ PLEK_SERVICE_STATIC_URI=assets.publishing.service.gov.uk bundle exec foreman start
+```
+
+Then visit [localhost:5000/component-guide](http://localhost:5000/component-guide).
 
 ### Test the component guide
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+bundle install
+
+if [[ $1 == "--live" ]] ; then
+  GOVUK_APP_DOMAIN=www.gov.uk \
+  GOVUK_WEBSITE_ROOT=https://www.gov.uk \
+  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
+  bundle exec rackup spec/dummy/config.ru --host 0.0.0.0 -p 3212
+else
+  bundle exec rackup spec/dummy/config.ru --host 0.0.0.0 -p 3212
+fi


### PR DESCRIPTION
Allow app to be started from VM like other apps:
`./startup.sh` or `./startup.sh —live`

Dummy app will be available at:
http://dev.gov.uk:3212/component-guide
http://publishing-components.dev.gov.uk/component-guide
  