### PR TITLE
Remove groups from component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Remove task list groups (PR #154), breaking change
+
 * To include the CSS for all components in the gem, you can now do:
 
 ```css

--- a/app/assets/javascripts/govuk_publishing_components/components/task-list.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/task-list.js
@@ -42,7 +42,6 @@
 
       rememberShownStep = !!$element.filter('[data-remember]').length;
       taskListSize = $element.hasClass('gem-c-task-list--large') ? 'Big' : 'Small';
-      var $groups = $element.find('.gem-c-task-list__group');
       var $steps = $element.find('.js-step');
       var $stepHeaders = $element.find('.js-toggle-panel');
       var totalSteps = $element.find('.js-panel').length;
@@ -170,7 +169,7 @@
           var stepView = new StepView($(this).closest('.js-step'));
           stepView.toggle();
 
-          var toggleClick = new StepToggleClick(event, stepView, $steps, tasklistTracker, $groups);
+          var toggleClick = new StepToggleClick(event, stepView, $steps, tasklistTracker);
           toggleClick.track();
 
           setShowHideAllText();
@@ -224,11 +223,11 @@
           removeActiveStateFromAllButCurrent($activeLinks, lastClicked);
           removeFromSessionStorage(sessionStoreLink);
         } else {
-          var activeLinkInActiveGroup = $element.find('.gem-c-task-list__group--active').find('.' + activeLinkClass).first();
+          var activeLinkInActiveStep = $element.find('.gem-c-task-list__step--active').find('.' + activeLinkClass).first();
 
-          if (activeLinkInActiveGroup.length) {
+          if (activeLinkInActiveStep.length) {
             $activeLinks.removeClass(activeLinkClass);
-            activeLinkInActiveGroup.addClass(activeLinkClass);
+            activeLinkInActiveStep.addClass(activeLinkClass);
           } else {
             $activeLinks.slice(1).removeClass(activeLinkClass);
           }
@@ -237,7 +236,7 @@
 
       function removeActiveStateFromAllButCurrent($links, current) {
         $links.each(function() {
-          if ($(this).find('.js-link').data('position') !== current) {
+          if ($(this).find('.js-link').data('position').toString() !== current.toString()) {
             $(this).removeClass(activeLinkClass);
           }
         });
@@ -377,11 +376,9 @@
       history.replaceState({}, '', newLocation);
     }
 
-    function StepToggleClick(event, stepView, $steps, tasklistTracker, $groups) {
+    function StepToggleClick(event, stepView, $steps, tasklistTracker) {
       this.track = trackClick;
       var $target = $(event.target);
-      var $thisGroup = stepView.element.closest('.gem-c-task-list__group');
-      var $thisGroupSteps = $thisGroup.find('.gem-c-task-list__step');
 
       function trackClick() {
         var tracking_options = {label: trackingLabel(), dimension28: stepView.numberOfContentItems().toString()}
@@ -404,7 +401,7 @@
         return $target.closest('.js-toggle-panel').attr('data-position') + ' - ' + stepView.title + ' - ' + locateClickElement() + ": " + taskListSize;
       }
 
-      // returns index of the clicked step in the overall number of accordion steps, regardless of how many per group
+      // returns index of the clicked step in the overall number of steps
       function stepIndex() {
         return $steps.index(stepView.element) + 1;
       }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_task-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_task-list.scss
@@ -19,12 +19,12 @@ $top-border: solid 2px $grey-3;
 }
 
 @mixin task-list-line-position {
-  left: -($gutter + $gutter-half);
+  left: 0;
   margin-left: ($number-circle-size / 2) - ($stroke-width / 2);
 }
 
 @mixin task-list-line-position-large {
-  left: -($gutter * 2);
+  left: 0;
   margin-left: ($number-circle-size-large / 2) - ($stroke-width-large / 2);
   border-width: $stroke-width-large;
 }
@@ -75,79 +75,15 @@ $top-border: solid 2px $grey-3;
   }
 }
 
-.gem-c-task-list__groups {
+.gem-c-task-list__steps {
   padding: 0;
   margin: 0;
 }
 
-.gem-c-task-list__group {
+.gem-c-task-list__step {
   position: relative;
   padding-left: $gutter + $gutter-half;
   list-style: none;
-
-  .gem-c-task-list--large & {
-    @include media(tablet) {
-      padding-left: $gutter * 2;
-    }
-  }
-}
-
-.gem-c-task-list__group:last-child {
-  // little dash at the bottom of the line
-  &:before {
-    content: "";
-    position: absolute;
-    z-index: 6;
-    bottom: 0;
-    left: 0;
-    margin-left: $number-circle-size / 4;
-    width: $number-circle-size / 2;
-    height: 0;
-    border-bottom: solid $stroke-width $grey-2;
-  }
-
-  .gem-c-task-list__step:last-child {
-    &:after {
-      // scss-lint:disable DuplicateProperty
-      height: -webkit-calc(100% - #{$gutter-half}); // fallback
-      height: calc(100% - #{$gutter-half});
-      // scss-lint:enable DuplicateProperty
-    }
-
-    .gem-c-task-list__help:after {
-      height: 100%;
-    }
-  }
-
-  .gem-c-task-list--large & {
-    @include media(tablet) {
-      &:before {
-        margin-left: $number-circle-size-large / 4;
-        width: $number-circle-size-large / 2;
-        border-width: $stroke-width-large;
-      }
-
-      .gem-c-task-list__step:last-child {
-        &:after {
-          height: calc(100% - #{$gutter});
-        }
-      }
-    }
-  }
-}
-
-.gem-c-task-list__group--active {
-  &:last-child:before,
-  .gem-c-task-list__circle--number,
-  .gem-c-task-list__step:after,
-  .gem-c-task-list__substep:after,
-  .gem-c-task-list__help:after {
-    border-color: $black;
-  }
-}
-
-.gem-c-task-list__step {
-  position: relative;
 
   // line down the side of a step
   &:after {
@@ -158,6 +94,8 @@ $top-border: solid 2px $grey-3;
 
   .gem-c-task-list--large & {
     @include media(tablet) {
+      padding-left: $gutter * 2;
+
       &:after {
         @include task-list-line-position-large;
         top: $gutter;
@@ -181,11 +119,62 @@ $top-border: solid 2px $grey-3;
   }
 }
 
+.gem-c-task-list__step:last-child {
+  // little dash at the bottom of the line
+  &:before {
+    content: "";
+    position: absolute;
+    z-index: 6;
+    bottom: 0;
+    left: 0;
+    margin-left: $number-circle-size / 4;
+    width: $number-circle-size / 2;
+    height: 0;
+    border-bottom: solid $stroke-width $grey-2;
+  }
+
+  &:after {
+    // scss-lint:disable DuplicateProperty
+    height: -webkit-calc(100% - #{$gutter-half}); // fallback for iphone 4
+    height: calc(100% - #{$gutter-half});
+    // scss-lint:enable DuplicateProperty
+  }
+
+  .gem-c-task-list__help:after {
+    height: 100%;
+  }
+
+  .gem-c-task-list--large & {
+    @include media(tablet) {
+      &:before {
+        margin-left: $number-circle-size-large / 4;
+        width: $number-circle-size-large / 2;
+        border-width: $stroke-width-large;
+      }
+
+      &:after {
+        height: calc(100% - #{$gutter});
+      }
+    }
+  }
+}
+
+.gem-c-task-list__step--active {
+  &:last-child:before,
+  .gem-c-task-list__circle--number,
+  &:after,
+  .gem-c-task-list__substep:after,
+  .gem-c-task-list__help:after {
+    border-color: $black;
+  }
+}
+
 .gem-c-task-list__circle {
   @include box-sizing(border-box);
   position: absolute;
   z-index: 5;
   top: $gutter-half;
+  left: 0;
   width: $number-circle-size;
   height: $number-circle-size;
   color: $black;
@@ -204,7 +193,6 @@ $top-border: solid 2px $grey-3;
 
 .gem-c-task-list__circle--number {
   @include _core-font-generator(16px, 16px, 16px, 23px, 23px, false, bold);
-  left: 0;
   border: solid $stroke-width $grey-2;
 
   .gem-c-task-list--large & {
@@ -218,14 +206,9 @@ $top-border: solid 2px $grey-3;
 
 .gem-c-task-list__circle--logic {
   @include _core-font-generator(16px, 16px, 16px, 28px, 28px, false, bold);
-  left: -($gutter + $gutter-half);
 
   .gem-c-task-list--large & {
     @include _core-font-generator(19px, 16px, 19px, 34px, 28px, false, bold);
-
-    @include media(tablet) {
-      left: -$gutter * 2;
-    }
   }
 }
 
@@ -434,6 +417,7 @@ $top-border: solid 2px $grey-3;
     @include task-list-line-position;
     z-index: 3;
     top: 0;
+    left: -($gutter + $gutter-half);
     height: calc(100% + #{$gutter});
   }
 
@@ -447,6 +431,7 @@ $top-border: solid 2px $grey-3;
     @include media(tablet) {
       &:after {
         @include task-list-line-position-large;
+        left: -($gutter * 2);
         height: calc(100% + #{$gutter} + #{$gutter-half});
       }
     }
@@ -472,6 +457,7 @@ $top-border: solid 2px $grey-3;
     @include task-list-line-position;
     z-index: 3;
     top: 0;
+    left: -($gutter + $gutter-half);
   }
 
   .gem-c-task-list--large & {
@@ -480,6 +466,7 @@ $top-border: solid 2px $grey-3;
 
       &:after {
         @include task-list-line-position-large;
+        left: -($gutter * 2);
       }
     }
   }

--- a/app/views/govuk_publishing_components/components/_task_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_task_list.html.erb
@@ -2,102 +2,97 @@
   options = {}
   options[:heading_level] = heading_level ||= 2
 
-  groups ||= false
+  steps ||= false
   small ||= false
   show_step ||= false
   remember_last_step ||= false
   task_list_url ||= false
   task_list_url_link_text ||= "Get help completing this step"
-  highlight_group ||= false
+  highlight_step ||= false
 
   step_count = 0
+  step_number = 0
 %>
-<% if groups %>
+<% if steps %>
   <div
     data-module="gemtasklist"
     class="gem-c-task-list js-hidden <% unless small %>gem-c-task-list--large<% end %>"
     <% if remember_last_step %>data-remember<% end %>
-    >
-    <ol class="gem-c-task-list__groups">
-      <% groups.each_with_index do |group, group_index| %>
+  >
+    <ol class="gem-c-task-list__steps">
+      <% steps.each_with_index do |step, step_index| %>
         <%
-          group_is_active = group_index + 1 == highlight_group
+          step_is_active = step_index + 1 == highlight_step
+          step_count += 1
+          id = TaskListHelper.new.generate_task_list_id(step[:title])
+
+          logic = false
+          logic = step[:logic] if ["and", "or"].include? step[:logic]
+          circle_class = "gem-c-task-list__circle--number"
+          circle_class = "gem-c-task-list__circle--logic" if logic
         %>
-        <li class="gem-c-task-list__group <%= 'gem-c-task-list__group--active' if group_is_active %>" <% if group_is_active %>aria-current="step"<% end %>>
-          <span class="gem-c-task-list__circle gem-c-task-list__circle--number">
+        <li class="gem-c-task-list__step js-step
+          <%= "gem-c-task-list__step--optional" if step[:optional] %>
+          <%= "gem-c-task-list__step--active" if step_is_active %>"
+          <% if step_is_active %>aria-current="step"<% end %>
+          <%= "data-show" if step_count == show_step %>
+          id="<%= id %>"
+          data-track-count="tasklistSection"
+        >
+          <div class="gem-c-task-list__circle <%= circle_class %>">
             <span class="gem-c-task-list__circle-inner">
               <span class="gem-c-task-list__circle-background">
-                <span class="visuallyhidden">Step</span> <%= group_index + 1 %>
+                <% if logic %>
+                  <%= logic %>
+                <% else %>
+                  <%
+                    step_number += 1
+                  %>
+                  <span class="visuallyhidden">Step</span> <%= step_number %>
+                <% end %>
               </span>
             </span>
-          </span>
+          </div>
 
-          <% group.each_with_index do |step, step_index| %>
+          <div class="gem-c-task-list__header js-toggle-panel" data-position="<%= "#{step_index + 1}" %>">
+            <%= content_tag("h#{heading_level}", step[:title], class: 'gem-c-task-list__title js-step-title') %>
+          </div>
+
+          <div class="gem-c-task-list__panel js-panel" id="step-panel-<%= id %>-<%= step_index + 1 %>">
             <%
-              step_count += 1
-              id = TaskListHelper.new.generate_task_list_id(step[:title])
-
-              logic = "and"
-              logic = step[:logic] if ["and", "or"].include? step[:logic]
+              in_substep = false
+              options[:step_index] = step_index
+              options[:link_index] = 0
             %>
-            <div
-              class="gem-c-task-list__step js-step <%= "gem-c-task-list__step--optional" if step[:optional] %>"
-              id="<%= id %>"
-              data-track-count="tasklistSection"
-              <%= "data-show" if step_count == show_step %>
-              >
-              <% if step_index > 0 %>
-                <div class="gem-c-task-list__circle gem-c-task-list__circle--logic">
-                  <span class="gem-c-task-list__circle-inner">
-                    <span class="gem-c-task-list__circle-background">
-                      <%= logic %>
-                    </span>
-                  </span>
-                </div>
-              <% end %>
+            <% step[:contents].each do |element| %>
+              <%= TaskListHelper.new.render_task_list_element(element, options) %>
+              <%
+                if element[:type] == 'list'
+                  options[:link_index] += element[:contents].length
+                end
+              %>
 
-              <div class="gem-c-task-list__header js-toggle-panel" data-position="<%= "#{group_index + 1}.#{step_index + 1}" %>">
-                <%= content_tag("h#{heading_level}", step[:title], class: 'gem-c-task-list__title js-step-title') %>
-              </div>
-
-              <div class="gem-c-task-list__panel js-panel" id="step-panel-<%= id %>-<%= step_index + 1 %>">
-                <%
-                  in_substep = false
-                  options[:group_index] = group_index
-                  options[:step_index] = step_index
-                  options[:link_index] = 0
-                %>
-                <% step[:contents].each do |element| %>
-                  <%= TaskListHelper.new.render_task_list_element(element, options) %>
-                  <%
-                    if element[:type] == 'list'
-                      options[:link_index] += element[:contents].length
-                    end
-                  %>
-
-                  <% if element[:type] == 'substep' %>
-                    <% if in_substep %>
-                      </div>
-                      <% in_substep = false %>
-                    <% end %>
-                    <div class="gem-c-task-list__substep <% if element[:optional] %>gem-c-task-list__substep--optional<% end %>">
-                    <% in_substep = true %>
-                  <% end %>
-                <% end %>
-
+              <% if element[:type] == 'substep' %>
                 <% if in_substep %>
                   </div>
+                  <% in_substep = false %>
                 <% end %>
+                <div class="gem-c-task-list__substep <% if element[:optional] %>gem-c-task-list__substep--optional<% end %>">
+                <% in_substep = true %>
+              <% end %>
+            <% end %>
 
-                <% if task_list_url && step[:show_help_link] %>
-                  <div class="gem-c-task-list__help">
-                    <a href="<%= task_list_url %>#<%= id %>" class="gem-c-task-list__help-link js-link" data-position="get-help"><%= task_list_url_link_text %></a>
-                  </div>
-                <% end %>
+            <% if in_substep %>
               </div>
+            <% end %>
 
-            </div>
-          <% end %>
+            <% if task_list_url && step[:show_help_link] %>
+              <div class="gem-c-task-list__help">
+                <a href="<%= task_list_url %>#<%= id %>" class="gem-c-task-list__help-link js-link" data-position="get-help"><%= task_list_url_link_text %></a>
+              </div>
+            <% end %>
+          </div>
+
         </li>
       <% end %>
     </ol>

--- a/app/views/govuk_publishing_components/components/docs/task_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/task_list.yml
@@ -1,7 +1,7 @@
 name: Task list
-description: Numbered groups containing expanding/collapsing steps
+description: A series of expanding/collapsing steps designed to navigate a user through a process
 body: |
-  Task lists are designed to show a sequence of steps towards a specific goal, such as 'learning to drive'. Each group of a task list can contain one or more steps. Each step can contain one or more links to pages. User research suggested that each step should be collapsed by default so that users are not overwhelmed with information.
+  Task lists are designed to show a sequence of steps towards a specific goal, such as 'learning to drive'. Each step can contain one or more links to pages. User research suggested that each step should be collapsed by default so that users are not overwhelmed with information.
 
   If JavaScript is disabled the task list expands fully. All of the task list functionality (including the icons and aria attributes) are added using JavaScript.
 
@@ -17,7 +17,7 @@ accessibility_criteria: |
   - be usable with a keyboard
   - allow users to show or hide all steps at once
   - inform the user which step a link belongs to
-  - inform the user which step the current page is in, particularly where there are multiple steps in one group
+  - inform the user which step the current page is in
   - be readable when only the text of the page is zoomed - achieved for the numbers and logic elements by their text being wrapped in several elements that give them a white background and ensure the text when zoomed expands to the left, not to the right, where it would obscure the step titles
 
   The show/hide all button only needs to list the first panel id in the aria-controls attribute, rather than all of them.
@@ -36,107 +36,106 @@ shared_accessibility_criteria:
 examples:
   default:
     data:
-      groups: [
-        [
-          {
-            title: "Do a thing",
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'This is a paragraph of text.'
-              },
-              {
-                type: 'paragraph',
-                text: 'This is also a paragraph of text that intentionally contains lots of words in order to fill the width of the page successfully to check layout and so forth.'
-              }
-            ]
-          },
-          {
-            title: "Do another thing",
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Groups can contain multiple steps, like this.'
-              },
-            ]
-          }
-        ],
-        [
-          {
-            title: "Do something else",
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'This is yet another paragraph.'
-              }
-            ]
-          }
-        ]
+      steps: [
+        {
+          title: "Do a thing",
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'This is a paragraph of text.'
+            },
+            {
+              type: 'paragraph',
+              text: 'This is also a paragraph of text that intentionally contains lots of words in order to fill the width of the page successfully to check layout and so forth.'
+            }
+          ]
+        },
+        {
+          title: "Do another thing",
+          logic: "and",
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Some more text.'
+            },
+          ]
+        },
+        {
+          title: "Do something else",
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'This is yet another paragraph.'
+            }
+          ]
+        }
       ]
   with_a_different_heading_level:
     description: Steps have a H2 by default, but this can be changed. The heading level does not change any styling.
     data:
       heading_level: 3
-      groups: [
-        [
-          {
-            title: 'This is a heading 3',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'This is yet another paragraph.'
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: 'This is also a heading 3',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'This is yet another paragraph.'
-              }
-            ]
-          }
-        ]
+      steps: [
+        {
+          title: 'This is a heading 3',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'This is yet another paragraph.'
+            }
+          ]
+        },
+        {
+          title: 'This is also a heading 3',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'This is yet another paragraph.'
+            }
+          ]
+        }
       ]
   open_a_step_by_default:
-    description: Pass the index of the step to open by default. This is the nth step, regardless of group number.
+    description: Pass the index of the step to open by default. This is the nth step in the list, regardless of the number shown next to the step. Note that in the example below, the third step is open by default, not the step numbered '3'.
     data:
       show_step: 3
-      groups: [
-        [
-          {
-            title: 'Closed by default',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Well, open now, obviously.'
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: 'Also closed by default',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Hello.'
-              }
-            ]
-          },
-          {
-            title: 'Open by default',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Hello!'
-              }
-            ]
-          }
-        ]
+      steps: [
+        {
+          title: 'Closed by default',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Well, open now, obviously.'
+            }
+          ]
+        },
+        {
+          title: 'Also closed by default',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Hello.'
+            }
+          ]
+        },
+        {
+          title: 'Open by default',
+          logic: "and",
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Hello!'
+            }
+          ]
+        },
+        {
+          title: 'And again closed by default',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Goodbye...'
+            }
+          ]
+        }
       ]
   remember_last_opened_step:
     description: |
@@ -145,29 +144,25 @@ examples:
       This behaviour is used with the 'links to more information' option.
     data:
       remember_last_step: true
-      groups: [
-        [
-          {
-            title: 'Remember this',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Hello!'
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: 'Or this',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Hello!'
-              }
-            ]
-          }
-        ]
+      steps: [
+        {
+          title: 'Remember this',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Hello!'
+            }
+          ]
+        },
+        {
+          title: 'Or this',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Hello!'
+            }
+          ]
+        }
       ]
   with_links:
     description: |
@@ -176,227 +171,219 @@ examples:
       - style, an attribute on the parent list that controls its appearance, either required (bold), optional (not bold) or choice (not bold, with bullets on the list). The default is optional.
       - context, an optional text field to show some extra information after the link, usually a monetary value
       - active, whether to make the link highlighted (to indicate the current page)
-      - highlight_group, a general option to highlight a specific group of steps. Usually the active link would be in the active group, but in some circumstances there might be an active group but no highlighted link.
+      - highlight_step, a general option to highlight the step. Usually the active link would be in the active step, but in some circumstances there might be an active step but no highlighted link.
     data:
-      highlight_group: 2
+      highlight_step: 2
       show_step: 2
-      groups: [
-        [
-          {
-            title: 'Links and paragraphs',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'These links represent tasks that are required.'
-              },
-              {
-                type: 'paragraph',
-                text: 'Spacing between a paragraph and a list of links should be smaller than the spacing between two paragraphs, in order to visually connect the two.'
-              },
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: '/component-guide/task_list/with_links/preview',
-                    text: 'Obtain a driving licence prior to driving a car',
-                    active: true
-                  },
-                  {
-                    href: '/component-guide/task_list/with_links/preview',
-                    text: 'Acquire food before attempting to cook',
-                    context: '1p to &pound;20',
-                    active: true
-                  },
-                  {
-                    href: '/component-guide/task_list/with_links/preview',
-                    text: 'Maintain contact with the ground at all times',
-                    active: true
-                  }
-                ]
-              },
-              {
-                type: 'paragraph',
-                text: 'These links represent tasks that are optional.'
-              },
-              {
-                type: 'list',
-                contents: [
-                  {
-                    href: '/component-guide/task_list/with_links/preview',
-                    text: 'Learn to play the saxophone',
-                    active: true
-                  },
-                  {
-                    href: '/component-guide/task_list/with_links/preview',
-                    text: 'Develop a new method of extracting juice from oranges',
-                    context: '&pound;0 to &pound;300',
-                    active: true
-                  },
-                  {
-                    href: '/component-guide/task_list/with_links/preview',
-                    text: 'Buy a race car',
-                    active: true
-                  }
-                ]
-              },
-              {
-                type: 'paragraph',
-                text: 'These links represent a choice:'
-              },
-              {
-                type: 'list',
-                style: 'choice',
-                contents: [
-                  {
-                    href: '/component-guide/task_list/',
-                    text: 'Leave school at sixteen',
-                    active: true
-                  },
-                  {
-                    href: '/component-guide/task_list/',
-                    text: 'Continue into higher education',
-                    context: '&pound;9,500',
-                    active: true
-                  }
-                ]
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: 'Active group and links',
-            contents: [
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: '/component-guide/task_list/',
-                    text: 'Check the reasons'
-                  },
-                  {
-                    href: '/component-guide/task_list/with_links/preview',
-                    text: 'Make the decisions based on available data and the reasonable assumptions that are possible at the time',
-                    context: '1p to &pound;20',
-                    active: true
-                  },
-                  {
-                    href: '/component-guide/task_list/with_links/preview',
-                    text: 'Do the things',
-                    active: true
-                  }
-                ]
-              },
-            ]
-          }
-        ]
+      steps: [
+        {
+          title: 'Links and paragraphs',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'These links represent tasks that are required.'
+            },
+            {
+              type: 'paragraph',
+              text: 'Spacing between a paragraph and a list of links should be smaller than the spacing between two paragraphs, in order to visually connect the two.'
+            },
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: '/component-guide/task_list/with_links/preview',
+                  text: 'Obtain a driving licence prior to driving a car',
+                  active: true
+                },
+                {
+                  href: '/component-guide/task_list/with_links/preview',
+                  text: 'Acquire food before attempting to cook',
+                  context: '1p to &pound;20',
+                  active: true
+                },
+                {
+                  href: '/component-guide/task_list/with_links/preview',
+                  text: 'Maintain contact with the ground at all times',
+                  active: true
+                }
+              ]
+            },
+            {
+              type: 'paragraph',
+              text: 'These links represent tasks that are optional.'
+            },
+            {
+              type: 'list',
+              contents: [
+                {
+                  href: '/component-guide/task_list/with_links/preview',
+                  text: 'Learn to play the saxophone',
+                  active: true
+                },
+                {
+                  href: '/component-guide/task_list/with_links/preview',
+                  text: 'Develop a new method of extracting juice from oranges',
+                  context: '&pound;0 to &pound;300',
+                  active: true
+                },
+                {
+                  href: '/component-guide/task_list/with_links/preview',
+                  text: 'Buy a race car',
+                  active: true
+                }
+              ]
+            },
+            {
+              type: 'paragraph',
+              text: 'These links represent a choice:'
+            },
+            {
+              type: 'list',
+              style: 'choice',
+              contents: [
+                {
+                  href: '/component-guide/task_list/',
+                  text: 'Leave school at sixteen',
+                  active: true
+                },
+                {
+                  href: '/component-guide/task_list/',
+                  text: 'Continue into higher education',
+                  context: '&pound;9,500',
+                  active: true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          title: 'Active step and links',
+          contents: [
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: '/component-guide/task_list/',
+                  text: 'Check the reasons'
+                },
+                {
+                  href: '/component-guide/task_list/with_links/preview',
+                  text: 'Make the decisions based on available data and the reasonable assumptions that are possible at the time',
+                  context: '1p to &pound;20',
+                  active: true
+                },
+                {
+                  href: '/component-guide/task_list/with_links/preview',
+                  text: 'Do the things',
+                  active: true
+                }
+              ]
+            },
+          ]
+        }
       ]
   with_headings:
     description: Headings can be included to break up complex content within steps. Headings are intended to be used to highlight 'Get help completing this step' information, but can be used in other contexts. The heading level is automatically determined based on the heading level of the step titles.
     data:
       show_step: 1
       heading_level: 3
-      groups: [
-        [
-          {
-            title: "Do something complicated",
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'This is an example of a step containing a heading. A section has been used with the heading to demonstrate the intended appearance of a Get Help section.'
-              },
-              {
-                type: 'substep',
-                optional: true
-              },
-              {
-                type: 'heading',
-                text: 'Get help completing this step'
-              },
-              {
-                type: 'list',
-                contents: [
-                  {
-                    href: '#',
-                    text: 'Apply online'
-                  },
-                  {
-                    href: '#',
-                    text: 'Talk to one of our advisers'
-                  },
-                  {
-                    href: '#',
-                    text: 'Search our website'
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+      steps: [
+        {
+          title: "Do something complicated",
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'This is an example of a step containing a heading. A section has been used with the heading to demonstrate the intended appearance of a Get Help section.'
+            },
+            {
+              type: 'substep',
+              optional: true
+            },
+            {
+              type: 'heading',
+              text: 'Get help completing this step'
+            },
+            {
+              type: 'list',
+              contents: [
+                {
+                  href: '#',
+                  text: 'Apply online'
+                },
+                {
+                  href: '#',
+                  text: 'Talk to one of our advisers'
+                },
+                {
+                  href: '#',
+                  text: 'Search our website'
+                }
+              ]
+            }
+          ]
+        }
       ]
   or_then:
     description: Some of the more complex things in a task list require an option for laying out links in a clear structure. If a link in a list is not given a href, only the text is displayed, allowing for structures like the one shown below.
     data:
       show_step: 1
-      groups: [
-        [
-          {
-            title: "Get a court to decide your child arrangements",
-            contents: [
-              {
-                type: 'paragraph',
-                text: "You can only apply for a court to make a decision if you've tried mediation or your family are at risk, for example domestic abuse."
-              },
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: 'http://solicitors.lawsociety.org.uk/',
-                    text: 'Hire a lawyer to represent you',
-                    context: '&pound;110 to &pound;410 per hour'
-                  },
-                  {
-                    text: 'or',
-                  },
-                  {
-                    href: 'http://localhost:3000/represent-yourself-in-court',
-                    text: 'Represent yourself in court'
-                  }
-                ]
-              },
-              {
-                type: 'paragraph',
-                text: 'then'
-              },
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: '/looking-after-children-divorce/apply-for-court-order',
-                    text: 'Apply for a court order',
-                    context: '&pound;215'
-                  },
-                  {
-                    href: 'https://courttribunalfinder.service.gov.uk/search/',
-                    text: 'Find the right court to send your application'
-                  },
-                  {
-                    href: '/get-help-with-court-fees',
-                    text: 'Get help with court fees'
-                  }
-                ]
-              },
-              {
-                type: 'paragraph',
-                text: "The court will send you a date for your first hearing 4 to 6 weeks after your application. You'll be told when and where your hearing will take place."
-              }
-            ]
-          }
-        ]
+      steps: [
+        {
+          title: "Get a court to decide your child arrangements",
+          contents: [
+            {
+              type: 'paragraph',
+              text: "You can only apply for a court to make a decision if you've tried mediation or your family are at risk, for example domestic abuse."
+            },
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: 'http://solicitors.lawsociety.org.uk/',
+                  text: 'Hire a lawyer to represent you',
+                  context: '&pound;110 to &pound;410 per hour'
+                },
+                {
+                  text: 'or',
+                },
+                {
+                  href: 'http://localhost:3000/represent-yourself-in-court',
+                  text: 'Represent yourself in court'
+                }
+              ]
+            },
+            {
+              type: 'paragraph',
+              text: 'then'
+            },
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: '/looking-after-children-divorce/apply-for-court-order',
+                  text: 'Apply for a court order',
+                  context: '&pound;215'
+                },
+                {
+                  href: 'https://courttribunalfinder.service.gov.uk/search/',
+                  text: 'Find the right court to send your application'
+                },
+                {
+                  href: '/get-help-with-court-fees',
+                  text: 'Get help with court fees'
+                }
+              ]
+            },
+            {
+              type: 'paragraph',
+              text: "The court will send you a date for your first hearing 4 to 6 weeks after your application. You'll be told when and where your hearing will take place."
+            }
+          ]
+        }
       ]
   solve_the_double_dot_problem:
     description: |
@@ -404,73 +391,69 @@ examples:
 
       JavaScript is included in the component to solve this. It uses sessionStorage to capture the data-position attribute of non-external links in the task list when clicked, and then uses this value to decide which link to highlight when the new page loads. This session storage data is immediately deleted after it is read on page load, mainly to prevent problems with highlighting if the user were to move between different task lists.
 
-      If a user has not clicked a link (i.e. has visited the page without first clicking on a task list) the first active link in the first active group will be highlighted. If there is no active group, the first active link will be highlighted (but there should always be an active group).
+      If a user has not clicked a link (i.e. has visited the page without first clicking on a task list) the first active link in the first active step will be highlighted. If there is no active step, the first active link will be highlighted (but there should always be an active step).
 
       The current page in the task list is an anchor link to the top of the page. If there are more than one of these and the user clicks one that is not currently highlighted, that one will be highlighted.
 
       The example below will show all links highlighted if JS is disabled, in the real world no more than two or three links are likely to be highlighted at once.
     data:
-      highlight_group: 2
+      highlight_step: 2
       show_step: 2
-      groups: [
-        [
-          {
-            title: "Not the active step",
-            contents: [
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: 'http://google.com',
-                    text: 'External link not set to active'
-                  },
-                  {
-                    href: '/component-guide/task_list/with_links/preview',
-                    text: 'Internal link set to active',
-                    active: true
-                  },
-                  {
-                    href: '/component-guide/task_list/with_links/preview',
-                    text: 'Internal link set to active',
-                    active: true
-                  },
-                  {
-                    href: 'http://google.com',
-                    text: 'External link not set to active'
-                  }
-                ]
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: "The active step",
-            contents: [
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: '/component-guide/task_list/with_links/preview',
-                    text: 'Internal link set to active - in the active group, should be set by default until another link is clicked',
-                    active: true
-                  },
-                  {
-                    href: '/component-guide/task_list/with_links/preview',
-                    text: 'Internal link set to active',
-                    active: true
-                  },
-                  {
-                    href: 'http://google.com',
-                    text: 'External link not set to active'
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+      steps: [
+        {
+          title: "Not the active step",
+          contents: [
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: 'http://google.com',
+                  text: 'External link not set to active'
+                },
+                {
+                  href: '/component-guide/task_list/with_links/preview',
+                  text: 'Internal link set to active',
+                  active: true
+                },
+                {
+                  href: '/component-guide/task_list/with_links/preview',
+                  text: 'Internal link set to active',
+                  active: true
+                },
+                {
+                  href: 'http://google.com',
+                  text: 'External link not set to active'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          title: "The active step",
+          contents: [
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: '/component-guide/task_list/with_links/preview',
+                  text: 'Internal link set to active - in the active step, should be set by default until another link is clicked',
+                  active: true
+                },
+                {
+                  href: '/component-guide/task_list/with_links/preview',
+                  text: 'Internal link set to active',
+                  active: true
+                },
+                {
+                  href: 'http://google.com',
+                  text: 'External link not set to active'
+                }
+              ]
+            }
+          ]
+        }
       ]
   with_optional_steps:
     description: |
@@ -478,152 +461,143 @@ examples:
 
       If a step is optional this should be conveyed by the text within that step.
     data:
-      groups: [
-        [
-          {
-            title: "Drive to work",
-            contents: [
-              {
-                type: paragraph,
-                text: 'If you do not have a car, you will need to choose an alternative.'
-              }
-            ]
-          },
-          {
-            title: "Walk to work",
-            optional: true,
-            logic: 'or',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Walking is healthy but may not be practical where large distances are concerned.'
-              }
-            ]
-          },
-          {
-            title: "Get public transport to work",
-            optional: true,
-            logic: 'or',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Public transport includes buses, trains and boats.'
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: "Do work",
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Once you have reached your destination you should be able to start work.'
-              }
-            ]
-          },
-          {
-            title: "Get paid",
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Your employer should pay you for hours worked.'
-              }
-            ]
-          }
-        ]
+      steps: [
+        {
+          title: "Drive to work",
+          contents: [
+            {
+              type: paragraph,
+              text: 'If you do not have a car, you will need to choose an alternative.'
+            }
+          ]
+        },
+        {
+          title: "Walk to work",
+          optional: true,
+          logic: 'or',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Walking is healthy but may not be practical where large distances are concerned.'
+            }
+          ]
+        },
+        {
+          title: "Get public transport to work",
+          optional: true,
+          logic: 'or',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Public transport includes buses, trains and boats.'
+            }
+          ]
+        },
+        {
+          title: "Do work",
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Once you have reached your destination you should be able to start work.'
+            }
+          ]
+        },
+        {
+          title: "Get paid",
+          logic: 'and',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Your employer should pay you for hours worked.'
+            }
+          ]
+        }
       ]
   with_sub_steps:
     description: Steps can also contain sub steps, which act either as a way to break up content or to indicate that some tasks are optional. Whenever a step or sub step is optional this should be made clear in the written content. Optional steps are styled differently but this should support the meaning, not convey it.
     data:
-      highlight_group: 2
+      highlight_step: 2
       show_step: 2
-      groups: [
-        [
-          {
-            title: "A required step",
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'This step ends with an optional sub step.'
-              },
-              {
-                type: 'substep',
-                optional: true
-              },
-              {
-                type: 'paragraph',
-                text: 'This paragraph is inside the sub step.'
-              },
-              {
-                type: 'list',
-                contents: [
-                  {
-                    href: '/test6',
-                    text: 'This link is also inside the sub step'
-                  }
-                ]
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: "An optional step",
-            optional: true,
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'This optional step contains multiple sub steps.'
-              },
-              {
-                type: 'substep',
-                optional: false
-              },
-              {
-                type: 'paragraph',
-                text: 'This paragraph is inside a required sub step.'
-              },
-              {
-                type: 'substep',
-                optional: true
-              },
-              {
-                type: 'paragraph',
-                text: 'This paragraph is inside an optional sub step.'
-              },
-              {
-                type: 'list',
-                contents: [
-                  {
-                    href: '/test7',
-                    text: 'This link is inside an optional sub step as well',
-                    active: true
-                  }
-                ]
-              },
-              {
-                type: 'substep',
-                optional: false
-              },
-              {
-                type: 'paragraph',
-                text: 'This paragraph is inside a required sub step.'
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: "Another required step",
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Um. Hello.'
-              }
-            ]
-          }
-        ]
+      steps: [
+        {
+          title: "A required step",
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'This step ends with an optional sub step.'
+            },
+            {
+              type: 'substep',
+              optional: true
+            },
+            {
+              type: 'paragraph',
+              text: 'This paragraph is inside the sub step.'
+            },
+            {
+              type: 'list',
+              contents: [
+                {
+                  href: '/test6',
+                  text: 'This link is also inside the sub step'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          title: "An optional step",
+          optional: true,
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'This optional step contains multiple sub steps.'
+            },
+            {
+              type: 'substep',
+              optional: false
+            },
+            {
+              type: 'paragraph',
+              text: 'This paragraph is inside a required sub step.'
+            },
+            {
+              type: 'substep',
+              optional: true
+            },
+            {
+              type: 'paragraph',
+              text: 'This paragraph is inside an optional sub step.'
+            },
+            {
+              type: 'list',
+              contents: [
+                {
+                  href: '/test7',
+                  text: 'This link is inside an optional sub step as well',
+                  active: true
+                }
+              ]
+            },
+            {
+              type: 'substep',
+              optional: false
+            },
+            {
+              type: 'paragraph',
+              text: 'This paragraph is inside a required sub step.'
+            }
+          ]
+        },
+        {
+          title: "Another required step",
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Um. Hello.'
+            }
+          ]
+        }
       ]
   get_help_links:
     description: |
@@ -636,249 +610,238 @@ examples:
       task_list_url: "/learn-to-do-something"
       task_list_url_link_text: "Get more information"
       show_step: 1
-      groups: [
-        [
-          {
-            title: "A link back to the main task list",
-            show_help_link: true,
-            contents: [
-              {
-                type: 'list',
-                contents: [
-                  {
-                    href: '/test7',
-                    text: 'This is a link'
-                  },
-                  {
-                    href: '/test7',
-                    text: 'This is another link'
-                  }
-                ]
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: "No help link here",
-            contents: [
-              {
-                type: 'list',
-                contents: [
-                  {
-                    href: '/test7',
-                    text: 'This is yet another link'
-                  },
-                  {
-                    href: '/test7',
-                    text: 'This is a further link'
-                  },
-                ]
-              }
-            ]
-          }
-        ]
+      steps: [
+        {
+          title: "A link back to the main task list",
+          show_help_link: true,
+          contents: [
+            {
+              type: 'list',
+              contents: [
+                {
+                  href: '/test7',
+                  text: 'This is a link'
+                },
+                {
+                  href: '/test7',
+                  text: 'This is another link'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          title: "No help link here",
+          contents: [
+            {
+              type: 'list',
+              contents: [
+                {
+                  href: '/test7',
+                  text: 'This is yet another link'
+                },
+                {
+                  href: '/test7',
+                  text: 'This is a further link'
+                },
+              ]
+            }
+          ]
+        }
       ]
   test_all_the_things:
     description: This component is very complicated so here is an example containing as many of the options available as possible.
     data:
       task_list_url: "/learn-to-setup-standup"
-      highlight_group: 2
-      groups: [
-        [
-          {
-            title: 'Get the TV ready',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Configure the television so it is ready for the standup. You will also need a laptop.'
-              },
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: 'https://en.wikipedia.org/wiki/HDMI',
-                    text: 'Remove the Chromebit from HDMI 1 on the TV'
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            title: 'Plug everything in',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Connect the relevant cables between the various devices.'
-              },
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: 'https://www.google.co.uk/',
-                    text: 'Run the HDMI - MINI DVI cable from the TV to the facilitators laptop'
-                  },
-                  {
-                    href: 'https://www.jabra.co.uk/',
-                    text: 'Plug the Jabra into the facilitators laptop'
-                  }
-                ]
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: 'Configure the catchbox',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'These steps are required.'
-              },
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Ensure the catchbox transmitter is plugged in at the mains wall'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Turn on the transmitter and wait for the switch to blink green'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Plug the transmitter USB cable into the facilitators laptop',
-                    active: true
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Twist and pull the black piece of foam out of the catchbox'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Turn on the catchbox and wait for the LED to turn green'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Wait for the transmitter light to turn solid green'
-                  }
-                ]
-              },
-              {
-                type: 'substep',
-                optional: true
-              },
-              {
-                type: 'heading',
-                text: 'Optional steps'
-              },
-              {
-                type: 'paragraph',
-                text: 'These steps are not required.'
-              },
-              {
-                type: 'list',
-                style: 'choice',
-                contents: [
-                  {
-                    href: 'https://www.google.co.uk/',
-                    text: "Get annoyed when it doesn't work"
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Try to find someone else who knows how to do it',
-                    context: '1 to 10 minutes'
-                  }
-                ]
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: 'Join and configure the standup',
-            show_help_link: true,
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Join the hangout and present to those on it.'
-              },
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Connect to standup hangout via the calendar invite'
-                  },
-                  {
-                    text: 'or'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Connect to standup hangout via the link in the team slack'
-                  }
-                ]
-              },
-              {
-                type: 'paragraph',
-                text: 'then'
-              },
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Click the three dots in the bottom hand corner to open settings'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Set speaker to "Jabra"'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Set microphone to "C Media USB"'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Click "present to meeting"'
-                  },
-                ]
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: 'Clear up',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Disconnect from the hangout and disconnect any cables.'
-              },
-              {
-                type: 'paragraph',
-                text: 'Most importantly, remember to switch off the catchbox to save the battery.'
-              }
-            ]
-          },
-          {
-            title: 'Get someone else to clear up',
-            logic: 'or',
-            optional: true,
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Schedule another meeting for right after the standup and force someone else to sort everything out.'
-              }
-            ]
-          }
-        ]
+      highlight_step: 3
+      steps: [
+        {
+          title: 'Get the TV ready',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Configure the television so it is ready for the standup. You will also need a laptop.'
+            },
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: 'https://en.wikipedia.org/wiki/HDMI',
+                  text: 'Remove the Chromebit from HDMI 1 on the TV'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          title: 'Plug everything in',
+          logic: "and",
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Connect the relevant cables between the various devices.'
+            },
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: 'https://www.google.co.uk/',
+                  text: 'Run the HDMI - MINI DVI cable from the TV to the facilitators laptop'
+                },
+                {
+                  href: 'https://www.jabra.co.uk/',
+                  text: 'Plug the Jabra into the facilitators laptop'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          title: 'Configure the catchbox',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'These steps are required.'
+            },
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: 'http://www.google.com',
+                  text: 'Ensure the catchbox transmitter is plugged in at the mains wall'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Turn on the transmitter and wait for the switch to blink green'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Plug the transmitter USB cable into the facilitators laptop',
+                  active: true
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Twist and pull the black piece of foam out of the catchbox'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Turn on the catchbox and wait for the LED to turn green'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Wait for the transmitter light to turn solid green'
+                }
+              ]
+            },
+            {
+              type: 'substep',
+              optional: true
+            },
+            {
+              type: 'heading',
+              text: 'Optional steps'
+            },
+            {
+              type: 'paragraph',
+              text: 'These steps are not required.'
+            },
+            {
+              type: 'list',
+              style: 'choice',
+              contents: [
+                {
+                  href: 'https://www.google.co.uk/',
+                  text: "Get annoyed when it doesn't work"
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Try to find someone else who knows how to do it',
+                  context: '1 to 10 minutes'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          title: 'Join and configure the standup',
+          show_help_link: true,
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Join the hangout and present to those on it.'
+            },
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: 'http://www.google.com',
+                  text: 'Connect to standup hangout via the calendar invite'
+                },
+                {
+                  text: 'or'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Connect to standup hangout via the link in the team slack'
+                }
+              ]
+            },
+            {
+              type: 'paragraph',
+              text: 'then'
+            },
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: 'http://www.google.com',
+                  text: 'Click the three dots in the bottom hand corner to open settings'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Set speaker to "Jabra"'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Set microphone to "C Media USB"'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Click "present to meeting"'
+                },
+              ]
+            }
+          ]
+        },
+        {
+          title: 'Clear up',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Disconnect from the hangout and disconnect any cables.'
+            },
+            {
+              type: 'paragraph',
+              text: 'Most importantly, remember to switch off the catchbox to save the battery.'
+            }
+          ]
+        },
+        {
+          title: 'Get someone else to clear up',
+          logic: 'or',
+          optional: true,
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Schedule another meeting for right after the standup and force someone else to sort everything out.'
+            }
+          ]
+        }
       ]
   small:
     description: Designed to fit in the sidebar of a page. Note that the small version of the task list should not become smaller on mobile, and the large version on mobile should be the same size as the small version. This example is a copy of the one above for comparison.
@@ -886,200 +849,193 @@ examples:
       small: true
       remember_last_step: true
       task_list_url: "/learn-to-setup-standup"
-      highlight_group: 2
-      groups: [
-        [
-          {
-            title: 'Get the TV ready (small)',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Configure the television so it is ready for the standup. You will also need a laptop.'
-              },
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: 'https://en.wikipedia.org/wiki/HDMI',
-                    text: 'Remove the Chromebit from HDMI 1 on the TV'
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            title: 'Plug everything in (small)',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Connect the relevant cables between the various devices.'
-              },
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: 'https://www.google.co.uk/',
-                    text: 'Run the HDMI - MINI DVI cable from the TV to the facilitators laptop'
-                  },
-                  {
-                    href: 'https://www.jabra.co.uk/',
-                    text: 'Plug the Jabra into the facilitators laptop'
-                  }
-                ]
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: 'Configure the catchbox (small)',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'These steps are required.'
-              },
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Ensure the catchbox transmitter is plugged in at the mains wall'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Turn on the transmitter and wait for the switch to blink green'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Plug the transmitter USB cable into the facilitators laptop',
-                    active: true
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Twist and pull the black piece of foam out of the catchbox'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Turn on the catchbox and wait for the LED to turn green'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Wait for the transmitter light to turn solid green'
-                  }
-                ]
-              },
-              {
-                type: 'substep',
-                optional: true
-              },
-              {
-                type: 'heading',
-                text: 'Optional steps'
-              },
-              {
-                type: 'paragraph',
-                text: 'These steps are not required.'
-              },
-              {
-                type: 'list',
-                style: 'choice',
-                contents: [
-                  {
-                    href: 'https://www.google.co.uk/',
-                    text: "Get annoyed when it doesn't work"
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Try to find someone else who knows how to do it',
-                    context: '1 to 10 minutes'
-                  }
-                ]
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: 'Join and configure the standup (small)',
-            show_help_link: true,
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Join the hangout and present to those on it.'
-              },
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Connect to standup hangout via the calendar invite'
-                  },
-                  {
-                    text: 'or'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Connect to standup hangout via the link in the team slack'
-                  }
-                ]
-              },
-              {
-                type: 'paragraph',
-                text: 'then'
-              },
-              {
-                type: 'list',
-                style: 'required',
-                contents: [
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Click the three dots in the bottom hand corner to open settings'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Set speaker to "Jabra"'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Set microphone to "C Media USB"'
-                  },
-                  {
-                    href: 'http://www.google.com',
-                    text: 'Click "present to meeting"'
-                  },
-                ]
-              }
-            ]
-          }
-        ],
-        [
-          {
-            title: 'Clear up (small)',
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Disconnect from the hangout and disconnect any cables.'
-              },
-              {
-                type: 'paragraph',
-                text: 'Most importantly, remember to switch off the catchbox to save the battery.'
-              }
-            ]
-          },
-          {
-            title: 'Get someone else to clear up (small)',
-            logic: 'or',
-            optional: true,
-            contents: [
-              {
-                type: 'paragraph',
-                text: 'Schedule another meeting for right after the standup and force someone else to sort everything out.'
-              }
-            ]
-          }
-        ]
+      highlight_step: 3
+      steps: [
+        {
+          title: 'Get the TV ready (small)',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Configure the television so it is ready for the standup. You will also need a laptop.'
+            },
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: 'https://en.wikipedia.org/wiki/HDMI',
+                  text: 'Remove the Chromebit from HDMI 1 on the TV'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          title: 'Plug everything in (small)',
+          logic: "and",
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Connect the relevant cables between the various devices.'
+            },
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: 'https://www.google.co.uk/',
+                  text: 'Run the HDMI - MINI DVI cable from the TV to the facilitators laptop'
+                },
+                {
+                  href: 'https://www.jabra.co.uk/',
+                  text: 'Plug the Jabra into the facilitators laptop'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          title: 'Configure the catchbox (small)',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'These steps are required.'
+            },
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: 'http://www.google.com',
+                  text: 'Ensure the catchbox transmitter is plugged in at the mains wall'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Turn on the transmitter and wait for the switch to blink green'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Plug the transmitter USB cable into the facilitators laptop',
+                  active: true
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Twist and pull the black piece of foam out of the catchbox'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Turn on the catchbox and wait for the LED to turn green'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Wait for the transmitter light to turn solid green'
+                }
+              ]
+            },
+            {
+              type: 'substep',
+              optional: true
+            },
+            {
+              type: 'heading',
+              text: 'Optional steps'
+            },
+            {
+              type: 'paragraph',
+              text: 'These steps are not required.'
+            },
+            {
+              type: 'list',
+              style: 'choice',
+              contents: [
+                {
+                  href: 'https://www.google.co.uk/',
+                  text: "Get annoyed when it doesn't work"
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Try to find someone else who knows how to do it',
+                  context: '1 to 10 minutes'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          title: 'Join and configure the standup (small)',
+          show_help_link: true,
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Join the hangout and present to those on it.'
+            },
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: 'http://www.google.com',
+                  text: 'Connect to standup hangout via the calendar invite'
+                },
+                {
+                  text: 'or'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Connect to standup hangout via the link in the team slack'
+                }
+              ]
+            },
+            {
+              type: 'paragraph',
+              text: 'then'
+            },
+            {
+              type: 'list',
+              style: 'required',
+              contents: [
+                {
+                  href: 'http://www.google.com',
+                  text: 'Click the three dots in the bottom hand corner to open settings'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Set speaker to "Jabra"'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Set microphone to "C Media USB"'
+                },
+                {
+                  href: 'http://www.google.com',
+                  text: 'Click "present to meeting"'
+                },
+              ]
+            }
+          ]
+        },
+        {
+          title: 'Clear up (small)',
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Disconnect from the hangout and disconnect any cables.'
+            },
+            {
+              type: 'paragraph',
+              text: 'Most importantly, remember to switch off the catchbox to save the battery.'
+            }
+          ]
+        },
+        {
+          title: 'Get someone else to clear up (small)',
+          logic: 'or',
+          optional: true,
+          contents: [
+            {
+              type: 'paragraph',
+              text: 'Schedule another meeting for right after the standup and force someone else to sort everything out.'
+            }
+          ]
+        }
       ]

--- a/lib/govuk_publishing_components/components/task_list_helper.rb
+++ b/lib/govuk_publishing_components/components/task_list_helper.rb
@@ -70,7 +70,7 @@ private
         href,
         rel: ("external" if href.start_with?('http')),
         data: {
-          position: "#{@options[:group_index] + 1}.#{@options[:step_index] + 1}.#{@link_index}"
+          position: "#{@options[:step_index] + 1}.#{@link_index}"
         },
         class: "gem-c-task-list__link-item js-link"
       ) do

--- a/spec/components/task_list_spec.rb
+++ b/spec/components/task_list_spec.rb
@@ -7,278 +7,274 @@ describe "Task List", type: :view do
 
   def tasklist
     [
-      [
-        {
-          title: 'Group 1 step 1',
-          show_help_link: true,
-          optional: true,
-          contents: [
-            {
-              type: 'paragraph',
-              text: 'Group 1 step 1 paragraph'
-            },
-            {
-              type: 'list',
-              style: 'required',
-              contents: [
-                {
-                  href: '/link1',
-                  text: 'Link 1.1.1',
-                },
-                {
-                  href: 'http://www.gov.uk',
-                  text: 'Link 1.1.2',
-                  context: '£0 to £300'
-                },
-              ]
-            },
-            {
-              type: 'substep',
-              optional: false
-            },
-            {
-              type: 'paragraph',
-              text: 'This paragraph is inside a required substep'
-            },
-            {
-              type: 'list',
-              style: 'required',
-              contents: [
-                {
-                  href: '/link3',
-                  text: 'Link 1.1.3',
-                },
-                {
-                  href: '/link4',
-                  text: 'Link 1.1.4'
-                }
-              ]
-            },
-          ]
-        },
-        {
-          title: 'Group 1 step 2',
-          optional: false,
-          contents: [
-            {
-              type: 'paragraph',
-              text: 'test'
-            }
-          ]
-        }
-      ],
-      [
-        {
-          title: 'Group 2 step 1',
-          contents: [
-            {
-              type: 'paragraph',
-              text: 'Group 2 step 1 paragraph'
-            },
-            {
-              type: 'list',
-              style: 'choice',
-              contents: [
-                {
-                  href: '/link5',
-                  text: 'Link 2.1.1',
-                },
-                {
-                  href: '/link6',
-                  active: true,
-                  text: 'Link 2.1.2',
-                },
-              ]
-            },
-            {
-              type: 'substep',
-              optional: true
-            },
-            {
-              type: 'paragraph',
-              text: 'This paragraph is inside an optional substep'
-            },
-          ]
-        },
-        {
-          title: 'Group 2 step 2',
-          logic: 'or',
-          contents: [
-            {
-              type: 'paragraph',
-              text: 'test'
-            },
-            {
-              type: 'list',
-              contents: [
-                {
-                  href: '/link7',
-                  text: 'Link 2.2.1'
-                },
-                {
-                  text: 'or'
-                },
-                {
-                  href: '/link8',
-                  text: 'Link 2.2.2'
-                }
-              ]
-            },
-            {
-              type: 'heading',
-              text: 'This is a heading'
-            }
-          ]
-        },
-        {
-          title: 'Group 2 step 3?"`_!',
-          contents: [
-            {
-              type: 'paragraph',
-              text: 'test'
-            }
-          ]
-        }
-      ]
+      {
+        title: 'Step 1',
+        show_help_link: true,
+        optional: true,
+        contents: [
+          {
+            type: 'paragraph',
+            text: 'Step 1 paragraph'
+          },
+          {
+            type: 'list',
+            style: 'required',
+            contents: [
+              {
+                href: '/link1',
+                text: 'Link 1.1.1',
+              },
+              {
+                href: 'http://www.gov.uk',
+                text: 'Link 1.1.2',
+                context: '£0 to £300'
+              },
+            ]
+          },
+          {
+            type: 'substep',
+            optional: false
+          },
+          {
+            type: 'paragraph',
+            text: 'This paragraph is inside a required substep'
+          },
+          {
+            type: 'list',
+            style: 'choice',
+            contents: [
+              {
+                href: '/link3',
+                text: 'Link 1.1.3',
+              },
+              {
+                href: '/link4',
+                text: 'Link 1.1.4'
+              }
+            ]
+          },
+        ]
+      },
+      {
+        title: 'Step 1 and',
+        optional: false,
+        logic: "and",
+        contents: [
+          {
+            type: 'paragraph',
+            text: 'Step 1 and paragraph'
+          }
+        ]
+      },
+      {
+        title: 'Step 2',
+        contents: [
+          {
+            type: 'paragraph',
+            text: 'Step 2 paragraph'
+          },
+          {
+            type: 'list',
+            style: 'choice',
+            contents: [
+              {
+                href: '/link5',
+                text: 'Link 2.1.1',
+              },
+              {
+                href: '/link6',
+                active: true,
+                text: 'Link 2.1.2',
+              },
+            ]
+          },
+          {
+            type: 'substep',
+            optional: true
+          },
+          {
+            type: 'paragraph',
+            text: 'This paragraph is inside an optional substep'
+          },
+        ]
+      },
+      {
+        title: 'Step 2 or',
+        logic: 'or',
+        contents: [
+          {
+            type: 'paragraph',
+            text: 'test'
+          },
+          {
+            type: 'list',
+            contents: [
+              {
+                href: '/link7',
+                text: 'Link 2.2.1'
+              },
+              {
+                text: 'or'
+              },
+              {
+                href: '/link8',
+                text: 'Link 2.2.2'
+              }
+            ]
+          },
+          {
+            type: 'heading',
+            text: 'This is a heading'
+          }
+        ]
+      },
+      {
+        title: 'Step 3?"`_!',
+        contents: [
+          {
+            type: 'paragraph',
+            text: 'test'
+          }
+        ]
+      }
     ]
   end
 
-  group1 = ".gem-c-task-list__group:nth-child(1)"
-  group1step1 = group1 + " .gem-c-task-list__step:nth-of-type(1)"
-  group1step2 = group1 + " .gem-c-task-list__step:nth-of-type(2)"
-
-  group2 = ".gem-c-task-list__group:nth-child(2)"
-  group2step1 = group2 + " .gem-c-task-list__step:nth-of-type(1)"
-  group2step2 = group2 + " .gem-c-task-list__step:nth-of-type(2)"
+  step1 = ".gem-c-task-list__step:nth-of-type(1)"
+  step1and = ".gem-c-task-list__step:nth-of-type(2)"
+  step2 = ".gem-c-task-list__step:nth-of-type(3)"
+  step2or = ".gem-c-task-list__step:nth-of-type(4)"
+  step3 = ".gem-c-task-list__step:nth-of-type(5)"
 
   it "renders nothing without passed content" do
     assert_empty render_component({})
   end
 
   it "renders paragraphs" do
-    render_component(groups: tasklist)
+    render_component(steps: tasklist)
     assert_select ".gem-c-task-list"
 
-    assert_select group1 + " .gem-c-task-list__step#group-1-step-1:nth-of-type(1)"
-    assert_select group1step1 + " .gem-c-task-list__title", text: "Group 1 step 1"
-    assert_select group1step1 + " .gem-c-task-list__paragraph", text: "Group 1 step 1 paragraph"
+    assert_select ".gem-c-task-list__step#step-1"
+    assert_select step1 + " .gem-c-task-list__title", text: "Step 1"
+    assert_select step1 + " .gem-c-task-list__paragraph", text: "Step 1 paragraph"
 
-    assert_select group2 + " .gem-c-task-list__step#group-2-step-2:nth-of-type(1)"
-    assert_select group2step1 + " .gem-c-task-list__title", text: "Group 2 step 1"
-    assert_select group2step1 + " .gem-c-task-list__paragraph", text: "Group 2 step 1 paragraph"
+    assert_select ".gem-c-task-list__step#step-2"
+    assert_select step2 + " .gem-c-task-list__title", text: "Step 2"
+    assert_select step2 + " .gem-c-task-list__paragraph", text: "Step 2 paragraph"
   end
 
   it "renders headings" do
-    render_component(groups: tasklist)
+    render_component(steps: tasklist)
 
-    assert_select group2step2 + " h3.gem-c-task-list__heading", text: "This is a heading"
+    assert_select step2or + " h3.gem-c-task-list__heading", text: "This is a heading"
   end
 
   it "renders a tasklist with different heading levels" do
-    render_component(groups: tasklist, heading_level: 4)
+    render_component(steps: tasklist, heading_level: 4)
 
-    assert_select group1step1 + " h4.gem-c-task-list__title", text: "Group 1 step 1"
-    assert_select group2step1 + " h4.gem-c-task-list__title", text: "Group 2 step 1"
+    assert_select step1 + " h4.gem-c-task-list__title", text: "Step 1"
+    assert_select step2 + " h4.gem-c-task-list__title", text: "Step 2"
   end
 
   it "renders headings correctly if the heading level is changed" do
-    render_component(groups: tasklist, heading_level: 4)
+    render_component(steps: tasklist, heading_level: 4)
 
-    assert_select group2step2 + " h5.gem-c-task-list__heading", text: "This is a heading"
+    assert_select step2or + " h5.gem-c-task-list__heading", text: "This is a heading"
   end
 
   it "opens a step by default" do
-    render_component(groups: tasklist, show_step: 2)
+    render_component(steps: tasklist, show_step: 2)
 
-    assert_select group1 + " .gem-c-task-list__step#group-1-step-2[data-show]"
+    assert_select ".gem-c-task-list__step#step-1-and[data-show]"
   end
 
   it "remembers last opened step" do
-    render_component(groups: tasklist, remember_last_step: true)
+    render_component(steps: tasklist, remember_last_step: true)
 
     assert_select ".gem-c-task-list[data-remember]"
   end
 
   it "generates IDs for steps correctly" do
-    render_component(groups: tasklist)
+    render_component(steps: tasklist)
 
-    assert_select group2step2 + " #step-panel-group-2-step-2-2.gem-c-task-list__panel"
-    assert_select group2 + " .gem-c-task-list__step:nth-of-type(3) #step-panel-group-2-step-3-3.gem-c-task-list__panel"
+    assert_select step1 + " #step-panel-step-1-1.gem-c-task-list__panel"
+    assert_select step1and + " #step-panel-step-1-and-2.gem-c-task-list__panel"
+    assert_select step3 + "#step-3"
   end
 
   it "renders correct list elements and includes length of lists" do
-    render_component(groups: tasklist)
+    render_component(steps: tasklist)
 
-    assert_select group2step1 + " ul.gem-c-task-list__links--choice[data-length='2']"
-    assert_select group2step2 + " ol.gem-c-task-list__links[data-length='3']"
+    assert_select step1 + " ul.gem-c-task-list__links--choice[data-length='2']"
+    assert_select step2or + " ol.gem-c-task-list__links[data-length='3']"
   end
 
   it "renders links and link attributes correctly" do
-    render_component(groups: tasklist)
+    render_component(steps: tasklist)
 
-    assert_select group1step1 + " .gem-c-task-list__link-item[href='/link1'][data-position='1.1.1']", text: "Link 1.1.1"
-    assert_select group1step1 + " .gem-c-task-list__link-item[href='/link1'][rel='external']", false
-    assert_select group1step1 + " .gem-c-task-list__link-item[href='http://www.gov.uk'][rel='external'][data-position='1.1.2']", text: "Link 1.1.2 £0 to £300"
-    assert_select group1step1 + " .gem-c-task-list__link-item[href='http://www.gov.uk'] .gem-c-task-list__context", text: "£0 to £300"
-    assert_select group1step1 + " .gem-c-task-list__link-item[href='/link3'][data-position='1.1.3']", text: "Link 1.1.3"
-    assert_select group1step1 + " .gem-c-task-list__link-item[href='/link4'][data-position='1.1.4']", text: "Link 1.1.4"
-    assert_select group2step2 + " .gem-c-task-list__link-item[href='/link8'][data-position='2.2.2']", text: "Link 2.2.2"
+    assert_select step1 + " .gem-c-task-list__link-item[href='/link1'][data-position='1.1']", text: "Link 1.1.1"
+    assert_select step1 + " .gem-c-task-list__link-item[href='/link1'][rel='external']", false
+    assert_select step1 + " .gem-c-task-list__link-item[href='http://www.gov.uk'][rel='external'][data-position='1.2']", text: "Link 1.1.2 £0 to £300"
+    assert_select step1 + " .gem-c-task-list__link-item[href='http://www.gov.uk'] .gem-c-task-list__context", text: "£0 to £300"
+    assert_select step1 + " .gem-c-task-list__link-item[href='/link3'][data-position='1.3']", text: "Link 1.1.3"
+    assert_select step1 + " .gem-c-task-list__link-item[href='/link4'][data-position='1.4']", text: "Link 1.1.4"
+    assert_select step2or + " .gem-c-task-list__link-item[href='/link8'][data-position='4.2']", text: "Link 2.2.2"
   end
 
   it "renders links without hrefs" do
-    render_component(groups: tasklist)
+    render_component(steps: tasklist)
 
-    assert_select group2step2 + " .gem-c-task-list__link .gem-c-task-list__link-item[href='/link7'][data-position='2.2.1']", text: "Link 2.2.1"
-    assert_select group2step2 + " .gem-c-task-list__link", text: "or"
-    assert_select group2step2 + " .gem-c-task-list__link .gem-c-task-list__link-item[href='/link8'][data-position='2.2.2']", text: "Link 2.2.2"
+    assert_select step2or + " .gem-c-task-list__link .gem-c-task-list__link-item[href='/link7'][data-position='4.1']", text: "Link 2.2.1"
+    assert_select step2or + " .gem-c-task-list__link", text: "or"
+    assert_select step2or + " .gem-c-task-list__link .gem-c-task-list__link-item[href='/link8'][data-position='4.2']", text: "Link 2.2.2"
   end
 
   it "renders optional steps, sub steps and optional sub steps" do
-    render_component(groups: tasklist)
+    render_component(steps: tasklist)
 
-    assert_select group1 + " .gem-c-task-list__step.gem-c-task-list__step--optional:nth-of-type(1)"
-    assert_select group1step1 + " .gem-c-task-list__substep .gem-c-task-list__paragraph", text: "This paragraph is inside a required substep"
-    assert_select group2step1 + " .gem-c-task-list__substep.gem-c-task-list__substep--optional .gem-c-task-list__paragraph", text: "This paragraph is inside an optional substep"
+    assert_select ".gem-c-task-list__step#step-1.gem-c-task-list__step--optional"
+    assert_select step1 + " .gem-c-task-list__substep .gem-c-task-list__paragraph", text: "This paragraph is inside a required substep"
+    assert_select step2 + " .gem-c-task-list__substep.gem-c-task-list__substep--optional .gem-c-task-list__paragraph", text: "This paragraph is inside an optional substep"
   end
 
   it "renders get help links back to the main task list" do
-    render_component(groups: tasklist, task_list_url: "/learn-to-drive", task_list_url_link_text: "Get help")
+    render_component(steps: tasklist, task_list_url: "/learn-to-drive", task_list_url_link_text: "Get help")
 
-    assert_select group1step1 + " .gem-c-task-list__help-link[href='/learn-to-drive#group-1-step-1']", text: "Get help"
-    assert_select group2step1 + " .gem-c-task-list__help-link[href='/learn-to-drive#group-2-step-1']", false
+    assert_select step1 + " .gem-c-task-list__help-link[href='/learn-to-drive#step-1']", text: "Get help"
+    assert_select step2 + " .gem-c-task-list__help-link[href='/learn-to-drive#step-2']", false
   end
 
-  it "displays group numbering and step logic correctly" do
-    render_component(groups: tasklist)
+  it "displays step numbering and step logic correctly" do
+    render_component(steps: tasklist)
 
-    assert_select group1 + " .gem-c-task-list__circle--number .gem-c-task-list__circle-inner .gem-c-task-list__circle-background", text: "Step 1"
-    assert_select group1step2 + " .gem-c-task-list__circle--logic .gem-c-task-list__circle-inner .gem-c-task-list__circle-background", text: "and"
-    assert_select group2 + " .gem-c-task-list__circle--number .gem-c-task-list__circle-inner .gem-c-task-list__circle-background", text: "Step 2"
-    assert_select group2step2 + " .gem-c-task-list__circle--logic .gem-c-task-list__circle-inner .gem-c-task-list__circle-background", text: "or"
+    assert_select step1 + " .gem-c-task-list__circle--number .gem-c-task-list__circle-inner .gem-c-task-list__circle-background", text: "Step 1"
+    assert_select step1and + " .gem-c-task-list__circle--logic .gem-c-task-list__circle-inner .gem-c-task-list__circle-background", text: "and"
+    assert_select step2 + " .gem-c-task-list__circle--number .gem-c-task-list__circle-inner .gem-c-task-list__circle-background", text: "Step 2"
+    assert_select step2or + " .gem-c-task-list__circle--logic .gem-c-task-list__circle-inner .gem-c-task-list__circle-background", text: "or"
   end
 
   it "applies the correct required and choice styles correctly to lists" do
-    render_component(groups: tasklist)
+    render_component(steps: tasklist)
 
-    assert_select group1step1 + " .gem-c-task-list__links.gem-c-task-list__links--required"
-    assert_select group2step1 + " .gem-c-task-list__links.gem-c-task-list__links--choice"
+    assert_select step1 + " .gem-c-task-list__links.gem-c-task-list__links--required"
+    assert_select step2 + " .gem-c-task-list__links.gem-c-task-list__links--choice"
   end
 
   it "allows steps to be open on page load" do
-    render_component(groups: tasklist, show_step: 3)
+    render_component(steps: tasklist, show_step: 3)
 
-    assert_select group2 + " .gem-c-task-list__step[data-show]:nth-of-type(1)"
+    assert_select ".gem-c-task-list__step#step-2[data-show]"
   end
 
-  it "can set active states on groups and links" do
-    render_component(groups: tasklist, highlight_group: 1)
+  it "can set active states on steps and links" do
+    render_component(steps: tasklist, highlight_step: 1)
 
-    assert_select group1 + ".gem-c-task-list__group--active"
-    assert_select group2step1 + " .gem-c-task-list__link.gem-c-task-list__link--active .gem-c-task-list__link-item[href='#content']", text: "You are currently viewing: Link 2.1.2"
+    assert_select ".gem-c-task-list__step--active#step-1"
+    assert_select step2 + " .gem-c-task-list__link.gem-c-task-list__link--active .gem-c-task-list__link-item[href='#content']", text: "You are currently viewing: Link 2.1.2"
   end
 
   it "renders a small tasklist" do
-    render_component(groups: tasklist, small: true)
+    render_component(steps: tasklist, small: true)
 
     assert_select ".gem-c-task-list"
     assert_select ".gem-c-task-list.gem-c-task-list--large", false

--- a/spec/javascripts/components/task-list-spec.js
+++ b/spec/javascripts/components/task-list-spec.js
@@ -5,69 +5,65 @@ describe('A tasklist module', function () {
   var tasklist;
   var html = '\
     <div data-module="gemtasklist" class="gem-c-task-list js-hidden">\
-      <ol class="gem-c-task-list__groups">\
-        <li class="gem-c-task-list__group">\
+      <ol class="gem-c-task-list__steps">\
+        <li class="gem-c-task-list__step js-step" id="topic-step-one" data-track-count="tasklistStep">\
           <span class="gem-c-task-list__number">\
             <span class="visuallyhidden">Step </span>1\
           </span>\
-          <div class="gem-c-task-list__step js-step" id="topic-step-one" data-track-count="tasklistStep">\
-            <div class="gem-c-task-list__header js-toggle-panel" data-position="1.1">\
-              <h2 class="gem-c-task-list__title js-step-title">Topic Step One</h2>\
-            </div>\
-            <div class="gem-c-task-list__panel js-panel" id="step-panel-topic-step-one-1">\
-              <ol class="gem-c-task-list__links" data-length="1">\
-                <li class="gem-c-task-list__link js-list-item">\
-                  <a href="/link1" class="gem-c-task-list__link-item js-link" data-position="1.1.1">Link 1</a>\
-                </li>\
-              </ol>\
-            </div>\
+          <div class="gem-c-task-list__header js-toggle-panel" data-position="1">\
+            <h2 class="gem-c-task-list__title js-step-title">Topic Step One</h2>\
           </div>\
-          <div class="gem-c-task-list__step js-step" id="topic-step-two" data-track-count="tasklistStep">\
-            <div class="gem-c-task-list__header js-toggle-panel" data-position="1.2">\
-              <h2 class="gem-c-task-list__title js-step-title">Topic Step Two</h2>\
-            </div>\
-            <div class="gem-c-task-list__panel js-panel" id="step-panel-topic-step-two-1">\
-              <ol class="gem-c-task-list__links" data-length="2">\
-                <li class="gem-c-task-list__link gem-c-task-list__link--active js-list-item">\
-                  <a href="/link2" class="gem-c-task-list__link-item js-link" data-position="1.2.1">Link 2</a>\
-                </li>\
-                <li class="gem-c-task-list__link js-list-item">\
-                  <a href="/link3" class="gem-c-task-list__link-item js-link" data-position="1.2.2">Link 3</a>\
-                </li>\
-              </ol>\
-              <div class="gem-c-task-list__help">\
-                <a href="/learn#step-one" class="gem-c-task-list__help-link js-link" data-position="get-help">Get help</a>\
-              </div>\
+          <div class="gem-c-task-list__panel js-panel" id="step-panel-topic-step-one-1">\
+            <ol class="gem-c-task-list__links" data-length="1">\
+              <li class="gem-c-task-list__link js-list-item">\
+                <a href="/link1" class="gem-c-task-list__link-item js-link" data-position="1.1">Link 1</a>\
+              </li>\
+            </ol>\
+          </div>\
+        </li>\
+        <li class="gem-c-task-list__step js-step" id="topic-step-two" data-track-count="tasklistStep">\
+          <div class="gem-c-task-list__header js-toggle-panel" data-position="2">\
+            <h2 class="gem-c-task-list__title js-step-title">Topic Step Two</h2>\
+          </div>\
+          <div class="gem-c-task-list__panel js-panel" id="step-panel-topic-step-two-1">\
+            <ol class="gem-c-task-list__links" data-length="2">\
+              <li class="gem-c-task-list__link gem-c-task-list__link--active js-list-item">\
+                <a href="/link2" class="gem-c-task-list__link-item js-link" data-position="2.1">Link 2</a>\
+              </li>\
+              <li class="gem-c-task-list__link js-list-item">\
+                <a href="/link3" class="gem-c-task-list__link-item js-link" data-position="2.2">Link 3</a>\
+              </li>\
+            </ol>\
+            <div class="gem-c-task-list__help">\
+              <a href="/learn#step-one" class="gem-c-task-list__help-link js-link" data-position="get-help">Get help</a>\
             </div>\
           </div>\
         </li>\
-        <li class="gem-c-task-list__group gem-c-task-list__group--active">\
+        <li class="gem-c-task-list__step gem-c-task-list__step--active js-step" id="topic-step-three" data-track-count="tasklistStep">\
           <span class="gem-c-task-list__number">\
             <span class="visuallyhidden">Step </span>2\
           </span>\
-          <div class="gem-c-task-list__step js-step" id="topic-step-three" data-track-count="tasklistStep">\
-            <div class="gem-c-task-list__header js-toggle-panel" data-position="2.1">\
-              <h2 class="gem-c-task-list__title js-step-title">Topic Step Three</h2>\
-            </div>\
-            <div class="gem-c-task-list__panel js-panel" id="step-panel-topic-step-three-1">\
-              <ol class="gem-c-task-list__links" data-length="5">\
-                <li class="gem-c-task-list__link gem-c-task-list__link--active js-list-item">\
-                  <a href="/link4" class="gem-c-task-list__link-item js-link" data-position="2.1.1">Link 4</a>\
-                </li>\
-                <li class="gem-c-task-list__link gem-c-task-list__link--active js-list-item">\
-                  <a href="/link5" class="gem-c-task-list__link-item js-link" data-position="2.1.2">Link 5</a>\
-                </li>\
-                <li class="gem-c-task-list__link js-list-item">\
-                  <a href="http://www.gov.uk" class="gem-c-task-list__link-item js-link" data-position="2.1.3" rel="external">Link 6</a>\
-                </li>\
-                <li class="gem-c-task-list__link gem-c-task-list__link--active js-list-item">\
-                  <a href="#content" class="gem-c-task-list__link-item js-link" data-position="2.1.4">Link 7</a>\
-                </li>\
-                <li class="gem-c-task-list__link gem-c-task-list__link--active js-list-item">\
-                  <a href="#content" class="gem-c-task-list__link-item js-link" data-position="2.1.5">Link 8</a>\
-                </li>\
-              </ol>\
-            </div>\
+          <div class="gem-c-task-list__header js-toggle-panel" data-position="3">\
+            <h2 class="gem-c-task-list__title js-step-title">Topic Step Three</h2>\
+          </div>\
+          <div class="gem-c-task-list__panel js-panel" id="step-panel-topic-step-three-1">\
+            <ol class="gem-c-task-list__links" data-length="5">\
+              <li class="gem-c-task-list__link gem-c-task-list__link--active js-list-item">\
+                <a href="/link4" class="gem-c-task-list__link-item js-link" data-position="3.1">Link 4</a>\
+              </li>\
+              <li class="gem-c-task-list__link gem-c-task-list__link--active js-list-item">\
+                <a href="/link5" class="gem-c-task-list__link-item js-link" data-position="3.2">Link 5</a>\
+              </li>\
+              <li class="gem-c-task-list__link js-list-item">\
+                <a href="http://www.gov.uk" class="gem-c-task-list__link-item js-link" data-position="3.3" rel="external">Link 6</a>\
+              </li>\
+              <li class="gem-c-task-list__link gem-c-task-list__link--active js-list-item">\
+                <a href="#content" class="gem-c-task-list__link-item js-link" data-position="3.4">Link 7</a>\
+              </li>\
+              <li class="gem-c-task-list__link gem-c-task-list__link--active js-list-item">\
+                <a href="#content" class="gem-c-task-list__link-item js-link" data-position="3.5">Link 8</a>\
+              </li>\
+            </ol>\
           </div>\
         </li>\
       </ol>\
@@ -215,7 +211,7 @@ describe('A tasklist module', function () {
       $stepLink.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistShown', {
-        label: '1.1 - Topic Step One - Heading click: Small',
+        label: '1 - Topic Step One - Heading click: Small',
         dimension26: expectedTasklistStepCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -233,7 +229,7 @@ describe('A tasklist module', function () {
       $stepIcon.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistShown', {
-        label: '1.1 - Topic Step One - Plus click: Small',
+        label: '1 - Topic Step One - Plus click: Small',
         dimension26: expectedTasklistStepCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -251,7 +247,7 @@ describe('A tasklist module', function () {
       $stepHeader.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistShown', {
-        label: '1.1 - Topic Step One - Elsewhere click: Small',
+        label: '1 - Topic Step One - Elsewhere click: Small',
         dimension26: expectedTasklistStepCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -292,7 +288,7 @@ describe('A tasklist module', function () {
       $stepLink.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistHidden', {
-        label: '1.1 - Topic Step One - Heading click: Small',
+        label: '1 - Topic Step One - Heading click: Small',
         dimension26: expectedTasklistStepCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -311,7 +307,7 @@ describe('A tasklist module', function () {
       $stepIcon.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistHidden', {
-        label: '1.1 - Topic Step One - Minus click: Small',
+        label: '1 - Topic Step One - Minus click: Small',
         dimension26: expectedTasklistStepCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -331,7 +327,7 @@ describe('A tasklist module', function () {
       $stepHeader.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistHidden', {
-        label: '1.1 - Topic Step One - Elsewhere click: Small',
+        label: '1 - Topic Step One - Elsewhere click: Small',
         dimension26: expectedTasklistStepCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -386,7 +382,7 @@ describe('A tasklist module', function () {
       $stepLink.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistShown', {
-        label: '1.1 - Topic Step One - Heading click: Big',
+        label: '1 - Topic Step One - Heading click: Big',
         dimension26: expectedTasklistStepCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -404,7 +400,7 @@ describe('A tasklist module', function () {
       $stepIcon.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistShown', {
-        label: '1.1 - Topic Step One - Plus click: Big',
+        label: '1 - Topic Step One - Plus click: Big',
         dimension26: expectedTasklistStepCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -422,7 +418,7 @@ describe('A tasklist module', function () {
       $stepHeader.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistShown', {
-        label: '1.1 - Topic Step One - Elsewhere click: Big',
+        label: '1 - Topic Step One - Elsewhere click: Big',
         dimension26: expectedTasklistStepCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -441,7 +437,7 @@ describe('A tasklist module', function () {
       $stepLink.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistHidden', {
-        label: '1.1 - Topic Step One - Heading click: Big',
+        label: '1 - Topic Step One - Heading click: Big',
         dimension26: expectedTasklistStepCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -460,7 +456,7 @@ describe('A tasklist module', function () {
       $stepIcon.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistHidden', {
-        label: '1.1 - Topic Step One - Minus click: Big',
+        label: '1 - Topic Step One - Minus click: Big',
         dimension26: expectedTasklistStepCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -480,7 +476,7 @@ describe('A tasklist module', function () {
       $stepHeader.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistHidden', {
-        label: '1.1 - Topic Step One - Elsewhere click: Big',
+        label: '1 - Topic Step One - Elsewhere click: Big',
         dimension26: expectedTasklistStepCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -526,7 +522,7 @@ describe('A tasklist module', function () {
       spyOn(GOVUK.analytics, 'trackEvent');
       $element.find('.js-link').first().click();
 
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('taskAccordionLinkClicked', '1.1.1', {
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('taskAccordionLinkClicked', '1.1', {
         label: '/link1 : Big',
         dimension26: expectedTasklistStepCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
@@ -562,7 +558,7 @@ describe('A tasklist module', function () {
     var $panelLink = $element.find('.js-link').first();
     $panelLink.click();
 
-    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('taskAccordionLinkClicked', '1.1.1', {
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('taskAccordionLinkClicked', '1.1', {
       label: '/link1 : Small',
       dimension26: expectedTasklistStepCount.toString(),
       dimension27: expectedTasklistLinkCount.toString(),
@@ -595,33 +591,33 @@ describe('A tasklist module', function () {
     });
 
     it("puts a clicked link in session storage", function () {
-      $element.find('.js-link[data-position="2.1.2"]').click();
-      expect(sessionStorage.getItem('govuk-task-list-active-link')).toBe('2.1.2');
+      $element.find('.js-link[data-position="3.1"]').click();
+      expect(sessionStorage.getItem('govuk-task-list-active-link')).toBe('3.1');
     });
 
     it("does not put an external clicked link in session storage", function () {
-      $element.find('.js-link[data-position="2.1.3"]').click();
+      $element.find('.js-link[data-position="3.3"]').click();
       expect(sessionStorage.getItem('govuk-task-list-active-link')).toBe(null);
     });
 
-    it("highlights the first active link in the first active group if no sessionStorage value is set", function () {
+    it("highlights the first active link in the first active step if no sessionStorage value is set", function () {
       expect(sessionStorage.getItem('govuk-task-list-active-link')).toBe(null);
-      expect($element.find('.js-link[data-position="2.1.1"]').closest('.js-list-item')).toHaveClass('gem-c-task-list__link--active');
+      expect($element.find('.js-link[data-position="3.1"]').closest('.js-list-item')).toHaveClass('gem-c-task-list__link--active');
       expect($element.find(('.gem-c-task-list__link--active')).length).toBe(1);
     });
 
     it("highlights a clicked #content link and removes other highlights", function () {
       expect($element.find(('.gem-c-task-list__link--active')).length).toBe(1);
 
-      var $firstLink = $element.find('.js-link[data-position="2.1.4"]');
+      var $firstLink = $element.find('.js-link[data-position="3.4"]');
       $firstLink.click();
-      expect(sessionStorage.getItem('govuk-task-list-active-link')).toBe('2.1.4');
+      expect(sessionStorage.getItem('govuk-task-list-active-link')).toBe('3.4');
       expect($firstLink.closest('.js-list-item')).toHaveClass('gem-c-task-list__link--active');
       expect($element.find(('.gem-c-task-list__link--active')).length).toBe(1);
 
-      var $secondLink = $element.find('.js-link[data-position="2.1.5"]');
+      var $secondLink = $element.find('.js-link[data-position="3.5"]');
       $secondLink.click();
-      expect(sessionStorage.getItem('govuk-task-list-active-link')).toBe('2.1.5');
+      expect(sessionStorage.getItem('govuk-task-list-active-link')).toBe('3.5');
       expect($secondLink.closest('.js-list-item')).toHaveClass('gem-c-task-list__link--active');
       expect($element.find(('.gem-c-task-list__link--active')).length).toBe(1);
     });
@@ -643,7 +639,7 @@ describe('A tasklist module', function () {
 
       tasklist = new GOVUK.Modules.Gemtasklist();
       $element = $(html);
-      sessionStorage.setItem('govuk-task-list-active-link', '2.1.5');
+      sessionStorage.setItem('govuk-task-list-active-link', '3.5');
       tasklist.start($element);
     });
 
@@ -652,22 +648,22 @@ describe('A tasklist module', function () {
     });
 
     it("highlights only one link", function () {
-      expect(sessionStorage.getItem('govuk-task-list-active-link')).toBe('2.1.5');
+      expect(sessionStorage.getItem('govuk-task-list-active-link')).toBe('3.5');
       expect($element.find(('.gem-c-task-list__link--active')).length).toBe(1);
     });
   });
 
-  describe('in a double dot situation where there is no active group', function () {
+  describe('in a double dot situation where there is no active step', function () {
     beforeEach(function () {
       $element = $(html);
-      $element.find('.gem-c-task-list__group').removeClass('gem-c-task-list__group--active');
+      $element.find('.gem-c-task-list__step').removeClass('gem-c-task-list__step--active');
       tasklist = new GOVUK.Modules.Gemtasklist();
       tasklist.start($element);
     });
 
     it("highlights the first active link if no sessionStorage value is set", function () {
       expect(sessionStorage.getItem('govuk-task-list-active-link')).toBe(null);
-      expect($element.find('.js-link[data-position="1.2.1"]').closest('.js-list-item')).toHaveClass('gem-c-task-list__link--active');
+      expect($element.find('.js-link[data-position="2.1"]').closest('.js-list-item')).toHaveClass('gem-c-task-list__link--active');
       expect($element.find(('.gem-c-task-list__link--active')).length).toBe(1);
     });
   });


### PR DESCRIPTION
# Note this PR contains breaking changes

To simplify the task list component code we are removing the concept of groups of steps. Instead, the task list data will simply be a series of steps, some of which can be configured to have the 'and' or 'or' appearance.

This means removing one of the nested arrays in the data structure, so that a task list is now defined by an array of objects, not an array of an array of objects.

i.e.

`
steps: [
   {
      title: 'A step'
   }
]
`

instead of

`
groups: [
   [
      {
         title: 'A step'
      }
   ]
]
`

**Breaking changes**

- data passed to component as 'groups' is now 'steps'
- steps that should be marked as 'and' instead of being numbered must now explicitly have the logic parameter, otherwise they'll just be given numbers
- any other references to groups such as 'highlight_group' are now steps, e.g. 'highlight_step'

Trello card: https://trello.com/c/G7kq47Db/467-remove-groups-from-component
