### PR TITLE
Add missing imports for margins

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_lead-paragraph.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_lead-paragraph.scss
@@ -1,3 +1,5 @@
+@import "mixins/margins";
+
 .gem-c-lead-paragraph {
   @include core-24;
   @include responsive-bottom-margin;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_translation-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_translation-nav.scss
@@ -1,3 +1,5 @@
+@import "mixins/margins";
+
 .gem-c-translation-nav {
   @include responsive-top-margin;
   @include core-16;


### PR DESCRIPTION
These components use the `margins` mixin but don't import it explicitly.