### PR TITLE
Tweak spacing for using inverse header on html pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Restore underline to step nav related links links (PR #236)
 * Improve substep creation (PR #231)
+* Improve spacing of inverse header to allow it to replace publication header component in government-frontend (PR #238)
 
 # 5.6.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (5.5.6)
+    govuk_publishing_components (5.6.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       govuk_navigation_helpers (~> 9.2.1)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -3,7 +3,8 @@
   background-color: $govuk-blue;
   color: $white;
   margin-bottom: $gutter;
-  padding: $gutter-half;
+  padding: $gutter-half $gutter $gutter;
+  box-sizing: border-box;
 }
 
 .gem-c-inverse-header a {
@@ -13,4 +14,5 @@
 .gem-c-inverse-header--full-width {
   padding-left: 0;
   padding-right: 0;
+  padding-bottom: $gutter-half;
 }

--- a/app/views/govuk_publishing_components/components/docs/inverse_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/inverse_header.yml
@@ -28,6 +28,17 @@ examples:
             Education, Training and Skills
           </h1>
         </div>
+  html_publication_header:
+    description: "The inverse header component is used on HTMl publications. [See example on GOV.UK here](https://www.gov.uk/government/publications/ln5-0at-jackson-homes-scopwick-ltd-environmental-permit-application-advertisement/ln5-0at-jackson-homes-scopwick-ltd-environmental-permit-application)"
+    data:
+      block: |
+        <div class="pub-c-title pub-c-title--inverse pub-c-title--bottom-margin">
+          <p class="pub-c-title__context">Notice</p>
+          <h1 class="pub-c-title__text">
+            LN5 0AT, Jackson Homes (Scopwick) Ltd: environmental permit application
+          </h1>
+        </div>
+        <p class="publication-header__last-changed">Published 22 April 2016</p>
   with_breadcrumbs_and_paragraph:
     data:
       block: |


### PR DESCRIPTION
Trello: https://trello.com/c/0pbli2e8/152-tech-debt-replace-publication-header-component-with-inverse-header-component
In Component Guide: https://govuk-publishing-compon-pr-238.herokuapp.com/component-guide/inverse_header

As the publication header and inverse header components are so similar, it makes sense to consolidate the two into one component.

To do this, we need to make a few spacing changes to the inverse header component so it works within the HTML publication layout.

This change should not break any current uses of the inverse header, e.g: on topic pages

**Before:**
<img width="997" alt="screen shot 2018-03-21 at 15 55 44" src="https://user-images.githubusercontent.com/29889908/37721002-6a7cd23c-2d20-11e8-9240-5bd4d30b6cbe.png">

**After:**
<img width="994" alt="screen shot 2018-03-21 at 15 56 18" src="https://user-images.githubusercontent.com/29889908/37721008-6f4f5d0c-2d20-11e8-88ed-4ed5981b43bd.png">

## On HTML Publications
This is how it will look on HTML publications:
<img width="1006" alt="screen shot 2018-03-21 at 15 57 44" src="https://user-images.githubusercontent.com/29889908/37721125-a9105d02-2d20-11e8-9d21-4a5369139a09.png">
