### PR TITLE
Version 5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# Unreleased
+# 5.6.0
 
 * Restore 'referer' field to feedback component form submission (PR #232)
+
 * Create single breadrumb and sidebar contextual navigation components. Not a breaking change, but you can drop `govuk_navigation_helpers` as a dependency now.
 
 * You can now add require a single Javascript to include all components, just like CSS.
@@ -12,7 +13,7 @@ Replace all individual includes with:
 //= require govuk_publishing_components/all_components
 ```
 
-* Update document list component with smaller margin spacing
+* Update document list component with smaller margin spacing (PR #234)
 
 # 5.5.6
 

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '5.5.6'.freeze
+  VERSION = '5.6.0'.freeze
 end


### PR DESCRIPTION
Includes the following changes:

 - Restore 'referer' field to feedback component form submission (PR #232)
- Create single breadrumb and sidebar contextual navigation components. Not a breaking change, but you can drop govuk_navigation_helpers as a dependency now.
- You can now add require a single Javascript to include all components, just like CSS.
- Update document list component with smaller margin spacing (PR #234)