### PR TITLE
Make components CSS available to static in the component guide

### DIFF
--- a/app/assets/stylesheets/component_guide/all_components.scss
+++ b/app/assets/stylesheets/component_guide/all_components.scss
@@ -1,0 +1,1 @@
+@import "../govuk_publishing_components/all_components";

--- a/app/assets/stylesheets/component_guide/all_components_print.scss
+++ b/app/assets/stylesheets/component_guide/all_components_print.scss
@@ -1,0 +1,1 @@
+@import "../govuk_publishing_components/all_components_print";

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -12,6 +12,12 @@
   </title>
   <%= stylesheet_link_tag "component_guide/application", media: "screen" %>
   <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_stylesheet}" %>
+
+  <% if GovukPublishingComponents::Config.static %>
+    <%= stylesheet_link_tag "component_guide/all_components", media: "screen" %>
+    <%= stylesheet_link_tag "component_guide/all_components_print", media: "print" %>
+  <% end %>
+
   <% if GovukPublishingComponents::Config.application_print_stylesheet %>
     <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_print_stylesheet}", media: "print" %>
   <% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,1 +1,6 @@
-Rails.application.config.assets.precompile += %w(govuk_publishing_components/component_guide.css govuk_publishing_components/search-button.png)
+Rails.application.config.assets.precompile += %w(
+  govuk_publishing_components/component_guide.css
+  component_guide/all_components.css
+  component_guide/all_components_print
+  govuk_publishing_components/search-button.png
+)


### PR DESCRIPTION
- applications include the styles for the components as part of the application's css, but static does not
- this means gem components viewed in the static component guide are not styled, which can cause accessibility errors to trigger
- adds logic and a couple of stylesheets to pull in the component styles if static is the application

This is a temporary (and slightly ugly) measure while all the components are migrated from static into the gem. If there's a cleaner way of doing it please let me know.
