### PR TITLE
[SPIKE] First attempt at a GOV.UK Frontend powered table helper

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -35,3 +35,5 @@ $govuk-global-images: "";
 @import "components/taxonomy-navigation";
 @import "components/title";
 @import "components/translation-nav";
+
+@import "../../../node_modules/@govuk-frontend/frontend/components/table/table";

--- a/app/views/govuk_publishing_components/components/docs/table.yml
+++ b/app/views/govuk_publishing_components/components/docs/table.yml
@@ -1,0 +1,9 @@
+name: Table
+description: A table
+accessibility_criteria:
+shared_accessibility_criteria:
+type: helper
+examples:
+  default:
+    data:
+      href: '#'

--- a/spec/dummy/app/helpers/govuk_table_helper.rb
+++ b/spec/dummy/app/helpers/govuk_table_helper.rb
@@ -1,0 +1,46 @@
+module GovukTableHelper
+  def govuk_table(caption = nil)
+    builder = TableBuilder.new(tag)
+
+    tag.table class: "govuk-table" do
+      concat tag.caption caption, class: "govuk-table__caption"
+      yield(builder)
+    end
+  end
+
+  class TableBuilder
+    attr_reader :tag
+
+    def initialize(tag)
+      @tag = tag
+    end
+
+    def head
+      tag.thead class: "govuk-table__head" do
+        tag.tr class: "govuk-table__row" do
+          yield(self)
+        end
+      end
+    end
+
+    def body
+      tag.tbody class: "govuk-table__body" do
+        yield(self)
+      end
+    end
+
+    def row
+      tag.tr class: "govuk-table__row" do
+        yield(self)
+      end
+    end
+
+    def header(str)
+      tag.th str, class: "govuk-table__header", scope: "col"
+    end
+
+    def cell(str)
+      tag.td str, class: "govuk-table__cell"
+    end
+  end
+end

--- a/spec/dummy/app/views/welcome/table.html.erb
+++ b/spec/dummy/app/views/welcome/table.html.erb
@@ -1,0 +1,29 @@
+<%= render 'govuk_publishing_components/components/title', title: "A table" %>
+
+<%= govuk_table "Income tax rates" do |t| %>
+  <%= t.head do %>
+    <%= t.header "Band" %>
+    <%= t.header "Taxable income" %>
+    <%= t.header "Tax rate" %>
+  <% end %>
+
+  <%= t.body do %>
+    <%= t.row do %>
+      <%= t.header "Personal Allowance" %>
+      <%= t.cell "Up to £11,850" %>
+      <%= t.cell "0%" %>
+    <% end %>
+
+    <%= t.row do %>
+      <%= t.header "Basic rate" %>
+      <%= t.cell "£11,851 to £46,350" %>
+      <%= t.cell "20%" %>
+    <% end %>
+
+    <%= t.row do %>
+      <%= t.header "Higher rate" %>
+      <%= t.cell link_to("over £150,000", "#") %>
+      <%= t.cell "45%" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   get 'step-nav/:slug', to: 'step_nav#show'
   get 'contextual-navigation', to: 'welcome#contextual_navigation'
   get 'contextual-navigation/*base_path', to: 'welcome#contextual_navigation'
+  get '/table', to: 'welcome#table'
 end


### PR DESCRIPTION
Builds on https://github.com/alphagov/govuk_publishing_components/pull/328.

A fully fledged table in [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) looks like this:

```html
<table class="govuk-table">
  <caption class="govuk-table__caption">Dates and amounts</caption>
  <thead class="govuk-table__head">
    <tr class="govuk-table__row">
      <th class="govuk-table__header" scope="col">Date</th>
      <th class="govuk-table__header" scope="col">Amount</th>
    </tr>
  </thead>
  <tbody class="govuk-table__body">
    <tr class="govuk-table__row">
      <th class="govuk-table__header" scope="row">First 6 weeks</th>
      <td class="govuk-table__cell ">£109.80 per week</td>
    </tr>
    <tr class="govuk-table__row">
      <th class="govuk-table__header" scope="row">Next 33 weeks</th>
      <td class="govuk-table__cell ">£109.80 per week</td>
    </tr>
    <tr class="govuk-table__row">
      <th class="govuk-table__header" scope="row">Total estimated pay</th>
      <td class="govuk-table__cell ">£4,282.20</td>
    </tr>
  </tbody>
</table>
```

On the table every element has its own class ([because of BEM](http://getbem.com/introduction/)). This makes writing tables pretty tedious. The normal component model of abstracting away CSS doesn't quite work for tables because you'd have to generate a large hash describing your table.

As an alternative, this creates a table helper.

The syntax is as follows:

```erb
<%= govuk_table "Income tax rates" do |t| %>
  <%= t.head do %>
    <%= t.header "Band" %>
    <%= t.header "Taxable income" %>
    <%= t.header "Tax rate" %>
  <% end %>

  <%= t.body do %>
    <%= t.row do %>
      <%= t.header "Personal Allowance" %>
      <%= t.cell "Up to £11,850" %>
      <%= t.cell "0%" %>
    <% end %>

    <%= t.row do %>
      <%= t.header "Basic rate" %>
      <%= t.cell "£11,851 to £46,350" %>
      <%= t.cell "20%" %>
    <% end %>

    <%= t.row do %>
      <%= t.header "Higher rate" %>
      <%= t.cell link_to("over £150,000", "#") %>
      <%= t.cell "45%" %>
    <% end %>
  <% end %>
<% end %>
```

Which generates a table like:

![screenshot-2018-5-24 dummy](https://user-images.githubusercontent.com/233676/40470473-7b8740b6-5f2b-11e8-9e73-84c9740bb80a.png)

## Doesn't work yet

- [ ] Correct `scope="col"` and `scope="row"`
- [ ] More block inputs
- [ ] Automatic header & body detection so we can drop `t.head` and `t.body`

## Future extension

I'm assuming we'll want to expand on tables in admin apps to add things like sorting (by clicking on a column in the header) and table filtering (a pattern we use in most apps). You could see things like that added by passing in arguments to `govuk_table`.

```erb
<%= govuk_table "Income tax rates", filter: true do |t| %>
 ...
<% end %>
```

https://trello.com/c/1S9peN8b