### PR TITLE
Restore underline to step nav related links links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Restore underline to step nav related links links (PR #236)
 * Improve substep creation (PR #231)
 
 # 5.6.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
@@ -29,11 +29,3 @@
     margin-top: 5px;
   }
 }
-
-.gem-c-step-nav-related__link {
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
-}


### PR DESCRIPTION
Change to make the links in the step nav related links component more consistently styled with the rest of the site.

Before:

![screen shot 2018-03-21 at 11 45 43](https://user-images.githubusercontent.com/861310/37708125-7097e53a-2cfd-11e8-809e-35cee95f8d82.png)

After:

![screen shot 2018-03-21 at 11 45 53](https://user-images.githubusercontent.com/861310/37708133-757d803c-2cfd-11e8-81ff-48c37b06b05e.png)
