### PR TITLE
Update document list with description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Update design of document list component for topic pages
+
 # 5.5.1
 
 * Fix bug in `related_navigation` helper that did not gracefully handle ordered

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -10,6 +10,10 @@
   @include bold-19;
 }
 
+.gem-c-document-list__item-description {
+  margin-bottom: 5px;
+}
+
 .gem-c-document-list__attribute {
   @include core-14;
   float: left;

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -14,16 +14,24 @@
             )
           %>
         </h3>
-        <ul>
-          <li class="gem-c-document-list__attribute">
-            <time datetime="<%= item[:metadata][:public_updated_at].iso8601 %>">
-              <%= l(item[:metadata][:public_updated_at], format: '%e %B %Y') %>
-            </time>
-          </li>
-          <li class="gem-c-document-list__attribute gem-c-document-list__attribute--document-type">
-            <%= item[:metadata][:document_type] %>
-          </li>
-        </ul>
+        <% if item[:link][:description] %>
+          <p class="gem-c-document-list__item-description" ><%= item[:link][:description] %></p>
+        <% end %>
+        <% if item[:metadata] %>
+          <ul>
+            <% item[:metadata].each do |item_metadata_key, item_metadata_value| %>
+              <li class="gem-c-document-list__attribute">
+                <% if item_metadata_key.to_s.eql?("public_updated_at") %>
+                  <time datetime="<%= item_metadata_value.iso8601 %>">
+                    <%= l(item_metadata_value, format: '%e %B %Y') %>
+                  </time>
+                <% else %>
+                  <%= item_metadata_value %>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
       </li>
     <% end %>
   </ol>

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -68,3 +68,11 @@ examples:
         metadata:
           public_updated_at: 2017-07-19 15:01:48
           document_type: 'Statutory guidance'
+  with_description:
+    description: Documents can be passed to the component with a description. This is for use on topic pages, to display lists of mainstream services.
+    data:
+      items:
+      - link:
+          text: 'Become an apprentice'
+          path: '/become-an-apprentice'
+          description: 'Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship.'

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -19,7 +19,7 @@ describe "Document list", type: :view do
         {
           link: {
             text: "School behaviour and attendance: parental responsibility measures",
-            path: "/government/publications/parental-responsibility-measures-for-behaviour-and-attendance"
+            path: "/government/publications/parental-responsibility-measures-for-behaviour-and-attendance",
           },
           metadata: {
             public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
@@ -28,8 +28,9 @@ describe "Document list", type: :view do
         },
         {
           link: {
-            text: "School exclusion",
-            path: "/government/publications/school-exclusion"
+            text: "Become an apprentice",
+            path: "/become-an-apprentice",
+            description: 'Becoming an apprentice - what to expect'
           },
           metadata: {
             public_updated_at: Time.zone.parse("2017-07-19 15:01:48 +0000"),
@@ -44,9 +45,10 @@ describe "Document list", type: :view do
     assert_select "#{li} a[href='/government/publications/parental-responsibility-measures-for-behaviour-and-attendance']", text: "School behaviour and attendance: parental responsibility measures"
     assert_select "#{attribute} time", text: "5 January 2017"
     assert_select "#{attribute} time[datetime='2017-01-05T14:50:33Z']"
-    assert_select ".gem-c-document-list__attribute--document-type", text: "Statutory guidance"
+    assert_select ".gem-c-document-list__attribute", text: "Statutory guidance"
 
-    assert_select "#{li} a[href='/government/publications/school-exclusion']", text: "School exclusion"
+    assert_select "#{li} a[href='/become-an-apprentice']", text: "Become an apprentice"
+    assert_select ".gem-c-document-list__item-description", text: 'Becoming an apprentice - what to expect'
     assert_select "#{attribute} time", text: "19 July 2017"
     assert_select "#{attribute} time[datetime='2017-07-19T15:01:48Z']"
   end


### PR DESCRIPTION
We want to make use of the document list component on topic pages. For mainstream services, we want to show a description of the document rather than metadata.

<img width="1007" alt="screen shot 2018-03-08 at 11 47 03" src="https://user-images.githubusercontent.com/29889908/37149569-7020e4b2-22c6-11e8-9af9-db0224077dea.png">

In the future, we may also want to supply additional metadata for each document, such as organisation and collection the document belongs to. This PR refactors the component to stop it being limited to only updated date and document type

Component Guide Link: https://govuk-publishing-compon-pr-202.herokuapp.com/component-guide/document_list