### PR TITLE
Add image card component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 * Import images for the button component from static (PR #338)
 * Add contents list component (PR #342)
+* BREAKING: Iterate share links component (PR #316)
+* Add image card component (PR #322)
 
 ## 8.2.0
 
@@ -22,7 +24,6 @@
 * Move the Next and previous component from static (PR #329)
 * Move the Government navigation component from static (PR #334)
 * Add a Phase banner component to replace the Alpha/Beta banners in Static (PR #333)
-* BREAKING: Iterate share links component (PR #316)
 
 ### Upgrade instructions
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -18,6 +18,7 @@
 @import "components/feedback";
 @import "components/fieldset";
 @import "components/heading";
+@import "components/image-card";
 @import "components/input";
 @import "components/inverse-header";
 @import "components/label";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -53,13 +53,13 @@
   }
 }
 
-.gem-c-image-card__metadata,
+.gem-c-image-card__context,
 .gem-c-image-card__description {
   position: relative;
   z-index: 2;
 }
 
-.gem-c-image-card__metadata {
+.gem-c-image-card__context {
   @include core-14;
   color: $grey-1;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -38,10 +38,12 @@
   color: $grey-1;
 }
 
+.gem-c-image-card__description {
+  padding-top: $gutter-one-quarter;
+}
+
 .gem-c-image-card__title {
   @include bold-19;
-  margin-bottom: $gutter-one-quarter;
-  text-decoration: none;
 }
 
 .gem-c-image-card__title-link {
@@ -50,9 +52,9 @@
     position: absolute;
     z-index: 1;
     top: 0;
-    left: 0;
+    left: $gutter-half;
+    right: $gutter-half;
     height: 100%;
-    width: 100%;
   }
 }
 
@@ -81,10 +83,33 @@
 
   .gem-c-image-card__title {
     @include bold-24;
-    margin-bottom: $gutter-one-third;
+    padding-bottom: $gutter-one-third;
   }
 
   .gem-c-image-card__description {
     @include core-19;
+  }
+}
+
+.gem-c-image-card__list {
+  position: relative;
+  z-index: 2;
+  padding: $gutter-one-quarter 0 0 0;
+  margin: 0;
+  list-style: none;
+
+  &.gem-c-image-card__list--indented {
+    padding-left: $gutter-half;
+
+    .gem-c-image-card__list-item {
+      position: relative;
+
+      &:before {
+        content: "-";
+        position: absolute;
+        top: 0;
+        left: -$gutter-half;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -1,0 +1,24 @@
+.gem-c-image-card {
+  position: relative;
+}
+
+.gem-c-image-card__image {
+  max-width: 100%;
+}
+
+.gem-c-image-card__title {
+  @include bold-19;
+  text-decoration: none;
+}
+
+.gem-c-image-card__title-link {
+  &:after {
+    content: "";
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -55,3 +55,36 @@
     width: 100%;
   }
 }
+
+.gem-c-image-card--large {
+  .gem-c-image-card__image-wrapper {
+    @include grid-column( 2 / 3, tablet );
+  }
+
+  .gem-c-image-card__text-wrapper {
+    @include grid-column( 1 / 3, tablet );
+  }
+
+  .gem-c-image-card__image-wrapper {
+    @include media(mobile) {
+      margin-bottom: $gutter-one-third;
+    }
+  }
+
+  .gem-c-image-card__image-wrapper,
+  .gem-c-image-card__text-wrapper {
+    @include media(mobile) {
+      float: none;
+      width: auto;
+    }
+  }
+
+  .gem-c-image-card__title {
+    @include bold-24;
+    margin-bottom: $gutter-one-third;
+  }
+
+  .gem-c-image-card__description {
+    @include core-19;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -1,16 +1,30 @@
+@import 'grid_layout';
+
 .gem-c-image-card {
+  // if this extends grid-row a margin-bottom can't
+  // be applied as the extend overrides it
+  @extend %contain-floats;
+  margin: 0 (-$gutter-half);
+  margin-bottom: $gutter;
   position: relative;
-  margin-bottom: $gutter-half;
+}
+
+.gem-c-image-card__image-wrapper {
+  @include grid-column( 1 / 3, mobile );
+  padding-right: 0;
 
   @include media(tablet) {
-    margin-bottom: $gutter;
+    margin-bottom: $gutter-one-third;
   }
 }
 
 .gem-c-image-card__image {
   display: block;
   max-width: 100%;
-  margin-bottom: $gutter-one-third;
+}
+
+.gem-c-image-card__text-wrapper {
+  @include grid-column( 2 / 3, mobile );
 }
 
 .gem-c-image-card__metadata,
@@ -22,10 +36,6 @@
 .gem-c-image-card__metadata {
   @include core-14;
   color: $grey-1;
-}
-
-.gem-c-image-card__description {
-
 }
 
 .gem-c-image-card__title {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -1,13 +1,36 @@
 .gem-c-image-card {
   position: relative;
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-bottom: $gutter;
+  }
 }
 
 .gem-c-image-card__image {
+  display: block;
   max-width: 100%;
+  margin-bottom: $gutter-one-third;
+}
+
+.gem-c-image-card__metadata,
+.gem-c-image-card__description {
+  position: relative;
+  z-index: 2;
+}
+
+.gem-c-image-card__metadata {
+  @include core-14;
+  color: $grey-1;
+}
+
+.gem-c-image-card__description {
+
 }
 
 .gem-c-image-card__title {
   @include bold-19;
+  margin-bottom: $gutter-one-quarter;
   text-decoration: none;
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -11,10 +11,15 @@
 
 .gem-c-image-card__image-wrapper {
   @include grid-column( 1 / 3, mobile );
-  padding-right: 0;
 
   @include media(tablet) {
     margin-bottom: $gutter-one-third;
+  }
+
+  + .gem-c-image-card__text-wrapper {
+    @include media(mobile) {
+      padding-left: 0;
+    }
   }
 }
 
@@ -25,6 +30,27 @@
 
 .gem-c-image-card__text-wrapper {
   @include grid-column( 2 / 3, mobile );
+}
+
+.gem-c-image-card__title {
+  @include bold-19;
+}
+
+.gem-c-image-card__title-link {
+  // the after element extends the link to cover the image, removing the
+  // need for a duplicate link. Other elements apart from the image are given
+  // position relative and a higher z-index to put them above the after element
+  &:after {
+    content: "";
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    left: $gutter-half;
+    right: $gutter-half;
+    height: 100%;
+    $ie-background: rgba(255, 255, 255, 0);
+    background: $ie-background; // because internet explorer
+  }
 }
 
 .gem-c-image-card__metadata,
@@ -42,19 +68,26 @@
   padding-top: $gutter-one-quarter;
 }
 
-.gem-c-image-card__title {
-  @include bold-19;
-}
+.gem-c-image-card__list {
+  position: relative;
+  z-index: 2;
+  padding: $gutter-one-quarter 0 0 0;
+  margin: 0;
+  list-style: none;
 
-.gem-c-image-card__title-link {
-  &:after {
-    content: "";
-    position: absolute;
-    z-index: 1;
-    top: 0;
-    left: $gutter-half;
-    right: $gutter-half;
-    height: 100%;
+  &.gem-c-image-card__list--indented {
+    padding-left: $gutter-half;
+
+    .gem-c-image-card__list-item {
+      position: relative;
+
+      &:before {
+        content: "-";
+        position: absolute;
+        top: 0;
+        left: -$gutter-half;
+      }
+    }
   }
 }
 
@@ -88,28 +121,5 @@
 
   .gem-c-image-card__description {
     @include core-19;
-  }
-}
-
-.gem-c-image-card__list {
-  position: relative;
-  z-index: 2;
-  padding: $gutter-one-quarter 0 0 0;
-  margin: 0;
-  list-style: none;
-
-  &.gem-c-image-card__list--indented {
-    padding-left: $gutter-half;
-
-    .gem-c-image-card__list-item {
-      position: relative;
-
-      &:before {
-        content: "-";
-        position: absolute;
-        top: 0;
-        left: -$gutter-half;
-      }
-    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -4,8 +4,7 @@
   // if this extends grid-row a margin-bottom can't
   // be applied as the extend overrides it
   @extend %contain-floats;
-  margin: 0 (-$gutter-half);
-  margin-bottom: $gutter;
+  margin: 0 (-$gutter-half) $gutter (-$gutter-half);
   position: relative;
 }
 
@@ -84,7 +83,6 @@
       &:before {
         content: "-";
         position: absolute;
-        top: 0;
         left: -$gutter-half;
       }
     }

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -9,28 +9,32 @@
 <% if href %>
   <div class="gem-c-image-card">
     <% if image_src %>
-      <img src="<%= image_src %>"
-        class="gem-c-image-card__image"
-        alt="<%= image_alt %>"
-      />
+      <figure class="gem-c-image-card__image-wrapper">
+        <img src="<%= image_src %>"
+          class="gem-c-image-card__image"
+          alt="<%= image_alt %>"
+        />
+      </figure>
     <% end %>
 
-    <% if metadata %>
-      <p class="gem-c-image-card__metadata">
-        <%= metadata %>
-      </p>
-    <% end %>
+    <div class="gem-c-image-card__text-wrapper">
+      <% if metadata %>
+        <p class="gem-c-image-card__metadata">
+          <%= metadata %>
+        </p>
+      <% end %>
 
-    <% if heading_text %>
-      <h2 class="gem-c-image-card__title">
-        <%= link_to heading_text, href, class: "gem-c-image-card__title-link" %>
-      </h2>
-    <% end %>
+      <% if heading_text %>
+        <h2 class="gem-c-image-card__title">
+          <%= link_to heading_text, href, class: "gem-c-image-card__title-link" %>
+        </h2>
+      <% end %>
 
-    <% if description %>
-      <p class="gem-c-image-card__description">
-        <%= description %>
-      </p>
-    <% end %>
+      <% if description %>
+        <p>
+          <%= description %>
+        </p>
+      <% end %>
+    </div>
   </div>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -6,6 +6,8 @@
   metadata ||= false
   description ||= false
   large ||= false
+  heading_level ||= 2
+  heading_tag = "h#{heading_level}" if [1, 2, 3, 4, 5, 6].include? heading_level
 %>
 <% if href %>
   <div class="gem-c-image-card <%= "gem-c-image-card--large" if large %>">
@@ -26,9 +28,10 @@
       <% end %>
 
       <% if heading_text %>
-        <h2 class="gem-c-image-card__title">
-          <%= link_to heading_text, href, class: "gem-c-image-card__title-link" %>
-        </h2>
+        <%= content_tag(heading_tag,
+          class: "gem-c-image-card__title") do %>
+            <%= link_to heading_text, href, class: "gem-c-image-card__title-link" %>
+        <% end %>
       <% end %>
 
       <% if description %>

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -1,0 +1,22 @@
+<%
+  href ||= false
+  image_src ||= false
+  image_alt ||= ""
+  heading_text ||= false
+%>
+<% if href %>
+  <div class="gem-c-image-card">
+    <% if image_src %>
+      <img src="<%= image_src %>"
+        class="gem-c-image-card__image"
+        alt="<%= image_alt %>"
+      />
+    <% end %>
+
+    <% if heading_text %>
+      <h2 class="gem-c-image-card__title">
+        <%= link_to heading_text, href, class: "gem-c-image-card__title-link" %>
+      </h2>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -8,6 +8,8 @@
   large ||= false
   heading_level ||= 2
   heading_tag = "h#{heading_level}" if [1, 2, 3, 4, 5, 6].include? heading_level
+  extra_links ||= []
+  extra_links_no_indent ||= false
 %>
 <% if href %>
   <div class="gem-c-image-card <%= "gem-c-image-card--large" if large %>">
@@ -38,6 +40,16 @@
         <p class="gem-c-image-card__description">
           <%= description %>
         </p>
+      <% end %>
+
+      <% if extra_links.any? %>
+        <ul class="gem-c-image-card__list <%= "gem-c-image-card__list--indented" if not extra_links_no_indent %>">
+          <% extra_links.each do |link| %>
+            <li class="gem-c-image-card__list-item">
+              <%= link_to link[:text], link[:href] %>
+            </li>
+          <% end %>
+        </ul>
       <% end %>
     </div>
   </div>

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -5,9 +5,10 @@
   heading_text ||= false
   metadata ||= false
   description ||= false
+  large ||= false
 %>
 <% if href %>
-  <div class="gem-c-image-card">
+  <div class="gem-c-image-card <%= "gem-c-image-card--large" if large %>">
     <% if image_src %>
       <figure class="gem-c-image-card__image-wrapper">
         <img src="<%= image_src %>"
@@ -31,7 +32,7 @@
       <% end %>
 
       <% if description %>
-        <p>
+        <p class="gem-c-image-card__description">
           <%= description %>
         </p>
       <% end %>

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -3,6 +3,8 @@
   image_src ||= false
   image_alt ||= ""
   heading_text ||= false
+  metadata ||= false
+  description ||= false
 %>
 <% if href %>
   <div class="gem-c-image-card">
@@ -13,10 +15,22 @@
       />
     <% end %>
 
+    <% if metadata %>
+      <p class="gem-c-image-card__metadata">
+        <%= metadata %>
+      </p>
+    <% end %>
+
     <% if heading_text %>
       <h2 class="gem-c-image-card__title">
         <%= link_to heading_text, href, class: "gem-c-image-card__title-link" %>
       </h2>
+    <% end %>
+
+    <% if description %>
+      <p class="gem-c-image-card__description">
+        <%= description %>
+      </p>
     <% end %>
   </div>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -10,9 +10,11 @@
   heading_tag = "h#{heading_level}" if [1, 2, 3, 4, 5, 6].include? heading_level
   extra_links ||= []
   extra_links_no_indent ||= false
+  brand ||= false
+  brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
 %>
 <% if href %>
-  <div class="gem-c-image-card <%= "gem-c-image-card--large" if large %>">
+  <div class="gem-c-image-card <%= "gem-c-image-card--large" if large %> <%= brand_helper.brand_class %>">
     <% if image_src %>
       <figure class="gem-c-image-card__image-wrapper">
         <img src="<%= image_src %>"
@@ -32,7 +34,7 @@
       <% if heading_text %>
         <%= content_tag(heading_tag,
           class: "gem-c-image-card__title") do %>
-            <%= link_to heading_text, href, class: "gem-c-image-card__title-link" %>
+            <%= link_to heading_text, href, class: "gem-c-image-card__title-link #{brand_helper.color_class}" %>
         <% end %>
       <% end %>
 
@@ -46,7 +48,7 @@
         <ul class="gem-c-image-card__list <%= "gem-c-image-card__list--indented" if not extra_links_no_indent %>">
           <% extra_links.each do |link| %>
             <li class="gem-c-image-card__list-item">
-              <%= link_to link[:text], link[:href] %>
+              <%= link_to link[:text], link[:href], class: brand_helper.color_class %>
             </li>
           <% end %>
         </ul>

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -1,67 +1,32 @@
 <%
-  href ||= false
-  href_data_attributes ||= []
-  image_src ||= false
-  image_alt ||= ""
-  heading_text ||= false
-  context ||= false
-  description ||= false
-  large ||= false
-  heading_level ||= 2
-  heading_tag = "h#{heading_level}" if [1, 2, 3, 4, 5, 6].include? heading_level
-  extra_links ||= []
-  extra_links_no_indent ||= false
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
-
-  def is_tracking?(href_data_attributes, extra_links)
-    return true if href_data_attributes.any?
-    if extra_links.any?
-      extra_links.each do |link|
-        return true if link[:data_attributes]
-      end
-    end
-  end
+  card_helper = GovukPublishingComponents::Presenters::ImageCardHelper.new(local_assigns)
 %>
-<% if href %>
-  <div class="gem-c-image-card <%= "gem-c-image-card--large" if large %> <%= brand_helper.brand_class %>"
-    <%= "data-module=track-click" if is_tracking?(href_data_attributes, extra_links) %>
+<% if card_helper.href %>
+  <div class="gem-c-image-card <%= "gem-c-image-card--large" if card_helper.large %> <%= brand_helper.brand_class %>"
+    <%= "data-module=track-click" if card_helper.is_tracking? %>
   >
-    <% if image_src %>
-      <figure class="gem-c-image-card__image-wrapper">
-        <img src="<%= image_src %>"
-          class="gem-c-image-card__image"
-          alt="<%= image_alt %>"
-        />
-      </figure>
-    <% end %>
+    <%= card_helper.image %>
 
     <div class="gem-c-image-card__text-wrapper">
-      <% if context %>
-        <p class="gem-c-image-card__context">
-          <%= context %>
-        </p>
-      <% end %>
+      <%= card_helper.context %>
 
-      <% if heading_text %>
-        <%= content_tag(heading_tag,
+      <% if card_helper.heading_text %>
+        <%= content_tag(card_helper.heading_tag,
           class: "gem-c-image-card__title") do %>
-            <%= link_to heading_text, href,
+            <%= link_to card_helper.heading_text, card_helper.href,
               class: "gem-c-image-card__title-link #{brand_helper.color_class}",
-              data: href_data_attributes
+              data: card_helper.href_data_attributes
             %>
         <% end %>
       <% end %>
 
-      <% if description %>
-        <p class="gem-c-image-card__description">
-          <%= description %>
-        </p>
-      <% end %>
+      <%= card_helper.description %>
 
-      <% if extra_links.any? %>
-        <ul class="gem-c-image-card__list <%= "gem-c-image-card__list--indented" if not extra_links_no_indent %>">
-          <% extra_links.each do |link| %>
+      <% if card_helper.extra_links %>
+        <ul class="gem-c-image-card__list <%= "gem-c-image-card__list--indented" if not card_helper.extra_links_no_indent %>">
+          <% card_helper.extra_links.each do |link| %>
             <li class="gem-c-image-card__list-item">
               <%= link_to link[:text], link[:href],
                 class: brand_helper.color_class,

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -3,7 +3,7 @@
   image_src ||= false
   image_alt ||= ""
   heading_text ||= false
-  metadata ||= false
+  context ||= false
   description ||= false
   large ||= false
   heading_level ||= 2
@@ -25,9 +25,9 @@
     <% end %>
 
     <div class="gem-c-image-card__text-wrapper">
-      <% if metadata %>
-        <p class="gem-c-image-card__metadata">
-          <%= metadata %>
+      <% if context %>
+        <p class="gem-c-image-card__context">
+          <%= context %>
         </p>
       <% end %>
 

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -1,5 +1,6 @@
 <%
   href ||= false
+  href_data_attributes ||= []
   image_src ||= false
   image_alt ||= ""
   heading_text ||= false
@@ -12,9 +13,20 @@
   extra_links_no_indent ||= false
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
+
+  def is_tracking?(href_data_attributes, extra_links)
+    return true if href_data_attributes.any?
+    if extra_links.any?
+      extra_links.each do |link|
+        return true if link[:data_attributes]
+      end
+    end
+  end
 %>
 <% if href %>
-  <div class="gem-c-image-card <%= "gem-c-image-card--large" if large %> <%= brand_helper.brand_class %>">
+  <div class="gem-c-image-card <%= "gem-c-image-card--large" if large %> <%= brand_helper.brand_class %>"
+    <%= "data-module=track-click" if is_tracking?(href_data_attributes, extra_links) %>
+  >
     <% if image_src %>
       <figure class="gem-c-image-card__image-wrapper">
         <img src="<%= image_src %>"
@@ -34,7 +46,10 @@
       <% if heading_text %>
         <%= content_tag(heading_tag,
           class: "gem-c-image-card__title") do %>
-            <%= link_to heading_text, href, class: "gem-c-image-card__title-link #{brand_helper.color_class}" %>
+            <%= link_to heading_text, href,
+              class: "gem-c-image-card__title-link #{brand_helper.color_class}",
+              data: href_data_attributes
+            %>
         <% end %>
       <% end %>
 
@@ -48,7 +63,10 @@
         <ul class="gem-c-image-card__list <%= "gem-c-image-card__list--indented" if not extra_links_no_indent %>">
           <% extra_links.each do |link| %>
             <li class="gem-c-image-card__list-item">
-              <%= link_to link[:text], link[:href], class: brand_helper.color_class %>
+              <%= link_to link[:text], link[:href],
+                class: brand_helper.color_class,
+                data: link[:data_attributes]
+              %>
             </li>
           <% end %>
         </ul>

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -114,3 +114,32 @@ examples:
       context: "14 Jun 2017 - Announcement"
       heading_text: "Something has happened nearby possibly"
       description: "Following a news report that something has happened, further details are emerging of the thing that has happened and what that means for you."
+  with_tracking:
+    data:
+      href: "/i-am-not-a-valid-link"
+      href_data_attributes: {
+        track_category: 'href_category',
+        track_action: 1.1,
+        track_label: 'href_label',
+        track_options: {
+          dimension28: 1,
+          dimension29: 'dimension29Href'
+        }
+      }
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      heading_text: "A link with tracking"
+      extra_links: [
+        {
+          text: "Another link with tracking",
+          href: "/1",
+          data_attributes: {
+            track_category: 'extra_category',
+            track_action: 2.1,
+            track_label: 'extra_label',
+            track_options: {
+              dimension28: 1,
+              dimension29: 'dimension29Extra'
+            }
+          }
+        }
+      ]

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -29,6 +29,40 @@ examples:
       metadata: '10 May 2018 - Press release'
       heading_text: 'Government does things'
       description: 'Following a thorough review of existing procedure, a government body has today announced that further work is necessary.'
+  with_extra_links:
+    data:
+      href: '/a-page-no-just-kidding'
+      image_src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG'
+      heading_text: 'Some more links'
+      description: 'Greater transparency across government is at the heart of our commitment to let you hold politicians and public bodies to account.'
+      extra_links: [
+        {
+          text: "Single departmental plans",
+          href: '/1'
+        },
+        {
+          text: "Prime Minister's and Cabinet Office ministers' transparency publications",
+          href: '/2'
+        },
+        {
+          text: "Government transparency data",
+          href: '/3'
+        },
+      ]
+  extra_links_without_indent:
+    description: Don't indent the extra links. Used for links to people pages.
+    data:
+      href: '/government/people/jeremy-wright'
+      image_src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/354/s216_TME_3860TME_3860_960_Jeremy_Wright.JPG'
+      metadata: 'The Rt Hon'
+      heading_text: 'Jeremy Wright QC MP'
+      extra_links: [
+        {
+          text: 'Attorney General',
+          href: '/government/ministers/attorney-general'
+        }
+      ]
+      extra_links_no_indent: true
   large_version:
     data:
       large: true

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -28,7 +28,7 @@ examples:
     data:
       href: "/also-not-a-page"
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
-      metadata: "10 May 2018 - Press release"
+      context: "10 May 2018 - Press release"
       heading_text: "Government does things"
       description: "Following a thorough review of existing procedure, a government body has today announced that further work is necessary."
   with_extra_links:
@@ -54,21 +54,21 @@ examples:
   extra_links_without_indent:
     description: Don't indent the extra links. Used for links to people pages.
     data:
-      href: "/government/people/jeremy-wright"
-      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/354/s216_TME_3860TME_3860_960_Jeremy_Wright.JPG"
-      metadata: "The Rt Hon"
-      heading_text: "Jeremy Wright QC MP"
+      href: "/government/people/"
+      image_src: "http://placekitten.com/215/140"
+      context: "The Rt Hon"
+      heading_text: "John Whiskers MP"
       extra_links: [
         {
-          text: "Attorney General",
-          href: "/government/ministers/attorney-general"
+          text: "Minister for Cats",
+          href: "/government/ministers/"
         }
       ]
       extra_links_no_indent: true
   with_branding:
     description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) can be added to the component as shown.
     data:
-      brand: 'attorney-generals-office'
+      brand: 'department-for-work-pensions'
       href: "/again-not-a-page"
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
       heading_text: "Something relating to this"
@@ -88,6 +88,6 @@ examples:
       large: true
       href: "/still-not-a-page"
       image_src: "https://assets.publishing.service.gov.uk/frontend/homepage/leaving-the-eu-bc9992ee672a30d8e8a3e195c9afa750e618748130a4e073a593ba36dfc29af9.jpg"
-      metadata: "14 Jun 2017 - Announcement"
+      context: "14 Jun 2017 - Announcement"
       heading_text: "Something has happened nearby possibly"
       description: "Following a news report that something has happened, further details are emerging of the thing that has happened and what that means for you."

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -3,7 +3,7 @@ description: Image and associated text with a link
 body: |
   An image and an associated link, meant for use for news articles and people. Includes optional paragraph and additional links.
 
-  Note that the component is generally to be used within a grid column but has no grid of its own, so the text and the images in the examples below may not always line up. This will normally look tidier, for example [on pages like this](https://www.gov.uk/government/organisations/attorney-generals-office).
+  The component is generally to be used within a grid column but has no grid of its own, so the text and the images in the examples below may not always line up. This will normally look tidier, for example [on pages like this](https://www.gov.uk/government/organisations/attorney-generals-office).
 accessibility_criteria: |
   The component must:
 
@@ -65,10 +65,33 @@ examples:
         }
       ]
       extra_links_no_indent: true
+  without_heading_text:
+    description: |
+      The only required parameter to the component is href but if no heading_text is supplied the link will not appear. This is to allow the component to use only extra links as shown.
+
+      In this situation the link could have been applied to the image but having a link on the image like this without text can be confusing.
+    data:
+      href: "/still-not-a-link"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      description: Here are some links to more information about the thing you are reading about.
+      extra_links: [
+        {
+          text: "More information",
+          href: "/1"
+        },
+        {
+          text: "Even more information",
+          href: "/2"
+        },
+        {
+          text: "One final bit of information we forgot to mention",
+          href: "/2"
+        }
+      ]
   with_branding:
     description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) can be added to the component as shown.
     data:
-      brand: 'department-for-work-pensions'
+      brand: "department-for-work-pensions"
       href: "/again-not-a-page"
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
       heading_text: "Something relating to this"

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -1,7 +1,9 @@
 name: Image card
 description: Image and associated text with a link
 body: |
-  An image and an associated link, meant for use for news articles and similar.
+  An image and an associated link, meant for use for news articles and people. Includes optional paragraph and additional links.
+
+  Note that the component is generally to be used within a grid column but has no grid of its own, so the text and the images in the examples below may not always line up. This will normally look tidier, for example [on pages like this](https://www.gov.uk/government/organisations/attorney-generals-office).
 accessibility_criteria: |
   The component must:
 
@@ -12,62 +14,62 @@ shared_accessibility_criteria:
 examples:
   default:
     data:
-      href: '/not-a-page'
-      image_src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG'
-      heading_text: 'News headline'
+      href: "/not-a-page"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      heading_text: "News headline"
   with_a_different_heading_level:
     description: Use a different heading level for the main link title. Defaults to H2 if not passed.
     data:
-      href: '/really-not-a-page'
-      image_src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG'
-      heading_text: 'I am a heading level 3'
+      href: "/really-not-a-page"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      heading_text: "I am a heading level 3"
       heading_level: 3
   with_more_information:
     data:
-      href: '/also-not-a-page'
-      image_src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG'
-      metadata: '10 May 2018 - Press release'
-      heading_text: 'Government does things'
-      description: 'Following a thorough review of existing procedure, a government body has today announced that further work is necessary.'
+      href: "/also-not-a-page"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      metadata: "10 May 2018 - Press release"
+      heading_text: "Government does things"
+      description: "Following a thorough review of existing procedure, a government body has today announced that further work is necessary."
   with_extra_links:
     data:
-      href: '/a-page-no-just-kidding'
-      image_src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG'
-      heading_text: 'Some more links'
-      description: 'Greater transparency across government is at the heart of our commitment to let you hold politicians and public bodies to account.'
+      href: "/a-page-no-just-kidding"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      heading_text: "Some more links"
+      description: "Greater transparency across government is at the heart of our commitment to let you hold politicians and public bodies to account."
       extra_links: [
         {
           text: "Single departmental plans",
-          href: '/1'
+          href: "/1"
         },
         {
           text: "Prime Minister's and Cabinet Office ministers' transparency publications",
-          href: '/2'
+          href: "/2"
         },
         {
           text: "Government transparency data",
-          href: '/3'
+          href: "/3"
         },
       ]
   extra_links_without_indent:
     description: Don't indent the extra links. Used for links to people pages.
     data:
-      href: '/government/people/jeremy-wright'
-      image_src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/354/s216_TME_3860TME_3860_960_Jeremy_Wright.JPG'
-      metadata: 'The Rt Hon'
-      heading_text: 'Jeremy Wright QC MP'
+      href: "/government/people/jeremy-wright"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/354/s216_TME_3860TME_3860_960_Jeremy_Wright.JPG"
+      metadata: "The Rt Hon"
+      heading_text: "Jeremy Wright QC MP"
       extra_links: [
         {
-          text: 'Attorney General',
-          href: '/government/ministers/attorney-general'
+          text: "Attorney General",
+          href: "/government/ministers/attorney-general"
         }
       ]
       extra_links_no_indent: true
   large_version:
     data:
       large: true
-      href: '/still-not-a-page'
-      image_src: 'https://assets.publishing.service.gov.uk/frontend/homepage/leaving-the-eu-bc9992ee672a30d8e8a3e195c9afa750e618748130a4e073a593ba36dfc29af9.jpg'
-      metadata: '14 Jun 2017 - Announcement'
-      heading_text: 'Something has happened nearby possibly'
-      description: 'Following a news report that something has happened, further details are emerging of the thing that has happened and what that means for you.'
+      href: "/still-not-a-page"
+      image_src: "https://assets.publishing.service.gov.uk/frontend/homepage/leaving-the-eu-bc9992ee672a30d8e8a3e195c9afa750e618748130a4e073a593ba36dfc29af9.jpg"
+      metadata: "14 Jun 2017 - Announcement"
+      heading_text: "Something has happened nearby possibly"
+      description: "Following a news report that something has happened, further details are emerging of the thing that has happened and what that means for you."

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -23,12 +23,14 @@ examples:
     data:
       href: "/really-not-a-page"
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      image_alt: "some meaningful alt text please"
       heading_text: "I am a heading level 3"
       heading_level: 3
   with_more_information:
     data:
       href: "/also-not-a-page"
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      image_alt: "some meaningful alt text please"
       context: "10 May 2018 - Press release"
       heading_text: "Government does things"
       description: "Following a thorough review of existing procedure, a government body has today announced that further work is necessary."
@@ -36,6 +38,7 @@ examples:
     data:
       href: "/a-page-no-just-kidding"
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      image_alt: "some meaningful alt text please"
       heading_text: "Some more links"
       description: "Greater transparency across government is at the heart of our commitment to let you hold politicians and public bodies to account."
       extra_links: [
@@ -57,6 +60,7 @@ examples:
     data:
       href: "/government/people/"
       image_src: "http://placekitten.com/215/140"
+      image_alt: "some meaningful alt text please"
       context: "The Rt Hon"
       heading_text: "John Whiskers MP"
       extra_links: [
@@ -74,6 +78,7 @@ examples:
     data:
       href: "/still-not-a-link"
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      image_alt: "some meaningful alt text please"
       description: Here are some links to more information about the thing you are reading about.
       extra_links: [
         {
@@ -89,12 +94,19 @@ examples:
           href: "/2"
         }
       ]
+  without_an_image:
+    description: Despite the name of the component, it is possible to have it display without an image.
+    data:
+      href: '/no-valid-links-here'
+      heading_text: 'John McJohnson'
+      description: 'Deputy director for Parks and Small Trees'
   with_branding:
     description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) can be added to the component as shown.
     data:
       brand: "department-for-work-pensions"
       href: "/again-not-a-page"
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      image_alt: "some meaningful alt text please"
       heading_text: "Something relating to this"
       description: "Public reform committee consultation vote department interior minister referendum."
       extra_links: [
@@ -112,6 +124,7 @@ examples:
       large: true
       href: "/still-not-a-page"
       image_src: "https://assets.publishing.service.gov.uk/frontend/homepage/leaving-the-eu-bc9992ee672a30d8e8a3e195c9afa750e618748130a4e073a593ba36dfc29af9.jpg"
+      image_alt: "some meaningful alt text please"
       context: "14 Jun 2017 - Announcement"
       heading_text: "Something has happened nearby possibly"
       description: "Following a news report that something has happened, further details are emerging of the thing that has happened and what that means for you."
@@ -128,6 +141,7 @@ examples:
         }
       }
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      image_alt: "some meaningful alt text please"
       heading_text: "A link with tracking"
       extra_links: [
         {

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -1,0 +1,19 @@
+name: Image card
+description: Image and associated text with a link
+body: |
+  An image and an associated link, meant for use for news articles and similar.
+accessibility_criteria: |
+  The component must:
+
+  - include alt text for images when present
+  - not have duplicate links for the image and the text
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      href: '/not-a-page'
+      image_src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG'
+      heading_text: 'News headline'
+
+      #https://assets.publishing.service.gov.uk/frontend/homepage/leaving-the-eu-bc9992ee672a30d8e8a3e195c9afa750e618748130a4e073a593ba36dfc29af9.jpg

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -22,5 +22,11 @@ examples:
       metadata: '10 May 2018 - Press release'
       heading_text: 'Government does things'
       description: 'Following a thorough review of existing procedure, a government body has today announced that further work is necessary.'
-
-      #https://assets.publishing.service.gov.uk/frontend/homepage/leaving-the-eu-bc9992ee672a30d8e8a3e195c9afa750e618748130a4e073a593ba36dfc29af9.jpg
+  large_version:
+    data:
+      large: true
+      href: '/still-not-a-page'
+      image_src: 'https://assets.publishing.service.gov.uk/frontend/homepage/leaving-the-eu-bc9992ee672a30d8e8a3e195c9afa750e618748130a4e073a593ba36dfc29af9.jpg'
+      metadata: '14 Jun 2017 - Announcement'
+      heading_text: 'Something has happened nearby possibly'
+      description: 'Following a news report that something has happened, further details are emerging of the thing that has happened and what that means for you.'

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -65,6 +65,24 @@ examples:
         }
       ]
       extra_links_no_indent: true
+  with_branding:
+    description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) can be added to the component as shown.
+    data:
+      brand: 'attorney-generals-office'
+      href: "/again-not-a-page"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      heading_text: "Something relating to this"
+      description: "Public reform committee consultation vote department interior minister referendum."
+      extra_links: [
+        {
+          text: "Something",
+          href: "/1"
+        },
+        {
+          text: "Something else",
+          href: "/2"
+        }
+      ]
   large_version:
     data:
       large: true

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -16,6 +16,7 @@ examples:
     data:
       href: "/not-a-page"
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      image_alt: "some meaningful alt text please"
       heading_text: "News headline"
   with_a_different_heading_level:
     description: Use a different heading level for the main link title. Defaults to H2 if not passed.

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -15,5 +15,12 @@ examples:
       href: '/not-a-page'
       image_src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG'
       heading_text: 'News headline'
+  with_more_information:
+    data:
+      href: '/also-not-a-page'
+      image_src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG'
+      metadata: '10 May 2018 - Press release'
+      heading_text: 'Government does things'
+      description: 'Following a thorough review of existing procedure, a government body has today announced that further work is necessary.'
 
       #https://assets.publishing.service.gov.uk/frontend/homepage/leaving-the-eu-bc9992ee672a30d8e8a3e195c9afa750e618748130a4e073a593ba36dfc29af9.jpg

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -15,6 +15,13 @@ examples:
       href: '/not-a-page'
       image_src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG'
       heading_text: 'News headline'
+  with_a_different_heading_level:
+    description: Use a different heading level for the main link title. Defaults to H2 if not passed.
+    data:
+      href: '/really-not-a-page'
+      image_src: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG'
+      heading_text: 'I am a heading level 3'
+      heading_level: 3
   with_more_information:
     data:
       href: '/also-not-a-page'

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -19,6 +19,7 @@ require "govuk_publishing_components/presenters/subscription_links_helper"
 require "govuk_publishing_components/presenters/schema_org"
 require "govuk_publishing_components/presenters/heading_helper"
 require "govuk_publishing_components/presenters/contents_list_helper"
+require "govuk_publishing_components/presenters/image_card_helper"
 
 require "govuk_publishing_components/app_helpers/taxon_breadcrumbs"
 require "govuk_publishing_components/app_helpers/brand_helper"

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -1,0 +1,55 @@
+module GovukPublishingComponents
+  module Presenters
+    class ImageCardHelper
+      include ActionView::Helpers
+      include ActionView::Context
+
+      attr_reader :href, :href_data_attributes, :extra_links, :large, :extra_links_no_indent, :heading_text
+
+      def initialize(local_assigns)
+        @href = local_assigns[:href]
+        @href_data_attributes = local_assigns[:href_data_attributes]
+        @extra_links = local_assigns[:extra_links]
+        @image_src = local_assigns[:image_src]
+        @image_alt = local_assigns[:image_alt] || ""
+        @context = local_assigns[:context]
+        @description = local_assigns[:description]
+        @large = local_assigns[:large]
+        @heading_text = local_assigns[:heading_text]
+        @heading_level = local_assigns[:heading_level]
+        @extra_links_no_indent = local_assigns[:extra_links_no_indent]
+      end
+
+      def is_tracking?
+        return true if @href_data_attributes
+        if @extra_links
+          @extra_links.each do |link|
+            return true if link[:data_attributes]
+          end
+        end
+        false
+      end
+
+      def image
+        if @image_src
+          content_tag(:figure, class: "gem-c-image-card__image-wrapper") do
+            image_tag(@image_src, class: "gem-c-image-card__image", alt: @image_alt)
+          end
+        end
+      end
+
+      def context
+        content_tag(:p, @context, class: "gem-c-image-card__context") if @context
+      end
+
+      def heading_tag
+        return "h#{@heading_level}" if [1, 2, 3, 4, 5, 6].include? @heading_level
+        "h2"
+      end
+
+      def description
+        content_tag(:p, @description, class: "gem-c-image-card__description") if @description
+      end
+    end
+  end
+end

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -31,13 +31,13 @@ describe "ImageCard", type: :view do
   end
 
   it "renders extra links" do
-    render_component(href: '#', extra_links: [{href: '/1', text: 'link1'}, {href: '/2', text: 'link2'}])
+    render_component(href: '#', extra_links: [{ href: '/1', text: 'link1' }, { href: '/2', text: 'link2' }])
     assert_select ".gem-c-image-card__list .gem-c-image-card__list-item a[href='/1']", text: 'link1'
     assert_select ".gem-c-image-card__list .gem-c-image-card__list-item a[href='/2']", text: 'link2'
   end
 
   it "renders extra links without indent" do
-    render_component(href: '#', extra_links: [{href: '/1', text: 'link1'}], extra_links_no_indent: true)
+    render_component(href: '#', extra_links: [{ href: '/1', text: 'link1' }], extra_links_no_indent: true)
     assert_select ".gem-c-image-card__list"
     assert_select ".gem-c-image-card__list.gem-c-image-card__list--indented", false
   end

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe "ImageCard", type: :view do
+  def component_name
+    "image_card"
+  end
+
+  it "renders nothing when no link provided" do
+    assert_empty render_component({})
+  end
+
+  it "shows an image" do
+    render_component(href: '#', image_src: '/moo.jpg', image_alt: 'some meaningful alt text')
+    assert_select ".gem-c-image-card .gem-c-image-card__image[src='/moo.jpg'][alt='some meaningful alt text']"
+  end
+
+  it "shows heading text" do
+    render_component(href: '#', heading_text: 'This is some text')
+    assert_select ".gem-c-image-card .gem-c-image-card__title", text: 'This is some text'
+  end
+end

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -24,9 +24,9 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card h1.gem-c-image-card__title", text: 'heading 1'
   end
 
-  it "shows metadata and description" do
-    render_component(href: '#', metadata: 'some metadata', description: 'description')
-    assert_select ".gem-c-image-card .gem-c-image-card__metadata", text: 'some metadata'
+  it "shows context and description" do
+    render_component(href: '#', context: 'some context', description: 'description')
+    assert_select ".gem-c-image-card .gem-c-image-card__context", text: 'some context'
     assert_select ".gem-c-image-card .gem-c-image-card__description", text: 'description'
   end
 

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -42,6 +42,13 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card__list.gem-c-image-card__list--indented", false
   end
 
+  it "applies branding" do
+    render_component(href: '#', heading_text: 'test', extra_links: [{ href: '/1', text: 'link1' }], brand: 'attorney-generals-office')
+    assert_select ".gem-c-image-card.brand--attorney-generals-office"
+    assert_select ".gem-c-image-card__title-link.brand__color"
+    assert_select ".gem-c-image-card__list-item .brand__color"
+  end
+
   it "renders a large version" do
     render_component(href: '#', large: true)
     assert_select ".gem-c-image-card.gem-c-image-card--large"

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -30,6 +30,18 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card .gem-c-image-card__description", text: 'description'
   end
 
+  it "renders extra links" do
+    render_component(href: '#', extra_links: [{href: '/1', text: 'link1'}, {href: '/2', text: 'link2'}])
+    assert_select ".gem-c-image-card__list .gem-c-image-card__list-item a[href='/1']", text: 'link1'
+    assert_select ".gem-c-image-card__list .gem-c-image-card__list-item a[href='/2']", text: 'link2'
+  end
+
+  it "renders extra links without indent" do
+    render_component(href: '#', extra_links: [{href: '/1', text: 'link1'}], extra_links_no_indent: true)
+    assert_select ".gem-c-image-card__list"
+    assert_select ".gem-c-image-card__list.gem-c-image-card__list--indented", false
+  end
+
   it "renders a large version" do
     render_component(href: '#', large: true)
     assert_select ".gem-c-image-card.gem-c-image-card--large"

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -19,6 +19,11 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card .gem-c-image-card__title", text: 'This is some text'
   end
 
+  it "can render different heading levels" do
+    render_component(href: '#', heading_text: 'heading 1', heading_level: 1)
+    assert_select ".gem-c-image-card h1.gem-c-image-card__title", text: 'heading 1'
+  end
+
   it "shows metadata and description" do
     render_component(href: '#', metadata: 'some metadata', description: 'description')
     assert_select ".gem-c-image-card .gem-c-image-card__metadata", text: 'some metadata'

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -53,4 +53,16 @@ describe "ImageCard", type: :view do
     render_component(href: '#', large: true)
     assert_select ".gem-c-image-card.gem-c-image-card--large"
   end
+
+  it "applies tracking attributes" do
+    render_component(href: '#', href_data_attributes: { track_category: 'cat' }, heading_text: 'test')
+    assert_select ".gem-c-image-card[data-module='track-click']"
+    assert_select ".gem-c-image-card__title-link[data-track-category='cat']"
+  end
+
+  it "applies tracking attributes for extra links" do
+    render_component(href: '#', extra_links: [{ href: '/', text: '1', data_attributes: { track_category: 'cat' } }])
+    assert_select ".gem-c-image-card[data-module='track-click']"
+    assert_select ".gem-c-image-card__list-item a[data-track-category='cat']"
+  end
 end

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -12,6 +12,7 @@ describe "ImageCard", type: :view do
   it "shows an image" do
     render_component(href: '#', image_src: '/moo.jpg', image_alt: 'some meaningful alt text')
     assert_select ".gem-c-image-card .gem-c-image-card__image[src='/moo.jpg'][alt='some meaningful alt text']"
+    assert_select ".gem-c-image-card[data-module='track-click']", false
   end
 
   it "shows heading text" do

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -24,4 +24,9 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card .gem-c-image-card__metadata", text: 'some metadata'
     assert_select ".gem-c-image-card .gem-c-image-card__description", text: 'description'
   end
+
+  it "renders a large version" do
+    render_component(href: '#', large: true)
+    assert_select ".gem-c-image-card.gem-c-image-card--large"
+  end
 end

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -18,4 +18,10 @@ describe "ImageCard", type: :view do
     render_component(href: '#', heading_text: 'This is some text')
     assert_select ".gem-c-image-card .gem-c-image-card__title", text: 'This is some text'
   end
+
+  it "shows metadata and description" do
+    render_component(href: '#', metadata: 'some metadata', description: 'description')
+    assert_select ".gem-c-image-card .gem-c-image-card__metadata", text: 'some metadata'
+    assert_select ".gem-c-image-card .gem-c-image-card__description", text: 'description'
+  end
 end


### PR DESCRIPTION
Adds a new component, image card, intended for use for news articles and people entries on organisation pages. See the [component guide](https://govuk-publishing-compon-pr-322.herokuapp.com/component-guide/image_card) for a full explanation.

Examples in context:

![screen shot 2018-05-29 at 10 01 46](https://user-images.githubusercontent.com/861310/40648860-58713636-6327-11e8-920a-f513b0a207fa.png)

Mobile:

<img width="411" alt="screen shot 2018-05-18 at 15 29 05" src="https://user-images.githubusercontent.com/861310/40240395-5fe2862e-5ab0-11e8-9b0d-97a53073a7c7.png">

Tested in IE8+, latest Chrome, Firefox, iphone 6, iphone 5, Google Nexus.

Component guide: https://govuk-publishing-compon-pr-322.herokuapp.com/component-guide/image_card
Trello card: https://trello.com/c/v8vHh54c/102-new-component-image-link