### PR TITLE
Version 9.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 9.2.1
 
 * Add no margin top option to translation nav (PR #368)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (9.2.0)
+    govuk_publishing_components (9.2.1)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '9.2.0'.freeze
+  VERSION = '9.2.1'.freeze
 end


### PR DESCRIPTION
Very small update - adding an option to translation nav for no top margin.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-369.herokuapp.com/component-guide/
