### PR TITLE
Always use the related links sidebar for travel advice

### DIFF
--- a/lib/govuk_publishing_components/presenters/navigation_type.rb
+++ b/lib/govuk_publishing_components/presenters/navigation_type.rb
@@ -7,6 +7,7 @@ module GovukPublishingComponents
       end
 
       def should_present_taxonomy_navigation?
+        @content_item.dig("document_type") != "travel_advice" &&
         !content_is_tagged_to_browse_pages? &&
           content_is_tagged_to_a_live_taxon?
       end

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -29,6 +29,13 @@ describe "Contextual navigation" do
     and_the_parent_based_breadcrumbs
   end
 
+  scenario "It's a travel advice page" do
+    given_there_is_a_travel_advice_page
+    and_i_visit_that_page
+    then_i_see_the_related_links_sidebar
+    and_the_parent_based_breadcrumbs
+  end
+
   scenario "There's a taxon tagged" do
     given_theres_a_guide_with_a_live_taxon_and_collection_tagged_to_it
     and_i_visit_that_page
@@ -66,6 +73,21 @@ describe "Contextual navigation" do
         "ordered_related_items" => [random_item("guide", "title" => "A related link curated in Publisher")]
       }
     )
+  end
+
+  def given_there_is_a_travel_advice_page
+    content_item = random_item(
+      "travel_advice",
+      "base_path" => "/page-with-contextual-navigation",
+      "document_type" => "travel_advice",
+      "links" => {
+        "parent" => [random_item("mainstream_browse_page", "title" => "A parent")],
+        "taxons" => [random_item("taxon", "phase" => "live")],
+        "ordered_related_items" => [random_item("guide", "title" => "A related link curated in Publisher")]
+      }
+    )
+
+    content_store_has_item(content_item["base_path"], content_item)
   end
 
   def given_theres_a_guide_with_a_live_taxon_and_collection_tagged_to_it


### PR DESCRIPTION
Travel advice is not tagged to mainstream, but it has related links. This causes the taxonomy sidebar to be rendered.

I think this is a temporary solution and we should probably consider checking for the presence of `ordered_related_links` rather than mainstream browse.

https://govuk.zendesk.com/agent/tickets/2646969