### PR TITLE
Add notice component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add contents list component (PR #342)
 * BREAKING: Iterate share links component (PR #316)
 * Add image card component (PR #322)
+* Add notice component (PR #346)
 
 ## 8.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -23,6 +23,7 @@
 @import "components/inverse-header";
 @import "components/label";
 @import "components/lead-paragraph";
+@import "components/notice";
 @import "components/phase-banner";
 @import "components/previous-and-next-navigation";
 @import "components/radio";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
@@ -1,0 +1,33 @@
+.gem-c-notice {
+  clear: both;
+  padding: $gutter-two-thirds;
+  border: 2px solid $govuk-blue;
+
+  @include media(mobile) {
+    padding: $gutter-half;
+  }
+
+  .govuk-govspeak {
+    p:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.gem-c-notice--bottom-margin {
+  @include responsive-bottom-margin;
+}
+
+.gem-c-notice__title {
+  @include bold-27;
+  margin-bottom: $gutter-one-third;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.gem-c-notice__description {
+  @include core-19;
+  margin-bottom: 0;
+}

--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -1,0 +1,22 @@
+<% if defined?(title) %>
+  <%
+    description_text ||= false
+    description_govspeak ||= false
+    margin_bottom_class = " gem-c-notice--bottom-margin" unless local_assigns[:margin_bottom]
+  %>
+  <section class="gem-c-notice<%= margin_bottom_class %>" aria-label="Notice" role="region">
+    <% if description_text || description_govspeak %>
+      <h2 class="gem-c-notice__title"><%= title %></h2>
+    <% else %>
+      <span class="gem-c-notice__title"><%= title %></span>
+    <% end %>
+
+    <% if description_text %>
+      <p class="gem-c-notice__description"><%= description_text %></p>
+    <% end %>
+
+    <% if description_govspeak %>
+      <%= render 'govuk_component/govspeak', content: description_govspeak %>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/notice.yml
+++ b/app/views/govuk_publishing_components/components/docs/notice.yml
@@ -1,0 +1,23 @@
+name: Notice
+description: A notice to convey and highlight information
+body: |
+  The notice component replaces the notice and withdrawal notice patterns on GOV.UK.
+
+  The component accepts either a simple string description_text parameter that it wraps in a paragraph, or a description_govspeak parameter that is rendered through govspeak for more complex HTML layout.
+accessibility_criteria: |
+  The notice must:
+
+  - have a border colour contrast ratio of more than 4.5:1 with its background to be visually distinct.
+  - always render headings with associated description content, so there are no isolated heading elements inside the component
+examples:
+  default:
+    data:
+      title: 'Statistics release cancelled'
+  with_description_text:
+    data:
+      title: 'Statistics release cancelled'
+      description_text: 'Duplicate, added in error'
+  with_description_govspeak:
+    data:
+      title: 'Statistics release update'
+      description_govspeak: '<p>The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p>This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a rel="external" href="https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/">www.ogauthority.co.uk</a></p>'

--- a/spec/components/notice_spec.rb
+++ b/spec/components/notice_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe "Notice", type: :view do
+  def component_name
+    "notice"
+  end
+
+  it "renders nothing when no params provided" do
+    assert_empty render_component({})
+  end
+
+  it "renders a notice with only a title and no description" do
+    render_component(title: "Statistics release cancelled")
+    assert_select ".gem-c-notice__title", text: "Statistics release cancelled"
+    assert_select ".gem-c-notice__description", false
+  end
+
+  it "renders a notice with an aria label and region" do
+    render_component(title: "Statistics release cancelled")
+    assert_select ".gem-c-notice[aria-label=Notice][role=region]"
+  end
+
+  it "renders a notice with a title and description text" do
+    render_component(title: "Statistics release cancelled", description_text: "Duplicate, added in error")
+    assert_select ".gem-c-notice__title", text: "Statistics release cancelled"
+    assert_select ".gem-c-notice__description", text: "Duplicate, added in error"
+  end
+
+  # rendering the govspeak component doesn't work here, so we visit a component guide page where it's already rendered and use that instead
+  # this is only a workaround until the govspeak component is also part of the gem
+  # note also that this test will fail if run individually because the govspeak component is rendered differently if run individually
+
+  it "renders a notice with a title and description govspeak" do
+    visit '/component-guide/notice/with_description_govspeak'
+
+    within '.component-guide-preview', match: :first do
+      assert page.has_selector?(".gem-c-notice__title", text: "Statistics release update")
+      assert page.has_selector?(".govuk-govspeak p", text: "The Oil & Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.")
+      assert page.has_selector?(".govuk-govspeak p", text: "This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to www.ogauthority.co.uk")
+      assert page.has_selector?(".govuk-govspeak p a[href=\"https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/\"][rel=\"external\"]", text: "www.ogauthority.co.uk")
+    end
+  end
+
+  it "renders title as heading only if description present" do
+    render_component(title: "Statistics release cancelled", description_text: "Duplicate, added in error")
+    assert_select "h2.gem-c-notice__title", text: "Statistics release cancelled"
+    assert_select "p.gem-c-notice__description", text: "Duplicate, added in error"
+  end
+
+  it "render title as paragraph if no description present" do
+    render_component(title: "Statistics release cancelled")
+    assert_select "span.gem-c-notice__title", text: "Statistics release cancelled"
+    assert_select ".gem-c-notice__description", false
+  end
+end

--- a/spec/dummy/app/views/govuk_component/govspeak.raw.html.erb
+++ b/spec/dummy/app/views/govuk_component/govspeak.raw.html.erb
@@ -1,0 +1,14 @@
+<%
+  direction_class = "direction-#{direction}" if local_assigns.include?(:direction)
+  rich_govspeak = local_assigns.fetch(:rich_govspeak) if local_assigns.include?(:rich_govspeak)
+  disable_youtube_expansions = local_assigns.fetch(:disable_youtube_expansions) if local_assigns.include?(:disable_youtube_expansions)
+
+  classes = []
+  classes << direction_class if direction_class
+  classes << "rich-govspeak" if rich_govspeak
+  classes << "disable-youtube" if disable_youtube_expansions
+%>
+
+<div class="govuk-govspeak <%= classes.join(" ") %>">
+  <%= raw content %>
+</div>


### PR DESCRIPTION
- from government-frontend
- changed CSS namespace from app-c to gem-c
- test file fairly heavily rewritten
- govspeak template included in dummy app to allow tests to work
- otherwise should be the same as the original component

PR to remove this component from government-frontend is here: https://github.com/alphagov/government-frontend/pull/916

Trello card: https://trello.com/c/vdIdfjHn/121-modify-component-notice
