### PR TITLE
Release 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-# Unreleased
+# 6.0.0
 
 * Fix visited link colour on focus for white feedback links (PR #239)
-* Fix input error colour
-* Add helper for generating breadcrumbs on taxon and taxonomy-based finder pages
+* Fix input error colour (PR #241)
+* Add helper for generating breadcrumbs on taxon and taxonomy-based finder pages (PR #242)
+* Breaking: merge the [govuk_navigation_helpers][] gem into this project (#244). To upgrade, you will have to use the contextual navigation components ([sidebar](https://govuk-publishing-components.herokuapp.com/component-guide/contextual_sidebar) and [breadcrumbs](https://govuk-publishing-components.herokuapp.com/component-guide/contextual_breadcrumbs)) .
+
+[govuk_navigation_helpers]: https://github.com/alphagov/govuk_navigation_helpers
 
 # 5.7.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (5.7.0)
+    govuk_publishing_components (6.0.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '5.7.0'.freeze
+  VERSION = '6.0.0'.freeze
 end


### PR DESCRIPTION
Breaking because it moves govuk_navigation_helpers into this app and renames its classes.