### PR TITLE
[DO NOT MERGE] Fix task list related component namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix task list related namespace (PR #141)
+
 # 4.1.0
 
 * Move error summary component into gem (PR #138)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_task-list-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_task-list-related.scss
@@ -1,15 +1,15 @@
-.pub-c-task-list-related {
+.gem-c-task-list-related {
   margin-bottom: $gutter-half;
 }
 
-.pub-c-task-list-related__heading,
-.pub-c-task-list-related__links {
+.gem-c-task-list-related__heading,
+.gem-c-task-list-related__links {
   @include bold-19;
   margin: 0;
   padding: 0;
 }
 
-.pub-c-task-list-related__pretitle {
+.gem-c-task-list-related__pretitle {
   display: block;
   margin-bottom: $gutter-half;
 
@@ -18,11 +18,11 @@
   }
 }
 
-.pub-c-task-list-related__links {
+.gem-c-task-list-related__links {
   list-style: none;
 }
 
-.pub-c-task-list-related__link-item {
+.gem-c-task-list-related__link-item {
   margin-top: $gutter-half;
 
   @include media(tablet) {
@@ -30,7 +30,7 @@
   }
 }
 
-.pub-c-task-list-related__link {
+.gem-c-task-list-related__link {
   text-decoration: none;
 
   &:hover {

--- a/app/views/govuk_publishing_components/components/_task_list_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_task_list_related.html.erb
@@ -3,12 +3,12 @@
   pretitle ||= t("govuk_component.task_list_related.part_of", default: "Part of")
 %>
 <% if links %>
-  <div class="pub-c-task-list-related" data-module="track-click">
-    <h2 class="pub-c-task-list-related__heading">
-      <span class="pub-c-task-list-related__pretitle"><%= pretitle %></span>
+  <div class="gem-c-task-list-related" data-module="track-click">
+    <h2 class="gem-c-task-list-related__heading">
+      <span class="gem-c-task-list-related__pretitle"><%= pretitle %></span>
       <% if links.length == 1 %>
           <a href="<%= links[0][:href] %>"
-            class="pub-c-task-list-related__link"
+            class="gem-c-task-list-related__link"
             data-track-category="tasklistPartOfClicked"
             data-track-action="<%= pretitle %>"
             data-track-label="<%= links[0][:href] %>"
@@ -19,11 +19,11 @@
         </h2>
       <% else %>
         </h2>
-        <ul class="pub-c-task-list-related__links">
+        <ul class="gem-c-task-list-related__links">
           <% links.each do |link| %>
-            <li class="pub-c-task-list-related__link-item">
+            <li class="gem-c-task-list-related__link-item">
               <a href="<%= link[:href] %>"
-                class="pub-c-task-list-related__link"
+                class="gem-c-task-list-related__link"
                 data-track-category="tasklistPartOfClicked"
                 data-track-action="<%= pretitle %>"
                 data-track-label="<%= link[:href] %>"

--- a/spec/components/task_list_related_spec.rb
+++ b/spec/components/task_list_related_spec.rb
@@ -34,9 +34,9 @@ describe "Task List Related", type: :view do
   it "displays one link inside a heading" do
     render_component(links: one_link)
 
-    this_link = ".pub-c-task-list-related .pub-c-task-list-related__heading .pub-c-task-list-related__link"
+    this_link = ".gem-c-task-list-related .gem-c-task-list-related__heading .gem-c-task-list-related__link"
 
-    assert_select ".pub-c-task-list-related .pub-c-task-list-related__heading .pub-c-task-list-related__pretitle", text: 'Part of'
+    assert_select ".gem-c-task-list-related .gem-c-task-list-related__heading .gem-c-task-list-related__pretitle", text: 'Part of'
     assert_select this_link + "[href='/link1']", text: 'Link 1'
     assert_select this_link + "[data-track-category='tasklistPartOfClicked']"
     assert_select this_link + "[data-track-action='Part of']"
@@ -48,10 +48,10 @@ describe "Task List Related", type: :view do
   it "displays more than one link in a list" do
     render_component(links: two_links)
 
-    this_link = ".pub-c-task-list-related .pub-c-task-list-related__links .pub-c-task-list-related__link[href='/link2']"
+    this_link = ".gem-c-task-list-related .gem-c-task-list-related__links .gem-c-task-list-related__link[href='/link2']"
 
-    assert_select ".pub-c-task-list-related .pub-c-task-list-related__heading .pub-c-task-list-related__pretitle", text: 'Part of'
-    assert_select ".pub-c-task-list-related .pub-c-task-list-related__links .pub-c-task-list-related__link[href='/link1']", text: 'Link 1'
+    assert_select ".gem-c-task-list-related .gem-c-task-list-related__heading .gem-c-task-list-related__pretitle", text: 'Part of'
+    assert_select ".gem-c-task-list-related .gem-c-task-list-related__links .gem-c-task-list-related__link[href='/link1']", text: 'Link 1'
     assert_select this_link, text: 'Link 2'
     assert_select this_link + "[data-track-category='tasklistPartOfClicked']"
     assert_select this_link + "[data-track-action='Part of']"
@@ -63,7 +63,7 @@ describe "Task List Related", type: :view do
   it "shows alternative heading text" do
     render_component(links: one_link, pretitle: 'Moo')
 
-    assert_select ".pub-c-task-list-related__pretitle", text: 'Moo'
-    assert_select ".pub-c-task-list-related__link[data-track-action='Moo']"
+    assert_select ".gem-c-task-list-related__pretitle", text: 'Moo'
+    assert_select ".gem-c-task-list-related__link[data-track-action='Moo']"
   end
 end


### PR DESCRIPTION
Task list related links component had the old pub-c namespace for CSS, not the new gem namespace, gem-c. Whoops.
