### PR TITLE
Make changes released in 5.5.3 backwards compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+Make changes released in 5.5.3 backwards compatible.
+
 # 5.5.3
 
 Enforce white content in inverse component (PR #214).

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -7,4 +7,6 @@ require "govuk_publishing_components/app_helpers/step_nav"
 require "govuk_publishing_components/app_helpers/step_nav_helper"
 
 module GovukPublishingComponents
+  StepNavHelper = GovukPublishingComponents::AppHelpers::StepNavHelper
+  StepNav = GovukPublishingComponents::AppHelpers::StepNav
 end


### PR DESCRIPTION
Because I didn't put in a changelog, 5.5.3 got accidentally released as a minor version (while https://github.com/alphagov/govuk_publishing_components/pull/206 is super breaking). 

This PR makes the changes backwards compatible so that apps don't have to update.

We'll do the updating at a later time, when there are more breaking changes to ship at the same time. That hopefully minimises the impact.