### PR TITLE
Move dependency imports into _all_components.scss

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -2,21 +2,27 @@
 // the components.
 
 // `govuk_frontend_toolkit`
-@import "measurements";
-@import "grid_layout";
-@import "typography";
 @import "colours";
+@import "css3";
+@import "design-patterns/buttons";
+@import "grid_layout";
+@import "measurements";
+@import "typography";
+
+@import "components/helpers/clearfix";
+@import "components/helpers/px-to-em";
+@import "components/helpers/variables";
 
 @import "components/back-link";
 @import "components/document-list";
 @import "components/error-summary";
+@import "components/feedback";
 @import "components/fieldset";
 @import "components/input";
+@import "components/inverse-header";
 @import "components/label";
 @import "components/radio";
 @import "components/related-navigation";
 @import "components/step-by-step-nav";
 @import "components/step-by-step-nav-header";
 @import "components/step-by-step-nav-related";
-@import "components/feedback";
-@import "components/inverse-header";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_back-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_back-link.scss
@@ -1,5 +1,3 @@
-@import "helpers/variables";
-
 .gem-c-back-link {
   position: relative;
   display: inline-block;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -1,7 +1,3 @@
-// govuk_frontend_toolkit
-@import 'grid_layout';
-@import 'design-patterns/buttons';
-
 .gem-c-feedback {
   max-width: 960px;
   margin: 0 auto;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_fieldset.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_fieldset.scss
@@ -1,6 +1,3 @@
-@import "helpers/variables";
-@import "helpers/clearfix";
-
 .gem-c-fieldset {
   margin: 0 0 $gem-spacing-scale-4;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_label.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_label.scss
@@ -1,5 +1,3 @@
-@import "helpers/variables";
-
 .gem-c-label {
   display: block;
   color: $gem-text-colour;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
@@ -1,6 +1,3 @@
-@import "helpers/variables";
-@import "helpers/px-to-em";
-
 .gem-c-radio {
   display: block;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -1,6 +1,3 @@
-// govuk_frontend_toolkit
-@import 'css3';
-
 $stroke-width: 2px;
 $stroke-width-large: 3px;
 $number-circle-size: 26px;


### PR DESCRIPTION
This is to resolve an issue I encountered where some components are
relying on imports made by different ones (in my example it was creating
an alert component that was similar to error-summary, which wouldn't
work as error_summary relied on variables included by _back-link).

Rather than having individual components require the files they need the
shared pool of dependencies is imported in the all components.

The advantages to this are:

- Components aren't vulnerable to break if component ordering is changed
  or some components are removed
- Imports are included once for the collection - if any of these were to
  output CSS it'd be included multiple times

The disadvantages are:

- It's no longer explicit that a particular component has a particular
  dependency

Ideally we'd want a way to import into just a particular scope rather
than global but I'm not aware of this functionality existing in SASS.