### PR TITLE
Add link to GitHub to find component usage

### DIFF
--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -53,6 +53,11 @@ module GovukPublishingComponents
       end
     end
 
+    def github_search_url
+      params = { q: "org:alphagov #{partial_path}", type: "Code" }
+      "https://github.com/search?#{params.to_query}"
+    end
+
   private
 
     def govspeak_to_html(govspeak)

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -22,7 +22,7 @@
   <div class="component-doc">
     <h2 class="component-doc-h2">How to call this component</h2>
     <%= render "govuk_publishing_components/component_guide/component_doc/call", component_doc: @component_doc, example: @component_doc.example %>
-
+    <%= link_to "Search for usage on GitHub", @component_doc.github_search_url %>
     <h2 class="component-doc-h2">How it looks</h2>
   </div>
 


### PR DESCRIPTION
This adds a link to GitHub code search (scoped to alphagov) for components. It allows you to easily find places where a certain component is used.

<img width="1252" alt="screen shot 2018-02-15 at 11 25 43" src="https://user-images.githubusercontent.com/233676/36254439-ffed0506-1242-11e8-9b7d-588ecba1987b.png">

https://trello.com/c/hIWEcXAo