### PR TITLE
Remove use of `html_safe` in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 7.0.0
+
+* Breaks the search component (at the moment only used by finder-frontend, so if
+  won't be breaking for other apps).
+
 # 6.7.0
 
 * Feedback component: send users a different survey (#280)

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -8,7 +8,6 @@
   value ||= ""
   id ||= "search-main-" + SecureRandom.hex(4)
   label_text ||= "Search GOV.UK"
-  label_text = "#{label_text}".html_safe
 %>
 
 <div class="gem-c-search <%= class_name %>" data-module="gem-toggle-input-class-on-focus">

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -21,8 +21,8 @@ describe "Search", type: :view do
   end
 
   it "renders a search box with a custom label content" do
-    render_component(inline_label: false, label_text: "<h1>This is a heading 1</h1>")
-    assert_select ".gem-c-search .gem-c-search__label h1", text: "This is a heading 1"
+    render_component(inline_label: false, label_text: "This is a heading 1")
+    assert_select ".gem-c-search .gem-c-search__label", text: "This is a heading 1"
     assert_select ".gem-c-search.gem-c-search--separate-label"
   end
 


### PR DESCRIPTION
The use of `html_safe` here caused a XSS vulnerability. It is currently fixed in finder-frontend (https://github.com/alphagov/finder-frontend/pull/480).

It's also possible to insert HTML without doing html_safe by using a capture block, so to avoid recurrence of the bug we'll remove `html_safe` here entirely. This will make sure we don't have to explicitly sanitise the input. 