### PR TITLE
Improve step nav substep creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Improve substep creation (PR #231)
+
 # 5.6.0
 
 * Restore 'referer' field to feedback component form submission (PR #232)

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
@@ -74,24 +74,12 @@
             %>
             <% step[:contents].each do |element| %>
               <%= step_nav_helper.render_step_nav_element(element, options) %>
+
               <%
                 if element[:type] == 'list'
                   options[:link_index] += element[:contents].length
                 end
               %>
-
-              <% if element[:type] == 'substep' %>
-                <% if in_substep %>
-                  </div>
-                  <% in_substep = false %>
-                <% end %>
-                <div class="gem-c-step-nav__substep <% if element[:optional] %>gem-c-step-nav__substep--optional<% end %>">
-                <% in_substep = true %>
-              <% end %>
-            <% end %>
-
-            <% if in_substep %>
-              </div>
             <% end %>
 
             <% if step_nav_url && step[:show_help_link] %>

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
@@ -295,26 +295,28 @@ examples:
             },
             {
               type: 'substep',
-              optional: true
-            },
-            {
-              type: 'heading',
-              text: 'Get help completing this step'
-            },
-            {
-              type: 'list',
+              optional: true,
               contents: [
                 {
-                  href: '#',
-                  text: 'Apply online'
+                  type: 'heading',
+                  text: 'Get help completing this step'
                 },
                 {
-                  href: '#',
-                  text: 'Talk to one of our advisers'
-                },
-                {
-                  href: '#',
-                  text: 'Search our website'
+                  type: 'list',
+                  contents: [
+                    {
+                      href: '#',
+                      text: 'Apply online'
+                    },
+                    {
+                      href: '#',
+                      text: 'Talk to one of our advisers'
+                    },
+                    {
+                      href: '#',
+                      text: 'Search our website'
+                    }
+                  ]
                 }
               ]
             }
@@ -523,18 +525,20 @@ examples:
             },
             {
               type: 'substep',
-              optional: true
-            },
-            {
-              type: 'paragraph',
-              text: 'This paragraph is inside the sub step.'
-            },
-            {
-              type: 'list',
+              optional: true,
               contents: [
                 {
-                  href: '/test6',
-                  text: 'This link is also inside the sub step'
+                  type: 'paragraph',
+                  text: 'This paragraph is inside the sub step.'
+                },
+                {
+                  type: 'list',
+                  contents: [
+                    {
+                      href: '/test6',
+                      text: 'This link is also inside the sub step'
+                    }
+                  ]
                 }
               ]
             }
@@ -550,38 +554,44 @@ examples:
             },
             {
               type: 'substep',
-              optional: false
-            },
-            {
-              type: 'paragraph',
-              text: 'This paragraph is inside a required sub step.'
-            },
-            {
-              type: 'substep',
-              optional: true
-            },
-            {
-              type: 'paragraph',
-              text: 'This paragraph is inside an optional sub step.'
-            },
-            {
-              type: 'list',
+              optional: false,
               contents: [
                 {
-                  href: '/test7',
-                  text: 'This link is inside an optional sub step as well',
-                  active: true
+                  type: 'paragraph',
+                  text: 'This paragraph is inside a required sub step.'
                 }
               ]
             },
             {
               type: 'substep',
-              optional: false
+              optional: true,
+              contents: [
+                {
+                  type: 'paragraph',
+                  text: 'This paragraph is inside an optional sub step.'
+                },
+                {
+                  type: 'list',
+                  contents: [
+                    {
+                      href: '/test7',
+                      text: 'This link is inside an optional sub step as well',
+                      active: true
+                    }
+                  ]
+                },
+              ]
             },
             {
-              type: 'paragraph',
-              text: 'This paragraph is inside a required sub step.'
-            }
+              type: 'substep',
+              optional: false,
+              contents: [
+                {
+                  type: 'paragraph',
+                  text: 'This paragraph is inside a required sub step.'
+                }
+              ]
+            },
           ]
         },
         {
@@ -730,28 +740,30 @@ examples:
             },
             {
               type: 'substep',
-              optional: true
-            },
-            {
-              type: 'heading',
-              text: 'Optional steps'
-            },
-            {
-              type: 'paragraph',
-              text: 'These steps are not required.'
-            },
-            {
-              type: 'list',
-              style: 'choice',
+              optional: true,
               contents: [
                 {
-                  href: 'https://www.google.co.uk/',
-                  text: "Get annoyed when it doesn't work"
+                  type: 'heading',
+                  text: 'Optional steps'
                 },
                 {
-                  href: 'http://www.google.com',
-                  text: 'Try to find someone else who knows how to do it',
-                  context: '1 to 10 minutes'
+                  type: 'paragraph',
+                  text: 'These steps are not required.'
+                },
+                {
+                  type: 'list',
+                  style: 'choice',
+                  contents: [
+                    {
+                      href: 'https://www.google.co.uk/',
+                      text: "Get annoyed when it doesn't work"
+                    },
+                    {
+                      href: 'http://www.google.com',
+                      text: 'Try to find someone else who knows how to do it',
+                      context: '1 to 10 minutes'
+                    }
+                  ]
                 }
               ]
             }
@@ -921,28 +933,30 @@ examples:
             },
             {
               type: 'substep',
-              optional: true
-            },
-            {
-              type: 'heading',
-              text: 'Optional steps'
-            },
-            {
-              type: 'paragraph',
-              text: 'These steps are not required.'
-            },
-            {
-              type: 'list',
-              style: 'choice',
+              optional: true,
               contents: [
                 {
-                  href: 'https://www.google.co.uk/',
-                  text: "Get annoyed when it doesn't work"
+                  type: 'heading',
+                  text: 'Optional steps'
                 },
                 {
-                  href: 'http://www.google.com',
-                  text: 'Try to find someone else who knows how to do it',
-                  context: '1 to 10 minutes'
+                  type: 'paragraph',
+                  text: 'These steps are not required.'
+                },
+                {
+                  type: 'list',
+                  style: 'choice',
+                  contents: [
+                    {
+                      href: 'https://www.google.co.uk/',
+                      text: "Get annoyed when it doesn't work"
+                    },
+                    {
+                      href: 'http://www.google.com',
+                      text: 'Try to find someone else who knows how to do it',
+                      context: '1 to 10 minutes'
+                    }
+                  ]
                 }
               ]
             }

--- a/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
+++ b/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
@@ -17,6 +17,8 @@ module GovukPublishingComponents
           heading(element[:text])
         when "list"
           list(element)
+        when "substep"
+          substep(element)
         end
       end
 
@@ -59,6 +61,20 @@ module GovukPublishingComponents
               ) do
                 create_list_item_content(contents)
               end
+            )
+          }
+        end
+      end
+
+      def substep(element)
+        optional = "gem-c-step-nav__substep--optional" if element[:optional] == true
+        content_tag(
+          :div,
+          class: "gem-c-step-nav__substep #{optional}"
+        ) do
+          element[:contents].collect { |contents|
+            concat(
+              render_step_nav_element(contents, @options)
             )
           }
         end

--- a/spec/components/step_by_step_nav_spec.rb
+++ b/spec/components/step_by_step_nav_spec.rb
@@ -32,26 +32,28 @@ describe "step nav", type: :view do
           },
           {
             type: 'substep',
-            optional: false
-          },
-          {
-            type: 'paragraph',
-            text: 'This paragraph is inside a required substep'
-          },
-          {
-            type: 'list',
-            style: 'choice',
+            optional: false,
             contents: [
               {
-                href: '/link3',
-                text: 'Link 1.1.3',
+                type: 'paragraph',
+                text: 'This paragraph is inside a required substep'
               },
               {
-                href: '/link4',
-                text: 'Link 1.1.4'
+                type: 'list',
+                style: 'choice',
+                contents: [
+                  {
+                    href: '/link3',
+                    text: 'Link 1.1.3',
+                  },
+                  {
+                    href: '/link4',
+                    text: 'Link 1.1.4'
+                  }
+                ]
               }
             ]
-          },
+          }
         ]
       },
       {
@@ -89,12 +91,14 @@ describe "step nav", type: :view do
           },
           {
             type: 'substep',
-            optional: true
-          },
-          {
-            type: 'paragraph',
-            text: 'This paragraph is inside an optional substep'
-          },
+            optional: true,
+            contents: [
+              {
+                type: 'paragraph',
+                text: 'This paragraph is inside an optional substep'
+              }
+            ]
+          }
         ]
       },
       {


### PR DESCRIPTION
- modify data structure so substeps themselves have contents, rather than occurring in a sequence of elements and relying on the template to close the substep div
- move substep generation into the helper rather than the template

**WARNING**: this is a breaking change. No live step nav currently uses substeps, but the publishing tool is currently using the old data structure.

Old data structure:

```
{
    type: 'substep',
    optional: true
},
(elements inside the substep)
```

New:

```
{
    type: 'substep',
    optional: true,
    contents: [
        (elements inside the substep)
    ]
},
```

Trello card: https://trello.com/c/PdxP84XT/410-refactor-task-list-component-code
