### PR TITLE
Allow step by step nav pages with 0 steps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (5.3.0)
+    govuk_publishing_components (5.4.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)

--- a/lib/govuk_publishing_components/step_nav.rb
+++ b/lib/govuk_publishing_components/step_nav.rb
@@ -13,7 +13,11 @@ module GovukPublishingComponents
     end
 
     def content
-      @content ||= content_item.dig(:details, :step_by_step_nav)
+      content_item.dig(:details, :step_by_step_nav)
+    end
+
+    def steps
+      content_item.dig(:details, :step_by_step_nav, :steps)
     end
 
   private

--- a/lib/govuk_publishing_components/step_nav_helper.rb
+++ b/lib/govuk_publishing_components/step_nav_helper.rb
@@ -12,9 +12,12 @@ module GovukPublishingComponents
     end
 
     def show_sidebar?
+      show_header? && first_step_nav.steps.present?
+    end
+
+    def show_header?
       step_navs.count == 1
     end
-    alias_method :show_header?, :show_sidebar?
 
     def show_related_links?
       step_navs.any? && step_navs.count < 5

--- a/spec/features/step_nav_helper_spec.rb
+++ b/spec/features/step_nav_helper_spec.rb
@@ -48,6 +48,34 @@ describe 'Specimen usage of step by step navigation helpers' do
     end
   end
 
+  context 'one related step by step navigation journey with no steps' do
+    before do
+      content_store_has_random_item(base_path: '/vomit-comet', schema: 'transaction', part_of_step_navs: [zero_steps_step_nav])
+
+      visit '/step-nav/vomit-comet'
+    end
+
+    it 'shows step nav related links' do
+      expect(page).to have_selector('.gem-c-step-nav-related')
+
+      within('.gem-c-step-nav-related') do
+        expect(page).to have_selector('.gem-c-step-nav-related__link', count: 1)
+        expect(page).to have_link('Learn to spacewalk: small step by giant leap', href: '/learn-to-spacewalk')
+      end
+    end
+
+    it 'does not show the full step nav sidebar' do
+      expect(page).to_not have_css('.gem-c-step-nav')
+    end
+
+    it 'shows the step nav header' do
+      within('.gem-c-step-nav-header') do
+        expect(page).to have_link('Learn to spacewalk: small step by giant leap', href: '/learn-to-spacewalk')
+      end
+    end
+  end
+
+
   context 'multiple related step by step navigation journeys' do
     before do
       content_store_has_random_item(base_path: '/vomit-comet', schema: 'transaction', part_of_step_navs: [
@@ -178,6 +206,27 @@ describe 'Specimen usage of step by step navigation helpers' do
               ]
             },
           ]
+        }
+      }
+    }
+  end
+
+  def zero_steps_step_nav
+    {
+      "content_id" => "8f5d4f2b-daf0-4460-88c1-fdd76c90f6f1",
+      "locale" => "en",
+      "title" => "Learn to spacewalk: small step by giant leap",
+      "base_path" => "/learn-to-spacewalk",
+      "details" => {
+        "step_by_step_nav": {
+          "title": "Learn to spacewalk: small step by giant leap",
+          "introduction": [
+            {
+              "content_type": "text/govspeak",
+              "content": "Check what you need to do to learn to spacewalk."
+            }
+          ],
+          "steps": []
         }
       }
     }

--- a/spec/lib/step_nav_helper_spec.rb
+++ b/spec/lib/step_nav_helper_spec.rb
@@ -6,7 +6,14 @@ RSpec.describe GovukPublishingComponents::StepNavHelper do
       {
         "content_id" => "cccc-dddd",
         "title" => "Learn to spacewalk: small step by giant leap",
-        "base_path" => "/learn-to-spacewalk"
+        "base_path" => "/learn-to-spacewalk",
+        "details" => {
+          "step_by_step_nav" => {
+            "steps" => [
+              "title": "Step one"
+            ]
+          }
+        }
       }
     end
 


### PR DESCRIPTION
To enable us to preview pages at all stages of the content design process we
need to be able to handle step by step navs with zero steps.

This adds tests and adjusts the show_sidebar logic to handle this.

We allow zero steps in https://github.com/alphagov/govuk-content-schemas/pull/734