### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ https://government-frontend.herokuapp.com/component-guide
 
 The guide includes your application’s `application.scss` and `application.js` files by default. This is [configurable](#configuration).
 
+You are encouraged to set up [Heroku review apps](https://docs.publishing.service.gov.uk/manual/review-apps.html) for your application, so that any changes to local components can be reviewed by looking at the component guide.
+
 ### Install gem
 
-Add this line to your application's Gemfile in the [development and test groups](http://bundler.io/v1.12/groups.html#grouping-your-dependencies):
+Add this line to your application's Gemfile:
 
 ```ruby
 gem 'govuk_publishing_components'
@@ -54,39 +56,13 @@ And then execute:
 $ bundle
 ```
 
-#### Integration with Heroku
-
-To make the best use of the component guide we use Heroku to serve the current `master` build and whenever a [pull request is added](https://devcenter.heroku.com/articles/github-integration-review-apps)
-
-When an app is deployed to Heroku it will be in `production` mode, so only gems that are in the main group will be installed and made available.
-To ensure that we only load the guide on Heroku and not when deployed to _production_ we need to have the gem included in the main bundle group in the Gemfile.
-For this use case we need `require: false` so that it's not loaded in _production_ but then we can manually `require` the gem in our `application.rb` based on the more complex environmental logic that we've specified.
-
-First move the gem outside of the `development`, `test` groups and set require to false. ([example](https://github.com/alphagov/government-frontend/blob/5110d3d33f7a6b63f218b889a5afec90e6df810f/Gemfile#L11)):
-
-```ruby
-# Gemfile
-gem 'govuk_publishing_components', require: false
-```
-
-Now we can manually require the gem ([example](https://github.com/alphagov/government-frontend/blob/5110d3d33f7a6b63f218b889a5afec90e6df810f/config/application.rb#L14)):
-
-```ruby
-# config/application.rb
-if !Rails.env.production? || ENV['HEROKU_APP_NAME'].present?
-  require 'govuk_publishing_components'
-end
-```
-
 ### Mount the component guide
 
 Mount the component guide in your application:
 
 ```ruby
 # config/routes.rb
-unless Rails.env.production?
-  mount GovukPublishingComponents::Engine, at: "/component-guide" if defined?(GovukPublishingComponents)
-end
+mount GovukPublishingComponents::Engine, at: "/component-guide"
 ```
 
 If your application was government-frontend the component guide would be at:
@@ -98,14 +74,12 @@ Use a config block in an initializer:
 
 ```ruby
 # config/initializers/govuk_publishing_components.rb
-if defined?(GovukPublishingComponents)
-  GovukPublishingComponents.configure do |c|
-    c.component_guide_title = "My component guide"
+GovukPublishingComponents.configure do |c|
+  c.component_guide_title = "My component guide"
 
-    c.application_stylesheet = "custom_stylesheet" # Defaults to "application"
-    c.application_print_stylesheet = "print" # Not included by default
-    c.application_javascript = "custom_javascript" # Defaults to "application"
-  end
+  c.application_stylesheet = "custom_stylesheet" # Defaults to "application"
+  c.application_print_stylesheet = "print" # Not included by default
+  c.application_javascript = "custom_javascript" # Defaults to "application"
 end
 ```
 


### PR DESCRIPTION
The installation of this gem has changed slightly since we're shipping components with it, since it'll always be loaded instead of just in development and on Heroku.

Closes https://github.com/alphagov/govuk_publishing_components/issues/145