### PR TITLE
Revert canonical URL meta tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Remove optional `canonical` meta tag (applications can add this tag explicitly if they need it)
+
 # 7.3.0
 
 * Fix automated a11y test error with input (PR #303)

--- a/app.json
+++ b/app.json
@@ -16,9 +16,6 @@
     },
     "PLEK_SERVICE_RUMMAGER_URI": {
       "value": "https://www.gov.uk/api"
-    },
-    "GOVUK_WEBSITE_ROOT": {
-      "value": "https://www.gov.uk"
     }
   },
   "formation": {},

--- a/app/views/govuk_publishing_components/components/docs/meta_tags.yml
+++ b/app/views/govuk_publishing_components/components/docs/meta_tags.yml
@@ -23,13 +23,3 @@ examples:
         links:
           world_locations:
           - analytics_identifier: WL3
-  with_default_canonical_path:
-    data:
-      content_item:
-        base_path: /test
-      canonical_path: true
-  with_overridden_canonical_path:
-    data:
-      content_item:
-        base_path: /test
-      canonical_path: /this-is-a-test-path

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -20,7 +20,6 @@ module GovukPublishingComponents
         meta_tags = add_political_tags(meta_tags)
         meta_tags = add_taxonomy_tags(meta_tags)
         meta_tags = add_step_by_step_tags(meta_tags)
-        meta_tags = add_canonical_tag(meta_tags)
         meta_tags
       end
 
@@ -104,20 +103,6 @@ module GovukPublishingComponents
         stepnavs = links[:part_of_step_navs] || []
         stepnavs_content = stepnavs.map { |stepnav| stepnav[:content_id] }.join(",")
         meta_tags["govuk:stepnavs"] = stepnavs_content if stepnavs_content.present?
-        meta_tags
-      end
-
-      def add_canonical_tag(meta_tags)
-        if local_assigns.key?(:canonical_path)
-          canonical_path = if local_assigns[:canonical_path] == true
-                             content_item[:base_path]
-                           else
-                             local_assigns[:canonical_path]
-                           end
-
-          meta_tags["canonical"] = Plek.new.website_root + canonical_path
-        end
-
         meta_tags
       end
 

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -31,30 +31,6 @@ describe "Meta tags", type: :view do
     assert_meta_tag('govuk:schema-name', 'publication')
   end
 
-  it "renders the canonical URL in a meta tag if requested" do
-    render_component(
-      content_item: { base_path: '/test' },
-      canonical_path: true,
-    )
-
-    assert_meta_tag('canonical', 'http://www.dev.gov.uk/test')
-  end
-
-  it "renders the canonical URL in a meta tag if overridden" do
-    render_component(
-      content_item: { base_path: '/test' },
-      canonical_path: '/test2',
-    )
-
-    assert_meta_tag('canonical', 'http://www.dev.gov.uk/test2')
-  end
-
-  it "doesn't renders the canonical URL in a meta tag if not requested" do
-    assert_empty render_component(content_item: {
-      base_path: '/test'
-    }).strip
-  end
-
   it "renders organisations in a meta tag with angle brackets" do
     content_item = {
       links: {


### PR DESCRIPTION
This reverts commit b53fa52329520c848ac0f9577f9f1fc500d9d7ed, reversing changes made to 8f9ed427d7fd6ae2fab198825b1055b77291fd7a.

After adding this we realised that it would be better placed for the individual frontend applications to add the canonical tag as they work closer to the content and would understand how to generate different canonical URLs depending on document type and various other factors.

Although we could choose to leave it in here, we felt it would be better for apps to be explicit about the tag rather than having a default which might cause more harm than good.

[Trello Card](https://trello.com/c/J67JSy8r/148-investigate-how-to-implement-canonical-tags-for-government-frontend-to-help-remove-duplicate-urls-2-hour-timebox)