### PR TITLE
Improve list and link classnames

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -27,7 +27,7 @@
     var rememberShownStep = false;
     var stepNavSize;
     var sessionStoreLink = 'govuk-step-nav-active-link';
-    var activeLinkClass = 'gem-c-step-nav__link--active';
+    var activeLinkClass = 'gem-c-step-nav__list-item--active';
     var activeLinkHref = '#content';
 
     this.start = function ($element) {
@@ -45,7 +45,7 @@
       var $steps = $element.find('.js-step');
       var $stepHeaders = $element.find('.js-toggle-panel');
       var totalSteps = $element.find('.js-panel').length;
-      var totalLinks = $element.find('.gem-c-step-nav__link-item').length;
+      var totalLinks = $element.find('.gem-c-step-nav__link').length;
 
       var $showOrHideAllButton;
 
@@ -437,7 +437,7 @@
 
       function trackClick() {
         var tracking_options = {label: $(event.target).attr('href') + " : " + stepNavSize};
-        var dimension28 = $(event.target).closest('.gem-c-step-nav__links').attr('data-length');
+        var dimension28 = $(event.target).closest('.gem-c-step-nav__list').attr('data-length');
 
         if (dimension28) {
           tracking_options['dimension28'] = dimension28;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -286,7 +286,7 @@ $top-border: solid 2px $grey-3;
   margin: 0;
   font-size: inherit;
 
-  + .gem-c-step-nav__links {
+  + .gem-c-step-nav__list {
     margin-top: -5px;
 
     .gem-c-step-nav--large & {
@@ -307,7 +307,7 @@ $top-border: solid 2px $grey-3;
   font-weight: bold;
 }
 
-.gem-c-step-nav__links {
+.gem-c-step-nav__list {
   padding: 0;
   padding-bottom: 10px;
 
@@ -318,30 +318,30 @@ $top-border: solid 2px $grey-3;
   }
 }
 
-.gem-c-step-nav__links--choice {
+.gem-c-step-nav__list--choice {
   $links-margin: 20px;
 
   margin-left: $links-margin;
   list-style: disc;
 
-  .gem-c-step-nav__link--active:before {
+  .gem-c-step-nav__list-item--active:before {
     left: -($gutter + $gutter-half) - $links-margin;
   }
 
   .gem-c-step-nav--large & {
     @include media(tablet) {
-      .gem-c-step-nav__link--active:before {
+      .gem-c-step-nav__list-item--active:before {
         left: -($gutter * 2) - $links-margin;
       }
     }
   }
 }
 
-.gem-c-step-nav__link {
+.gem-c-step-nav__list-item {
   margin-bottom: 10px;
 }
 
-.gem-c-step-nav__link--active {
+.gem-c-step-nav__list-item--active {
   position: relative;
 
   &:before {
@@ -369,7 +369,7 @@ $top-border: solid 2px $grey-3;
     }
   }
 
-  .gem-c-step-nav__link-item {
+  .gem-c-step-nav__link {
     color: $black;
     text-decoration: none;
 

--- a/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
+++ b/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
@@ -46,7 +46,7 @@ module GovukPublishingComponents
       def list(element)
         content_tag(
           get_list_element(element[:style]),
-          class: "gem-c-step-nav__links #{get_list_style(element[:style])}",
+          class: "gem-c-step-nav__list #{get_list_style(element[:style])}",
           data: {
             length: element[:contents].length
           }
@@ -55,7 +55,7 @@ module GovukPublishingComponents
             concat(
               content_tag(
                 :li,
-                class: "gem-c-step-nav__link js-list-item #{link_active(contents[:active])}"
+                class: "gem-c-step-nav__list-item js-list-item #{link_active(contents[:active])}"
               ) do
                 create_list_item_content(contents)
               end
@@ -76,7 +76,7 @@ module GovukPublishingComponents
             data: {
               position: "#{@options[:step_index] + 1}.#{@link_index}"
             },
-            class: "gem-c-step-nav__link-item js-link"
+            class: "gem-c-step-nav__link js-link"
           ) do
             text
           end
@@ -90,7 +90,7 @@ module GovukPublishingComponents
       end
 
       def get_list_style(style)
-        "gem-c-step-nav__links--choice" if style == "choice"
+        "gem-c-step-nav__list--choice" if style == "choice"
       end
 
       def get_list_element(style)
@@ -106,7 +106,7 @@ module GovukPublishingComponents
       end
 
       def link_active(active)
-        "gem-c-step-nav__link--active" if active
+        "gem-c-step-nav__list-item--active" if active
       end
     end
   end

--- a/spec/components/step_by_step_nav_spec.rb
+++ b/spec/components/step_by_step_nav_spec.rb
@@ -204,28 +204,28 @@ describe "step nav", type: :view do
   it "renders correct list elements and includes length of lists" do
     render_component(steps: stepnav)
 
-    assert_select step1 + " ul.gem-c-step-nav__links--choice[data-length='2']"
-    assert_select step2or + " ol.gem-c-step-nav__links[data-length='3']"
+    assert_select step1 + " ul.gem-c-step-nav__list--choice[data-length='2']"
+    assert_select step2or + " ol.gem-c-step-nav__list[data-length='3']"
   end
 
   it "renders links and link attributes correctly" do
     render_component(steps: stepnav)
 
-    assert_select step1 + " .gem-c-step-nav__link-item[href='/link1'][data-position='1.1']", text: "Link 1.1.1"
-    assert_select step1 + " .gem-c-step-nav__link-item[href='/link1'][rel='external']", false
-    assert_select step1 + " .gem-c-step-nav__link-item[href='http://www.gov.uk'][rel='external'][data-position='1.2']", text: "Link 1.1.2 £0 to £300"
-    assert_select step1 + " .gem-c-step-nav__link-item[href='http://www.gov.uk'] .gem-c-step-nav__context", text: "£0 to £300"
-    assert_select step1 + " .gem-c-step-nav__link-item[href='/link3'][data-position='1.3']", text: "Link 1.1.3"
-    assert_select step1 + " .gem-c-step-nav__link-item[href='/link4'][data-position='1.4']", text: "Link 1.1.4"
-    assert_select step2or + " .gem-c-step-nav__link-item[href='/link8'][data-position='4.2']", text: "Link 2.2.2"
+    assert_select step1 + " .gem-c-step-nav__link[href='/link1'][data-position='1.1']", text: "Link 1.1.1"
+    assert_select step1 + " .gem-c-step-nav__link[href='/link1'][rel='external']", false
+    assert_select step1 + " .gem-c-step-nav__link[href='http://www.gov.uk'][rel='external'][data-position='1.2']", text: "Link 1.1.2 £0 to £300"
+    assert_select step1 + " .gem-c-step-nav__link[href='http://www.gov.uk'] .gem-c-step-nav__context", text: "£0 to £300"
+    assert_select step1 + " .gem-c-step-nav__link[href='/link3'][data-position='1.3']", text: "Link 1.1.3"
+    assert_select step1 + " .gem-c-step-nav__link[href='/link4'][data-position='1.4']", text: "Link 1.1.4"
+    assert_select step2or + " .gem-c-step-nav__link[href='/link8'][data-position='4.2']", text: "Link 2.2.2"
   end
 
   it "renders links without hrefs" do
     render_component(steps: stepnav)
 
-    assert_select step2or + " .gem-c-step-nav__link .gem-c-step-nav__link-item[href='/link7'][data-position='4.1']", text: "Link 2.2.1"
-    assert_select step2or + " .gem-c-step-nav__link", text: "or"
-    assert_select step2or + " .gem-c-step-nav__link .gem-c-step-nav__link-item[href='/link8'][data-position='4.2']", text: "Link 2.2.2"
+    assert_select step2or + " .gem-c-step-nav__list-item .gem-c-step-nav__link[href='/link7'][data-position='4.1']", text: "Link 2.2.1"
+    assert_select step2or + " .gem-c-step-nav__list-item", text: "or"
+    assert_select step2or + " .gem-c-step-nav__list-item .gem-c-step-nav__link[href='/link8'][data-position='4.2']", text: "Link 2.2.2"
   end
 
   it "renders optional steps, sub steps and optional sub steps" do
@@ -255,7 +255,7 @@ describe "step nav", type: :view do
   it "applies the correct styles to lists" do
     render_component(steps: stepnav)
 
-    assert_select step2 + " .gem-c-step-nav__links.gem-c-step-nav__links--choice"
+    assert_select step2 + " .gem-c-step-nav__list.gem-c-step-nav__list--choice"
   end
 
   it "allows steps to be open on page load" do
@@ -268,7 +268,7 @@ describe "step nav", type: :view do
     render_component(steps: stepnav, highlight_step: 1)
 
     assert_select ".gem-c-step-nav__step--active#step-1"
-    assert_select step2 + " .gem-c-step-nav__link.gem-c-step-nav__link--active .gem-c-step-nav__link-item[href='#content']", text: "You are currently viewing: Link 2.1.2"
+    assert_select step2 + " .gem-c-step-nav__list-item.gem-c-step-nav__list-item--active .gem-c-step-nav__link[href='#content']", text: "You are currently viewing: Link 2.1.2"
   end
 
   it "renders a small stepnav" do

--- a/spec/features/step_nav_helper_spec.rb
+++ b/spec/features/step_nav_helper_spec.rb
@@ -37,7 +37,7 @@ describe 'Specimen usage of step by step navigation helpers' do
     it 'shows the full step nav sidebar' do
       within('.gem-c-step-nav') do
         expect(page).to have_css('h3', count: 3)
-        expect(page).to have_css('.gem-c-step-nav__link--active', count: 1, text: 'Experience zero gravity in the atmosphere') # one active link
+        expect(page).to have_css('.gem-c-step-nav__list-item--active', count: 1, text: 'Experience zero gravity in the atmosphere') # one active link
       end
     end
 

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -20,9 +20,9 @@ describe('A stepnav module', function () {
             </h2>\
           </div>\
           <div class="gem-c-step-nav__panel js-panel" id="step-panel-topic-step-one-1">\
-            <ol class="gem-c-step-nav__links" data-length="1">\
-              <li class="gem-c-step-nav__link js-list-item">\
-                <a href="/link1" class="gem-c-step-nav__link-item js-link" data-position="1.1">Link 1</a>\
+            <ol class="gem-c-step-nav__list" data-length="1">\
+              <li class="gem-c-step-nav__list-item js-list-item">\
+                <a href="/link1" class="gem-c-step-nav__link js-link" data-position="1.1">Link 1</a>\
               </li>\
             </ol>\
           </div>\
@@ -41,12 +41,12 @@ describe('A stepnav module', function () {
             </h2>\
           </div>\
           <div class="gem-c-step-nav__panel js-panel" id="step-panel-topic-step-two-1">\
-            <ol class="gem-c-step-nav__links" data-length="2">\
-              <li class="gem-c-step-nav__link gem-c-step-nav__link--active js-list-item">\
-                <a href="/link2" class="gem-c-step-nav__link-item js-link" data-position="2.1">Link 2</a>\
+            <ol class="gem-c-step-nav__list" data-length="2">\
+              <li class="gem-c-step-nav__list-item gem-c-step-nav__list-item--active js-list-item">\
+                <a href="/link2" class="gem-c-step-nav__link js-link" data-position="2.1">Link 2</a>\
               </li>\
-              <li class="gem-c-step-nav__link js-list-item">\
-                <a href="/link3" class="gem-c-step-nav__link-item js-link" data-position="2.2">Link 3</a>\
+              <li class="gem-c-step-nav__list-item js-list-item">\
+                <a href="/link3" class="gem-c-step-nav__link js-link" data-position="2.2">Link 3</a>\
               </li>\
             </ol>\
             <div class="gem-c-step-nav__help">\
@@ -68,21 +68,21 @@ describe('A stepnav module', function () {
             </h2>\
           </div>\
           <div class="gem-c-step-nav__panel js-panel" id="step-panel-topic-step-three-1">\
-            <ol class="gem-c-step-nav__links" data-length="5">\
-              <li class="gem-c-step-nav__link gem-c-step-nav__link--active js-list-item">\
-                <a href="/link4" class="gem-c-step-nav__link-item js-link" data-position="3.1">Link 4</a>\
+            <ol class="gem-c-step-nav__list" data-length="5">\
+              <li class="gem-c-step-nav__list-item gem-c-step-nav__list-item--active js-list-item">\
+                <a href="/link4" class="gem-c-step-nav__link js-link" data-position="3.1">Link 4</a>\
               </li>\
-              <li class="gem-c-step-nav__link gem-c-step-nav__link--active js-list-item">\
-                <a href="/link5" class="gem-c-step-nav__link-item js-link" data-position="3.2">Link 5</a>\
+              <li class="gem-c-step-nav__list-item gem-c-step-nav__list-item--active js-list-item">\
+                <a href="/link5" class="gem-c-step-nav__link js-link" data-position="3.2">Link 5</a>\
               </li>\
-              <li class="gem-c-step-nav__link js-list-item">\
-                <a href="http://www.gov.uk" class="gem-c-step-nav__link-item js-link" data-position="3.3" rel="external">Link 6</a>\
+              <li class="gem-c-step-nav__list-item js-list-item">\
+                <a href="http://www.gov.uk" class="gem-c-step-nav__link js-link" data-position="3.3" rel="external">Link 6</a>\
               </li>\
-              <li class="gem-c-step-nav__link gem-c-step-nav__link--active js-list-item">\
-                <a href="#content" class="gem-c-step-nav__link-item js-link" data-position="3.4">Link 7</a>\
+              <li class="gem-c-step-nav__list-item gem-c-step-nav__list-item--active js-list-item">\
+                <a href="#content" class="gem-c-step-nav__link js-link" data-position="3.4">Link 7</a>\
               </li>\
-              <li class="gem-c-step-nav__link gem-c-step-nav__link--active js-list-item">\
-                <a href="#content" class="gem-c-step-nav__link-item js-link" data-position="3.5">Link 8</a>\
+              <li class="gem-c-step-nav__list-item gem-c-step-nav__list-item--active js-list-item">\
+                <a href="#content" class="gem-c-step-nav__link js-link" data-position="3.5">Link 8</a>\
               </li>\
             </ol>\
           </div>\
@@ -100,7 +100,7 @@ describe('A stepnav module', function () {
     stepnav.start($element);
     expectedstepnavStepCount = $element.find('.gem-c-step-nav__step').length;
     expectedstepnavContentCount = $element.find('.gem-c-step-nav__step').first().find('.js-link').length;
-    expectedstepnavLinkCount = $element.find('.gem-c-step-nav__link-item').length;
+    expectedstepnavLinkCount = $element.find('.gem-c-step-nav__list-item').length;
   });
 
   afterEach(function () {
@@ -658,24 +658,24 @@ describe('A stepnav module', function () {
 
     it("highlights the first active link in the first active step if no sessionStorage value is set", function () {
       expect(sessionStorage.getItem('govuk-step-nav-active-link')).toBe(null);
-      expect($element.find('.js-link[data-position="3.1"]').closest('.js-list-item')).toHaveClass('gem-c-step-nav__link--active');
-      expect($element.find(('.gem-c-step-nav__link--active')).length).toBe(1);
+      expect($element.find('.js-link[data-position="3.1"]').closest('.js-list-item')).toHaveClass('gem-c-step-nav__list-item--active');
+      expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1);
     });
 
     it("highlights a clicked #content link and removes other highlights", function () {
-      expect($element.find(('.gem-c-step-nav__link--active')).length).toBe(1);
+      expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1);
 
       var $firstLink = $element.find('.js-link[data-position="3.4"]');
       $firstLink.click();
       expect(sessionStorage.getItem('govuk-step-nav-active-link')).toBe('3.4');
-      expect($firstLink.closest('.js-list-item')).toHaveClass('gem-c-step-nav__link--active');
-      expect($element.find(('.gem-c-step-nav__link--active')).length).toBe(1);
+      expect($firstLink.closest('.js-list-item')).toHaveClass('gem-c-step-nav__list-item--active');
+      expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1);
 
       var $secondLink = $element.find('.js-link[data-position="3.5"]');
       $secondLink.click();
       expect(sessionStorage.getItem('govuk-step-nav-active-link')).toBe('3.5');
-      expect($secondLink.closest('.js-list-item')).toHaveClass('gem-c-step-nav__link--active');
-      expect($element.find(('.gem-c-step-nav__link--active')).length).toBe(1);
+      expect($secondLink.closest('.js-list-item')).toHaveClass('gem-c-step-nav__list-item--active');
+      expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1);
     });
   });
 
@@ -705,7 +705,7 @@ describe('A stepnav module', function () {
 
     it("highlights only one link", function () {
       expect(sessionStorage.getItem('govuk-step-nav-active-link')).toBe('3.5');
-      expect($element.find(('.gem-c-step-nav__link--active')).length).toBe(1);
+      expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1);
     });
   });
 
@@ -719,8 +719,8 @@ describe('A stepnav module', function () {
 
     it("highlights the first active link if no sessionStorage value is set", function () {
       expect(sessionStorage.getItem('govuk-step-nav-active-link')).toBe(null);
-      expect($element.find('.js-link[data-position="2.1"]').closest('.js-list-item')).toHaveClass('gem-c-step-nav__link--active');
-      expect($element.find(('.gem-c-step-nav__link--active')).length).toBe(1);
+      expect($element.find('.js-link[data-position="2.1"]').closest('.js-list-item')).toHaveClass('gem-c-step-nav__list-item--active');
+      expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1);
     });
   });
 


### PR DESCRIPTION
This refers to links that appear within the content of an expandable section of a step by step nav. Links always appear inside a list.

- existing classes were __links (ul/ol), __link (li), __link-item (a)
- new classes are __list (ul/ol), __list-item (li), __link (a)

Trello card: https://trello.com/c/PdxP84XT/350-refactor-task-list-component-code
