### PR TITLE
Merge in govuk_navigation_helpers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     govuk_publishing_components (5.7.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
-      govuk_navigation_helpers (~> 9.2.1)
       rails (>= 5.0.0.1)
       rake
       rouge
@@ -105,14 +104,9 @@ GEM
       rubocop (~> 0.51.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
-    govuk_ab_testing (2.4.1)
     govuk_frontend_toolkit (7.4.2)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (9.2.1)
-      activesupport (~> 5.1)
-      gds-api-adapters (>= 43.0)
-      govuk_ab_testing (~> 2.4)
     govuk_schemas (3.1.0)
       json-schema (~> 2.8.0)
     hashdiff (0.3.7)

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -24,9 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency "rouge"
   s.add_dependency "rake"
 
-  # TODO: merge this govuk_navigation_helpers into this gem
-  s.add_dependency "govuk_navigation_helpers", "~> 9.2.1"
-
   s.add_development_dependency "govuk-lint", "~> 3.3"
   s.add_development_dependency "rspec-rails", "~> 3.6"
   s.add_development_dependency "capybara", "~> 2.14.4"

--- a/lib/govuk_navigation_helpers.rb
+++ b/lib/govuk_navigation_helpers.rb
@@ -1,0 +1,55 @@
+require 'active_support'
+require 'active_support/core_ext/hash/keys'
+require 'active_support/core_ext/object/blank'
+
+require_relative "govuk_navigation_helpers/breadcrumbs"
+require_relative "govuk_navigation_helpers/related_items"
+require_relative "govuk_navigation_helpers/taxon_breadcrumbs"
+require_relative "govuk_navigation_helpers/taxonomy_sidebar"
+require_relative "govuk_navigation_helpers/rummager_taxonomy_sidebar_links"
+require_relative "govuk_navigation_helpers/curated_taxonomy_sidebar_links"
+
+module GovukNavigationHelpers
+  class NavigationHelper
+    def initialize(content_item)
+      @content_item = content_item
+    end
+
+    # Generate a breadcrumb trail
+    #
+    # @return [Hash] Payload for the GOV.UK breadcrumbs component
+    # @see http://govuk-component-guide.herokuapp.com/components/breadcrumbs
+    def breadcrumbs
+      Breadcrumbs.new(content_item).breadcrumbs
+    end
+
+    # Generate a breadcrumb trail for a taxon, using the taxon_parent link field
+    #
+    # @return [Hash] Payload for the GOV.UK breadcrumbs component
+    # @see http://govuk-component-guide.herokuapp.com/components/breadcrumbs
+    def taxon_breadcrumbs
+      TaxonBreadcrumbs.new(content_item).breadcrumbs
+    end
+
+    # Generate a payload containing taxon sidebar data. Intended for use with
+    # the related items component.
+    #
+    # @return [Hash] Payload for the GOV.UK related items component
+    # @see http://govuk-component-guide.herokuapp.com/components/related_items
+    def taxonomy_sidebar
+      TaxonomySidebar.new(content_item).sidebar
+    end
+
+    # Generate a related items payload
+    #
+    # @return [Hash] Payload for the GOV.UK Component
+    # @see http://govuk-component-guide.herokuapp.com/components/related_items
+    def related_items
+      RelatedItems.new(content_item).related_items
+    end
+
+  private
+
+    attr_reader :content_item
+  end
+end

--- a/lib/govuk_navigation_helpers/breadcrumbs.rb
+++ b/lib/govuk_navigation_helpers/breadcrumbs.rb
@@ -1,0 +1,36 @@
+module GovukNavigationHelpers
+  class Breadcrumbs
+    def initialize(content_item)
+      @content_item = ContentItem.new(content_item)
+    end
+
+    def breadcrumbs
+      ordered_parents = all_parents.map do |parent|
+        { title: parent.title, url: parent.base_path }
+      end
+
+      ordered_parents << { title: "Home", url: "/" }
+
+      {
+        breadcrumbs: ordered_parents.reverse
+      }
+    end
+
+  private
+
+    attr_reader :content_item
+
+    def all_parents
+      parents = []
+
+      direct_parent = content_item.parent
+      while direct_parent
+        parents << direct_parent
+
+        direct_parent = direct_parent.parent
+      end
+
+      parents
+    end
+  end
+end

--- a/lib/govuk_navigation_helpers/configuration.rb
+++ b/lib/govuk_navigation_helpers/configuration.rb
@@ -1,0 +1,35 @@
+module GovukNavigationHelpers
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield configuration if block_given?
+  end
+
+  class Configuration
+    attr_writer :error_handler, :statsd
+
+    def error_handler
+      @error_handler ||= NoErrorHandler.new
+    end
+
+    def statsd
+      @statsd ||= NoStatsd.new
+    end
+
+    class NoStatsd
+      def increment(*); end
+
+      def time(*)
+        yield
+      end
+    end
+
+    class NoErrorHandler
+      def notify(exception, *_args)
+        puts exception
+      end
+    end
+  end
+end

--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -1,0 +1,154 @@
+module GovukNavigationHelpers
+  # Simple wrapper around a content store representation of a content item.
+  # Works for both the main content item and the expanded links in the links
+  # hash.
+  #
+  # @private
+  class ContentItem
+    attr_reader :content_store_response
+
+    def initialize(content_store_response)
+      @content_store_response = content_store_response.to_h
+    end
+
+    def parent
+      parent_item = content_store_response.dig("links", "parent", 0)
+      return unless parent_item
+      ContentItem.new(parent_item)
+    end
+
+    def parent_taxon
+      # TODO: Determine what to do when there are multiple taxons/parents. For
+      # now just display the first of each.
+      parent_taxons.sort_by(&:title).first
+    end
+
+    def parent_taxons
+      @_parent_taxons ||= begin
+        taxon_links
+          .select { |t| phase_is_live?(t) }
+          .map { |taxon| ContentItem.new(taxon) }.sort_by(&:title)
+      end
+    end
+
+    def phase_is_live?(taxon)
+      taxon["phase"] == "live"
+    end
+
+    def mainstream_browse_pages
+      content_store_response.dig("links", "mainstream_browse_pages").to_a.map do |link|
+        ContentItem.new(link)
+      end
+    end
+
+    def title
+      content_store_response.fetch("title")
+    end
+
+    def base_path
+      content_store_response.fetch("base_path")
+    end
+
+    def description
+      content_store_response.fetch("description", "")
+    end
+
+    def content_id
+      content_store_response.fetch("content_id")
+    end
+
+    def related_links
+      content_store_response.dig("links", "ordered_related_items").to_a.map do |link|
+        ContentItem.new(link)
+      end
+    end
+
+    def curated_taxonomy_sidebar_links
+      content_store_response.dig("links", "ordered_related_items_overrides").to_a.map do |link|
+        ContentItem.new(link)
+      end
+    end
+
+    def related_ordered_items
+      content_store_response.dig("links", "ordered_related_items").to_a
+    end
+
+    def quick_links
+      content_store_response.dig("details", "quick_links").to_a
+    end
+
+    def related_collections
+      filter_link_type(content_store_response.dig("links", "document_collections").to_a, "document_collection")
+    end
+
+    def related_other_contacts
+      filter_link_type(content_store_response.dig("links", "related").to_a, "contact")
+    end
+
+    def related_organisations
+      filter_link_type(content_store_response.dig("links", "organisations").to_a, "organisation")
+    end
+
+    def related_policies
+      filter_link_type(content_store_response.dig("links", "related_policies").to_a, "policy")
+    end
+
+    def related_statistical_data_sets
+      filter_link_type(content_store_response.dig("links", "related_statistical_data_sets").to_a, "statistical_data_set")
+    end
+
+    def related_topics
+      filter_link_type(content_store_response.dig("links", "topics").to_a, "topic")
+    end
+
+    def related_topical_events
+      filter_link_type(content_store_response.dig("links", "topical_events").to_a, "topical_event")
+    end
+
+    def related_world_locations
+      content_store_response.dig("links", "world_locations").to_a
+    end
+
+    def related_worldwide_organisations
+      filter_link_type(content_store_response.dig("links", "worldwide_organisations").to_a, "worldwide_organisation")
+    end
+
+    def external_links
+      content_store_response.dig("details", "external_related_links").to_a
+    end
+
+    def as_taxonomy_sidebar_link
+      {
+        title: title,
+        link: base_path,
+      }
+    end
+
+    def ==(other)
+      content_id == other.content_id
+    end
+
+    def hash
+      content_id.hash
+    end
+
+    def eql?(other)
+      self == other
+    end
+
+  private
+
+    def taxon_links
+      # A normal content item's taxon links are stored in ["links"]["taxons"]
+      # whereas a Taxon content item's taxon links are stored in ["links"]["parent_taxons"]
+      # so here we cater for both possibilities
+      content_store_response.dig("links", "taxons") || content_store_response.dig("links", "parent_taxons") || []
+    end
+
+    def filter_link_type(links, type)
+      links.select do |link|
+        link["document_type"] == type
+      end
+    end
+  end
+end

--- a/lib/govuk_navigation_helpers/curated_taxonomy_sidebar_links.rb
+++ b/lib/govuk_navigation_helpers/curated_taxonomy_sidebar_links.rb
@@ -1,0 +1,96 @@
+require 'set'
+
+module GovukNavigationHelpers
+  class CuratedTaxonomySidebarLinks
+    def initialize(content_item)
+      @content_item = content_item
+    end
+
+    def related_items
+      @related_items ||=
+        taxon_links +
+        elsewhere_on_gov_uk_links +
+        elsewhere_on_the_web_links
+    end
+
+  private
+
+    def taxon_links
+      @content_item.parent_taxons.map do |taxon|
+        {
+          title: taxon.title,
+          url: taxon.base_path,
+          description: taxon.description,
+          related_content: format_for_sidebar(related_content_by_taxon[taxon]),
+        }
+      end
+    end
+
+    def elsewhere_on_gov_uk_links
+      elsewhere_items = related_content_elsewhere_on_govuk
+      return [] if elsewhere_items.empty?
+
+      [
+        {
+          title: 'Elsewhere on GOV.UK',
+          related_content: format_for_sidebar(elsewhere_items),
+        },
+      ]
+    end
+
+    def elsewhere_on_the_web_links
+      return [] if @content_item.external_links.empty?
+
+      external_links = @content_item.external_links.map do |link|
+        {
+          title: link['title'],
+          link: link['url'],
+        }
+      end
+
+      [
+        {
+          title: 'Elsewhere on the web',
+          related_content: external_links,
+        },
+      ]
+    end
+
+    def related_content_by_taxon
+      @related_items_by_taxon ||= begin
+        curated_related_items = @content_item.curated_taxonomy_sidebar_links.to_set
+
+        @content_item.parent_taxons.each_with_object({}) do |taxon, items_by_taxon|
+          items_related_to_taxon = filter_items_by_taxon(curated_related_items, taxon)
+          items_by_taxon[taxon] = items_related_to_taxon
+          curated_related_items = undisplayed_items(curated_related_items, items_related_to_taxon)
+        end
+      end
+    end
+
+    def related_content_elsewhere_on_govuk
+      @related_content_elsewhere_on_govuk ||= begin
+        related_content = @content_item.curated_taxonomy_sidebar_links.to_set
+        related_taxon_content = related_content_by_taxon.values.flatten.to_set
+        related_content - related_taxon_content
+      end
+    end
+
+    def filter_items_by_taxon(items, taxon)
+      items.select do |item|
+        item.parent_taxons.include?(taxon)
+      end
+    end
+
+    def undisplayed_items(all_items, displayed_items)
+      all_items - displayed_items
+    end
+
+    def format_for_sidebar(collection)
+      collection
+        .to_a
+        .sort_by(&:title)
+        .map(&:as_taxonomy_sidebar_link)
+    end
+  end
+end

--- a/lib/govuk_navigation_helpers/grouped_related_links.rb
+++ b/lib/govuk_navigation_helpers/grouped_related_links.rb
@@ -1,0 +1,47 @@
+module GovukNavigationHelpers
+  # Take a content item and group the related links according to an algorithm
+  # that is intended to display the related links into three groups, depending
+  # on how much they have in common with the main content item.
+  #
+  # @private
+  class GroupedRelatedLinks
+    attr_reader :content_item
+
+    def initialize(content_item)
+      @content_item = content_item
+    end
+
+    # This will return related items that are tagged to the same mainstream
+    # browse page as the main content item.
+    def tagged_to_same_mainstream_browse_page
+      return [] unless content_item.parent
+
+      @tagged_to_same_mainstream_browse_page ||= content_item.related_links.select do |related_item|
+        related_item.mainstream_browse_pages.map(&:content_id).include?(content_item.parent.content_id)
+      end
+    end
+
+    # This will return related items whose parents are tagged to the same mainstream
+    # browse page as the main content item's parent.
+    def parents_tagged_to_same_mainstream_browse_page
+      return [] unless content_item.parent && content_item.parent.parent
+
+      common_parent_content_ids = tagged_to_same_mainstream_browse_page.map(&:content_id)
+
+      @parents_tagged_to_same_mainstream_browse_page ||= content_item.related_links.select do |related_item|
+        next if common_parent_content_ids.include?(related_item.content_id)
+        related_item.mainstream_browse_pages.map(&:parent).map(&:content_id).include?(content_item.parent.parent.content_id)
+      end
+    end
+
+    # This will return related links that are tagged to mainstream browse
+    # pages unrelated to the main content item.
+    def tagged_to_different_mainstream_browse_pages
+      all_content_ids = (tagged_to_same_mainstream_browse_page + parents_tagged_to_same_mainstream_browse_page).map(&:content_id)
+
+      @tagged_to_different_mainstream_browse_pages ||= content_item.related_links.reject do |related_item|
+        all_content_ids.include?(related_item.content_id)
+      end
+    end
+  end
+end

--- a/lib/govuk_navigation_helpers/related_items.rb
+++ b/lib/govuk_navigation_helpers/related_items.rb
@@ -1,0 +1,92 @@
+require 'govuk_navigation_helpers/grouped_related_links'
+require 'govuk_navigation_helpers/content_item'
+
+module GovukNavigationHelpers
+  # Generate data for the "Related Items" component
+  #
+  # http://govuk-component-guide.herokuapp.com/components/related_items
+  #
+  # The procedure to group the links is quite complicated. In short, related links
+  # are grouped by how related they are to the current page.
+  #
+  # The wiki page on related items has more information:
+  #
+  # https://gov-uk.atlassian.net/wiki/pages/viewpage.action?pageId=99876878
+  class RelatedItems
+    def initialize(content_item)
+      @content_item = ContentItem.new(content_item)
+    end
+
+    def related_items
+      {
+        sections: [
+          tagged_to_same_mainstream_browse_page_section,
+          parents_tagged_to_same_mainstream_browse_page_section,
+          tagged_to_different_mainstream_browse_pages_section,
+          related_external_links_section,
+        ].compact
+      }
+    end
+
+  private
+
+    attr_reader :content_item
+
+    def tagged_to_same_mainstream_browse_page_section
+      return unless grouped.tagged_to_same_mainstream_browse_page.any?
+
+      items = grouped.tagged_to_same_mainstream_browse_page.map do |related_item|
+        {
+          title: related_item.title,
+          url: related_item.base_path
+        }
+      end
+
+      { title: content_item.parent.title, url: content_item.parent.base_path, items: items }
+    end
+
+    def parents_tagged_to_same_mainstream_browse_page_section
+      return unless grouped.parents_tagged_to_same_mainstream_browse_page.any?
+
+      items = grouped.parents_tagged_to_same_mainstream_browse_page.map do |related_item|
+        {
+          title: related_item.title,
+          url: related_item.base_path
+        }
+      end
+
+      { title: content_item.parent.parent.title, url: content_item.parent.parent.base_path, items: items }
+    end
+
+    def tagged_to_different_mainstream_browse_pages_section
+      return unless grouped.tagged_to_different_mainstream_browse_pages.any?
+
+      items = grouped.tagged_to_different_mainstream_browse_pages.map do |related_item|
+        {
+          title: related_item.title,
+          url: related_item.base_path
+        }
+      end
+
+      { title: "Elsewhere on GOV.UK", items: items }
+    end
+
+    def related_external_links_section
+      return unless content_item.external_links.any?
+
+      items = content_item.external_links.map do |h|
+        {
+          title: h.fetch("title"),
+          url: h.fetch("url"),
+          rel: "external"
+        }
+      end
+
+      { title: "Elsewhere on the web", items: items }
+    end
+
+    def grouped
+      @grouped ||= GroupedRelatedLinks.new(content_item)
+    end
+  end
+end

--- a/lib/govuk_navigation_helpers/rummager_taxonomy_sidebar_links.rb
+++ b/lib/govuk_navigation_helpers/rummager_taxonomy_sidebar_links.rb
@@ -1,0 +1,61 @@
+module GovukNavigationHelpers
+  class RummagerTaxonomySidebarLinks
+    def initialize(content_item)
+      @content_item = content_item
+    end
+
+    def related_items
+      parent_taxons = @content_item.parent_taxons
+      used_related_links = Set.new
+
+      parent_taxons.each_with_index.map do |parent_taxon, index|
+        related_content = index < 2 ? content_related_to(parent_taxon, used_related_links) : []
+
+        used_related_links.merge(
+          related_content.map { |content| content[:link] }
+        )
+
+        {
+          title: parent_taxon.title,
+          url: parent_taxon.base_path,
+          description: parent_taxon.description,
+          related_content: related_content,
+        }
+      end
+    end
+
+  private
+
+    # This method will fetch content related to content_item, and tagged to taxon. This is a
+    # temporary method that uses search to achieve this. This behaviour is to be moved into
+    # the content store
+    def content_related_to(taxon, used_related_links)
+      statsd.time(:taxonomy_sidebar_search_time) do
+        begin
+          results = Services.rummager.search(
+            similar_to: @content_item.base_path,
+            start: 0,
+            count: 3,
+            filter_taxons: [taxon.content_id],
+            filter_navigation_document_supertype: 'guidance',
+            reject_link: used_related_links.to_a,
+            fields: %w[title link],
+          )['results']
+
+          statsd.increment(:taxonomy_sidebar_searches)
+
+          results
+            .map { |result| { title: result['title'], link: result['link'], } }
+            .sort_by { |result| result[:title] }
+        rescue StandardError => e
+          GovukNavigationHelpers.configuration.error_handler.notify(e)
+          []
+        end
+      end
+    end
+
+    def statsd
+      GovukNavigationHelpers.configuration.statsd
+    end
+  end
+end

--- a/lib/govuk_navigation_helpers/services.rb
+++ b/lib/govuk_navigation_helpers/services.rb
@@ -1,0 +1,9 @@
+require 'gds_api/rummager'
+
+module GovukNavigationHelpers
+  module Services
+    def self.rummager
+      @rummager ||= GdsApi::Rummager.new(Plek.find('rummager'))
+    end
+  end
+end

--- a/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
+++ b/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
@@ -1,0 +1,43 @@
+module GovukNavigationHelpers
+  class TaxonBreadcrumbs
+    def initialize(content_item)
+      @content_item = ContentItem.new(content_item)
+    end
+
+    def breadcrumbs
+      ordered_parents = all_parents.map.with_index do |parent, index|
+        {
+          title: parent.title,
+          url: parent.base_path,
+          is_page_parent: index.zero?
+        }
+      end
+
+      ordered_parents << {
+        title: "Home",
+        url: "/",
+        is_page_parent: ordered_parents.empty?
+      }
+
+      {
+        breadcrumbs: ordered_parents.reverse
+      }
+    end
+
+  private
+
+    attr_reader :content_item
+
+    def all_parents
+      parents = []
+
+      direct_parent = content_item.parent_taxon
+      while direct_parent
+        parents << direct_parent
+        direct_parent = direct_parent.parent_taxon
+      end
+
+      parents
+    end
+  end
+end

--- a/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
+++ b/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
@@ -1,0 +1,47 @@
+require 'govuk_navigation_helpers/services'
+require 'govuk_navigation_helpers/configuration'
+
+module GovukNavigationHelpers
+  class TaxonomySidebar
+    def initialize(content_item)
+      @content_item = ContentItem.new content_item
+    end
+
+    def sidebar
+      {
+        items: related_items,
+        collections: collections,
+      }
+    end
+
+  private
+
+    def there_are_related_item_overrides?
+      # TODO: We should check for any external links when we have "new"
+      # external links being curated in Content Tagger
+      @content_item.curated_taxonomy_sidebar_links.any?
+    end
+
+    def related_items
+      related_items_factory.new(@content_item).related_items
+    end
+
+    def related_items_factory
+      if there_are_related_item_overrides?
+        CuratedTaxonomySidebarLinks
+      else
+        RummagerTaxonomySidebarLinks
+      end
+    end
+
+    def collections
+      links = @content_item.related_collections
+      links.map do |link|
+        {
+          path: link["base_path"],
+          text: link["title"]
+        }
+      end
+    end
+  end
+end

--- a/spec/govuk_navigation_helpers/breadcrumbs_spec.rb
+++ b/spec/govuk_navigation_helpers/breadcrumbs_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+RSpec.describe GovukNavigationHelpers::Breadcrumbs do
+  describe "#breadcrumbs" do
+    it "can handle any valid content item" do
+      payload = GovukSchemas::RandomExample.for_schema(frontend_schema: "placeholder")
+
+      expect { GovukNavigationHelpers::Breadcrumbs.new(payload).breadcrumbs }.to_not raise_error
+    end
+
+    it "returns the root when parent is not specified" do
+      content_item = { "links" => {} }
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        breadcrumbs: [
+          { title: "Home", url: "/" },
+        ]
+      )
+    end
+
+    it "returns the root when parent is empty" do
+      content_item = content_item_with_parents([])
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        breadcrumbs: [
+          { title: "Home", url: "/" },
+        ]
+      )
+    end
+
+    it "places parent under the root when there is a parent" do
+      parent = {
+        "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+        "locale" => "en",
+        "title" => "A-parent",
+        "base_path" => "/a-parent",
+      }
+
+      content_item = content_item_with_parents([parent])
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        breadcrumbs: [
+          { title: "Home", url: "/" },
+          { title: "A-parent", url: "/a-parent" }
+        ]
+      )
+    end
+
+    it "includes grandparent when available" do
+      grandparent = {
+        "title" => "Another-parent",
+        "base_path" => "/another-parent",
+        "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+        "locale" => "en",
+      }
+
+      parent = {
+        "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+        "locale" => "en",
+        "title" => "A-parent",
+        "base_path" => "/a-parent",
+        "links" => {
+          "parent" => [grandparent]
+        }
+      }
+
+      content_item = content_item_with_parents([parent])
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        breadcrumbs: [
+          { title: "Home", url: "/" },
+          { title: "Another-parent", url: "/another-parent" },
+          { title: "A-parent", url: "/a-parent" }
+        ]
+      )
+    end
+  end
+
+  def content_item_with_parents(parents)
+    {
+      "links" => { "parent" => parents }
+    }
+  end
+
+  def breadcrumbs_for(content_item)
+    fully_valid_content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "placeholder") do |random_item|
+      random_item.merge(content_item)
+    end
+
+    # Use the main class instead of GovukNavigationHelpers::Breadcrumbs, so that
+    # we're testing both at the same time.
+    GovukNavigationHelpers::NavigationHelper.new(fully_valid_content_item).breadcrumbs
+  end
+end

--- a/spec/govuk_navigation_helpers/content_item_spec.rb
+++ b/spec/govuk_navigation_helpers/content_item_spec.rb
@@ -1,0 +1,197 @@
+require "spec_helper"
+
+RSpec.describe GovukNavigationHelpers::ContentItem do
+  describe "#parent_taxons" do
+    context "for a content item with taxons links" do
+      context "with a parent taxon with phase set to 'live'" do
+        let(:taxon) do
+          {
+            "content_id" => "cccc-dddd",
+            "title" => "Taxon",
+            "phase" => "live",
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "content_id" => "aaaa-bbbb",
+                  "title" => "Taxon",
+                }
+              ]
+            }
+          }
+        end
+
+        let(:content_item_response) do
+          {
+            "title" => "Some Answer Content Item",
+            "document_type" => "answer",
+            "links" => {
+              "taxons" => [taxon],
+            }
+          }
+        end
+
+        it "returns the parent taxons" do
+          expected_parent_taxon = described_class.new(taxon)
+          expect(described_class.new(content_item_response).parent_taxons).to contain_exactly(expected_parent_taxon)
+        end
+      end
+
+      context "with a parent taxon with phase not set to 'live'" do
+        let(:taxon) do
+          {
+            "content_id" => "cccc-dddd",
+            "title" => "Taxon",
+            "phase" => "beta",
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "content_id" => "xxxx-xxxx",
+                  "title" => "Non Whitelisted Taxon",
+                }
+              ]
+            }
+          }
+        end
+
+        let(:content_item_response) do
+          {
+            "title" => "Some Answer Content Item",
+            "document_type" => "answer",
+            "links" => {
+              "taxons" => [taxon],
+            }
+          }
+        end
+
+        it "returns an empty array" do
+          expect(described_class.new(content_item_response).parent_taxons).to eq([])
+        end
+      end
+    end
+
+    context "for a content item with no taxons links" do
+      context "with missing links hash" do
+        let(:content_item_response) do
+          {
+            "title" => "Some Answer Content Item",
+            "document_type" => "answer",
+          }
+        end
+
+        it "returns an empty array" do
+          expect(described_class.new(content_item_response).parent_taxons).to eq([])
+        end
+      end
+
+      context "with missing taxons links hash" do
+        let(:content_item_response) do
+          {
+            "title" => "Some Answer Content Item",
+            "document_type" => "answer",
+            "links" => {},
+          }
+        end
+
+        it "returns an empty array" do
+          expect(described_class.new(content_item_response).parent_taxons).to eq([])
+        end
+      end
+    end
+
+    context "for a taxon content item with parent taxon links" do
+      context "with a parent taxon with phase set to 'live'" do
+        let(:taxon) do
+          {
+            "content_id" => "cccc-dddd",
+            "title" => "Taxon",
+            "phase" => "live",
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "content_id" => "aaaa-bbbb",
+                  "title" => "Taxon",
+                }
+              ]
+            }
+          }
+        end
+
+        let(:content_item_response) do
+          {
+            "title" => "Some Taxon Content Item",
+            "document_type" => "taxon",
+            "links" => {
+              "parent_taxons" => [taxon],
+            }
+          }
+        end
+
+        it "returns the parent taxons" do
+          expected_parent_taxon = described_class.new(taxon)
+          expect(described_class.new(content_item_response).parent_taxons).to contain_exactly(expected_parent_taxon)
+        end
+      end
+
+      context "with a parent taxon with phase not set to 'live'" do
+        let(:taxon) do
+          {
+            "content_id" => "cccc-dddd",
+            "title" => "Taxon",
+            "phase" => "beta",
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "content_id" => "xxxx-xxxx",
+                  "title" => "Non Whitelisted Taxon",
+                }
+              ]
+            }
+          }
+        end
+
+        let(:content_item_response) do
+          {
+            "title" => "Some Taxon Content Item",
+            "document_type" => "taxon",
+            "links" => {
+              "parent_taxons" => [taxon],
+            }
+          }
+        end
+
+        it "returns an empty array" do
+          expect(described_class.new(content_item_response).parent_taxons).to eq([])
+        end
+      end
+    end
+
+    context "for a taxon content item with no parent taxons links" do
+      context "with missing links hash" do
+        let(:content_item_response) do
+          {
+            "title" => "Some Taxon Content Item",
+            "document_type" => "taxon",
+          }
+        end
+
+        it "returns an empty array" do
+          expect(described_class.new(content_item_response).parent_taxons).to eq([])
+        end
+      end
+
+      context "with missing parent taxons links hash" do
+        let(:content_item_response) do
+          {
+            "title" => "Some Taxon Content Item",
+            "document_type" => "taxon",
+            "links" => {},
+          }
+        end
+
+        it "returns an empty array" do
+          expect(described_class.new(content_item_response).parent_taxons).to eq([])
+        end
+      end
+    end
+  end
+end

--- a/spec/govuk_navigation_helpers/related_items_spec.rb
+++ b/spec/govuk_navigation_helpers/related_items_spec.rb
@@ -1,0 +1,268 @@
+require "spec_helper"
+
+RSpec.describe GovukNavigationHelpers::RelatedItems do
+  def payload_for(content_item)
+    fully_valid_content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "placeholder") do |random_item|
+      random_item.merge(content_item)
+    end
+    GovukNavigationHelpers::NavigationHelper.new(fully_valid_content_item).related_items
+  end
+
+  describe "#related_items" do
+    it "can handle randomly generated content" do
+      payload = GovukSchemas::RandomExample.for_schema(frontend_schema: "placeholder")
+
+      expect { payload_for(payload) }.to_not raise_error
+    end
+
+    it "returns nothing if there are no related links" do
+      nothing = payload_for(
+        "details" => {
+          "external_related_links" => []
+        },
+        "links" => {
+        }
+      )
+
+      expect(nothing).to eql(sections: [])
+    end
+
+    it "returns an elswhere on GOV.UK section for related items with no browse pages in common" do
+      payload = payload_for(
+        "details" => {
+          "external_related_links" => []
+        },
+        "links" => {
+          "ordered_related_items" => [
+            {
+              "title" => "Foo",
+              "content_id" => "fdbf634c-06f5-43ea-915a-53b34b660353",
+              "base_path" => "/foo",
+              "locale" => "en"
+            }
+          ]
+        }
+      )
+
+      expect(payload).to eql(
+        sections: [
+          {
+            title: "Elsewhere on GOV.UK",
+            items: [
+              { title: "Foo", url: "/foo" },
+            ]
+          },
+        ]
+      )
+    end
+
+    it "returns the external related links" do
+      payload = payload_for(
+        "details" => {
+          "external_related_links" => [
+            { "title" => "Foo", "url" => "https://example.org/foo" },
+            { "title" => "Bar", "url" => "https://example.org/bar" }
+          ]
+        },
+        "links" => {
+        }
+      )
+
+      expect(payload).to eql(
+        sections: [
+          {
+            title: "Elsewhere on the web",
+            items: [
+              { title: "Foo", url: "https://example.org/foo", rel: "external" },
+              { title: "Bar", url: "https://example.org/bar", rel: "external" },
+            ]
+          },
+        ]
+      )
+    end
+
+    it "returns a primary section for related items tagged to the same mainstream browse page as the item" do
+      payload = payload_for(
+        "details" => {
+          "external_related_links" => []
+        },
+        "links" => {
+          "parent" => [
+            {
+              "title" => "Foo's parent",
+              "content_id" => "a9c6f24a-92a1-4ead-a776-532d1d99123c",
+              "base_path" => "/foo-parent",
+              "locale" => "en"
+            }
+          ],
+          "ordered_related_items" => [
+            {
+              "content_id" => "9effaabe-346d-4ad0-9c1b-baa49bc084d6",
+              "title" => "Foo",
+              "base_path" => "/bar",
+              "locale" => "en",
+              "links" => {
+                "mainstream_browse_pages" => [
+                  {
+                    "title" => "Foo's parent",
+                    "content_id" => "a9c6f24a-92a1-4ead-a776-532d1d99123c",
+                    "base_path" => "/foo-parent",
+                    "locale" => "en"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      )
+
+      expect(payload).to eql(
+        sections: [
+          {
+            title: "Foo's parent",
+            url: "/foo-parent",
+            items: [
+              { title: "Foo", url: "/bar" },
+            ]
+          },
+        ]
+      )
+    end
+
+    it "returns a secondary section for related items tagged to the same mainstream browse page as the item's parent" do
+      payload = payload_for(
+        "details" => {
+          "external_related_links" => []
+        },
+        "links" => {
+          "parent" => [
+            {
+              "title" => "Foo's parent",
+              "content_id" => "67c28e19-9934-462c-b174-db5b8e566384",
+              "base_path" => "/foo-parent",
+              "locale" => "en",
+              "links" => {
+                "parent" => [
+                  {
+                    "title" => "Foo's grandparent",
+                    "content_id" => "a9c6f24a-92a1-4ead-a776-532d1d99123c",
+                    "base_path" => "/foo-grand-parent",
+                    "locale" => "en",
+                  }
+                ]
+              }
+            }
+          ],
+          "ordered_related_items" => [
+            {
+              "content_id" => "9effaabe-346d-4ad0-9c1b-baa49bc084d6",
+              "title" => "Foo",
+              "base_path" => "/bar",
+              "locale" => "en",
+              "links" => {
+                "mainstream_browse_pages" => [
+                  {
+                    "title" => "Some sibling of foo-parent",
+                    "content_id" => "c34672dc-2ff3-4d28-92fd-bcba382e8a0b",
+                    "base_path" => "/foo-sibling",
+                    "locale" => "en",
+                    "links" => {
+                      "parent" => [
+                        {
+                          "title" => "Foo's grandparent",
+                          "content_id" => "a9c6f24a-92a1-4ead-a776-532d1d99123c",
+                          "base_path" => "/foo-grand-parent",
+                          "locale" => "en",
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      )
+
+      expect(payload).to eql(
+        sections: [
+          {
+            title: "Foo's grandparent",
+            url: "/foo-grand-parent",
+            items: [
+              { title: "Foo", url: "/bar" },
+            ]
+          },
+        ]
+      )
+    end
+
+    it "returns only related items in the primary section where they are tagged to the same mainstream browse pages as both the item and the item's parent" do
+      payload = payload_for(
+        "details" => {
+          "external_related_links" => []
+        },
+        "links" => {
+          "parent" => [
+            {
+              "title" => "Foo's parent",
+              "content_id" => "67c28e19-9934-462c-b174-db5b8e566384",
+              "base_path" => "/foo-parent",
+              "locale" => "en",
+              "links" => {
+                "parent" => [
+                  {
+                    "title" => "Foo's grandparent",
+                    "content_id" => "a9c6f24a-92a1-4ead-a776-532d1d99123c",
+                    "base_path" => "/foo-grand-parent",
+                    "locale" => "en",
+                  }
+                ]
+              }
+            }
+          ],
+          "ordered_related_items" => [
+            {
+              "content_id" => "9effaabe-346d-4ad0-9c1b-baa49bc084d6",
+              "title" => "Foo",
+              "base_path" => "/bar",
+              "locale" => "en",
+              "links" => {
+                "mainstream_browse_pages" => [
+                  {
+                    "title" => "Foo's parent",
+                    "content_id" => "67c28e19-9934-462c-b174-db5b8e566384",
+                    "base_path" => "/foo-parent",
+                    "locale" => "en",
+                    "links" => {
+                      "parent" => [
+                        {
+                          "title" => "Foo's grandparent",
+                          "content_id" => "a9c6f24a-92a1-4ead-a776-532d1d99123c",
+                          "base_path" => "/foo-grand-parent",
+                          "locale" => "en",
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      )
+
+      expect(payload).to eql(
+        sections: [
+          {
+            title: "Foo's parent",
+            url: "/foo-parent",
+            items: [
+              { title: "Foo", url: "/bar" },
+            ]
+          },
+        ]
+      )
+    end
+  end
+end

--- a/spec/govuk_navigation_helpers/taxon_breadcrumbs_spec.rb
+++ b/spec/govuk_navigation_helpers/taxon_breadcrumbs_spec.rb
@@ -1,0 +1,180 @@
+require 'spec_helper'
+
+RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
+  describe "Taxon breadcrumbs" do
+    it "can handle any valid content item" do
+      payload = GovukSchemas::RandomExample.for_schema(
+        frontend_schema: "taxon",
+      )
+
+      expect {
+        GovukNavigationHelpers::TaxonBreadcrumbs.new(
+          payload
+        ).breadcrumbs
+      }.to_not raise_error
+    end
+
+    it "returns the root when taxon is not specified" do
+      content_item = {
+        "title" => "Some Content",
+        "document_type" => "answer",
+        "links" => {},
+      }
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        breadcrumbs: [
+          { title: "Home", url: "/", is_page_parent: true },
+        ]
+      )
+    end
+
+    it "places parent under the root when there is a taxon" do
+      content_item = content_item_tagged_to_taxon([])
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        breadcrumbs: [
+          { title: "Home", url: "/", is_page_parent: false },
+          { title: "Taxon", url: "/taxon", is_page_parent: true },
+        ]
+      )
+    end
+
+    context 'with a taxon with taxon parents' do
+      it "includes parents and grandparents when available" do
+        grandparent = {
+          "title" => "Another-parent",
+          "base_path" => "/another-parent",
+          "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+          "locale" => "en",
+          "phase" => "live",
+        }
+
+        parent = {
+          "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+          "locale" => "en",
+          "title" => "A-parent",
+          "base_path" => "/a-parent",
+          "phase" => "live",
+          "links" => {
+            "parent_taxons" => [grandparent]
+          }
+        }
+
+        content_item = content_item_tagged_to_taxon([parent])
+        breadcrumbs = breadcrumbs_for(content_item)
+
+        expect(breadcrumbs).to eq(
+          breadcrumbs: [
+            { title: "Home", url: "/", is_page_parent: false },
+            { title: "Another-parent", url: "/another-parent", is_page_parent: false },
+            { title: "A-parent", url: "/a-parent", is_page_parent: false },
+            { title: "Taxon", url: "/taxon", is_page_parent: true },
+          ]
+        )
+      end
+    end
+
+    context 'with a taxon content item with parent taxons' do
+      it "includes parents and grandparents when available" do
+        parent = {
+          "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+          "locale" => "en",
+          "title" => "A-parent",
+          "base_path" => "/a-parent",
+          "phase" => "live",
+          "links" => {
+            "parent_taxons" => []
+          }
+        }
+
+        content_item = taxon_with_parent_taxons([parent])
+        breadcrumbs = breadcrumbs_for(content_item)
+
+        expect(breadcrumbs).to eq(
+          breadcrumbs: [
+            { title: "Home", url: "/", is_page_parent: false },
+            { title: "A-parent", url: "/a-parent", is_page_parent: true },
+          ]
+        )
+      end
+    end
+
+    context 'with multiple parents' do
+      it "selects the first parent taxon in alphabetical order by title" do
+        parent1 = {
+          "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+          "locale" => "en",
+          "title" => "Parent A",
+          "base_path" => "/parent-a",
+          "phase" => "live",
+          "links" => {
+            "parent_taxons" => []
+          }
+        }
+        parent2 = {
+          "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+          "locale" => "en",
+          "title" => "Parent B",
+          "base_path" => "/parent-b",
+          "phase" => "live",
+          "links" => {
+            "parent_taxons" => []
+          }
+        }
+
+        content_item = taxon_with_parent_taxons([parent2, parent1])
+        breadcrumbs = breadcrumbs_for(content_item)
+
+        expect(breadcrumbs).to eq(
+          breadcrumbs: [
+            { title: "Home", url: "/", is_page_parent: false },
+            { title: "Parent A", url: "/parent-a", is_page_parent: true },
+          ]
+        )
+      end
+    end
+  end
+
+  def breadcrumbs_for(content_item)
+    fully_valid_content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: content_item["document_type"]) do |random_item|
+      random_item.merge(content_item)
+    end
+
+    # Use the main class instead of GovukNavigationHelpers::Breadcrumbs, so that
+    # we're testing both at the same time.
+    GovukNavigationHelpers::NavigationHelper.new(fully_valid_content_item).taxon_breadcrumbs
+  end
+
+  def taxon_with_parent_taxons(parents)
+    {
+      "title" => "Taxon",
+      "document_type" => "taxon",
+      "links" => {
+        "parent_taxons" => parents,
+      },
+    }
+  end
+
+  def content_item_tagged_to_taxon(parents)
+    {
+      "title" => "Some Content",
+      "document_type" => "answer",
+      "links" => {
+        "taxons" => [
+          {
+            "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+            "locale" => "en",
+            "title" => "Taxon",
+            "base_path" => "/taxon",
+            "phase" => "live",
+            "links" => {
+              "parent_taxons" => parents
+            },
+          },
+        ],
+      },
+    }
+  end
+end

--- a/spec/govuk_navigation_helpers/taxonomy_sidebar_spec.rb
+++ b/spec/govuk_navigation_helpers/taxonomy_sidebar_spec.rb
@@ -1,0 +1,569 @@
+require 'spec_helper'
+require 'webmock/rspec'
+require 'gds_api/test_helpers/rummager'
+
+include GdsApi::TestHelpers::Rummager
+
+RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
+  describe '#sidebar' do
+    it 'can handle any valid content item' do
+      stub_any_rummager_search_to_return_no_results
+
+      payload = GovukSchemas::RandomExample.for_schema(
+        frontend_schema: 'placeholder',
+      )
+
+      expect { sidebar_for(payload) }.to_not raise_error
+    end
+
+    context 'given a content item not tagged to any taxon with no document collections' do
+      it 'returns an empty sidebar hash' do
+        content_item = { "links" => {} }
+
+        expect(sidebar_for(content_item)).to eq(
+          items: [],
+          collections: []
+        )
+      end
+    end
+
+    context 'given a content item tagged to taxons and with related items' do
+      before do
+        stub_any_rummager_search
+          .to_return(
+            body: {
+              'results': [
+                { 'title': 'Related item C', 'link': '/related-item-c', },
+                { 'title': 'Related item B', 'link': '/related-item-b', },
+                { 'title': 'Related item A', 'link': '/related-item-a', },
+              ],
+            }.to_json
+          )
+      end
+
+      it 'returns a sidebar hash containing a sorted list of parent taxons and related content' do
+        expect(GovukNavigationHelpers.configuration.statsd).to receive(
+          :increment
+        ).with(
+          :taxonomy_sidebar_searches
+        ).twice
+
+        content_item = content_item_tagged_to_taxon
+
+        expect(sidebar_for(content_item)).to eq(
+          items: [
+            {
+              title: "Taxon A",
+              url: "/taxon-a",
+              description: "The A taxon.",
+              related_content: [
+                { 'title': 'Related item A', 'link': '/related-item-a', },
+                { 'title': 'Related item B', 'link': '/related-item-b', },
+                { 'title': 'Related item C', 'link': '/related-item-c', },
+              ],
+            },
+            {
+              title: "Taxon B",
+              url: "/taxon-b",
+              description: "The B taxon.",
+              related_content: [
+                { 'title': 'Related item A', 'link': '/related-item-a', },
+                { 'title': 'Related item B', 'link': '/related-item-b', },
+                { 'title': 'Related item C', 'link': '/related-item-c', },
+              ],
+            },
+          ],
+          collections: [],
+        )
+      end
+
+      it 'only shows related links for the first 2 taxons with related content' do
+        expect(GovukNavigationHelpers.configuration.statsd).to receive(
+          :increment
+        ).with(
+          :taxonomy_sidebar_searches
+        ).twice
+
+        content_item = content_item_tagged_to_taxon
+
+        content_item['links']['taxons'] << {
+          "title" => "Taxon C",
+          "base_path" => "/taxon-c",
+          "content_id" => "taxon-c",
+          "description" => "The C taxon.",
+          "phase" => "live",
+        }
+
+        expect(sidebar_for(content_item)).to eq(
+          items: [
+            {
+              title: "Taxon A",
+              url: "/taxon-a",
+              description: "The A taxon.",
+              related_content: [
+                { 'title': 'Related item A', 'link': '/related-item-a', },
+                { 'title': 'Related item B', 'link': '/related-item-b', },
+                { 'title': 'Related item C', 'link': '/related-item-c', },
+              ],
+            },
+            {
+              title: "Taxon B",
+              url: "/taxon-b",
+              description: "The B taxon.",
+              related_content: [
+                { 'title': 'Related item A', 'link': '/related-item-a', },
+                { 'title': 'Related item B', 'link': '/related-item-b', },
+                { 'title': 'Related item C', 'link': '/related-item-c', },
+              ],
+            },
+            {
+              title: "Taxon C",
+              url: "/taxon-c",
+              description: "The C taxon.",
+              related_content: [],
+            },
+          ],
+          collections: [],
+        )
+      end
+    end
+
+    context 'given there are repeated related links across different parent taxons' do
+      before do
+        # First taxon should have links A and B
+        stub_request(
+          :get,
+          %r{.*search.json?.*\&filter_taxons%5B%5D=taxon-a.*}
+        ).to_return(
+          body: {
+            'results': [
+              { 'title': 'Related item A', 'link': '/related-item-a', },
+              { 'title': 'Related item B', 'link': '/related-item-b', },
+            ],
+          }.to_json
+        )
+
+        # Second taxon should only return link C, and reject the other 2
+        stub_request(
+          :get,
+          %r{.*search.json?.*\&filter_taxons%5B%5D=taxon-b.*&reject_link%5B%5D=/related-item-a&reject_link%5B%5D=/related-item-b.*}
+        ).to_return(
+          body: {
+            'results': [
+              { 'title': 'Related item C', 'link': '/related-item-c', },
+            ],
+          }.to_json
+        )
+      end
+
+      it 'does not duplicate the related links across each taxon' do
+        expect(GovukNavigationHelpers.configuration.statsd).to receive(
+          :increment
+        ).with(
+          :taxonomy_sidebar_searches
+        ).twice
+
+        content_item = content_item_tagged_to_taxon
+
+        expect(sidebar_for(content_item)).to eq(
+          items: [
+            {
+              title: "Taxon A",
+              url: "/taxon-a",
+              description: "The A taxon.",
+              related_content: [
+                { 'title': 'Related item A', 'link': '/related-item-a', },
+                { 'title': 'Related item B', 'link': '/related-item-b', },
+              ],
+            },
+            {
+              title: "Taxon B",
+              url: "/taxon-b",
+              description: "The B taxon.",
+              related_content: [
+                { 'title': 'Related item C', 'link': '/related-item-c', },
+              ],
+            }
+          ],
+          collections: [],
+        )
+      end
+    end
+
+    context 'when there are related link overrides' do
+      context 'belonging to the same taxon' do
+        it 'displays the related link overrides under a single taxon' do
+          content_item = content_item_tagged_to_taxon
+
+          content_item['links']['ordered_related_items_overrides'] = [
+            {
+              'title' => 'Related link override B',
+              'base_path' => '/override-b',
+              'content_id' => 'override-b',
+              'links' => {
+                'taxons' => [
+                  content_item['links']['taxons'][0],
+                ],
+              },
+            },
+          ]
+
+          expect(sidebar_for(content_item)).to eq(
+            items: [
+              {
+                title: "Taxon A",
+                url: "/taxon-a",
+                description: "The A taxon.",
+                related_content: [],
+              },
+              {
+                title: "Taxon B",
+                url: "/taxon-b",
+                description: "The B taxon.",
+                related_content: [
+                  { title: 'Related link override B', link: '/override-b' },
+                ],
+              }
+            ],
+            collections: [],
+          )
+        end
+
+        it 'displays the related link overrides under a multiple taxons' do
+          content_item = content_item_tagged_to_taxon
+
+          content_item['links']['ordered_related_items_overrides'] = [
+            {
+              'title' => 'Related link override B',
+              'base_path' => '/override-b',
+              'content_id' => 'override-b',
+              'links' => {
+                'taxons' => [
+                  content_item['links']['taxons'][0],
+                ],
+              },
+            },
+            {
+              'title' => 'Related link override A-2',
+              'base_path' => '/override-a-2',
+              'content_id' => 'override-a-2',
+              'links' => {
+                'taxons' => [
+                  content_item['links']['taxons'][1],
+                ],
+              },
+            },
+            {
+              'title' => 'Related link override A-1',
+              'base_path' => '/override-a-1',
+              'content_id' => 'override-a-1',
+              'links' => {
+                'taxons' => [
+                  content_item['links']['taxons'][1],
+                ],
+              },
+            },
+          ]
+
+          expect(sidebar_for(content_item)).to eq(
+            items: [
+              {
+                title: "Taxon A",
+                url: "/taxon-a",
+                description: "The A taxon.",
+                related_content: [
+                  { 'title': 'Related link override A-1', 'link': '/override-a-1' },
+                  { 'title': 'Related link override A-2', 'link': '/override-a-2' },
+                ],
+              },
+              {
+                title: "Taxon B",
+                url: "/taxon-b",
+                description: "The B taxon.",
+                related_content: [
+                  { 'title': 'Related link override B', 'link': '/override-b' },
+                ],
+              }
+            ],
+            collections: [],
+          )
+        end
+
+        it 'displays a related link tagged to multiple taxons under a single taxon' do
+          content_item = content_item_tagged_to_taxon
+
+          content_item['links']['ordered_related_items_overrides'] = [
+            {
+              'title' => 'Related link override',
+              'base_path' => '/override',
+              'content_id' => 'override',
+              'links' => {
+                'taxons' => [
+                  content_item['links']['taxons'][0],
+                  content_item['links']['taxons'][1],
+                ],
+              },
+            },
+          ]
+
+          expect(sidebar_for(content_item)).to eq(
+            items: [
+              {
+                title: "Taxon A",
+                url: "/taxon-a",
+                description: "The A taxon.",
+                related_content: [
+                  { 'title': 'Related link override', 'link': '/override' },
+                ],
+              },
+              {
+                title: "Taxon B",
+                url: "/taxon-b",
+                description: "The B taxon.",
+                related_content: [],
+              }
+            ],
+            collections: [],
+          )
+        end
+
+        it 'displays a related link tagged to another taxon under "Elsewhere"' do
+          content_item = content_item_tagged_to_taxon
+
+          content_item['links']['ordered_related_items_overrides'] = [
+            {
+              'title' => 'Related link override',
+              'base_path' => '/override',
+              'content_id' => 'override',
+              'links' => {
+                'taxons' => [
+                  {
+                    'title' => 'Some other taxon',
+                    'content_id' => 'some-other-taxon',
+                    'base_path' => '/some-other-taxon',
+                  }
+                ],
+              },
+            },
+          ]
+
+          expect(sidebar_for(content_item)).to eq(
+            items: [
+              {
+                title: "Taxon A",
+                url: "/taxon-a",
+                description: "The A taxon.",
+                related_content: [],
+              },
+              {
+                title: "Taxon B",
+                url: "/taxon-b",
+                description: "The B taxon.",
+                related_content: [],
+              },
+              {
+                title: "Elsewhere on GOV.UK",
+                related_content: [
+                  { title: 'Related link override', link: '/override' }
+                ],
+              },
+            ],
+            collections: [],
+          )
+        end
+
+        it 'displays a related link not tagged to any taxons under "Elsewhere"' do
+          content_item = content_item_tagged_to_taxon
+
+          content_item['links']['ordered_related_items_overrides'] = [
+            {
+              'title' => 'Related link override',
+              'base_path' => '/override',
+              'content_id' => 'override',
+              'links' => {},
+            },
+          ]
+
+          expect(sidebar_for(content_item)).to eq(
+            items: [
+              {
+                title: "Taxon A",
+                url: "/taxon-a",
+                description: "The A taxon.",
+                related_content: [],
+              },
+              {
+                title: "Taxon B",
+                url: "/taxon-b",
+                description: "The B taxon.",
+                related_content: [],
+              },
+              {
+                title: "Elsewhere on GOV.UK",
+                related_content: [
+                  { title: 'Related link override', link: '/override' }
+                ],
+              },
+            ],
+            collections: [],
+          )
+        end
+
+        it 'displays an external related link under "Elsewhere"' do
+          content_item = content_item_tagged_to_taxon
+
+          content_item['links']['ordered_related_items_overrides'] = [
+            {
+              'title' => 'Related link override',
+              'base_path' => '/override',
+              'content_id' => 'override',
+              'links' => {},
+            },
+          ]
+
+          content_item['details'] = {
+            'external_related_links' => [
+              {
+                'title' => 'External related link',
+                'url' => 'http://example.com',
+              },
+            ]
+          }
+
+          expect(sidebar_for(content_item)).to eq(
+            items: [
+              {
+                title: "Taxon A",
+                url: "/taxon-a",
+                description: "The A taxon.",
+                related_content: [],
+              },
+              {
+                title: "Taxon B",
+                url: "/taxon-b",
+                description: "The B taxon.",
+                related_content: [],
+              },
+              {
+                title: "Elsewhere on GOV.UK",
+                related_content: [
+                  { title: 'Related link override', link: '/override' }
+                ],
+              },
+              {
+                title: "Elsewhere on the web",
+                related_content: [
+                  { title: 'External related link', link: 'http://example.com' }
+                ],
+              },
+            ],
+            collections: [],
+          )
+        end
+      end
+    end
+
+    context 'given a content item with document collections' do
+      it 'returns a sidebar hash containing document collections' do
+        content_item = content_item_with_document_collections
+
+        expect(sidebar_for(content_item)).to eq(
+          items: [],
+          collections: [
+            {
+              path: "/collection-b",
+              text: "Collection B",
+            },
+            {
+              path: "/collection-a",
+              text: "Collection A",
+            },
+            ]
+        )
+      end
+    end
+    context 'when Rummager raises an exception' do
+      error_handler = nil
+
+      before(:each) do
+        stub_any_rummager_search
+            .to_return(status: 500)
+
+        error_handler = spy('error_handler')
+
+        GovukNavigationHelpers.configure do |config|
+          config.error_handler = error_handler
+        end
+
+        expect(GovukNavigationHelpers.configuration.statsd).to_not receive(
+          :increment
+        )
+      end
+
+      it 'does not re-raise' do
+        content_item = content_item_tagged_to_taxon
+
+        expect { sidebar_for(content_item) }.to_not raise_error
+      end
+
+      it 'logs an error' do
+        content_item = content_item_tagged_to_taxon
+        sidebar_for(content_item)
+
+        expect(error_handler).to have_received(:notify).at_least(1).times
+      end
+    end
+  end
+
+  def sidebar_for(content_item)
+    GovukNavigationHelpers::NavigationHelper.new(content_item).taxonomy_sidebar
+  end
+
+  def content_item_tagged_to_taxon
+    {
+      "title" => "A piece of content",
+      "base_path" => "/a-piece-of-content",
+      "links" => {
+        "taxons" => [
+          {
+            "title" => "Taxon B",
+            "base_path" => "/taxon-b",
+            "content_id" => "taxon-b",
+            "description" => "The B taxon.",
+            "phase" => "live",
+          },
+          {
+            "title" => "Taxon A",
+            "base_path" => "/taxon-a",
+            "content_id" => "taxon-a",
+            "description" => "The A taxon.",
+            "phase" => "live",
+          },
+        ],
+      },
+    }
+  end
+
+  def content_item_with_document_collections
+    {
+      "title" => "A piece of content",
+      "base_path" => "/a-piece-of-content",
+      "links" => {
+        "document_collections" => [
+          {
+            "title" => "Collection B",
+            "base_path" => "/collection-b",
+            "content_id" => "collection-b",
+            "document_type" => "document_collection",
+          },
+          {
+            "title" => "Collection A",
+            "base_path" => "/collection-a",
+            "content_id" => "collection-a",
+            "document_type" => "document_collection",
+          },
+        ],
+      },
+    }
+  end
+end


### PR DESCRIPTION
This commit merges in the govuk_navigation_helpers gem so that we can drop the dependency.

In subsequent PRs we'll merge in the classes properly and make everything part of the same namespace, but I think this is worthwhile as a first PR.

https://trello.com/c/WJlqy3VD