### PR TITLE
Refactor component guide code

### DIFF
--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -3,17 +3,17 @@ module GovukPublishingComponents
     append_view_path File.join(Rails.root, "app", "views", GovukPublishingComponents::Config.component_directory_name)
 
     def index
-      @component_docs = component_documentation_resolver.all
-      @gem_component_docs = gem_component_documentation_resolver.all
+      @component_docs = component_docs.all
+      @gem_component_docs = gem_component_docs.all
     end
 
     def show
-      @component_doc = component_documentation_resolver.get(params[:component])
+      @component_doc = component_docs.get(params[:component])
       @guide_breadcrumbs = [index_breadcrumb, component_breadcrumb(@component_doc)]
     end
 
     def example
-      @component_doc = component_documentation_resolver.get(params[:component])
+      @component_doc = component_docs.get(params[:component])
       @component_example = @component_doc.examples.find { |f| f.id == params[:example] }
       @guide_breadcrumbs = [
                              index_breadcrumb,
@@ -26,7 +26,7 @@ module GovukPublishingComponents
 
     def preview
       @component_examples = []
-      @component_doc = component_documentation_resolver.get(params[:component])
+      @component_doc = component_docs.get(params[:component])
       @preview = true
 
       if params[:example].present?
@@ -38,12 +38,12 @@ module GovukPublishingComponents
 
   private
 
-    def component_documentation_resolver
-      @component_documentation_resolver ||= ComponentDocResolver.new
+    def component_docs
+      @component_docs ||= ComponentDocs.new
     end
 
-    def gem_component_documentation_resolver
-      @gem_component_documentation_resolver ||= ComponentDocResolver.new(gem_components: true)
+    def gem_component_docs
+      @gem_component_docs ||= ComponentDocs.new(gem_components: true)
     end
 
     def index_breadcrumb

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -66,7 +66,7 @@ module GovukPublishingComponents
     def examples
       @examples ||= component[:examples].map do |id, example_data|
         example_data = example_data || {}
-        ComponentExample.new(id.to_s, example_data["data"], example_data["context"], example_data["description"])
+        ComponentExample.new(id.to_s, example_data)
       end
     end
 

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -4,25 +4,36 @@ module GovukPublishingComponents
                 :name,
                 :description,
                 :body,
-                :accessibility_criteria,
+                :component,
                 :accessibility_excluded_rules,
                 :examples,
                 :source
 
     def initialize(
       component,
-      accessibility_criteria,
       examples
     )
+      @component = component
       @id = component[:id]
       @name = component[:name]
       @description = component[:description]
       @body = component[:body]
-      @accessibility_criteria = accessibility_criteria
       @accessibility_excluded_rules = component[:accessibility_excluded_rules]
       @examples = examples
       @source = component[:source]
       @display_html = component[:display_html]
+    end
+
+    def accessibility_criteria
+      shared_accessibility_criteria = []
+
+      if component[:shared_accessibility_criteria].present?
+        component[:shared_accessibility_criteria].each do |criteria|
+          shared_accessibility_criteria << SharedAccessibilityCriteria.send(criteria) if SharedAccessibilityCriteria.respond_to? criteria
+        end
+      end
+
+      "#{component[:accessibility_criteria]}\n#{shared_accessibility_criteria.join("\n")}"
     end
 
     def example

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -16,7 +16,6 @@ module GovukPublishingComponents
       @body = component[:body]
       @accessibility_excluded_rules = component[:accessibility_excluded_rules]
       @source = component[:source]
-      @display_html = component[:display_html]
     end
 
     def accessibility_criteria
@@ -40,7 +39,7 @@ module GovukPublishingComponents
     end
 
     def display_html?
-      @display_html
+      component[:display_html]
     end
 
     def html_body

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -10,25 +10,19 @@ module GovukPublishingComponents
                 :source
 
     def initialize(
-      id,
-      name,
-      description,
-      body,
+      component,
       accessibility_criteria,
-      accessibility_excluded_rules,
-      examples,
-      source,
-      display_html
+      examples
     )
-      @id = id
-      @name = name
-      @description = description
-      @body = body
+      @id = component[:id]
+      @name = component[:name]
+      @description = component[:description]
+      @body = component[:body]
       @accessibility_criteria = accessibility_criteria
-      @accessibility_excluded_rules = accessibility_excluded_rules
+      @accessibility_excluded_rules = component[:accessibility_excluded_rules]
       @examples = examples
-      @source = source
-      @display_html = display_html
+      @source = component[:source]
+      @display_html = component[:display_html]
     end
 
     def example

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -6,20 +6,15 @@ module GovukPublishingComponents
                 :body,
                 :component,
                 :accessibility_excluded_rules,
-                :examples,
                 :source
 
-    def initialize(
-      component,
-      examples
-    )
+    def initialize(component)
       @component = component
       @id = component[:id]
       @name = component[:name]
       @description = component[:description]
       @body = component[:body]
       @accessibility_excluded_rules = component[:accessibility_excluded_rules]
-      @examples = examples
       @source = component[:source]
       @display_html = component[:display_html]
     end
@@ -67,6 +62,13 @@ module GovukPublishingComponents
     def github_search_url
       params = { q: "org:alphagov #{partial_path}", type: "Code" }
       "https://github.com/search?#{params.to_query}"
+    end
+
+    def examples
+      @examples ||= component[:examples].map do |id, example_data|
+        example_data = example_data || {}
+        ComponentExample.new(id.to_s, example_data["data"], example_data["context"], example_data["description"])
+      end
     end
 
   private

--- a/app/models/govuk_publishing_components/component_doc_resolver.rb
+++ b/app/models/govuk_publishing_components/component_doc_resolver.rb
@@ -17,15 +17,7 @@ module GovukPublishingComponents
   private
 
     def build(component)
-      examples = component[:examples].map { |id, example|
-        example = example || {}
-        ComponentExample.new(id.to_s, example["data"], example["context"], example["description"])
-      }
-
-      ComponentDoc.new(
-        component,
-        examples,
-      )
+      ComponentDoc.new(component)
     end
 
     def fetch_component_docs

--- a/app/models/govuk_publishing_components/component_doc_resolver.rb
+++ b/app/models/govuk_publishing_components/component_doc_resolver.rb
@@ -24,20 +24,8 @@ module GovukPublishingComponents
 
       ComponentDoc.new(
         component,
-        combined_accessibility_criteria(component),
         examples,
       )
-    end
-
-    def combined_accessibility_criteria(component)
-      shared_accessibility_criteria = []
-
-      if component[:shared_accessibility_criteria].present?
-        component[:shared_accessibility_criteria].each do |criteria|
-          shared_accessibility_criteria << SharedAccessibilityCriteria.send(criteria) if SharedAccessibilityCriteria.respond_to? criteria
-        end
-      end
-      "#{component[:accessibility_criteria]}\n#{shared_accessibility_criteria.join("\n")}"
     end
 
     def fetch_component_docs

--- a/app/models/govuk_publishing_components/component_doc_resolver.rb
+++ b/app/models/govuk_publishing_components/component_doc_resolver.rb
@@ -23,15 +23,9 @@ module GovukPublishingComponents
       }
 
       ComponentDoc.new(
-        component[:id],
-        component[:name],
-        component[:description],
-        component[:body],
+        component,
         combined_accessibility_criteria(component),
-        component[:accessibility_excluded_rules],
         examples,
-        component[:source],
-        component[:display_html],
       )
     end
 

--- a/app/models/govuk_publishing_components/component_docs.rb
+++ b/app/models/govuk_publishing_components/component_docs.rb
@@ -1,6 +1,6 @@
 module GovukPublishingComponents
   # @private
-  class ComponentDocResolver
+  class ComponentDocs
     def initialize(gem_components: false)
       @documentation_directory = gem_components ? gem_documentation_directory : app_documentation_directory
     end

--- a/app/models/govuk_publishing_components/component_example.rb
+++ b/app/models/govuk_publishing_components/component_example.rb
@@ -8,11 +8,11 @@ module GovukPublishingComponents
                 :description,
                 :block
 
-    def initialize(id, data, context, description)
+    def initialize(id, example)
       @id = id
-      @data = data || {}
-      @context = context || {}
-      @description = description || false
+      @data = example["data"] || {}
+      @context = example["context"] || {}
+      @description = example["description"] || false
       @block = @data.delete(:block) || false
     end
 


### PR DESCRIPTION
This refactors the component guide code by minimising the arguments to the constructors, renaming to reveal more meaning and removing some indirection. Read the commits for all the details.