### PR TITLE
Fix the branding documentation

### DIFF
--- a/docs/component_branding.md
+++ b/docs/component_branding.md
@@ -17,11 +17,11 @@ To add colours to a component, modify the component to follow the example below.
 %>
 
 <div class="gem-c-component <%= brand_helper.brand_class %>">
-  <div class="gem-c-component__title <%= brand_helper.brand_border_color %>">
+  <div class="gem-c-component__title <%= brand_helper.border_color_class %>">
     Example element that requires a coloured border
   </div>
 
-  <a href="#" class="<%= brand_helper.brand_color %>">
+  <a href="#" class="<%= brand_helper.color_class %>">
     Example element that requires coloured text
   </a>
 </div>
@@ -29,10 +29,10 @@ To add colours to a component, modify the component to follow the example below.
 
 Note that the helper must be called for each element that needs a border or link colour applying. This allows for flexibility if one is required but not the other.
 
-The `brand_border_color` method/class can also be applied to the main element of a component if needed, for example where the component is only one element. This is currently not possible with `brand_color` as there is no requirement for this.
+The `border_color_class` method/class can also be applied to the main element of a component if needed, for example where the component is only one element. This is currently not possible with `color_class` as there is no requirement for this.
 
 ```
-<h1 class="gem-c-component <%= brand_helper.brand_class %> <%= brand_helper.brand_border_color %>">Heading</h1>
+<h1 class="gem-c-component <%= brand_helper.brand_class %> <%= brand_helper.border_color_class %>">Heading</h1>
 ```
 
 For borders, the applied class only adds a `border-color` attribute. You will need to add the rest of the border style attributes to the component itself, for example:


### PR DESCRIPTION
I updated the branding model but evidently didn't proof read my own documentation fully. This should now be correct.

For reviewing, check the [brand helper file](https://github.com/alphagov/govuk_publishing_components/blob/master/lib/govuk_publishing_components/app_helpers/brand_helper.rb) to be sure.