### PR TITLE
Add Person schema for use on people pages

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
@@ -22,7 +22,6 @@ examples:
         details: {}
       schema: :article
       canonical_url: "https://www.gov.uk/foreign-travel-advice/andorra/health"
-
   with_body:
     data:
       content_item:
@@ -31,3 +30,10 @@ examples:
         details: {}
       schema: :article
       body: "Some other body"
+  person_schema:
+    data:
+      content_item:
+        title: "A. Person"
+        base_path: "/foo"
+        details: {}
+      schema: :person

--- a/lib/govuk_publishing_components/presenters/machine_readable/person_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/person_schema.rb
@@ -1,0 +1,39 @@
+module GovukPublishingComponents
+  module Presenters
+    class PersonSchema
+      attr_reader :page
+
+      def initialize(page)
+        @page = page
+      end
+
+      def structured_data
+        # http://schema.org/Person
+        {
+          "@context" => "http://schema.org",
+          "@type" => "Person",
+          "mainEntityOfPage" => {
+            "@type" => "WebPage",
+            "@id" => page.canonical_url,
+          },
+          "name" => page.title,
+          "description" => page.body
+        }.merge(image_schema)
+      end
+
+    private
+
+      attr_reader :presenter
+
+      def image_schema
+        return {} unless page.has_image?
+
+        {
+          "image" => [
+            page.image_url
+          ]
+        }
+      end
+    end
+  end
+end

--- a/lib/govuk_publishing_components/presenters/schema_org.rb
+++ b/lib/govuk_publishing_components/presenters/schema_org.rb
@@ -1,6 +1,7 @@
 require 'govuk_publishing_components/presenters/machine_readable/page'
 require 'govuk_publishing_components/presenters/machine_readable/article_schema'
 require 'govuk_publishing_components/presenters/machine_readable/news_article_schema'
+require 'govuk_publishing_components/presenters/machine_readable/person_schema'
 
 module GovukPublishingComponents
   module Presenters
@@ -16,6 +17,8 @@ module GovukPublishingComponents
           ArticleSchema.new(page).structured_data
         elsif page.schema == :news_article
           NewsArticleSchema.new(page).structured_data
+        elsif page.schema == :person
+          PersonSchema.new(page).structured_data
         else
           raise "#{page.schema} is not supported"
         end

--- a/spec/components/machine_readable_metadata_spec.rb
+++ b/spec/components/machine_readable_metadata_spec.rb
@@ -5,9 +5,18 @@ describe "Machine readable metadata", type: :view do
     "machine_readable_metadata"
   end
 
-  it "generates machine readable JSON-LD" do
+  it "generates machine readable JSON-LD for articles" do
     example = GovukSchemas::RandomExample.for_schema(frontend_schema: "generic")
     render_component(content_item: example, schema: :article)
+
+    json_linked_data = Nokogiri::HTML(rendered).css('script').text
+
+    assert JSON.parse(json_linked_data)
+  end
+
+  it "generates machine readable JSON-LD for people" do
+    example = GovukSchemas::RandomExample.for_schema(frontend_schema: "person")
+    render_component(content_item: example, schema: :person)
 
     json_linked_data = Nokogiri::HTML(rendered).css('script').text
 

--- a/spec/lib/presenters/schema_org_spec.rb
+++ b/spec/lib/presenters/schema_org_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
       expect(structured_data['@type']).to eql("NewsArticle")
     end
 
+    it "generates schema.org Person" do
+      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "person")
+
+      structured_data = generate_structured_data(
+        content_item: content_item,
+        schema: :person,
+      ).structured_data
+
+      expect(structured_data['@type']).to eql("Person")
+    end
+
     it "allows override of the URL" do
       content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "answer") do |random_item|
         random_item.merge(


### PR DESCRIPTION
This implements http://schema.org/Person. It's to be used on pages like https://www.gov.uk/government/people/theresa-may.

https://trello.com/c/gKHoUGuA