### PR TITLE
Port input field component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/application.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/application.scss
@@ -7,6 +7,7 @@
 @import "components/back-link";
 @import "components/error-summary";
 @import "components/fieldset";
+@import "components/input";
 @import "components/label";
 @import "components/radio";
 @import "components/task-list";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -1,0 +1,61 @@
+// Forked from GOV.UK Frontend, namespace changed to ensure no conflicts.
+
+$app-spacing-scale-0: 0;
+$app-spacing-scale-1: 5px;
+$app-spacing-scale-2: 10px;
+$app-spacing-scale-3: 15px;
+$app-spacing-scale-4: 20px;
+$app-spacing-scale-5: 30px;
+$app-spacing-scale-6: 40px;
+$app-spacing-scale-7: 50px;
+$app-spacing-scale-8: 60px;
+
+// Border widths
+$app-border-width-form-element: 2px;
+
+// Focus
+$app-focus-width: 3px;
+$app-focus-colour: $focus-colour;
+
+$app-error-colour: $red;
+$app-border-width-error: 4px;
+
+.gem-c-input {
+  @include core-19;
+
+  box-sizing: border-box;
+  width: 100%;
+  height: 2.10526em;
+  margin-top: 0;
+  margin-bottom: 20px;
+
+  padding: $app-spacing-scale-1;
+  // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
+  // as background-color and color need to always be set together, color should not be set either
+  border: $app-border-width-form-element solid;
+  border-radius: 0;
+
+  // Disable inner shadow and remove rounded corners
+  appearance: none;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-c-input {
+    margin-bottom: 30px;
+  }
+}
+
+.gem-c-input:focus {
+  outline: $app-focus-width solid $app-focus-colour;
+}
+
+.gem-c-input--error {
+  border: $app-border-width-error solid $app-error-colour;
+}
+
+// Replace this with the error message component.
+.gem-c-input__label-error {
+  font-weight: bold;
+  color: $app-error-colour;
+  padding-top: 4px;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -1,25 +1,3 @@
-// Forked from GOV.UK Frontend, namespace changed to ensure no conflicts.
-
-$app-spacing-scale-0: 0;
-$app-spacing-scale-1: 5px;
-$app-spacing-scale-2: 10px;
-$app-spacing-scale-3: 15px;
-$app-spacing-scale-4: 20px;
-$app-spacing-scale-5: 30px;
-$app-spacing-scale-6: 40px;
-$app-spacing-scale-7: 50px;
-$app-spacing-scale-8: 60px;
-
-// Border widths
-$app-border-width-form-element: 2px;
-
-// Focus
-$app-focus-width: 3px;
-$app-focus-colour: $focus-colour;
-
-$app-error-colour: $red;
-$app-border-width-error: 4px;
-
 .gem-c-input {
   @include core-19;
 
@@ -29,10 +7,10 @@ $app-border-width-error: 4px;
   margin-top: 0;
   margin-bottom: 20px;
 
-  padding: $app-spacing-scale-1;
+  padding: $gem-spacing-scale-1;
   // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
   // as background-color and color need to always be set together, color should not be set either
-  border: $app-border-width-form-element solid;
+  border: $gem-border-width-form-element solid;
   border-radius: 0;
 
   // Disable inner shadow and remove rounded corners
@@ -46,16 +24,16 @@ $app-border-width-error: 4px;
 }
 
 .gem-c-input:focus {
-  outline: $app-focus-width solid $app-focus-colour;
+  outline: $gem-focus-width solid $gem-focus-colour;
 }
 
 .gem-c-input--error {
-  border: $app-border-width-error solid $app-error-colour;
+  border: $gem-border-width-error solid $gem-error-colour;
 }
 
 // Replace this with the error message component.
 .gem-c-input__label-error {
   font-weight: bold;
-  color: $app-error-colour;
+  color: $gem-error-colour;
   padding-top: 4px;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_variables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_variables.scss
@@ -17,6 +17,7 @@ $gem-secondary-text-colour: $grey-1;
 $gem-border-width-mobile: 4px;
 $gem-border-width-tablet: 5px;
 $gem-border-width-form-element: 2px;
+$gem-border-width-error: 4px;
 
 // Focus
 $gem-focus-width: 3px;

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -1,0 +1,31 @@
+<%
+  id ||= "input-#{SecureRandom.hex(4)}"
+  hint_id ||= "hint-#{SecureRandom.hex(4)}"
+  value ||= false
+  error_message ||= false
+  label ||= {}
+%>
+
+<%= render "govuk_publishing_components/components/label", {
+  text: label[:text],
+  html_for: id,
+  hint_text: error_message,
+  hint_text_classes: "gem-c-input__label-error",
+  hint_id: hint_id,
+  bold: error_message ? true : false,
+} %>
+
+<input
+  class="gem-c-input <%= "gem-c-input--error" if error_message %>"
+  id="<%= id %>"
+  name="<%= name %>"
+  type="text"
+
+  <% if error_message %>
+    aria-describedby="<%= hint_id %>"
+  <% end %>
+
+  <% if value %>
+    value="<%= value %>"
+  <% end %>
+>

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -1,0 +1,22 @@
+name: Form input
+description: A single-line text field.
+body: |
+  [Forked from GOV.UK Frontend](https://govuk-frontend-review.herokuapp.com/components/input)
+accessibility_criteria: |
+  Markdown listing what this component must do to be accessible. For example:
+
+  The link must:
+
+  * be keyboard focusable
+examples:
+  default:
+    data:
+      label:
+        text: "What is your email address?"
+      name: "address"
+  with_error:
+    data:
+      label:
+        text: "What is your email address?"
+      name: "address"
+      error_message: "Email address not recognised"

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+describe "Input", type: :view do
+  def render_component(locals)
+    render file: "govuk_publishing_components/components/_input", locals: locals
+  end
+
+  it "fails to render when no data is given" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  it "renders text input with name and label text" do
+    render_component(
+      label: { text: "What is your email address?" },
+      name: "email-address",
+    )
+
+    assert_select ".gem-c-input[type='text']"
+    assert_select ".gem-c-input[name='email-address']"
+
+    assert_select ".gem-c-label", text: "What is your email address?"
+  end
+
+  it "sets the 'for' on the label to the input id" do
+    render_component(name: "email-address")
+
+    input = css_select(".gem-c-input")
+    input_id = input.attr("id").text
+
+    assert_select ".gem-c-label__text[for='#{input_id}']"
+  end
+
+  it "sets the value when provided" do
+    render_component(
+      name: "email-address",
+      value: "example@example.com",
+    )
+
+    assert_select ".gem-c-input[value='example@example.com']"
+  end
+
+  context "when an error_message is provided" do
+    before do
+      render_component(
+        name: "email-address",
+        error_message: "Please enter a valid email address",
+      )
+    end
+
+    it "renders the error message as the label's hint" do
+      assert_select ".gem-c-label__hint", text: "Please enter a valid email address"
+    end
+
+    it "makes the label bold" do
+      assert_select ".gem-c-label--bold"
+    end
+
+    it "sets the 'aria-describedby' on the input to the hint id" do
+      hint = css_select(".gem-c-label__hint")
+      hint_id = hint.attr("id").text
+
+      assert_select ".gem-c-input[aria-describedby='#{hint_id}']"
+    end
+  end
+
+  context "when an error_message is not provided" do
+    before { render_component(name: "email-address") }
+
+    it "does not render the label's hint" do
+      assert_select ".gem-c-label__hint", count: 0
+    end
+
+    it "does not make the label bold" do
+      assert_select ".gem-c-label--bold", count: 0
+    end
+
+    it "does not set the 'aria-describedby' on the input" do
+      input = css_select(".gem-c-input")
+      expect(input.attr("aria-describedby")).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This imports the `input` component from [email-alert-frontend](https://github.com/alphagov/email-alert-frontend). We intend to use this in the new survey component, which has a number of forms (https://github.com/alphagov/govuk_publishing_components/pull/151).

The code is unchanged, except for changing the class names from `pub-c-*` to `gem-c-*`.

Component preview:

👉 https://govuk-publishing-compon-pr-152.herokuapp.com/component-guide/input

https://trello.com/c/oRLXhaTU