### PR TITLE
Add alpha & beta banners from static

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -21,6 +21,7 @@
 @import "components/step-by-step-nav-header";
 @import "components/step-by-step-nav-related";
 @import "components/feedback";
+@import "components/phase-banner";
 @import "components/inverse-header";
 @import "components/success-alert";
 @import "components/taxonomy-navigation";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
@@ -1,0 +1,7 @@
+@import "mixins/touch-friendly-links";
+@import "design-patterns/alpha-beta";
+
+.gem-c-phase-banner {
+  @include phase-banner;
+  @include touch-friendly-links;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_touch-friendly-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_touch-friendly-links.scss
@@ -1,0 +1,11 @@
+// This mixin will expand the clickable area for a link to make it easier to click on a touch-enabled
+// device.
+
+@mixin touch-friendly-links($padding: 3px) {
+  a {
+    padding: $padding;
+    margin: -1 * $padding;
+    outline-color: transparent;
+    display: inline-block;
+  }
+}

--- a/app/views/govuk_publishing_components/components/_alpha_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_alpha_banner.html.erb
@@ -1,0 +1,2 @@
+<% message ||= 'This part of GOV.UK is being built &ndash; <a href="/service-manual/phases/ideal-alphas">find out what alpha means</a>' %>
+<%= render 'govuk_publishing_components/shared/phase_banner', phase: 'Alpha', message: message %>

--- a/app/views/govuk_publishing_components/components/_beta_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_beta_banner.html.erb
@@ -1,0 +1,2 @@
+<% message ||= 'This part of GOV.UK is being rebuilt &ndash; <a href="/help/beta">find out what beta means</a>' %>
+<%= render 'govuk_publishing_components/shared/phase_banner', phase: 'Beta', message: message %>

--- a/app/views/govuk_publishing_components/components/docs/alpha_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/alpha_banner.yml
@@ -1,0 +1,18 @@
+name: Alpha banner
+description: A banner that indicates content is in an alpha phase, with an optional
+  explanation
+body: |
+  There's also an <a href="/component-guide/beta_banner">beta banner</a>.
+accessibility_criteria: |
+  The alpha label must:
+
+  - have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data: {}
+  with_message:
+    data:
+      message: This is an optional different message to explain what Alpha means in
+        this context which can take <a href='https://www.gov.uk'>HTML</a>

--- a/app/views/govuk_publishing_components/components/docs/beta_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/beta_banner.yml
@@ -1,0 +1,18 @@
+name: Beta banner
+description: |
+  A banner that indicates content is in a beta phase, with an optional explanation
+body: |
+  There's also a <a href="/component-guide/alpha_banner">alpha banner</a>.
+accessibility_criteria: |
+  The beta label must:
+
+  - have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data: {}
+  with_message:
+    data:
+      message: This is an optional different message to explain what Beta means in this
+        context which can take <a href='https://www.gov.uk'>HTML</a>

--- a/app/views/govuk_publishing_components/shared/_phase_banner.html.erb
+++ b/app/views/govuk_publishing_components/shared/_phase_banner.html.erb
@@ -1,0 +1,6 @@
+<div class="gem-c-phase-banner">
+  <p>
+    <strong class="phase-tag"><%= phase %></strong>
+    <span><%= raw message %></span>
+  </p>
+</div>

--- a/spec/components/alpha_banner_spec.rb
+++ b/spec/components/alpha_banner_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe "Alpha banner", type: :view do
+  def component_name
+    "alpha_banner"
+  end
+
+  it "does not error without a message" do
+    render_component({})
+    assert_select ".gem-c-phase-banner"
+  end
+
+  it "shows a custom message" do
+    render_component(message: "custom message")
+    assert_select ".gem-c-phase-banner span", text: "custom message"
+  end
+
+  it "allows custom message HTML" do
+    render_component(message: "custom <strong>message</strong>")
+    assert_select ".gem-c-phase-banner strong", text: "message"
+  end
+end

--- a/spec/components/beta_banner_spec.rb
+++ b/spec/components/beta_banner_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe "Beta banner", type: :view do
+  def component_name
+    "beta_banner"
+  end
+
+  it "does not error without a message" do
+    render_component({})
+    assert_select ".gem-c-phase-banner"
+  end
+
+  it "shows a custom message" do
+    render_component(message: "custom message")
+    assert_select ".gem-c-phase-banner span", text: "custom message"
+  end
+
+  it "allows custom message HTML" do
+    render_component(message: "custom <strong>message</strong>")
+    assert_select ".gem-c-phase-banner strong", text: "message"
+  end
+end


### PR DESCRIPTION
This ports over the alpha & beta banners from static. No visual changes have been made. I've refactored the two components to use the same HTML and CSS because they're identical.

I'm not a 100% sure about the sharing of CSS/HTML, comments welcome. 


https://trello.com/c/qtXCDGQI