### PR TITLE
Feedback component: Fix styling on pages with older layouts

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -47,6 +47,9 @@
   @include bold-19;
   display: inline-block;
 
+  // There's a global h3 rule in some layouts that interferes with this component
+  margin-top: 0;
+
   &:focus {
     outline: 0;
   }


### PR DESCRIPTION
I suspect that this was caused by https://github.com/alphagov/govuk_publishing_components/pull/190, but can't be sure.

## Before

![screen shot 2018-02-27 at 15 31 11](https://user-images.githubusercontent.com/233676/36737560-48455e2c-1bd3-11e8-8dfa-2ee868f80c2d.png)

## After

![screen shot 2018-02-27 at 15 31 03](https://user-images.githubusercontent.com/233676/36737572-4eadb052-1bd3-11e8-8da9-260d4d4670fe.png)

