### PR TITLE
Set feedback component font sizes for initial state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Feedback: set font sizes (PR #190)
 * Feedback: improve link spacing (PR #188)
 
 # 5.2.1

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -39,19 +39,26 @@
 
 .gem-c-feedback__prompt-question,
 .gem-c-feedback__prompt-success {
-  display: inline;
-  font-weight: bold;
+  @include bold-19;
+  display: inline-block;
 
   &:focus {
     outline: 0;
   }
+
+  @include media(tablet) {
+    @include bold-16;
+    float: left;
+  }
 }
 
 .gem-c-feedback__prompt-link {
-  display: inline-block;
+  @include core-19;
   margin-left: $gutter-half;
 
   @include media(tablet) {
+    @include core-16;
+    float: left; // needed to ensure vertical alignment consistent with prompt-link--wrong
     margin-left: $gutter-one-third;
   }
 }
@@ -63,11 +70,13 @@
 
 .gem-c-feedback__prompt-link--wrong {
   display: block;
+  clear: both;
   margin-top: $gutter-half;
   margin-left: 0;
 
   @include media(tablet) {
     float: right;
+    clear: none;
     margin-top: 0;
     margin-left: $gutter-one-third;
   }


### PR DESCRIPTION
- set font size for 'is this page useful?' and links beside it
- various apps have styles that were affecting the component, defining them explicitly like this should help
- does prevent an earlier accessibility fix to allow text resizing in the browser settings to work, but since that doesn't work in the rest of the component where we already defined font sizes, or even in the rest of GOV.UK, this doesn't seem like a huge concern

No visual changes.

Trello card: https://trello.com/c/vKfhGFtn/4-font-sizing-on-frontend-whitehall