### PR TITLE
Add margin_top flag to feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add optional margin top flag for feedback component (PR #222)
+
 # 5.5.5
 * Add optional flags for spacing around document list component (PR #217)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (5.5.2)
+    govuk_publishing_components (5.5.5)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -5,6 +5,9 @@
 .gem-c-feedback {
   max-width: 960px;
   margin: 0 auto;
+}
+
+.gem-c-feedback--top-margin {
   margin-top: $gutter;
 
   @include media(tablet) {

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -1,8 +1,10 @@
 <%
   contact_govuk_path = "/contact/govuk"
+  margin_top ||= 1
+  margin_top_class = "gem-c-feedback--top-margin" if margin_top == 1
 %>
 
-<div class="gem-c-feedback" data-module="feedback">
+<div class="gem-c-feedback <%= margin_top_class %>" data-module="feedback">
   <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
     <div class="js-prompt-questions">
       <h3 class="gem-c-feedback__prompt-question">Is this page useful?</h3>

--- a/spec/components/feedback_spec.rb
+++ b/spec/components/feedback_spec.rb
@@ -17,4 +17,10 @@ describe "Feedback", type: :view do
 
     assert_select ".gem-c-feedback .gem-c-feedback__prompt-link--wrong[href='/contact/govuk']", text: 'Is there anything wrong with this page?'
   end
+
+  it "removes top margin when margin_top flag is set" do
+    render_component(margin_top: 0)
+
+    assert_select ".gem-c-feedback.gem-c-feedback--margin-top", false
+  end
 end


### PR DESCRIPTION
Topic pages need the feedback component to be flush with the bottom of the taxon grid. We therefore need to be able to add a flag to remove the top margin in these cases

Example use on a topic page:

<img width="1440" alt="screen shot 2018-03-15 at 10 27 52" src="https://user-images.githubusercontent.com/29889908/37458021-8a12d9fa-283b-11e8-8939-18f0b9549a7f.png">
