### PR TITLE
[WIP] Create layout component for admin apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add experimental Admin layout (PR #371)
 * Add the [GOV.UK Frontend](https://design-system.service.gov.uk/) library to the gem (PR #398)
 
 ## 9.3.6

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -50,6 +50,16 @@ $border-color: #ccc;
   }
 }
 
+.component-warning {
+  border: 3px solid $orange;
+  margin: 0 0 $gutter;
+  padding: $gutter $gutter 0 $gutter;
+
+  .component-warning__title {
+    @include bold-24;
+  }
+}
+
 .component-doc-h2 {
   @include bold-27;
   margin: ($gutter * 1.5) 0 $gutter;

--- a/app/assets/stylesheets/govuk_publishing_components/admin_styles.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/admin_styles.scss
@@ -1,0 +1,15 @@
+// Include all of the GOV.UK Frontend styles. This includes global styles, fonts,
+// and individual components.
+$govuk-global-styles: true;
+$govuk-image-url-function: 'image-url';
+$govuk-font-url-function: 'font-url';
+
+@import "../../../node_modules/govuk-frontend/all";
+
+// Include our GOV.UK components
+@import "govuk_publishing_components/all_components";
+
+// Components that are only available inside the admin layout
+@import "govuk_publishing_components/components/layout-header";
+@import "govuk_publishing_components/components/layout-footer";
+@import "govuk_publishing_components/components/layout-main";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
@@ -1,0 +1,1 @@
+// This component relies on styles from GOV.UK Frontend

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-admin.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-admin.scss
@@ -1,0 +1,1 @@
+// This component relies on styles from GOV.UK Frontend

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -1,0 +1,19 @@
+// This component relies on styles from GOV.UK Frontend
+
+.govuk-header--production .govuk-header__container {
+  border-bottom: 10px solid govuk-colour("bright-red");
+}
+
+.govuk-header--integration .govuk-header__container,
+.govuk-header--staging .govuk-header__container {
+  border-bottom: 10px solid govuk-colour("yellow");
+}
+
+.govuk-header--development .govuk-header__container {
+  border-bottom: 10px solid govuk-colour("grey-1");
+}
+
+// Fix the logo
+.govuk-header__logo {
+  width: 33%;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-main.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-main.scss
@@ -1,0 +1,3 @@
+.gem-c-admin-layout__main {
+  min-height: 400px;
+}

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -42,6 +42,14 @@ module GovukPublishingComponents
       component[:display_html]
     end
 
+    def part_of_admin_layout?
+      component[:part_of_admin_layout]
+    end
+
+    def display_preview?
+      component[:display_preview].nil? ? true : component[:display_preview]
+    end
+
     def html_body
       govspeak_to_html(body) if body.present?
     end
@@ -56,6 +64,10 @@ module GovukPublishingComponents
       else
         "#{GovukPublishingComponents::Config.component_directory_name}/#{id}"
       end
+    end
+
+    def govuk_frontend_components
+      component[:govuk_frontend_components].to_a
     end
 
     def github_search_url

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
@@ -1,8 +1,10 @@
-<div data-module="test-a11y" data-excluded-rules="<%= @component_doc.accessibility_excluded_rules %>">
-  <%= render "govuk_publishing_components/component_guide/component_doc/component", component_doc: @component_doc, example: example, preview_page: false %>
-  <div class="component-guide-preview component-guide-preview--violation" data-module="test-a11y-violation" data-content="Accessibility Issues"></div>
-  <div class="component-guide-preview component-guide-preview--warning" data-module="test-a11y-warning" data-content="Potential accessibility issues: need manual check"></div>
-</div>
+<% if component_doc.display_preview? %>
+  <div data-module="test-a11y" data-excluded-rules="<%= @component_doc.accessibility_excluded_rules %>">
+    <%= render "govuk_publishing_components/component_guide/component_doc/component", component_doc: @component_doc, example: example, preview_page: false %>
+    <div class="component-guide-preview component-guide-preview--violation" data-module="test-a11y-violation" data-content="Accessibility Issues"></div>
+    <div class="component-guide-preview component-guide-preview--warning" data-module="test-a11y-warning" data-content="Potential accessibility issues: need manual check"></div>
+  </div>
+<% end %>
 
 <% if component_doc.display_html? %>
   <div class="component-guide-preview component-call component-highlight component-output" data-content="HTML OUTPUT">

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -1,6 +1,15 @@
 <% content_for :title, "#{@component_doc.name} component" %>
 <%= render 'govuk_publishing_components/components/title', title: @component_doc.name, context: "Component" %>
 
+<% if @component_doc.part_of_admin_layout? %>
+<div class="component-warning">
+  <h2 class="component-warning__title">Admin layout only</h2>
+  <p>
+    This component uses the Design System, so only works inside the <%= link_to "admin layout", "/component-guide/layout_for_admin" %>
+  </p>
+</div>
+<% end %>
+
 <div class="component-show">
   <div class="grid-row">
     <div class="column-two-thirds">
@@ -27,6 +36,19 @@
   </div>
 
   <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, example: @component_doc.example %>
+
+  <% if @component_doc.govuk_frontend_components.any? %>
+    <h2 class="component-doc-h2">GOV.UK Design System</h2>
+    <%= render 'govuk_publishing_components/components/govspeak' do %>
+      <p>This component incorporates components from the <%= link_to "GOV.UK Design System", "https://design-system.service.gov.uk" %>:</p>
+
+      <ul>
+      <% @component_doc.govuk_frontend_components.each do |component| %>
+        <li><%= link_to component.humanize, "https://design-system.service.gov.uk/components/#{component}" %></li>
+      <% end %>
+      </ul>
+    <% end %>
+  <% end %>
 
   <% if @component_doc.accessibility_criteria.present? %>
     <div class="grid-row component-accessibility-criteria">

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -1,0 +1,35 @@
+<footer class="govuk-footer" role="contentinfo">
+  <div class="govuk-width-container">
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        <svg
+          role="presentation"
+          class="govuk-footer__licence-logo"
+          xmlns="http://www.w3.org/2000/svg"
+          viewbox="0 0 483.2 195.7"
+          height="17"
+          width="41"
+        >
+          <path
+            fill="currentColor"
+            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+          />
+        </svg>
+        <span class="govuk-footer__licence-description">
+          All content is available under the
+          <a
+            class="govuk-footer__link"
+            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+            rel="license"
+          >Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a
+          class="govuk-footer__link govuk-footer__copyright-logo"
+          href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/"
+        >© Crown copyright</a>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title><%= browser_title %></title>
+    <%= stylesheet_link_tag 'govuk_publishing_components/admin_styles' %>
+    <%= csrf_meta_tag %>
+  </head>
+  <body class="govuk-template__body">
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -1,0 +1,49 @@
+<header class="govuk-header govuk-header--<%= environment %>" role="banner" data-module="header">
+  <div class="govuk-header__container govuk-width-container">
+    <div class="govuk-header__logo">
+      <a href="/" class="govuk-header__link govuk-header__link--homepage">
+        <span class="govuk-header__logotype">
+          <svg
+            role="presentation"
+            focusable="false"
+            class="govuk-header__logotype-crown"
+            xmlns="http://www.w3.org/2000/svg"
+            viewbox="0 0 132 97"
+            height="32"
+            width="36"
+          >
+            <path
+              fill="currentColor" fill-rule="evenodd"
+              d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+            ></path>
+
+            <image src="<%= image_url "govuk-logotype-crown.png" %>" class="govuk-header__logotype-crown-fallback-image"></image>
+          </svg>
+          <span class="govuk-header__logotype-text">
+            GOV.UK
+          </span>
+        </span>
+      </a>
+    </div>
+
+    <div class="govuk-header__content">
+      <a href="#" class="govuk-header__link govuk-header__link--service-name">
+        Admin
+      </a>
+
+      <button role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+
+      <% if defined?(navigation_links) && navigation_links %>
+        <nav>
+          <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+            <% navigation_links.each do |item| %>
+              <li class="govuk-header__navigation-item <%= item[:active] ? "govuk-header__navigation-item--active" : nil %>">
+                <%= link_to item[:name], item[:href], class: 'govuk-header__link' %>
+              </li>
+            <% end %>
+          </ul>
+        </nav>
+      <% end %>
+    </div>
+  </div>
+</header>

--- a/app/views/govuk_publishing_components/components/_layout_main.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_main.html.erb
@@ -1,0 +1,19 @@
+<div class="gem-c-admin-layout__main govuk-width-container">
+  <% if flash[:error] %>
+    <div class="govuk-error-summary govuk-!-mt-r7" role="alert" tabindex="-1">
+      <div class="govuk-error-summary__body">
+        <%= flash[:error] %>
+      </div>
+    </div>
+  <% end %>
+
+  <% if flash[:notice] %>
+    <div class="govuk-panel govuk-panel--confirmation govuk-!-mt-r7">
+      <div class="govuk-panel__body">
+        <%= flash[:notice] %>
+      </div>
+    </div>
+  <% end %>
+
+  <%= yield %>
+</div>

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -1,0 +1,9 @@
+name: Layout footer (experimental)
+description: The footer provides copyright, licensing and other information
+part_of_admin_layout: true
+govuk_frontend_components:
+  - footer
+examples:
+  default:
+    data: {}
+accessibility_criteria: |

--- a/app/views/govuk_publishing_components/components/docs/layout_for_admin.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_admin.yml
@@ -1,0 +1,28 @@
+name: Admin layout (experimental)
+description: A layout to be used by admin applications
+body: |
+  This component uses [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend),
+  part of the GOV.UK Design System.
+
+  It also includes the styles for the other components in this gem, so that you can use
+  these components as well.
+
+  This component is experimental. Breaking changes are likely and we'll not release
+  major version of the gem for these changes.
+
+  Because it is an entire layout, this component can only be [previewed on a separate page](/admin).
+
+  Typically you'll use this together with the [layout_header](/component-guide/layout_header),
+  [layout_main](/component-guide/layout_main) and
+  [layout_footer](/component-guide/layout_footer).
+
+display_preview: false
+display_html: true
+accessibility_criteria: |
+  TBD
+examples:
+  default:
+    data:
+      browser_title: 'A page title'
+      block: |
+        <!-- You probably want to use the header, main & footer components here -->

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -1,0 +1,31 @@
+name: Layout header (experimental)
+description: Shows users that they are on GOV.UK and which service they are using
+body: |
+  Requires the specification of the environment (development, integration,
+  staging or production).
+part_of_admin_layout: true
+govuk_frontend_components:
+  - header
+examples:
+  default:
+    data:
+      environment: "production"
+  staging_environment:
+    data:
+      environment: "staging"
+  integration_environment:
+    data:
+      environment: "integration"
+  development_environment:
+    data:
+      environment: "development"
+  with_navigation_links:
+    data:
+      environment: "production"
+      navigation_links:
+        - name: Foo
+          href: '#'
+          active: true
+        - name: Bar
+          href: '#'
+accessibility_criteria: |

--- a/app/views/govuk_publishing_components/components/docs/layout_main.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_main.yml
@@ -1,0 +1,24 @@
+name: Layout main section (experimental)
+description: The main section of the page. Includes support for flash messages.
+part_of_admin_layout: true
+govuk_frontend_components:
+  - panel
+  - error-summary
+examples:
+  default:
+    data:
+      block: |
+        The content.
+  with_an_error:
+    data:
+      flash:
+        error: "Something went wrong"
+      block: |
+        The content.
+  with_a_notice:
+    data:
+      flash:
+        notice: "How are you today?"
+      block: |
+        The content.
+accessibility_criteria: |

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -16,6 +16,11 @@
   <% if GovukPublishingComponents::Config.application_print_stylesheet %>
     <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_print_stylesheet}", media: "print" %>
   <% end %>
+
+  <% if @component_doc && @component_doc.part_of_admin_layout? %>
+    <%= stylesheet_link_tag "govuk_publishing_components/admin_styles" %>
+  <% end %>
+
   <%= javascript_include_tag "component_guide/application" %>
   <%= javascript_include_tag "#{GovukPublishingComponents::Config.application_javascript}" %>
   <%= csrf_meta_tags %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,4 +1,5 @@
 Rails.application.config.assets.precompile += %w(
+  govuk_publishing_components/admin_styles.css
   govuk_publishing_components/component_guide.css
   component_guide/all_components.css
   component_guide/all_components_print.css
@@ -12,4 +13,15 @@ Rails.application.config.assets.precompile += %w(
   govuk_publishing_components/govuk-schema-placeholder-1x1.png
   govuk_publishing_components/govuk-schema-placeholder-4x3.png
   govuk_publishing_components/govuk-schema-placeholder-16x9.png
+)
+
+# Add GOV.Frontend assets
+
+Rails.application.config.assets.precompile += %w(
+  govuk-logotype-crown.png
+)
+
+Rails.application.config.assets.paths += %W(
+  #{__dir__}/../../node_modules/govuk-frontend/assets/images
+  #{__dir__}/../../node_modules/govuk-frontend/assets/fonts
 )

--- a/spec/components/all_components_spec.rb
+++ b/spec/components/all_components_spec.rb
@@ -24,13 +24,13 @@ describe "All components" do
       it "has a correctly named spec file", skip: component_name.in?(%w[contextual_breadcrumbs contextual_sidebar success_alert taxonomy_navigation]) do
         rspec_file = "#{__dir__}/../../spec/components/#{component_name.tr('-', '_')}_spec.rb"
 
-        expect(File).to exist(rspec_file)
+        expect(File).to exist(rspec_file), rspec_file
       end
 
       it "has a correctly named SCSS file", not_applicable: component_name.in?(%w[contextual_breadcrumbs contextual_sidebar government_navigation machine_readable_metadata meta_tags]) do
         css_file = "#{__dir__}/../../app/assets/stylesheets/govuk_publishing_components/components/_#{component_name.tr('_', '-')}.scss"
 
-        expect(File).to exist(css_file)
+        expect(File).to exist(css_file), css_file
       end
 
       it "doesn't use `html_safe`", not_applicable: component_name.in?(%w[govspeak]) do

--- a/spec/components/layout_footer_spec.rb
+++ b/spec/components/layout_footer_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe "Layout footer", type: :view do
+  def component_name
+    "layout_footer"
+  end
+
+  it "renders the footer" do
+    render_component({})
+
+    assert_select ".govuk-footer"
+  end
+end

--- a/spec/components/layout_for_admin_spec.rb
+++ b/spec/components/layout_for_admin_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe "Layout for admin", type: :view do
+  def component_name
+    "layout_for_admin"
+  end
+
+  it "adds the <title> tag" do
+    render_component(browser_title: "Hello, admin page", environment: "production")
+
+    assert_select "title", visible: false, text: "Hello, admin page"
+  end
+end

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe "Layout header", type: :view do
+  def component_name
+    "layout_header"
+  end
+
+  it "renders the header" do
+    render_component(environment: "staging")
+
+    assert_select ".govuk-header"
+  end
+
+  it "renders the header with navigation links" do
+    navigation_links = [
+      { name: "Foo", href: "/foo", active: true },
+      { name: "Bar", href: "/bar" },
+    ]
+
+    render_component(environment: "staging", navigation_links: navigation_links)
+
+    assert_select ".govuk-header__navigation-item.govuk-header__navigation-item--active", text: "Foo"
+    assert_select ".govuk-header__navigation-item", text: "Bar"
+  end
+end

--- a/spec/components/layout_main_spec.rb
+++ b/spec/components/layout_main_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe "Layout main", type: :view do
+  def component_name
+    "layout_main"
+  end
+
+  it "renders a flash error" do
+    render_component(flash: { error: "Something went wrong" })
+
+    assert_select ".govuk-error-summary__body", text: "Something went wrong"
+  end
+
+  it "renders a flash notice" do
+    render_component(flash: { notice: "Something went neutral" })
+
+    assert_select ".govuk-panel__body", text: "Something went neutral"
+  end
+end

--- a/spec/dummy/app/controllers/welcome_controller.rb
+++ b/spec/dummy/app/controllers/welcome_controller.rb
@@ -16,4 +16,9 @@ class WelcomeController < ApplicationController
       @content_item = Services.content_store.content_item("/" + params[:base_path])
     end
   end
+
+  def admin
+    response.headers[Slimmer::Headers::SKIP_HEADER] = "true"
+    render 'admin_example', layout: 'dummy_admin_layout'
+  end
 end

--- a/spec/dummy/app/views/layouts/dummy_admin_layout.html.erb
+++ b/spec/dummy/app/views/layouts/dummy_admin_layout.html.erb
@@ -1,0 +1,18 @@
+<% navigation_links = [
+  {
+    name: 'An active item',
+    href: '#',
+  },
+  {
+    name: 'Another item',
+    href: '#',
+  }
+] %>
+
+<%= render 'govuk_publishing_components/components/layout_for_admin', browser_title: 'Example admin page' do %>
+  <%= render 'govuk_publishing_components/components/layout_header', environment: 'production', navigation_links: navigation_links %>
+  <%= render 'govuk_publishing_components/components/layout_main' do %>
+    <%= yield %>
+  <% end %>
+  <%= render 'govuk_publishing_components/components/layout_footer' %>
+<% end %>

--- a/spec/dummy/app/views/welcome/admin_example.html.erb
+++ b/spec/dummy/app/views/welcome/admin_example.html.erb
@@ -1,0 +1,5 @@
+<%= render 'govuk_publishing_components/components/title', title: "Hello! I am an example admin page" %>
+
+<p class="govuk-body">
+  Pages with the admin layout can use GOV.UK styles directly.
+</p>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   get 'step-nav/:slug', to: 'step_nav#show'
   get 'contextual-navigation', to: 'welcome#contextual_navigation'
   get 'contextual-navigation/*base_path', to: 'welcome#contextual_navigation'
+  get 'admin', to: 'welcome#admin'
 end


### PR DESCRIPTION
This PR creates a template for admin apps using GOV.UK Frontend, split up in 4 components.

This layout will be used by the Release app in https://github.com/alphagov/release/pull/228, and is intended to be used after that by the new publisher workflow app, organisations publisher and an app to manage content.

This follows on earlier spikes https://github.com/alphagov/govuk_publishing_components/pull/328 and https://github.com/alphagov/govuk_publishing_components/pull/331, which were used to identify how we might consume GOV.UK Frontend.

## Preview

- [Component guide](https://govuk-publishing-compon-pr-371.herokuapp.com/component-guide/layout_for_admin)
- [Special preview page](https://govuk-publishing-compon-pr-371.herokuapp.com/admin)

<img width="1157" alt="screen shot 2018-06-11 at 16 38 30" src="https://user-images.githubusercontent.com/233676/41241848-e8011ac8-6d95-11e8-9918-2c552735ad32.png">

https://trello.com/c/09fVPrRN