### PR TITLE
Allow description to be overridden

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
@@ -14,6 +14,16 @@ examples:
         base_path: "/foo"
         details: {}
       schema: :article
+
+  with_description:
+    data:
+      content_item:
+        title: "A title"
+        base_path: "/foo"
+        details: {}
+      schema: :article
+      description: "Some manually set description of the page"
+
   with_canonical_url:
     data:
       content_item:

--- a/lib/govuk_publishing_components/presenters/machine_readable/page.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/page.rb
@@ -24,7 +24,7 @@ module GovukPublishingComponents
       end
 
       def description
-        content_item["description"]
+        local_assigns[:description] || content_item["description"]
       end
 
       def has_image?


### PR DESCRIPTION
This will allow apps to set the `description` directly, instead of relying on the content item.

Will be used by https://github.com/alphagov/manuals-frontend/pull/392.

https://trello.com/c/gKHoUGuA