### PR TITLE
Version 8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.0.1
+
+* Fix a bug in subscription links attributes (PR #314)
+
 # 8.0.0
 
 * Use new breadcrumbs component in contextual breadcrumbs (PR #313)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (8.0.0)
+    govuk_publishing_components (8.0.1)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '8.0.0'.freeze
+  VERSION = '8.0.1'.freeze
 end


### PR DESCRIPTION
Fixes an issue with the subscription links component that was blocking upgrading government-frontend as it was causing a test to fail.