### PR TITLE
Support govspeak in a fieldset legend

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (5.1.1)
+    govuk_publishing_components (5.1.3)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)
@@ -95,7 +95,7 @@ GEM
       rubocop (~> 0.51.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
-    govuk_frontend_toolkit (7.4.0)
+    govuk_frontend_toolkit (7.4.1)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
     hashdiff (0.3.7)

--- a/app/views/govuk_publishing_components/components/_fieldset.html.erb
+++ b/app/views/govuk_publishing_components/components/_fieldset.html.erb
@@ -1,6 +1,14 @@
-<% text = text || yield %>
+<%
+text = text || yield
+legend_govspeak ||= nil
+govspeak_classes = legend_govspeak ? %w[govuk-govspeak] : []
+if legend_govspeak.respond_to?(:[])
+  govspeak_classes << "rich-govspeak" if legend_govspeak[:rich]
+  govspeak_classes << "direction-#{legend_govspeak[:direction]}" if legend_govspeak[:direction]
+end
+%>
 <fieldset class="gem-c-fieldset">
-  <legend class="gem-c-fieldset__legend">
+  <legend class="gem-c-fieldset__legend <%= govspeak_classes.join(" ") %>">
     <%= legend_text %>
   </legend>
   <%= text %>

--- a/app/views/govuk_publishing_components/components/docs/fieldset.yml
+++ b/app/views/govuk_publishing_components/components/docs/fieldset.yml
@@ -32,3 +32,31 @@ examples:
 
         <input type="radio" id="html-legend-no" name="html-legend">
         <label for="html-legend-no">No</label>
+  with_govspeak_legend:
+    description: "If you want to use govspeak inside the legend you won\'t be able to use the [govspeak component](http://govuk-static.herokuapp.com/component-guide/govspeak) as it is wrapped in a div which is not allowed by HTML. You can instead pass a legend_govspeak option"
+    data:
+      legend_govspeak: true
+      legend_text: <h2>Do you have a passport?</h2>
+      text: |
+        <!-- Use the radio component, this is hardcoded only for this example -->
+        <input type="radio" id="govspeak-legend-yes" name="govspeak-legend">
+        <label for="govspeak-legend-yes">Yes</label>
+
+        <input type="radio" id="govspeak-legend-no" name="govspeak-legend">
+        <label for="govspeak-legend-no">No</label>
+  with_govspeak_options_legend:
+    description: "You may need additional options for govspeak"
+    data:
+      legend_govspeak:
+        direction: "rtl"
+        rich: true
+      legend_text: |
+        <h2>مع بدء هذا الشهر الفضيل أتمنى للمسلمين في أنحاء العالم - في آسيا وأفريقيا والشرق الأوسط وأوروبا وغيرها من مناطق العالم - شهر رمضان مبارك</h2>
+        <p>مع بدء هذا الشهر الفضيل أتمنى للمسلمين في أنحاء العالم - في آسيا وأفريقيا <strong>والشرق</strong> الأوسط وأوروبا وغيرها من مناطق العالم - شهر رمضان مبارك</p>
+      text: |
+        <!-- Use the radio component, this is hardcoded only for this example -->
+        <input type="radio" id="govspeak-options-legend-yes" name="govspeak-options-legend">
+        <label for="govspeak-options-legend-yes">Yes</label>
+
+        <input type="radio" id="govspeak-options-legend-no" name="govspeak-options-legend">
+        <label for="govspeak-options-legend-no">No</label>


### PR DESCRIPTION
We cannot put a govspeak component inside a fieldset legend as div is not an allowed child of a legend. This adds an option to the fieldset component which will give govspeak styling to the contents of a legend.

The need for this addition was prompted by [this situation](https://github.com/alphagov/email-alert-frontend/pull/135) we encountered on email-alert-frontend where it was difficult to add styling to the legend.

See example 👉 https://govuk-publishing-compon-pr-178.herokuapp.com/component-guide/fieldset

I'm not hugely convinced this change is a great idea since it means replicating some of the responsibility of the govspeak component, but it seems potentially the best approach in a frustrating situation. 

I think on an ideal level it'd be far better to have means to call the styles produced by govspeak by putting classes on the individual elements, but that seems a challenge to reach.

/cc @andysellick 

