### PR TITLE
Update document list documentation

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -104,7 +104,7 @@ examples:
           text: 'School exclusion'
           path: '/government/publications/school-exclusion'
   with_context:
-    description: Context can be provided to render next to the item title. This will be used on /government/organisations to indicate if an organisation is hosted on a separate website or being moved to GOV.UK
+    description: Context can be provided to render next to the item title.
     data:
       items:
       - link:


### PR DESCRIPTION
The document list component was going to be used on the new /government/organisations pages in Collections. However, we've decided that using this component will introduce more limitations.
We therefore need to update this documentation in case it misleads people in the future.

Component guide for this PR:
https://govuk-publishing-compon-pr-370.herokuapp.com/component-guide/document_list
