### PR TITLE
Add margin spacing to document list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-Enforce white content in inverse component (PR #214).
+* Enforce white content in inverse component (PR #214).
+* Add optional flags for spacing around document list component
 
 # 5.5.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -20,3 +20,20 @@
   list-style: none;
   padding-right: $gutter-two-thirds;
 }
+
+.gem-c-document-list--bottom-margin {
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-bottom: $gutter * 1.5;
+  }
+}
+
+.gem-c-document-list--top-margin {
+  margin-top: $gutter-half;
+
+  @include media(tablet) {
+    margin-top: $gutter * 1.5;
+  }
+}
+

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -1,8 +1,10 @@
 <%
   items ||= []
+  margin_top_class = " gem-c-document-list--top-margin" if local_assigns[:margin_top]
+  margin_bottom_class = " gem-c-document-list--bottom-margin" if local_assigns[:margin_bottom]
 %>
 <% if items.any? %>
-  <ol class="gem-c-document-list">
+  <ol class="gem-c-document-list<%= margin_bottom_class %><%= margin_top_class %>">
     <% items.each do |item| %>
       <li class="gem-c-document-list__item">
         <h3 class="gem-c-document-list__item-title">

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -13,6 +13,27 @@ describe "Document list", type: :view do
     assert_empty render_component(items: [])
   end
 
+  it 'adds spacing around the document list when margin flags are set' do
+    render_component(
+      margin_bottom: true,
+      margin_top: true,
+      items: [
+        {
+          link: {
+            text: "School behaviour and attendance: parental responsibility measures",
+            path: "/government/publications/parental-responsibility-measures-for-behaviour-and-attendance",
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+            document_type: "Statutory guidance"
+          }
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list.gem-c-document-list--top-margin.gem-c-document-list--bottom-margin'
+  end
+
   it "renders a document list correctly" do
     render_component(
       items: [


### PR DESCRIPTION
We require the document list component to have top and bottom margins around it on topic pages. This commit allows us to set `margin_bottom` and `margin_top` flags to set this spacing.

<img width="942" alt="screen shot 2018-03-13 at 15 34 37" src="https://user-images.githubusercontent.com/29889908/37351939-12683138-26d4-11e8-9d9d-97af86932310.png">
