### PR TITLE
Enforce white text and links for inverse header component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+Enforce white content in inverse component (PR #214).
+
 # 5.5.2
 
 * Add `full-width` flag to remove left and right padding when using a full width page header (PR #212).

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -1,8 +1,13 @@
 .gem-c-inverse-header {
   width: 100%;
   background-color: $govuk-blue;
+  color: $white;
   margin-bottom: $gutter;
   padding: $gutter-half;
+}
+
+.gem-c-inverse-header a {
+  color: $white;
 }
 
 .gem-c-inverse-header--full-width {

--- a/app/views/govuk_publishing_components/components/docs/inverse_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/inverse_header.yml
@@ -1,7 +1,7 @@
 name: Inverse header
 description: A wrapper to contain header content in white text
 body: |
-  This component can be passed a block of template code and will wrap it in a blue header. This is as light-touch as possible and doesn't attempt to deal with the margins and paddings of its content, neither does it enforce the white text it requires. Implemented to accomodate topic and list page headings and breadcrumbs but unopinionated about its contents.
+  This component can be passed a block of template code and will wrap it in a blue header. This is as light-touch as possible and doesn't attempt to deal with the margins and paddings of its content. White text is enforced on content and would need to be overriden where unwanted. Implemented to accomodate topic and list page headings and breadcrumbs but unopinionated about its contents.
 
 accessibility_criteria: |
   The component must:


### PR DESCRIPTION
Tests for accessibility in other apps failed where the inverse header component in isolation didn't have the required context to make its example content render in white. Since the point of an inverse state is to have light on dark, I have updated the component to be more opinionated about white text. This would require overrides if white weren't desired but all planned implementations currently use white anyway. Unfortunately, this has required me to colour the "a" tag as the component is unaware of what CSS classes might be applied. 