### PR TITLE
Redirect dummy app root to component guide

### DIFF
--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -4,7 +4,7 @@ describe 'Component guide index' do
   # Load ordering test can only fail if run as the first test in suite
   # https://github.com/rails/rails/issues/12168
   it 'renders using gem layout not app layout after viewing a page on the application' do
-    visit '/'
+    visit '/test'
     expect(page).to have_title 'Dummy'
     visit '/component-guide'
     expect(page).to have_title 'GOV.UK Component Guide'

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   mount GovukPublishingComponents::Engine, at: "/component-guide"
-  root to: 'welcome#index'
+  root to: redirect('/component-guide')
+  get 'test', to: 'welcome#index'
 end


### PR DESCRIPTION
Means review apps can be visited directly without needing to append the
component guide URL to the end.

Links to Heroku review apps in Github PRs will work as expected.

eg https://govuk-publishing-compon-pr-189.herokuapp.com/