### PR TITLE
Remove padding from HTML code examples

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -122,6 +122,10 @@ $border-color: #ccc;
     background-color: $govuk-blue;
   }
 
+  &.component-output {
+    padding: 0;
+  }
+
   padding: ($gutter * 1.5) $gutter $gutter;
   border: 1px solid $border-colour;
   position: relative;


### PR DESCRIPTION
Follows PR #320, removes excess padding from HTML examples.

Example link: https://govuk-publishing-compon-pr-323.herokuapp.com/component-guide/machine_readable_metadata