### PR TITLE
Fix visited link colour on focus for white feedback links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix visited link colour on focus for white feedback links (PR #239)
+
 # 5.7.0
 
 * Restore underline to step nav related links links (PR #236)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -77,6 +77,10 @@
 .gem-c-feedback__prompt-link:link,
 .gem-c-feedback__prompt-link:visited {
   color: $white;
+
+  &:focus {
+    color: $link-colour;
+  }
 }
 
 .gem-c-feedback__prompt-link--wrong {


### PR DESCRIPTION
When the link was visited (i.e. user had visited `/contact/govuk`, the
`:visited` styles would be more specific than the focus styles provided
by govuk_template, meaning the link would stay white and be hard to
read.

Steps to reproduce:
* Visit: https://www.gov.uk/contact/govuk
* Visit https://www.gov.uk/government/publications/vat-information-sheet-0218-impact-on-existing-cost-share-groups-following-changes-to-hmrcs-policy
* Focus "Is there anything wrong with the page"

## Before

![screen shot 2018-03-22 at 13 18 00](https://user-images.githubusercontent.com/319055/37773230-f13023c4-2dd4-11e8-9cb0-dc7da9c21430.png)

## After

![screen shot 2018-03-22 at 13 24 21](https://user-images.githubusercontent.com/319055/37773229-f118c2e2-2dd4-11e8-81e0-bdee2905e756.png)