### PR TITLE
[SPIKE] Use Simple Form to build GOV.UK Frontend-ready forms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       rake
       rouge
       sass-rails (>= 5.0.4)
+      simple_form
       slimmer (>= 11.1.0)
 
 GEM
@@ -71,7 +72,7 @@ GEM
       xpath (~> 2.0)
     cliver (0.3.2)
     coderay (1.1.2)
-    commander (4.4.4)
+    commander (4.4.5)
       highline (~> 1.7.2)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
@@ -82,7 +83,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.1)
     execjs (2.7.0)
-    faraday (0.14.0)
+    faraday (0.15.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.23)
     foreman (0.84.0)
@@ -111,12 +112,12 @@ GEM
       rubocop (~> 0.51.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
-    govuk_app_config (1.4.2)
+    govuk_app_config (1.5.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
       unicorn (~> 5.4.0)
-    govuk_frontend_toolkit (7.4.2)
+    govuk_frontend_toolkit (7.5.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_schemas (3.1.0)
@@ -162,11 +163,11 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    money (6.11.0)
+    money (6.11.3)
       i18n (>= 0.6.4, < 1.1)
     multipart-post (2.0.0)
     netrc (0.11.0)
-    nio4r (2.3.0)
+    nio4r (2.3.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     nokogumbo (1.5.0)
@@ -260,7 +261,7 @@ GEM
       rubocop (>= 0.51.0)
     ruby-progressbar (1.9.0)
     safe_yaml (1.0.4)
-    sanitize (4.6.4)
+    sanitize (4.6.5)
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
       nokogumbo (~> 1.4)
@@ -278,9 +279,12 @@ GEM
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
-    sentry-raven (2.7.2)
+    sentry-raven (2.7.3)
       faraday (>= 0.7.6, < 1.0)
-    slimmer (12.0.0)
+    simple_form (4.0.1)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+    slimmer (12.1.0)
       activesupport
       json
       nokogiri (~> 1.7)
@@ -340,4 +344,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app/assets/stylesheets/govuk_publishing_components/_admin_layout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_admin_layout.scss
@@ -13,3 +13,15 @@ $govuk-global-styles: true;
 // GOV.UK Frontend doesn't have a header component yet so this is stolen from the
 // Design System code: https://github.com/alphagov/govuk-design-system/blob/8b4019d6f184586aa0ab513b9bc704bf5bda42ad/src/stylesheets/components/_header.scss
 @import "govuk_publishing_components/components/admin_layout/header_hack";
+
+// We can't override SimpleForm's label class for the label
+// https://github.com/plataformatec/simple_form/blob/1e35f201b4e934e3e58491659581bbc94cd370f5/lib/simple_form/tags.rb#L51
+.collection_radio_buttons {
+  @extend .govuk-radios__label;
+}
+
+// We can't override SimpleForm's label class for the label
+// https://github.com/plataformatec/simple_form/blob/1e35f201b4e934e3e58491659581bbc94cd370f5/lib/simple_form/tags.rb#L65
+.collection_check_boxes {
+  @extend .govuk-checkboxes__label;
+}

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "govspeak", ">= 5.0.3"
   s.add_dependency "rouge"
   s.add_dependency "rake"
+  s.add_dependency "simple_form"
 
   s.add_development_dependency "govuk-lint", "~> 3.3"
   s.add_development_dependency "rspec-rails", "~> 3.6"

--- a/spec/dummy/app/controllers/admin_controller.rb
+++ b/spec/dummy/app/controllers/admin_controller.rb
@@ -1,3 +1,5 @@
+require 'active_model'
+
 class AdminController < ApplicationController
   layout 'admin'
 
@@ -5,5 +7,31 @@ class AdminController < ApplicationController
     response.headers[Slimmer::Headers::SKIP_HEADER] = "true"
   end
 
+  class ExampleObject
+    include ActiveModel::Model
+
+    attr_reader :name_with_existing_value,
+      :name_without_existing_value,
+      :some_yes_no_question,
+      :some_long_text,
+      :password,
+      :choose_a_number,
+      :choose_another_number
+
+    def name_with_existing_value
+      @name_with_existing_value ||= "Already in the database"
+    end
+  end
+
   def index; end
+
+  def form
+    @object = ExampleObject.new
+  end
+
+  def admin_controller_example_objects_path(*)
+    '#'
+  end
+
+  helper_method :admin_controller_example_objects_path
 end

--- a/spec/dummy/app/controllers/admin_controller.rb
+++ b/spec/dummy/app/controllers/admin_controller.rb
@@ -16,6 +16,7 @@ class AdminController < ApplicationController
       :some_long_text,
       :password,
       :choose_a_number,
+      :choose_some_numbers,
       :choose_another_number
 
     def name_with_existing_value

--- a/spec/dummy/app/views/admin/form.html.erb
+++ b/spec/dummy/app/views/admin/form.html.erb
@@ -1,0 +1,31 @@
+<%= render "govuk_publishing_components/components/title", title: "Hello GOV.UK" %>
+
+<%= simple_form_for @object do |f| %>
+  <%= f.input :name_with_existing_value %>
+  <%= f.input :name_without_existing_value %>
+  <%= f.input :password %>
+  <%= f.input :some_yes_no_question, as: :boolean, wrapper_html: { class: 'govuk-checkboxes__item' }, label_html: { class: 'govuk-checkboxes__label' } %>
+
+  <%= f.input :some_long_text, as: :text %>
+  <%= f.input :choose_a_number, collection: 18..60 %>
+
+  <%= f.input :choose_another_number,
+    collection: 5..10,
+    as: :radio_buttons,
+    wrapper_html: { class: 'govuk-radios' },
+    item_wrapper_class: 'govuk-radios__item',
+    label_html: { class: 'LABEL SHOULD NOT BE HERE - SHOULD BE FIELDSET' }
+  %>
+
+  <%= f.input :choose_another_number,
+    collection: 5..10,
+    as: :check_boxes,
+    wrapper_html: { class: 'govuk-checkboxes' },
+    item_wrapper_class: 'govuk-checkboxes__item',
+    item_label_class: 'govuk-label govuk-checkboxes__label', # DOES NOT WORK
+    label_html: { class: 'LABEL SHOULD NOT BE HERE - SHOULD BE FIELDSET' }
+  %>
+
+  <%= f.button :submit %>
+
+<% end %>

--- a/spec/dummy/app/views/admin/form.html.erb
+++ b/spec/dummy/app/views/admin/form.html.erb
@@ -4,28 +4,10 @@
   <%= f.input :name_with_existing_value %>
   <%= f.input :name_without_existing_value %>
   <%= f.input :password %>
-  <%= f.input :some_yes_no_question, as: :boolean, wrapper_html: { class: 'govuk-checkboxes__item' }, label_html: { class: 'govuk-checkboxes__label' } %>
-
+  <%= f.input :some_yes_no_question, as: :boolean %>
   <%= f.input :some_long_text, as: :text %>
   <%= f.input :choose_a_number, collection: 18..60 %>
-
-  <%= f.input :choose_another_number,
-    collection: 5..10,
-    as: :radio_buttons,
-    wrapper_html: { class: 'govuk-radios' },
-    item_wrapper_class: 'govuk-radios__item',
-    label_html: { class: 'LABEL SHOULD NOT BE HERE - SHOULD BE FIELDSET' }
-  %>
-
-  <%= f.input :choose_another_number,
-    collection: 5..10,
-    as: :check_boxes,
-    wrapper_html: { class: 'govuk-checkboxes' },
-    item_wrapper_class: 'govuk-checkboxes__item',
-    item_label_class: 'govuk-label govuk-checkboxes__label', # DOES NOT WORK
-    label_html: { class: 'LABEL SHOULD NOT BE HERE - SHOULD BE FIELDSET' }
-  %>
-
+  <%= f.input :choose_some_numbers, collection: 5..10, as: :check_boxes %>
+  <%= f.input :choose_another_number, collection: 5..10, as: :radio_buttons %>
   <%= f.button :submit %>
-
 <% end %>

--- a/spec/dummy/app/views/admin/form.html.erb
+++ b/spec/dummy/app/views/admin/form.html.erb
@@ -1,7 +1,7 @@
 <%= render "govuk_publishing_components/components/title", title: "Hello GOV.UK" %>
 
 <%= simple_form_for @object do |f| %>
-  <%= f.input :name_with_existing_value %>
+  <%= f.input :name_with_existing_value, hint: "This field has been pre-filled" %>
   <%= f.input :name_without_existing_value %>
   <%= f.input :password %>
   <%= f.input :some_yes_no_question, as: :boolean %>

--- a/spec/dummy/config/initializers/simple_form.rb
+++ b/spec/dummy/config/initializers/simple_form.rb
@@ -8,6 +8,17 @@ module GovukFrontendInputs
   end
 
   class BooleanInput < SimpleForm::Inputs::BooleanInput
+    def options
+      original_options = super
+
+      original_options[:wrapper_html] ||= {}
+      original_options[:wrapper_html][:class] = 'govuk-checkboxes__item'
+      original_options[:label_html] ||= {}
+      original_options[:label_html][:class] = 'govuk-checkboxes__label'
+
+      original_options
+    end
+
     def input_html_classes
       super.push('govuk-checkboxes__input')
     end
@@ -35,11 +46,31 @@ module GovukFrontendInputs
     def input_html_classes
       super.push('govuk-radios__input')
     end
+
+    def input_options
+      opts = super
+      opts[:item_wrapper_tag] = "div"
+      opts[:item_wrapper_class] = "govuk-radios__item"
+
+      opts[:collection_wrapper_tag] = "div"
+      opts[:collection_wrapper_class] = "govuk-radios"
+      opts
+    end
   end
 
   class CollectionCheckBoxesInput < SimpleForm::Inputs::CollectionCheckBoxesInput
     def input_html_classes
       super.push('govuk-checkboxes__input')
+    end
+
+    def input_options
+      opts = super
+      opts[:item_wrapper_tag] = "div"
+      opts[:item_wrapper_class] = "govuk-checkboxes__item"
+
+      opts[:collection_wrapper_tag] = "div"
+      opts[:collection_wrapper_class] = "govuk-checkboxes"
+      opts
     end
   end
 end

--- a/spec/dummy/config/initializers/simple_form.rb
+++ b/spec/dummy/config/initializers/simple_form.rb
@@ -45,13 +45,6 @@ module GovukFrontendInputs
 end
 
 SimpleForm.setup do |config|
-
-  # ,
-  #   hint_class: :field_with_hint,
-  #   error_class: :field_with_errors,
-  #   valid_class: :field_without_errors
-  #
-
   config.wrappers :default, class: 'govuk-form-group' do |b|
     # Determines whether to use HTML5 (:email, :url, ...)
     # and required attributes

--- a/spec/dummy/config/initializers/simple_form.rb
+++ b/spec/dummy/config/initializers/simple_form.rb
@@ -1,0 +1,211 @@
+require 'simple_form'
+
+module GovukFrontendInputs
+  class StringInput < SimpleForm::Inputs::TextInput
+    def input_html_classes
+      super.push('govuk-input')
+    end
+  end
+
+  class BooleanInput < SimpleForm::Inputs::BooleanInput
+    def input_html_classes
+      super.push('govuk-checkboxes__input')
+    end
+  end
+
+  class PasswordInput < SimpleForm::Inputs::PasswordInput
+    def input_html_classes
+      super.push('govuk-input')
+    end
+  end
+
+  class TextInput < SimpleForm::Inputs::TextInput
+    def input_html_classes
+      super.push('govuk-textarea')
+    end
+  end
+
+  class CollectionSelectInput < SimpleForm::Inputs::CollectionSelectInput
+    def input_html_classes
+      super.push('govuk-select')
+    end
+  end
+
+  class CollectionRadioButtonsInput < SimpleForm::Inputs::CollectionRadioButtonsInput
+    def input_html_classes
+      super.push('govuk-radios__input')
+    end
+  end
+
+  class CollectionCheckBoxesInput < SimpleForm::Inputs::CollectionCheckBoxesInput
+    def input_html_classes
+      super.push('govuk-checkboxes__input')
+    end
+  end
+end
+
+SimpleForm.setup do |config|
+
+  # ,
+  #   hint_class: :field_with_hint,
+  #   error_class: :field_with_errors,
+  #   valid_class: :field_without_errors
+  #
+
+  config.wrappers :default, class: 'govuk-form-group' do |b|
+    # Determines whether to use HTML5 (:email, :url, ...)
+    # and required attributes
+    b.use :html5
+
+    # Calculates placeholders automatically from I18n
+    # You can also pass a string as f.input placeholder: "Placeholder"
+    b.use :placeholder
+
+    ## Optional extensions
+    # They are disabled unless you pass `f.input EXTENSION_NAME => true`
+    # to the input. If so, they will retrieve the values from the model
+    # if any exists. If you want to enable any of those
+    # extensions by default, you can change `b.optional` to `b.use`.
+
+    # Calculates maxlength from length validations for string inputs
+    # and/or database column lengths
+    b.optional :maxlength
+
+    # Calculate minlength from length validations for string inputs
+    b.optional :minlength
+
+    # Calculates pattern from format validations for string inputs
+    b.optional :pattern
+
+    # Calculates min and max from length validations for numeric inputs
+    b.optional :min_max
+
+    # Calculates readonly automatically from readonly attributes
+    b.optional :readonly
+
+    b.use :label_input
+    b.use :hint,  wrap_with: { tag: :span, class: 'govuk-hint' }
+    b.use :error, wrap_with: { tag: :span, class: :error }
+
+    ## full_messages_for
+    # If you want to display the full error message for the attribute, you can
+    # use the component :full_error, like:
+    #
+    # b.use :full_error, wrap_with: { tag: :span, class: :error }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :inline
+
+  # Default class for buttons
+  config.button_class = 'govuk-button'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  # config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'error_notification'
+
+  # ID to add for error notification helper.
+  # config.error_notification_id = nil
+
+  # Series of attempts to detect a default label method for collection.
+  # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
+
+  # Series of attempts to detect a default value method for collection.
+  # config.collection_value_methods = [ :id, :to_s ]
+
+  # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
+  config.collection_wrapper_tag = 'div'
+
+  # # You can define the class to use on all collection wrappers. Defaulting to none.
+  # config.collection_wrapper_class = 'govuk-checkboxes'
+  #
+  # # You can wrap each item in a collection of radio/check boxes with a tag,
+  # # defaulting to :span.
+  # config.item_wrapper_tag = 'div'
+  #
+  # # You can define a class to use in all item wrappers. Defaulting to none.
+  # config.item_wrapper_class = 'govuk-checkboxes__item'
+  #
+  # # How the label text should be generated altogether with the required text.
+  # # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+  #
+  # You can define the class to use on all labels. Default is nil.
+  config.label_class = 'govuk-label'
+
+  # You can define the default class to be used on forms. Can be overriden
+  # with `html: { :class }`. Defaulting to none.
+  # config.default_form_class = nil
+
+  # You can define which elements should obtain additional classes
+  # config.generate_additional_classes_for = [:wrapper, :label, :input]
+
+  # Whether attributes are required by default (or not). Default is true.
+  # config.required_by_default = true
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Collection of methods to detect if a file type was given.
+  # config.file_methods = [ :mounted_as, :file?, :public_filename, :attached? ]
+
+  # Custom mappings for input types. This should be a hash containing a regexp
+  # to match as key, and the input type that will be used when the field name
+  # matches the regexp as value.
+  # config.input_mappings = { /count/ => :integer }
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  # config.wrapper_mappings = { string: :prepend }
+
+  # Namespaces where SimpleForm should look for custom input classes that
+  # override default inputs.
+  config.custom_inputs_namespaces << "GovukFrontendInputs"
+
+  # Default priority for time_zone inputs.
+  # config.time_zone_priority = nil
+
+  # Default priority for country inputs.
+  # config.country_priority = nil
+
+  # When false, do not use translations for labels.
+  # config.translate_labels = true
+
+  # Automatically discover new inputs in Rails' autoload path.
+  # config.inputs_discovery = true
+
+  # Cache SimpleForm inputs discovery
+  # config.cache_discovery = !Rails.env.development?
+
+  # Default class for inputs
+  # config.input_class = 'govuk-input'
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'checkbox'
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  # config.include_default_input_wrapper_class = true
+
+  # Defines which i18n scope will be used in Simple Form.
+  # config.i18n_scope = 'simple_form'
+
+  # Defines validation classes to the input_field. By default it's nil.
+  # config.input_field_valid_class = 'is-valid'
+  # config.input_field_error_class = 'is-invalid'
+end

--- a/spec/dummy/config/initializers/simple_form.rb
+++ b/spec/dummy/config/initializers/simple_form.rb
@@ -107,9 +107,10 @@ SimpleForm.setup do |config|
     # Calculates readonly automatically from readonly attributes
     b.optional :readonly
 
-    b.use :label_input
+    b.use :label
     b.use :hint,  wrap_with: { tag: :span, class: 'govuk-hint' }
     b.use :error, wrap_with: { tag: :span, class: :error }
+    b.use :input
 
     ## full_messages_for
     # If you want to display the full error message for the attribute, you can
@@ -117,6 +118,22 @@ SimpleForm.setup do |config|
     #
     # b.use :full_error, wrap_with: { tag: :span, class: :error }
   end
+
+  config.wrappers :checks, class: 'govuk-form-group' do |b|
+      b.use :html5
+      b.use :placeholder
+      b.optional :maxlength
+      b.optional :pattern
+      b.optional :min_max
+      b.optional :readonly
+
+      ## Inputs
+      b.use :label_input
+      b.use :hint,  wrap_with: { tag: :span, class: :hint }
+      b.use :error, wrap_with: { tag: :span, class: :error }
+  end
+
+  config.wrapper_mappings = { boolean: :checks }
 
   # The default wrapper to be used by the FormBuilder.
   config.default_wrapper = :default

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get 'contextual-navigation/*base_path', to: 'welcome#contextual_navigation'
 
   get '/admin', to: 'admin#index'
+  get '/admin/form', to: 'admin#form'
   get '/admin/tag', to: 'admin#tag'
   get '/admin/taxons', to: 'admin#taxons'
   get '/admin/users', to: 'admin#users'


### PR DESCRIPTION
This builds on top of https://github.com/alphagov/govuk_publishing_components/pull/331.

[Simple Form](https://github.com/plataformatec/simple_form) allows you to build forms using a simple DSL:

```erb
<%= simple_form_for @user do |f| %>
  <%= f.input :username %>
  <%= f.input :password %>
  <%= f.button :submit %>
<% end %>
```

We are already using Simple Form in [contacts admin](https://github.com/alphagov/contacts-admin) and [content tagger](https://github.com/alphagov/content-tagger). We also have a [standard configuration for Simple Form in govuk_admin_template](https://github.com/alphagov/govuk_admin_template#forms).

This PR attempts to create [a configuration file](https://github.com/alphagov/govuk_publishing_components/blob/simple-form/spec/dummy/config/initializers/simple_form.rb) that uses [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend). If it works, it will allow developers to forms with the correct markup without knowing anything about GOV.UK Frontend. Existing forms in content tagger might even be converted to use the new styling simply by switching out the config.

## Things that "just work"

- [x] Text input
- [x] Textarea
- [x] Submit button
- [x] Select box
- [x] Single check box (boolean)
- [x] List of checkboxes
- [x] List of radio buttons
- [x] Hints

## Things that don't work yet

- [ ] Errors (still to do)
- [ ] The [Date input](https://govuk-design-system-production.cloudapps.digital/components/date-input/) component
- [ ] Fieldset & legend for the radio & select boxes
- [ ] General spacing
- [ ] Avoid having to `@extend` the checkbox & radio classes

## Screenshot

https://govuk-publishing-compon-pr-336.herokuapp.com/admin/form

![screenshot-2018-5-30 welcome to gov uk](https://user-images.githubusercontent.com/233676/40706957-305cdaae-63e7-11e8-9589-341d6add0a47.png)

https://trello.com/c/1S9peN8b/62-spike-a-layout-system-for-admin-apps