### PR TITLE
Move document_list component from government-frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add document_list component from government-frontend, so that it can be used by collections. This is not a breaking change, but it is not backwards compatible with previous versions of the component. (PR #199)
+
 # 5.3.0
 
 * Add step by step navigation component helpers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (5.2.3)
+    govuk_publishing_components (5.3.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)
@@ -90,7 +90,7 @@ GEM
       rest-client (~> 2.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    govspeak (5.4.0)
+    govspeak (5.5.0)
       actionview (>= 4.1, < 6)
       addressable (>= 2.3.8, < 3)
       commander (~> 4.4)
@@ -104,7 +104,7 @@ GEM
       rubocop (~> 0.51.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
-    govuk_frontend_toolkit (7.4.1)
+    govuk_frontend_toolkit (7.4.2)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_schemas (3.1.0)

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -8,6 +8,7 @@
 @import "colours";
 
 @import "components/back-link";
+@import "components/document-list";
 @import "components/error-summary";
 @import "components/fieldset";
 @import "components/input";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -1,0 +1,18 @@
+.gem-c-document-list__item {
+  overflow: hidden;
+  margin-bottom: $gutter-one-third;
+  padding-bottom: $gutter-one-third;
+  border-bottom: 1px solid $border-colour;
+  list-style: none;
+}
+
+.gem-c-document-list__item-title {
+  @include bold-19;
+}
+
+.gem-c-document-list__attribute {
+  @include core-14;
+  float: left;
+  list-style: none;
+  padding-right: $gutter-two-thirds;
+}

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -1,0 +1,30 @@
+<%
+  items ||= []
+%>
+<% if items.any? %>
+  <ol class="gem-c-document-list">
+    <% items.each do |item| %>
+      <li class="gem-c-document-list__item">
+        <h3 class="gem-c-document-list__item-title">
+          <%=
+            link_to(
+              item[:link][:text],
+              item[:link][:path],
+              data: item[:link][:data_attributes]
+            )
+          %>
+        </h3>
+        <ul>
+          <li class="gem-c-document-list__attribute">
+            <time datetime="<%= item[:metadata][:public_updated_at].iso8601 %>">
+              <%= l(item[:metadata][:public_updated_at], format: '%e %B %Y') %>
+            </time>
+          </li>
+          <li class="gem-c-document-list__attribute gem-c-document-list__attribute--document-type">
+            <%= item[:metadata][:document_type] %>
+          </li>
+        </ul>
+      </li>
+    <% end %>
+  </ol>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -1,0 +1,70 @@
+name: Document list
+description: An ordered list of links to documents including document type and when updated.
+body: |
+  Outputs a list of links to documents, based on an array of document data. This must include:
+
+  * link text
+  * link href
+  * last updated date object
+  * document type
+
+  Tracking can be added to the links by supplying optional data attributes for each.
+
+  Documents are presented in an ordered list as the component expects that the ordering of the documents is relevant.
+accessibility_criteria: |
+  The component must:
+
+  * inform the user how many items are in the list
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      items:
+      - link:
+          text: 'Alternative provision'
+          path: '/government/publications/alternative-provision'
+        metadata:
+          public_updated_at: 2016-06-27 10:29:44
+          document_type: 'Statutory guidance'
+      - link:
+          text: 'Behaviour and discipline in schools: guide for governing bodies'
+          path: '/government/publications/behaviour-and-discipline-in-schools-guidance-for-governing-bodies'
+        metadata:
+          public_updated_at: 2015-09-24 16:42:48
+          document_type: 'Statutory guidance'
+      - link:
+          text: 'Children missing education'
+          path: '/government/publications/children-missing-education'
+        metadata:
+          public_updated_at: 2016-09-05 16:48:27
+          document_type: 'Statutory guidance'
+  with_data_attributes_on_links:
+    data:
+      items:
+      - link:
+          text: 'School behaviour and attendance: parental responsibility measures'
+          path: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+          data_attributes:
+            track_category: 'navDocumentCollectionLinkClicked'
+            track_action: 1.1
+            track_label: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+            track_options:
+              dimension28: 2
+              dimension29: 'School behaviour and attendance: parental responsibility measures'
+        metadata:
+          public_updated_at: 2017-01-05 14:50:33
+          document_type: 'Statutory guidance'
+      - link:
+          text: 'School exclusion'
+          path: '/government/publications/school-exclusion'
+          data_attributes:
+            track_category: 'navDocumentCollectionLinkClicked'
+            track_action: 1.2
+            track_label: '/government/publications/school-exclusion'
+            track_options:
+              dimension28: 2
+              dimension29: 'School exclusion'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Statutory guidance'

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+describe "Document list", type: :view do
+  def component_name
+    "document_list"
+  end
+
+  it "renders nothing when no data is given" do
+    assert_empty render_component({})
+  end
+
+  it "renders nothing when an empty array is passed in" do
+    assert_empty render_component(items: [])
+  end
+
+  it "renders a document list correctly" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "School behaviour and attendance: parental responsibility measures",
+            path: "/government/publications/parental-responsibility-measures-for-behaviour-and-attendance"
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+            document_type: "Statutory guidance"
+          }
+        },
+        {
+          link: {
+            text: "School exclusion",
+            path: "/government/publications/school-exclusion"
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-07-19 15:01:48 +0000"),
+            document_type: "Statutory guidance"
+          }
+        }
+      ]
+    )
+    li = ".gem-c-document-list__item-title"
+    attribute = ".gem-c-document-list__attribute"
+
+    assert_select "#{li} a[href='/government/publications/parental-responsibility-measures-for-behaviour-and-attendance']", text: "School behaviour and attendance: parental responsibility measures"
+    assert_select "#{attribute} time", text: "5 January 2017"
+    assert_select "#{attribute} time[datetime='2017-01-05T14:50:33Z']"
+    assert_select ".gem-c-document-list__attribute--document-type", text: "Statutory guidance"
+
+    assert_select "#{li} a[href='/government/publications/school-exclusion']", text: "School exclusion"
+    assert_select "#{attribute} time", text: "19 July 2017"
+    assert_select "#{attribute} time[datetime='2017-07-19T15:01:48Z']"
+  end
+
+  it "renders a document list with link tracking" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Link 1",
+            path: "/link1",
+            data_attributes: {
+              track_category: "navDocumentCollectionLinkClicked",
+              track_action: "1.1",
+              track_label: "/link1",
+              track_options: {
+                dimension28: "2",
+                dimension29: "Link 1"
+              }
+            }
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+            document_type: "Statutory guidance"
+          }
+        },
+        {
+          link: {
+            text: "Link 2",
+            path: "/link2",
+            data_attributes: {
+              track_category: "navDocumentCollectionLinkClicked",
+              track_action: "1.2",
+              track_label: "/link2",
+              track_options: {
+                dimension28: "2",
+                dimension29: "Link 2"
+              }
+            }
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-07-19 15:01:48 +0000"),
+            document_type: "Statutory guidance"
+          }
+        }
+      ]
+    )
+    li = ".gem-c-document-list__item-title"
+
+    assert_select "#{li} a[href='/link1']", text: "Link 1"
+    assert_select "#{li} a[data-track-category='navDocumentCollectionLinkClicked']", text: "Link 1"
+    assert_select "#{li} a[data-track-action='1.1']", text: "Link 1"
+    assert_select "#{li} a[data-track-label='/link1']", text: "Link 1"
+    assert_select "#{li} a[data-track-options='{\"dimension28\":\"2\",\"dimension29\":\"Link 1\"}']", text: "Link 1"
+
+    assert_select "#{li} a[href='/link2']", text: "Link 2"
+    assert_select "#{li} a[data-track-category='navDocumentCollectionLinkClicked']", text: "Link 2"
+    assert_select "#{li} a[data-track-action='1.2']", text: "Link 2"
+    assert_select "#{li} a[data-track-label='/link2']", text: "Link 2"
+    assert_select "#{li} a[data-track-options='{\"dimension28\":\"2\",\"dimension29\":\"Link 2\"}']", text: "Link 2"
+  end
+end


### PR DESCRIPTION
The new topic pages will need to use the document-list component to display a list of content items.

We therefore need to move the component into govuk_publishing_components so it can be accessed by the Collections app (where topic pages will live)

<img width="659" alt="screen shot 2018-03-06 at 15 25 30" src="https://user-images.githubusercontent.com/29889908/37040818-a0219492-2152-11e8-8085-9eaf9076ec7b.png">

<img width="995" alt="screen shot 2018-03-06 at 15 23 51" src="https://user-images.githubusercontent.com/29889908/37040741-6a7c0912-2152-11e8-8789-c784db9feafe.png">
