### PR TITLE
Extract the error_summary component from government-frontend

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/error-summary.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/error-summary.js
@@ -1,0 +1,20 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (global, GOVUK) {
+  'use strict'
+
+  var $ = global.jQuery
+
+  GOVUK.Modules.ErrorSummary = function () {
+    this.start = function (element) {
+      element.focus()
+      // Focus on inputs with errors, so they're easier to discover
+      element.on('click', '.js-error-summary__link', function (event) {
+        event.preventDefault()
+        var href = $(this).attr('href')
+        $(href).focus()
+      })
+    }
+  }
+})(window, window.GOVUK)

--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -5,6 +5,7 @@
 @import "colours";
 
 @import "components/back-link";
+@import "components/error-summary";
 @import "components/fieldset";
 @import "components/label";
 @import "components/radio";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-summary.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-summary.scss
@@ -1,0 +1,73 @@
+.gem-c-error-summary {
+  color: $gem-text-colour;
+  padding: $gem-spacing-scale-3;
+
+  border: $gem-border-width-mobile solid $gem-error-colour;
+
+  @include media(tablet) {
+
+    padding: $gem-spacing-scale-4;
+
+    border: $gem-border-width-tablet solid $gem-error-colour;
+  }
+}
+
+.gem-c-error-summary:focus {
+  outline: $gem-focus-width solid $gem-focus-colour;
+}
+
+.gem-c-error-summary__title {
+  margin-top: 0;
+  margin-bottom: $gem-spacing-scale-3;
+
+  @include media(tablet) {
+    margin-bottom: $gem-spacing-scale-4;
+  }
+
+  @include bold-24;
+}
+
+.gem-c-error-summary__body {
+  @include core-19;
+}
+
+.gem-c-error-summary__text {
+  margin-top: 0;
+  margin-bottom: $gem-spacing-scale-3;
+
+  @include media(tablet) {
+    margin-bottom: $gem-spacing-scale-4;
+  }
+}
+
+.gem-c-error-summary__list {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.gem-c-error-summary__list__item {
+  margin-bottom: $gem-spacing-scale-2;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.gem-c-error-summary__link {
+  &:link,
+  &:link:focus,
+  &:focus,
+  &:visited,
+  &:hover,
+  &:active {
+    color: $gem-error-colour;
+    font-weight: bold;
+    text-decoration: underline;
+  }
+
+  &:hover {
+    color: darken($gem-error-colour, 10%);
+  }
+}

--- a/app/views/govuk_publishing_components/components/_error_summary.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_summary.html.erb
@@ -1,0 +1,33 @@
+<%
+  description ||= false
+  items ||= []
+  title_id ||= "error-summary-title-#{SecureRandom.hex(4)}"
+%>
+<div
+  class="gem-c-error-summary"
+  data-module="error-summary"
+  aria-labelledby="<%= title_id %>"
+  role="alert"
+  tabindex="-1"
+>
+  <h2 class="gem-c-error-summary__title" id="<%= title_id %>">
+    <%= title %>
+  </h2>
+  <div class="gem-c-error-summary__body">
+    <% if description %>
+      <p class="gem-c-error-summary__text"><%= description %></p>
+    <% end %>
+    <% if items.present? %>
+      <ul class="gem-c-error-summary__list">
+        <% items.each_with_index do |item, index| %>
+          <li class="gem-c-error-summary__list__item">
+            <a
+              class="js-error-summary__link gem-c-error-summary__link"
+              href="<%= item[:href] %>"
+            ><%= item[:text] %></a>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+</div>

--- a/app/views/govuk_publishing_components/components/docs/error_summary.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_summary.yml
@@ -1,0 +1,26 @@
+name: Form error summary
+description: Used at the top of the page, to summarise validation errors.
+accessibility_criteria: |
+  - should be focused on page load, to ensure this error is noticed by assistive tech
+  - list of errors should be clickable and focus the inputs with errors
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      title: Message to alert the user to a problem goes here
+      description: Optional description of the errors and how to correct them
+      items:
+      - text: Descriptive link to the question with an error
+        href: '#example-error-1'
+  with_many_errors:
+    data:
+      title: Message to alert the user to a problem goes here
+      description: Optional description of the errors and how to correct them
+      items:
+      - text: Descriptive link to the question with an error 1
+        href: '#example-error-1'
+      - text: Descriptive link to the question with an error 2
+        href: '#example-error-2'
+      - text: Descriptive link to the question with an error 3
+        href: '#example-error-3'

--- a/spec/components/error_summary_spec.rb
+++ b/spec/components/error_summary_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+describe "Error summary", type: :view do
+  def render_component(locals)
+    render file: "govuk_publishing_components/components/_error_summary", locals: locals
+  end
+
+  it "fails to render when no data is given" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  it "renders an error summary with title and aria-labelledby set correctly" do
+    render_component(
+      title: 'Message to alert the user to a problem goes here'
+    )
+
+    aria_labelledby_id = ''
+    assert_select(".gem-c-error-summary") do |element|
+      aria_labelledby_id = element.css('.gem-c-error-summary').first.attributes["aria-labelledby"].value
+    end
+
+    assert_select ".gem-c-error-summary__title[id='#{aria_labelledby_id}']", text: 'Message to alert the user to a problem goes here'
+    assert_select ".gem-c-error-summary__text", count: 0
+    assert_select ".gem-c-error-summary__list", count: 0
+  end
+
+  it "renders an error summary with items" do
+    render_component(
+      title: 'Message to alert the user to a problem goes here',
+      description: 'Optional description of the errors and how to correct them',
+      items: [
+        {
+          text: 'Descriptive link to the question with an error',
+          href: '#example-error-1'
+        }
+      ]
+    )
+    assert_select ".gem-c-error-summary__title", text: 'Message to alert the user to a problem goes here'
+    assert_select ".gem-c-error-summary__text", text: 'Optional description of the errors and how to correct them'
+    assert_select(
+      "ul li a.gem-c-error-summary__link:first-of-type[href='#example-error-1']",
+      text: 'Descriptive link to the question with an error'
+    )
+  end
+
+  it "renders an error summary with multiple links" do
+    render_component(
+      title: 'Message to alert the user to a problem goes here',
+      description: 'Optional description of the errors and how to correct them',
+      items: [
+        {
+          text: 'Descriptive link to the question with an error 1',
+          href: '#example-error-1'
+        },
+        {
+          text: 'Descriptive link to the question with an error 2',
+          href: '#example-error-2'
+        },
+        {
+          text: 'Descriptive link to the question with an error 3',
+          href: '#example-error-3'
+        }
+      ]
+    )
+
+    assert_select ".gem-c-error-summary__title", text: 'Message to alert the user to a problem goes here'
+    assert_select ".gem-c-error-summary__text", text: 'Optional description of the errors and how to correct them'
+
+    assert_select(
+      "ul li a.gem-c-error-summary__link:first-of-type[href='#example-error-1']",
+      text: 'Descriptive link to the question with an error 1'
+    )
+    assert_select(
+      "ul li a.gem-c-error-summary__link:nth-of-type(1)[href='#example-error-2']",
+      text: 'Descriptive link to the question with an error 2'
+    )
+    assert_select(
+      "ul li a.gem-c-error-summary__link:last-of-type[href='#example-error-3']",
+      text: 'Descriptive link to the question with an error 3'
+    )
+  end
+end

--- a/spec/javascripts/components/error-summary-spec.js
+++ b/spec/javascripts/components/error-summary-spec.js
@@ -1,0 +1,72 @@
+/* global describe afterEach beforeEach it expect */
+
+var $ = window.jQuery
+
+function isFocused (element) {
+  return $(element)[0] === $(element)[0].ownerDocument.activeElement
+}
+
+describe('An error summary component', function () {
+  'use strict'
+
+  var GOVUK = window.GOVUK
+  var module
+  var element
+
+  beforeEach(function () {
+    element = $(
+      '<div ' +
+        'class="gem-c-error-summary" ' +
+        'data-module="error-summary" ' +
+        'aria-labelledby="error-summary-title-id" ' +
+        'role="alert" ' +
+        'tabindex="-1" ' +
+      '> ' +
+        '<h2 class="gem-c-error-summary__title" id="error-summary-title-id"> ' +
+          'Message to alert the user to a problem goes here ' +
+        '</h2> ' +
+        '<div class="gem-c-error-summary__body"> ' +
+          '<p class="gem-c-error-summary__text"> ' +
+            'Optional description of the errors and how to correct them ' +
+          '</p> ' +
+          '<ul class="gem-c-error-summary__list"> ' +
+            '<li class="gem-c-error-summary__list__item"> ' +
+              '<a ' +
+                'class="js-error-summary__link gem-c-error-summary__link" ' +
+                'href="#example-error-1" ' +
+              '>Descriptive link to the question with an error</a> ' +
+            '</li> ' +
+          '</ul> ' +
+        '</div> ' +
+      '</div>'
+    )
+    $(document.body).append(element)
+    document.body.focus()
+    module = new GOVUK.Modules.ErrorSummary()
+  })
+
+  afterEach(function () {
+    // clean up the test element after each test
+    element.remove()
+    element = undefined
+  })
+
+  it('is focused on load', function () {
+    module.start(element)
+
+    expect(isFocused(element)).toBe(true)
+  })
+
+  it('focuses inputs with no location change when clicking error links', function () {
+    var originalHref = window.location.href
+    var inputElement = $('<input type="text" id="example-error-1" name="example-error-1" />')
+    $(document.body).append(inputElement)
+
+    module.start(element)
+
+    element.find('.js-error-summary__link').trigger('click')
+
+    expect(isFocused(inputElement)).toBe(true)
+    expect(originalHref).toBe(window.location.href)
+  })
+})


### PR DESCRIPTION
We’d like to use this in email-alert-frontend

https://trello.com/c/HSre7K10/453-style-the-mvp-email-collection-page-needed-by-jan

Screenshot demonstrating the focus on page load:

![screen shot 2018-01-10 at 10 45 50](https://user-images.githubusercontent.com/892251/34769480-d64bc872-f5f5-11e7-8a32-1b84a02f5274.png)
