### PR TITLE
Move text for JS appended elements into step nav template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Move text for JS appended elements into step nav template (PR #263)
 * Add link to step nav research (PR #261)
 * Add search component (PR #267)
 

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -1,29 +1,10 @@
-// Most of this is originally from the service manual but has changed considerably since then
-
 (function (Modules) {
   "use strict";
   window.GOVUK = window.GOVUK || {};
 
   Modules.Gemstepnav = function () {
 
-    var actions = {
-      showLinkText: "Show",
-      hideLinkText: "Hide"
-    };
-
-    var bulkActions = {
-      showAll: {
-        buttonText: "Show all",
-        eventLabel: "Show All",
-        linkText: "Show"
-      },
-      hideAll: {
-        buttonText: "Hide all",
-        eventLabel: "Hide All",
-        linkText: "Hide"
-      }
-    };
-
+    var actions = {}; // stores text for JS appended elements 'show' and 'hide' on steps, and 'show/hide all' button
     var rememberShownStep = false;
     var stepNavSize;
     var sessionStoreLink = 'govuk-step-nav-active-link';
@@ -52,6 +33,7 @@
       var uniqueId = $element.data('id') || false;
       var stepNavTracker = new StepNavTracker(totalSteps, totalLinks, uniqueId);
 
+      getTextForInsertedElements();
       addButtonstoSteps();
       addShowHideAllButton();
       addShowHideToggle();
@@ -64,6 +46,13 @@
       bindToggleForSteps(stepNavTracker);
       bindToggleShowHideAllButton(stepNavTracker);
       bindComponentLinkClicks(stepNavTracker);
+
+      function getTextForInsertedElements() {
+        actions.showText = $element.attr('data-show-text');
+        actions.hideText = $element.attr('data-hide-text');
+        actions.showAllText = $element.attr('data-show-all-text');
+        actions.hideAllText = $element.attr('data-hide-all-text');
+      }
 
       // When navigating back in browser history to the step nav, the browser will try to be "clever" and return
       // the user to their previous scroll position. However, since we collapse all but the currently-anchored
@@ -84,15 +73,15 @@
       }
 
       function addShowHideAllButton() {
-        $element.prepend('<div class="gem-c-step-nav__controls"><button aria-expanded="false" class="gem-c-step-nav__button gem-c-step-nav__button--controls js-step-controls-button">' + bulkActions.showAll.buttonText + '</button></div>');
+        $element.prepend('<div class="gem-c-step-nav__controls"><button aria-expanded="false" class="gem-c-step-nav__button gem-c-step-nav__button--controls js-step-controls-button">' + actions.showAllText + '</button></div>');
       }
 
       function addShowHideToggle() {
         $stepHeaders.each(function() {
-          var linkText = actions.showLinkText;
+          var linkText = actions.showText;
 
           if (headerIsOpen($(this))) {
-            linkText = actions.hideLinkText;
+            linkText = actions.hideText;
           }
           if (!$(this).find('.js-toggle-link').length) {
             $(this).find('.js-step-title-button').append('<span class="gem-c-step-nav__toggle-link js-toggle-link" aria-hidden="true">' + linkText + '</span>');
@@ -254,21 +243,21 @@
         $showOrHideAllButton.on('click', function () {
           var shouldshowAll;
 
-          if ($showOrHideAllButton.text() == bulkActions.showAll.buttonText) {
-            $showOrHideAllButton.text(bulkActions.hideAll.buttonText);
-            $element.find('.js-toggle-link').text(actions.hideLinkText)
+          if ($showOrHideAllButton.text() == actions.showAllText) {
+            $showOrHideAllButton.text(actions.hideAllText);
+            $element.find('.js-toggle-link').text(actions.hideText)
             shouldshowAll = true;
 
             stepNavTracker.track('pageElementInteraction', 'stepNavAllShown', {
-              label: bulkActions.showAll.eventLabel + ": " + stepNavSize
+              label: actions.showAllText + ": " + stepNavSize
             });
           } else {
-            $showOrHideAllButton.text(bulkActions.showAll.buttonText);
-            $element.find('.js-toggle-link').text(actions.showLinkText);
+            $showOrHideAllButton.text(actions.showAllText);
+            $element.find('.js-toggle-link').text(actions.showText);
             shouldshowAll = false;
 
             stepNavTracker.track('pageElementInteraction', 'stepNavAllHidden', {
-              label: bulkActions.hideAll.eventLabel + ": " + stepNavSize
+              label: actions.hideAllText + ": " + stepNavSize
             });
           }
 
@@ -285,9 +274,9 @@
         var shownSteps = $element.find('.step-is-shown').length;
         // Find out if the number of is-opens == total number of steps
         if (shownSteps === totalSteps) {
-          $showOrHideAllButton.text(bulkActions.hideAll.buttonText);
+          $showOrHideAllButton.text(actions.hideAllText);
         } else {
-          $showOrHideAllButton.text(bulkActions.showAll.buttonText);
+          $showOrHideAllButton.text(actions.showAllText);
         }
       }
 
@@ -332,7 +321,7 @@
         $stepElement.toggleClass('step-is-shown', isShown);
         $stepContent.toggleClass('js-hidden', !isShown);
         $titleLink.attr("aria-expanded", isShown);
-        $stepElement.find('.js-toggle-link').text(isShown ? actions.hideLinkText : actions.showLinkText);
+        $stepElement.find('.js-toggle-link').text(isShown ? actions.hideText : actions.showText);
 
         if (shouldUpdateHash) {
           updateHash($stepElement);

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
@@ -22,6 +22,10 @@
     class="gem-c-step-nav js-hidden <% unless small %>gem-c-step-nav--large<% end %>"
     <%= "data-remember" if remember_last_step %>
     <%= "data-id=#{tracking_id}" if tracking_id %>
+    data-show-text="<%= t("govuk_component.step_by_step_nav.show", default: "Show") %>"
+    data-hide-text="<%= t("govuk_component.step_by_step_nav.hide", default: "Hide") %>"
+    data-show-all-text="<%= t("govuk_component.step_by_step_nav.show_all", default: "Show all") %>"
+    data-hide-all-text="<%= t("govuk_component.step_by_step_nav.hide_all", default: "Hide all") %>"
   >
     <ol class="gem-c-step-nav__steps">
       <% steps.each_with_index do |step, step_index| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,11 @@ en:
       topics: "Explore the topic"
       topical_events: "Topical event"
       world_locations: "World locations"
+    step_by_step_nav:
+      show: "Show"
+      hide: "Hide"
+      show_all: "Show all"
+      hide_all: "Hide all"
     step_by_step_nav_related:
       part_of: "Part of"
     taxonomy_navigation:

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -4,7 +4,7 @@ describe('A stepnav module', function () {
   var $element;
   var stepnav;
   var html = '\
-    <div data-module="gemstepnav" class="gem-c-step-nav js-hidden" data-id="unique-id">\
+    <div data-module="gemstepnav" class="gem-c-step-nav js-hidden" data-id="unique-id" data-show-text="Show" data-hide-text="Hide" data-show-all-text="Show all" data-hide-all-text="Hide all">\
       <ol class="gem-c-step-nav__steps">\
         <li class="gem-c-step-nav__step js-step" id="topic-step-one" data-track-count="stepnavStep">\
           <div class="gem-c-step-nav__header js-toggle-panel" data-position="1">\
@@ -178,7 +178,7 @@ describe('A stepnav module', function () {
 
     it("triggers a google analytics custom event", function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllShown', {
-        label: 'Show All: Small',
+        label: 'Show all: Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
         dimension96: "unique-id"
@@ -198,7 +198,7 @@ describe('A stepnav module', function () {
       clickShowHideAll();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllHidden', {
-        label: 'Hide All: Small',
+        label: 'Hide all: Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
         dimension96: "unique-id"
@@ -523,7 +523,7 @@ describe('A stepnav module', function () {
       clickShowHideAll();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllShown', {
-        label: 'Show All: Big',
+        label: 'Show all: Big',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
         dimension96: "unique-id"
@@ -540,7 +540,7 @@ describe('A stepnav module', function () {
       clickShowHideAll();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllHidden', {
-        label: 'Hide All: Big',
+        label: 'Hide all: Big',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
         dimension96: "unique-id"
@@ -741,7 +741,7 @@ describe('A stepnav module', function () {
       clickShowHideAll();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllShown', {
-        label: 'Show All: Small',
+        label: 'Show all: Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
         dimension96: false
@@ -759,7 +759,7 @@ describe('A stepnav module', function () {
       clickShowHideAll();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllHidden', {
-        label: 'Hide All: Small',
+        label: 'Hide all: Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
         dimension96: false


### PR DESCRIPTION
Step by step navigation component has JS appended elements 'show' and 'hide' on all steps, plus 'show/hide all' button. Currently all that text is hard coded into the JS, which means it can't be translated in Rails.

- move text from JS to data attributes within the component template
- add translation stuff for the text (although it's still all in English)
- also simplify how the text is stored in JS and remove unnecessary distinction between 'Show all' in FE and 'Show All' in analytics - now both 'Show all'

No visual changes to the component.

Trello card: https://trello.com/c/PdxP84XT/410-refactor-task-list-component-code
