### PR TITLE
Fix a bug in subscription links attributes

### DIFF
--- a/lib/govuk_publishing_components/presenters/subscription_links_helper.rb
+++ b/lib/govuk_publishing_components/presenters/subscription_links_helper.rb
@@ -36,8 +36,8 @@ module GovukPublishingComponents
 
       def feed_link_data_attributes
         data = @local_assigns[:feed_link_data_attributes] || {}
-        data[:controls] = feed_box_id
-        data[:expanded] = "false"
+        data[:controls] = feed_box_id if feed_link_box_value
+        data[:expanded] = "false" if feed_link_box_value
         data
       end
     end

--- a/spec/components/subscription_links_spec.rb
+++ b/spec/components/subscription_links_spec.rb
@@ -17,6 +17,7 @@ describe "subscription links", type: :view do
   it "renders a feed link" do
     render_component(feed_link: 'singapore.atom')
     assert_select ".gem-c-subscription-links__link--feed[href=\"singapore.atom\"]", text: "Subscribe to feed"
+    assert_select ".gem-c-subscription-links__link--feed[data-controls][data-expanded]", false
   end
 
   it "renders both email signup and feed links" do


### PR DESCRIPTION
- only show data attributes for controls and expanded if this element is going to actually do that
- was causing an integration test in government-frontend to fail as with the attributes it wasn't rendering visibly