### PR TITLE
Fix automated a11y test error with input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix automated a11y test error with input (PR #303)
 * Add an optional `canonical` meta tag (PR #302)
 * Iterate branding model (PR #300)
 

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -32,12 +32,12 @@ examples:
     description: |
       Allows the addition of an aria-describedby attribute. Note that this will be overridden in the event of an error, where the error will be used for the describedby attribute value.
 
-      The example below uses the ID of the skiplink container for demonstration purposes, in real use this would be passed the ID of an element that correctly described the input.
+      The example below uses the ID of the main container for demonstration purposes as there aren't any useful elements with IDs in the component guide. In real use this would be passed the ID of an element that correctly described the input.
     data:
       label:
         text: "This might not work"
       name: "labelledby"
-      describedby: "skiplink-container"
+      describedby: "wrapper"
   with_error:
     data:
       label:


### PR DESCRIPTION
This is to fix the failing build currently happening with https://github.com/alphagov/collections/pull/651 which is being caused by version 7.2.0 of the components gem. That PR will need a new version of this gem once this PR has been merged in order to pass the build tests.

- test was rendering a page where it couldn't find the ID being used in the example for the aria-describedby attribute, so Axe was throwing an accessibility error
- can't add an arbitrary ID into the page, so now using the id of the main wrapper, which prevents the error occurring
- documentation updated to explain this