### PR TITLE
Make sure we bundle development gems too on Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,6 +5,9 @@
     "GOVUK_APP_DOMAIN": {
       "value": "www.gov.uk"
     },
+    "BUNDLE_WITHOUT": {
+      "value": "test"
+    },
     "PLEK_SERVICE_STATIC_URI": {
       "value": "assets.digital.cabinet-office.gov.uk"
     }


### PR DESCRIPTION
Heroku needs uglifier, which is a development dependency. Setting this environment variable will make Heroku install the development dependencies too. I got https://github.com/alphagov/govuk_publishing_components/pull/149 working by doing this manually, but having it in app.json will make it work for Review apps too.