### PR TITLE
Fix feedback component accessibility issues

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -36,6 +36,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         e.preventDefault();
         toggleForm($(e.target).attr('aria-controls'));
         setInitialAriaAttributes();
+        revealInitialPrompt();
       });
 
       this.$pageIsUsefulButton.on('click', function(e) {
@@ -113,10 +114,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
       }
 
-      function clearMessages () {
-        $element.find('.js-errors').html('').addClass(jshiddenClass);
-      }
-
       function showError (error) {
         var error = [
           '<h2 class="gem-c-feedback__heading">',
@@ -131,10 +128,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
         var $errors = that.$activeForm.find('.js-errors');
         $errors.html(error).removeClass(jshiddenClass).focus();
-      }
-
-      function clearAllInputs () {
-        that.$fields.val('');
       }
 
       function showFormSuccess () {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -39,8 +39,8 @@
 
 .gem-c-feedback__prompt-question,
 .gem-c-feedback__prompt-success {
-  @include bold-16;
   display: inline;
+  font-weight: bold;
 
   &:focus {
     outline: 0;

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -64,7 +64,8 @@
           label: {
             text: "What were you doing?"
           },
-          name: "what_doing"
+          name: "what_doing",
+          describedby: "feedback_explanation"
         } %>
 
         <%= render "govuk_publishing_components/components/input", {
@@ -102,7 +103,8 @@
             text: "Email address"
           },
           name: "email_survey_signup[email_address]",
-          type: "email"
+          type: "email",
+          describedby: "survey_explanation"
         } %>
 
         <%# TODO: use button component once available in gem %>

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -5,6 +5,7 @@
   error_message ||= false
   label ||= {}
   type ||= "text"
+  describedby ||= false
 %>
 
 <%= render "govuk_publishing_components/components/label", {
@@ -24,6 +25,8 @@
 
   <% if error_message %>
     aria-describedby="<%= hint_id %>"
+  <% elsif describedby %>
+    aria-describedby="<%= describedby %>"
   <% end %>
 
   <% if value %>

--- a/app/views/govuk_publishing_components/components/docs/feedback.yml
+++ b/app/views/govuk_publishing_components/components/docs/feedback.yml
@@ -1,5 +1,5 @@
 name: Feedback
-description: Invites user feedback on the current page
+description: Invites user feedback on the current page.
 body: |
   This component is designed to sit at the bottom of pages on GOV.UK to allow users to submit feedback on that page. It is based on the 'improve this page' component from the Service manual, but changes have been made.
 

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -1,25 +1,41 @@
 name: Form input
-description: A single-line text field.
+description: A form input field and an associated label.
 body: |
   [Forked from GOV.UK Frontend](https://govuk-frontend-review.herokuapp.com/components/input)
 accessibility_criteria: |
-  Markdown listing what this component must do to be accessible. For example:
+  Inputs in the component must:
 
-  The link must:
-
-  * be keyboard focusable
+  * accept focus
+  * be focusable with a keyboard
+  * be usable with a keyboard
+  * be usable with touch
+  * indicate when they have focus
+  * be recognisable as form input elements
+  * have correctly associated labels
+  * be of the appropriate type for their use, e.g. password inputs should be of type 'password'
 examples:
   default:
     data:
       label:
         text: "What is your name?"
       name: "name"
-  email_type:
+  specific_input_type:
+    description: By default the input will be type="text". This parameter accepts an alternative, e.g. "search" or "email". No validation is done on this input.
     data:
       label:
         text: "What is your email address?"
       name: "address"
       type: "email"
+  aria_described_by:
+    description: |
+      Allows the addition of an aria-describedby attribute. Note that this will be overridden in the event of an error, where the error will be used for the describedby attribute value.
+
+      The example below uses the ID of the skiplink container for demonstration purposes, in real use this would be passed the ID of an element that correctly described the input.
+    data:
+      label:
+        text: "This might not work"
+      name: "labelledby"
+      labelledby: "skiplink-container"
   with_error:
     data:
       label:

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -51,11 +51,22 @@ describe "Input", type: :view do
     assert_select ".gem-c-input[value='example@example.com']"
   end
 
+  it "renders inputs with an aria-describedby if provided" do
+    render_component(
+      label: { text: "What is your email address?" },
+      name: "email-address",
+      describedby: "some-other-element"
+    )
+
+    assert_select ".gem-c-input[aria-describedby='some-other-element']"
+  end
+
   context "when an error_message is provided" do
     before do
       render_component(
         name: "email-address",
         error_message: "Please enter a valid email address",
+        describedby: "some-other-element"
       )
     end
 
@@ -67,7 +78,7 @@ describe "Input", type: :view do
       assert_select ".gem-c-label--bold"
     end
 
-    it "sets the 'aria-describedby' on the input to the hint id" do
+    it "sets the 'aria-describedby' on the input to the hint id and overrides a describedby parameter" do
       hint = css_select(".gem-c-label__hint")
       hint_id = hint.attr("id").text
 

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -254,6 +254,7 @@ describe("Feedback component", function () {
 
     it("shows the prompt", function() {
       expect($('.gem-c-feedback .js-prompt')).not.toHaveClass('js-hidden');
+      expect(document.activeElement).toBe($('.gem-c-feedback .js-prompt').get(0));
     });
 
     it("conveys that the feedback form is hidden", function() {
@@ -283,6 +284,7 @@ describe("Feedback component", function () {
 
     it("shows the prompt", function() {
       expect($('.gem-c-feedback .js-prompt')).not.toHaveClass('js-hidden');
+      expect(document.activeElement).toBe($('.gem-c-feedback .js-prompt').get(0));
     });
 
     it("conveys that the feedback form is hidden", function() {


### PR DESCRIPTION
Changes in response to [accessibility review of the feedback component](https://github.com/alphagov/govuk_publishing_components/pull/163#issuecomment-366267858)

Issues addressed:

- 2, expanded the input component used by the feedback component to include an aria-describedby attribute, then set to the id of the describing paragraph. Have only tested this in VO on Safari.
- 3, have set focus back to the initial 'is something wrong' prompt on form close.
- 5, can't do much against the GOV.UK font mixins, but I've removed the explicit definition on the initial 'is something wrong' text so it's at least consistent compared with the links next to it (i.e. all of them are now resizable)

I don't currently have fixes for the remaining issues, @selfthinker happy to discuss further.