### PR TITLE
Show breadcrumbs on non live taxons

### DIFF
--- a/lib/govuk_publishing_components/app_helpers/taxon_breadcrumbs.rb
+++ b/lib/govuk_publishing_components/app_helpers/taxon_breadcrumbs.rb
@@ -59,7 +59,6 @@ module GovukPublishingComponents
           @_parent_taxons ||= begin
             content_item.dig("links", "parent_taxons")
               .to_a
-              .select { |t| phase_is_live?(t) }
               .map { |taxon| ContentItem.new(taxon) }
           end
         end

--- a/lib/govuk_publishing_components/app_helpers/taxon_breadcrumbs.rb
+++ b/lib/govuk_publishing_components/app_helpers/taxon_breadcrumbs.rb
@@ -60,7 +60,7 @@ module GovukPublishingComponents
             content_item.dig("links", "parent_taxons")
               .to_a
               .select { |t| phase_is_live?(t) }
-              .map { |taxon| ContentItem.new(taxon) }.sort_by(&:title)
+              .map { |taxon| ContentItem.new(taxon) }
           end
         end
 

--- a/lib/govuk_publishing_components/app_helpers/taxon_breadcrumbs.rb
+++ b/lib/govuk_publishing_components/app_helpers/taxon_breadcrumbs.rb
@@ -52,14 +52,10 @@ module GovukPublishingComponents
         end
 
         def parent_taxon
-          parent_taxons.first
-        end
+          @_parent_taxon ||= begin
+            parent_content_item = content_item.dig("links", "parent_taxons", 0)
 
-        def parent_taxons
-          @_parent_taxons ||= begin
-            content_item.dig("links", "parent_taxons")
-              .to_a
-              .map { |taxon| ContentItem.new(taxon) }
+            ContentItem.new(parent_content_item) unless parent_content_item.nil?
           end
         end
 


### PR DESCRIPTION
When looking at a taxon, it's useful to see the breadcrumbs regardless
of the phase it's in as without the breadcrumbs it's hard to navigate
up the taxonomy.

Therefore, apply the restriction regarding the phase only if the
content item isn't a taxon.

## Before
![before](https://user-images.githubusercontent.com/1130010/39264678-61b6395a-48bd-11e8-9aab-054a244b16f1.png)

## After
![after](https://user-images.githubusercontent.com/1130010/39264687-66cd276e-48bd-11e8-9303-71eb84c3116b.png)
