### PR TITLE
Tweak context spacing on document list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+* Tweaks document list spacing for context text on smaller screens (PR #363)
+
 ## 9.1.1
 
 * Add placeholders for pages that don't have an image (#359)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -15,9 +15,12 @@
   display: inline-block;
 }
 
+.gem-c-document-list__item-title--context {
+  margin-right: $gutter-one-third;
+}
+
 .gem-c-document-list__item-context {
   color: $grey-1;
-  margin-left: $gutter-one-third;
 }
 
 .gem-c-document-list__item-description {

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -2,6 +2,7 @@
   items ||= []
   margin_top_class = " gem-c-document-list--top-margin" if local_assigns[:margin_top]
   margin_bottom_class = " gem-c-document-list--bottom-margin" if local_assigns[:margin_bottom]
+  title_with_context_class = " gem-c-document-list__item-title--context"
 
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
@@ -12,24 +13,17 @@
       <li class="gem-c-document-list__item">
         <% if item[:link][:description] || item[:metadata] %>
           <h3 class="gem-c-document-list__item-title">
-            <%=
-              link_to(
-                item[:link][:text],
-                item[:link][:path],
-                data: item[:link][:data_attributes],
-                class: brand_helper.color_class
-              )
-            %>
+        <% end %>
+        <%=
+          link_to(
+            item[:link][:text],
+            item[:link][:path],
+            data: item[:link][:data_attributes],
+            class: "gem-c-document-list__item-title #{brand_helper.color_class} #{title_with_context_class if item[:link][:context]}"
+          )
+        %>
+        <% if item[:link][:description] || item[:metadata] %>
           </h3>
-        <% else%>
-          <%=
-            link_to(
-              item[:link][:text],
-              item[:link][:path],
-              data: item[:link][:data_attributes],
-              class: "gem-c-document-list__item-title #{brand_helper.color_class}"
-            )
-          %>
         <% end %>
 
         <% if item[:link][:context] %>

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -182,7 +182,7 @@ describe "Document list", type: :view do
       ]
     )
 
-    assert_select '.gem-c-document-list__item a[href="/link/path"]', text: 'Link Title'
+    assert_select '.gem-c-document-list__item-title--context[href="/link/path"]', text: 'Link Title'
     assert_select '.gem-c-document-list__item-context', text: 'some context'
   end
 end


### PR DESCRIPTION
The spacing on the document list component was originally set on the context element itself.
This meant that on smaller screens, the context text appeared to be indented from the left when it wrapped onto a new line. By moving the margin to the link title, the context text will appear in line with the link title (on the left) if it wraps.

This also refactors the logic for displaying the link title as a heading or not, so we don't repeat the link HTML twice.

**Before:**
<img width="156" alt="screen shot 2018-06-07 at 09 54 18" src="https://user-images.githubusercontent.com/29889908/41089019-cb23278a-6a38-11e8-9638-0cd3c626eed8.png">

**After:**
<img width="155" alt="screen shot 2018-06-07 at 09 54 29" src="https://user-images.githubusercontent.com/29889908/41089029-cec1e00c-6a38-11e8-8268-83a869ac62d4.png">

---

Component guide for this PR:
https://govuk-publishing-compon-pr-363.herokuapp.com/component-guide/document_list
https://govuk-publishing-compon-pr-363.herokuapp.com/component-guide/document_list/with_context
