### PR TITLE
Update Machine readable metadata component to include Facebook, Twitter, SEO things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ## Unreleased
 
+* Add better meta tags for third parties to the Machine readable metadata
+  component. If you're using this component you should remove any canonical
+  tags, OpenGraph tags and Twitter cards (#335).
 * Move the Title component from static (PR #324)
 * Move the Lead paragraph component from static (PR #325)
 * Add a Phase banner component to replace the Alpha/Beta banners in Static (PR #333)

--- a/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
@@ -4,6 +4,9 @@
 <script type="application/ld+json">
   <%= raw structured_data.to_json %>
 </script>
+
+<link rel="canonical" href="<%= page.canonical_url %>" />
+
 <meta property="og:site_name" content="GOV.UK" />
 <meta property="og:type" content="article" />
 <meta property="og:url" content="<%= page.canonical_url %>" />

--- a/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
@@ -1,4 +1,5 @@
-<% structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(local_assigns).structured_data %>
+<% page = GovukPublishingComponents::Presenters::Page.new(local_assigns) %>
+<% structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(page).structured_data %>
 
 <script type="application/ld+json">
   <%= raw structured_data.to_json %>

--- a/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
@@ -4,3 +4,19 @@
 <script type="application/ld+json">
   <%= raw structured_data.to_json %>
 </script>
+<meta property="og:site_name" content="GOV.UK" />
+<meta property="og:type" content="article" />
+<meta property="og:url" content="<%= page.canonical_url %>" />
+<meta property="og:title" content="<%= page.title %>" />
+<meta property="og:description" content="<%= strip_tags(page.description) %>" />
+
+<% if page.has_image? %>
+  <meta property="og:image" content="<%= page.image_url %>" />
+  <meta property="og:image:alt" content="<%= page.image_alt_text %>" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="<%= page.image_url %>" />
+  <meta name="twitter:image:alt" content="<%= page.image_alt_text %>" />
+<% else %>
+  <meta name="twitter:card" content="summary" />
+<% end %>

--- a/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
@@ -1,0 +1,76 @@
+module GovukPublishingComponents
+  module Presenters
+    class ArticleSchema
+      attr_reader :page
+
+      def initialize(page)
+        @page = page
+      end
+
+      def structured_data
+        # http://schema.org/Article
+        {
+          "@context" => "http://schema.org",
+          "@type" => "Article",
+          "mainEntityOfPage" => {
+            "@type" => "WebPage",
+            "@id" => page.canonical_url,
+          },
+          "headline" => page.title,
+          "datePublished" => page.content_item["first_published_at"],
+          "dateModified" => page.content_item["public_updated_at"],
+          "description" => page.content_item["description"],
+          "publisher" => {
+            "@type" => "Organization",
+            "name" => "GOV.UK",
+            "url" => "https://www.gov.uk",
+          }
+        }.merge(image_schema).merge(author_schema).merge(body)
+      end
+
+    private
+
+      attr_reader :presenter
+
+      # Not all formats have a `body` - some have their content split over
+      # multiple fields. In this case we'll skip the `articleBody` field
+      def body
+        return {} unless page.body
+
+        {
+          "articleBody" => page.body
+        }
+      end
+
+      def image_schema
+        return {} unless image
+
+        {
+          "image" => [
+            image["url"],
+          ]
+        }
+      end
+
+      def author_schema
+        return {} unless publishing_organisation
+
+        {
+          "author" => {
+            "@type" => "Organization",
+            "name" => publishing_organisation["title"],
+            "url" => Plek.current.website_root + publishing_organisation["base_path"],
+          }
+        }
+      end
+
+      def publishing_organisation
+        page.content_item.dig("links", "primary_publishing_organisation").to_a.first
+      end
+
+      def image
+        page.content_item.dig("details", "image")
+      end
+    end
+  end
+end

--- a/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
@@ -19,7 +19,7 @@ module GovukPublishingComponents
           "headline" => page.title,
           "datePublished" => page.content_item["first_published_at"],
           "dateModified" => page.content_item["public_updated_at"],
-          "description" => page.content_item["description"],
+          "description" => page.description,
           "publisher" => {
             "@type" => "Organization",
             "name" => "GOV.UK",
@@ -43,11 +43,11 @@ module GovukPublishingComponents
       end
 
       def image_schema
-        return {} unless image
+        return {} unless page.has_image?
 
         {
           "image" => [
-            image["url"],
+            page.image_url
           ]
         }
       end
@@ -66,10 +66,6 @@ module GovukPublishingComponents
 
       def publishing_organisation
         page.content_item.dig("links", "primary_publishing_organisation").to_a.first
-      end
-
-      def image
-        page.content_item.dig("details", "image")
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/machine_readable/news_article_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/news_article_schema.rb
@@ -1,0 +1,16 @@
+module GovukPublishingComponents
+  module Presenters
+    class NewsArticleSchema
+      def initialize(page)
+        @page = page
+      end
+
+      def structured_data
+        # http://schema.org/NewsArticle
+        data = ArticleSchema.new(@page).structured_data
+        data["@type"] = "NewsArticle"
+        data
+      end
+    end
+  end
+end

--- a/lib/govuk_publishing_components/presenters/machine_readable/page.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/page.rb
@@ -1,0 +1,31 @@
+module GovukPublishingComponents
+  module Presenters
+    class Page
+      attr_reader :local_assigns
+
+      def initialize(local_assigns)
+        @local_assigns = local_assigns
+      end
+
+      def schema
+        local_assigns.fetch(:schema)
+      end
+
+      def canonical_url
+        local_assigns[:canonical_url] || (Plek.current.website_root + content_item["base_path"])
+      end
+
+      def body
+        local_assigns[:body] || content_item["details"]["body"]
+      end
+
+      def title
+        local_assigns[:title] || content_item["title"]
+      end
+
+      def content_item
+        local_assigns[:content_item]
+      end
+    end
+  end
+end

--- a/lib/govuk_publishing_components/presenters/machine_readable/page.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/page.rb
@@ -23,6 +23,22 @@ module GovukPublishingComponents
         local_assigns[:title] || content_item["title"]
       end
 
+      def description
+        content_item["description"]
+      end
+
+      def has_image?
+        content_item.dig("details", "image").present?
+      end
+
+      def image_url
+        content_item.dig("details", "image", "url")
+      end
+
+      def image_alt_text
+        content_item.dig("details", "image", "alt_text")
+      end
+
       def content_item
         local_assigns[:content_item]
       end

--- a/lib/govuk_publishing_components/presenters/schema_org.rb
+++ b/lib/govuk_publishing_components/presenters/schema_org.rb
@@ -1,3 +1,7 @@
+require 'govuk_publishing_components/presenters/machine_readable/page'
+require 'govuk_publishing_components/presenters/machine_readable/article_schema'
+require 'govuk_publishing_components/presenters/machine_readable/news_article_schema'
+
 module GovukPublishingComponents
   module Presenters
     class SchemaOrg
@@ -14,120 +18,6 @@ module GovukPublishingComponents
           NewsArticleSchema.new(page).structured_data
         else
           raise "#{page.schema} is not supported"
-        end
-      end
-
-      class Page
-        attr_reader :local_assigns
-
-        def initialize(local_assigns)
-          @local_assigns = local_assigns
-        end
-
-        def schema
-          local_assigns.fetch(:schema)
-        end
-
-        def canonical_url
-          local_assigns[:canonical_url] || (Plek.current.website_root + content_item["base_path"])
-        end
-
-        def body
-          local_assigns[:body] || content_item["details"]["body"]
-        end
-
-        def title
-          local_assigns[:title] || content_item["title"]
-        end
-
-        def content_item
-          local_assigns[:content_item]
-        end
-      end
-
-      class NewsArticleSchema
-        def initialize(page)
-          @page = page
-        end
-
-        def structured_data
-          # http://schema.org/NewsArticle
-          data = ArticleSchema.new(@page).structured_data
-          data["@type"] = "NewsArticle"
-          data
-        end
-      end
-
-      class ArticleSchema
-        attr_reader :page
-
-        def initialize(page)
-          @page = page
-        end
-
-        def structured_data
-          # http://schema.org/Article
-          {
-            "@context" => "http://schema.org",
-            "@type" => "Article",
-            "mainEntityOfPage" => {
-              "@type" => "WebPage",
-              "@id" => page.canonical_url,
-            },
-            "headline" => page.title,
-            "datePublished" => page.content_item["first_published_at"],
-            "dateModified" => page.content_item["public_updated_at"],
-            "description" => page.content_item["description"],
-            "publisher" => {
-              "@type" => "Organization",
-              "name" => "GOV.UK",
-              "url" => "https://www.gov.uk",
-            }
-          }.merge(image_schema).merge(author_schema).merge(body)
-        end
-
-      private
-
-        attr_reader :presenter
-
-        # Not all formats have a `body` - some have their content split over
-        # multiple fields. In this case we'll skip the `articleBody` field
-        def body
-          return {} unless page.body
-
-          {
-            "articleBody" => page.body
-          }
-        end
-
-        def image_schema
-          return {} unless image
-
-          {
-            "image" => [
-              image["url"],
-            ]
-          }
-        end
-
-        def author_schema
-          return {} unless publishing_organisation
-
-          {
-            "author" => {
-              "@type" => "Organization",
-              "name" => publishing_organisation["title"],
-              "url" => Plek.current.website_root + publishing_organisation["base_path"],
-            }
-          }
-        end
-
-        def publishing_organisation
-          page.content_item.dig("links", "primary_publishing_organisation").to_a.first
-        end
-
-        def image
-          page.content_item.dig("details", "image")
         end
       end
     end

--- a/lib/govuk_publishing_components/presenters/schema_org.rb
+++ b/lib/govuk_publishing_components/presenters/schema_org.rb
@@ -7,8 +7,8 @@ module GovukPublishingComponents
     class SchemaOrg
       attr_reader :page
 
-      def initialize(local_assigns)
-        @page = Page.new(local_assigns)
+      def initialize(page)
+        @page = page
       end
 
       def structured_data

--- a/spec/lib/presenters/schema_org_spec.rb
+++ b/spec/lib/presenters/schema_org_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
         )
       end
 
-      structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(
+      structured_data = generate_structured_data(
         content_item: content_item,
         schema: :article,
       ).structured_data
@@ -25,7 +25,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
     it "generates schema.org NewsArticles" do
       content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "answer")
 
-      structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(
+      structured_data = generate_structured_data(
         content_item: content_item,
         schema: :news_article,
       ).structured_data
@@ -40,7 +40,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
         )
       end
 
-      structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(
+      structured_data = generate_structured_data(
         content_item: content_item,
         schema: :article,
         canonical_url: "https://www.gov.uk/foo/bar"
@@ -59,7 +59,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
         )
       end
 
-      structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(
+      structured_data = generate_structured_data(
         content_item: content_item,
         schema: :article,
         body: "Bar"
@@ -84,7 +84,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
         )
       end
 
-      structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(
+      structured_data = generate_structured_data(
         content_item: content_item,
         schema: :article,
       ).structured_data
@@ -98,12 +98,16 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
         random_item
       end
 
-      structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(
+      structured_data = generate_structured_data(
         content_item: content_item,
         schema: :article,
       ).structured_data
 
       expect(structured_data['image']).to eql(["/foo"])
+    end
+
+    def generate_structured_data(args)
+      GovukPublishingComponents::Presenters::SchemaOrg.new(GovukPublishingComponents::Presenters::Page.new(args))
     end
   end
 end


### PR DESCRIPTION
This merges things that currently only live in government-frontend (alphagov/government-frontend#878, alphagov/government-frontend#898) so we can re-use it on other content pages.

To implement this some refactoring was necessary, see the first 4 commits.

https://trello.com/c/Mx5D1JB3/31-add-more-twitter-facebook-things-to-pages