### PR TITLE
Improve feedback component layout on mobile

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -65,6 +65,7 @@
   margin-bottom: $gutter-half;
   padding: $gutter-half;
   border: solid 4px $error-colour;
+  clear: both;
 
   &:focus {
     outline: solid 3px $focus-colour;
@@ -122,12 +123,22 @@
 
 .gem-c-feedback__close {
   @include core-19;
-  text-align: right;
+  float: right;
   margin-bottom: $gutter-one-third;
 
   @include media(tablet) {
-    float: right;
     padding-top: 0;
+  }
+}
+
+.gem-c-feedback__email-link {
+  display: block;
+  margin-top: $gutter-half;
+
+  @include media(tablet) {
+    display: inline-block;
+    margin-top: 0;
+    margin-left: $gutter-half;
   }
 }
 

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -107,7 +107,7 @@
 
         <%# TODO: use button component once available in gem %>
         <input class="gem-c-feedback__submit" type="submit" value="Send me the survey">
-        <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=<%= request.fullpath -%>&amp;gcl=1627485790.1515403243" id="take-survey" target="_blank" rel="noopener noreferrer">Don’t have an email address?</a>
+        <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=<%= request.fullpath -%>&amp;gcl=1627485790.1515403243" class="gem-c-feedback__email-link" id="take-survey" target="_blank" rel="noopener noreferrer">Don’t have an email address?</a>
       </div>
     </div>
   </form>


### PR DESCRIPTION
- make close button position consistent
- improve layout of link "don't have an email address" by putting on newline on mobile and improving spacing on tablet and above

Before:

![screen shot 2018-02-16 at 10 38 52](https://user-images.githubusercontent.com/861310/36303911-b3b470a2-1305-11e8-8ad4-b5e3023d898a.png)

After:

![screen shot 2018-02-16 at 10 39 28](https://user-images.githubusercontent.com/861310/36303919-b97a0ed4-1305-11e8-94c9-fc7c3d5f581e.png)

https://trello.com/c/8TC3AEms