### PR TITLE
Make form contents font sizes consistent

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -77,12 +77,12 @@
   // this comes from the backend so we can't put a class on it
   h2,
   .gem-c-feedback__heading {
-    @include bold-19;
+    @include bold-24;
     margin: 0;
   }
 
   p {
-    @include core-16;
+    @include core-19;
     margin: $gutter-one-third 0;
   }
 }
@@ -105,12 +105,12 @@
 }
 
 .gem-c-feedback__form-heading {
-  @include bold-19;
+  @include bold-24;
   margin-bottom: $gutter-half;
 }
 
 .gem-c-feedback__form-paragraph {
-  @include core-16;
+  @include core-19;
   margin-bottom: $gutter;
 }
 
@@ -121,7 +121,7 @@
 }
 
 .gem-c-feedback__close {
-  @include core-16;
+  @include core-19;
   text-align: right;
   margin-bottom: $gutter-one-third;
 


### PR DESCRIPTION
The input/label component used in this component has a font size of core-19, which is bigger than the core-16 design for the rest of this component. This PR brings the other fonts inside these forms inline with the input/label component. Elements are:

- headings and error headings
- paragraphs and error paragraphs
- close buttons

This may be slightly controversial as it goes against the design, but I figure consistency with the rest of our components is a good idea and the larger font size is much easier to read.

Haven't changed the font size of the initial state of the component.

Before:

![screen shot 2018-02-16 at 10 48 05](https://user-images.githubusercontent.com/861310/36304325-264b4554-1307-11e8-8f6d-4f05301891e5.png)

After:

![screen shot 2018-02-16 at 10 47 42](https://user-images.githubusercontent.com/861310/36304319-21bf0174-1307-11e8-8ef9-0bbc6c17c9b6.png)

https://trello.com/c/8TC3AEms