### PR TITLE
Change feedback tracking

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -35,6 +35,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.$closeForms.on('click', function(e) {
         e.preventDefault();
         toggleForm($(e.target).attr('aria-controls'));
+        trackEvent(getTrackEventParams($(this)));
         setInitialAriaAttributes();
         revealInitialPrompt();
       });

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -47,8 +47,19 @@
     </div>
   </div>
 
-  <form action="/contact/govuk/problem_reports" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="Onsite Feedback" data-track-action="GOV.UK Send Form" method="post">
-    <a href="#" class="gem-c-feedback__close gem-c-feedback__js-show js-close-form" aria-controls="something-is-wrong" aria-expanded="true" role="button">Close</a>
+  <form action="/contact/govuk/problem_reports"
+    id="something-is-wrong"
+    class="gem-c-feedback__form js-feedback-form js-hidden"
+    data-track-category="Onsite Feedback"
+    data-track-action="GOV.UK Send Form"
+    method="post">
+    <a href="#"
+      class="gem-c-feedback__close gem-c-feedback__js-show js-close-form"
+      data-track-category="Onsite Feedback"
+      data-track-action="GOV.UK Close Form"
+      aria-controls="something-is-wrong"
+      aria-expanded="true"
+      role="button">Close</a>
 
     <div class="gem-c-feedback__grid-row">
       <div class="gem-c-feedback__column-two-thirds">
@@ -81,8 +92,19 @@
     </div>
   </form>
 
-  <form action="/contact/govuk/email-survey-signup" id="page-is-not-useful" class="gem-c-feedback__form gem-c-feedback__form--email gem-c-feedback__js-show js-feedback-form js-hidden" data-track-category="user_satisfaction_survey" data-track-action="banner_taken" method="post">
-    <a href="#" class="gem-c-feedback__close js-close-form" aria-controls="page-is-not-useful" aria-expanded="true" role="button">Close</a>
+  <form action="/contact/govuk/email-survey-signup"
+    id="page-is-not-useful"
+    class="gem-c-feedback__form gem-c-feedback__form--email gem-c-feedback__js-show js-feedback-form js-hidden"
+    data-track-category="user_satisfaction_survey"
+    data-track-action="banner_taken"
+    method="post">
+    <a href="#"
+      class="gem-c-feedback__close js-close-form"
+      data-track-category="yesNoFeedbackForm"
+      data-track-action="ffFormClose"
+      aria-controls="page-is-not-useful"
+      aria-expanded="true"
+      role="button">Close</a>
 
     <div class="gem-c-feedback__grid-row">
       <div class="gem-c-feedback__column-two-thirds">

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -10,7 +10,7 @@
       <%= link_to contact_govuk_path, {
         class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful',
         data: {
-          'track-category' => 'Onsite Feedback',
+          'track-category' => 'yesNoFeedbackForm',
           'track-action' => 'ffYesClick'
           },
         } do %>
@@ -20,7 +20,7 @@
       <%= link_to contact_govuk_path, {
         class: 'gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful',
         data: {
-          'track-category' => 'Onsite Feedback',
+          'track-category' => 'yesNoFeedbackForm',
           'track-action' => 'ffNoClick'
           },
           'aria-controls': 'page-is-not-useful',
@@ -95,8 +95,8 @@
   <form action="/contact/govuk/email-survey-signup"
     id="page-is-not-useful"
     class="gem-c-feedback__form gem-c-feedback__form--email gem-c-feedback__js-show js-feedback-form js-hidden"
-    data-track-category="user_satisfaction_survey"
-    data-track-action="banner_taken"
+    data-track-category="yesNoFeedbackForm"
+    data-track-action="Send Form"
     method="post">
     <a href="#"
       class="gem-c-feedback__close js-close-form"

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -10,7 +10,7 @@
       <%= link_to contact_govuk_path, {
         class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful',
         data: {
-          'track-category' => 'yesNoFeedbackForm',
+          'track-category' => 'Onsite Feedback',
           'track-action' => 'ffYesClick'
           },
         } do %>
@@ -20,7 +20,7 @@
       <%= link_to contact_govuk_path, {
         class: 'gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful',
         data: {
-          'track-category' => 'yesNoFeedbackForm',
+          'track-category' => 'Onsite Feedback',
           'track-action' => 'ffNoClick'
           },
           'aria-controls': 'page-is-not-useful',
@@ -32,7 +32,7 @@
       <%= link_to contact_govuk_path, {
         class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong',
         data: {
-          'track-category' => 'yesNoFeedbackForm',
+          'track-category' => 'Onsite Feedback',
           'track-action' => 'ffWrongClick'
           },
           'aria-controls': 'something-is-wrong',
@@ -47,7 +47,7 @@
     </div>
   </div>
 
-  <form action="/contact/govuk/problem_reports" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="yesNoFeedbackForm" data-track-action="ffFormSubmit" method="post">
+  <form action="/contact/govuk/problem_reports" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="Onsite Feedback" data-track-action="ffFormSubmit" method="post">
     <a href="#" class="gem-c-feedback__close gem-c-feedback__js-show js-close-form" aria-controls="something-is-wrong" aria-expanded="true" role="button">Close</a>
 
     <div class="gem-c-feedback__grid-row">

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -47,7 +47,7 @@
     </div>
   </div>
 
-  <form action="/contact/govuk/problem_reports" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="Onsite Feedback" data-track-action="ffFormSubmit" method="post">
+  <form action="/contact/govuk/problem_reports" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="Onsite Feedback" data-track-action="GOV.UK Send Form" method="post">
     <a href="#" class="gem-c-feedback__close gem-c-feedback__js-show js-close-form" aria-controls="something-is-wrong" aria-expanded="true" role="button">Close</a>
 
     <div class="gem-c-feedback__grid-row">

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -33,7 +33,7 @@
         class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong',
         data: {
           'track-category' => 'Onsite Feedback',
-          'track-action' => 'ffWrongClick'
+          'track-action' => 'GOV.UK Open Form'
           },
           'aria-controls': 'something-is-wrong',
           'aria-expanded': false

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -15,7 +15,7 @@ describe("Feedback component", function () {
       '</div>' +
 
       '<form action="/contact/govuk/page_improvements" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="Onsite Feedback" data-track-action="GOV.UK Send Form">' +
-        '<a href="#" class="gem-c-feedback__close js-close-form" aria-controls="something-is-wrong" aria-expanded="true">Close</a>' +
+        '<a href="#" class="gem-c-feedback__close js-close-form" aria-controls="something-is-wrong" aria-expanded="true" data-track-category="Onsite Feedback" data-track-action="GOV.UK Close Form">Close</a>' +
 
         '<div class="grid-row">' +
           '<div class="column-two-thirds">' +
@@ -47,7 +47,7 @@ describe("Feedback component", function () {
       '</form>' +
 
       '<form action="/contact/govuk/email-survey-signup" id="page-is-not-useful" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="user_satisfaction_survey" data-track-action="banner_taken">' +
-        '<a href="#" class="gem-c-feedback__close js-close-form" aria-controls="page-is-not-useful" aria-expanded="true">Close</a>' +
+        '<a href="#" class="gem-c-feedback__close js-close-form" aria-controls="page-is-not-useful" aria-expanded="true" data-track-category="yesNoFeedbackForm" data-track-action="ffFormClose">Close</a>' +
 
         '<div class="grid-row">' +
           '<div class="column-two-thirds">' +
@@ -269,6 +269,19 @@ describe("Feedback component", function () {
       expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false');
       expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false');
     });
+
+    it("triggers a Google Analytics event", function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      $('#something-is-wrong a.js-close-form').click();
+
+      expect(GOVUK.analytics.trackEvent).
+        toHaveBeenCalledWith('Onsite Feedback', 'GOV.UK Close Form');
+    });
   })
 
   describe("Clicking the close link in the 'not useful' form", function () {
@@ -298,6 +311,19 @@ describe("Feedback component", function () {
 
       expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false');
       expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false');
+    });
+
+    it("triggers a Google Analytics event", function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      $('#page-is-not-useful a.js-close-form').click();
+
+      expect(GOVUK.analytics.trackEvent).
+        toHaveBeenCalledWith('yesNoFeedbackForm', 'ffFormClose');
     });
   })
 

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -6,7 +6,7 @@ describe("Feedback component", function () {
           '<h3 class="gem-c-feedback__is-useful-question">Is this page useful?</h3>' +
           '<a href="/contact/govuk" class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful" data-track-category="Onsite Feedback" data-track-action="ffYesClick">Yes <span class="visually-hidden">this page is useful</span></a>' +
           '<a href="/contact/govuk" class="gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="Onsite Feedback" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">No <span class="visually-hidden">this page is not useful</span></a>' +
-          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="ffWrongClick" aria-controls="something-is-wrong" aria-expanded="false">Is there anything wrong with this page?</a>' +
+          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV.UK Open Form" aria-controls="something-is-wrong" aria-expanded="false">Is there anything wrong with this page?</a>' +
         '</div>' +
 
         '<div class="gem-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">' +
@@ -237,7 +237,7 @@ describe("Feedback component", function () {
       $('a.js-something-is-wrong').click();
 
       expect(GOVUK.analytics.trackEvent).
-        toHaveBeenCalledWith('Onsite Feedback', 'ffWrongClick');
+        toHaveBeenCalledWith('Onsite Feedback', 'GOV.UK Open Form');
     });
   });
 

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -4,8 +4,8 @@ describe("Feedback component", function () {
       '<div class="gem-c-feedback__prompt js-prompt" tabindex="-1">' +
         '<div class="js-prompt-questions">' +
           '<h3 class="gem-c-feedback__is-useful-question">Is this page useful?</h3>' +
-          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful" data-track-category="Onsite Feedback" data-track-action="ffYesClick">Yes <span class="visually-hidden">this page is useful</span></a>' +
-          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="Onsite Feedback" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">No <span class="visually-hidden">this page is not useful</span></a>' +
+          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">Yes <span class="visually-hidden">this page is useful</span></a>' +
+          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">No <span class="visually-hidden">this page is not useful</span></a>' +
           '<a href="/contact/govuk" class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV.UK Open Form" aria-controls="something-is-wrong" aria-expanded="false">Is there anything wrong with this page?</a>' +
         '</div>' +
 
@@ -46,7 +46,7 @@ describe("Feedback component", function () {
         '</div>' +
       '</form>' +
 
-      '<form action="/contact/govuk/email-survey-signup" id="page-is-not-useful" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="user_satisfaction_survey" data-track-action="banner_taken">' +
+      '<form action="/contact/govuk/email-survey-signup" id="page-is-not-useful" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="yesNoFeedbackForm" data-track-action="Send Form">' +
         '<a href="#" class="gem-c-feedback__close js-close-form" aria-controls="page-is-not-useful" aria-expanded="true" data-track-category="yesNoFeedbackForm" data-track-action="ffFormClose">Close</a>' +
 
         '<div class="grid-row">' +
@@ -133,7 +133,7 @@ describe("Feedback component", function () {
       $('a.js-page-is-useful').click();
 
       expect(GOVUK.analytics.trackEvent).
-        toHaveBeenCalledWith('Onsite Feedback', 'ffYesClick');
+        toHaveBeenCalledWith('yesNoFeedbackForm', 'ffYesClick');
     });
   });
 
@@ -185,7 +185,7 @@ describe("Feedback component", function () {
       $('a.js-page-is-not-useful').click();
 
       expect(GOVUK.analytics.trackEvent).
-        toHaveBeenCalledWith('Onsite Feedback', 'ffNoClick');
+        toHaveBeenCalledWith('yesNoFeedbackForm', 'ffNoClick');
     });
   });
 
@@ -453,7 +453,7 @@ describe("Feedback component", function () {
       });
 
       expect(GOVUK.analytics.trackEvent).
-        toHaveBeenCalledWith('user_satisfaction_survey', 'banner_taken');
+        toHaveBeenCalledWith('yesNoFeedbackForm', 'Send Form');
     });
 
     it("submits the feedback to the feedback frontend", function () {

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -14,7 +14,7 @@ describe("Feedback component", function () {
         '</div>' +
       '</div>' +
 
-      '<form action="/contact/govuk/page_improvements" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="Onsite Feedback" data-track-action="ffFormSubmit">' +
+      '<form action="/contact/govuk/page_improvements" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="Onsite Feedback" data-track-action="GOV.UK Send Form">' +
         '<a href="#" class="gem-c-feedback__close js-close-form" aria-controls="something-is-wrong" aria-expanded="true">Close</a>' +
 
         '<div class="grid-row">' +
@@ -327,7 +327,7 @@ describe("Feedback component", function () {
       });
 
       expect(GOVUK.analytics.trackEvent).
-        toHaveBeenCalledWith('Onsite Feedback', 'ffFormSubmit');
+        toHaveBeenCalledWith('Onsite Feedback', 'GOV.UK Send Form');
     });
 
     it("submits the feedback to the feedback frontend", function () {

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -4,9 +4,9 @@ describe("Feedback component", function () {
       '<div class="gem-c-feedback__prompt js-prompt" tabindex="-1">' +
         '<div class="js-prompt-questions">' +
           '<h3 class="gem-c-feedback__is-useful-question">Is this page useful?</h3>' +
-          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">Yes <span class="visually-hidden">this page is useful</span></a>' +
-          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">No <span class="visually-hidden">this page is not useful</span></a>' +
-          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong" data-track-category="yesNoFeedbackForm" data-track-action="ffWrongClick" aria-controls="something-is-wrong" aria-expanded="false">Is there anything wrong with this page?</a>' +
+          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful" data-track-category="Onsite Feedback" data-track-action="ffYesClick">Yes <span class="visually-hidden">this page is useful</span></a>' +
+          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="Onsite Feedback" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">No <span class="visually-hidden">this page is not useful</span></a>' +
+          '<a href="/contact/govuk" class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="ffWrongClick" aria-controls="something-is-wrong" aria-expanded="false">Is there anything wrong with this page?</a>' +
         '</div>' +
 
         '<div class="gem-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">' +
@@ -14,7 +14,7 @@ describe("Feedback component", function () {
         '</div>' +
       '</div>' +
 
-      '<form action="/contact/govuk/page_improvements" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="yesNoFeedbackForm" data-track-action="ffFormSubmit">' +
+      '<form action="/contact/govuk/page_improvements" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="Onsite Feedback" data-track-action="ffFormSubmit">' +
         '<a href="#" class="gem-c-feedback__close js-close-form" aria-controls="something-is-wrong" aria-expanded="true">Close</a>' +
 
         '<div class="grid-row">' +
@@ -133,7 +133,7 @@ describe("Feedback component", function () {
       $('a.js-page-is-useful').click();
 
       expect(GOVUK.analytics.trackEvent).
-        toHaveBeenCalledWith('yesNoFeedbackForm', 'ffYesClick');
+        toHaveBeenCalledWith('Onsite Feedback', 'ffYesClick');
     });
   });
 
@@ -185,7 +185,7 @@ describe("Feedback component", function () {
       $('a.js-page-is-not-useful').click();
 
       expect(GOVUK.analytics.trackEvent).
-        toHaveBeenCalledWith('yesNoFeedbackForm', 'ffNoClick');
+        toHaveBeenCalledWith('Onsite Feedback', 'ffNoClick');
     });
   });
 
@@ -237,7 +237,7 @@ describe("Feedback component", function () {
       $('a.js-something-is-wrong').click();
 
       expect(GOVUK.analytics.trackEvent).
-        toHaveBeenCalledWith('yesNoFeedbackForm', 'ffWrongClick');
+        toHaveBeenCalledWith('Onsite Feedback', 'ffWrongClick');
     });
   });
 
@@ -327,7 +327,7 @@ describe("Feedback component", function () {
       });
 
       expect(GOVUK.analytics.trackEvent).
-        toHaveBeenCalledWith('yesNoFeedbackForm', 'ffFormSubmit');
+        toHaveBeenCalledWith('Onsite Feedback', 'ffFormSubmit');
     });
 
     it("submits the feedback to the feedback frontend", function () {


### PR DESCRIPTION
Changes to the GA tracking on the new feedback component for GOV.UK.

Link for testing: https://govuk-publishing-compon-pr-184.herokuapp.com/component-guide/feedback/preview

- Trello card: https://trello.com/c/3RTCSaMA/8-change-the-ga-tracking-for-is-there-anything-wrong-with-this-page-cta
- Component guide: https://govuk-publishing-compon-pr-184.herokuapp.com/component-guide/feedback
