### PR TITLE
Use NavigationHelper classes directly

### DIFF
--- a/lib/govuk_navigation_helpers.rb
+++ b/lib/govuk_navigation_helpers.rb
@@ -8,48 +8,4 @@ require_relative "govuk_navigation_helpers/taxon_breadcrumbs"
 require_relative "govuk_navigation_helpers/taxonomy_sidebar"
 require_relative "govuk_navigation_helpers/rummager_taxonomy_sidebar_links"
 require_relative "govuk_navigation_helpers/curated_taxonomy_sidebar_links"
-
-module GovukNavigationHelpers
-  class NavigationHelper
-    def initialize(content_item)
-      @content_item = content_item
-    end
-
-    # Generate a breadcrumb trail
-    #
-    # @return [Hash] Payload for the GOV.UK breadcrumbs component
-    # @see http://govuk-component-guide.herokuapp.com/components/breadcrumbs
-    def breadcrumbs
-      Breadcrumbs.new(content_item).breadcrumbs
-    end
-
-    # Generate a breadcrumb trail for a taxon, using the taxon_parent link field
-    #
-    # @return [Hash] Payload for the GOV.UK breadcrumbs component
-    # @see http://govuk-component-guide.herokuapp.com/components/breadcrumbs
-    def taxon_breadcrumbs
-      TaxonBreadcrumbs.new(content_item).breadcrumbs
-    end
-
-    # Generate a payload containing taxon sidebar data. Intended for use with
-    # the related items component.
-    #
-    # @return [Hash] Payload for the GOV.UK related items component
-    # @see http://govuk-component-guide.herokuapp.com/components/related_items
-    def taxonomy_sidebar
-      TaxonomySidebar.new(content_item).sidebar
-    end
-
-    # Generate a related items payload
-    #
-    # @return [Hash] Payload for the GOV.UK Component
-    # @see http://govuk-component-guide.herokuapp.com/components/related_items
-    def related_items
-      RelatedItems.new(content_item).related_items
-    end
-
-  private
-
-    attr_reader :content_item
-  end
-end
+require_relative "govuk_navigation_helpers/content_item"

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -14,11 +14,11 @@ module GovukPublishingComponents
       end
 
       def taxonomy_sidebar
-        nav_helper.taxonomy_sidebar
+        @taxonomy_sidebar ||= GovukNavigationHelpers::TaxonomySidebar.new(content_item).sidebar
       end
 
       def taxon_breadcrumbs
-        nav_helper.taxon_breadcrumbs
+        @taxon_breadcrumbs ||= GovukNavigationHelpers::TaxonBreadcrumbs.new(content_item).breadcrumbs
       end
 
       def breadcrumbs
@@ -37,7 +37,7 @@ module GovukPublishingComponents
             }
           ]
         else
-          nav_helper.breadcrumbs[:breadcrumbs]
+          GovukNavigationHelpers::Breadcrumbs.new(content_item).breadcrumbs[:breadcrumbs]
         end
       end
 
@@ -48,12 +48,6 @@ module GovukPublishingComponents
 
       def step_nav_helper
         @step_nav_helper ||= GovukPublishingComponents::Presenters::StepNavHelper.new(content_item, request_path)
-      end
-
-    private
-
-      def nav_helper
-        @nav_helper ||= GovukNavigationHelpers::NavigationHelper.new(content_item)
       end
     end
   end

--- a/spec/govuk_navigation_helpers/breadcrumbs_spec.rb
+++ b/spec/govuk_navigation_helpers/breadcrumbs_spec.rb
@@ -91,8 +91,6 @@ RSpec.describe GovukNavigationHelpers::Breadcrumbs do
       random_item.merge(content_item)
     end
 
-    # Use the main class instead of GovukNavigationHelpers::Breadcrumbs, so that
-    # we're testing both at the same time.
-    GovukNavigationHelpers::NavigationHelper.new(fully_valid_content_item).breadcrumbs
+    GovukNavigationHelpers::Breadcrumbs.new(fully_valid_content_item).breadcrumbs
   end
 end

--- a/spec/govuk_navigation_helpers/related_items_spec.rb
+++ b/spec/govuk_navigation_helpers/related_items_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe GovukNavigationHelpers::RelatedItems do
     fully_valid_content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "placeholder") do |random_item|
       random_item.merge(content_item)
     end
-    GovukNavigationHelpers::NavigationHelper.new(fully_valid_content_item).related_items
+    GovukNavigationHelpers::RelatedItems.new(fully_valid_content_item).related_items
   end
 
   describe "#related_items" do

--- a/spec/govuk_navigation_helpers/taxon_breadcrumbs_spec.rb
+++ b/spec/govuk_navigation_helpers/taxon_breadcrumbs_spec.rb
@@ -142,9 +142,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
       random_item.merge(content_item)
     end
 
-    # Use the main class instead of GovukNavigationHelpers::Breadcrumbs, so that
-    # we're testing both at the same time.
-    GovukNavigationHelpers::NavigationHelper.new(fully_valid_content_item).taxon_breadcrumbs
+    GovukNavigationHelpers::TaxonBreadcrumbs.new(fully_valid_content_item).breadcrumbs
   end
 
   def taxon_with_parent_taxons(parents)

--- a/spec/govuk_navigation_helpers/taxonomy_sidebar_spec.rb
+++ b/spec/govuk_navigation_helpers/taxonomy_sidebar_spec.rb
@@ -516,7 +516,7 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
   end
 
   def sidebar_for(content_item)
-    GovukNavigationHelpers::NavigationHelper.new(content_item).taxonomy_sidebar
+    GovukNavigationHelpers::TaxonomySidebar.new(content_item).sidebar
   end
 
   def content_item_tagged_to_taxon


### PR DESCRIPTION
This removes some indirection by using `TaxonomySidebar`, `TaxonBreadcrumbs`, `Breadcrumbs` directly. It will make future refactoring easier.

Follows the merging in of govuk_navigation_helpers (https://github.com/alphagov/govuk_publishing_components/pull/244).
