### PR TITLE
Add a canonical URL meta tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add an optional `canonical` meta tag.
+
 # 7.2.0
 
 * Add department colours to components (PR #296)

--- a/app.json
+++ b/app.json
@@ -16,6 +16,9 @@
     },
     "PLEK_SERVICE_RUMMAGER_URI": {
       "value": "https://www.gov.uk/api"
+    },
+    "GOVUK_WEBSITE_ROOT": {
+      "value": "https://www.gov.uk"
     }
   },
   "formation": {},

--- a/app/views/govuk_publishing_components/components/docs/meta_tags.yml
+++ b/app/views/govuk_publishing_components/components/docs/meta_tags.yml
@@ -23,3 +23,13 @@ examples:
         links:
           world_locations:
           - analytics_identifier: WL3
+  with_default_canonical_path:
+    data:
+      content_item:
+        base_path: /test
+      canonical_path: true
+  with_overridden_canonical_path:
+    data:
+      content_item:
+        base_path: /test
+      canonical_path: /this-is-a-test-path

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -20,6 +20,7 @@ module GovukPublishingComponents
         meta_tags = add_political_tags(meta_tags)
         meta_tags = add_taxonomy_tags(meta_tags)
         meta_tags = add_step_by_step_tags(meta_tags)
+        meta_tags = add_canonical_tag(meta_tags)
         meta_tags
       end
 
@@ -103,6 +104,20 @@ module GovukPublishingComponents
         stepnavs = links[:part_of_step_navs] || []
         stepnavs_content = stepnavs.map { |stepnav| stepnav[:content_id] }.join(",")
         meta_tags["govuk:stepnavs"] = stepnavs_content if stepnavs_content.present?
+        meta_tags
+      end
+
+      def add_canonical_tag(meta_tags)
+        if local_assigns.key?(:canonical_path)
+          canonical_path = if local_assigns[:canonical_path] == true
+                             content_item[:base_path]
+                           else
+                             local_assigns[:canonical_path]
+                           end
+
+          meta_tags["canonical"] = Plek.new.website_root + canonical_path
+        end
+
         meta_tags
       end
 

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -31,6 +31,30 @@ describe "Meta tags", type: :view do
     assert_meta_tag('govuk:schema-name', 'publication')
   end
 
+  it "renders the canonical URL in a meta tag if requested" do
+    render_component(
+      content_item: { base_path: '/test' },
+      canonical_path: true,
+    )
+
+    assert_meta_tag('canonical', 'http://www.dev.gov.uk/test')
+  end
+
+  it "renders the canonical URL in a meta tag if overridden" do
+    render_component(
+      content_item: { base_path: '/test' },
+      canonical_path: '/test2',
+    )
+
+    assert_meta_tag('canonical', 'http://www.dev.gov.uk/test2')
+  end
+
+  it "doesn't renders the canonical URL in a meta tag if not requested" do
+    assert_empty render_component(content_item: {
+      base_path: '/test'
+    }).strip
+  end
+
   it "renders organisations in a meta tag with angle brackets" do
     content_item = {
       links: {


### PR DESCRIPTION
This is built from the base_path of the content item which means it strips out any query parameters or fragments.

[Trello Card](https://trello.com/c/J67JSy8r/148-investigate-how-to-implement-canonical-tags-for-government-frontend-to-help-remove-duplicate-urls-2-hour-timebox)