### PR TITLE
remove top padding from .gem-c-inverse-header

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -3,7 +3,7 @@
   background-color: $govuk-blue;
   color: $white;
   margin-bottom: $gutter;
-  padding: $gutter-half $gutter $gutter;
+  padding: 0 $gutter $gutter;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
to make the whitespace above the breadcrumb consistent with other page layouts