### PR TITLE
Fix error styles on input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Fix visited link colour on focus for white feedback links (PR #239)
+* Fix input error colour
 
 # 5.7.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -25,12 +25,6 @@ input[type=text].gem-c-input {
 }
 // scss-lint:enable QualifyingElement
 
-@media (min-width: 40.0625em) {
-  .govuk-c-input {
-    margin-bottom: 30px;
-  }
-}
-
 .gem-c-input:focus {
   outline: $gem-focus-width solid $gem-focus-colour;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -22,20 +22,13 @@ input[type=text].gem-c-input {
 
   // Disable inner shadow and remove rounded corners
   appearance: none;
+
+  &.gem-c-input:focus {
+    outline: $gem-focus-width solid $gem-focus-colour;
+  }
+
+  &.gem-c-input--error {
+    border: $gem-border-width-error solid $gem-error-colour;
+  }
 }
 // scss-lint:enable QualifyingElement
-
-.gem-c-input:focus {
-  outline: $gem-focus-width solid $gem-focus-colour;
-}
-
-.gem-c-input--error {
-  border: $gem-border-width-error solid $gem-error-colour;
-}
-
-// Replace this with the error message component.
-.gem-c-input__label-error {
-  font-weight: bold;
-  color: $gem-error-colour;
-  padding-top: 4px;
-}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_label.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_label.scss
@@ -16,3 +16,10 @@
   color: $gem-secondary-text-colour;
   font-weight: 400;
 }
+
+// TODO: Replace this with the error message component.
+.gem-c-label__error {
+  font-weight: bold;
+  color: $gem-error-colour;
+  padding-top: 4px;
+}

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -12,7 +12,7 @@
   text: label[:text],
   html_for: id,
   hint_text: error_message,
-  hint_text_classes: "gem-c-input__label-error",
+  hint_text_classes: "gem-c-label__error",
   hint_id: hint_id,
   bold: error_message ? true : false,
 } %>

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -13,6 +13,8 @@ accessibility_criteria: |
   * be recognisable as form input elements
   * have correctly associated labels
   * be of the appropriate type for their use, e.g. password inputs should be of type 'password'
+
+  Labels use the [label component](/component-guide/label).
 examples:
   default:
     data:

--- a/app/views/govuk_publishing_components/components/docs/label.yml
+++ b/app/views/govuk_publishing_components/components/docs/label.yml
@@ -5,9 +5,17 @@ body: |
 
   Forked from the upcoming [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend), when GOV.UK Frontend release we can replace these source files.
 accessibility_criteria: |
-  - have a text contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+  All text must have a contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+
+  Labels must:
+
   - have visible text
-  - `hint_id` is matched with an `aria-describedby` property on the input your label is associated with.
+
+  Hint text must:
+
+  - be associated with an input. The `hint_id` must match the `aria-describedby` property on the input your label is associated with.
+
+  If hint text is within a label it will be announced in its entirity by screen readers. By putting the hint alongside labels and associating hints with inputs using `aria-describedby`, then screen readers will read the label, describe the type of input (eg radio) and then read additional text. It means users of screen readers can scan and skip options as easy as people making choices with sight. [A discussion of this approach](https://github.com/alphagov/govuk_elements/issues/574).
 examples:
   default:
     data:


### PR DESCRIPTION
Spotted on https://github.com/alphagov/email-alert-frontend/pull/183 where the error message wasn't showing in red as expected.

* Rearrange styling classes so that correct red text and borders apply to field
* Update documentation to clarify why hint text is not inside a label

See: https://govuk-publishing-compon-pr-241.herokuapp.com/component-guide/input

## Before
![screen shot 2018-03-23 at 15 44 17](https://user-images.githubusercontent.com/319055/37838943-233f7888-2eb1-11e8-8010-b3e3fe810eae.png)

## After
![screen shot 2018-03-23 at 15 43 59](https://user-images.githubusercontent.com/319055/37838944-23613c16-2eb1-11e8-93c2-f91afffb2eb5.png)
