### PR TITLE
Update document list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Extend the document list component (PR #355)
+
 ## 9.0.1
 
 * The component guide is no longer using `Slimmer::GovukComponents`, so this

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -12,6 +12,12 @@
 
 .gem-c-document-list__item-title {
   @include bold-19;
+  display: inline-block;
+}
+
+.gem-c-document-list__item-context {
+  color: $grey-1;
+  margin-left: $gutter-one-third;
 }
 
 .gem-c-document-list__item-description {

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -10,16 +10,28 @@
   <ol class="gem-c-document-list<%= margin_bottom_class %><%= margin_top_class %> <%= brand_helper.brand_class %>">
     <% items.each do |item| %>
       <li class="gem-c-document-list__item">
-        <h3 class="gem-c-document-list__item-title">
+        <% if item[:link][:description] || item[:metadata] %>
+          <h3 class="gem-c-document-list__item-title">
+            <%=
+              link_to(
+                item[:link][:text],
+                item[:link][:path],
+                data: item[:link][:data_attributes],
+                class: brand_helper.color_class
+              )
+            %>
+          </h3>
+        <% else%>
           <%=
             link_to(
               item[:link][:text],
               item[:link][:path],
               data: item[:link][:data_attributes],
-              class: brand_helper.color_class
+              class: "gem-c-document-list__item-title #{brand_helper.color_class}"
             )
           %>
-        </h3>
+        <% end %>
+
         <% if item[:link][:description] %>
           <p class="gem-c-document-list__item-description" ><%= item[:link][:description] %></p>
         <% end %>

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -32,9 +32,14 @@
           %>
         <% end %>
 
+        <% if item[:link][:context] %>
+          <span class="gem-c-document-list__item-context"><%= item[:link][:context] %></span>
+        <% end %>
+
         <% if item[:link][:description] %>
           <p class="gem-c-document-list__item-description" ><%= item[:link][:description] %></p>
         <% end %>
+
         <% if item[:metadata] %>
           <ul>
             <% item[:metadata].each do |item_metadata_key, item_metadata_value| %>

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -103,3 +103,16 @@ examples:
       - link:
           text: 'School exclusion'
           path: '/government/publications/school-exclusion'
+  with_context:
+    description: Context can be provided to render next to the item title. This will be used on /government/organisations to indicate if an organisation is hosted on a separate website or being moved to GOV.UK
+    data:
+      items:
+      - link:
+          text: 'Forestry Commission'
+          path: '/government/organisations/forestry-commission'
+          context: 'separate website'
+      - link:
+          text: 'Advisory Committee on the Microbiological Safety of Food'
+          path: '/government/organisations/advisory-committee-on-the-microbiological-safety-of-food'
+          context: 'moving to GOV.UK'
+          description: "Works with 4 agencies and public bodies"

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -93,3 +93,13 @@ examples:
         metadata:
           public_updated_at: 2017-07-19 15:01:48
           document_type: 'Statutory guidance'
+  with_only_link:
+    description: When only link text and path is provided to the component (no description or metadata), this will render the link without wrapping it in a heading element.
+    data:
+      items:
+      - link:
+          text: 'School behaviour and attendance: parental responsibility measures'
+          path: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+      - link:
+          text: 'School exclusion'
+          path: '/government/publications/school-exclusion'

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -168,4 +168,21 @@ describe "Document list", type: :view do
     assert_select '.gem-c-document-list__item h3', false, 'Element should not be wrapped in heading if it is not acting as a heading for any other content'
     assert_select '.gem-c-document-list__item a[href="/link/path"]', text: 'Link Title'
   end
+
+  it "renders the item title with context when provided" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+            context: "some context"
+          }
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list__item a[href="/link/path"]', text: 'Link Title'
+    assert_select '.gem-c-document-list__item-context', text: 'some context'
+  end
 end

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -152,4 +152,20 @@ describe "Document list", type: :view do
     assert_select '.gem-c-document-list.brand--attorney-generals-office'
     assert_select '.gem-c-document-list .gem-c-document-list__item-title .brand__color'
   end
+
+  it "does not wrap link in heading element if no description or metadata provided" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+          }
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list__item h3', false, 'Element should not be wrapped in heading if it is not acting as a heading for any other content'
+    assert_select '.gem-c-document-list__item a[href="/link/path"]', text: 'Link Title'
+  end
 end


### PR DESCRIPTION
Extends the document list component with the following changes: 

* If only passing link text and path to the component, render that as a link rather than a heading.
* Add option to pass title 'context'

**Context example:**
<img width="797" alt="screen shot 2018-06-05 at 12 03 22" src="https://user-images.githubusercontent.com/29889908/40972381-776d411a-68b8-11e8-9c4c-56e0b7d01a0f.png">

Component guide for this PR:
https://govuk-publishing-compon-pr-355.herokuapp.com/component-guide/document_list
