### PR TITLE
Fix RSpec tests in CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
-if defined?(RSpec)
+begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+  puts "Running in production mode"
 end
 
 APP_RAKEFILE = File.expand_path("../spec/dummy/Rakefile", __FILE__)


### PR DESCRIPTION
It appears that RSpec is not available until it's been required.  This was causing rspec tests to not be run as part of `bundle exec rake` or `bundle exec rake spec`.

(I'm not sure whether this fixes the problem it was originally changed to resolve.)