### PR TITLE
Fix print styles

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/component_guide_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/component_guide_print.scss
@@ -1,3 +1,1 @@
 @import "typography";
-@import "components/print/step-by-step-nav";
-@import "components/print/step-by-step-nav-header";

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -13,6 +13,11 @@
   <%= stylesheet_link_tag "govuk_publishing_components/component_guide", media: "screen" %>
   <%= stylesheet_link_tag "govuk_publishing_components/component_guide_print", media: "print" %>
   <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_stylesheet}" %>
+
+  <% if GovukPublishingComponents::Config.application_print_stylesheet %>
+    <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_print_stylesheet}", media: "print" %>
+  <% end %>
+
   <%= javascript_include_tag "govuk_publishing_components/application" %>
   <%= javascript_include_tag "#{GovukPublishingComponents::Config.application_javascript}" %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
This adds the print stylesheet from the application to the component guide. That stylesheet includes the print styles for the components. They're removed from the main stylesheet of the component guide because that should not contain component code.