### PR TITLE
Add breadcrumbs component from static

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -10,6 +10,7 @@
 @import "components/helpers/organisation-colours";
 
 @import "components/back-link";
+@import "components/breadcrumbs";
 @import "components/button";
 @import "components/document-list";
 @import "components/error-summary";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -1,0 +1,43 @@
+@import "design-patterns/breadcrumbs";
+@import "mixins/back-arrow";
+@import "mixins/media-down";
+@import "mixins/touch-friendly-links";
+
+.govuk-breadcrumbs {
+  // reset the default browser styles
+  ol {
+    padding: 0;
+    margin: 0;
+  }
+
+  @include breadcrumbs;
+  @include touch-friendly-links();
+
+  .breadcrumb-for-current-page {
+    color: $secondary-text-colour;
+    text-decoration: none;
+  }
+
+  @include media-down(mobile) {
+    &.collapse-on-mobile li {
+      display: none;
+
+      &.parent-breadcrumb {
+        background-image: none;
+        display: block;
+        margin-left: 0;
+        padding-left: 14px;
+        position: relative;
+
+        &:before {
+          @include back-arrow;
+        }
+      }
+    }
+  }
+}
+
+.breadcrumb-for-current-page.govuk-breadcrumbs--inverse,
+.govuk-breadcrumbs .govuk-breadcrumbs--inverse {
+  color: $white;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -3,7 +3,7 @@
 @import "mixins/media-down";
 @import "mixins/touch-friendly-links";
 
-.govuk-breadcrumbs {
+.gem-c-breadcrumbs {
   // reset the default browser styles
   ol {
     padding: 0;
@@ -13,16 +13,16 @@
   @include breadcrumbs;
   @include touch-friendly-links();
 
-  .breadcrumb-for-current-page {
+  .gem-c-breadcrumbs--current {
     color: $secondary-text-colour;
     text-decoration: none;
   }
 
   @include media-down(mobile) {
-    &.collapse-on-mobile li {
+    &.gem-c-breadcrumbs--collapse-on-mobile li {
       display: none;
 
-      &.parent-breadcrumb {
+      &.gem-c-breadcrumbs--parent {
         background-image: none;
         display: block;
         margin-left: 0;
@@ -37,7 +37,7 @@
   }
 }
 
-.breadcrumb-for-current-page.govuk-breadcrumbs--inverse,
-.govuk-breadcrumbs .govuk-breadcrumbs--inverse {
+.gem-c-breadcrumbs--current.gem-c-breadcrumbs--inverse,
+.gem-c-breadcrumbs .gem-c-breadcrumbs--inverse {
   color: $white;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -19,7 +19,7 @@
   }
 
   @include media-down(mobile) {
-    &.gem-c-breadcrumbs--collapse-on-mobile li {
+    &.gem-c-breadcrumbs--collapse-on-mobile .gem-c-breadcrumbs--item {
       display: none;
 
       &.gem-c-breadcrumbs--parent {

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_back-arrow.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_back-arrow.scss
@@ -1,0 +1,13 @@
+// An arrow to represent a "back" link
+
+@mixin back-arrow {
+  border-bottom: 5px solid transparent;
+  border-right: 6px solid;
+  border-top: 5px solid transparent;
+  content: '';
+  display: block;
+  left: 0;
+  margin-top: -6px;
+  position: absolute;
+  top: 50%;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_touch-friendly-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_touch-friendly-links.scss
@@ -1,0 +1,11 @@
+// This mixin will expand the clickable area for a link to make it easier to click on a touch-enabled
+// device.
+
+@mixin touch-friendly-links($padding: 3px) {
+  a {
+    padding: $padding;
+    margin: -1 * $padding;
+    outline-color: transparent;
+    display: inline-block;
+  }
+}

--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -16,7 +16,7 @@
       css_class = invert_class.concat(crumb[:is_current_page] ? ' gem-c-breadcrumbs--current ' : '')
     %>
 
-    <li class='<%= "gem-c-breadcrumbs--parent" if crumb[:is_page_parent] %>'>
+    <li class='gem-c-breadcrumbs--item <%= "gem-c-breadcrumbs--parent" if crumb[:is_page_parent] %>'>
       <% if is_link %>
         <%= link_to(
           crumb[:title],

--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -2,21 +2,21 @@
   breadcrumbs ||= []
   collapse_on_mobile ||= false
   inverse ||= false
-  collapse_class =  collapse_on_mobile && breadcrumbs.any? { |crumb| crumb[:is_page_parent] } ? "collapse-on-mobile" : ""
-  invert_class = inverse ? "govuk-breadcrumbs--inverse" : ""
+  collapse_class =  collapse_on_mobile && breadcrumbs.any? { |crumb| crumb[:is_page_parent] } ? "gem-c-breadcrumbs--collapse-on-mobile" : ""
+  invert_class = inverse ? "gem-c-breadcrumbs--inverse" : ""
 %>
 
-<div class="govuk-breadcrumbs <%= collapse_class %>" data-module="track-click">
+<div class="gem-c-breadcrumbs <%= collapse_class %>" data-module="track-click">
   <ol>
   <% breadcrumbs.each_with_index do |crumb, index| %>
     <%
       is_link = crumb[:url].present? || crumb[:is_current_page]
       path = crumb[:is_current_page] ? '#content' : crumb[:url]
       aria_current = crumb[:is_current_page] ? 'page' : 'false'
-      css_class = invert_class.concat(crumb[:is_current_page] ? ' breadcrumb-for-current-page ' : '')
+      css_class = invert_class.concat(crumb[:is_current_page] ? ' gem-c-breadcrumbs--current ' : '')
     %>
 
-    <li class='<%= "parent-breadcrumb" if crumb[:is_page_parent] %>'>
+    <li class='<%= "gem-c-breadcrumbs--parent" if crumb[:is_page_parent] %>'>
       <% if is_link %>
         <%= link_to(
           crumb[:title],

--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -1,0 +1,44 @@
+<%
+  breadcrumbs ||= []
+  collapse_on_mobile ||= false
+  inverse ||= false
+  collapse_class =  collapse_on_mobile && breadcrumbs.any? { |crumb| crumb[:is_page_parent] } ? "collapse-on-mobile" : ""
+  invert_class = inverse ? "govuk-breadcrumbs--inverse" : ""
+%>
+
+<div class="govuk-breadcrumbs <%= collapse_class %>" data-module="track-click">
+  <ol>
+  <% breadcrumbs.each_with_index do |crumb, index| %>
+    <%
+      is_link = crumb[:url].present? || crumb[:is_current_page]
+      path = crumb[:is_current_page] ? '#content' : crumb[:url]
+      aria_current = crumb[:is_current_page] ? 'page' : 'false'
+      css_class = invert_class.concat(crumb[:is_current_page] ? ' breadcrumb-for-current-page ' : '')
+    %>
+
+    <li class='<%= "parent-breadcrumb" if crumb[:is_page_parent] %>'>
+      <% if is_link %>
+        <%= link_to(
+          crumb[:title],
+          path,
+          data: {
+            track_category: 'breadcrumbClicked',
+            track_action: index + 1,
+            track_label: path,
+            track_options: {
+              dimension28: breadcrumbs.length.to_s,
+              dimension29: crumb[:title]
+            }
+          },
+          class: css_class,
+          aria: {
+            current: aria_current,
+          }
+        ) %>
+      <% else %>
+        <%= crumb[:title] %>
+      <% end %>
+    </li>
+  <% end %>
+  </ol>
+</div>

--- a/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
@@ -1,0 +1,94 @@
+name: "Breadcrumbs"
+description: "Navigational breadcrumbs, showing page hierarchy"
+body: |
+  Accepts an array of breadcrumb objects. Each crumb must have a title and a URL.
+shared_accessibility_criteria:
+  - link
+accessibility_criteria:
+  The breadcrumb links must have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+  (this especially applies when [using the inverse flag](/component-guide/breadcrumbs/inverse)).
+examples:
+  default:
+    data:
+      breadcrumbs:
+      - title: 'Section'
+        url: '/section'
+      - title: 'Sub-section'
+        url: '/section/sub-section'
+  inverse:
+    description: On a dark background, such as the header of topic pages
+    data:
+      breadcrumbs:
+      - title: 'Section'
+        url: '/section'
+      - title: 'Sub-section'
+        url: '/section/sub-section'
+        title: 'Education of disadvantaged children'
+        is_current_page: true
+      inverse: true
+    context:
+      dark_background: true
+  no_breadcrumbs:
+    data:
+      breadcrumbs: []
+  single_section:
+    data:
+      breadcrumbs:
+      - title: 'Section'
+        url: '/section'
+  many_breadcrumbs:
+    data:
+      breadcrumbs:
+      - title: 'Home'
+        url: '/'
+      - title: 'Section'
+        url: '/section'
+      - title: 'Sub-section'
+        url: '/section/sub-section'
+      - title: 'Sub Sub-section'
+        url: '/section/sub-section/sub-sub-section'
+  no_home:
+    data:
+      breadcrumbs:
+      - title: 'Service Manual'
+        url: '/service-manual'
+      - title: 'Agile Delivery'
+        url: '/service-manual/agile-delivery'
+  real:
+    data:
+      breadcrumbs:
+      - title: 'Home'
+        url: '/'
+      - title: 'Passports, travel and living abroad'
+        url: '/browse/abroad'
+      - title: 'Travel abroad'
+        url: '/browse/abroad/travel-abroad'
+  last_breadcrumb_is_current_page:
+    data:
+      breadcrumbs:
+      - title: 'Home'
+        url: '/'
+      - title: 'Passports, travel and living abroad'
+        url: '/browse/abroad'
+      - title: 'Travel abroad'
+  highlight_current_page:
+    description: This is currently used on pages tagged to the taxonomy, such as [on this page](https://www.gov.uk/guidance/pupil-premium-information-for-schools-and-alternative-provision-settings).
+    data:
+      breadcrumbs:
+      - title: 'Home'
+        url: '/'
+      - title: 'Education, training and skills'
+        url: '/education'
+      - title: 'Education of disadvantaged children'
+        is_current_page: true
+  collapse_on_mobile:
+    description: This is currently used within on pages tagged to the taxonomy, such as [on this page](https://www.gov.uk/guidance/pupil-premium-information-for-schools-and-alternative-provision-settings).
+    data:
+      collapse_on_mobile: true
+      breadcrumbs:
+      - title: 'Home'
+        url: '/'
+      - title: 'Education, training and skills'
+        url: '/education'
+        is_page_parent: true
+      - title: 'Education of disadvantaged children'

--- a/app/views/govuk_publishing_components/components/docs/inverse_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/inverse_header.yml
@@ -43,13 +43,13 @@ examples:
     data:
       padding_top: false
       block: |
-        <div class="govuk-breadcrumbs " data-module="track-click">
+        <div class="gem-c-breadcrumbs " data-module="track-click">
           <ol>
             <li class="">
-                <a data-track-category="breadcrumbClicked" data-track-action="1" data-track-label="/section" data-track-options="{&quot;dimension28&quot;:&quot;2&quot;,&quot;dimension29&quot;:&quot;Section&quot;}" class="govuk-breadcrumbs--inverse" aria-current="false" href="/section">Section</a>
+                <a data-track-category="breadcrumbClicked" data-track-action="1" data-track-label="/section" data-track-options="{&quot;dimension28&quot;:&quot;2&quot;,&quot;dimension29&quot;:&quot;Section&quot;}" class="gem-c-breadcrumbs--inverse" aria-current="false" href="/section">Section</a>
             </li>
             <li class="">
-                <a data-track-category="breadcrumbClicked" data-track-action="2" data-track-label="#content" data-track-options="{&quot;dimension28&quot;:&quot;2&quot;,&quot;dimension29&quot;:&quot;Education of disadvantaged children&quot;}" class="govuk-breadcrumbs--inverse breadcrumb-for-current-page " aria-current="page" href="#content">Education of disadvantaged children</a>
+                <a data-track-category="breadcrumbClicked" data-track-action="2" data-track-label="#content" data-track-options="{&quot;dimension28&quot;:&quot;2&quot;,&quot;dimension29&quot;:&quot;Education of disadvantaged children&quot;}" class="gem-c-breadcrumbs--inverse gem-c-breadcrumbs--current " aria-current="page" href="#content">Education of disadvantaged children</a>
             </li>
           </ol>
         </div>

--- a/spec/components/breadcrumbs_spec.rb
+++ b/spec/components/breadcrumbs_spec.rb
@@ -17,7 +17,7 @@ describe "Breadcrumbs", type: :view do
   it "renders a single breadcrumb" do
     render_component(breadcrumbs: [{ title: 'Section', url: '/section' }])
 
-    assert_link_with_text_in('ol li:first-child', '/section', 'Section')
+    assert_link_with_text_in('.gem-c-breadcrumbs--item:first-child', '/section', 'Section')
   end
 
   it "renders all data attributes for tracking" do
@@ -29,10 +29,10 @@ describe "Breadcrumbs", type: :view do
     }
 
     assert_select '.gem-c-breadcrumbs[data-module="track-click"]', 1
-    assert_select 'ol li:first-child a[data-track-action="1"]', 1
-    assert_select 'ol li:first-child a[data-track-label="/section"]', 1
-    assert_select 'ol li:first-child a[data-track-category="breadcrumbClicked"]', 1
-    assert_select "ol li:first-child a[data-track-options='#{expected_tracking_options.to_json}']", 1
+    assert_select '.gem-c-breadcrumbs--item:first-child a[data-track-action="1"]', 1
+    assert_select '.gem-c-breadcrumbs--item:first-child a[data-track-label="/section"]', 1
+    assert_select '.gem-c-breadcrumbs--item:first-child a[data-track-category="breadcrumbClicked"]', 1
+    assert_select ".gem-c-breadcrumbs--item:first-child a[data-track-options='#{expected_tracking_options.to_json}']", 1
   end
 
   it "tracks the total breadcrumb count on each breadcrumb" do
@@ -49,9 +49,9 @@ describe "Breadcrumbs", type: :view do
       { dimension28: "3", dimension29: "Section 3" },
     ]
 
-    assert_select "ol li:nth-child(1) a[data-track-options='#{expected_tracking_options[0].to_json}']", 1
-    assert_select "ol li:nth-child(2) a[data-track-options='#{expected_tracking_options[1].to_json}']", 1
-    assert_select "ol li:nth-child(3) a[data-track-options='#{expected_tracking_options[2].to_json}']", 1
+    assert_select ".gem-c-breadcrumbs--item:nth-child(1) a[data-track-options='#{expected_tracking_options[0].to_json}']", 1
+    assert_select ".gem-c-breadcrumbs--item:nth-child(2) a[data-track-options='#{expected_tracking_options[1].to_json}']", 1
+    assert_select ".gem-c-breadcrumbs--item:nth-child(3) a[data-track-options='#{expected_tracking_options[2].to_json}']", 1
   end
 
   it "renders a list of breadcrumbs" do
@@ -61,9 +61,9 @@ describe "Breadcrumbs", type: :view do
         { title: 'Sub-section', url: '/sub-section' },
       ])
 
-    assert_link_with_text_in('ol li:first-child', '/', 'Home')
-    assert_link_with_text_in('ol li:first-child + li', '/section', 'Section')
-    assert_link_with_text_in('ol li:last-child', '/sub-section', 'Sub-section')
+    assert_link_with_text_in('.gem-c-breadcrumbs--item:first-child', '/', 'Home')
+    assert_link_with_text_in('.gem-c-breadcrumbs--item:first-child + li', '/section', 'Section')
+    assert_link_with_text_in('.gem-c-breadcrumbs--item:last-child', '/sub-section', 'Sub-section')
   end
 
   it "renders inverted breadcrumbs when passed a flag" do
@@ -82,6 +82,6 @@ describe "Breadcrumbs", type: :view do
         { title: 'Current Page' },
       ]
     )
-    assert_select('ol li:last-child', 'Current Page')
+    assert_select('.gem-c-breadcrumbs--item:last-child', 'Current Page')
   end
 end

--- a/spec/components/breadcrumbs_spec.rb
+++ b/spec/components/breadcrumbs_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+describe "Breadcrumbs", type: :view do
+  def component_name
+    "breadcrumbs"
+  end
+
+  def assert_link_with_text_in(selector, link, text)
+    assert_select "#{selector} a[href=\"#{link}\"]", text: text
+  end
+
+  it "no error if no parameters passed in" do
+    render_component({})
+    assert_select ".govuk-breadcrumbs"
+  end
+
+  it "renders a single breadcrumb" do
+    render_component(breadcrumbs: [{ title: 'Section', url: '/section' }])
+
+    assert_link_with_text_in('ol li:first-child', '/section', 'Section')
+  end
+
+  it "renders all data attributes for tracking" do
+    render_component(breadcrumbs: [{ title: 'Section', url: '/section' }])
+
+    expected_tracking_options = {
+      dimension28: "1",
+      dimension29: "Section"
+    }
+
+    assert_select '.govuk-breadcrumbs[data-module="track-click"]', 1
+    assert_select 'ol li:first-child a[data-track-action="1"]', 1
+    assert_select 'ol li:first-child a[data-track-label="/section"]', 1
+    assert_select 'ol li:first-child a[data-track-category="breadcrumbClicked"]', 1
+    assert_select "ol li:first-child a[data-track-options='#{expected_tracking_options.to_json}']", 1
+  end
+
+  it "tracks the total breadcrumb count on each breadcrumb" do
+    breadcrumbs = [
+      { title: 'Section 1', url: '/section-1' },
+      { title: 'Section 2', url: '/section-2' },
+      { title: 'Section 3', url: '/section-3' },
+    ]
+    render_component(breadcrumbs: breadcrumbs)
+
+    expected_tracking_options = [
+      { dimension28: "3", dimension29: "Section 1" },
+      { dimension28: "3", dimension29: "Section 2" },
+      { dimension28: "3", dimension29: "Section 3" },
+    ]
+
+    assert_select "ol li:nth-child(1) a[data-track-options='#{expected_tracking_options[0].to_json}']", 1
+    assert_select "ol li:nth-child(2) a[data-track-options='#{expected_tracking_options[1].to_json}']", 1
+    assert_select "ol li:nth-child(3) a[data-track-options='#{expected_tracking_options[2].to_json}']", 1
+  end
+
+  it "renders a list of breadcrumbs" do
+    render_component(breadcrumbs: [
+        { title: 'Home', url: '/' },
+        { title: 'Section', url: '/section' },
+        { title: 'Sub-section', url: '/sub-section' },
+      ])
+
+    assert_link_with_text_in('ol li:first-child', '/', 'Home')
+    assert_link_with_text_in('ol li:first-child + li', '/section', 'Section')
+    assert_link_with_text_in('ol li:last-child', '/sub-section', 'Sub-section')
+  end
+
+  it "renders inverted breadcrumbs when passed a flag" do
+    render_component(breadcrumbs: [
+        { title: 'Home', url: '/' },
+        { title: 'Section', url: '/section' },
+      ], inverse: true)
+
+    assert_select ".govuk-breadcrumbs--inverse"
+  end
+
+  it "allows the last breadcrumb to be text only" do
+    render_component(
+      breadcrumbs: [
+        { title: 'Topic', url: '/topic' },
+        { title: 'Current Page' },
+      ]
+    )
+    assert_select('ol li:last-child', 'Current Page')
+  end
+end

--- a/spec/components/breadcrumbs_spec.rb
+++ b/spec/components/breadcrumbs_spec.rb
@@ -11,7 +11,7 @@ describe "Breadcrumbs", type: :view do
 
   it "no error if no parameters passed in" do
     render_component({})
-    assert_select ".govuk-breadcrumbs"
+    assert_select ".gem-c-breadcrumbs"
   end
 
   it "renders a single breadcrumb" do
@@ -28,7 +28,7 @@ describe "Breadcrumbs", type: :view do
       dimension29: "Section"
     }
 
-    assert_select '.govuk-breadcrumbs[data-module="track-click"]', 1
+    assert_select '.gem-c-breadcrumbs[data-module="track-click"]', 1
     assert_select 'ol li:first-child a[data-track-action="1"]', 1
     assert_select 'ol li:first-child a[data-track-label="/section"]', 1
     assert_select 'ol li:first-child a[data-track-category="breadcrumbClicked"]', 1
@@ -72,7 +72,7 @@ describe "Breadcrumbs", type: :view do
         { title: 'Section', url: '/section' },
       ], inverse: true)
 
-    assert_select ".govuk-breadcrumbs--inverse"
+    assert_select ".gem-c-breadcrumbs--inverse"
   end
 
   it "allows the last breadcrumb to be text only" do


### PR DESCRIPTION
This moves over [the breadcrumbs component from static](https://govuk-static.herokuapp.com/component-guide/breadcrumbs).

[Trello Card](https://trello.com/c/t11eJLxC/138-implement-breadcrumb-schema-3)

https://trello.com/c/XLuzv0pB/25-move-the-breadcrumbs-component-to-the-gem