### PR TITLE
Reduce spacing for margins on document list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Replace all individual includes with:
 //= require govuk_publishing_components/all_components
 ```
 
+* Update document list component with smaller margin spacing
+
 # 5.5.6
 
 * Add optional margin top flag for feedback component (PR #222)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -22,18 +22,10 @@
 }
 
 .gem-c-document-list--bottom-margin {
-  margin-bottom: $gutter-half;
-
-  @include media(tablet) {
-    margin-bottom: $gutter * 1.5;
-  }
+  margin-bottom: $gutter-two-thirds;
 }
 
 .gem-c-document-list--top-margin {
-  margin-top: $gutter-half;
-
-  @include media(tablet) {
-    margin-top: $gutter * 1.5;
-  }
+  margin-top: $gutter-two-thirds;
 }
 


### PR DESCRIPTION
We added the top and bottom margin flags for the document list component for use on topic pages.
However, the margin values are too large - we need to shrink them to work with our designs.