### PR TITLE
Show "normal" navigation in addition to step by step, make sidebars consistent

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
@@ -9,7 +9,7 @@
 }
 
 .gem-c-related-navigation__sub-heading {
-  @include core-19;
+  @include core-16;
   border-top: 1px solid $border-colour;
   padding-top: $gutter-half;
 }
@@ -29,20 +29,19 @@
 
 .gem-c-related-navigation__link {
   list-style-type: none;
-
   margin-top: $gutter-half;
 
   @include media(tablet) {
-    margin-top: 10px;
+    margin-top: 5px;
   }
 }
 
 .gem-c-related-navigation__section-link {
-  @include bold-19;
+  @include bold-16;
 }
 
 .gem-c-related-navigation__section-link--other {
-  @include core-19;
+  @include core-16;
 }
 
 // reset the default browser styles

--- a/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
@@ -3,12 +3,13 @@
 }
 
 .gem-c-related-navigation__main-heading {
+  @include bold-19;
   margin-top: $gutter-half;
   margin-bottom: $gutter-one-third;
-  @include bold-19;
 }
 
 .gem-c-related-navigation__sub-heading {
+  @include core-19;
   border-top: 1px solid $border-colour;
   padding-top: $gutter-half;
 }
@@ -28,16 +29,20 @@
 
 .gem-c-related-navigation__link {
   list-style-type: none;
-  margin-bottom: $gutter-one-third;
+
+  margin-top: $gutter-half;
+
+  @include media(tablet) {
+    margin-top: 10px;
+  }
 }
 
 .gem-c-related-navigation__section-link {
-  text-decoration: none;
   @include bold-19;
 }
 
 .gem-c-related-navigation__section-link--other {
-  text-decoration: none;
+  @include core-19;
 }
 
 // reset the default browser styles

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
@@ -10,7 +10,7 @@
 }
 
 .gem-c-step-nav-related__links {
-  @include bold-19;
+  @include bold-16;
   margin: 0;
   padding: 0;
 }
@@ -32,6 +32,6 @@
   margin-top: $gutter-half;
 
   @include media(tablet) {
-    margin-top: 10px;
+    margin-top: 5px;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
@@ -1,8 +1,14 @@
 .gem-c-step-nav-related {
-  margin-bottom: $gutter-half;
+  border-top: 2px solid $govuk-blue;
+  margin-bottom: $gutter * 1.5;
 }
 
-.gem-c-step-nav-related__heading,
+.gem-c-step-nav-related__heading {
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-one-third;
+  @include bold-19;
+}
+
 .gem-c-step-nav-related__links {
   @include bold-19;
   margin: 0;
@@ -26,6 +32,6 @@
   margin-top: $gutter-half;
 
   @include media(tablet) {
-    margin-top: 5px;
+    margin-top: 10px;
   }
 }

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -3,23 +3,21 @@
 <% if navigation.step_nav_helper.show_related_links? %>
   <!-- Rendering step by step related items -->
   <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links %>
+<% end %>
 
-  <% if navigation.step_nav_helper.show_sidebar? %>
-    <!-- Rendering step by step sidebar because there's 1 step by step list -->
-    <%= render 'govuk_publishing_components/components/step_by_step_nav', navigation.step_nav_helper.sidebar %>
-  <% end %>
+<% if navigation.step_nav_helper.show_sidebar? %>
+  <!-- Rendering step by step sidebar because there's 1 step by step list -->
+  <%= render 'govuk_publishing_components/components/step_by_step_nav', navigation.step_nav_helper.sidebar %>
+<% elsif navigation.content_tagged_to_mainstream_browse_pages? %>
+  <!-- Rendering related navigation sidebar because the page is tagged to mainstream browse -->
+  <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
+<% elsif navigation.content_has_curated_related_items? %>
+  <!-- Rendering related navigation sidebar because the page has curated related links -->
+  <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
+<% elsif navigation.content_is_tagged_to_a_live_taxon? %>
+  <!-- Rendering taxonomy sidebar because the page is tagged to live taxons -->
+  <%= render 'govuk_publishing_components/components/taxonomy_navigation', navigation.taxonomy_sidebar %>
 <% else %>
-  <% if navigation.content_tagged_to_mainstream_browse_pages? %>
-    <!-- Rendering related navigation sidebar because the page is tagged to mainstream browse -->
-    <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
-  <% elsif navigation.content_has_curated_related_items? %>
-    <!-- Rendering related navigation sidebar because the page has curated related links -->
-    <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
-  <% elsif navigation.content_is_tagged_to_a_live_taxon? %>
-    <!-- Rendering taxonomy sidebar because the page is tagged to live taxons -->
-    <%= render 'govuk_publishing_components/components/taxonomy_navigation', navigation.taxonomy_sidebar %>
-  <% else %>
-    <!-- Rendering related navigation sidebar because no browse, no related links, no live taxons -->
-    <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
-  <% end %>
+  <!-- Rendering related navigation sidebar because no browse, no related links, no live taxons -->
+  <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -1,11 +1,11 @@
 <% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request.path) %>
 
-<% if navigation.step_nav_helper.show_related_links? %>
-  <!-- Rendering step by step related items -->
+<% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
+  <!-- Rendering step by step related items because there are a few but not too many of them -->
   <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links %>
 <% end %>
 
-<% if navigation.step_nav_helper.show_sidebar? %>
+<% if navigation.content_tagged_to_single_step_by_step? %>
   <!-- Rendering step by step sidebar because there's 1 step by step list -->
   <%= render 'govuk_publishing_components/components/step_by_step_nav', navigation.step_nav_helper.sidebar %>
 <% elsif navigation.content_tagged_to_mainstream_browse_pages? %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -1,8 +1,8 @@
 <%
-  links ||= false
+  links ||= []
   pretitle ||= t("govuk_component.step_by_step_nav_related.part_of", default: "Part of")
 %>
-<% if links %>
+<% if links.any? %>
   <div class="gem-c-step-nav-related" data-module="track-click">
     <h2 class="gem-c-step-nav-related__heading">
       <span class="gem-c-step-nav-related__pretitle"><%= pretitle %></span>

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -29,3 +29,16 @@ examples:
           ordered_related_items:
             - title: "Find an apprenticeship"
               base_path: "/apply-apprenticeship"
+  with_step_by_step:
+    data:
+      content_item:
+        title: "A content item"
+        links:
+          part_of_step_navs:
+            - title: "Choosing a micropig or micropug: step by step"
+              base_path: "/micropigs-vs-micropugs"
+            - title: "Walk your micropig: step by step"
+              base_path: "/porgs-step-by-step"
+          ordered_related_items:
+            - title: "Find an apprenticeship"
+              base_path: "/apply-apprenticeship"

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -56,6 +56,10 @@ module GovukPublishingComponents
         step_nav_helper.show_header?
       end
 
+      def content_tagged_to_a_reasonable_number_of_step_by_steps?
+        step_nav_helper.show_related_links?
+      end
+
       def step_nav_helper
         @step_nav_helper ||= PageWithStepByStepNavigation.new(content_item, request_path)
       end


### PR DESCRIPTION
Currently, when the page is tagged to 2,3 or 4 step by step lists, the sidebar will only show links to those steps by steps and hide the navigation that would otherwise be there.

I think it's a good change to make because this way we don't lose the normal navigation once a page is added to a step by step. It also makes the [logic for the sidebar](https://docs.google.com/document/d/1DQRTt0AYuPXSHkYvpcwPEEUDc3MHN2VubgYJA-hzeOM/edit) simpler. In the future we can integrate the code as well, making the components simpler.

## Impact

There is 1 page that will be affected: https://www.gov.uk/book-driving-test

### Before

![screen shot 2018-04-13 at 12 41 31](https://user-images.githubusercontent.com/233676/38732977-26da5202-3f18-11e8-9c7f-e3f156e09300.png)

https://govuk-publishing-components.herokuapp.com/contextual-navigation/book-driving-test

### After

https://govuk-publishing-compon-pr-275.herokuapp.com/contextual-navigation/book-driving-test

https://trello.com/c/rWqoHcOu/26-simplify-logic-around-related-links-on-content-pages