### PR TITLE
Remove preventLinkFollowingForCurrentTab code

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -170,7 +170,6 @@
 
       function bindToggleForSteps(stepNavTracker) {
         $element.find('.js-toggle-panel').click(function (event) {
-          preventLinkFollowingForCurrentTab(event);
           var $step = $(this).closest('.js-step');
 
           var stepView = new StepView($step);
@@ -248,16 +247,6 @@
             $(this).removeClass(activeLinkClass);
           }
         });
-      }
-
-      function preventLinkFollowingForCurrentTab(event) {
-        // If the user is holding the ⌘ or Ctrl key, they're trying
-        // to open the link in a new window, so let the click happen
-        if (event.metaKey || event.ctrlKey) {
-          return;
-        }
-
-        event.preventDefault();
       }
 
       function bindToggleShowHideAllButton(stepNavTracker) {


### PR DESCRIPTION
Remove unnecessary JS from the step nav component.

- this was a hangover from the original code where the element in question was a link, not a button
- allowed users to open the link in a new tab, but buttons don't allow this

https://trello.com/c/PdxP84XT/350-refactor-task-list-component-code

Please check thoroughly as I am currently somewhat sleep-deprived although my [GCS](https://en.wikipedia.org/wiki/Glasgow_Coma_Scale) is at least 13.