### PR TITLE
Support different input types for Input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Support other a customisable type attribute for input component (PR #165)
 * Add unique tracking to all GA events on step nav components (PR #162)
 
 # 5.0.0

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -4,6 +4,7 @@
   value ||= false
   error_message ||= false
   label ||= {}
+  type ||= "text"
 %>
 
 <%= render "govuk_publishing_components/components/label", {
@@ -19,7 +20,7 @@
   class="gem-c-input <%= "gem-c-input--error" if error_message %>"
   id="<%= id %>"
   name="<%= name %>"
-  type="text"
+  type="<%= type %>"
 
   <% if error_message %>
     aria-describedby="<%= hint_id %>"

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -12,11 +12,17 @@ examples:
   default:
     data:
       label:
-        text: "What is your email address?"
-      name: "address"
-  with_error:
+        text: "What is your name?"
+      name: "name"
+  email_type:
     data:
       label:
         text: "What is your email address?"
       name: "address"
-      error_message: "Email address not recognised"
+      type: "email"
+  with_error:
+    data:
+      label:
+        text: "What is your name?"
+      name: "name"
+      error_message: "Please could you provide your name"

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -23,6 +23,16 @@ describe "Input", type: :view do
     assert_select ".gem-c-label", text: "What is your email address?"
   end
 
+  it "renders inputs with a configurable type" do
+    render_component(
+      name: "email-address",
+      type: "email",
+    )
+
+    assert_select ".gem-c-input[type='email']"
+    assert_select ".gem-c-input[name='email-address']"
+  end
+
   it "sets the 'for' on the label to the input id" do
     render_component(name: "email-address")
 


### PR DESCRIPTION
Hello :wave:

This allows the rendered HTML to be `<input type="email" />` or whatever
other incarnation may be needed. By default this will be text.

There's potential here that you could hit some rendering issues by
putting in something wacky here, but it feels too restrictive to try
prevent that here.

See the [rendered component](https://govuk-publishing-compon-pr-165.herokuapp.com/component-guide/input)