### PR TITLE
Add option to display the generated HTML for components

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -106,6 +106,12 @@ $border-color: #ccc;
   }
 }
 
+.component-output {
+  > pre {
+    max-height: 200px;
+  }
+}
+
 .component-guide-preview {
   &.direction-rtl {
     direction: rtl;

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -17,7 +17,8 @@ module GovukPublishingComponents
       accessibility_criteria,
       accessibility_excluded_rules,
       examples,
-      source
+      source,
+      display_html
     )
       @id = id
       @name = name
@@ -27,6 +28,7 @@ module GovukPublishingComponents
       @accessibility_excluded_rules = accessibility_excluded_rules
       @examples = examples
       @source = source
+      @display_html = display_html
     end
 
     def example
@@ -35,6 +37,10 @@ module GovukPublishingComponents
 
     def other_examples
       examples.slice(1..-1)
+    end
+
+    def display_html?
+      @display_html
     end
 
     def html_body

--- a/app/models/govuk_publishing_components/component_doc_resolver.rb
+++ b/app/models/govuk_publishing_components/component_doc_resolver.rb
@@ -31,6 +31,7 @@ module GovukPublishingComponents
         component[:accessibility_excluded_rules],
         examples,
         component[:source],
+        component[:display_html],
       )
     end
 

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
@@ -2,12 +2,5 @@
             <% if example.right_to_left? %>direction-rtl<% end %>
             <% if example.dark_background? %>dark-background<% end %>
             <% if preview_page %>component-guide-preview--simple<% end %>" data-content="EXAMPLE">
-
-  <% if example.has_block? %>
-    <%= render component_doc.partial_path, example.html_safe_data do %>
-      <%= example.block.html_safe %>
-    <% end %>
-  <% else %>
-    <%= render component_doc.partial_path, example.html_safe_data %>
-  <% end %>
+  <%= render "govuk_publishing_components/component_guide/component_doc/component_output", example: example, component_doc: component_doc %>
 </div>

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_component_output.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_component_output.html.erb
@@ -1,0 +1,7 @@
+<% if example.has_block? %>
+  <%= render component_doc.partial_path, example.html_safe_data do %>
+    <%= example.block.html_safe %>
+  <% end %>
+<% else %>
+  <%= render component_doc.partial_path, example.html_safe_data %>
+<% end %>

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
@@ -3,3 +3,10 @@
   <div class="component-guide-preview component-guide-preview--violation" data-module="test-a11y-violation" data-content="Accessibility Issues"></div>
   <div class="component-guide-preview component-guide-preview--warning" data-module="test-a11y-warning" data-content="Potential accessibility issues: need manual check"></div>
 </div>
+
+<% if component_doc.display_html? %>
+  <div class="component-guide-preview component-call component-highlight component-output" data-content="HTML OUTPUT">
+    <% html_output = render "govuk_publishing_components/component_guide/component_doc/component_output", example: example, component_doc: component_doc %>
+    <pre><code><%= raw example.highlight_code(html_output.strip) %></code></pre>
+  </div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
@@ -7,6 +7,7 @@ shared_accessibility_criteria:
 accessibility_criteria:
   The breadcrumb links must have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
   (this especially applies when [using the inverse flag](/component-guide/breadcrumbs/inverse)).
+display_html: true
 examples:
   default:
     data:

--- a/app/views/govuk_publishing_components/components/docs/meta_tags.yml
+++ b/app/views/govuk_publishing_components/components/docs/meta_tags.yml
@@ -7,6 +7,7 @@ body: |
   The code which reads the meta tags can be found <a href="https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/static-analytics.js#L76-L96">in static-analytics.js</a>.
 accessibility_criteria: |
   The analytics meta tags component should not be visible to any users.
+display_html: true
 examples:
   with_organisations:
     data:


### PR DESCRIPTION
In some cases it's useful to be able to see the resulting HTML of the component. This adds an option to do this and enables it for the meta tags component.

## Preview

https://govuk-publishing-compon-pr-320.herokuapp.com/component-guide/machine_readable_metadata
https://govuk-publishing-compon-pr-320.herokuapp.com/component-guide/breadcrumbs
https://govuk-publishing-compon-pr-320.herokuapp.com/component-guide/meta_tags