### PR TITLE
Prefill step nav tracking_id

### DIFF
--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -1,7 +1,6 @@
 <%
   links ||= false
   pretitle ||= t("govuk_component.step_by_step_nav_related.part_of", default: "Part of")
-  tracking_id ||= false
 %>
 <% if links %>
   <div class="gem-c-step-nav-related" data-module="track-click">
@@ -15,7 +14,7 @@
             data-track-label="<%= links[0][:href] %>"
             data-track-dimension="<%= links[0][:text] %>"
             data-track-dimension-index="29"
-            data-track-options='{"dimension96" : "<%= tracking_id %>" }'>
+            data-track-options='{"dimension96" : "<%= links[0][:tracking_id] %>" }'>
             <%= links[0][:text] %>
           </a>
         </h2>
@@ -31,7 +30,7 @@
                 data-track-label="<%= link[:href] %>"
                 data-track-dimension="<%= link[:text] %>"
                 data-track-dimension-index="29"
-                data-track-options='{"dimension96" : "<%= tracking_id %>" }'>
+                data-track-options='{"dimension96" : "<%= link[:tracking_id] %>" }'>
                 <%= link[:text] %>
               </a>
             </li>

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
@@ -72,7 +72,7 @@ examples:
       ]
   with_unique_tracking:
     description: |
-      We need to uniquely identify each step by step navigation in Google Analytics. If this parameter is added to the component, its value is included in any tracking events, specifically in dimension96.
+      In order to identify the step by step navigation the component is part of, we need to track a unique ID of the navigation in Google Analytics. This ID should be the same across all pages that are linked from and are part of that navigation. Its value is included in any tracking events, specifically in dimension96. It refers to the ID of the step nav page.
 
       This includes show/hide all, show/hide step and any link clicks.
     data:

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav_header.yml
@@ -17,7 +17,7 @@ examples:
       title: 'Having children: step by step'
       path: /childcare-parenting/pregnancy-and-birth
   with_unique_tracking:
-    description: We need to uniquely identify each step by step navigation in Google Analytics. If this parameter is added to the component, its value is included in any tracking events, specifically in dimension96.
+    description: In order to identify the step by step navigation the component is part of, we need to track a unique ID of the navigation in Google Analytics. This ID should be the same across all pages that are linked from and are part of that navigation. Its value is included in any tracking events, specifically in dimension96. It refers to the ID of the step nav that the component links to.
     data:
       title: 'With a tracking id'
       path: '#'

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav_related.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav_related.yml
@@ -53,7 +53,7 @@ examples:
         }
       ]
   with_unique_tracking:
-    description: We need to uniquely identify each step by step navigation in Google Analytics. If this parameter is added to the component, its value is included in any tracking events, specifically in dimension96.
+    description: In order to identify the step by step navigation the component is part of, we need to track a unique ID of the navigation in Google Analytics. This ID should be the same across all pages that are linked from and are part of that navigation. Its value is included in any tracking events, specifically in dimension96. It refers to the ID of the step nav that the component links to. Where there are multiple links, they will have different tracking IDs.
     data:
       links: [
         {

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav_related.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav_related.yml
@@ -55,10 +55,10 @@ examples:
   with_unique_tracking:
     description: We need to uniquely identify each step by step navigation in Google Analytics. If this parameter is added to the component, its value is included in any tracking events, specifically in dimension96.
     data:
-      tracking_id: 'this-is-the-tracking-id'
       links: [
         {
           href: '#',
-          text: 'With a tracking id'
+          text: 'With a tracking id',
+          tracking_id: 'this-is-the-tracking-id'
         }
       ]

--- a/lib/govuk_publishing_components/app_helpers/step_nav.rb
+++ b/lib/govuk_publishing_components/app_helpers/step_nav.rb
@@ -13,6 +13,10 @@ module GovukPublishingComponents
         content_item[:base_path]
       end
 
+      def content_id
+        content_item[:content_id]
+      end
+
       def content
         content_item.dig(:details, :step_by_step_nav)
       end

--- a/lib/govuk_publishing_components/app_helpers/step_nav_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/step_nav_helper.rb
@@ -28,7 +28,8 @@ module GovukPublishingComponents
         step_navs.map do |step_nav|
           {
             href: step_nav.base_path,
-            text: step_nav.title
+            text: step_nav.title,
+            tracking_id: step_nav.content_id
           }
         end
       end

--- a/lib/govuk_publishing_components/app_helpers/step_nav_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/step_nav_helper.rb
@@ -37,7 +37,7 @@ module GovukPublishingComponents
         if show_sidebar?
           @sidebar ||= first_step_nav.content.tap do |sb|
             configure_for_sidebar(sb)
-            sb.merge!(small: true, heading_level: 3)
+            sb.merge!(small: true, heading_level: 3, tracking_id: first_step_nav.content_id)
           end
         end
       end
@@ -46,7 +46,8 @@ module GovukPublishingComponents
         if show_header?
           {
             title: first_step_nav.title,
-            path: first_step_nav.base_path
+            path: first_step_nav.base_path,
+            tracking_id: first_step_nav.content_id
           }
         else
           {}

--- a/spec/components/step_by_step_nav_related_spec.rb
+++ b/spec/components/step_by_step_nav_related_spec.rb
@@ -27,6 +27,31 @@ describe "Step by step navigation related", type: :view do
     ]
   end
 
+  def one_link_with_tracking
+    [
+      {
+        href: '/link1',
+        text: 'Link 1',
+        tracking_id: 'peter'
+      }
+    ]
+  end
+
+  def two_links_with_tracking
+    [
+      {
+        href: '/link1',
+        text: 'Link 1',
+        tracking_id: 'peter'
+      },
+      {
+        href: '/link2',
+        text: 'Link 2',
+        tracking_id: 'paul'
+      }
+    ]
+  end
+
   it "renders nothing without passed content" do
     assert_empty render_component({})
   end
@@ -68,15 +93,15 @@ describe "Step by step navigation related", type: :view do
   end
 
   it "adds a tracking id to one link" do
-    render_component(links: one_link, tracking_id: "peter")
+    render_component(links: one_link_with_tracking)
 
     assert_select ".gem-c-step-nav-related .gem-c-step-nav-related__link[data-track-options='{\"dimension96\" : \"peter\" }']"
   end
 
   it "adds a tracking id to every link when there are more than one" do
-    render_component(links: two_links, tracking_id: "peter")
+    render_component(links: two_links_with_tracking)
 
     assert_select ".gem-c-step-nav-related .gem-c-step-nav-related__link-item:nth-child(1) .gem-c-step-nav-related__link[data-track-options='{\"dimension96\" : \"peter\" }']"
-    assert_select ".gem-c-step-nav-related .gem-c-step-nav-related__link-item:nth-child(2) .gem-c-step-nav-related__link[data-track-options='{\"dimension96\" : \"peter\" }']"
+    assert_select ".gem-c-step-nav-related .gem-c-step-nav-related__link-item:nth-child(2) .gem-c-step-nav-related__link[data-track-options='{\"dimension96\" : \"paul\" }']"
   end
 end

--- a/spec/lib/app_helpers/step_nav_helper_spec.rb
+++ b/spec/lib/app_helpers/step_nav_helper_spec.rb
@@ -60,7 +60,8 @@ RSpec.describe GovukPublishingComponents::AppHelpers::StepNavHelper do
         expect(step_nav_links.show_header?).to be true
         expect(step_nav_links.header).to eq(
           path: "/learn-to-spacewalk",
-          title: "Learn to spacewalk: small step by giant leap"
+          title: "Learn to spacewalk: small step by giant leap",
+          tracking_id: "cccc-dddd"
         )
 
         expect(step_nav_links.show_related_links?).to be true

--- a/spec/lib/app_helpers/step_nav_helper_spec.rb
+++ b/spec/lib/app_helpers/step_nav_helper_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe GovukPublishingComponents::AppHelpers::StepNavHelper do
         expect(step_nav_links.related_links).to eq([
           {
             href: "/learn-to-spacewalk",
-            text: "Learn to spacewalk: small step by giant leap"
+            text: "Learn to spacewalk: small step by giant leap",
+            tracking_id: "cccc-dddd"
           }
         ])
 
@@ -104,11 +105,13 @@ RSpec.describe GovukPublishingComponents::AppHelpers::StepNavHelper do
         expect(step_nav_links.related_links).to eq([
           {
             href: "/learn-to-spacewalk",
-            text: "Learn to spacewalk: small step by giant leap"
+            text: "Learn to spacewalk: small step by giant leap",
+            tracking_id: "cccc-dddd"
           },
           {
             href: "/lose-your-lunch",
-            text: "Lose your lunch: lurch by lurch"
+            text: "Lose your lunch: lurch by lurch",
+            tracking_id: "aaaa-bbbb"
           }
         ])
 


### PR DESCRIPTION
This prefills the `tracking_id` for step nav components introduced in #162 with the <del>slug</del> <ins>content_id</ins> of each step nav.
It also corrects the use of that option in the `step_by_step_nav_related` component to be set per step nav and not per the whole component.

We need this to be able to differentiate between different step navs as soon as a page is shared between two or more step navs.

[Trello card](https://trello.com/c/xzXqnQgf)