### PR TITLE
Bump version to 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Unreleased
+# 6.1.0
 
 * Add taxonomy navigation component, this will eventually supersede the static component.
+  It may well be possible to merge with parts of the related navigation component as some
+  of the functionality is shared between the two.
 
 # 6.0.0
 

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '6.0.0'.freeze
+  VERSION = '6.1.0'.freeze
 end


### PR DESCRIPTION
https://trello.com/c/Ar1mXL7Y/159-add-missing-related-links-to-taxonomy-sidebar

* Add taxonomy navigation component, this will eventually supersede the static component.
  It may well be possible to merge with parts of the related navigation component as some
  of the functionality is shared between the two.
