### PR TITLE
Translation nav add brand and tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   you'll have to call `html_safe` on it yourself. Probably the only affected
   application is `frontend` (#305)
 * Remove optional `canonical` meta tag (applications can add this tag explicitly if they need it)
+* Translation nav add brand and tracking (PR #298)
 
 # 7.3.0
 

--- a/app/views/govuk_publishing_components/components/_translation-nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_translation-nav.html.erb
@@ -1,23 +1,16 @@
 <%
-  translations ||= []
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
-
-  def tracking_is_present(translations)
-    translations.each do |translation|
-      return true if translation[:data_attributes]
-    end
-    false
-  end
+  translation_helper = GovukPublishingComponents::Presenters::TranslationNavHelper.new(local_assigns)
 %>
-<% if translations.length > 1 %>
+<% if translation_helper.has_translations? %>
   <nav role="navigation"
     class="gem-c-translation-nav <%= brand_helper.brand_class %>"
     aria-label="<%= t("common.translations") %>"
-    <%= "data-module=\"track-click\"" if tracking_is_present(translations) %>
+    <%= "data-module=\"track-click\"" if translation_helper.tracking_is_present? %>
   >
     <ul class="gem-c-translation-nav__list">
-      <% translations.each.with_index do |translation, i| %>
+      <% translation_helper.translations.each.with_index do |translation, i| %>
         <li class="gem-c-translation-nav__list-item">
           <% if translation[:active] %>
             <span lang="<%= translation[:locale] %>"><%= translation[:text] %></span>

--- a/app/views/govuk_publishing_components/components/_translation-nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_translation-nav.html.erb
@@ -1,7 +1,7 @@
 <%
   translations ||= []
   brand ||= false
-  brand_helper = GovukPublishingComponents::Presenters::BrandHelper.new(brand)
+  brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
 
   def tracking_is_present(translations)
     translations.each do |translation|
@@ -12,7 +12,7 @@
 %>
 <% if translations.length > 1 %>
   <nav role="navigation"
-    class="gem-c-translation-nav <%= brand_helper.get_brand %>"
+    class="gem-c-translation-nav <%= brand_helper.brand_class %>"
     aria-label="<%= t("common.translations") %>"
     <%= "data-module=\"track-click\"" if tracking_is_present(translations) %>
   >
@@ -26,7 +26,7 @@
               hreflang: translation[:locale],
               lang: translation[:locale],
               rel: "alternate",
-              class: brand_helper.get_brand_element("color"),
+              class: brand_helper.color_class,
               data: translation[:data_attributes]
             %>
           <% end %>

--- a/app/views/govuk_publishing_components/components/_translation-nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_translation-nav.html.erb
@@ -1,13 +1,25 @@
-<% translations ||= [] %>
+<%
+  translations ||= []
+  brand ||= false
+  brand_helper = GovukPublishingComponents::Presenters::BrandHelper.new(brand)
+%>
 <% if translations.length > 1 %>
-  <nav role="navigation" class="gem-c-translation-nav" aria-label="<%= t("common.translations") %>">
+  <nav role="navigation"
+    class="gem-c-translation-nav <%= brand_helper.get_brand %>"
+    aria-label="<%= t("common.translations") %>"
+  >
     <ul class="gem-c-translation-nav__list">
       <% translations.each.with_index do |translation, i| %>
         <li class="gem-c-translation-nav__list-item">
           <% if translation[:active] %>
             <span lang="<%= translation[:locale] %>"><%= translation[:text] %></span>
           <% else %>
-            <%= link_to translation[:text], translation[:base_path], hreflang: translation[:locale], lang: translation[:locale], rel: "alternate" %>
+            <%= link_to translation[:text], translation[:base_path],
+              hreflang: translation[:locale],
+              lang: translation[:locale],
+              rel: "alternate",
+              class: brand_helper.get_brand_element("color")
+            %>
           <% end %>
         </li>
       <% end %>

--- a/app/views/govuk_publishing_components/components/_translation-nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_translation-nav.html.erb
@@ -2,11 +2,19 @@
   translations ||= []
   brand ||= false
   brand_helper = GovukPublishingComponents::Presenters::BrandHelper.new(brand)
+
+  def tracking_is_present(translations)
+    translations.each do |translation|
+      return true if translation[:data_attributes]
+    end
+    false
+  end
 %>
 <% if translations.length > 1 %>
   <nav role="navigation"
     class="gem-c-translation-nav <%= brand_helper.get_brand %>"
     aria-label="<%= t("common.translations") %>"
+    <%= "data-module=\"track-click\"" if tracking_is_present(translations) %>
   >
     <ul class="gem-c-translation-nav__list">
       <% translations.each.with_index do |translation, i| %>
@@ -18,7 +26,8 @@
               hreflang: translation[:locale],
               lang: translation[:locale],
               rel: "alternate",
-              class: brand_helper.get_brand_element("color")
+              class: brand_helper.get_brand_element("color"),
+              data: translation[:data_attributes]
             %>
           <% end %>
         </li>

--- a/app/views/govuk_publishing_components/components/docs/translation-nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/translation-nav.yml
@@ -59,3 +59,16 @@ examples:
           active: true
     context:
       right_to_left: true
+  with_branding:
+    description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) can be added to the component as shown.
+    data:
+      brand: 'wales-office'
+      translations:
+      - locale: 'en'
+        base_path: '/en'
+        text: 'English'
+        active: true
+      - locale: 'cy'
+        base_path: '/cy'
+        text: 'Cymraeg'
+

--- a/app/views/govuk_publishing_components/components/docs/translation-nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/translation-nav.yml
@@ -71,4 +71,29 @@ examples:
       - locale: 'cy'
         base_path: '/cy'
         text: 'Cymraeg'
+  with_tracking:
+    description: Data attributes can be passed for each link as shown.
+    data:
+      translations:
+      - locale: 'en'
+        base_path: '/en'
+        text: 'English'
+        active: true
+        data_attributes:
+          track_category: 'categoryEnglish'
+          track_action: 1.1
+          track_label: 'labelEnglish'
+          track_options:
+            dimension28: 1
+            dimension29: 'dimension29English'
+      - locale: 'cy'
+        base_path: '/cy'
+        text: 'Cymraeg'
+        data_attributes:
+          track_category: 'categoryWelsh'
+          track_action: 1.2
+          track_label: 'labelWelsh'
+          track_options:
+            dimension28: 1
+            dimension29: 'dimension29Welsh'
 

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -12,6 +12,7 @@ require "govuk_publishing_components/presenters/taxonomy_navigation"
 require "govuk_publishing_components/presenters/rummager_taxonomy_sidebar_links"
 require "govuk_publishing_components/presenters/curated_taxonomy_sidebar_links"
 require "govuk_publishing_components/presenters/content_item"
+require "govuk_publishing_components/presenters/translation_nav_helper"
 
 require "govuk_publishing_components/app_helpers/taxon_breadcrumbs"
 require "govuk_publishing_components/app_helpers/brand_helper"

--- a/lib/govuk_publishing_components/presenters/translation_nav_helper.rb
+++ b/lib/govuk_publishing_components/presenters/translation_nav_helper.rb
@@ -1,0 +1,23 @@
+module GovukPublishingComponents
+  module Presenters
+    class TranslationNavHelper
+      attr_reader :translations
+
+      def initialize(local_assigns)
+        @translations = []
+        @translations = local_assigns[:translations] if local_assigns[:translations]
+      end
+
+      def has_translations?
+        true if @translations.length > 1
+      end
+
+      def tracking_is_present?
+        @translations.each do |translation|
+          return true if translation[:data_attributes]
+        end
+        false
+      end
+    end
+  end
+end

--- a/spec/components/translation_nav_test_spec.rb
+++ b/spec/components/translation_nav_test_spec.rb
@@ -69,4 +69,10 @@ describe "Translation nav", type: :view do
     render_component(translations: multiple_translations)
     assert_select "nav[role='navigation'][aria-label='Translations']"
   end
+
+  it "adds branding correctly" do
+    render_component(translations: multiple_translations, brand: 'attorney-generals-office')
+    assert_select ".gem-c-translation-nav.brand--attorney-generals-office"
+    assert_select ".gem-c-translation-nav .brand__color"
+  end
 end

--- a/spec/components/translation_nav_test_spec.rb
+++ b/spec/components/translation_nav_test_spec.rb
@@ -75,4 +75,11 @@ describe "Translation nav", type: :view do
     assert_select ".gem-c-translation-nav.brand--attorney-generals-office"
     assert_select ".gem-c-translation-nav .brand__color"
   end
+
+  it "adds data tracking" do
+    translations_with_tracking = multiple_translations
+    translations_with_tracking[1][:data_attributes] = { track_category: 'category', track_label: 'label' }
+    render_component(translations: translations_with_tracking)
+    assert_select ".gem-c-translation-nav a[data-track-category='category'][data-track-label='label']", text: "हिंदी"
+  end
 end


### PR DESCRIPTION
Adds the following options to the translation nav component:

- branding (to change the colour of the links given a parameter matching a department name, ahead of using this component on organisation pages)
- tracking (to add any passed GA tracking attributes to each link, if passed to the component)

Preview: https://govuk-publishing-compon-pr-298.herokuapp.com/component-guide/translation-nav
Trello card: https://trello.com/c/ehg2nkE9/53-modify-component-translation-nav