### PR TITLE
Remove policies from taxonomy sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Extend the document list component (PR #355)
+* Remove policies from the taxonomy navigation sidebar
 
 ## 9.0.1
 

--- a/app/views/govuk_publishing_components/components/docs/taxonomy_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/taxonomy_navigation.yml
@@ -11,7 +11,7 @@ body: |
   associated with that item.
 
   Sections of links appear below the main taxonomy-driven navigation items. These are
-  Collections, Policies, Statistical data sets, Topical events and World locations.
+  Collections, Statistical data sets, Topical events and World locations.
 
   This implementation is very similar to the related-navigation component in that the
   same sections are appended. The two components should ultimately be merged to form
@@ -77,9 +77,6 @@ examples:
       collections:
         - text: "Statistics: outcome based success measures"
           path: "/government/collections/statistics-outcome-based-success-measures"
-      policies:
-        - text: "Teaching and school leadership"
-          path: "/government/policies/teaching-and-school-leadership"
       world_locations:
         - text: "Afghanistan"
           path: "/world/afghanistan/news"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,7 +55,6 @@ en:
       subscriptions: "Subscriptions"
     taxonomy_navigation:
       collections: "Collection"
-      policies: "Policy"
       related_content: "Related content"
       statistical_data_sets: "Statistical data set"
       topical_events: "Topical event"

--- a/lib/govuk_publishing_components/presenters/taxonomy_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/taxonomy_navigation.rb
@@ -2,7 +2,6 @@ module GovukPublishingComponents
   module Presenters
     class TaxonomyNavigation
       RELATED_SECTIONS = %w(
-        policies
         topical_events
         world_locations
         statistical_data_sets

--- a/spec/lib/presenters/taxonomy_navigation_spec.rb
+++ b/spec/lib/presenters/taxonomy_navigation_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
         expect(sidebar_for(content_item)).to eq(
           items: [],
           collections: [],
-          policies: [],
           statistical_data_sets: [],
           topical_events: [],
           world_locations: [],
@@ -78,7 +77,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
             },
           ],
           collections: [],
-          policies: [],
           statistical_data_sets: [],
           topical_events: [],
           world_locations: [],
@@ -132,7 +130,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
             },
           ],
           collections: [],
-          policies: [],
           statistical_data_sets: [],
           topical_events: [],
           world_locations: [],
@@ -198,7 +195,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
             }
           ],
           collections: [],
-          policies: [],
           statistical_data_sets: [],
           topical_events: [],
           world_locations: [],
@@ -242,7 +238,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
               }
             ],
             collections: [],
-            policies: [],
             statistical_data_sets: [],
             topical_events: [],
             world_locations: [],
@@ -306,7 +301,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
               }
             ],
             collections: [],
-            policies: [],
             statistical_data_sets: [],
             topical_events: [],
             world_locations: [],
@@ -348,7 +342,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
               }
             ],
             collections: [],
-            policies: [],
             statistical_data_sets: [],
             topical_events: [],
             world_locations: [],
@@ -397,7 +390,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
               },
             ],
             collections: [],
-            policies: [],
             statistical_data_sets: [],
             topical_events: [],
             world_locations: [],
@@ -438,7 +430,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
               },
             ],
             collections: [],
-            policies: [],
             statistical_data_sets: [],
             topical_events: [],
             world_locations: [],
@@ -494,7 +485,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
               },
             ],
             collections: [],
-            policies: [],
             statistical_data_sets: [],
             topical_events: [],
             world_locations: [],
@@ -517,23 +507,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
               text: "Collection A",
             },
           ],
-          policies: [],
-          statistical_data_sets: [],
-          topical_events: [],
-          world_locations: [],
-        )
-      end
-    end
-
-    context 'given a content item with policies' do
-      it 'returns a sidebar hash containing policies' do
-        expect(sidebar_for(content_item_with_policies)).to eq(
-          items: [],
-          collections: [],
-          policies: [
-            { path: "/policy-b", text: "Policy B" },
-            { path: "/policy-a", text: "Policy A" },
-          ],
           statistical_data_sets: [],
           topical_events: [],
           world_locations: [],
@@ -546,7 +519,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
         expect(sidebar_for(content_item_with_statistical_data_sets)).to eq(
           items: [],
           collections: [],
-          policies: [],
           statistical_data_sets: [
             { path: "/statistical-data-set-b", text: "Statistical data set B" },
             { path: "/statistical-data-set-a", text: "Statistical data set A" },
@@ -562,7 +534,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
         expect(sidebar_for(content_item_with_topical_events)).to eq(
           items: [],
           collections: [],
-          policies: [],
           statistical_data_sets: [],
           topical_events: [{ path: "/topical-event-b", text: "Topical event B" }],
           world_locations: [],
@@ -575,7 +546,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
         expect(sidebar_for(content_item_with_world_locations)).to eq(
           items: [],
           collections: [],
-          policies: [],
           statistical_data_sets: [],
           topical_events: [],
           world_locations: [{ path: "/world/world-location-b/news", text: "World location B" }],
@@ -653,25 +623,6 @@ RSpec.describe GovukPublishingComponents::Presenters::TaxonomyNavigation do
           "base_path" => "/collection-a",
           "content_id" => "collection-a",
           "document_type" => "document_collection",
-        },
-      ]
-    )
-  end
-
-  def content_item_with_policies
-    content_item_with(
-      "related_policies" => [
-        {
-          "title" => "Policy B",
-          "base_path" => "/policy-b",
-          "content_id" => "policy-b",
-          "document_type" => "policy",
-        },
-        {
-          "title" => "Policy A",
-          "base_path" => "/policy-a",
-          "content_id" => "policy-a",
-          "document_type" => "policy",
         },
       ]
     )


### PR DESCRIPTION
Trello card:
https://trello.com/c/3xOhZgEJ/127-removing-policy-links-from-the-taxonomy-sidebar

As policies are planning on being retired we need to remove policy links
from the taxonomy sidebar as there shouldn't be lots of different pages
showing the same content. This is because the same content is tagged to the Brexit
taxon and Brexit policy.

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-357.herokuapp.com/component-guide/
