### PR TITLE
Only add `articleBody` field when present

### DIFF
--- a/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
@@ -39,7 +39,7 @@ module GovukPublishingComponents
       # Not all formats have a `body` - some have their content split over
       # multiple fields. In this case we'll skip the `articleBody` field
       def body
-        return {} unless page.body
+        return {} unless page.body.present?
 
         {
           "articleBody" => page.body


### PR DESCRIPTION
In certain cases this can be an empty string, in which case we'll omit the field entirely.

https://trello.com/c/gKHoUGuA