### PR TITLE
Add contents list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Import images for the button component from static (PR #338)
+* Add contents list component (PR #342)
 
 ## 8.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -12,6 +12,7 @@
 @import "components/back-link";
 @import "components/breadcrumbs";
 @import "components/button";
+@import "components/contents-list";
 @import "components/document-list";
 @import "components/error-summary";
 @import "components/feedback";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -7,6 +7,7 @@
 @import "typography";
 @import "colours";
 
+@import "components/print/contents-list";
 @import "components/print/feedback";
 @import "components/print/step-by-step-nav-header";
 @import "components/print/step-by-step-nav";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -1,0 +1,70 @@
+@import "helpers/contents-list-helper";
+
+.gem-c-contents-list {
+  // Always render the contents list above a
+  // back to contents link
+  position: relative;
+  margin-bottom: $gutter-two-thirds;
+  z-index: 1;
+  background: $white;
+  box-shadow: 0 20px 15px -10px $white;
+}
+
+.gem-c-contents-list--no-underline {
+  .gem-c-contents-list__link {
+    text-decoration: none;
+
+    &:hover,
+    &:focus,
+    &:active {
+      text-decoration: underline;
+    }
+  }
+}
+
+.gem-c-contents-list__link {
+  .gem-c-contents-list__list-item--parent > & {
+    font-weight: bold;
+  }
+}
+
+.gem-c-contents-list__list-item {
+  padding-top: $gutter-one-third;
+  line-height: 1.3;
+  list-style-type: none;
+
+  @include media(tablet) {
+    padding-top: $gutter-one-quarter;
+  }
+}
+
+.gem-c-contents-list__list-item--dashed {
+  $contents-spacing: $gutter-half + 10;
+  margin-left: $contents-spacing;
+  padding-right: $contents-spacing;
+
+  &:before {
+    content: "— ";
+    margin-left: -$contents-spacing;
+    padding-right: 5px;
+
+    .direction-rtl & {
+      margin-left: 0;
+      margin-right: -$contents-spacing;
+      padding-right: 0;
+      padding-left: 5px;
+    }
+  }
+
+  // Focus styles on IE8 and older include the
+  // left margin, creating an odd white box with
+  // orange border around the em dash.
+  // Use inline-block and vertical alignment to
+  // fix focus styles
+  //
+  // https://github.com/alphagov/government-frontend/pull/420#issuecomment-320632386
+  .lte-ie8 & .gem-c-contents-list__link {
+    display: inline-block;
+    vertical-align: top;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_contents-list-helper.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_contents-list-helper.scss
@@ -1,0 +1,25 @@
+// Contents list helper is used in both print and screen stylesheets
+.gem-c-contents-list__list-item--numbered {
+  .gem-c-contents-list__link {
+    display: table;
+  }
+}
+
+.gem-c-contents-list__number,
+.gem-c-contents-list__numbered-text {
+  display: table-cell;
+}
+
+.gem-c-contents-list__number {
+  min-width: 1.5em;
+}
+
+.gem-c-contents-list__numbered-text {
+  $contents-text-padding: 0.3em;
+  padding-left: $contents-text-padding;
+
+  .direction-rtl & {
+    padding-left: 0;
+    padding-right: $contents-text-padding;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_contents-list.scss
@@ -1,0 +1,19 @@
+@import "../helpers/contents-list-helper";
+
+// Override default browser indentation
+.gem-c-contents-list__list,
+.gem-c-contents-list__nested-list {
+  padding-left: 0;
+  margin-left: 0;
+}
+
+// Put indentation back where we use list style types
+.gem-c-contents-list__list-item--dashed {
+  margin-left: $gutter / 2;
+  list-style-type: disc;
+}
+
+.gem-c-contents-list__list-item--numbered,
+.gem-c-contents-list__list-item--parent {
+  list-style-type: none;
+}

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -1,0 +1,80 @@
+<%
+  cl_helper = GovukPublishingComponents::Presenters::ContentsListHelper.new
+  format_numbers ||= false
+  underline_links ||= false
+  contents ||= []
+  aria_label ||= ''
+  nested = !!contents.find { |c| c[:items] && c[:items].any? }
+  parent_list_item_modifier = if nested
+                                'parent'
+                              elsif format_numbers
+                                'numbered'
+                              else
+                                'dashed'
+                              end
+%>
+<% if contents.any? %>
+  <nav
+    role="navigation"
+    class="gem-c-contents-list <%= 'gem-c-contents-list--no-underline' unless underline_links %>"
+    data-module="track-click"
+    <% if aria_label.present? %>
+      aria-label="<%= aria_label %>"
+    <% end %>
+  >
+    <h2>
+      <%= t("components.contents_list.contents") %>
+    </h2>
+    <ol class="gem-c-contents-list__list">
+      <% contents.each.with_index(1) do |contents_item, position| %>
+        <%
+            active_class = "gem-c-contents-list__list-item--active" if contents_item[:active]
+            aria_current = "aria-current = true" if contents_item[:active]
+        %>
+        <li
+          class="gem-c-contents-list__list-item gem-c-contents-list__list-item--<%= parent_list_item_modifier %> <%= active_class %>"
+          <%= aria_current %>
+        >
+          <% link_text = format_numbers ? cl_helper.wrap_numbers_with_spans(contents_item[:text]) : contents_item[:text] %>
+          <%= link_to_if !contents_item[:active], link_text, contents_item[:href],
+               class: 'gem-c-contents-list__link',
+               data: {
+                 track_category: 'contentsClicked',
+                 track_action: "content_item #{position}",
+                 track_label: contents_item[:href],
+                 track_options: {
+                   dimension29: contents_item[:text]
+                  }
+                }
+          %>
+          <% if contents_item[:items] && contents_item[:items].any? %>
+            <ol class="gem-c-contents-list__nested-list">
+              <% contents_item[:items].each.with_index(1) do |nested_contents_item, nested_position| %>
+              <%
+                active_class = "gem-c-contents-list__list-item--active" if nested_contents_item[:active]
+                aria_current = "aria-current = true" if nested_contents_item[:active]
+              %>
+                <li
+                  class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed <%= active_class %>"
+                  <%= aria_current %>
+                >
+                  <%= link_to_if !nested_contents_item[:active], nested_contents_item[:text], nested_contents_item[:href],
+                    class: 'gem-c-contents-list__link',
+                    data: {
+                      track_category: 'contentsClicked',
+                      track_action: "nested_content_item #{position}:#{nested_position}",
+                      track_label: nested_contents_item[:href],
+                      track_options: {
+                        dimension29: nested_contents_item[:text]
+                      }
+                    }
+                  %>
+                </li>
+              <% end %>
+            </ol>
+          <% end %>
+        </li>
+      <% end %>
+    </ol>
+  </nav>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -1,0 +1,191 @@
+name: Contents list
+description: Lists a page’s contents with links pointing to headings within the document
+body: |
+  Pass a list of contents each with an `href` and `text`. The `href` should point at the ID of a heading within the page.
+
+  Supports nesting contents one level deep, currently only used by specialist documents. When nesting the top level list items
+  display in bold.
+
+  `format_numbers` option will pull out numbers in the link text to render them as though they were the list style type. Applies to
+  numbers at the start of text, with or without a decimal. See the [format complex numbers fixture](/component-guide/contents-list/formats_complex_numbers) for details.
+accessibility_criteria: |
+  The component must be [a landmark with a navigation role](https://accessibility.blog.gov.uk/2016/05/27/using-navigation-landmarks/).
+
+  The contents list must:
+
+  - inform the user how many items are in the list
+  - convey the content structure
+  - indicate the current page when contents span different pages, and not link to itself
+
+  The contents list may:
+  - include an aria-label to contextualise the list if helpful
+
+  Links with formatted numbers must separate the number and text with a space for correct screen reader pronunciation. This changes pronunciation from "1 dot Item" to "1 Item".
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      contents:
+        - href: "#first-thing"
+          text: First thing
+        - href: "#second-thing"
+          text: Second thing
+        - href: "#third-thing"
+          text: Third thing
+  underline_links:
+    description: By default we do not underline links in this component even though this is the general approach on GOV.UK. This is because some of the examples below (particularly those with numbers) do not work well with underlined links. Instead, this option allows the links to be underlined where appropriate.
+    data:
+      underline_links: true
+      contents:
+        - href: "#first-thing"
+          text: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        - href: "#second-thing"
+          text: Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        - href: "#third-thing"
+          text: Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+  long_text:
+    data:
+      contents:
+        - href: "#first-thing"
+          text: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        - href: "#second-thing"
+          text: Another pretty long contents list entry, not as long as the first, but still a little.
+        - href: "#third-thing"
+          text: Third thing
+  active_content_link:
+    description: 'An active state allows for "you are here" items in a contents list that spans different pages to avoid linking back to the current page.'
+    data:
+      contents:
+        - href: "#first-thing"
+          text: First
+        - href: "#two"
+          text: Second
+          active: true
+        - href: "#third-thing"
+          text: Third thing
+  aria_label:
+    description: 'An aria-label string can be used to contextualise the navigation for assistive technology.'
+    data:
+      aria_label: "Pages in this guide"
+      contents:
+        - href: "#first-thing"
+          text: First
+        - href: "#two"
+          text: Second
+          active: true
+        - href: "#third-thing"
+          text: Third thing
+  nested_contents_lists:
+    data:
+      contents:
+        - href: "#first-thing"
+          text: First thing
+        - href: "#second-thing"
+          text: Second thing
+        - href: "#third-thing"
+          text: Third thing
+          items:
+            - href: "#sub-third-thing"
+              text: Sub third thing
+            - href: "#another-third-thing"
+              text: Another third thing
+        - href: "#fourth-thing"
+          text: Fourth thing
+  formats_numbers:
+    data:
+      format_numbers: true
+      contents:
+        - href: "#first-thing"
+          text: 1. First thing
+        - href: "#two"
+          active: true
+          text: 2. Second thing
+        - href: "#third-thing"
+          text: 3. Third thing
+  formats_complex_numbers:
+    data:
+      format_numbers: true
+      contents:
+        - href: "#"
+          text: 1. Item
+        - href: "#"
+          text: 1.1 Sub item
+        - href: "#"
+          text: 1.2 Sub item
+        - href: "#"
+          text: "1.02 longer decimals allowed"
+        - href: "#"
+          text: "1.021 even longer decimals ignored"
+        - href: "#"
+          text: 1 Number without period
+        - href: "#"
+          text: 10. Two digit numbers
+        - href: "#"
+          text: 99. Two digit numbers
+        - href: "#"
+          text: 100. Three digit numbers
+        - href: "#"
+          text: 2017 four digit numbers ignored
+        - href: "#"
+          text: "2001: A space odyssey"
+  nested_with_formatted_numbers:
+    data:
+      format_numbers: true
+      contents:
+        - href: "#first-thing"
+          text: 1. First thing
+          items:
+          - href: "#second-thing"
+            text: 2. Numbers not parsed
+          - href: "#third-thing"
+            text: 3. Numbers are just text
+        - href: "#first-thing"
+          text: 2. Next thing
+          items:
+          - href: "#second-thing"
+            text: No numbers here
+          - href: "#third-thing"
+            active: true
+            text: None here either
+  right_to_left:
+    data:
+      contents:
+        - href: "#section"
+          text: "هل يمكنك تقديم"
+        - href: "#section-1"
+          text: "أعد مستند"
+        - href: "#section-2"
+          text: "تقديم الطلب"
+    context:
+      right_to_left: true
+  right_to_left_with_formatted_numbers:
+    data:
+      format_numbers: true
+      contents:
+        - href: "#section"
+          text: "هل يمكنك تقديم"
+        - href: "#section-1"
+          text: "أعد مستند"
+        - href: "#section-2"
+          text: "تقديم الطلب"
+    context:
+      right_to_left: true
+  right_to_left_with_nested_contents_lists:
+    data:
+      contents:
+        - href: "#section"
+          text: "هل يمكنك تقديم"
+        - href: "#section-1"
+          text: "أعد مستند"
+        - href: "#section-2"
+          text: "تقديم الطلب"
+          items:
+            - href: "#section"
+              text: "هل يمكنك تقديم"
+            - href: "#section-1"
+              text: "أعد مستند"
+            - href: "#section-2"
+              text: "تقديم الطلب"
+    context:
+      right_to_left: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,8 @@ en:
   components:
     back_link:
       back: 'Back'
+    contents_list:
+      contents: Contents
     radio:
       or: 'or'
     related_navigation:

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -18,6 +18,7 @@ require "govuk_publishing_components/presenters/sanitisation"
 require "govuk_publishing_components/presenters/subscription_links_helper"
 require "govuk_publishing_components/presenters/schema_org"
 require "govuk_publishing_components/presenters/heading_helper"
+require "govuk_publishing_components/presenters/contents_list_helper"
 
 require "govuk_publishing_components/app_helpers/taxon_breadcrumbs"
 require "govuk_publishing_components/app_helpers/brand_helper"

--- a/lib/govuk_publishing_components/presenters/contents_list_helper.rb
+++ b/lib/govuk_publishing_components/presenters/contents_list_helper.rb
@@ -1,0 +1,27 @@
+require 'action_view'
+
+module GovukPublishingComponents
+  module Presenters
+    class ContentsListHelper
+      include ActionView::Helpers::SanitizeHelper
+
+      def wrap_numbers_with_spans(content_item_link)
+        content_item_text = strip_tags(content_item_link) #just the text of the link
+
+        # Must start with a number
+        # Number must be between 1 and 999 (ie not 2014)
+        # Must be followed by a space
+        # May contain a period `1.`
+        # May be a decimal `1.2`
+        number = /^\d{1,3}(\.?|\.\d{1,2})(?=\s)/.match(content_item_text)
+
+        if number
+          words = content_item_text.sub(number.to_s, '').strip #remove the number from the text
+          content_item_link.sub(content_item_text, "<span class=\"gem-c-contents-list__number\">#{number} </span><span class=\"gem-c-contents-list__numbered-text\">#{words}</span>").squish.html_safe
+        else
+          content_item_link
+        end
+      end
+    end
+  end
+end

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+describe "Contents list", type: :view do
+  def component_name
+    "contents_list"
+  end
+
+  def contents_list
+    [
+      { href: '/one', text: "1. One" },
+      { href: '/two', text: "2. Two" }
+    ]
+  end
+
+  def contents_list_with_active_item
+    [
+      { href: '/one', text: "1. One" },
+      { href: '/two', text: "2. Two", active: true },
+      { href: '/three', text: "3. Three" }
+    ]
+  end
+
+  def nested_contents_list
+    contents_list << {
+                       href: '/three',
+                       text: "3. Three",
+                       items: [
+                         { href: '/nested-one', text: "Nested one" },
+                         { href: '/nested-two', text: "Nested two" },
+                         { href: '/nested-four', text: "4. Four" },
+                       ]
+                     }
+  end
+
+  def assert_tracking_link(name, value, total = 1)
+    assert_select "a[data-track-#{name}='#{value}']", total
+  end
+
+  it "renders nothing without provided contents" do
+    assert_empty render_component({})
+  end
+
+  it "renders a list of contents links" do
+    render_component(contents: contents_list)
+    assert_select ".gem-c-contents-list.gem-c-contents-list--no-underline"
+    assert_select ".gem-c-contents-list__link[href='/one']", text: "1. One"
+    assert_select ".gem-c-contents-list__link[href='/two']", text: "2. Two"
+  end
+
+  it "renders with the underline option" do
+    render_component(contents: contents_list, underline_links: true)
+    assert_select ".gem-c-contents-list"
+    assert_select ".gem-c-contents-list.gem-c-contents-list--no-underline", false
+  end
+
+  it "renders text only when link is active" do
+    render_component(contents: contents_list_with_active_item)
+    assert_select ".gem-c-contents-list"
+    assert_select ".gem-c-contents-list__link[href='/one']", text: "1. One"
+    assert_select ".gem-c-contents-list__link[href='/two']", count: 0
+    assert_select ".gem-c-contents-list__list-item[2]", text: '2. Two'
+    assert_select ".gem-c-contents-list__list-item--active[aria-current='true']"
+  end
+
+  it "renders text only when link is active for numbered lists" do
+    render_component(contents: contents_list_with_active_item, format_numbers: true)
+    assert_select ".gem-c-contents-list"
+    assert_select ".gem-c-contents-list__link[href='/one']", text: "1. One"
+    assert_select ".gem-c-contents-list__link[href='/two']", count: 0
+    assert_select ".gem-c-contents-list__list-item[2]", text: '2. Two'
+    assert_select ".gem-c-contents-list__list-item[2] .gem-c-contents-list__number", text: '2.'
+    assert_select ".gem-c-contents-list__list-item--active[aria-current='true']"
+  end
+
+  it "renders a nested list of contents links" do
+    render_component(contents: nested_contents_list)
+    nested_link_selector = ".gem-c-contents-list__list-item--parent ol li .gem-c-contents-list__link"
+
+    assert_select "#{nested_link_selector}[href='/nested-one']", text: "Nested one"
+    assert_select "#{nested_link_selector}[href='/nested-two']", text: "Nested two"
+  end
+
+  it "renders data attributes for tracking" do
+    render_component(contents: nested_contents_list)
+
+    assert_select ".gem-c-contents-list[data-module='track-click']"
+
+    assert_tracking_link("category", "contentsClicked", 6)
+    assert_tracking_link("action", "content_item 1")
+    assert_tracking_link("label", "/one")
+    assert_tracking_link("options", { dimension29: "1. One" }.to_json)
+
+    assert_tracking_link("action", "nested_content_item 3:1")
+    assert_tracking_link("label", "/nested-one")
+    assert_tracking_link("options", { dimension29: "Nested one" }.to_json)
+  end
+
+
+  it "formats numbers in contents links" do
+    render_component(contents: contents_list, format_numbers: true)
+    link_selector = ".gem-c-contents-list__list-item--numbered a[href='/one']"
+
+    assert_select "#{link_selector} .gem-c-contents-list__number", text: "1."
+    assert_select "#{link_selector} .gem-c-contents-list__numbered-text", text: "One"
+  end
+
+  it "does not format numbers in a nested list" do
+    render_component(contents: nested_contents_list, format_numbers: true)
+
+    link_selector = ".gem-c-contents-list__list-item--parent a[href='/one']"
+    assert_select "#{link_selector} .gem-c-contents-list__number", text: "1."
+    assert_select "#{link_selector} .gem-c-contents-list__numbered-text", text: "One"
+
+    nested_link_selector = ".gem-c-contents-list__list-item--parent ol li a[href='/nested-four']"
+    assert_select "#{nested_link_selector} .gem-c-contents-list__number", count: 0
+    assert_select "#{nested_link_selector} .gem-c-contents-list__numbered-text", count: 0
+  end
+
+  it "aria label is rendered when supplied" do
+    render_component(contents: contents_list_with_active_item, aria_label: "All pages in this guide")
+    assert_select ".gem-c-contents-list[aria-label=\"All pages in this guide\"]"
+  end
+end

--- a/spec/lib/components/contents_list_helper_spec.rb
+++ b/spec/lib/components/contents_list_helper_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+require 'action_view'
+include ActionView::Helpers::SanitizeHelper
+
+RSpec.describe GovukPublishingComponents::Presenters::ContentsListHelper do
+  describe "Contents list helper" do
+    it "wraps a number and text in separate span elements" do
+      assert_split_number_and_text('1. Thing', '1.', 'Thing')
+      assert_split_number_and_text('10. Thing', '10.', 'Thing')
+      assert_split_number_and_text('100. Thing', '100.', 'Thing')
+    end
+
+    it "keeps a space between number and text for screen reader pronunciation" do
+      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new
+      # 1.Thing can be pronounced "1 dot Thing"
+      # 1. Thing is always pronounced "1 Thing"
+      text = "1. Thing"
+      wrapped_html = cl.wrap_numbers_with_spans("<a href=\"#link\">#{text}</a>")
+      expect(strip_tags(wrapped_html)).to eql(text)
+    end
+
+    it "wraps a number and text in span elements if it's a number without a period" do
+      assert_split_number_and_text('1 Thing', '1', 'Thing')
+    end
+
+    it "wraps a number in the form X.Y" do
+      assert_split_number_and_text('1.2 Vision', '1.2', 'Vision')
+    end
+
+    it "does nothing if no number is found" do
+      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new
+      input = '<a href="#vision">Vision</a>'
+      expected = '<a href="#vision">Vision</a>'
+      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+    end
+
+    it "does nothing if it's just a number" do
+      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new
+      input = '<a href="#first">1</a>'
+      expected = '<a href="#first">1</a>'
+      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+    end
+
+    it "does nothing if the number is part of the word" do
+      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new
+      input = '<a href="#vision">1Vision</a>'
+      expected = '<a href="#vision">1Vision</a>'
+      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+
+      input = '<a href="#vision">1.Vision</a>'
+      expected = '<a href="#vision">1.Vision</a>'
+      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+    end
+
+    it "does nothing if it starts with a number longer than 3 digits" do
+      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new
+      input = '<a href="#vision">2014 Vision</a>'
+      expected = '<a href="#vision">2014 Vision</a>'
+      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+
+      input = '<a href="#vision">2014. Vision</a>'
+      expected = '<a href="#vision">2014. Vision</a>'
+      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+
+      input = '<a href="#vision">10001. Vision</a>'
+      expected = '<a href="#vision">10001. Vision</a>'
+      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+    end
+
+    it "does nothing if a number is present but not at the start" do
+      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new
+      input = '<a href="#run-an-effective-welfare-system">Run an effective welfare system part 1. Social Care</a>'
+      expected = '<a href="#run-an-effective-welfare-system">Run an effective welfare system part 1. Social Care</a>'
+      expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+    end
+  end
+
+  def assert_split_number_and_text(number_and_text, number, text)
+    cl = GovukPublishingComponents::Presenters::ContentsListHelper.new
+    number_class = "gem-c-contents-list__number"
+    numbered_text_class = "gem-c-contents-list__numbered-text"
+
+    input = "<a href=\"#link\">#{number_and_text}</a>"
+    expected = "<a href=\"#link\"><span class=\"#{number_class}\">#{number} </span><span class=\"#{numbered_text_class}\">#{text}</span></a>"
+    expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
+  end
+end


### PR DESCRIPTION
We need to use contents lists in the new organisation pages, which are held in collections. A [separate PR has been opened](https://github.com/alphagov/government-frontend/pull/915) to update government-frontend to use this component.

- from government-frontend
- only change is to CSS namespace from app-c to gem-c

Trello card: https://trello.com/c/aDQ8nEKO/90-modify-component-contents-list