### PR TITLE
Update gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (5.1.1)
+    govuk_publishing_components (5.1.3)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)
@@ -95,7 +95,7 @@ GEM
       rubocop (~> 0.51.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
-    govuk_frontend_toolkit (7.4.0)
+    govuk_frontend_toolkit (7.4.1)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
     hashdiff (0.3.7)


### PR DESCRIPTION
This resolves the issue where this won't install gems in deployment mode
as the gemfile is locked to version 5.1.1 whereas the gem is at 5.1.3.

At the moment this is blocking deployments to heroku.