### PR TITLE
Iterate contents list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * BREAKING: Iterate share links component (PR #316)
 * Add image card component (PR #322)
 * Add notice component (PR #346)
+* Iterate contents list component (PR #351)
 
 ## 8.2.0
 

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -14,6 +14,7 @@
                               end
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
+  hide_title ||= false
 %>
 <% if contents.any? %>
   <nav
@@ -24,9 +25,10 @@
       aria-label="<%= aria_label %>"
     <% end %>
   >
-    <h2>
-      <%= t("components.contents_list.contents") %>
-    </h2>
+    <% unless hide_title %>
+      <h2 class="gem-c-contents-list__title"><%= t("components.contents_list.contents") %></h2>
+    <% end %>
+
     <ol class="gem-c-contents-list__list">
       <% contents.each.with_index(1) do |contents_item, position| %>
         <%

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -12,11 +12,13 @@
                               else
                                 'dashed'
                               end
+  brand ||= false
+  brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
 %>
 <% if contents.any? %>
   <nav
     role="navigation"
-    class="gem-c-contents-list <%= 'gem-c-contents-list--no-underline' unless underline_links %>"
+    class="gem-c-contents-list <%= 'gem-c-contents-list--no-underline' unless underline_links %> <%= brand_helper.brand_class %>"
     data-module="track-click"
     <% if aria_label.present? %>
       aria-label="<%= aria_label %>"
@@ -28,8 +30,8 @@
     <ol class="gem-c-contents-list__list">
       <% contents.each.with_index(1) do |contents_item, position| %>
         <%
-            active_class = "gem-c-contents-list__list-item--active" if contents_item[:active]
-            aria_current = "aria-current = true" if contents_item[:active]
+          active_class = "gem-c-contents-list__list-item--active" if contents_item[:active]
+          aria_current = "aria-current = true" if contents_item[:active]
         %>
         <li
           class="gem-c-contents-list__list-item gem-c-contents-list__list-item--<%= parent_list_item_modifier %> <%= active_class %>"
@@ -37,15 +39,15 @@
         >
           <% link_text = format_numbers ? cl_helper.wrap_numbers_with_spans(contents_item[:text]) : contents_item[:text] %>
           <%= link_to_if !contents_item[:active], link_text, contents_item[:href],
-               class: 'gem-c-contents-list__link',
-               data: {
-                 track_category: 'contentsClicked',
-                 track_action: "content_item #{position}",
-                 track_label: contents_item[:href],
-                 track_options: {
-                   dimension29: contents_item[:text]
-                  }
-                }
+            class: "gem-c-contents-list__link #{brand_helper.color_class}",
+            data: {
+              track_category: 'contentsClicked',
+              track_action: "content_item #{position}",
+              track_label: contents_item[:href],
+              track_options: {
+                dimension29: contents_item[:text]
+              }
+            }
           %>
           <% if contents_item[:items] && contents_item[:items].any? %>
             <ol class="gem-c-contents-list__nested-list">
@@ -59,7 +61,7 @@
                   <%= aria_current %>
                 >
                   <%= link_to_if !nested_contents_item[:active], nested_contents_item[:text], nested_contents_item[:href],
-                    class: 'gem-c-contents-list__link',
+                    class: "gem-c-contents-list__link #{brand_helper.color_class}",
                     data: {
                       track_category: 'contentsClicked',
                       track_action: "nested_content_item #{position}:#{nested_position}",

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -189,3 +189,17 @@ examples:
               text: "تقديم الطلب"
     context:
       right_to_left: true
+  with_branding:
+    description: Where this component could be used on an organisation page (such as the [Attorney General's Office](https://www.gov.uk/government/organisations/attorney-generals-office)) branding can be applied for link colours and border colours. See the [branding documentation](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) for more details.
+    data:
+      brand: 'department-for-environment-food-rural-affairs'
+      format_numbers: true
+      contents:
+        - href: "#first-thing"
+          text: 1. First thing
+          items:
+          - href: "#second-thing"
+            text: 2. Numbers not parsed
+          - href: "#third-thing"
+            text: 3. Numbers are just text
+

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -202,4 +202,16 @@ examples:
             text: 2. Numbers not parsed
           - href: "#third-thing"
             text: 3. Numbers are just text
+  without_a_title:
+    description: The component can be used to provide a list of links to other pages, in which case the 'Contents' title is inappropriate and can be removed.
+    data:
+      hide_title: true
+      contents:
+        - href: "#first-thing"
+          text: Community best practice
+          items:
+          - href: "#second-thing"
+            text: Guidance and regulation
+          - href: "#third-thing"
+            text: Consultations
 

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -1,13 +1,14 @@
 name: Contents list
-description: Lists a page’s contents with links pointing to headings within the document
+description: Provides a list of links with options for dashes or numbering.
 body: |
-  Pass a list of contents each with an `href` and `text`. The `href` should point at the ID of a heading within the page.
+  Commonly used to lists a page’s contents with links pointing to headings within the document, but can also be used for a list of links to other pages.
+
+  Pass a list of contents each with an `href` and `text`. The `href` can point at the ID of a heading within the page.
 
   Supports nesting contents one level deep, currently only used by specialist documents. When nesting the top level list items
   display in bold.
 
-  `format_numbers` option will pull out numbers in the link text to render them as though they were the list style type. Applies to
-  numbers at the start of text, with or without a decimal. See the [format complex numbers fixture](/component-guide/contents-list/formats_complex_numbers) for details.
+  `format_numbers` option will pull out numbers in the link text to render them as though they were the list style type. Applies to numbers at the start of text, with or without a decimal. See the [format complex numbers fixture](/component-guide/contents-list/formats_complex_numbers) for details.
 accessibility_criteria: |
   The component must be [a landmark with a navigation role](https://accessibility.blog.gov.uk/2016/05/27/using-navigation-landmarks/).
 

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -127,4 +127,9 @@ describe "Contents list", type: :view do
     assert_select ".gem-c-contents-list__link", count: 6
     assert_select ".gem-c-contents-list__link.brand__color", count: 6
   end
+
+  it "hides the title" do
+    render_component(contents: nested_contents_list, hide_title: true)
+    assert_select ".gem-c-contents-list__title", false
+  end
 end

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -120,4 +120,11 @@ describe "Contents list", type: :view do
     render_component(contents: contents_list_with_active_item, aria_label: "All pages in this guide")
     assert_select ".gem-c-contents-list[aria-label=\"All pages in this guide\"]"
   end
+
+  it "applies branding correctly" do
+    render_component(contents: nested_contents_list, format_numbers: true, brand: 'attorney-generals-office')
+    assert_select ".gem-c-contents-list.brand--attorney-generals-office"
+    assert_select ".gem-c-contents-list__link", count: 6
+    assert_select ".gem-c-contents-list__link.brand__color", count: 6
+  end
 end


### PR DESCRIPTION
Expand the contents list component to be used on organisation pages, specifically:

- add option for organisation branding
- add option to hide title

Component guide: https://govuk-publishing-compon-pr-351.herokuapp.com/component-guide/contents_list
Trello card: https://trello.com/c/aDQ8nEKO/90-modify-component-contents-list
