### PR TITLE
Version 7.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 7.3.0
 
 * Fix automated a11y test error with input (PR #303)
 * Add an optional `canonical` meta tag (PR #302)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (7.2.0)
+    govuk_publishing_components (7.3.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '7.2.0'.freeze
+  VERSION = '7.3.0'.freeze
 end


### PR DESCRIPTION
* Fix automated a11y test error with input (PR #303)
* Add an optional `canonical` meta tag (PR #302)
* Iterate branding model (PR #300)

PR 300 is a fairly major change but its not in use on production yet.