### PR TITLE
Remove underline on image card title link

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -36,6 +36,12 @@
 }
 
 .gem-c-image-card__title-link {
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
   // the after element extends the link to cover the image, removing the
   // need for a duplicate link. Other elements apart from the image are given
   // position relative and a higher z-index to put them above the after element


### PR DESCRIPTION
Replace with underline on hover.

Trello card: https://trello.com/c/cCRI0WQg/184-modify-image-card-component

---

Component guide for this PR:
https://govuk-publishing-compon-pr-375.herokuapp.com/component-guide/
