### PR TITLE
Add step by step navigation component helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add step by step navigation component helpers
+
 # 5.2.3
 
 * Feedback: add role button to links (PR #193)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    PriorityQueue (0.1.2)
     actioncable (5.1.5)
       actionpack (= 5.1.5)
       nio4r (~> 2.0)
@@ -55,6 +56,7 @@ GEM
     arel (8.0.0)
     ast (2.4.0)
     builder (3.2.3)
+    byebug (10.0.0)
     capybara (2.14.4)
       addressable
       mime-types (>= 1.16)
@@ -63,6 +65,7 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     cliver (0.3.2)
+    coderay (1.1.2)
     commander (4.4.4)
       highline (~> 1.7.2)
     concurrent-ruby (1.0.5)
@@ -77,6 +80,14 @@ GEM
     ffi (1.9.21)
     foreman (0.84.0)
       thor (~> 0.19.1)
+    gds-api-adapters (51.2.0)
+      addressable
+      link_header
+      lrucache (~> 0.1.1)
+      null_logger
+      plek (>= 1.9.0)
+      rack-cache
+      rest-client (~> 2.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     govspeak (5.4.0)
@@ -115,9 +126,12 @@ GEM
     json-schema (2.8.0)
       addressable (>= 2.4)
     kramdown (1.15.0)
+    link_header (0.0.8)
     loofah (2.2.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    lrucache (0.1.4)
+      PriorityQueue (~> 0.1.2)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
@@ -144,8 +158,16 @@ GEM
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     public_suffix (3.0.2)
     rack (2.0.4)
+    rack-cache (1.7.1)
+      rack (>= 0.4)
     rack-test (0.8.2)
       rack (>= 1.0, < 3)
     rails (5.1.5)
@@ -268,11 +290,13 @@ PLATFORMS
 DEPENDENCIES
   capybara (~> 2.14.4)
   foreman (~> 0.64)
+  gds-api-adapters
   govuk-lint (~> 3.3)
   govuk_publishing_components!
   govuk_schemas (~> 3.1)
   jasmine (~> 2.4.0)
   poltergeist (~> 1.16.0)
+  pry-byebug
   rspec-rails (~> 3.6)
   uglifier (>= 1.3.0)
   webmock (~> 3.0.1)

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -31,8 +31,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency "jasmine", "~> 2.4.0"
   s.add_development_dependency "uglifier", ">= 1.3.0"
   s.add_development_dependency "foreman", "~> 0.64"
+  s.add_development_dependency "gds-api-adapters"
   s.add_development_dependency "govuk_schemas", "~> 3.1"
   # Needed to load slimmer test helpers
   # https://github.com/alphagov/slimmer/issues/201
   s.add_development_dependency "webmock", "~> 3.0.1"
+  s.add_development_dependency "pry-byebug"
 end

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -3,5 +3,8 @@ require "govuk_publishing_components/engine"
 require "govuk_publishing_components/components/step_by_step_nav_helper"
 require "govuk_publishing_components/components/related_navigation_helper"
 
+require "govuk_publishing_components/step_nav"
+require "govuk_publishing_components/step_nav_helper"
+
 module GovukPublishingComponents
 end

--- a/lib/govuk_publishing_components/step_nav.rb
+++ b/lib/govuk_publishing_components/step_nav.rb
@@ -1,0 +1,23 @@
+module GovukPublishingComponents
+  class StepNav
+    def initialize(content_item)
+      @content_item = content_item.deep_symbolize_keys
+    end
+
+    def title
+      content_item[:title]
+    end
+
+    def base_path
+      content_item[:base_path]
+    end
+
+    def content
+      @content ||= content_item.dig(:details, :step_by_step_nav)
+    end
+
+  private
+
+    attr_reader :content_item
+  end
+end

--- a/lib/govuk_publishing_components/step_nav_helper.rb
+++ b/lib/govuk_publishing_components/step_nav_helper.rb
@@ -1,0 +1,86 @@
+module GovukPublishingComponents
+  class StepNavHelper
+    def initialize(content_store_response, current_path)
+      @content_item = content_store_response.to_h
+      @current_path = current_path
+    end
+
+    def step_navs
+      @step_navs ||= parsed_step_navs.map do |step_nav|
+        StepNav.new(step_nav)
+      end
+    end
+
+    def show_sidebar?
+      step_navs.count == 1
+    end
+    alias_method :show_header?, :show_sidebar?
+
+    def show_related_links?
+      step_navs.any? && step_navs.count < 5
+    end
+
+    def related_links
+      step_navs.map do |step_nav|
+        {
+          href: step_nav.base_path,
+          text: step_nav.title
+        }
+      end
+    end
+
+    def sidebar
+      if show_sidebar?
+        @sidebar ||= first_step_nav.content.tap do |sb|
+          configure_for_sidebar(sb)
+          sb.merge!(small: true, heading_level: 3)
+        end
+      end
+    end
+
+    def header
+      if show_header?
+        {
+          title: first_step_nav.title,
+          path: first_step_nav.base_path
+        }
+      else
+        {}
+      end
+    end
+
+  private
+
+    attr_reader :content_item, :current_path
+
+    def first_step_nav
+      step_navs.first
+    end
+
+    def steps
+      @steps ||= step_nav[:steps]
+    end
+
+    def parsed_step_navs
+      content_item.dig("links", "part_of_step_navs").to_a
+    end
+
+    def configure_for_sidebar(step_nav_content)
+      step_nav_content[:steps].each_with_index do |step, step_index|
+        step[:contents].each do |content|
+          next unless content[:contents]
+
+          content[:contents].each do |link|
+            if link[:href] == current_path
+              link[:active] = true
+              step_nav_content[:show_step] = step_index + 1
+              step_nav_content[:highlight_step] = step_index + 1
+              return step_nav_content
+            end
+          end
+        end
+      end
+      step_nav_content
+    end
+  end
+end

--- a/spec/dummy/app/controllers/step_nav_controller.rb
+++ b/spec/dummy/app/controllers/step_nav_controller.rb
@@ -1,0 +1,12 @@
+class StepNavController < ApplicationController
+  def show
+    content_item = Services.content_store.content_item(base_path)
+    @step_nav_helper = GovukPublishingComponents::StepNavHelper.new(content_item, base_path)
+  end
+
+private
+
+  def base_path
+    "/#{params[:slug]}"
+  end
+end

--- a/spec/dummy/app/lib/services.rb
+++ b/spec/dummy/app/lib/services.rb
@@ -1,0 +1,10 @@
+require 'gds_api/content_store'
+
+module Services
+  def self.content_store
+    @content_store ||= GdsApi::ContentStore.new(
+      Plek.new.find('content-store'),
+      disable_cache: true
+    )
+  end
+end

--- a/spec/dummy/app/views/step_nav/show.html.erb
+++ b/spec/dummy/app/views/step_nav/show.html.erb
@@ -1,0 +1,17 @@
+<header>
+<% if @step_nav_helper.show_header? %>
+  <%= render 'govuk_publishing_components/components/step_by_step_nav_header',
+    @step_nav_helper.header %>
+<% end %>
+</header>
+
+<aside>
+<% if @step_nav_helper.show_related_links? %>
+  <%= render 'govuk_publishing_components/components/step_by_step_nav_related',
+    links: @step_nav_helper.related_links %>
+<% end %>
+<% if @step_nav_helper.show_sidebar? %>
+  <%= render 'govuk_publishing_components/components/step_by_step_nav',
+    @step_nav_helper.sidebar %>
+<% end %>
+</aside>

--- a/spec/dummy/config/initializers/gds_api.rb
+++ b/spec/dummy/config/initializers/gds_api.rb
@@ -1,0 +1,1 @@
+require 'gds_api/base'

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   mount GovukPublishingComponents::Engine, at: "/component-guide"
   root to: redirect('/component-guide')
   get 'test', to: 'welcome#index'
+  get 'step-nav/:slug', to: 'step_nav#show'
 end

--- a/spec/features/step_nav_helper_spec.rb
+++ b/spec/features/step_nav_helper_spec.rb
@@ -1,0 +1,185 @@
+require "rails_helper"
+require "gds_api/test_helpers/content_store"
+
+describe 'Specimen usage of step by step navigation helpers' do
+  include GdsApi::TestHelpers::ContentStore
+
+  context 'no related step by step navigation journeys' do
+    before do
+      content_store_has_random_item(base_path: '/vomit-comet', schema: 'transaction', part_of_step_navs: nil)
+
+      visit '/step-nav/vomit-comet'
+    end
+
+    it 'does not show step nav related components' do
+      expect(page).not_to have_selector('.gem-c-step-nav-header')
+      expect(page).not_to have_selector('.gem-c-step-nav-related')
+      expect(page).not_to have_selector('.gem-c-step-nav')
+    end
+  end
+
+  context 'one related step by step navigation journey' do
+    before do
+      content_store_has_random_item(base_path: '/vomit-comet', schema: 'transaction', part_of_step_navs: [spacewalk_step_nav])
+
+      visit '/step-nav/vomit-comet'
+    end
+
+    it 'shows step nav related links' do
+      expect(page).to have_selector('.gem-c-step-nav-related')
+
+      within('.gem-c-step-nav-related') do
+        expect(page).to have_selector('.gem-c-step-nav-related__link', count: 1)
+        expect(page).to have_link('Learn to spacewalk: small step by giant leap', href: '/learn-to-spacewalk')
+      end
+    end
+
+    it 'shows the full step nav sidebar' do
+      within('.gem-c-step-nav') do
+        expect(page).to have_css('h3', count: 3)
+        expect(page).to have_css('.gem-c-step-nav__link--active', count: 1, text: 'Experience zero gravity in the atmosphere') # one active link
+      end
+    end
+
+    it 'shows the step nav header' do
+      within('.gem-c-step-nav-header') do
+        expect(page).to have_link('Learn to spacewalk: small step by giant leap', href: '/learn-to-spacewalk')
+      end
+    end
+  end
+
+  context 'multiple related step by step navigation journeys' do
+    before do
+      content_store_has_random_item(base_path: '/vomit-comet', schema: 'transaction', part_of_step_navs: [
+        {
+          "content_id" => "8f5d4f2b-daf0-4460-88c1-fdd76c90f6f1",
+          "locale" => "en",
+          "title" => "Learn to spacewalk: small step by giant leap",
+          "base_path" => "/learn-to-spacewalk"
+        },
+        {
+          "content_id" => "8f5d4f2b-daf0-4460-88c1-fdd76c90f6f2",
+          "locale" => "en",
+          "title" => "Lose your lunch: lurch by lurch",
+          "base_path" => "/lose-your-lunch"
+        }
+      ])
+
+      visit '/step-nav/vomit-comet'
+    end
+
+    it 'shows step nav related links' do
+      expect(page).to have_selector('.gem-c-step-nav-related')
+
+      within('.gem-c-step-nav-related') do
+        expect(page).to have_selector('.gem-c-step-nav-related__link-item', count: 2)
+        expect(page).to have_link('Learn to spacewalk: small step by giant leap', href: '/learn-to-spacewalk')
+        expect(page).to have_link('Lose your lunch: lurch by lurch', href: '/lose-your-lunch')
+      end
+    end
+
+    it "doesn't show the full step nav sidebar or header" do
+      expect(page).not_to have_selector('.gem-c-step-nav-header')
+      expect(page).not_to have_selector('.gem-c-step-nav')
+    end
+  end
+
+
+  def content_store_has_random_item(base_path:, schema: 'placeholder', part_of_step_navs: [])
+    links = if part_of_step_navs
+              { 'part_of_step_navs' => part_of_step_navs }
+            else
+              {}
+            end
+
+    content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: schema) do |item|
+      item.merge(
+        'base_path' => base_path,
+        'links' => links
+      )
+    end
+    content_store_has_item(content_item['base_path'], content_item)
+    content_item
+  end
+
+  def spacewalk_step_nav
+    {
+      "content_id" => "8f5d4f2b-daf0-4460-88c1-fdd76c90f6f1",
+      "locale" => "en",
+      "title" => "Learn to spacewalk: small step by giant leap",
+      "base_path" => "/learn-to-spacewalk",
+      "details" => {
+        "step_by_step_nav": {
+          "title": "Learn to spacewalk: small step by giant leap",
+          "introduction": [
+            {
+              "content_type": "text/govspeak",
+              "content": "Check what you need to do to learn to spacewalk."
+            }
+          ],
+          "steps": [
+            {
+              "title": "Check you're allowed to spacewalk",
+              "contents": [
+                {
+                  "type": "paragraph",
+                  "text": "Most people can spacewalk unless they are banned by the federation of planets."
+                },
+                {
+                  "type": "list",
+                  "style": "required",
+                  "contents": [
+                    {
+                      "href": "/am-i-banned",
+                      "text": "Check if you're banned"
+                    },
+                    {
+                      "href": "/get-a-medical",
+                      "text": "You need to pass a medical"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Book the vomit coment",
+              "logic": "and",
+              "contents": [
+                {
+                  "type": "paragraph",
+                  "text": "There may be a waiting list of several months."
+                },
+                {
+                  "type": "list",
+                  "style": "required",
+                  "contents": [
+                    {
+                      "href": "/vomit-comet",
+                      "text": "Experience zero gravity in the atmosphere"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Get a job as an astronaut",
+              "contents": [
+                {
+                  "type": "list",
+                  "style": "required",
+                  "contents": [
+                    {
+                      "href": "/apply-for-astronaut-position",
+                      "text": "Apply to join the astronaut program",
+                      "context": "Application fee: £34"
+                    }
+                  ]
+                }
+              ]
+            },
+          ]
+        }
+      }
+    }
+  end
+end

--- a/spec/lib/step_nav_helper_spec.rb
+++ b/spec/lib/step_nav_helper_spec.rb
@@ -1,0 +1,289 @@
+require "spec_helper"
+
+RSpec.describe GovukPublishingComponents::StepNavHelper do
+  context "rules for handling differing numbers of linked step navs" do
+    let(:step_nav) do
+      {
+        "content_id" => "cccc-dddd",
+        "title" => "Learn to spacewalk: small step by giant leap",
+        "base_path" => "/learn-to-spacewalk"
+      }
+    end
+
+    context "for a content item with no step nav links" do
+      let(:content_store_response) do
+        {
+          "title" => "Building giant swimming pools",
+          "document_type" => "guide",
+        }
+      end
+
+      it "handled gracefully" do
+        step_nav_links = described_class.new(content_store_response, '/giant-pool/planning')
+
+        expect(step_nav_links.step_navs.count).to eq(0)
+
+        expect(step_nav_links.show_header?).to be false
+        expect(step_nav_links.header).to eq({})
+
+        expect(step_nav_links.show_related_links?).to be false
+        expect(step_nav_links.related_links).to eq([])
+
+        expect(step_nav_links.show_sidebar?).to be false
+        expect(step_nav_links.sidebar).to eq(nil)
+      end
+    end
+
+    context "for a content item with `part_of_step_navs` links" do
+      let(:content_store_response) do
+        {
+          "title" => "Book a session in the vomit comet",
+          "document_type" => "transaction",
+          "links" => {
+            "part_of_step_navs" => [step_nav],
+          }
+        }
+      end
+
+      it "parses the content item" do
+        step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+        expect(step_nav_links.step_navs.count).to eq(1)
+
+        expect(step_nav_links.show_header?).to be true
+        expect(step_nav_links.header).to eq(
+          path: "/learn-to-spacewalk",
+          title: "Learn to spacewalk: small step by giant leap"
+        )
+
+        expect(step_nav_links.show_related_links?).to be true
+        expect(step_nav_links.related_links).to eq([
+          {
+            href: "/learn-to-spacewalk",
+            text: "Learn to spacewalk: small step by giant leap"
+          }
+        ])
+
+        expect(step_nav_links.show_sidebar?).to be true
+      end
+    end
+
+    context "for a content item with a couple of `part_of_step_navs` links" do
+      let(:step_nav2) do
+        {
+          "content_id" => "aaaa-bbbb",
+          "title" => "Lose your lunch: lurch by lurch",
+          "base_path" => "/lose-your-lunch"
+        }
+      end
+
+      let(:content_store_response) do
+        {
+          "title" => "Book a session in the vomit comet",
+          "document_type" => "transaction",
+          "links" => {
+            "part_of_step_navs" => [step_nav, step_nav2],
+          }
+        }
+      end
+
+      it "parses the content item" do
+        step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+        expect(step_nav_links.step_navs.count).to eq(2)
+
+        expect(step_nav_links.show_related_links?).to be true
+        expect(step_nav_links.related_links).to eq([
+          {
+            href: "/learn-to-spacewalk",
+            text: "Learn to spacewalk: small step by giant leap"
+          },
+          {
+            href: "/lose-your-lunch",
+            text: "Lose your lunch: lurch by lurch"
+          }
+        ])
+
+        expect(step_nav_links.show_header?).to be false
+        expect(step_nav_links.show_sidebar?).to be false
+      end
+    end
+
+
+    context "for a content item with many `part_of_step_navs` links" do
+      let(:content_store_response) do
+        {
+          "title" => "Book a session in the vomit comet",
+          "document_type" => "transaction",
+          "links" => {
+            "part_of_step_navs" => Array.new(6, step_nav),
+          }
+        }
+      end
+
+      it "parses the content item" do
+        step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+        expect(step_nav_links.step_navs.count).to eq(6)
+
+        expect(step_nav_links.show_header?).to be false
+        expect(step_nav_links.show_related_links?).to be false
+        expect(step_nav_links.show_sidebar?).to be false
+      end
+    end
+  end
+
+  context "configuring step by step content for a sidebar navigation element" do
+    let(:content_item) {
+      payload_for("guide",
+        "links" => {
+          "part_of_step_navs" => [
+            {
+              "api_path": "/api/content/learn-to-drive-a-car",
+              "base_path": "/learn-to-drive-a-car",
+              "content_id": "e01e924b-9c7c-4c71-8241-66a575c2f61f",
+              "description": "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
+              "document_type": "step_by_step_nav",
+              "locale": "en",
+              "public_updated_at": "2018-02-20T12:37:16Z",
+              "schema_name": "step_by_step_nav",
+              "title": "Learn to drive a car: step by step",
+              "withdrawn": false,
+              "details": {
+                "step_by_step_nav": {
+                  "title": "Learn to drive a car: step by step",
+                  "introduction": [
+                    {
+                      "content_type": "text/govspeak",
+                      "content": "Check what you need to do to learn to drive."
+                    }
+                  ],
+                  "steps": [
+                    {
+                      "title": "Check you're allowed to drive",
+                      "contents": [
+                        {
+                          "type": "paragraph",
+                          "text": "Most people can start learning to drive when they’re 17."
+                        },
+                        {
+                          "type": "list",
+                          "style": "required",
+                          "contents": [
+                            {
+                              "href": "/vehicles-can-drive",
+                              "text": "Check what age you can drive"
+                            },
+                            {
+                              "href": "/legal-obligations-drivers-riders",
+                              "text": "Requirements for driving legally"
+                            },
+                            {
+                              "href": "/driving-eyesight-rules",
+                              "text": "Driving eyesight rules"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "title": "Driving lessons and practice",
+                      "contents": [
+                        {
+                          "type": "paragraph",
+                          "text": "You need a provisional driving licence to take lessons or practice."
+                        },
+                        {
+                          "type": "list",
+                          "style": "required",
+                          "contents": [
+                            {
+                              "href": "/guidance/the-highway-code",
+                              "text": "The Highway Code"
+                            },
+                            {
+                              "href": "/driving-lessons-learning-to-drive",
+                              "text": "Taking driving lessons"
+                            },
+                            {
+                              "href": "/find-driving-schools-and-lessons",
+                              "text": "Find driving schools, lessons and instructors"
+                            },
+                            {
+                              "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions",
+                              "text": "Practise vehicle safety questions"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "title": "Prepare for your theory test",
+                      "logic": "and",
+                      "contents": [
+                        {
+                          "type": "list",
+                          "style": "required",
+                          "contents": [
+                            {
+                              "href": "/theory-test/revision-and-practice",
+                              "text": "Theory test revision and practice"
+                            },
+                            {
+                              "href": "/take-practice-theory-test",
+                              "text": "Take a practice theory test"
+                            },
+                            {
+                              "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
+                              "text": "Theory and hazard perception test app"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        })
+    }
+
+    it "sets up navigation appropriately" do
+      step_nav_helper = described_class.new(content_item, "/random_url")
+      expect(step_nav_helper.step_navs.count).to eq(1)
+
+      sidebar = step_nav_helper.sidebar
+
+      # the step nav should be configured to display on a sidebar
+      expect(sidebar[:heading_level]).to eq(3)
+      expect(sidebar[:small]).to be(true)
+
+      # the page isn't in the step nav so nothing should be highlighted
+      expect(sidebar[:show_step]).to be nil
+      expect(sidebar[:highlight_step]).to be nil
+    end
+
+    it "configures active links appropriately" do
+      step_nav_helper = described_class.new(content_item, "/driving-lessons-learning-to-drive")
+      sidebar = step_nav_helper.sidebar
+
+      expect(step_nav_helper.step_navs.count).to eq(1)
+
+      # shows the step with /driving-lessons-learning-to-drive
+      expect(sidebar[:show_step]).to eq(2)
+
+      # highlights the step with /driving-lessons-learning-to-drive
+      expect(sidebar[:highlight_step]).to be(2)
+
+      # sets the /driving-lessons-learning-to-drive link to active
+      expect(sidebar[:steps][1][:contents][1][:contents][1][:active]).to be true
+    end
+  end
+
+  def payload_for(schema, content_item)
+    GovukSchemas::RandomExample.for_schema(frontend_schema: schema) do |payload|
+      payload.merge(content_item)
+    end
+  end
+end


### PR DESCRIPTION
There is a version of this in govuk_navigation_helpers which provided similar assistance when we were using hard coded step navigation configuration held in the gem.  We are retiring that approach for two reasons:

- govuk_navigation helpers is too closely coupled to govuk_publishing_components so we need to move [those coupled things](https://github.com/alphagov/govuk_navigation_helpers/blob/master/lib/govuk_navigation_helpers/step_nav_content.rb) out of that gem and into this one.
- we can now use linked `part_of_step_navs` content to power the step nav configuration so we can get move away from hardcoded files.

`step_nav` is fairly barebones, but I intend to expand this in future to replace [the current equivalent in collections](https://github.com/alphagov/collections/blob/086758a7ec50e33f94f137b4606299b5fe7bbf50/app/services/step_nav_content.rb).

`step_nav_helper` does most of the heavy lifting for transforming a linked step by step navigation content item into something that can be easily used to show the navigation components.

There's some specimen usage for this in `spec/dummy/app/views/step_nav/show.html.erb`
which is based on the default rules we've settled on.  These are:

- if a piece of content is in one step by step navigation, show the header,
  a related links item (it's the title) and the sidebar component
- if it's in 2, 3 or 4 step navs, just show the related step navigation components
  for each of them
- if it's in 0 or > 4, don't show any of the step nav elements (probably fall back to topics)

We're patching links to the learn-to-drive-a-car step by step navigation here: https://github.com/alphagov/collections-publisher/pull/330

Once these two things are merged, we can start to migrate the frontend apps off the hardcoded config in govuk_navigation_helpers.

https://trello.com/c/nhjWvdTN/535-update-govukpublishingcomponents-to-read-sidebar-nav-data-from-links-data
