### PR TITLE
Drop govuk-content-schema-test-helpers dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,8 +89,6 @@ GEM
       money (~> 6.7)
       nokogiri (~> 1.5)
       sanitize (~> 2.1.0)
-    govuk-content-schema-test-helpers (1.6.0)
-      json-schema (~> 2.8.0)
     govuk-lint (3.6.0)
       rubocop (~> 0.51.0)
       rubocop-rspec (~> 1.19.0)
@@ -270,7 +268,6 @@ PLATFORMS
 DEPENDENCIES
   capybara (~> 2.14.4)
   foreman (~> 0.64)
-  govuk-content-schema-test-helpers (~> 1.6)
   govuk-lint (~> 3.3)
   govuk_publishing_components!
   govuk_schemas (~> 3.1)

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "poltergeist", "~> 1.16.0"
   s.add_development_dependency "jasmine", "~> 2.4.0"
   s.add_development_dependency "uglifier", ">= 1.3.0"
-  s.add_development_dependency "govuk-content-schema-test-helpers", "~> 1.6"
   s.add_development_dependency "foreman", "~> 0.64"
   s.add_development_dependency "govuk_schemas", "~> 3.1"
   # Needed to load slimmer test helpers


### PR DESCRIPTION
This isn't actually used.

cc @emmabeynon 