### PR TITLE
Bump to 5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 5.4.1
+
+* Remove worldwide organisation links from the payload used by the `related_navigation` component, as they're not required.
+* Fix bug where the correct number of mainstream browse pages weren't displaying
+in the `related_navigation` component in cases where a grandparent mainstream
+browse page is present.
+
 # 5.4.0
 
 * Add document_list component from government-frontend, so that it can be used by collections. This is not a breaking change, but it is not backwards compatible with previous versions of the component. (PR #199)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (5.4.0)
+    govuk_publishing_components (5.4.1)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '5.4.0'.freeze
+  VERSION = '5.4.1'.freeze
 end


### PR DESCRIPTION
For https://trello.com/c/nGtzTPCu/283-update-government-frontend-to-use-relatednavigation-component