### PR TITLE
Add no margin top option to translation nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add no margin top option to translation nav (PR #368)
+
 ## 9.2.0
 
 * Add organisation logo component from static (PR #365)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_translation-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_translation-nav.scss
@@ -35,3 +35,7 @@
   border-right: 0;
   border-left: 0;
 }
+
+.gem-c-translation-nav--no-margin-top {
+  margin-top: 0;
+}

--- a/app/views/govuk_publishing_components/components/_translation-nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_translation-nav.html.erb
@@ -5,7 +5,7 @@
 %>
 <% if translation_helper.has_translations? %>
   <nav role="navigation"
-    class="gem-c-translation-nav <%= brand_helper.brand_class %>"
+    class="gem-c-translation-nav <%= translation_helper.margin_class %> <%= brand_helper.brand_class %>"
     aria-label="<%= t("common.translations") %>"
     <%= "data-module=\"track-click\"" if translation_helper.tracking_is_present? %>
   >

--- a/app/views/govuk_publishing_components/components/docs/translation-nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/translation-nav.yml
@@ -71,6 +71,17 @@ examples:
       - locale: 'cy'
         base_path: '/cy'
         text: 'Cymraeg'
+  with_no_top_margin:
+    data:
+      no_margin_top: true
+      translations:
+      - locale: 'en'
+        base_path: '/en'
+        text: 'English'
+        active: true
+      - locale: 'cy'
+        base_path: '/cy'
+        text: 'Cymraeg'
   with_tracking:
     description: Data attributes can be passed for each link as shown.
     data:

--- a/lib/govuk_publishing_components/presenters/translation_nav_helper.rb
+++ b/lib/govuk_publishing_components/presenters/translation_nav_helper.rb
@@ -6,6 +6,7 @@ module GovukPublishingComponents
       def initialize(local_assigns)
         @translations = []
         @translations = local_assigns[:translations] if local_assigns[:translations]
+        @no_margin_top = local_assigns[:no_margin_top]
       end
 
       def has_translations?
@@ -17,6 +18,10 @@ module GovukPublishingComponents
           return true if translation[:data_attributes]
         end
         false
+      end
+
+      def margin_class
+        "gem-c-translation-nav--no-margin-top" if @no_margin_top
       end
     end
   end

--- a/spec/components/translation_nav_spec.rb
+++ b/spec/components/translation_nav_spec.rb
@@ -82,4 +82,9 @@ describe "Translation nav", type: :view do
     render_component(translations: translations_with_tracking)
     assert_select ".gem-c-translation-nav a[data-track-category='category'][data-track-label='label']", text: "हिंदी"
   end
+
+  it "has no margin top when option passed" do
+    render_component(translations: multiple_translations, no_margin_top: true)
+    assert_select ".gem-c-translation-nav--no-margin-top"
+  end
 end


### PR DESCRIPTION
By default the component has a large margin top, this option allows it to be turned off, something we need for positioning the translation nav on the new org pages.

Trello card: https://trello.com/c/pa4kkZwL/166-modify-component-translation-nav

---

Component guide for this PR:
https://govuk-publishing-compon-pr-368.herokuapp.com/component-guide/
