### PR TITLE
Add unique tracking id option to step by step nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add unique tracking to all GA events on step nav components (PR #162)
+
 # 5.0.0
 
 * Rename task list components (PR #156), breaking change

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -49,7 +49,8 @@
 
       var $showOrHideAllButton;
 
-      var stepNavTracker = new StepNavTracker(totalSteps, totalLinks);
+      var uniqueId = $element.data('id') || false;
+      var stepNavTracker = new StepNavTracker(totalSteps, totalLinks, uniqueId);
 
       addButtonstoSteps();
       addShowHideAllButton();
@@ -450,7 +451,7 @@
 
     // A helper that sends a custom event request to Google Analytics if
     // the GOVUK module is setup
-    function StepNavTracker(totalSteps, totalLinks) {
+    function StepNavTracker(totalSteps, totalLinks, uniqueId) {
       this.track = function(category, action, options) {
         // dimension26 records the total number of expand/collapse steps in this step nav
         // dimension27 records the total number of links in this step nav
@@ -459,6 +460,7 @@
           options = options || {};
           options["dimension26"] = options["dimension26"] || totalSteps.toString();
           options["dimension27"] = options["dimension27"] || totalLinks.toString();
+          options["dimension96"] = options["dimension96"] || uniqueId;
           GOVUK.analytics.trackEvent(category, action, options);
         }
       }

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
@@ -9,6 +9,7 @@
   step_nav_url ||= false
   step_nav_link_text ||= "Get help completing this step"
   highlight_step ||= false
+  tracking_id ||= false
 
   step_count = 0
   step_number = 0
@@ -17,7 +18,8 @@
   <div
     data-module="gemstepnav"
     class="gem-c-step-nav js-hidden <% unless small %>gem-c-step-nav--large<% end %>"
-    <% if remember_last_step %>data-remember<% end %>
+    <%= "data-remember" if remember_last_step %>
+    <%= "data-id=#{tracking_id}" if tracking_id %>
   >
     <ol class="gem-c-step-nav__steps">
       <% steps.each_with_index do |step, step_index| %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
@@ -3,6 +3,7 @@
   path ||= false
   skip_link ||= false
   skip_link_text ||= "Skip content"
+  tracking_id ||= false
 %>
 <% if title %>
   <div class="gem-c-step-nav-header" data-module="track-click">
@@ -14,7 +15,8 @@
         data-track-action="top"
         data-track-label="<%= path %>"
         data-track-dimension="<%= title %>"
-        data-track-dimension-index="29">
+        data-track-dimension-index="29"
+        data-track-options='{"dimension96" : "<%= tracking_id %>" }'>
         <%= title %>
       </a>
     <% else %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -1,6 +1,7 @@
 <%
   links ||= false
   pretitle ||= t("govuk_component.step_by_step_nav_related.part_of", default: "Part of")
+  tracking_id ||= false
 %>
 <% if links %>
   <div class="gem-c-step-nav-related" data-module="track-click">
@@ -13,7 +14,8 @@
             data-track-action="<%= pretitle %>"
             data-track-label="<%= links[0][:href] %>"
             data-track-dimension="<%= links[0][:text] %>"
-            data-track-dimension-index="29">
+            data-track-dimension-index="29"
+            data-track-options='{"dimension96" : "<%= tracking_id %>" }'>
             <%= links[0][:text] %>
           </a>
         </h2>
@@ -28,7 +30,8 @@
                 data-track-action="<%= pretitle %>"
                 data-track-label="<%= link[:href] %>"
                 data-track-dimension="<%= link[:text] %>"
-                data-track-dimension-index="29">
+                data-track-dimension-index="29"
+                data-track-options='{"dimension96" : "<%= tracking_id %>" }'>
                 <%= link[:text] %>
               </a>
             </li>

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
@@ -70,6 +70,29 @@ examples:
           ]
         }
       ]
+  with_unique_tracking:
+    description: |
+      We need to uniquely identify each step by step navigation in Google Analytics. If this parameter is added to the component, its value is included in any tracking events, specifically in dimension96.
+
+      This includes show/hide all, show/hide step and any link clicks.
+    data:
+      tracking_id: 'this-is-the-tracking-id'
+      steps: [
+        {
+          title: 'Unique tracking id',
+          contents: [
+            {
+              type: 'list',
+              contents: [
+                {
+                  href: '#',
+                  text: 'This is a link'
+                }
+              ]
+            }
+          ]
+        }
+      ]
   with_a_different_heading_level:
     description: Steps have a H2 by default, but this can be changed. The heading level does not change any styling.
     data:

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav_header.yml
@@ -18,6 +18,12 @@ examples:
     data:
       title: 'Having children: step by step'
       path: /childcare-parenting/pregnancy-and-birth
+  with_unique_tracking:
+    description: We need to uniquely identify each step by step navigation in Google Analytics. If this parameter is added to the component, its value is included in any tracking events, specifically in dimension96.
+    data:
+      title: 'With a tracking id'
+      path: '#'
+      tracking_id: 'this-is-the-tracking-id'
   with_a_skip_link:
     description: This option allows the insertion of a skip link to a step by step navigation elsewhere on the page. This aids navigation when using a keyboard or screen reader. The skip link is visually hidden until it receives focus.
     data:

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav_related.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav_related.yml
@@ -52,3 +52,13 @@ examples:
           text: 'Learn to drive a motorbike: step by step'
         }
       ]
+  with_unique_tracking:
+    description: We need to uniquely identify each step by step navigation in Google Analytics. If this parameter is added to the component, its value is included in any tracking events, specifically in dimension96.
+    data:
+      tracking_id: 'this-is-the-tracking-id'
+      links: [
+        {
+          href: '#',
+          text: 'With a tracking id'
+        }
+      ]

--- a/spec/components/step_by_step_nav_header_spec.rb
+++ b/spec/components/step_by_step_nav_header_spec.rb
@@ -28,6 +28,12 @@ describe "Step by step navigation header", type: :view do
     assert_select link + "[data-track-dimension-index='29']"
   end
 
+  it "adds a tracking id" do
+    render_component(title: "This is my title", path: "/notalink", tracking_id: "brian")
+
+    assert_select ".gem-c-step-nav-header .gem-c-step-nav-header__title[data-track-options='{\"dimension96\" : \"brian\" }']"
+  end
+
   it "renders with a skip link" do
     render_component(title: "This is my title", skip_link: "#skiplink")
 

--- a/spec/components/step_by_step_nav_related_spec.rb
+++ b/spec/components/step_by_step_nav_related_spec.rb
@@ -66,4 +66,17 @@ describe "Step by step navigation related", type: :view do
     assert_select ".gem-c-step-nav-related__pretitle", text: 'Moo'
     assert_select ".gem-c-step-nav-related__link[data-track-action='Moo']"
   end
+
+  it "adds a tracking id to one link" do
+    render_component(links: one_link, tracking_id: "peter")
+
+    assert_select ".gem-c-step-nav-related .gem-c-step-nav-related__link[data-track-options='{\"dimension96\" : \"peter\" }']"
+  end
+
+  it "adds a tracking id to every link when there are more than one" do
+    render_component(links: two_links, tracking_id: "peter")
+
+    assert_select ".gem-c-step-nav-related .gem-c-step-nav-related__link-item:nth-child(1) .gem-c-step-nav-related__link[data-track-options='{\"dimension96\" : \"peter\" }']"
+    assert_select ".gem-c-step-nav-related .gem-c-step-nav-related__link-item:nth-child(2) .gem-c-step-nav-related__link[data-track-options='{\"dimension96\" : \"peter\" }']"
+  end
 end

--- a/spec/components/step_by_step_nav_spec.rb
+++ b/spec/components/step_by_step_nav_spec.rb
@@ -279,4 +279,10 @@ describe "step nav", type: :view do
     assert_select ".gem-c-step-nav"
     assert_select ".gem-c-step-nav.gem-c-step-nav--large", false
   end
+
+  it "adds a tracking id" do
+    render_component(steps: stepnav, tracking_id: "harold")
+
+    assert_select ".gem-c-step-nav[data-id='harold']"
+  end
 end

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -4,7 +4,7 @@ describe('A stepnav module', function () {
   var $element;
   var stepnav;
   var html = '\
-    <div data-module="gemstepnav" class="gem-c-step-nav js-hidden">\
+    <div data-module="gemstepnav" class="gem-c-step-nav js-hidden" data-id="unique-id">\
       <ol class="gem-c-step-nav__steps">\
         <li class="gem-c-step-nav__step js-step" id="topic-step-one" data-track-count="stepnavStep">\
           <span class="gem-c-step-nav__number">\
@@ -159,7 +159,8 @@ describe('A stepnav module', function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllShown', {
         label: 'Show All: Small',
         dimension26: expectedstepnavStepCount.toString(),
-        dimension27: expectedstepnavLinkCount.toString()
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension96: "unique-id"
       });
     });
   });
@@ -178,13 +179,13 @@ describe('A stepnav module', function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllHidden', {
         label: 'Hide All: Small',
         dimension26: expectedstepnavStepCount.toString(),
-        dimension27: expectedstepnavLinkCount.toString()
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension96: "unique-id"
       });
     });
   });
 
   describe('Opening a step', function () {
-
     // When a step is open (testing: toggleStep, openStep)
     it("has a class of step-is-shown", function () {
       var $stepLink = $element.find('.gem-c-step-nav__header .gem-c-step-nav__button--title');
@@ -214,7 +215,8 @@ describe('A stepnav module', function () {
         label: '1 - Topic Step One - Heading click: Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
-        dimension28: expectedstepnavContentCount.toString()
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: "unique-id"
       });
     });
 
@@ -232,7 +234,8 @@ describe('A stepnav module', function () {
         label: '1 - Topic Step One - Plus click: Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
-        dimension28: expectedstepnavContentCount.toString()
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: "unique-id"
       });
     });
 
@@ -250,13 +253,13 @@ describe('A stepnav module', function () {
         label: '1 - Topic Step One - Elsewhere click: Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
-        dimension28: expectedstepnavContentCount.toString()
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: "unique-id"
       });
     });
   });
 
   describe('Hiding a step', function () {
-
     // When a step is hidden (testing: toggleStep, hideStep)
     it("removes the step-is-shown class", function () {
       var $stepLink = $element.find('.gem-c-step-nav__header .gem-c-step-nav__button--title');
@@ -291,7 +294,8 @@ describe('A stepnav module', function () {
         label: '1 - Topic Step One - Heading click: Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
-        dimension28: expectedstepnavContentCount.toString()
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: "unique-id"
       });
     });
 
@@ -310,7 +314,8 @@ describe('A stepnav module', function () {
         label: '1 - Topic Step One - Minus click: Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
-        dimension28: expectedstepnavContentCount.toString()
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: "unique-id"
       });
     });
 
@@ -321,7 +326,6 @@ describe('A stepnav module', function () {
       };
       spyOn(GOVUK.analytics, 'trackEvent');
 
-      stepnav.start($element);
       var $stepHeader = $element.find('.gem-c-step-nav__header');
       $stepHeader.click();
       $stepHeader.click();
@@ -330,7 +334,8 @@ describe('A stepnav module', function () {
         label: '1 - Topic Step One - Elsewhere click: Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
-        dimension28: expectedstepnavContentCount.toString()
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: "unique-id"
       });
     });
   });
@@ -385,7 +390,8 @@ describe('A stepnav module', function () {
         label: '1 - Topic Step One - Heading click: Big',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
-        dimension28: expectedstepnavContentCount.toString()
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: "unique-id"
       });
     });
 
@@ -403,7 +409,8 @@ describe('A stepnav module', function () {
         label: '1 - Topic Step One - Plus click: Big',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
-        dimension28: expectedstepnavContentCount.toString()
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: "unique-id"
       });
     });
 
@@ -421,7 +428,8 @@ describe('A stepnav module', function () {
         label: '1 - Topic Step One - Elsewhere click: Big',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
-        dimension28: expectedstepnavContentCount.toString()
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: "unique-id"
       });
     });
 
@@ -440,7 +448,8 @@ describe('A stepnav module', function () {
         label: '1 - Topic Step One - Heading click: Big',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
-        dimension28: expectedstepnavContentCount.toString()
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: "unique-id"
       });
     });
 
@@ -459,7 +468,8 @@ describe('A stepnav module', function () {
         label: '1 - Topic Step One - Minus click: Big',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
-        dimension28: expectedstepnavContentCount.toString()
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: "unique-id"
       });
     });
 
@@ -479,7 +489,8 @@ describe('A stepnav module', function () {
         label: '1 - Topic Step One - Elsewhere click: Big',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
-        dimension28: expectedstepnavContentCount.toString()
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: "unique-id"
       });
     });
 
@@ -494,7 +505,8 @@ describe('A stepnav module', function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllShown', {
         label: 'Show All: Big',
         dimension26: expectedstepnavStepCount.toString(),
-        dimension27: expectedstepnavLinkCount.toString()
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension96: "unique-id"
       });
     });
 
@@ -510,7 +522,8 @@ describe('A stepnav module', function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllHidden', {
         label: 'Hide All: Big',
         dimension26: expectedstepnavStepCount.toString(),
-        dimension27: expectedstepnavLinkCount.toString()
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension96: "unique-id"
       });
     });
 
@@ -526,7 +539,8 @@ describe('A stepnav module', function () {
         label: '/link1 : Big',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
-        dimension28: expectedstepnavContentCount.toString()
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: "unique-id"
       });
     });
 
@@ -543,7 +557,8 @@ describe('A stepnav module', function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('stepNavLinkClicked', 'get-help', {
         label: '/learn#step-one : Big',
         dimension26: expectedstepnavStepCount.toString(),
-        dimension27: expectedstepnavLinkCount.toString()
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension96: "unique-id"
       });
     });
   });
@@ -562,7 +577,8 @@ describe('A stepnav module', function () {
       label: '/link1 : Small',
       dimension26: expectedstepnavStepCount.toString(),
       dimension27: expectedstepnavLinkCount.toString(),
-      dimension28: expectedstepnavContentCount.toString()
+      dimension28: expectedstepnavContentCount.toString(),
+      dimension96: "unique-id"
     });
   });
 
@@ -579,7 +595,8 @@ describe('A stepnav module', function () {
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('stepNavLinkClicked', 'get-help', {
       label: '/learn#step-one : Small',
       dimension26: expectedstepnavStepCount.toString(),
-      dimension27: expectedstepnavLinkCount.toString()
+      dimension27: expectedstepnavLinkCount.toString(),
+      dimension96: "unique-id"
     });
   });
 
@@ -665,6 +682,154 @@ describe('A stepnav module', function () {
       expect(sessionStorage.getItem('govuk-step-nav-active-link')).toBe(null);
       expect($element.find('.js-link[data-position="2.1"]').closest('.js-list-item')).toHaveClass('gem-c-step-nav__link--active');
       expect($element.find(('.gem-c-step-nav__link--active')).length).toBe(1);
+    });
+  });
+
+  describe('if no unique id is set', function () {
+    beforeEach(function () {
+      stepnav = new GOVUK.Modules.Gemstepnav();
+      $element = $(html);
+      $element.removeAttr('data-id');
+      stepnav.start($element);
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+    });
+
+    it("triggers a google analytics custom event on show all", function () {
+      clickShowHideAll();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllShown', {
+        label: 'Show All: Small',
+        dimension26: expectedstepnavStepCount.toString(),
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension96: false
+      });
+    });
+
+    it("triggers a google analytics custom event on hide all", function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      clickShowHideAll();
+      clickShowHideAll();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllHidden', {
+        label: 'Hide All: Small',
+        dimension26: expectedstepnavStepCount.toString(),
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension96: false
+      });
+    });
+
+    it("triggers a google analytics custom event on step show when clicking on the title", function () {
+      var $stepLink = $element.find('.gem-c-step-nav__header .gem-c-step-nav__button--title');
+      $stepLink.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavShown', {
+        label: '1 - Topic Step One - Heading click: Small',
+        dimension26: expectedstepnavStepCount.toString(),
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: false
+      });
+    });
+
+    it("triggers a google analytics custom event on step show when clicking on the icon", function () {
+      var $stepIcon = $element.find('.js-toggle-link');
+      $stepIcon.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavShown', {
+        label: '1 - Topic Step One - Plus click: Small',
+        dimension26: expectedstepnavStepCount.toString(),
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: false
+      });
+    });
+
+    it("triggers a google analytics custom event on step show when clicking on space in the header", function () {
+      var $stepHeader = $element.find('.gem-c-step-nav__header');
+      $stepHeader.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavShown', {
+        label: '1 - Topic Step One - Elsewhere click: Small',
+        dimension26: expectedstepnavStepCount.toString(),
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: false
+      });
+    });
+
+    it("triggers a google analytics custom event on step hide when clicking on the title", function () {
+      var $stepLink = $element.find('.gem-c-step-nav__header .gem-c-step-nav__button--title');
+      $stepLink.click();
+      $stepLink.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavHidden', {
+        label: '1 - Topic Step One - Heading click: Small',
+        dimension26: expectedstepnavStepCount.toString(),
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: false
+      });
+    });
+
+    it("triggers a google analytics custom event on step hide when clicking on the icon", function () {
+      var $stepIcon = $element.find('.js-toggle-link');
+      $stepIcon.click();
+      $stepIcon.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavHidden', {
+        label: '1 - Topic Step One - Minus click: Small',
+        dimension26: expectedstepnavStepCount.toString(),
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: false
+      });
+    });
+
+    it("triggers a google analytics custom event on step hide when clicking on space in the header", function () {
+      var $stepHeader = $element.find('.gem-c-step-nav__header');
+      $stepHeader.click();
+      $stepHeader.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavHidden', {
+        label: '1 - Topic Step One - Elsewhere click: Small',
+        dimension26: expectedstepnavStepCount.toString(),
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: false
+      });
+    });
+
+    it("triggers a google analytics custom event when clicking on a panel link", function () {
+      $element.find('.js-link').first().click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('stepNavLinkClicked', '1.1', {
+        label: '/link1 : Small',
+        dimension26: expectedstepnavStepCount.toString(),
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension28: expectedstepnavContentCount.toString(),
+        dimension96: false
+      });
+    });
+
+    it("triggers a google analytics custom event when clicking on a get help link", function () {
+      var $link = $element.find('.gem-c-step-nav__help-link.js-link');
+      $link.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('stepNavLinkClicked', 'get-help', {
+        label: '/learn#step-one : Small',
+        dimension26: expectedstepnavStepCount.toString(),
+        dimension27: expectedstepnavLinkCount.toString(),
+        dimension96: false
+      });
     });
   });
 


### PR DESCRIPTION
Add the option to all step nav components to pass an id that will be included in all GA events as dimension96.

Trello card: https://trello.com/c/J3VzLCnk/493-add-unique-id-parameter-to-step-nav-components-for-dimension96-tracking