### PR TITLE
Version 9.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 9.2.0
 
 * Add organisation logo component from static (PR #365)
 * Tweaks document list spacing for context text on smaller screens (PR #363)
+* Makes heading component use h2 by default (PR #362)
 
 ## 9.1.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (9.1.1)
+    govuk_publishing_components (9.2.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '9.1.1'.freeze
+  VERSION = '9.2.0'.freeze
 end


### PR DESCRIPTION
* Add organisation logo component from static (PR #365)
 * Tweaks document list spacing for context text on smaller screens (PR #363)
* Makes heading component use h2 by default (PR #362)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-366.herokuapp.com/component-guide/
