### PR TITLE
Make legend optional on a fieldset

### DIFF
--- a/app/views/govuk_publishing_components/components/_fieldset.html.erb
+++ b/app/views/govuk_publishing_components/components/_fieldset.html.erb
@@ -1,7 +1,12 @@
 <% text = text || yield %>
-<fieldset class="gem-c-fieldset">
-  <legend class="gem-c-fieldset__legend">
-    <%= legend_text %>
-  </legend>
-  <%= text %>
-</fieldset>
+<% legend_text = legend_text || nil %>
+<% if text.present? || legend_text.present? %>
+  <fieldset class="gem-c-fieldset">
+    <% if legend_text %>
+      <legend class="gem-c-fieldset__legend">
+        <%= legend_text %>
+      </legend>
+    <% end %>
+    <%= text %>
+  </fieldset>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/fieldset.yml
+++ b/app/views/govuk_publishing_components/components/docs/fieldset.yml
@@ -32,3 +32,12 @@ examples:
 
         <input type="radio" id="html-legend-no" name="html-legend">
         <label for="html-legend-no">No</label>
+  without_legend:
+    data:
+      text: |
+        <!-- Use the radio component, this is hardcoded only for this example -->
+        <input type="radio" id="html-legend-yes" name="html-legend">
+        <label for="html-legend-yes">Yes</label>
+
+        <input type="radio" id="html-legend-no" name="html-legend">
+        <label for="html-legend-no">No</label>

--- a/spec/components/fieldset_test_spec.rb
+++ b/spec/components/fieldset_test_spec.rb
@@ -5,10 +5,8 @@ describe "Fieldset", type: :view do
     render file: "govuk_publishing_components/components/_fieldset", locals: locals
   end
 
-  it "fails to render when no data is given" do
-    assert_raises do
-      render_component({})
-    end
+  it "does not render anything if no data is passed" do
+    assert_empty render_component({})
   end
 
   it "renders a fieldset correctly" do
@@ -18,6 +16,15 @@ describe "Fieldset", type: :view do
     )
 
     assert_select ".gem-c-fieldset__legend", text: 'Do you have a passport?'
+    assert_select ".gem-c-fieldset", text: /Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vel ad neque, maxime est ea laudantium totam fuga!/
+  end
+
+  it "renders a fieldset without a legend" do
+    render_component(
+      text: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vel ad neque, maxime est ea laudantium totam fuga!'
+    )
+
+    assert_select ".gem-c-fieldset__legend", false
     assert_select ".gem-c-fieldset", text: /Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vel ad neque, maxime est ea laudantium totam fuga!/
   end
 end


### PR DESCRIPTION
Legend is an optional child of a fieldset element however this component previously required one which meant if you couldn't use the legend for some reason you would have to abandon the component.

On email-alert-frontend we were specifically caught out by wanting to style headers and copy via govspeak (which means it can't go into the legend as the govspeak component uses a `<div>`) and so we've gone without a fieldset which has left us missing a vertical margin:

<img width="634" alt="screen shot 2018-02-19 at 18 14 33" src="https://user-images.githubusercontent.com/282717/36391985-eed2f6f2-15a0-11e8-99b3-cbb1c1c66e65.png">

Other options to fix our immediate problem would be:

- Keeping the text in the legend but finding a way to style it and then:
  - Having a govspeak class on the legend itself (I believe we're allowed `h*` / `p` elements in a `legend` but not `div`) or
  - Using something else to replicate the govspeak styling on the legend
- Having a margin-bottom modifier for radio buttons and not using the fieldset (which I mocked up in a [different branch](https://github.com/alphagov/govuk_publishing_components/tree/radio-button-margin-bottom) but then decided it was probably better to try maintain a fieldset)

/cc @andysellick 
