### PR TITLE
Using html_safe in organisation logo

### DIFF
--- a/lib/govuk_publishing_components/presenters/organisation_logo_helper.rb
+++ b/lib/govuk_publishing_components/presenters/organisation_logo_helper.rb
@@ -7,10 +7,17 @@ module GovukPublishingComponents
       attr_reader :name, :url, :crest, :image, :logo_image_src, :logo_image_alt
 
       def initialize(local_assigns)
-        @name = local_assigns[:organisation][:name]
+        if local_assigns[:organisation][:name]
+          @name = local_assigns[:organisation][:name]
+          @name.gsub! "<script>", ""
+          @name.gsub! "</script>", ""
+          @name = @name.html_safe
+        end
+
         @url = local_assigns[:organisation][:url]
         @crest = local_assigns[:organisation][:crest]
         @image = local_assigns[:organisation][:image] || false
+
         if @image
           @logo_image_src = local_assigns[:organisation][:image][:url] || false
           @logo_image_alt = local_assigns[:organisation][:image][:alt_text] || false

--- a/spec/components/organisation_logo_spec.rb
+++ b/spec/components/organisation_logo_spec.rb
@@ -70,4 +70,11 @@ describe "Organisation logo", type: :view do
     render_component(organisation: { data_attributes: data_attributes })
     assert_select ".gem-c-organisation-logo a.gem-c-organisation-logo__container.gem-c-organisation-logo__link[data-track-category='someLinkClicked']", false
   end
+
+  it "doesn't let malicious tags into the organisation name even though we're using html_safe" do
+    component_name = "<script>alert('Hello!')</script>"
+    render_component(organisation: { name: component_name })
+
+    assert_select ".gem-c-organisation-logo", text: "alert('Hello!')"
+  end
 end


### PR DESCRIPTION
- component gets passed org names that have BR tags in for formatting
- some of our apps (collections) don't let us use html_safe, so it has to go in the component itself
- component strips out script tags just in case, although input for this field shouldn't ever come from a user

---

Component guide for this PR:
https://govuk-publishing-compon-pr-367.herokuapp.com/component-guide/
