### PR TITLE
Make input work on older layouts

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -1,10 +1,17 @@
-.gem-c-input {
+// scss-lint:disable QualifyingElement
+.gem-c-input,
+
+// Explicitly set the input type so that we have higher specificity than
+// https://github.com/alphagov/static/blob/79d29b6a4221874ead27e67d007704a6be166a57/app/assets/stylesheets/helpers/_buttons.scss#L91-L122
+// This can be removed once everything is using `core_layout`.
+input[type=text].gem-c-input {
   @include core-19;
 
   box-sizing: border-box;
   width: 100%;
   height: 2.10526em;
-  margin-top: 0;
+
+  margin: 0; // Override unwanted global cascaded styles
   margin-bottom: 20px;
 
   padding: $gem-spacing-scale-1;
@@ -16,6 +23,7 @@
   // Disable inner shadow and remove rounded corners
   appearance: none;
 }
+// scss-lint:enable QualifyingElement
 
 @media (min-width: 40.0625em) {
   .govuk-c-input {


### PR DESCRIPTION
The bank holidays page is using an older layout, which includes [the button CSS](https://github.com/alphagov/static/blob/79d29b6a4221874ead27e67d007704a6be166a57/app/assets/stylesheets/helpers/_buttons.scss#L91-L122). This contains a style rule on the `input` element, rather than a class.

To make the  styles for the `input` component work on these layouts we need to make the component more specific (unfortunately). We also reset the margin to override the styles from buttons.css.

Paired with @andysellick on this.

## Before

<img width="1438" alt="screen shot 2018-02-16 at 12 04 26" src="https://user-images.githubusercontent.com/233676/36307232-1c481fbc-1313-11e8-96ce-788e99a82126.png">

## After

<img width="1440" alt="screen shot 2018-02-16 at 12 07 40" src="https://user-images.githubusercontent.com/233676/36307235-1f3f2986-1313-11e8-8157-3db474673fce.png">


https://trello.com/c/8TC3AEms