### PR TITLE
Add feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Support other a customisable type attribute for input component (PR #165)
 * Add unique tracking to all GA events on step nav components (PR #162)
+* Add feedback component (PR #163)
 
 # 5.0.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -1,0 +1,152 @@
+window.GOVUK = window.GOVUK || {};
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  "use strict";
+  window.GOVUK = window.GOVUK || {};
+
+  Modules.Feedback = function () {
+
+    this.start = function ($element) {
+      this.$prompt = $element.find('.js-prompt');
+      this.$fields = $element.find('.gem-c-feedback__form-field');
+      this.$forms = $element.find('.js-feedback-form');
+      this.$toggleForms = $element.find('.js-toggle-form');
+      this.$closeForms = $element.find('.js-close-form');
+      this.$activeForm = false;
+      this.$pageIsUsefulButton = $element.find('.js-page-is-useful');
+      this.$pageIsNotUsefulButton = $element.find('.js-page-is-not-useful');
+      this.$somethingIsWrongButton = $element.find('.js-something-is-wrong');
+      this.$promptQuestions = $element.find('.js-prompt-questions');
+      this.$promptSuccessMessage = $element.find('.js-prompt-success');
+
+      var that = this;
+      var jshiddenClass = 'js-hidden';
+
+      setInitialAriaAttributes();
+
+      this.$toggleForms.on('click', function(e) {
+        e.preventDefault();
+        toggleForm($(e.target).attr('aria-controls'));
+        trackEvent(getTrackEventParams($(this)));
+        updateAriaAttributes($(this));
+      });
+
+      this.$closeForms.on('click', function(e) {
+        e.preventDefault();
+        toggleForm($(e.target).attr('aria-controls'));
+        setInitialAriaAttributes();
+      });
+
+      this.$pageIsUsefulButton.on('click', function(e) {
+        e.preventDefault();
+        trackEvent(getTrackEventParams(that.$pageIsUsefulButton));
+        showFormSuccess();
+        revealInitialPrompt();
+      });
+
+      $element.find('form').on('submit', function(e) {
+        e.preventDefault();
+        var $form = $(this);
+        $.ajax({
+          type: "POST",
+          url: $form.attr('action'),
+          dataType: "json",
+          data: $form.serialize(),
+          beforeSend: disableSubmitFormButton($form),
+          timeout: 6000
+        }).done(function (xhr) {
+          trackEvent(getTrackEventParams($form));
+          showFormSuccess(xhr.message);
+          revealInitialPrompt();
+          setInitialAriaAttributes();
+          that.$activeForm.toggleClass(jshiddenClass);
+        }).fail(function (xhr) {
+          showError(xhr);
+          enableSubmitFormButton($form);
+        });
+      });
+
+      function disableSubmitFormButton ($form) {
+        $form.find('input[type="submit"]').prop('disabled', true);
+      }
+
+      function enableSubmitFormButton ($form) {
+        $form.find('input[type="submit"]').removeAttr('disabled');
+      }
+
+      function setInitialAriaAttributes () {
+        that.$forms.attr('aria-hidden', true);
+        that.$pageIsNotUsefulButton.attr('aria-expanded', false);
+        that.$somethingIsWrongButton.attr('aria-expanded', false);
+      }
+
+      function updateAriaAttributes (linkClicked) {
+        linkClicked.attr('aria-expanded', true);
+        $('#' + linkClicked.attr('aria-controls')).attr('aria-hidden', false);
+      }
+
+      function toggleForm (formId) {
+        that.$activeForm = $element.find('#' + formId);
+        that.$activeForm.toggleClass(jshiddenClass);
+        that.$prompt.toggleClass(jshiddenClass);
+
+        var formIsVisible = !that.$activeForm.hasClass(jshiddenClass);
+
+        if (formIsVisible) {
+          that.$activeForm.find('.gem-c-input').first().focus();
+        } else {
+          that.$activeForm = false;
+        }
+      }
+
+      function getTrackEventParams ($node) {
+        return {
+          category: $node.data('track-category'),
+          action: $node.data('track-action')
+        }
+      }
+
+      function trackEvent (trackEventParams) {
+        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+          GOVUK.analytics.trackEvent(trackEventParams.category, trackEventParams.action);
+        }
+      }
+
+      function clearMessages () {
+        $element.find('.js-errors').html('').addClass(jshiddenClass);
+      }
+
+      function showError (error) {
+        var error = [
+          '<h2 class="gem-c-feedback__heading">',
+          '  Sorry, we’re unable to receive your message right now. ',
+          '</h2>',
+          '<p>If the problem persists, we have other ways for you to provide',
+          ' feedback on the <a href="/contact/govuk">contact page</a>.</p>'
+        ].join('');
+
+        if (typeof(error.responseJSON) !== 'undefined') {
+          error = typeof(error.responseJSON.message) == 'undefined' ? error : error.responseJSON.message;
+        }
+        var $errors = that.$activeForm.find('.js-errors');
+        $errors.html(error).removeClass(jshiddenClass).focus();
+      }
+
+      function clearAllInputs () {
+        that.$fields.val('');
+      }
+
+      function showFormSuccess () {
+        that.$promptQuestions.addClass(jshiddenClass);
+        that.$promptSuccessMessage.removeClass(jshiddenClass).focus();
+      }
+
+      function revealInitialPrompt () {
+        that.$prompt.removeClass(jshiddenClass);
+        that.$prompt.focus();
+      }
+    }
+
+  };
+})(window.GOVUK.Modules);

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -16,3 +16,4 @@
 @import "components/step-by-step-nav";
 @import "components/step-by-step-nav-header";
 @import "components/step-by-step-nav-related";
+@import "components/feedback";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -9,3 +9,4 @@
 
 @import "components/print/step-by-step-nav";
 @import "components/print/step-by-step-nav-header";
+@import "components/print/feedback";

--- a/app/assets/stylesheets/govuk_publishing_components/component_guide_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/component_guide_print.scss
@@ -1,3 +1,0 @@
-@import "typography";
-@import "components/print/step-by-step-nav";
-@import "components/print/step-by-step-nav-header";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -1,0 +1,136 @@
+// govuk_frontend_toolkit
+@import 'grid_layout';
+@import 'design-patterns/buttons';
+
+.gem-c-feedback {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+// hide without js
+// show with js, unless also has the js-hidden class
+.gem-c-feedback__js-show {
+  display: none;
+
+  .js-enabled & {
+    display: block;
+
+    &.js-hidden {
+      display: none;
+    }
+  }
+}
+
+.gem-c-feedback__grid-row {
+  @extend %grid-row;
+}
+
+.gem-c-feedback__column-two-thirds {
+  @include grid-column( 2 / 3 );
+}
+
+.gem-c-feedback__prompt {
+  @extend %contain-floats;
+  background-color: $govuk-blue;
+  color: $white;
+  padding: $gutter-one-third $gutter-half 0;
+  outline: 0;
+}
+
+.gem-c-feedback__prompt-question,
+.gem-c-feedback__prompt-success {
+  @include bold-16;
+  display: inline;
+
+  &:focus {
+    outline: 0;
+  }
+}
+
+.gem-c-feedback__prompt-link:link,
+.gem-c-feedback__prompt-link:visited {
+  color: $white;
+  display: inline-block;
+}
+
+.gem-c-feedback__prompt-link--useful {
+  margin-right: 0.2em;
+}
+
+.gem-c-feedback__prompt-link--wrong {
+  float: right;
+}
+
+.gem-c-feedback__error-summary {
+  margin-bottom: $gutter-half;
+  padding: $gutter-half;
+  border: solid 4px $error-colour;
+
+  &:focus {
+    outline: solid 3px $focus-colour;
+  }
+
+  @include media(tablet) {
+    border-width: 5px;
+  }
+
+  // this comes from the backend so we can't put a class on it
+  h2,
+  .gem-c-feedback__heading {
+    @include bold-19;
+    margin: 0;
+  }
+
+  p {
+    @include core-16;
+    margin: $gutter-one-third 0;
+  }
+}
+
+.gem-c-feedback__error-message {
+  @include bold-19;
+  display: block;
+  padding: 4px 0 0;
+  color: $error-colour;
+}
+
+.gem-c-feedback__form {
+  margin-top: $gutter-half;
+  padding: $gutter-half 0;
+  border-top: $gutter-one-third solid $govuk-blue;
+
+  @include media(tablet) {
+    padding: $gutter 0;
+  }
+}
+
+.gem-c-feedback__form-heading {
+  @include bold-19;
+  margin-bottom: $gutter-half;
+}
+
+.gem-c-feedback__form-paragraph {
+  @include core-16;
+  margin-bottom: $gutter;
+}
+
+.gem-c-feedback__form-label {
+  @include core-16;
+  display: block;
+  padding-bottom: $gutter-half;
+}
+
+.gem-c-feedback__close {
+  @include core-16;
+  text-align: right;
+  margin-bottom: $gutter-one-third;
+
+  @include media(tablet) {
+    float: right;
+    padding-top: 0;
+  }
+}
+
+.gem-c-feedback__submit {
+  @include button;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_feedback.scss
@@ -1,0 +1,3 @@
+.gem-c-feedback {
+  display: none;
+}

--- a/app/controllers/govuk_publishing_components/application_controller.rb
+++ b/app/controllers/govuk_publishing_components/application_controller.rb
@@ -14,7 +14,7 @@ module GovukPublishingComponents
   private
 
     def set_custom_slimmer_headers
-      set_slimmer_headers(report_a_problem: 'false', remove_search: true)
+      set_slimmer_headers(remove_search: true)
     end
 
     def set_x_frame_options_header

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -1,0 +1,115 @@
+<%
+  contact_govuk_path = "/contact/govuk"
+%>
+
+<div class="gem-c-feedback" data-module="feedback">
+  <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
+    <div class="js-prompt-questions">
+      <h3 class="gem-c-feedback__prompt-question">Is this page useful?</h3>
+
+      <%= link_to contact_govuk_path, {
+        class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful',
+        data: {
+          'track-category' => 'yesNoFeedbackForm',
+          'track-action' => 'ffYesClick'
+          },
+        } do %>
+          Yes <span class="visually-hidden">this page is useful</span>
+      <% end %>
+
+      <%= link_to contact_govuk_path, {
+        class: 'gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful',
+        data: {
+          'track-category' => 'yesNoFeedbackForm',
+          'track-action' => 'ffNoClick'
+          },
+          'aria-controls': 'page-is-not-useful',
+          'aria-expanded': false
+        } do %>
+          No <span class="visually-hidden">this page is not useful</span>
+      <% end %>
+
+      <%= link_to contact_govuk_path, {
+        class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong',
+        data: {
+          'track-category' => 'yesNoFeedbackForm',
+          'track-action' => 'ffWrongClick'
+          },
+          'aria-controls': 'something-is-wrong',
+          'aria-expanded': false
+        } do %>
+          Is there anything wrong with this page?
+      <% end %>
+    </div>
+
+    <div class="gem-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">
+      Thank you for your feedback
+    </div>
+  </div>
+
+  <form action="/contact/govuk/problem_reports" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="yesNoFeedbackForm" data-track-action="ffFormSubmit">
+    <a href="#" class="gem-c-feedback__close gem-c-feedback__js-show js-close-form" aria-controls="something-is-wrong" aria-expanded="true" role="button">Close</a>
+
+    <div class="gem-c-feedback__grid-row">
+      <div class="gem-c-feedback__column-two-thirds">
+        <div class="gem-c-feedback__error-summary gem-c-feedback__js-show js-hidden js-errors" tabindex="-1"></div>
+
+        <input type="hidden" name="url" value="<%= request.original_url -%>">
+        <input type="hidden" name="user_agent" value="<%= request.user_agent -%>">
+
+        <h2 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h2>
+        <p id="feedback_explanation" class="gem-c-feedback__form-paragraph">Don’t include personal or financial information like your National Insurance number or credit card details.</p>
+
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "What were you doing?"
+          },
+          name: "what_doing"
+        } %>
+
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "What went wrong?"
+          },
+          name: "what_wrong"
+        } %>
+
+        <%# TODO: use button component once available in gem %>
+        <input class="gem-c-feedback__submit" type="submit" value="Send">
+      </div>
+    </div>
+  </form>
+
+  <form action="/contact/govuk/email-survey-signup" id="page-is-not-useful" class="gem-c-feedback__form gem-c-feedback__form--email gem-c-feedback__js-show js-feedback-form js-hidden" data-track-category="user_satisfaction_survey" data-track-action="banner_taken">
+    <a href="#" class="gem-c-feedback__close js-close-form" aria-controls="page-is-not-useful" aria-expanded="true" role="button">Close</a>
+
+    <div class="gem-c-feedback__grid-row">
+      <div class="gem-c-feedback__column-two-thirds">
+        <div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>
+
+        <input type="hidden" name="url" value="<%= request.original_url -%>">
+        <input type="hidden" name="user_agent" value="<%= request.user_agent -%>">
+
+        <input name="email_survey_signup[survey_id]" type="hidden" value="user_satisfaction_survey">
+        <input name="email_survey_signup[survey_source]" type="hidden" value="<%= request.original_url -%>">
+        <input name="email_survey_signup[ga_client_id]" type="hidden" value="1627485790.1515403243">
+
+        <h2 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h2>
+        <p id="survey_explanation" class="gem-c-feedback__form-paragraph">To help us improve GOV.UK, we’d like to know more about your visit today. We’ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don’t worry we won’t send you spam or share your email address with anyone.</p>
+
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "Email address"
+          },
+          name: "email_survey_signup[email_address]",
+          type: "email"
+        } %>
+
+        <%# TODO: use button component once available in gem %>
+        <input class="gem-c-feedback__submit" type="submit" value="Send me the survey">
+        <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=<%= request.fullpath -%>&amp;gcl=1627485790.1515403243" id="take-survey" target="_blank" rel="noopener noreferrer">Don’t have an email address?</a>
+      </div>
+    </div>
+  </form>
+
+</div>

--- a/app/views/govuk_publishing_components/components/docs/feedback.yml
+++ b/app/views/govuk_publishing_components/components/docs/feedback.yml
@@ -1,0 +1,22 @@
+name: Feedback
+description: Invites user feedback on the current page
+body: |
+  This component is designed to sit at the bottom of pages on GOV.UK to allow users to submit feedback on that page. It is based on the 'improve this page' component from the Service manual, but changes have been made.
+
+  This component includes imported button styles, which is not ideal (styles are duplicated). Once the [button component](/component-guide/button) has been moved to the gem, this should be used instead.
+accessibility_criteria: |
+  Form elements in the component must:
+
+  * accept focus
+  * be focusable with a keyboard
+  * be usable with a keyboard
+  * be usable with touch
+  * indicate when they have focus
+  * be recognisable as form input elements
+  * have correctly associated labels
+  * be of the appropriate type for their use, e.g. password inputs should be of type 'password'
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data: {}

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -11,8 +11,10 @@
     <%= yield :title %><% if content_for(:title) %> - <% end %><%= GovukPublishingComponents::Config.component_guide_title %>
   </title>
   <%= stylesheet_link_tag "govuk_publishing_components/component_guide", media: "screen" %>
-  <%= stylesheet_link_tag "govuk_publishing_components/component_guide_print", media: "print" %>
   <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_stylesheet}" %>
+  <% if GovukPublishingComponents::Config.application_print_stylesheet %>
+    <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_print_stylesheet}", media: "print" %>
+  <% end %>
   <%= javascript_include_tag "govuk_publishing_components/application" %>
   <%= javascript_include_tag "#{GovukPublishingComponents::Config.application_javascript}" %>
   <%= csrf_meta_tags %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,1 +1,1 @@
-Rails.application.config.assets.precompile += %w(govuk_publishing_components/component_guide.css govuk_publishing_components/component_guide_print.css)
+Rails.application.config.assets.precompile += %w(govuk_publishing_components/component_guide.css)

--- a/spec/components/feedback_spec.rb
+++ b/spec/components/feedback_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe "Feedback", type: :view do
+  def render_component(locals)
+    render file: "govuk_publishing_components/components/_feedback", locals: locals
+  end
+
+  it "asks the user if the page is useful without javascript enabled" do
+    render_component({})
+
+    assert_select ".gem-c-feedback .gem-c-feedback__prompt-link--useful[href='/contact/govuk']", text: 'Yes this page is useful'
+    assert_select ".gem-c-feedback .gem-c-feedback__prompt-link.js-page-is-not-useful[href='/contact/govuk']", text: 'No this page is not useful'
+  end
+
+  it "asks the user if there is anything wrong with the page without javascript enabled" do
+    render_component({})
+
+    assert_select ".gem-c-feedback .gem-c-feedback__prompt-link--wrong[href='/contact/govuk']", text: 'Is there anything wrong with this page?'
+  end
+end

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -1,0 +1,718 @@
+describe("Feedback component", function () {
+   var FIXTURE =
+    '<div class="gem-c-feedback">' +
+      '<div class="gem-c-feedback__prompt js-prompt" tabindex="-1">' +
+        '<div class="js-prompt-questions">' +
+          '<h3 class="gem-c-feedback__is-useful-question">Is this page useful?</h3>' +
+          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">Yes <span class="visually-hidden">this page is useful</span></a>' +
+          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">No <span class="visually-hidden">this page is not useful</span></a>' +
+          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong" data-track-category="yesNoFeedbackForm" data-track-action="ffWrongClick" aria-controls="something-is-wrong" aria-expanded="false">Is there anything wrong with this page?</a>' +
+        '</div>' +
+
+        '<div class="gem-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">' +
+          'Thanks for your feedback.' +
+        '</div>' +
+      '</div>' +
+
+      '<form action="/contact/govuk/page_improvements" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="yesNoFeedbackForm" data-track-action="ffFormSubmit">' +
+        '<a href="#" class="gem-c-feedback__close js-close-form" aria-controls="something-is-wrong" aria-expanded="true">Close</a>' +
+
+        '<div class="grid-row">' +
+          '<div class="column-two-thirds">' +
+            '<div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>' +
+
+            '<input type="hidden" name="url" value="http://example.com/path/to/page">' +
+            '<input type="hidden" name="user_agent" value="Safari">' +
+
+            '<h2 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h2>' +
+            '<p class="gem-c-feedback__form-paragraph">Don\'t include personal or financial information like your National Insurance number or credit card details.</p>' +
+
+            '<div class="gem-c-label">' +
+              '<label class="gem-c-label__text" for="input-29a3904f">' +
+                'What were you doing?' +
+              '</label>' +
+            '</div>' +
+            '<input class="gem-c-input " id="input-29a3904f" name="what_doing" type="text">' +
+
+            '<div class="gem-c-label">' +
+              '<label class="gem-c-label__text" for="input-3ad718b1">' +
+                'What went wrong?' +
+              '</label>' +
+            '</div>' +
+            '<input class="gem-c-input " id="input-3ad718b1" name="what_wrong" type="text">' +
+
+            '<input class="gem-c-feedback__submit" type="submit" value="Submit">' +
+          '</div>' +
+        '</div>' +
+      '</form>' +
+
+      '<form action="/contact/govuk/email-survey-signup" id="page-is-not-useful" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="user_satisfaction_survey" data-track-action="banner_taken">' +
+        '<a href="#" class="gem-c-feedback__close js-close-form" aria-controls="page-is-not-useful" aria-expanded="true">Close</a>' +
+
+        '<div class="grid-row">' +
+          '<div class="column-two-thirds">' +
+            '<div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>' +
+
+            '<input type="hidden" name="url" value="http://example.com/path/to/page">' +
+            '<input type="hidden" name="user_agent" value="Safari">' +
+
+            '<h2 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h2>' +
+            '<p class="gem-c-feedback__form-paragraph">To help us improve GOV.UK, we\'d like to know more about your visit today. We\'ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don\'t worry we won\'t send you spam or share your email address with anyone.</p>' +
+
+            '<div class="gem-c-label">' +
+              '<label class="gem-c-label__text" for="input-111111">' +
+                'Email address' +
+              '</label>' +
+            '</div>' +
+            '<input class="gem-c-input " id="input-111111" name="email_survey_signup[email_address]" type="text">' +
+
+            '<input class="gem-c-feedback__submit" type="submit" value="Send me the survey">' +
+            '<a href="FIXME" class="">Don\'t have an email address?</a>' +
+          '</div>' +
+        '</div>' +
+      '</form>' +
+    '</div>';
+
+  beforeEach(function () {
+    setFixtures(FIXTURE);
+  });
+
+  it("hides the forms", function () {
+    loadFeedbackComponent();
+
+    expect($('.gem-c-feedback .js-feedback-form')).toHaveClass('js-hidden');
+  });
+
+  it("shows the prompt", function () {
+    loadFeedbackComponent();
+
+    expect($('.gem-c-feedback .js-prompt')).not.toHaveClass('js-hidden');
+    expect($('.gem-c-feedback .js-prompt-questions')).not.toHaveClass('js-hidden');
+  });
+
+  it("conveys that the feedback forms are hidden", function() {
+    loadFeedbackComponent();
+
+    expect($('.js-feedback-form#something-is-wrong').attr('aria-hidden')).toBe('true');
+    expect($('.js-feedback-form#page-is-not-useful').attr('aria-hidden')).toBe('true');
+  });
+
+  it("conveys that the form is not expanded", function () {
+    loadFeedbackComponent();
+
+    expect($('.js-toggle-form[aria-controls="page-is-not-useful"]').attr('aria-expanded')).toBe('false');
+    expect($('.js-toggle-form[aria-controls="something-is-wrong"]').attr('aria-expanded')).toBe('false');
+  });
+
+  describe("clicking the 'page was useful' link", function () {
+    it("displays a success message", function () {
+      loadFeedbackComponent();
+      $('a.js-page-is-useful').click();
+
+      var $success = $('.js-prompt-success');
+
+      expect($success).not.toHaveClass('js-hidden');
+      expect($success).toHaveText("Thanks for your feedback.");
+    });
+
+    it("hides the question links", function () {
+      loadFeedbackComponent();
+      $('a.js-page-is-useful').click();
+
+      expect($('.js-prompt-questions')).toHaveClass('js-hidden');
+    });
+
+    it("triggers a Google Analytics event", function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      loadFeedbackComponent();
+      $('a.js-page-is-useful').click();
+
+      expect(GOVUK.analytics.trackEvent).
+        toHaveBeenCalledWith('yesNoFeedbackForm', 'ffYesClick');
+    });
+  });
+
+  describe("clicking the 'page was not useful' link", function () {
+    it("shows the feedback form", function () {
+      loadFeedbackComponent();
+      $('a.js-page-is-not-useful').click();
+
+      expect($('.gem-c-feedback .js-feedback-form#page-is-not-useful')).not.toHaveClass('js-hidden');
+    });
+
+    it("hides the prompt", function () {
+      loadFeedbackComponent();
+      $('a.js-page-is-not-useful').click();
+
+      expect($('.gem-c-feedback .js-prompt')).toHaveClass('js-hidden');
+    });
+
+    it("conveys that the form is now visible", function () {
+      loadFeedbackComponent();
+      $('a.js-page-is-not-useful').click();
+
+      expect($('.js-feedback-form#page-is-not-useful').attr('aria-hidden')).toBe('false');
+    });
+
+    it("conveys that the form is now expanded", function () {
+      loadFeedbackComponent();
+      $('a.js-page-is-not-useful').click();
+
+      expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('true');
+      expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false');
+    });
+
+    it("focusses the first field in the form", function () {
+      loadFeedbackComponent();
+      $('a.js-page-is-not-useful').click();
+
+      expect(document.activeElement).toBe($('#page-is-not-useful .gem-c-input').get(0));
+    });
+
+    it("triggers a Google Analytics event", function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      loadFeedbackComponent();
+      $('a.js-page-is-not-useful').click();
+
+      expect(GOVUK.analytics.trackEvent).
+        toHaveBeenCalledWith('yesNoFeedbackForm', 'ffNoClick');
+    });
+  });
+
+  describe("Clicking the 'is there anything wrong with this page' link", function () {
+    it("shows the form", function () {
+      loadFeedbackComponent();
+      $('a.js-something-is-wrong').click();
+
+      expect($('.gem-c-feedback .js-feedback-form#something-is-wrong')).not.toHaveClass('js-hidden');
+    });
+
+    it("hides the prompt", function () {
+      loadFeedbackComponent();
+      $('a.js-something-is-wrong').click();
+
+      expect($('.gem-c-feedback .js-prompt')).toHaveClass('js-hidden');
+    });
+
+    it("conveys that the form is now visible", function () {
+      loadFeedbackComponent();
+      $('a.js-something-is-wrong').click();
+
+      expect($('.js-feedback-form').attr('aria-hidden')).toBe('false');
+    });
+
+    it("conveys that the form is now expanded", function () {
+      loadFeedbackComponent();
+      $('a.js-something-is-wrong').click();
+
+      expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false');
+      expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('true');
+    });
+
+    it("focusses the first field in the form", function () {
+      loadFeedbackComponent();
+      $('a.js-something-is-wrong').click();
+
+      expect(document.activeElement).toBe($('#something-is-wrong .gem-c-input').get(0));
+    });
+
+    it("triggers a Google Analytics event", function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      loadFeedbackComponent();
+      $('a.js-something-is-wrong').click();
+
+      expect(GOVUK.analytics.trackEvent).
+        toHaveBeenCalledWith('yesNoFeedbackForm', 'ffWrongClick');
+    });
+  });
+
+  describe("Clicking the close link in the 'something is wrong' form", function () {
+    beforeEach(function () {
+      loadFeedbackComponent();
+      $('a.js-something-is-wrong').click();
+      $('#something-is-wrong a.js-close-form').click();
+    });
+
+    it("hides the form", function() {
+      expect($('.gem-c-feedback #something-is-wrong')).toHaveClass('js-hidden');
+    });
+
+    it("shows the prompt", function() {
+      expect($('.gem-c-feedback .js-prompt')).not.toHaveClass('js-hidden');
+    });
+
+    it("conveys that the feedback form is hidden", function() {
+      loadFeedbackComponent();
+
+      expect($('#something-is-wrong.js-feedback-form').attr('aria-hidden')).toBe('true');
+    });
+
+    it("conveys that the form is not expanded", function () {
+      loadFeedbackComponent();
+
+      expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false');
+      expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false');
+    });
+  })
+
+  describe("Clicking the close link in the 'not useful' form", function () {
+    beforeEach(function () {
+      loadFeedbackComponent();
+      $('a.js-page-is-not-useful').click();
+      $('#page-is-not-useful a.js-close-form').click();
+    })
+
+    it("hides the form", function() {
+      expect($('.gem-c-feedback #page-is-not-useful')).toHaveClass('js-hidden');
+    });
+
+    it("shows the prompt", function() {
+      expect($('.gem-c-feedback .js-prompt')).not.toHaveClass('js-hidden');
+    });
+
+    it("conveys that the feedback form is hidden", function() {
+      loadFeedbackComponent();
+
+      expect($('#page-is-not-useful.js-feedback-form').attr('aria-hidden')).toBe('true');
+    });
+
+    it("conveys that the form is not expanded", function () {
+      loadFeedbackComponent();
+
+      expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false');
+      expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false');
+    });
+  })
+
+  describe("successfully submitting the 'is there anything wrong with this page' form", function () {
+    beforeEach(function() {
+      jasmine.Ajax.install();
+    });
+
+    afterEach(function() {
+      jasmine.Ajax.uninstall();
+    });
+
+    it("triggers a Google Analytics event", function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'text/plain',
+        responseText: '{ "message": "ok" }'
+      });
+
+      expect(GOVUK.analytics.trackEvent).
+        toHaveBeenCalledWith('yesNoFeedbackForm', 'ffFormSubmit');
+    });
+
+    it("submits the feedback to the feedback frontend", function () {
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      request = jasmine.Ajax.requests.mostRecent();
+      expect(request.url).toBe('/contact/govuk/page_improvements');
+      expect(request.method).toBe('POST');
+      expect(request.data()).toEqual({
+        url: ["http://example.com/path/to/page"],
+        what_doing: ["I was looking for some information about local government."],
+        what_wrong: ["The background should be green."],
+        user_agent: ["Safari"]
+      });
+    });
+
+    it("displays a success message", function () {
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      var $success = $('.js-prompt-success');
+
+      expect($success).not.toHaveClass('js-hidden');
+      expect($success).toHaveText("Thanks for your feedback.");
+    });
+
+    it("focusses the success message", function () {
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      expect(document.activeElement).toBe($('.gem-c-feedback .js-prompt').get(0));
+    })
+
+    it("hides the form", function() {
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      expect($('#something-is-wrong')).toHaveClass('js-hidden');
+    });
+
+    it("hides the links to show the feedback form", function () {
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      expect($('.js-prompt-questions')).toHaveClass('js-hidden');
+    });
+  });
+
+  describe("successfully submitting the 'page is not useful' form", function () {
+    beforeEach(function() {
+      jasmine.Ajax.install();
+    });
+
+    afterEach(function() {
+      jasmine.Ajax.uninstall();
+    });
+
+    it("triggers a Google Analytics event", function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'text/plain',
+        responseText: '{ "message": "ok" }'
+      });
+
+      expect(GOVUK.analytics.trackEvent).
+        toHaveBeenCalledWith('user_satisfaction_survey', 'banner_taken');
+    });
+
+    it("submits the feedback to the feedback frontend", function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      request = jasmine.Ajax.requests.mostRecent();
+      expect(request.url).toBe('/contact/govuk/email-survey-signup');
+      expect(request.method).toBe('POST');
+      expect(request.data()).toEqual({
+        url: ["http://example.com/path/to/page"],
+        'email_survey_signup[email_address]': ["test@test.com"],
+        user_agent: ["Safari"]
+      });
+    });
+
+    it("displays a success message", function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      var $prompt = $('.js-prompt-success');
+
+      expect($prompt).not.toHaveClass('js-hidden');
+      expect($prompt).toHaveText("Thanks for your feedback.");
+    });
+
+    it("focusses the success message", function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      expect(document.activeElement).toBe($('.gem-c-feedback .js-prompt').get(0));
+    })
+
+    it("hides the form", function() {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      expect($('.js-feedback-form')).toHaveClass('js-hidden');
+    });
+
+    it("hides the links to show the feedback form", function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      expect($('.js-prompt-questions')).toHaveClass('js-hidden');
+    });
+  });
+
+  describe("submitting the 'is something wrong with this page' form with invalid data", function () {
+    beforeEach(function() {
+      jasmine.Ajax.install();
+    });
+
+    afterEach(function() {
+      jasmine.Ajax.uninstall();
+    });
+
+    it("disables the submit button until the server responds", function () {
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      expect($('.gem-c-feedback form [type=submit]')).toBeDisabled();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+      });
+
+      expect($('.gem-c-feedback form [type=submit]')).not.toBeDisabled();
+    });
+
+    it('retains the feedback the user originally entered', function () {
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+      });
+
+      expect($('[name=what_doing]').val()).toEqual("I was looking for some information about local government.");
+      expect($('[name=what_wrong]').val()).toEqual("The background should be green.");
+    });
+
+    it("displays a generic error if the field isn't a visible part of the form", function () {
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"path": ["can\'t be blank"], "another": ["weird error"]}}'
+      });
+
+      expect($('#something-is-wrong .js-errors').html()).toContainText(
+        'Sorry, we’re unable to receive your message right now. ' +
+        'If the problem persists, we have other ways for you to provide ' +
+        'feedback on the contact page.'
+      );
+    });
+
+    it("focusses the error message", function () {
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      var $shouldBe = $('#something-is-wrong .js-errors').get(0);
+      expect(document.activeElement).toBe($shouldBe);
+    });
+  });
+
+  describe("Submitting the 'page is not useful' form with invalid data", function () {
+    beforeEach(function() {
+      jasmine.Ajax.install();
+    });
+
+    afterEach(function() {
+      jasmine.Ajax.uninstall();
+    });
+
+    it("disables the submit button until the server responds", function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      expect($('.gem-c-feedback form [type=submit]')).toBeDisabled();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+      });
+
+      expect($('.gem-c-feedback form [type=submit]')).not.toBeDisabled();
+    });
+
+    it('retains the feedback the user originally entered', function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+      });
+
+      expect($("[name='email_survey_signup[email_address]']").val()).toEqual("test@test.com");
+    });
+
+    it("displays a generic error if the field isn't a visible part of the form", function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"path": ["can\'t be blank"], "another": ["weird error"]}}'
+      });
+
+      expect($('#page-is-not-useful .js-errors').html()).toContainText(
+        'Sorry, we’re unable to receive your message right now. ' +
+        'If the problem persists, we have other ways for you to provide ' +
+        'feedback on the contact page.'
+      );
+    });
+
+    it("focusses the generic error", function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"path": ["can\'t be blank"], "description": ["can\'t be blank"]}}'
+      });
+
+      expect(document.activeElement).toBe($('#page-is-not-useful .js-errors').get(0));
+    });
+  });
+
+  describe("submitting a form that fails for some reason", function () {
+    beforeEach(function() {
+      jasmine.Ajax.install();
+
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 500,
+        contentType: 'text/plain',
+        responseText: ''
+      });
+    });
+
+    afterEach(function() {
+      jasmine.Ajax.uninstall();
+    });
+
+    it("displays a generic error message", function () {
+      expect($('.gem-c-feedback__error-summary').html()).toContainText(
+        'Sorry, we’re unable to receive your message right now. ' +
+        'If the problem persists, we have other ways for you to provide ' +
+        'feedback on the contact page.'
+      );
+    });
+
+    it('retains the feedback the user originally entered', function () {
+      expect($('[name=what_doing]').val()).toEqual('I was looking for some information about local government.');
+      expect($('[name=what_wrong]').val()).toEqual('The background should be green.');
+    });
+
+    it('re-enables the submit button', function () {
+      expect($('.gem-c-feedback form [type=submit]')).not.toBeDisabled();
+    });
+  });
+
+  describe("submitting a form that times out", function () {
+    beforeEach(function() {
+      jasmine.Ajax.install();
+      jasmine.clock().install();
+
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+      jasmine.Ajax.requests.mostRecent().responseTimeout();
+    });
+
+    afterEach(function() {
+      jasmine.Ajax.uninstall();
+      jasmine.clock().uninstall();
+    });
+
+    it('displays a generic error message', function () {
+      expect($('.gem-c-feedback__error-summary').html()).toContainText(
+        'Sorry, we’re unable to receive your message right now. ' +
+        'If the problem persists, we have other ways for you to provide ' +
+        'feedback on the contact page.'
+      );
+    });
+  });
+
+  function loadFeedbackComponent () {
+    var feedback = new GOVUK.Modules.Feedback();
+    feedback.start($('.gem-c-feedback'));
+  }
+
+  function fillAndSubmitSomethingIsWrongForm () {
+    $('a.js-something-is-wrong').click();
+    $form = $('.gem-c-feedback #something-is-wrong');
+    $form.find("[name=what_doing]").val("I was looking for some information about local government.");
+    $form.find("[name=what_wrong]").val("The background should be green.");
+    $form.find("[type=submit]").click();
+  }
+
+  function fillAndSubmitPageIsNotUsefulForm () {
+    $('a.js-page-is-not-useful').click();
+    $form = $('.gem-c-feedback #page-is-not-useful');
+    $form.find("[name='email_survey_signup[email_address]']").val("test@test.com");
+    $form.find("[type=submit]").click();
+  }
+});

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -14,6 +14,7 @@ src_files:
   - spec/javascripts/helpers/jquery-1.12.4.js
   - spec/javascripts/helpers/jasmine-jquery-2.0.5.js
   - spec/javascripts/helpers/SpecHelper.js
+  - spec/javascripts/vendor/mock-ajax.js
   - assets/govuk_publishing_components/application.js
 
 # stylesheets

--- a/spec/javascripts/vendor/mock-ajax.js
+++ b/spec/javascripts/vendor/mock-ajax.js
@@ -1,0 +1,774 @@
+/*
+
+Jasmine-Ajax - v3.2.0: a set of helpers for testing AJAX requests under the Jasmine
+BDD framework for JavaScript.
+
+http://github.com/jasmine/jasmine-ajax
+
+Jasmine Home page: http://jasmine.github.io/
+
+Copyright (c) 2008-2015 Pivotal Labs
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+//Module wrapper to support both browser and CommonJS environment
+(function (root, factory) {
+    if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
+        // CommonJS
+        var jasmineRequire = require('jasmine-core');
+        module.exports = factory(root, function() {
+            return jasmineRequire;
+        });
+    } else {
+        // Browser globals
+        window.MockAjax = factory(root, getJasmineRequireObj);
+    }
+}(typeof window !== 'undefined' ? window : global, function (global, getJasmineRequireObj) {
+
+//
+getJasmineRequireObj().ajax = function(jRequire) {
+  var $ajax = {};
+
+  $ajax.RequestStub = jRequire.AjaxRequestStub();
+  $ajax.RequestTracker = jRequire.AjaxRequestTracker();
+  $ajax.StubTracker = jRequire.AjaxStubTracker();
+  $ajax.ParamParser = jRequire.AjaxParamParser();
+  $ajax.event = jRequire.AjaxEvent();
+  $ajax.eventBus = jRequire.AjaxEventBus($ajax.event);
+  $ajax.fakeRequest = jRequire.AjaxFakeRequest($ajax.eventBus);
+  $ajax.MockAjax = jRequire.MockAjax($ajax);
+
+  return $ajax.MockAjax;
+};
+
+getJasmineRequireObj().AjaxEvent = function() {
+  function now() {
+    return new Date().getTime();
+  }
+
+  function noop() {
+  }
+
+  // Event object
+  // https://dom.spec.whatwg.org/#concept-event
+  function XMLHttpRequestEvent(xhr, type) {
+    this.type = type;
+    this.bubbles = false;
+    this.cancelable = false;
+    this.timeStamp = now();
+
+    this.isTrusted = false;
+    this.defaultPrevented = false;
+
+    // Event phase should be "AT_TARGET"
+    // https://dom.spec.whatwg.org/#dom-event-at_target
+    this.eventPhase = 2;
+
+    this.target = xhr;
+    this.currentTarget = xhr;
+  }
+
+  XMLHttpRequestEvent.prototype.preventDefault = noop;
+  XMLHttpRequestEvent.prototype.stopPropagation = noop;
+  XMLHttpRequestEvent.prototype.stopImmediatePropagation = noop;
+
+  function XMLHttpRequestProgressEvent() {
+    XMLHttpRequestEvent.apply(this, arguments);
+
+    this.lengthComputable = false;
+    this.loaded = 0;
+    this.total = 0;
+  }
+
+  // Extend prototype
+  XMLHttpRequestProgressEvent.prototype = XMLHttpRequestEvent.prototype;
+
+  return {
+    event: function(xhr, type) {
+      return new XMLHttpRequestEvent(xhr, type);
+    },
+
+    progressEvent: function(xhr, type) {
+      return new XMLHttpRequestProgressEvent(xhr, type);
+    }
+  };
+};
+getJasmineRequireObj().AjaxEventBus = function(eventFactory) {
+  function EventBus(source) {
+    this.eventList = {};
+    this.source = source;
+  }
+
+  function ensureEvent(eventList, name) {
+    eventList[name] = eventList[name] || [];
+    return eventList[name];
+  }
+
+  function findIndex(list, thing) {
+    if (list.indexOf) {
+      return list.indexOf(thing);
+    }
+
+    for(var i = 0; i < list.length; i++) {
+      if (thing === list[i]) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  EventBus.prototype.addEventListener = function(event, callback) {
+    ensureEvent(this.eventList, event).push(callback);
+  };
+
+  EventBus.prototype.removeEventListener = function(event, callback) {
+    var index = findIndex(this.eventList[event], callback);
+
+    if (index >= 0) {
+      this.eventList[event].splice(index, 1);
+    }
+  };
+
+  EventBus.prototype.trigger = function(event) {
+    var evt;
+
+    // Event 'readystatechange' is should be a simple event.
+    // Others are progress event.
+    // https://xhr.spec.whatwg.org/#events
+    if (event === 'readystatechange') {
+      evt = eventFactory.event(this.source, event);
+    } else {
+      evt = eventFactory.progressEvent(this.source, event);
+    }
+
+    var eventListeners = this.eventList[event];
+
+    if (eventListeners) {
+      for (var i = 0; i < eventListeners.length; i++) {
+        eventListeners[i].call(this.source, evt);
+      }
+    }
+  };
+
+  return function(source) {
+    return new EventBus(source);
+  };
+};
+
+getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
+  function extend(destination, source, propertiesToSkip) {
+    propertiesToSkip = propertiesToSkip || [];
+    for (var property in source) {
+      if (!arrayContains(propertiesToSkip, property)) {
+        destination[property] = source[property];
+      }
+    }
+    return destination;
+  }
+
+  function arrayContains(arr, item) {
+    for (var i = 0; i < arr.length; i++) {
+      if (arr[i] === item) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function wrapProgressEvent(xhr, eventName) {
+    return function() {
+      if (xhr[eventName]) {
+        xhr[eventName].apply(xhr, arguments);
+      }
+    };
+  }
+
+  function initializeEvents(xhr) {
+    xhr.eventBus.addEventListener('readystatechange', wrapProgressEvent(xhr, 'onreadystatechange'));
+    xhr.eventBus.addEventListener('loadstart', wrapProgressEvent(xhr, 'onloadstart'));
+    xhr.eventBus.addEventListener('load', wrapProgressEvent(xhr, 'onload'));
+    xhr.eventBus.addEventListener('loadend', wrapProgressEvent(xhr, 'onloadend'));
+    xhr.eventBus.addEventListener('progress', wrapProgressEvent(xhr, 'onprogress'));
+    xhr.eventBus.addEventListener('error', wrapProgressEvent(xhr, 'onerror'));
+    xhr.eventBus.addEventListener('abort', wrapProgressEvent(xhr, 'onabort'));
+    xhr.eventBus.addEventListener('timeout', wrapProgressEvent(xhr, 'ontimeout'));
+  }
+
+  function unconvertibleResponseTypeMessage(type) {
+    var msg = [
+      "Can't build XHR.response for XHR.responseType of '",
+      type,
+      "'.",
+      "XHR.response must be explicitly stubbed"
+    ];
+    return msg.join(' ');
+  }
+
+  function fakeRequest(global, requestTracker, stubTracker, paramParser) {
+    function FakeXMLHttpRequest() {
+      requestTracker.track(this);
+      this.eventBus = eventBusFactory(this);
+      initializeEvents(this);
+      this.requestHeaders = {};
+      this.overriddenMimeType = null;
+    }
+
+    function findHeader(name, headers) {
+      name = name.toLowerCase();
+      for (var header in headers) {
+        if (header.toLowerCase() === name) {
+          return headers[header];
+        }
+      }
+    }
+
+    function normalizeHeaders(rawHeaders, contentType) {
+      var headers = [];
+
+      if (rawHeaders) {
+        if (rawHeaders instanceof Array) {
+          headers = rawHeaders;
+        } else {
+          for (var headerName in rawHeaders) {
+            if (rawHeaders.hasOwnProperty(headerName)) {
+              headers.push({ name: headerName, value: rawHeaders[headerName] });
+            }
+          }
+        }
+      } else {
+        headers.push({ name: "Content-Type", value: contentType || "application/json" });
+      }
+
+      return headers;
+    }
+
+    function parseXml(xmlText, contentType) {
+      if (global.DOMParser) {
+        return (new global.DOMParser()).parseFromString(xmlText, 'text/xml');
+      } else {
+        var xml = new global.ActiveXObject("Microsoft.XMLDOM");
+        xml.async = "false";
+        xml.loadXML(xmlText);
+        return xml;
+      }
+    }
+
+    var xmlParsables = ['text/xml', 'application/xml'];
+
+    function getResponseXml(responseText, contentType) {
+      if (arrayContains(xmlParsables, contentType.toLowerCase())) {
+        return parseXml(responseText, contentType);
+      } else if (contentType.match(/\+xml$/)) {
+        return parseXml(responseText, 'text/xml');
+      }
+      return null;
+    }
+
+    var iePropertiesThatCannotBeCopied = ['responseBody', 'responseText', 'responseXML', 'status', 'statusText', 'responseTimeout', 'responseURL'];
+    extend(FakeXMLHttpRequest.prototype, new global.XMLHttpRequest(), iePropertiesThatCannotBeCopied);
+    extend(FakeXMLHttpRequest.prototype, {
+      open: function() {
+        this.method = arguments[0];
+        this.url = arguments[1];
+        this.username = arguments[3];
+        this.password = arguments[4];
+        this.readyState = 1;
+        this.requestHeaders = {};
+        this.eventBus.trigger('readystatechange');
+      },
+
+      setRequestHeader: function(header, value) {
+        if(this.requestHeaders.hasOwnProperty(header)) {
+          this.requestHeaders[header] = [this.requestHeaders[header], value].join(', ');
+        } else {
+          this.requestHeaders[header] = value;
+        }
+      },
+
+      overrideMimeType: function(mime) {
+        this.overriddenMimeType = mime;
+      },
+
+      abort: function() {
+        this.readyState = 0;
+        this.status = 0;
+        this.statusText = "abort";
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('abort');
+        this.eventBus.trigger('loadend');
+      },
+
+      readyState: 0,
+
+      onloadstart: null,
+      onprogress: null,
+      onabort: null,
+      onerror: null,
+      onload: null,
+      ontimeout: null,
+      onloadend: null,
+      onreadystatechange: null,
+
+      addEventListener: function() {
+        this.eventBus.addEventListener.apply(this.eventBus, arguments);
+      },
+
+      removeEventListener: function(event, callback) {
+        this.eventBus.removeEventListener.apply(this.eventBus, arguments);
+      },
+
+      status: null,
+
+      send: function(data) {
+        this.params = data;
+        this.eventBus.trigger('loadstart');
+
+        var stub = stubTracker.findStub(this.url, data, this.method);
+
+        this.dispatchStub(stub);
+      },
+
+      dispatchStub: function(stub) {
+        if (stub) {
+          if (stub.isReturn()) {
+            this.respondWith(stub);
+          } else if (stub.isError()) {
+            this.responseError();
+          } else if (stub.isTimeout()) {
+            this.responseTimeout();
+          } else if (stub.isCallFunction()) {
+            this.responseCallFunction(stub);
+          }
+        }
+      },
+
+      contentType: function() {
+        return findHeader('content-type', this.requestHeaders);
+      },
+
+      data: function() {
+        if (!this.params) {
+          return {};
+        }
+
+        return paramParser.findParser(this).parse(this.params);
+      },
+
+      getResponseHeader: function(name) {
+        name = name.toLowerCase();
+        var resultHeader;
+        for(var i = 0; i < this.responseHeaders.length; i++) {
+          var header = this.responseHeaders[i];
+          if (name === header.name.toLowerCase()) {
+            if (resultHeader) {
+              resultHeader = [resultHeader, header.value].join(', ');
+            } else {
+              resultHeader = header.value;
+            }
+          }
+        }
+        return resultHeader;
+      },
+
+      getAllResponseHeaders: function() {
+        var responseHeaders = [];
+        for (var i = 0; i < this.responseHeaders.length; i++) {
+          responseHeaders.push(this.responseHeaders[i].name + ': ' +
+            this.responseHeaders[i].value);
+        }
+        return responseHeaders.join('\r\n') + '\r\n';
+      },
+
+      responseText: null,
+      response: null,
+      responseType: null,
+      responseURL: null,
+
+      responseValue: function() {
+        switch(this.responseType) {
+          case null:
+          case "":
+          case "text":
+            return this.readyState >= 3 ? this.responseText : "";
+          case "json":
+            return JSON.parse(this.responseText);
+          case "arraybuffer":
+            throw unconvertibleResponseTypeMessage('arraybuffer');
+          case "blob":
+            throw unconvertibleResponseTypeMessage('blob');
+          case "document":
+            return this.responseXML;
+        }
+      },
+
+
+      respondWith: function(response) {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+
+        this.status = response.status;
+        this.statusText = response.statusText || "";
+        this.responseHeaders = normalizeHeaders(response.responseHeaders, response.contentType);
+        this.readyState = 2;
+        this.eventBus.trigger('readystatechange');
+
+        this.responseText = response.responseText || "";
+        this.responseType = response.responseType || "";
+        this.responseURL = response.responseURL || null;
+        this.readyState = 4;
+        this.responseXML = getResponseXml(response.responseText, this.getResponseHeader('content-type') || '');
+        if (this.responseXML) {
+          this.responseType = 'document';
+        }
+
+        if ('response' in response) {
+          this.response = response.response;
+        } else {
+          this.response = this.responseValue();
+        }
+
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('load');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseTimeout: function() {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+        this.readyState = 4;
+        jasmine.clock().tick(30000);
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('timeout');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseError: function() {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+        this.readyState = 4;
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('error');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseCallFunction: function(stub) {
+        stub.action = undefined;
+        stub.functionToCall(stub, this);
+        this.dispatchStub(stub);
+      }
+    });
+
+    return FakeXMLHttpRequest;
+  }
+
+  return fakeRequest;
+};
+
+getJasmineRequireObj().MockAjax = function($ajax) {
+  function MockAjax(global) {
+    var requestTracker = new $ajax.RequestTracker(),
+      stubTracker = new $ajax.StubTracker(),
+      paramParser = new $ajax.ParamParser(),
+      realAjaxFunction = global.XMLHttpRequest,
+      mockAjaxFunction = $ajax.fakeRequest(global, requestTracker, stubTracker, paramParser);
+
+    this.install = function() {
+      if (global.XMLHttpRequest === mockAjaxFunction) {
+        throw "MockAjax is already installed.";
+      }
+
+      global.XMLHttpRequest = mockAjaxFunction;
+    };
+
+    this.uninstall = function() {
+      if (global.XMLHttpRequest !== mockAjaxFunction) {
+        throw "MockAjax not installed.";
+      }
+      global.XMLHttpRequest = realAjaxFunction;
+
+      this.stubs.reset();
+      this.requests.reset();
+      paramParser.reset();
+    };
+
+    this.stubRequest = function(url, data, method) {
+      var stub = new $ajax.RequestStub(url, data, method);
+      stubTracker.addStub(stub);
+      return stub;
+    };
+
+    this.withMock = function(closure) {
+      this.install();
+      try {
+        closure();
+      } finally {
+        this.uninstall();
+      }
+    };
+
+    this.addCustomParamParser = function(parser) {
+      paramParser.add(parser);
+    };
+
+    this.requests = requestTracker;
+    this.stubs = stubTracker;
+  }
+
+  return MockAjax;
+};
+
+getJasmineRequireObj().AjaxParamParser = function() {
+  function ParamParser() {
+    var defaults = [
+      {
+        test: function(xhr) {
+          return (/^application\/json/).test(xhr.contentType());
+        },
+        parse: function jsonParser(paramString) {
+          return JSON.parse(paramString);
+        }
+      },
+      {
+        test: function(xhr) {
+          return true;
+        },
+        parse: function naiveParser(paramString) {
+          var data = {};
+          var params = paramString.split('&');
+
+          for (var i = 0; i < params.length; ++i) {
+            var kv = params[i].replace(/\+/g, ' ').split('=');
+            var key = decodeURIComponent(kv[0]);
+            data[key] = data[key] || [];
+            data[key].push(decodeURIComponent(kv[1]));
+          }
+          return data;
+        }
+      }
+    ];
+    var paramParsers = [];
+
+    this.add = function(parser) {
+      paramParsers.unshift(parser);
+    };
+
+    this.findParser = function(xhr) {
+        for(var i in paramParsers) {
+          var parser = paramParsers[i];
+          if (parser.test(xhr)) {
+            return parser;
+          }
+        }
+    };
+
+    this.reset = function() {
+      paramParsers = [];
+      for(var i in defaults) {
+        paramParsers.push(defaults[i]);
+      }
+    };
+
+    this.reset();
+  }
+
+  return ParamParser;
+};
+
+getJasmineRequireObj().AjaxRequestStub = function() {
+  var RETURN = 0,
+      ERROR = 1,
+      TIMEOUT = 2,
+      CALL = 3;
+
+  function RequestStub(url, stubData, method) {
+    var normalizeQuery = function(query) {
+      return query ? query.split('&').sort().join('&') : undefined;
+    };
+
+    if (url instanceof RegExp) {
+      this.url = url;
+      this.query = undefined;
+    } else {
+      var split = url.split('?');
+      this.url = split[0];
+      this.query = split.length > 1 ? normalizeQuery(split[1]) : undefined;
+    }
+
+    this.data = (stubData instanceof RegExp) ? stubData : normalizeQuery(stubData);
+    this.method = method;
+
+    this.andReturn = function(options) {
+      this.action = RETURN;
+      this.status = options.status || 200;
+
+      this.contentType = options.contentType;
+      this.response = options.response;
+      this.responseText = options.responseText;
+      this.responseHeaders = options.responseHeaders;
+      this.responseURL = options.responseURL;
+    };
+
+    this.isReturn = function() {
+      return this.action === RETURN;
+    };
+
+    this.andError = function() {
+      this.action = ERROR;
+    };
+
+    this.isError = function() {
+      return this.action === ERROR;
+    };
+
+    this.andTimeout = function() {
+      this.action = TIMEOUT;
+    };
+
+    this.isTimeout = function() {
+      return this.action === TIMEOUT;
+    };
+
+    this.andCallFunction = function(functionToCall) {
+      this.action = CALL;
+      this.functionToCall = functionToCall;
+    };
+
+    this.isCallFunction = function() {
+      return this.action === CALL;
+    };
+
+    this.matches = function(fullUrl, data, method) {
+      var urlMatches = false;
+      fullUrl = fullUrl.toString();
+      if (this.url instanceof RegExp) {
+        urlMatches = this.url.test(fullUrl);
+      } else {
+        var urlSplit = fullUrl.split('?'),
+            url = urlSplit[0],
+            query = urlSplit[1];
+        urlMatches = this.url === url && this.query === normalizeQuery(query);
+      }
+      var dataMatches = false;
+      if (this.data instanceof RegExp) {
+        dataMatches = this.data.test(data);
+      } else {
+        dataMatches = !this.data || this.data === normalizeQuery(data);
+      }
+      return urlMatches && dataMatches && (!this.method || this.method === method);
+    };
+  }
+
+  return RequestStub;
+};
+
+getJasmineRequireObj().AjaxRequestTracker = function() {
+  function RequestTracker() {
+    var requests = [];
+
+    this.track = function(request) {
+      requests.push(request);
+    };
+
+    this.first = function() {
+      return requests[0];
+    };
+
+    this.count = function() {
+      return requests.length;
+    };
+
+    this.reset = function() {
+      requests = [];
+    };
+
+    this.mostRecent = function() {
+      return requests[requests.length - 1];
+    };
+
+    this.at = function(index) {
+      return requests[index];
+    };
+
+    this.filter = function(url_to_match) {
+      var matching_requests = [];
+
+      for (var i = 0; i < requests.length; i++) {
+        if (url_to_match instanceof RegExp &&
+            url_to_match.test(requests[i].url)) {
+            matching_requests.push(requests[i]);
+        } else if (url_to_match instanceof Function &&
+            url_to_match(requests[i])) {
+            matching_requests.push(requests[i]);
+        } else {
+          if (requests[i].url === url_to_match) {
+            matching_requests.push(requests[i]);
+          }
+        }
+      }
+
+      return matching_requests;
+    };
+  }
+
+  return RequestTracker;
+};
+
+getJasmineRequireObj().AjaxStubTracker = function() {
+  function StubTracker() {
+    var stubs = [];
+
+    this.addStub = function(stub) {
+      stubs.push(stub);
+    };
+
+    this.reset = function() {
+      stubs = [];
+    };
+
+    this.findStub = function(url, data, method) {
+      for (var i = stubs.length - 1; i >= 0; i--) {
+        var stub = stubs[i];
+        if (stub.matches(url, data, method)) {
+          return stub;
+        }
+      }
+    };
+  }
+
+  return StubTracker;
+};
+
+
+    var jRequire = getJasmineRequireObj();
+    var MockAjax = jRequire.ajax(jRequire);
+    jasmine.Ajax = new MockAjax(global);
+
+    return MockAjax;
+}));


### PR DESCRIPTION
Build the new feedback form to go at the foot of all GOV.UK pages. This is based on the code from the Service Manual but with some changes, as this version requires additional functionality.

Ultimately this component will be moved to the publishing components gem, but I started building it in static so getting it reviewed here because the commit history might prove useful to that.

Initial state:

![screen shot 2018-02-06 at 14 58 57](https://user-images.githubusercontent.com/861310/35866143-4c06d9c2-0b4e-11e8-92c8-ef46f4a21191.png)

Users have three options:

1. click 'yes' (page is useful) records a GA event and shows a 'thanks for your feedback' message
2. click 'no' (page is not useful) opens a form to take an email address to send a link to a survey to. This is a rework of the form that currently appears underneath the header of GOV.UK for some users at some times (you can trigger this by visiting GOV.UK and running GOVUK.userSurveys.displaySurvey(GOVUK.userSurveys.defaultSurvey) in the browser console)
3. click 'is there anything wrong with this page?' opens a feedback form. This is a rework of the existing feedback form at the foot of GOV.UK

**Result of option 1 (and the others, if submitted successfully):**

![screen shot 2018-02-06 at 15 02 41](https://user-images.githubusercontent.com/861310/35866325-cdcb9268-0b4e-11e8-852b-e2564114ce6b.png)

**'Page is not useful' form:**

<img width="1021" alt="screen shot 2018-02-15 at 08 49 19" src="https://user-images.githubusercontent.com/861310/36247771-28735cc0-122d-11e8-8389-3f94864dd409.png">

**'Something wrong with page' form:**

<img width="1016" alt="screen shot 2018-02-15 at 08 48 27" src="https://user-images.githubusercontent.com/861310/36247738-0e52c736-122d-11e8-8aff-0d025fae8697.png">

If javascript is disabled, this form should be the only element that appears, and should still function.

- this code was originally in static, where it received some feedback, [original PR is here](https://github.com/alphagov/static/pull/1235)
- [Trello card](https://trello.com/c/oRLXhaTU/155-make-the-service-manual-feedback-pattern-a-component)
- [Component guide](https://govuk-static-pr-1235.herokuapp.com/component-guide/feedback)