### PR TITLE
Fix spacing issue in radio buttons

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
@@ -26,6 +26,7 @@
 }
 
 .gem-c-radio__input {
+  font-size: inherit;
   position: absolute;
 
   z-index: 1;


### PR DESCRIPTION
This component doesn't work in some situations (https://github.com/alphagov/frontend/pull/1509#discussion_r187015238). The clickable area of the radio button is about half the size that it should be.

![](https://user-images.githubusercontent.com/233676/39805809-c214a5ea-536f-11e8-8be1-4456e6e8cc06.png)

According to @andysellick in https://github.com/alphagov/frontend/pull/1509#discussion_r187015238:

> Seems to be that the component is inadvertently relying upon some core styles for inputs, which includes font-size: inherit. As a test, if you replace these two lines with that, the input comes out at the right size. Suggest we make an adjustment to the component to define an
explicit font size so this works in isolation - might be able to move the font size declaration for the label higher up so it applies to the whole component.