### PR TITLE
Create contextual navigation components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Create single breadrumb and sidebar contextual navigation components. Not a breaking change, but you can drop `govuk_navigation_helpers` as a dependency now.
+
 * You can now add require a single Javascript to include all components, just like CSS.
 
 Replace all individual includes with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     govuk_publishing_components (5.5.6)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
+      govuk_navigation_helpers (~> 9.2.1)
       rails (>= 5.0.0.1)
       rake
       rouge
@@ -104,9 +105,14 @@ GEM
       rubocop (~> 0.51.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
+    govuk_ab_testing (2.4.1)
     govuk_frontend_toolkit (7.4.2)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
+    govuk_navigation_helpers (9.2.1)
+      activesupport (~> 5.1)
+      gds-api-adapters (>= 43.0)
+      govuk_ab_testing (~> 2.4)
     govuk_schemas (3.1.0)
       json-schema (~> 2.8.0)
     hashdiff (0.3.7)
@@ -144,7 +150,7 @@ GEM
     money (6.10.1)
       i18n (>= 0.6.4, < 1.0)
     netrc (0.11.0)
-    nio4r (2.2.0)
+    nio4r (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     null_logger (0.0.1)

--- a/app.json
+++ b/app.json
@@ -10,6 +10,12 @@
     },
     "PLEK_SERVICE_STATIC_URI": {
       "value": "assets.digital.cabinet-office.gov.uk"
+    },
+    "PLEK_SERVICE_CONTENT_STORE_URI": {
+      "value": "https://www.gov.uk/api"
+    },
+    "PLEK_SERVICE_RUMMAGER_URI": {
+      "value": "https://www.gov.uk/api"
     }
   },
   "formation": {},

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -1,0 +1,20 @@
+<% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request.path) %>
+
+<% if navigation.step_nav_helper.show_header? %>
+  <!-- Rendering step by step nav -->
+  <%= render 'govuk_publishing_components/components/step_by_step_nav_header', navigation.step_nav_helper.header %>
+<% else %>
+  <% if navigation.should_present_taxonomy_navigation? %>
+    <!-- Rendering taxonomy breadcrumbs -->
+    <% if navigation.taxon_breadcrumbs.any? %>
+      <%= render 'govuk_component/breadcrumbs',
+        breadcrumbs: navigation.taxon_breadcrumbs[:breadcrumbs],
+        collapse_on_mobile: true %>
+    <% end %>
+  <% else %>
+    <!-- Rendering normal breadcrumbs -->
+    <% if navigation.breadcrumbs.any? %>
+      <%= render 'govuk_component/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -1,0 +1,19 @@
+<% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request.path) %>
+
+<% if navigation.step_nav_helper.show_related_links? %>
+  <!-- rendering step by step related items -->
+  <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links %>
+
+  <% if navigation.step_nav_helper.show_sidebar? %>
+    <!-- rendering step by step sidebar -->
+    <%= render 'govuk_publishing_components/components/step_by_step_nav', navigation.step_nav_helper.sidebar %>
+  <% end %>
+<% else %>
+  <% if navigation.should_present_taxonomy_navigation? %>
+    <!-- rendering taxonomy sidebar -->
+    <%= render partial: 'govuk_component/taxonomy_sidebar', locals: navigation.taxonomy_sidebar %>
+  <% else %>
+    <!-- rendering related navigation sidebar -->
+    <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/contextual_breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_breadcrumbs.yml
@@ -1,0 +1,25 @@
+name: Contextual breadcrumbs
+description: Breadcrumbs that shows different things depending on the page
+body: |
+  This is a complex component that calls other components. For more accurate
+  preview with real data, see the [contextual navigation preview][preview].
+
+  There are 3 main variants of the component:
+
+  - Step by step, which uses the [step by step header][header]
+  - Parent breadcrumb, which uses the `parent` link of the page with the [breadcrumbs component][breadcrumbs]
+  - Taxon breadcrumb, which uses the `taxons` link of the page with the [breadcrumbs component][breadcrumbs]
+
+  It must always used [together with the contextual sidebar][sidebar].
+
+  [preview]: https://govuk-publishing-components.herokuapp.com/contextual-navigation
+  [header]: /component-guide/step_by_step_nav_header
+  [sidebar]: /component-guide/contextual_sidebar
+  [breadcrumbs]: https://govuk-static.herokuapp.com/component-guide/breadcrumbs
+accessibility_criteria: |
+  Components called by this component must be accessible
+examples:
+  default:
+    data:
+      content_item:
+        title: "A content item"

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -1,0 +1,27 @@
+name: Contextual sidebar
+description: Sidebar that shows different things depending on the page
+body: |
+  This is a complex component that calls other components. For more accurate
+  preview with real data, see the [contextual navigation preview][preview].
+
+  There are 4 main variants of the component:
+
+  - Step by step, which uses the [step by step nav][step-by-step]
+  - Taxonomy, which uses the new taxonomy in the [taxonomy-sidebar component][taxonomy-sidebar]
+  - Mainstream, which uses related links in the [related navigation component][related_navigation]
+  - Related navigation, which uses legacy taxonomies in the [related navigation component][related_navigation]
+
+  It must always used [together with the contextual breadcrumbs][contextual_breadcrumbs].
+
+  [preview]: https://govuk-publishing-components.herokuapp.com/contextual-navigation
+  [step-by-step]: /component-guide/step_by_step_nav
+  [related_navigation]: /component-guide/related_navigation
+  [taxonomy-sidebar]: https://govuk-static.herokuapp.com/component-guide/taxonomy_sidebar
+  [contextual_breadcrumbs]: /component-guide/contextual_breadcrumbs
+accessibility_criteria: |
+  Components called by this component must be accessible
+examples:
+  default:
+    data:
+      content_item:
+        title: "A content item"

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -24,6 +24,9 @@ Gem::Specification.new do |s|
   s.add_dependency "rouge"
   s.add_dependency "rake"
 
+  # TODO: merge this govuk_navigation_helpers into this gem
+  s.add_dependency "govuk_navigation_helpers", "~> 9.2.1"
+
   s.add_development_dependency "govuk-lint", "~> 3.3"
   s.add_development_dependency "rspec-rails", "~> 3.6"
   s.add_development_dependency "capybara", "~> 2.14.4"

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -2,6 +2,8 @@ require "govuk_publishing_components/config"
 require "govuk_publishing_components/engine"
 require "govuk_publishing_components/presenters/step_by_step_nav_helper"
 require "govuk_publishing_components/presenters/related_navigation_helper"
+require "govuk_publishing_components/presenters/contextual_navigation"
+require "govuk_publishing_components/presenters/navigation_type"
 
 require "govuk_publishing_components/app_helpers/step_nav"
 require "govuk_publishing_components/app_helpers/step_nav_helper"

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -1,0 +1,60 @@
+require 'govuk_navigation_helpers'
+
+module GovukPublishingComponents
+  module Presenters
+    # @private
+    class ContextualNavigation
+      attr_reader :content_item, :request_path
+
+      # @param content_item A content item hash with strings as keys
+      # @param request_path `request.path`
+      def initialize(content_item, request_path)
+        @content_item = content_item
+        @request_path = request_path
+      end
+
+      def taxonomy_sidebar
+        nav_helper.taxonomy_sidebar
+      end
+
+      def taxon_breadcrumbs
+        nav_helper.taxon_breadcrumbs
+      end
+
+      def breadcrumbs
+        if content_item["schema_name"] == "specialist_document"
+          parent_finder = content_item.dig("links", "finder", 0)
+          return [] unless parent_finder
+
+          [
+            {
+              title: "Home",
+              url: "/",
+            },
+            {
+              title: parent_finder['title'],
+              url: parent_finder['base_path'],
+            }
+          ]
+        else
+          nav_helper.breadcrumbs[:breadcrumbs]
+        end
+      end
+
+      def should_present_taxonomy_navigation?
+        navigation = GovukPublishingComponents::Presenters::NavigationType.new(content_item)
+        navigation.should_present_taxonomy_navigation?
+      end
+
+      def step_nav_helper
+        @step_nav_helper ||= GovukPublishingComponents::AppHelpers::StepNavHelper.new(content_item, request_path)
+      end
+
+    private
+
+      def nav_helper
+        @nav_helper ||= GovukNavigationHelpers::NavigationHelper.new(content_item)
+      end
+    end
+  end
+end

--- a/lib/govuk_publishing_components/presenters/navigation_type.rb
+++ b/lib/govuk_publishing_components/presenters/navigation_type.rb
@@ -1,0 +1,33 @@
+module GovukPublishingComponents
+  module Presenters
+    # @private
+    class NavigationType
+      GUIDANCE_SCHEMAS =
+        %w{answer contact guide detailed_guide document_collection publication}.freeze
+
+      def initialize(content_item)
+        @content_item = content_item
+      end
+
+      def should_present_taxonomy_navigation?
+        !content_is_tagged_to_browse_pages? &&
+          content_is_tagged_to_a_live_taxon? &&
+          content_schema_is_guidance?
+      end
+
+    private
+
+      def content_is_tagged_to_a_live_taxon?
+        @content_item.dig("links", "taxons").to_a.any? { |taxon| taxon["phase"] == "live" }
+      end
+
+      def content_is_tagged_to_browse_pages?
+        @content_item.dig("links", "mainstream_browse_pages").present?
+      end
+
+      def content_schema_is_guidance?
+        GUIDANCE_SCHEMAS.include? @content_item["schema_name"]
+      end
+    end
+  end
+end

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -141,8 +141,8 @@ module GovukPublishingComponents
         contacts = filter_link_type("related", "contact")
         return [] unless contacts.any?
         [
-          title: "Other contacts",
-          links: build_links_for_sidebar(contacts).map
+          "title" => "Other contacts",
+          "links" => build_links_for_sidebar(contacts)
         ]
       end
 

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  include Slimmer::GovukComponents
 end

--- a/spec/dummy/app/controllers/welcome_controller.rb
+++ b/spec/dummy/app/controllers/welcome_controller.rb
@@ -1,2 +1,19 @@
 class WelcomeController < ApplicationController
+  def contextual_navigation
+    @urls = {
+      "HMRC org page (no navigation)" => "/government/organisations/hm-revenue-customs",
+      "Mainstream browse page with related links" => "/complain-independent-case-examiner",
+      "Vehicles you can drive (with step by step)" => "/vehicles-can-drive",
+      "Corporation tax (related links)" => "/corporation-tax",
+      "Guidance tagged to the education taxonomy" => "/guidance/teachers-student-loan-reimbursement-guidance-for-teachers-and-schools",
+      "Travel advice Afghanistan" => "/foreign-travel-advice/afghanistan",
+      "HMRC contact" => "/government/organisations/hm-revenue-customs/contact/agent-dedicated-line-self-assessment-or-paye-for-individuals",
+      "AAIB report (specialist document)" => "/aaib-reports/aaib-investigation-to-airbus-helicopters-ec120b-colibri-g-swng",
+      "Guidance with a policy" => "/government/publications/helping-british-nationals-overseas-our-service-on-twitter-fcotravel--2",
+    }
+
+    if params[:base_path]
+      @content_item = Services.content_store.content_item("/" + params[:base_path])
+    end
+  end
 end

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -9,7 +9,9 @@
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
-  <body id='wrapper'>
-    <%= yield %>
+  <body>
+    <div id='wrapper'>
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/spec/dummy/app/views/welcome/contextual_navigation.html.erb
+++ b/spec/dummy/app/views/welcome/contextual_navigation.html.erb
@@ -1,0 +1,41 @@
+<% if @content_item %>
+  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item.parsed_content %>
+<% end %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title', title: @content_item ? "Contextual navigation for '#{@content_item["title"]}'" : 'Contextual navigation reference' %>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <% content = capture do %>
+      <% if @content_item %>
+          <p>You're looking at the contextual navigation for the page <%= link_to @content_item["title"], "https://www.gov.uk#{@content_item["base_path"]}", target: '_blank' %></p>
+      <% end %>
+
+      <p>You can look at the contextual navigation for any page by replacing the part after /contextual-navigation in the URL (eg. /contextual-navigation<strong>/state-pension-calculator</strong>).</p>
+
+      <p>Note that this displays what the contextual navigation would look like if it were implemented. If the application hasn't been upgraded, it will show something else.</p>
+
+      <h3>Example pages</h3>
+
+      <ul>
+      <% @urls.each do |name, base_path| %>
+        <li>
+          <%= link_to name, "/contextual-navigation#{base_path}" %>
+        </li>
+      <% end %>
+      </ul>
+    <% end %>
+
+    <%= render 'govuk_component/govspeak', content: content, rich_govspeak: true %>
+  </div>
+
+  <div class="column-one-third">
+    <% if @content_item %>
+      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item.parsed_content %>
+    <% end %>
+  </div>
+</div>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -3,4 +3,6 @@ Rails.application.routes.draw do
   root to: redirect('/component-guide')
   get 'test', to: 'welcome#index'
   get 'step-nav/:slug', to: 'step_nav#show'
+  get 'contextual-navigation', to: 'welcome#contextual_navigation'
+  get 'contextual-navigation/*base_path', to: 'welcome#contextual_navigation'
 end

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -1,0 +1,173 @@
+require "rails_helper"
+
+describe "Contextual navigation" do
+  scenario "There's a step by step list" do
+    given_theres_a_page_with_a_step_by_step
+    and_i_visit_that_page
+    then_i_see_the_step_by_step
+    and_the_step_by_step_header
+  end
+
+  scenario "There's between 2-5 step by step lists" do
+    given_theres_are_two_step_by_step_lists
+    and_i_visit_that_page
+    then_i_just_see_the_step_by_step_related_links
+    and_no_step_by_step_header
+  end
+
+  scenario "There's 6 or more step by step lists" do
+    given_theres_are_six_step_by_step_lists
+    and_i_visit_that_page
+    then_theres_no_step_by_step_at_all
+    and_no_step_by_step_header
+  end
+
+  scenario "There's a mainstream browse page tagged" do
+    given_theres_a_page_with_browse_page
+    and_i_visit_that_page
+    then_i_see_the_related_links_sidebar
+    and_the_parent_based_breadcrumbs
+  end
+
+  scenario "There's a taxon tagged" do
+    given_theres_a_guide_with_a_live_taxon_and_collection_tagged_to_it
+    and_i_visit_that_page
+    then_i_see_the_taxonomy_sidebar_and_collection
+    and_the_taxonomy_breadcrumbs
+  end
+
+  scenario "There's legacy things tagged" do
+    given_theres_a_page_with_just_legacy_taxonomy
+    and_i_visit_that_page
+    then_i_see_the_related_navigation_sidebar
+    and_the_parent_based_breadcrumbs
+  end
+
+  include GdsApi::TestHelpers::ContentStore
+  include Slimmer::TestHelpers::GovukComponents
+
+  def given_theres_a_page_with_a_step_by_step
+    content_store_has_random_item(links: { part_of_step_navs: [random_item("step_by_step_nav")] })
+  end
+
+  def given_theres_are_two_step_by_step_lists
+    content_store_has_random_item(links: { part_of_step_navs: 2.times.map { random_item("step_by_step_nav") } })
+  end
+
+  def given_theres_are_six_step_by_step_lists
+    content_store_has_random_item(links: { part_of_step_navs: 6.times.map { random_item("step_by_step_nav") } })
+  end
+
+  def given_theres_a_page_with_browse_page
+    content_store_has_random_item(
+      links: {
+        "parent" => [random_item("mainstream_browse_page", "title" => "A parent")],
+        "mainstream_browse_pages" => [random_item("mainstream_browse_page")],
+        "ordered_related_items" => [random_item("guide", "title" => "A related link curated in Publisher")]
+      }
+    )
+  end
+
+  def given_theres_a_guide_with_a_live_taxon_and_collection_tagged_to_it
+    document_collection = random_item("document_collection", "title" => "A cool document collection")
+    alpha_taxon = random_item("taxon", "title" => "An alpha taxon", "phase" => "alpha")
+    live_taxon = random_item("taxon", "title" => "A live taxon", "phase" => "live")
+
+    stub_request(:get, "http://rummager.dev.gov.uk/search.json?count=3&fields%5B%5D=link&fields%5B%5D=title&filter_navigation_document_supertype=guidance&filter_taxons%5B%5D=#{live_taxon['content_id']}&similar_to=/page-with-contextual-navigation&start=0").
+      to_return(body: { results: [{ title: 'A similar item' }] }.to_json)
+
+    content_store_has_random_item(
+      schema: "guide",
+      links: {
+        "taxons" => [live_taxon, alpha_taxon],
+        "document_collections" => [document_collection],
+      }
+    )
+  end
+
+  def given_theres_a_page_with_just_legacy_taxonomy
+    topic = random_item("topic", "title" => "A legacy topic")
+    content_store_has_random_item(links: { "topics" => [topic], parent: [random_item("guide", "title" => "A parent")] })
+  end
+
+  def and_i_visit_that_page
+    visit "/contextual-navigation/page-with-contextual-navigation"
+  end
+
+  def then_i_see_the_step_by_step
+    expect(page).to have_selector(".gem-c-step-nav-related")
+    expect(page).to have_selector(".gem-c-step-nav__header")
+  end
+
+  def and_the_step_by_step_header
+    expect(page).to have_selector(".gem-c-step-nav-header")
+  end
+
+  def then_i_just_see_the_step_by_step_related_links
+    expect(page).to have_selector(".gem-c-step-nav-related")
+    expect(page).not_to have_selector(".gem-c-step-nav__header")
+  end
+
+  def and_no_step_by_step_header
+    expect(page).not_to have_selector(".gem-c-step-nav-header")
+  end
+
+  def then_theres_no_step_by_step_at_all
+    expect(page).not_to have_selector(".gem-c-step-nav-related")
+    expect(page).not_to have_selector(".gem-c-step-nav__header")
+  end
+
+  def then_i_see_the_related_links_sidebar
+    expect(page).to have_selector(".gem-c-related-navigation")
+    expect(page).to have_content("A related link curated in Publisher")
+  end
+
+  def and_the_parent_based_breadcrumbs
+    payload = within(shared_component_selector('breadcrumbs')) do
+      JSON.parse(page.text)
+    end
+
+    expect(payload.dig("breadcrumbs", 1, "title")).to eql("A parent")
+  end
+
+  def and_the_taxonomy_breadcrumbs
+    payload = within(shared_component_selector('breadcrumbs')) do
+      JSON.parse(page.text)
+    end
+
+    expect(payload.dig("breadcrumbs", 1, "title")).to eql("A live taxon")
+  end
+
+  def then_i_see_the_taxonomy_sidebar_and_collection
+    # The taxonomy sidebar is currently render via a shared slimmer component.
+    # It should move into this gem so that we can test the actual HTML instead
+    # of just the JSON payload.
+
+    payload = within(shared_component_selector('taxonomy_sidebar')) do
+      JSON.parse(page.text)
+    end
+
+    expect(payload.dig("items", 0, "title")).to eql("A live taxon")
+    expect(payload.dig("items", 0, "related_content", 0, "title")).to eql("A similar item")
+
+    expect(payload.dig("collections", 0, "text")).to eql("A cool document collection")
+  end
+
+  def then_i_see_the_related_navigation_sidebar
+    expect(page).to have_selector(".gem-c-related-navigation")
+    expect(page).to have_content("A legacy topic")
+  end
+
+  def content_store_has_random_item(schema: "placeholder", links: {})
+    content_item = random_item(schema, "base_path" => "/page-with-contextual-navigation",
+        "links" => links)
+
+    content_store_has_item(content_item["base_path"], content_item)
+  end
+
+  def random_item(schema_name, merge_with = {})
+    GovukSchemas::RandomExample.for_schema(frontend_schema: schema_name) do |random_item|
+      random_item.merge(merge_with)
+    end
+  end
+end

--- a/spec/features/step_nav_helper_spec.rb
+++ b/spec/features/step_nav_helper_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-require "gds_api/test_helpers/content_store"
 
 describe 'Specimen usage of step by step navigation helpers' do
   include GdsApi::TestHelpers::ContentStore

--- a/spec/lib/presenters/related_navigation_helper_spec.rb
+++ b/spec/lib/presenters/related_navigation_helper_spec.rb
@@ -349,6 +349,32 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
 
       expect(payload).to include(expected)
     end
+
+    it "returns an 'Other contacts' section" do
+      payload = payload_for("contact",
+        "links" => {
+          "related" => [
+            {
+              "content_id" => "d636b991-a239-497b-be51-1617b0299cf5",
+              "locale" => "en",
+              "base_path" => "/foo",
+              "document_type" => "contact",
+              "title" => "Foo"
+            }
+          ]
+        },)
+
+      expected = {
+        "Other_contacts" => [
+          {
+            path: "/foo",
+            text: "Foo",
+          }
+        ]
+      }
+
+      expect(payload).to include(expected)
+    end
   end
 
   describe "#other" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'capybara/rails'
 require 'capybara/poltergeist'
 require 'govuk_schemas'
 require_relative 'support/components_helper.rb'
+require "gds_api/test_helpers/content_store"
 
 WebMock.disable_net_connect!(allow_localhost: true)
 

--- a/startup.sh
+++ b/startup.sh
@@ -5,6 +5,8 @@ bundle install
 if [[ $1 == "--live" ]] ; then
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
+  PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
+  PLEK_SERVICE_RUMMAGER_URI=${PLEK_SERVICE_RUMMAGER_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
   bundle exec rackup spec/dummy/config.ru --host 0.0.0.0 -p 3212
 else


### PR DESCRIPTION
This PR adds 2 new components: the contextual breadcrumbs and contextual sidebar. The idea behind the new components is that they encapsulate all of the logic for the breadcrumbs and sidebars. They only take a content item as input and make the decisions what to show based on that.

https://govuk-publishing-compon-pr-228.herokuapp.com/component-guide/contextual_sidebar
https://govuk-publishing-compon-pr-228.herokuapp.com/component-guide/contextual_breadcrumbs

I hope we can achieve the following:

- Have a single place that makes the decisions about sidebar & breadcrumbs. This avoids confusion about the what we should show and makes it easier to understand and and communicate this.
- Avoid duplication between applications: currently the taxonomy logic is duplicated in government-frontend and the navigation helpers gem, which caused the bug described in https://github.com/alphagov/government-frontend/pull/828.
- Have a clear place to add new things. For example, the contextual comms work that @emmabeynon will be doing can use the contextual sidebar to make changes to all content pages really quickly.
- Introduce a pattern for future work. In the future I expect there to be a "contextual footer" component to show related things below the main body text (see https://trello.com/c/DbDHkJ0S for design examples).
- Put step by step in the same codebase as the related navigation. This makes it possible to start mixing & matching the step by step and navs as described in the first designs of https://trello.com/c/wOlc65rO.

This PR consists of 3 things:

- The **component code**. The code for this is extracted from government-frontend (PR) and rewritten slightly. The code is not yet refactored, I've tried to keep the changes to a minimum. Among other things, we'll merge in the navigation helpers gem and refactor the StepNavHelper and ContextualNavigation classes (they do kind of the same thing). Note that there's not much in the component examples. I've considered adding full content items to them, but that didn't seem maintainable and not that useful.

- **Contextual navigation preview**. This is a page in the dummy app which is available on Heroku (https://govuk-publishing-compon-pr-228.herokuapp.com/contextual-navigation). It will allow you do see what the contextual navigation for any page on GOV.UK would be if it were using the components. There's a hard coded list of examples which we can refer to. I hope that that gives us more visibility on the different types of navigation that exist. Some examples of this:
  - https://govuk-publishing-compon-pr-228.herokuapp.com/contextual-navigation/complain-independent-case-examiner
  -  https://govuk-publishing-compon-pr-228.herokuapp.com/contextual-navigation/corporation-tax
  - https://govuk-publishing-compon-pr-228.herokuapp.com/contextual-navigation/guidance/teachers-student-loan-reimbursement-guidance-for-teachers-and-schools

- A new **feature test**. This integration test covers all the use cases for the contextual navigation. I've kept it as high level as possible, hopefully this can stay relatively small. This replaces the tests in the applications itself. 

## Usage in apps

- https://github.com/alphagov/government-frontend/pull/837
- https://github.com/alphagov/calendars/pull/250

https://trello.com/c/1LEofaHC