### PR TITLE
Release version 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.0
+
+* Move error summary component into gem (PR #138)
+
 # 4.0.0
 
 * Namespace hosted components with `govuk_publishing_components` (PR #136)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '4.0.0'.freeze
+  VERSION = '4.1.0'.freeze
 end


### PR DESCRIPTION
https://trello.com/c/HSre7K10/453-style-the-mvp-email-collection-page-needed-by-jan

I'd like to update government-frontend to use the latest version of this gem. It makes sense to release the error summary changes before I do this so I can make all the updates in one go.