### PR TITLE
Add organisation logo component from static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   of the commit log.
 
 ## Unreleased
+
+* Add organisation logo component from static (PR #365)
 * Tweaks document list spacing for context text on smaller screens (PR #363)
 
 ## 9.1.1

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -25,6 +25,7 @@
 @import "components/label";
 @import "components/lead-paragraph";
 @import "components/notice";
+@import "components/organisation-logo";
 @import "components/phase-banner";
 @import "components/previous-and-next-navigation";
 @import "components/radio";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -1,0 +1,141 @@
+// Default logo corresponds with the "medium stacked" Whitehall equivalent
+.gem-c-organisation-logo {
+  font-family: $helvetica-regular;
+  font-size: 13px;
+  line-height: (15 / 13);
+  font-weight: 400;
+
+  @include media(tablet) {
+    font-size: 18px;
+    line-height: 20px;
+  }
+}
+
+.gem-c-organisation-logo__container {
+  text-transform: none;
+  text-decoration: none;
+  display: block;
+  color: $black;
+  height: auto;
+  width: auto;
+
+  // Logo direction never changes, even for rtl content.
+  direction: ltr;
+}
+
+// Scale images on smaller viewports
+.gem-c-organisation-logo__image {
+  max-width: 100%;
+}
+
+.gem-c-organisation-logo__crest {
+  // Default brand colour
+  border-left: 2px solid $black;
+  padding-top: 20px;
+  padding-left: 6px;
+
+  @include media(tablet) {
+    padding-top: 25px;
+    padding-left: 7px;
+  }
+
+  .brand--executive-office & {
+    border-left-width: 0;
+    padding-left: 0;
+    background-position: 0 0;
+  }
+}
+
+.gem-c-organisation-logo__name {
+  position: relative;
+  top: 3px;
+}
+
+.gem-c-organisation-logo__link:link,
+.gem-c-organisation-logo__link:visited {
+  color: $black;
+}
+
+.gem-c-organisation-logo__link:hover,
+.gem-c-organisation-logo__link:focus {
+  text-decoration: underline;
+}
+
+// all crest images are currently in whitehall
+@mixin crest($crest) {
+  background: image-url('crests/#{$crest}_13px.png') no-repeat 5px 0;
+  background-size: auto 20px;
+
+  @include device-pixel-ratio() {
+    background-image: image-url('crests/#{$crest}_13px_x2.png');
+  }
+
+  @include media(tablet) {
+    background: image-url('crests/#{$crest}_18px.png') no-repeat 6px 0;
+    background-size: auto 26px;
+
+    @include device-pixel-ratio() {
+      background-image: image-url('crests/#{$crest}_18px_x2.png');
+    }
+  }
+}
+
+@mixin tall-crest {
+  padding-top: 25px;
+  background-size: auto 25px;
+
+  @include media(tablet) {
+    padding-top: 35px;
+    background-size: auto 34px;
+  }
+}
+
+.gem-c-organisation-logo__crest--dit {
+  @include crest('dit_crest');
+}
+
+.gem-c-organisation-logo__crest--bis {
+  @include crest('bis_crest');
+}
+
+.gem-c-organisation-logo__crest--hmrc {
+  @include crest('hmrc_crest');
+}
+
+.gem-c-organisation-logo__crest--ho {
+  @include crest('ho_crest');
+  @include tall-crest;
+}
+
+.gem-c-organisation-logo__crest--mod {
+  @include crest('mod_crest');
+  @include tall-crest;
+}
+
+.gem-c-organisation-logo__crest--single-identity,
+.gem-c-organisation-logo__crest--eo,
+.gem-c-organisation-logo__crest--org {
+  @include crest('org_crest');
+}
+
+.gem-c-organisation-logo__crest--portcullis {
+  @include crest('portcullis');
+}
+
+.gem-c-organisation-logo__crest--so {
+  @include crest('so_crest');
+}
+
+.gem-c-organisation-logo__crest--ukaea {
+  @include crest('ukaea_crest');
+}
+
+.gem-c-organisation-logo__crest--ukho {
+  @include crest('ukho');
+  @include tall-crest;
+}
+
+.gem-c-organisation-logo__crest--wales {
+  @include crest('wales_crest');
+  @include tall-crest;
+}

--- a/app/views/govuk_publishing_components/components/_organisation_logo.html.erb
+++ b/app/views/govuk_publishing_components/components/_organisation_logo.html.erb
@@ -1,0 +1,21 @@
+<%
+  logo_helper = GovukPublishingComponents::Presenters::OrganisationLogoHelper.new(local_assigns)
+  brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(organisation[:brand])
+  organisation ||= {}
+%>
+<div
+  class="gem-c-organisation-logo <%= brand_helper.brand_class %>"
+  <%= "data-module=track-click" if organisation[:data_attributes] %>
+>
+  <% if organisation[:url] %>
+    <%= link_to organisation[:url],
+      class: "#{logo_helper.logo_container_class} #{brand_helper.border_color_class}",
+      data: organisation[:data_attributes] do %>
+      <%= logo_helper.logo_content %>
+    <% end %>
+  <% else %>
+    <div class="<%= logo_helper.logo_container_class %> <%= brand_helper.border_color_class %>">
+      <%= logo_helper.logo_content %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
+++ b/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
@@ -1,0 +1,164 @@
+name: "Organisation logo"
+description: "Organisation text with crest and branded border colour"
+body: |
+  Organisation name must be provided with pre-formatted line breaks.
+  These cannot be inferred from the name alone.
+
+  Alternatively a custom organisation logo can be provided as an image.
+
+  Data tracking attributes can be provided to add tracking to each organisation logo.
+  This will only apply to organisations with a link. Example here: [with_data_attributes](/component-guide/organisation_logo/with_data_attributes)
+accessibility_criteria: |
+  The crest image itself must be presentational and ignored by screen readers.
+
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      organisation:
+        name: 'Organisation<br>Name'
+        url: 'http://www.gov.uk'
+  single_identity:
+    data:
+      organisation:
+        name: 'Single Identity'
+        url: 'http://www.gov.uk'
+        crest: 'single-identity'
+  attorney_generals_office:
+    data:
+      organisation:
+        name: 'Attorney <br>General’s <br>Office'
+        url: '/government/organisations/attorney-generals-office'
+        brand: 'attorney-generals-office'
+        crest: 'single-identity'
+  department_for_business_innovation_and_skills:
+    data:
+      organisation:
+        name: 'Department <br>for Business<br>Innovation &amp; Skills'
+        url: '/government/organisations/department-for-business-innovation-skills'
+        brand: 'department-for-business-innovation-skills'
+        crest: 'bis'
+  department_for_international_trade:
+    data:
+      organisation:
+        name: 'Department for<br>International Trade'
+        url: '/government/organisations/department-for-international-trade'
+        brand: 'department-for-international-trade'
+        crest: 'dit'
+  executive_office:
+    data:
+      organisation:
+        name: Prime Minister's Office, 10 Downing Street
+        url: '/government/organisations/prime-ministers-office-10-downing-street'
+        brand: 'executive-office'
+        crest: 'eo'
+  home_office:
+    data:
+      organisation:
+        name: 'Home Office'
+        url: '/government/organisations/home-office'
+        brand: 'home-office'
+        crest: 'ho'
+  ministry_of_defence:
+    data:
+      organisation:
+        name: 'Ministry<br>of Defence'
+        url: '/government/organisations/ministry-of-defence'
+        brand: 'ministry-of-defence'
+        crest: 'mod'
+  office_of_the_advocate_general_for_scotland:
+    data:
+      organisation:
+        name: 'Office of the<br>Advocate General<br>for Scotland'
+        url: '/government/organisations/office-of-the-advocate-general-for-scotland'
+        brand: 'office-of-the-advocate-general-for-scotland'
+        crest: 'so'
+  office_of_the_leader_of_the_house_of_commons:
+    data:
+      organisation:
+        name: 'Office of the <br>Leader of the <br>House of Commons'
+        url: '/government/organisations/the-office-of-the-leader-of-the-house-of-commons'
+        brand: 'the-office-of-the-leader-of-the-house-of-commons'
+        crest: 'portcullis'
+  wales_office:
+    data:
+      organisation:
+        name: 'Wales Office<br>Swyddfa Cymru'
+        url: '/government/organisations/wales-office'
+        brand: 'wales_office'
+        crest: 'wales'
+  uk_atomic_energy_authority:
+    data:
+      organisation:
+        name: 'UK Atomic <br>Energy <br>Authority'
+        url: '/government/organisations/uk-atomic-energy-authority'
+        brand: 'department-for-business-innovation-skills'
+        crest: 'ukaea'
+  wales_office:
+    data:
+      organisation:
+        name: 'Wales Office<br>Swyddfa Cymru'
+        url: '/government/organisations/wales-office'
+        brand: 'wales_office'
+        crest: 'wales'
+  hm_revenue_customs:
+    data:
+      organisation:
+        name: 'HM Revenue<br>&amp; Customs'
+        url: '/government/organisations/hm-revenue-customs'
+        brand: 'hm-revenue-customs'
+        crest: 'hmrc'
+  bona_vacantia:
+    data:
+      organisation:
+        name: 'Bona Vacantia'
+        url: '/government/organisations/bona-vacantia'
+        brand: 'attorney-generals-office'
+        crest: 'org'
+  treasury_solicitors_office:
+    data:
+      organisation:
+        name: 'Treasury <br>Solicitor’s <br>Department'
+        url: '/government/organisations/treasury-solicitor-s-department'
+        brand: 'attorney-generals-office'
+        crest: 'org'
+  land_registry:
+    data:
+      organisation:
+        name: 'Land Registry'
+        url: '/government/organisations/land-registry'
+        brand: 'department-for-business-innovation-skills'
+        crest: null
+        image:
+          url: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/69/HMLR_logo.png'
+          alt_text: 'Land Registry'
+  hm_prison_service:
+    data:
+      organisation:
+        name: 'HM Prison Service'
+        url: '/government/organisations/hm-prison-service'
+        brand: 'ministry-of-justice'
+        image:
+          url: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/321/HMPS.jpg'
+          alt_text: 'HM Prison Service'
+  with_data_attributes:
+    data:
+      organisation:
+        name: Cabinet Office
+        url: '/government/organisations/cabinet-office'
+        brand: cabinet-office
+        crest: 'single-identity'
+        data_attributes:
+          track_category: "navOrganisationLinkClicked"
+          track_action: 1
+          track_label: '/government/organisations/cabinet-office'
+          track_options:
+            dimension28: 2
+            dimension29: Cabinet Office
+  without_a_link:
+    data:
+      organisation:
+        name: Cabinet Office
+        brand: cabinet-office
+        crest: 'single-identity'

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -19,6 +19,7 @@ require "govuk_publishing_components/presenters/schema_org"
 require "govuk_publishing_components/presenters/heading_helper"
 require "govuk_publishing_components/presenters/contents_list_helper"
 require "govuk_publishing_components/presenters/image_card_helper"
+require "govuk_publishing_components/presenters/organisation_logo_helper"
 
 require "govuk_publishing_components/app_helpers/taxon_breadcrumbs"
 require "govuk_publishing_components/app_helpers/brand_helper"

--- a/lib/govuk_publishing_components/presenters/organisation_logo_helper.rb
+++ b/lib/govuk_publishing_components/presenters/organisation_logo_helper.rb
@@ -1,0 +1,36 @@
+module GovukPublishingComponents
+  module Presenters
+    class OrganisationLogoHelper
+      include ActionView::Helpers
+      include ActionView::Context
+
+      attr_reader :name, :url, :crest, :image, :logo_image_src, :logo_image_alt
+
+      def initialize(local_assigns)
+        @name = local_assigns[:organisation][:name]
+        @url = local_assigns[:organisation][:url]
+        @crest = local_assigns[:organisation][:crest]
+        @image = local_assigns[:organisation][:image] || false
+        if @image
+          @logo_image_src = local_assigns[:organisation][:image][:url] || false
+          @logo_image_alt = local_assigns[:organisation][:image][:alt_text] || false
+        end
+      end
+
+      def logo_content
+        if image
+          image_tag(logo_image_src, alt: logo_image_alt, class: "gem-c-organisation-logo__image")
+        else
+          content_tag('span', name, class: "gem-c-organisation-logo__name")
+        end
+      end
+
+      def logo_container_class
+        logo_class = "gem-c-organisation-logo__container"
+        logo_class = "#{logo_class} gem-c-organisation-logo__link" if url
+        logo_class = "#{logo_class} gem-c-organisation-logo__crest gem-c-organisation-logo__crest--#{crest}" if crest
+        logo_class
+      end
+    end
+  end
+end

--- a/spec/components/organisation_logo_spec.rb
+++ b/spec/components/organisation_logo_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+describe "Organisation logo", type: :view do
+  def component_name
+    "organisation_logo"
+  end
+
+  it "error if no parameters passed in" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  it "shows an organisation name" do
+    render_component(organisation: { name: "Organisation name" })
+    assert_select ".gem-c-organisation-logo .gem-c-organisation-logo__container", text: "Organisation name"
+  end
+
+  it "adds branding to the wrapping container" do
+    render_component(organisation: { name: "Branded", brand: "department-for-international-trade" })
+    assert_select ".gem-c-organisation-logo.brand--department-for-international-trade", text: "Branded"
+  end
+
+  it "includes a link when a URL is provided" do
+    render_component(organisation: { name: "Linked", url: "/somewhere" })
+    assert_select ".gem-c-organisation-logo a.gem-c-organisation-logo__container.gem-c-organisation-logo__link[href='/somewhere']", text: "Linked"
+  end
+
+  it "doesn't include a link when a URL is not provided" do
+    render_component(organisation: { name: "Linked" })
+    assert_select "a.gem-c-organisation-logo__container.gem-c-organisation-logo__link[href='/somewhere']", false
+    assert_select ".gem-c-organisation-logo__container"
+  end
+
+  it "adds a crest class when specified" do
+    render_component(organisation: { name: "Crested", crest: "single-identity" })
+    assert_select ".gem-c-organisation-logo__container.gem-c-organisation-logo__crest.gem-c-organisation-logo__crest--single-identity"
+  end
+
+  it "renders an image when specified" do
+    render_component(organisation: { name: "Custom image", image: { url: "/url", alt_text: "alt" } })
+    assert_select ".gem-c-organisation-logo__container img[src='/url'][alt='alt']"
+  end
+
+  it "adds data tracking attributes when specified" do
+    data_attributes = {
+      track_category: "someLinkClicked",
+      track_action: 1,
+      track_label: "/some-link",
+      track_options: {
+        dimension28: 2,
+        dimension29: "Organisation link"
+      }
+    }
+
+    render_component(organisation: { url: "/some-link", data_attributes: data_attributes })
+
+    assert_select ".gem-c-organisation-logo[data-module='track-click']"
+    assert_select ".gem-c-organisation-logo a.gem-c-organisation-logo__container.gem-c-organisation-logo__link[data-track-category='someLinkClicked']"
+    assert_select ".gem-c-organisation-logo a.gem-c-organisation-logo__container.gem-c-organisation-logo__link[data-track-action='1']"
+    assert_select ".gem-c-organisation-logo a.gem-c-organisation-logo__container.gem-c-organisation-logo__link[data-track-label='/some-link']"
+    assert_select ".gem-c-organisation-logo a.gem-c-organisation-logo__container.gem-c-organisation-logo__link[data-track-options='{\"dimension28\":2,\"dimension29\":\"Organisation link\"}']"
+  end
+
+  it "doesn't add data tracking attributes when no link is specified" do
+    data_attributes = {
+      track_category: "someLinkClicked"
+    }
+
+    render_component(organisation: { data_attributes: data_attributes })
+    assert_select ".gem-c-organisation-logo a.gem-c-organisation-logo__container.gem-c-organisation-logo__link[data-track-category='someLinkClicked']", false
+  end
+end


### PR DESCRIPTION
- now uses gem-c css namespace
- modified to use a helper method
- gem branding model replaces existing branding mechanism
- test for no link added now included, test names rewritten
- example for without link added to documentation
- crest images still live in whitehall
- css restructured but essentially the same

---

Component guide for this PR:
https://govuk-publishing-compon-pr-365.herokuapp.com/component-guide/
