### PR TITLE
Avoid usage of html_safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* The Button component no longer accepts unescaped HTML in the `info_text`,
+  you'll have to call `html_safe` on it yourself. Probably the only affected
+  application is `frontend` (#305)
 * Remove optional `canonical` meta tag (applications can add this tag explicitly if they need it)
 
 # 7.3.0

--- a/app/views/govuk_publishing_components/components/_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_button.html.erb
@@ -18,12 +18,12 @@
   html_options[:title] = title if title
 %>
 <% if href %>
-  <%= link_to(text, href.try(:html_safe), html_options) %>
+  <%= link_to(text, href, html_options) %>
 <% else %>
   <%= button_tag(text, html_options) %>
 <% end %>
 <% if info_text %>
   <span class="gem-c-button__info-text">
-    <%= info_text.try(:html_safe) %>
+    <%= info_text %>
   </span>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_taxonomy_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_taxonomy_navigation.html.erb
@@ -102,7 +102,7 @@
                 </li>
                 <li class="gem-c-taxonomy-navigation__link">
                   <span id="toggle_<%= section_name %>" class="js-hidden">
-                    <%= hidden_links.to_sentence.html_safe %>
+                    <%= to_sentence(hidden_links) %>
                   </span>
                 </li>
               <% end %>

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -55,7 +55,7 @@
 
       <li class="gem-c-related-navigation__link">
         <span id="toggle_<%= section_title %>" class="js-hidden">
-          <%= constructed_link_array.to_sentence.html_safe %>
+          <%= to_sentence(constructed_link_array) %>
         </span>
       </li>
     <% end %>

--- a/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
+++ b/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
@@ -84,7 +84,12 @@ module GovukPublishingComponents
         if link[:href]
           @link_index += 1
           href = link_href(link[:active], link[:href])
-          text = "#{link_text(link[:active], link[:text])} #{create_context(link[:context])}".html_safe
+
+          text = capture do
+            concat link_text(link[:active], link[:text])
+            concat " "
+            concat create_context(link[:context])
+          end
 
           link_to(
             href,

--- a/spec/components/all_components_spec.rb
+++ b/spec/components/all_components_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe "All components" do
+  it "doesn't use `html_safe`" do
+    files_with_html_safe = `grep -rni "html_safe" app/views/govuk_publishing_components/components`.lines
+
+    expect(files_with_html_safe).to be_empty
+  end
+end


### PR DESCRIPTION
This is a follow up to an [incident last month][repo] where we found a XSS vulnerability caused by `html_safe` being called on untrusted user input (see https://github.com/alphagov/finder-frontend/pull/480 and follow ups). 

To avoid recurrence, this PR makes sure that 1) we're never calling `html_safe` so that everything is escaped by default, 2) we can't use it anymore. This makes escaping and calling `html_safe` the exclusive responsibility of the application. 

See the individual commits for details. 

[repo]: https://docs.google.com/document/d/1HDpDuEtmR0PVt2Te5OgMGb6MnLlPU1s6Rhlt9Qhva1Y/edit#heading=h.v4arcxojubbv