### PR TITLE
Use a different survey from the footer

### DIFF
--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -117,7 +117,7 @@
         <input type="hidden" name="url" value="<%= request.original_url -%>">
         <input type="hidden" name="user_agent" value="<%= request.user_agent -%>">
 
-        <input name="email_survey_signup[survey_id]" type="hidden" value="user_satisfaction_survey">
+        <input name="email_survey_signup[survey_id]" type="hidden" value="footer_satisfaction_survey">
         <input name="email_survey_signup[survey_source]" type="hidden" value="<%= request.original_url -%>">
         <input name="email_survey_signup[ga_client_id]" type="hidden" value="1627485790.1515403243">
 


### PR DESCRIPTION
When you click "No" in the feedback component you're asked to fill in your email address so we can send you a survey. The survey link we currently send (https://www.smartsurvey.co.uk/s/gov-uk) is the default survey that is also present in the blue banner. This makes analysing the data very difficult.

This commit makes the component use a different survey_id, which is created in https://github.com/alphagov/feedback/pull/371. Don't merge this until that PR is deployed.