### PR TITLE
Handle related items not tagged to mainstream browse pages

### DIFF
--- a/lib/govuk_publishing_components/components/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/components/related_navigation_helper.rb
@@ -212,7 +212,7 @@ private
 
     @parents_tagged_to_same_mainstream_browse_page ||= related_links.select do |related_item|
       next if common_parent_content_ids.include?(related_item["content_id"])
-      mainstream_browse_pages = related_item.dig("links", "mainstream_browse_pages")
+      mainstream_browse_pages = related_item.dig("links", "mainstream_browse_pages") || []
       parents = mainstream_browse_pages.map { |page| page["links"]["parent"][0] }
       content_ids = parents.map { |parent| parent["content_id"] }
       content_ids.include?(grandparent["content_id"])

--- a/spec/lib/related_navigation_helper_spec.rb
+++ b/spec/lib/related_navigation_helper_spec.rb
@@ -314,6 +314,17 @@ RSpec.describe RelatedNavigationHelper do
       expect(payload).to include(expected)
     end
 
+    it "handles ordered related items that aren't tagged to a mainstream browse page" do
+      example = GovukSchemas::Example.find("guide", example_name: "single-page-guide")
+      payload = RelatedNavigationHelper.new(example).related_navigation
+      expected = {
+        "topics" => [
+          { text: "Pets", path: "/topic/animal-welfare/pets" },
+          { text: "Arriving in the UK", path: "/browse/visas-immigration/arriving-in-the-uk" },
+        ]
+      }
+      expect(payload).to include(expected)
+    end
     it "returns an Elsewhere on the web section for external related links" do
       payload = payload_for("placeholder",
         "details" => {


### PR DESCRIPTION
For https://trello.com/c/nGtzTPCu/283-update-government-frontend-to-use-relatednavigation-component

Some work unrelated to this PR has flagged that there are occasions where an
ordered related link may not be tagged to a mainstream browse pages, and the
current implementation does not handle this gracefully, so we update it to
better handle this edge case.