### PR TITLE
Remove bottom border for last item in document lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Remove bottom border for last item in document lists 
+
 # 6.2.0
 
 * Always use the related links sidebar for travel advice (PR #264)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -4,6 +4,10 @@
   padding-bottom: $gutter-one-third;
   border-bottom: 1px solid $border-colour;
   list-style: none;
+
+  &:last-child {
+    border-bottom: none;
+  }
 }
 
 .gem-c-document-list__item-title {
@@ -28,4 +32,3 @@
 .gem-c-document-list--top-margin {
   margin-top: $gutter-two-thirds;
 }
-


### PR DESCRIPTION
Fixes https://github.com/alphagov/government-frontend/issues/744

When the list is against another component with a border it can look like there is a missing list item. Removing the border fixes this issue until we redesign the list styles.

https://govuk-publishing-compon-pr-266.herokuapp.com/component-guide/document_list

## Before
![screen shot 2018-04-03 at 16 54 10](https://user-images.githubusercontent.com/319055/38260493-a6cfe6cc-375f-11e8-9862-9cd8b1b8c820.png)

## After
![screen shot 2018-04-03 at 16 54 03](https://user-images.githubusercontent.com/319055/38260494-a8622b12-375f-11e8-99da-20429b8fb347.png)