### PR TITLE
Restore 'referer' field to feedback component form submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+
+* Restore 'referer' field to feedback component form submission (PR #232)
 * Create single breadrumb and sidebar contextual navigation components. Not a breaking change, but you can drop `govuk_navigation_helpers` as a dependency now.
 
 * You can now add require a single Javascript to include all components, just like CSS.

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -19,11 +19,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.$somethingIsWrongButton = $element.find('.js-something-is-wrong');
       this.$promptQuestions = $element.find('.js-prompt-questions');
       this.$promptSuccessMessage = $element.find('.js-prompt-success');
+      this.$somethingIsWrongForm = $element.find('#something-is-wrong');
 
       var that = this;
       var jshiddenClass = 'js-hidden';
 
       setInitialAriaAttributes();
+      setHiddenValues();
 
       this.$toggleForms.on('click', function(e) {
         e.preventDefault();
@@ -81,6 +83,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         that.$forms.attr('aria-hidden', true);
         that.$pageIsNotUsefulButton.attr('aria-expanded', false);
         that.$somethingIsWrongButton.attr('aria-expanded', false);
+      }
+
+      function setHiddenValues () {
+        that.$somethingIsWrongForm.append('<input type="hidden" name="javascript_enabled" value="true"/>');
+        that.$somethingIsWrongForm.append($('<input type="hidden" name="referrer">').val(document.referrer || "unknown"));
       }
 
       function updateAriaAttributes (linkClicked) {

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -104,6 +104,12 @@ describe("Feedback component", function () {
     expect($('.js-toggle-form[aria-controls="something-is-wrong"]').attr('aria-expanded')).toBe('false');
   });
 
+  it("should append a hidden 'referrer' field to the form", function() {
+    loadFeedbackComponent();
+
+    expect($('#something-is-wrong').find("[name=referrer]").val()).toBe("unknown");
+  });
+
   describe("clicking the 'page was useful' link", function () {
     it("displays a success message", function () {
       loadFeedbackComponent();
@@ -367,7 +373,9 @@ describe("Feedback component", function () {
         url: ["http://example.com/path/to/page"],
         what_doing: ["I was looking for some information about local government."],
         what_wrong: ["The background should be green."],
-        user_agent: ["Safari"]
+        user_agent: ["Safari"],
+        referrer: ["unknown"],
+        javascript_enabled: ["true"]
       });
     });
 


### PR DESCRIPTION
- was in original feedback form but I missed it when developing the new one
- is appended on page load with JS

Trello card: https://trello.com/c/vNYebDCP/193-new-feedback-component-does-not-pass-referrer
