### PR TITLE
Add link to research

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Unreleased
 
+* Add link to step nav research (PR #261)
 * Add search component (PR #267)
 
 # 6.3.0
 
 * Remove bottom border for last item in document lists (PR #266)
 * Create success alert component (PR #254)
+* Add padding-top flag to inverse header
 
 # 6.2.0
 

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
@@ -9,6 +9,8 @@ body: |
 
   - step by step navigations are needed throughout GOV.UK and extending the accordion to be this component would require it to be moved out of that application, which would break integration testing
   - creating a new component allows further iteration without impacting the accordion
+
+  Background information relating to the testing and research behind this component can be found on the [Modelling Services wiki](https://gov-uk.atlassian.net/wiki/spaces/MS/pages) in Q2 to Q4, 2017/18.
 accessibility_criteria: |
   The step by step navigation must:
 


### PR DESCRIPTION
Add a link in the documentation for the step by step navigation component to the research and testing done during its development.

Trello card: https://trello.com/c/Ax13WPYH/574-add-link-to-evidence-from-step-nav-component-guide
