### PR TITLE
Add shared helper for taxon breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix visited link colour on focus for white feedback links (PR #239)
 * Fix input error colour
+* Add helper for generating breadcrumbs on taxon and taxonomy-based finder pages
 
 # 5.7.0
 

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -7,6 +7,7 @@ require "govuk_publishing_components/presenters/navigation_type"
 
 require "govuk_publishing_components/app_helpers/step_nav"
 require "govuk_publishing_components/app_helpers/step_nav_helper"
+require "govuk_publishing_components/app_helpers/taxon_breadcrumbs"
 
 module GovukPublishingComponents
   StepNavHelper = GovukPublishingComponents::AppHelpers::StepNavHelper

--- a/lib/govuk_publishing_components/app_helpers/taxon_breadcrumbs.rb
+++ b/lib/govuk_publishing_components/app_helpers/taxon_breadcrumbs.rb
@@ -1,0 +1,81 @@
+module GovukPublishingComponents
+  module AppHelpers
+    class TaxonBreadcrumbs
+      # @param content_item A taxon
+      def initialize(content_item)
+        @content_item = TaxonBreadcrumbs::ContentItem.new(content_item)
+      end
+
+      # Generate a breadcrumb trail for a taxon, using the taxon_parent link field
+      #
+      # @return [Hash] Payload for the GOV.UK breadcrumbs component
+      # @see https://govuk-component-guide.herokuapp.com/components/breadcrumbs
+      def breadcrumbs
+        ordered_parents = all_parents.map.with_index do |parent, index|
+          {
+            title: parent.title,
+            url: parent.base_path,
+            is_page_parent: index.zero?
+          }
+        end
+
+        ordered_parents << {
+          title: "Home",
+          url: "/",
+          is_page_parent: ordered_parents.empty?
+        }
+
+        ordered_parents.reverse
+      end
+
+    private
+
+      attr_reader :content_item
+
+      def all_parents
+        parents = []
+
+        direct_parent = content_item.parent_taxon
+        while direct_parent
+          parents << direct_parent
+          direct_parent = direct_parent.parent_taxon
+        end
+
+        parents
+      end
+
+      class ContentItem
+        attr_reader :content_item
+
+        def initialize(content_item)
+          @content_item = content_item
+        end
+
+        def parent_taxon
+          parent_taxons.first
+        end
+
+        def parent_taxons
+          @_parent_taxons ||= begin
+            content_item.dig("links", "parent_taxons")
+              .to_a
+              .select { |t| phase_is_live?(t) }
+              .map { |taxon| ContentItem.new(taxon) }.sort_by(&:title)
+          end
+        end
+
+        def phase_is_live?(taxon)
+          taxon["phase"] == "live"
+        end
+
+        def title
+          content_item.fetch("title")
+        end
+
+        def base_path
+          content_item.fetch("base_path")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/app_helpers/taxon_breadcrumbs_spec.rb
+++ b/spec/lib/app_helpers/taxon_breadcrumbs_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+RSpec.describe GovukPublishingComponents::AppHelpers::TaxonBreadcrumbs do
+  describe "Taxon breadcrumbs" do
+    it "can handle any valid content item" do
+      payload = GovukSchemas::RandomExample.for_schema(
+        frontend_schema: "taxon",
+      )
+
+      expect {
+        described_class.new(payload).breadcrumbs
+      }.to_not raise_error
+    end
+
+    it "returns the root when taxon is not specified" do
+      content_item = {
+        "title" => "Some Content",
+        "document_type" => "answer",
+        "links" => {},
+      }
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        [
+          { title: "Home", url: "/", is_page_parent: true },
+        ]
+      )
+    end
+
+    it "places parent under the root when it's a root-level taxon" do
+      content_item = taxon_with_parent_taxons([])
+
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        [
+          { title: "Home", url: "/", is_page_parent: true },
+        ]
+      )
+    end
+
+    context 'with a taxon with taxon parents' do
+      it "includes parents and grandparents when available" do
+        grandparent = {
+          "title" => "Another-parent",
+          "base_path" => "/another-parent",
+          "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+          "locale" => "en",
+          "phase" => "live",
+        }
+
+        parent = {
+          "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+          "locale" => "en",
+          "title" => "A-parent",
+          "base_path" => "/a-parent",
+          "phase" => "live",
+          "links" => {
+            "parent_taxons" => [grandparent]
+          }
+        }
+
+        content_item = taxon_with_parent_taxons([parent])
+        breadcrumbs = breadcrumbs_for(content_item)
+
+        expect(breadcrumbs).to eq(
+          [
+            { title: "Home", url: "/", is_page_parent: false },
+            { title: "Another-parent", url: "/another-parent", is_page_parent: false },
+            { title: "A-parent", url: "/a-parent", is_page_parent: true },
+          ]
+        )
+      end
+    end
+  end
+
+  def breadcrumbs_for(content_item)
+    fully_valid_content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: content_item["document_type"]) do |random_item|
+      random_item.merge(content_item)
+    end
+
+    described_class.new(fully_valid_content_item).breadcrumbs
+  end
+
+  def taxon_with_parent_taxons(parents)
+    {
+      "title" => "Taxon",
+      "document_type" => "taxon",
+      "links" => {
+        "parent_taxons" => parents,
+      },
+    }
+  end
+end


### PR DESCRIPTION
These breadcrumbs are shown on the new finder pages (finder-frontend) and the new topic pages (collections).

cc @steventux @leenagupte 

https://trello.com/c/WJlqy3VD