### PR TITLE
Add option to removed side padding if full width

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -1,5 +1,11 @@
 .gem-c-inverse-header {
   width: 100%;
   background-color: $govuk-blue;
+  margin-bottom: $gutter;
   padding: $gutter-half;
+}
+
+.gem-c-inverse-header--full-width {
+  padding-left: 0;
+  padding-right: 0;
 }

--- a/app/views/govuk_publishing_components/components/_inverse_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_inverse_header.html.erb
@@ -1,6 +1,10 @@
+<%
+  full_width ||= false
+  header_class = full_width ? "gem-c-inverse-header--full-width" : ""
+%>
 <% block = yield %>
 <% unless block.empty? %>
-  <header class="gem-c-inverse-header">
+  <header class="gem-c-inverse-header <%= header_class %>">
     <%= block %>
   </header>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/inverse_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/inverse_header.yml
@@ -18,6 +18,16 @@ examples:
             Education, Training and Skills
           </h1>
         </div>
+  for_full_page_width:
+    description: "Used when the header covers the full width of the page, but it's content is in the grid layout. The left-right padding is removed to make the contents line up with the other items on the page."
+    data:
+      full_width: true
+      block: |
+        <div class="pub-c-title pub-c-title--inverse">
+          <h1 class="pub-c-title__text ">
+            Education, Training and Skills
+          </h1>
+        </div>
   with_breadcrumbs_and_paragraph:
     data:
       block: |

--- a/spec/components/inverse_header_spec.rb
+++ b/spec/components/inverse_header_spec.rb
@@ -30,4 +30,10 @@ describe "Inverse header", type: :view do
     assert_select ".gem-c-inverse-header div.pub-c-title"
     assert_select ".gem-c-inverse-header h1", text: "HTML publication page title"
   end
+
+  it "renders correct css class when header is to be full page width" do
+    render(component_path, full_width: true) { block }
+
+    assert_select ".gem-c-inverse-header--full-width"
+  end
 end


### PR DESCRIPTION
In this commit I have added the option to pass a flag to the component
to indicate if the header component will cover the full width of the
page. If so, the left-right padding is removed for the header so it’s 
content can line up with the rest of the content on the page.

I also added a bottom margin of 30px to the component.

https://trello.com/c/xfcxY63h/122-correct-page-header-component-padding