### PR TITLE
[Don't merge] Allow all types of documents to appear in taxonomy sidebar

### DIFF
--- a/lib/govuk_publishing_components/presenters/rummager_taxonomy_sidebar_links.rb
+++ b/lib/govuk_publishing_components/presenters/rummager_taxonomy_sidebar_links.rb
@@ -41,7 +41,6 @@ module GovukPublishingComponents
               start: 0,
               count: 3,
               filter_taxons: [taxon.content_id],
-              filter_navigation_document_supertype: 'guidance',
               reject_link: used_related_links.to_a,
               fields: %w[title link],
             )['results']

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -95,7 +95,7 @@ describe "Contextual navigation" do
     alpha_taxon = random_item("taxon", "title" => "An alpha taxon", "phase" => "alpha")
     live_taxon = random_item("taxon", "title" => "A live taxon", "phase" => "live")
 
-    stub_request(:get, "http://rummager.dev.gov.uk/search.json?count=3&fields%5B%5D=link&fields%5B%5D=title&filter_navigation_document_supertype=guidance&filter_taxons%5B%5D=#{live_taxon['content_id']}&similar_to=/page-with-contextual-navigation&start=0").
+    stub_request(:get, "http://rummager.dev.gov.uk/search.json?count=3&fields%5B%5D=link&fields%5B%5D=title&filter_taxons%5B%5D=#{live_taxon['content_id']}&similar_to=/page-with-contextual-navigation&start=0").
       to_return(body: { results: [{ title: 'A similar item' }] }.to_json)
 
     content_store_has_random_item(

--- a/spec/features/taxonomy_navigation_spec.rb
+++ b/spec/features/taxonomy_navigation_spec.rb
@@ -15,7 +15,7 @@ describe "Taxonomy navigation" do
     alpha_taxon = random_item("taxon", "title" => "An alpha taxon", "phase" => "alpha")
     live_taxon = random_item("taxon", "title" => "A live taxon", "phase" => "live")
 
-    stub_request(:get, "http://rummager.dev.gov.uk/search.json?count=3&fields%5B%5D=link&fields%5B%5D=title&filter_navigation_document_supertype=guidance&filter_taxons%5B%5D=#{live_taxon['content_id']}&similar_to=/page-with-contextual-navigation&start=0").
+    stub_request(:get, "http://rummager.dev.gov.uk/search.json?count=3&fields%5B%5D=link&fields%5B%5D=title&filter_taxons%5B%5D=#{live_taxon['content_id']}&similar_to=/page-with-contextual-navigation&start=0").
       to_return(body: { results: [{ title: 'A similar item' }] }.to_json)
 
     content_store_has_random_item(


### PR DESCRIPTION
Currently we filter the related links in the taxonomy sidebar to pages that are "guidance". The definition of guidance we use was created when we had the old new education navigation pages. This supertype is being removed (https://github.com/alphagov/rummager/pull/1222, https://github.com/alphagov/govuk_document_types/pull/43), so we need to update the sidebar logic as well.

An alternative to this is to use another supertype (like [content purpose](https://docs.publishing.service.gov.uk/document-types/content_purpose_supergroup.html)), but I suspect no filtering will yield better results.

We'll have to do some before/after analysis before merging this.

https://trello.com/c/6wRHXCyT
