### PR TITLE
Add Machine readable metadata component

### DIFF
--- a/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
@@ -1,0 +1,5 @@
+<% structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(local_assigns).structured_data %>
+
+<script type="application/ld+json">
+  <%= raw structured_data.to_json %>
+</script>

--- a/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
@@ -1,0 +1,33 @@
+name: Machine readable metadata
+description: Generates schema.org JSON-LD for use by search engines
+body: |
+  This component doesn't output anything visible. It generates "structured data"
+  in JSON-LD format, with [schema.org](http://schema.org) schemas.
+accessibility_criteria: |
+  The HTML should not be visible.
+display_html: true
+examples:
+  default:
+    data:
+      content_item:
+        title: "A title"
+        base_path: "/foo"
+        details: {}
+      schema: :article
+  with_canonical_url:
+    data:
+      content_item:
+        title: "A title"
+        base_path: "/foo"
+        details: {}
+      schema: :article
+      canonical_url: "https://www.gov.uk/foreign-travel-advice/andorra/health"
+
+  with_body:
+    data:
+      content_item:
+        title: "A title"
+        base_path: "/foo"
+        details: {}
+      schema: :article
+      body: "Some other body"

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -15,6 +15,7 @@ require "govuk_publishing_components/presenters/curated_taxonomy_sidebar_links"
 require "govuk_publishing_components/presenters/content_item"
 require "govuk_publishing_components/presenters/translation_nav_helper"
 require "govuk_publishing_components/presenters/subscription_links_helper"
+require "govuk_publishing_components/presenters/schema_org"
 require "govuk_publishing_components/presenters/heading_helper"
 
 require "govuk_publishing_components/app_helpers/taxon_breadcrumbs"

--- a/lib/govuk_publishing_components/presenters/schema_org.rb
+++ b/lib/govuk_publishing_components/presenters/schema_org.rb
@@ -1,0 +1,113 @@
+module GovukPublishingComponents
+  module Presenters
+    class SchemaOrg
+      def initialize(local_assigns)
+        @local_assigns = local_assigns
+      end
+
+      def structured_data
+        if @local_assigns.fetch(:schema) == :article
+          ArticleSchema.new(@local_assigns).structured_data
+        elsif @local_assigns.fetch(:schema) == :news_article
+          NewsArticleSchema.new(@local_assigns).structured_data
+        else
+          raise "#{@local_assigns.fetch(:schema)} is not supported"
+        end
+      end
+
+      class NewsArticleSchema
+        def initialize(local_assigns)
+          @local_assigns = local_assigns
+        end
+
+        def structured_data
+          # http://schema.org/NewsArticle
+          data = ArticleSchema.new(@local_assigns).structured_data
+          data["@type"] = "NewsArticle"
+          data
+        end
+      end
+
+      class ArticleSchema
+        attr_reader :content_item, :canonical_url, :local_assigns
+
+        def initialize(local_assigns)
+          @local_assigns = local_assigns
+
+          @content_item = local_assigns[:content_item]
+          @canonical_url = local_assigns[:canonical_url]
+          @custom_body = local_assigns[:body]
+        end
+
+        def structured_data
+          # http://schema.org/Article
+          {
+            "@context" => "http://schema.org",
+            "@type" => "Article",
+            "mainEntityOfPage" => {
+              "@type" => "WebPage",
+              "@id" => canonical_url || page_url_from_content_item,
+            },
+            "headline" => local_assigns[:title] || content_item["title"],
+            "datePublished" => content_item["first_published_at"],
+            "dateModified" => content_item["public_updated_at"],
+            "description" => content_item["description"],
+            "publisher" => {
+              "@type" => "Organization",
+              "name" => "GOV.UK",
+              "url" => "https://www.gov.uk",
+            }
+          }.merge(image_schema).merge(author_schema).merge(body)
+        end
+
+      private
+
+        attr_reader :presenter
+
+        # Not all formats have a `body` - some have their content split over
+        # multiple fields. In this case we'll skip the `articleBody` field
+        def body
+          return {} unless @custom_body || content_item["details"]["body"]
+
+          {
+            "articleBody" => @custom_body || content_item["details"]["body"]
+          }
+        end
+
+        def image_schema
+          return {} unless image
+
+          {
+            "image" => [
+              image["url"],
+            ]
+          }
+        end
+
+        def author_schema
+          return {} unless publishing_organisation
+
+          {
+            "author" => {
+              "@type" => "Organization",
+              "name" => publishing_organisation["title"],
+              "url" => Plek.current.website_root + publishing_organisation["base_path"],
+            }
+          }
+        end
+
+        def publishing_organisation
+          content_item.dig("links", "primary_publishing_organisation").to_a.first
+        end
+
+        def page_url_from_content_item
+          Plek.current.website_root + content_item["base_path"]
+        end
+
+        def image
+          content_item.dig("details", "image")
+        end
+      end
+    end
+  end
+end

--- a/spec/components/machine_readable_metadata_spec.rb
+++ b/spec/components/machine_readable_metadata_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe "Machine readable metadata", type: :view do
+  def component_name
+    "machine_readable_metadata"
+  end
+
+  it "generates machine readable JSON-LD" do
+    example = GovukSchemas::RandomExample.for_schema(frontend_schema: "generic")
+    render_component(content_item: example, schema: :article)
+
+    json_linked_data = Nokogiri::HTML(rendered).css('script').text
+
+    assert JSON.parse(json_linked_data)
+  end
+end

--- a/spec/lib/presenters/schema_org_spec.rb
+++ b/spec/lib/presenters/schema_org_spec.rb
@@ -1,0 +1,109 @@
+require "spec_helper"
+
+RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
+  describe "#structured_data" do
+    it "generates schema.org Articles" do
+      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "answer") do |random_item|
+        random_item.merge(
+          "base_path" => "/foo",
+          "details" => {
+            "body" => "Foo"
+          }
+        )
+      end
+
+      structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(
+        content_item: content_item,
+        schema: :article,
+      ).structured_data
+
+      expect(structured_data['@type']).to eql("Article")
+      expect(structured_data['mainEntityOfPage']['@id']).to eql("http://www.dev.gov.uk/foo")
+      expect(structured_data['articleBody']).to eql("Foo")
+    end
+
+    it "generates schema.org NewsArticles" do
+      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "answer")
+
+      structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(
+        content_item: content_item,
+        schema: :news_article,
+      ).structured_data
+
+      expect(structured_data['@type']).to eql("NewsArticle")
+    end
+
+    it "allows override of the URL" do
+      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "answer") do |random_item|
+        random_item.merge(
+          "base_path" => "/foo"
+        )
+      end
+
+      structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(
+        content_item: content_item,
+        schema: :article,
+        canonical_url: "https://www.gov.uk/foo/bar"
+      ).structured_data
+
+      expect(structured_data['mainEntityOfPage']['@id']).to eql("https://www.gov.uk/foo/bar")
+    end
+
+    it "allows override of the body" do
+      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "answer") do |random_item|
+        random_item.merge(
+          "base_path" => "/foo",
+          "details" => {
+            "body" => "Foo"
+          }
+        )
+      end
+
+      structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(
+        content_item: content_item,
+        schema: :article,
+        body: "Bar"
+      ).structured_data
+
+      expect(structured_data['articleBody']).to eql("Bar")
+    end
+
+    it "adds the primary publishing org as the author" do
+      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "answer") do |random_item|
+        random_item.merge(
+          "links" => {
+            "primary_publishing_organisation" => [
+              {
+                "content_id" => "d944229b-a5ad-453d-8e16-cb5dcfcdb866",
+                "title" => "Foo org",
+                "locale" => "en",
+                "base_path" => "/orgs/foo",
+              }
+            ]
+          }
+        )
+      end
+
+      structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(
+        content_item: content_item,
+        schema: :article,
+      ).structured_data
+
+      expect(structured_data['author']['name']).to eql("Foo org")
+    end
+
+    it "adds an image if it's available" do
+      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "news_article") do |random_item|
+        random_item["details"]["image"] = { "url" => "/foo" }
+        random_item
+      end
+
+      structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(
+        content_item: content_item,
+        schema: :article,
+      ).structured_data
+
+      expect(structured_data['image']).to eql(["/foo"])
+    end
+  end
+end


### PR DESCRIPTION
This component generates JSON-LD scripts with schema.org schemas.

The name is broad because I expect that we'll expand on this in the future to also include opengraph meta tags (currently only present in government-frontend).

## How this will be used

- https://github.com/alphagov/government-frontend/pull/905
- https://github.com/alphagov/frontend/pull/1514
- https://github.com/alphagov/calendars/pull/294

## Component guide

- [Machine readable component](https://govuk-publishing-compon-pr-318.herokuapp.com/component-guide/machine_readable_metadata)

https://trello.com/c/RLQI1IUV