### PR TITLE
Add padding-top flag to inverse header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add padding-top flag to inverse header
+
 # 6.1.0
 
 * Add taxonomy navigation component, this will eventually supersede the static component.

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -3,7 +3,7 @@
   background-color: $govuk-blue;
   color: $white;
   margin-bottom: $gutter;
-  padding: $gutter-half $gutter $gutter;
+  padding: 0 $gutter $gutter;
   box-sizing: border-box;
 }
 
@@ -15,4 +15,8 @@
   padding-left: 0;
   padding-right: 0;
   padding-bottom: $gutter-half;
+}
+
+.gem-c-inverse-header--padding-top {
+  padding-top: $gutter-half;
 }

--- a/app/views/govuk_publishing_components/components/_inverse_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_inverse_header.html.erb
@@ -1,10 +1,11 @@
 <%
-  full_width ||= false
-  header_class = full_width ? "gem-c-inverse-header--full-width" : ""
+  css_classes = []
+  css_classes << " gem-c-inverse-header--full-width" if local_assigns[:full_width]
+  css_classes << " gem-c-inverse-header--padding-top" unless local_assigns[:padding_top].eql?(false)
 %>
 <% block = yield %>
 <% unless block.empty? %>
-  <header class="gem-c-inverse-header <%= header_class %>">
+  <header class="gem-c-inverse-header <%= css_classes.join(' ') %> ">
     <%= block %>
   </header>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/inverse_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/inverse_header.yml
@@ -41,6 +41,7 @@ examples:
         <p class="publication-header__last-changed">Published 22 April 2016</p>
   with_breadcrumbs_and_paragraph:
     data:
+      padding_top: false
       block: |
         <div class="govuk-breadcrumbs " data-module="track-click">
           <ol>

--- a/spec/components/inverse_header_spec.rb
+++ b/spec/components/inverse_header_spec.rb
@@ -36,4 +36,10 @@ describe "Inverse header", type: :view do
 
     assert_select ".gem-c-inverse-header--full-width"
   end
+
+  it "renders correct css class when padding_top flag is set to false" do
+    render(component_path, padding_top: false) { block }
+
+    assert_select ".gem-c-inverse-header--padding-top", false
+  end
 end


### PR DESCRIPTION
This will be set on topic pages so the breadcrumb renders in a consistent place with the rest of GOV.UK.

**Before:**
<img width="923" alt="screen shot 2018-03-29 at 10 03 18" src="https://user-images.githubusercontent.com/29889908/38080080-6be4131a-3338-11e8-9cd5-91029f21660d.png">

**After:**
<img width="924" alt="screen shot 2018-03-29 at 10 02 36" src="https://user-images.githubusercontent.com/29889908/38080059-5be387f2-3338-11e8-9930-ff683964f22e.png">

Component Guide: https://govuk-publishing-compon-pr-260.herokuapp.com/component-guide/inverse-header

Topic Page: https://www.gov.uk/education
Other GOV.UK page with breadcrumbs for comparison: https://www.gov.uk/student-finance