### PR TITLE
Use h2 as the default for `heading` component

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/heading.yml
+++ b/app/views/govuk_publishing_components/components/docs/heading.yml
@@ -3,6 +3,8 @@ description: A text heading
 body: |
   A versatile heading tag component, including options for different heading levels and font sizes.
 
+  This is a `h2` by default.
+
   Real world examples:
 
   - [Publication](/government/publications/recognising-the-terrorist-threat)

--- a/lib/govuk_publishing_components/presenters/heading_helper.rb
+++ b/lib/govuk_publishing_components/presenters/heading_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
       attr_reader :heading_tag, :id, :classes
 
       def initialize(options)
-        @heading_tag = "h1"
+        @heading_tag = "h2"
         @heading_tag = "h#{options[:heading_level]}" if [1, 2, 3, 4, 5, 6].include? options[:heading_level]
         @id = options[:id]
 

--- a/spec/components/heading_spec.rb
+++ b/spec/components/heading_spec.rb
@@ -13,7 +13,7 @@ describe "Heading", type: :view do
 
   it "renders a heading correctly" do
     render_component(text: 'Download documents')
-    assert_select "h1.gem-c-heading", text: 'Download documents'
+    assert_select "h2.gem-c-heading", text: 'Download documents'
   end
 
   it "renders a different heading level" do


### PR DESCRIPTION
The heading component currently is a h1 by default.

However, most common usage of this component is to add subheadings in a
page, not a page title (for which we tend to use the `title` component).

This changes the default to a `h2` because it's more intuitive and
apparently more expected - it fixes a number of duplicated h1s in
government-frontend.

Examples:

- https://github.com/alphagov/government-frontend/blob/69c11af5b67c1b27bce047372fb2e899fee3b873/app/views/content_items/_publication_inline_body.html.erb#L12-L15
- https://github.com/alphagov/government-frontend/blob/69c11af5b67c1b27bce047372fb2e899fee3b873/app/views/content_items/consultation.html.erb#L40