### PR TITLE
Version 8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# Unreleased
+# 8.0.0
 
+* Use new breadcrumbs component in contextual breadcrumbs (PR #313)
 * Add share links component (PR #308)
 * The Button component no longer accepts unescaped HTML in the `info_text`,
   you'll have to call `html_safe` on it yourself. Probably the only affected

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (7.3.0)
+    govuk_publishing_components (8.0.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '7.3.0'.freeze
+  VERSION = '8.0.0'.freeze
 end


### PR DESCRIPTION
Includes the following. Changes to the heading component are breaking (about to create a PR on government-frontend to account for that)

- Use new breadcrumbs component in contextual breadcrumbs (PR #313)
- Add share links component (PR #308)
- The Button component no longer accepts unescaped HTML in the info_text, you'll have to call html_safe on it yourself. Probably the only affected application is frontend (#305)
- Remove optional canonical meta tag (applications can add this tag explicitly if they need it)
- Translation nav add brand and tracking (PR #298)
- Subscription links add colour and tracking (PR #299)
- Iterate heading component (PR #307)