### PR TITLE
Add no10 to the branding model

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -8,6 +8,10 @@
     .brand--#{nth($organisation, 1)} {
       .brand__color {
         color: nth($organisation, 3);
+
+        &:hover {
+          color: darken( nth($organisation, 3), 10% );
+        }
       }
 
       // the & declaration allows border-color to also be applied to the parent
@@ -25,6 +29,10 @@
 .brand--prime-ministers-office-10-downing-street {
   .brand__color {
     color: $fuschia;
+
+    &:hover {
+      color: darken( $fuschia, 10% );
+    }
   }
 
   &.brand__border-color,

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -21,3 +21,14 @@
 }
 
 @include organisation-brand-colour;
+
+.brand--prime-ministers-office-10-downing-street {
+  .brand__color {
+    color: $fuschia;
+  }
+
+  &.brand__border-color,
+  .brand__border-color {
+    border-color: $black;
+  }
+}


### PR DESCRIPTION
- prime ministers office brand colours are not included in the list of organisations pulled from frontend toolkit, added manually
- also add hover effect

---

Component guide for this PR:
https://govuk-publishing-compon-pr-372.herokuapp.com/component-guide/
