### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (4.1.0)
+    govuk_publishing_components (5.0.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)
@@ -63,7 +63,7 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     cliver (0.3.2)
-    commander (4.4.3)
+    commander (4.4.4)
       highline (~> 1.7.2)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
@@ -138,7 +138,7 @@ GEM
     parser (2.4.0.2)
       ast (~> 2.3)
     phantomjs (2.1.1.0)
-    plek (2.0.0)
+    plek (2.1.1)
     poltergeist (1.16.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -181,7 +181,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.1.0)
+    rouge (3.1.1)
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -250,7 +250,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.4)
+    unf_ext (0.0.7.5)
     unicode-display_width (1.3.0)
     webmock (3.0.1)
       addressable (>= 2.3.6)


### PR DESCRIPTION
The tests in https://github.com/alphagov/govuk_publishing_components/pull/159 are failing, and I think it's related to the Gemfile. This diff is generated by running `bundle`.