### PR TITLE
Add role button to links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Feedback: add role button to links (PR #193)
+
 # 5.2.2
 
 * Feedback: add spacing above component (PR #191)

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -24,7 +24,8 @@
           'track-action' => 'ffNoClick'
           },
           'aria-controls': 'page-is-not-useful',
-          'aria-expanded': false
+          'aria-expanded': false,
+          'role': 'button'
         } do %>
           No <span class="visually-hidden">this page is not useful</span>
       <% end %>
@@ -36,7 +37,8 @@
           'track-action' => 'GOV.UK Open Form'
           },
           'aria-controls': 'something-is-wrong',
-          'aria-expanded': false
+          'aria-expanded': false,
+          'role': 'button'
         } do %>
           Is there anything wrong with this page?
       <% end %>


### PR DESCRIPTION
Add role="button" to the 'No' and 'Is anything wrong with this page?' links for screen reader users.

Trello card: https://trello.com/c/mTVAGvjC/13-feedback-survey-control-needs-to-be-a-button-or-link-with-rolebutton