### PR TITLE
Notice title containing markup option

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/notice.yml
+++ b/app/views/govuk_publishing_components/components/docs/notice.yml
@@ -21,3 +21,7 @@ examples:
     data:
       title: 'Statistics release update'
       description_govspeak: '<p>The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p>This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a rel="external" href="https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/">www.ogauthority.co.uk</a></p>'
+  with_markup_in_the_title:
+    description: In some circumstances it may be necessary to include simple markup in the title, such as a link. Note that this will be wrapped in a H2 tag if there is no description included, so be sure that any markup inserted is valid inside that tag (e.g. another heading tag inside a H2 would be invalid).
+    data:
+      title: 'Advisory Committee on Novel Foods and Processes has a <a href="http://www.food.gov.uk/acnfp">separate website</a>'

--- a/spec/components/notice_spec.rb
+++ b/spec/components/notice_spec.rb
@@ -46,4 +46,9 @@ describe "Notice", type: :view do
     assert_select "span.gem-c-notice__title", text: "Statistics release cancelled"
     assert_select ".gem-c-notice__description", false
   end
+
+  it "renders simple markup in the title" do
+    render_component(title: 'Advisory Committee on Novel Foods and Processes has a <a href="http://www.food.gov.uk/acnfp">separate website</a>')
+    assert_select ".gem-c-notice__title", text: 'Advisory Committee on Novel Foods and Processes has a <a href="http://www.food.gov.uk/acnfp">separate website</a>'
+  end
 end


### PR DESCRIPTION
Will need to be able to add links into notice titles, for organisation pages.

- already possible, added example and guidance to documentation
- added test

---

Component guide for this PR:
https://govuk-publishing-compon-pr-352.herokuapp.com/component-guide/
Trello card: https://trello.com/c/vdIdfjHn/121-modify-component-notice