### PR TITLE
Modify share links component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -11,6 +11,7 @@
 @import "components/print/feedback";
 @import "components/print/govspeak-html-publication";
 @import "components/print/govspeak";
+@import "components/print/share-links";
 @import "components/print/step-by-step-nav-header";
 @import "components/print/step-by-step-nav";
 @import "components/print/title";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -25,7 +25,7 @@ $share-button-height: 32px;
   margin-bottom: $gutter-one-third;
 }
 
-.gem-c-share-links__link__icon {
+.gem-c-share-links__link-icon {
   position: absolute;
   top: 0;
   left: 0;
@@ -46,7 +46,7 @@ $share-button-height: 32px;
     padding-right: ($share-button-width + $gutter-one-third);
   }
 
-  .gem-c-share-links__link__icon {
+  .gem-c-share-links__link-icon {
     left: auto;
     right: 0;
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -6,13 +6,18 @@ $share-button-height: 32px;
 }
 
 .gem-c-share-links__list-item {
+  @include box-sizing(border-box);
+  position: relative;
   display: inline-block;
+  min-height: $share-button-height;
+  padding-top: $share-button-height / 8;
+  padding-left: ($share-button-width + $gutter-one-third);
   margin-bottom: $gutter-one-third;
 }
 
 .gem-c-share-links__link {
+  @include bold-16;
   margin-right: $gutter;
-  @include bold-16($line-height: $share-button-height, $line-height-640: $share-button-height);
   text-decoration: none;
 }
 
@@ -21,29 +26,29 @@ $share-button-height: 32px;
 }
 
 .gem-c-share-links__link__icon {
-  display: inline-block;
+  position: absolute;
+  top: 0;
+  left: 0;
   width: $share-button-width;
   height: $share-button-height;
-  margin-right: $gutter-one-third;
   vertical-align: top;
 }
 
 .direction-rtl {
   .gem-c-share-links__link {
-    // By changing the link to inline-block the browser
-    // calculates the icon and the text as a single run of text
-    // rather than two. When they are considered to be two runs
-    // the browser splits the first link, putting the text before
-    // the second link, and the icon after the second link.
     display: inline-block;
     margin-right: 0;
     margin-left: $gutter;
+  }
 
-    .gem-c-share-links__link__icon {
-      margin-right: 0;
-      margin-left: $gutter-one-third;
-      vertical-align: middle;
-    }
+  .gem-c-share-links__list-item {
+    padding-left: 0;
+    padding-right: ($share-button-width + $gutter-one-third);
+  }
+
+  .gem-c-share-links__link__icon {
+    left: auto;
+    right: 0;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_share-links.scss
@@ -1,0 +1,3 @@
+.gem-c-share-links {
+  display: none;
+}

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -66,7 +66,7 @@
                 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="9 9 32 32"><path fill="currentColor" d="M9 9h32v32H9V9z"/><path fill="#FFF" d="M12.84 14.12v19.2h5.76l5.76 5.76v-5.76h12.8v-19.2H12.84zm3.2 8.32H28.2V25H16.04v-2.56zm16 7.68h-16v-2.56h16v2.56zm1.92-10.24H16.04v-2.56h17.92v2.56z"/></svg>
 
               <% end %>
-            </span><span class="visually-hidden">Share on </span><%= link[:text] %><% end %>
+            </span><%= link[:text] %><% end %>
         </li>
       <% end %>
     </ul>

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -27,7 +27,7 @@
           %>
           <%= link_to link[:href],
             target: "_blank",
-            rel: "noopener noreferrer",
+            rel: "noopener noreferrer external",
             data: {
               'track-category': 'social media',
               'track-action': link[:icon],

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -34,7 +34,7 @@
               'track-options': track_options
             },
             class: "gem-c-share-links__link #{brand_helper.color_class}" do %>
-            <span class="gem-c-share-links__link__icon">
+            <span class="gem-c-share-links__link-icon">
               <% if link[:icon] == 'facebook' %>
                 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
                   <path fill="currentColor" d="M31.006 0H.993A.997.997 0 0 0 0 .993v30.014c0 .55.452.993.993.993h30.013a.998.998 0 0 0 .994-.993V.993A.999.999 0 0 0 31.006 0z"/>

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -8,7 +8,7 @@
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
 %>
 <% if links.any? %>
-  <div class="gem-c-share-links dont-print <%= brand_helper.brand_class %> <%= 'gem-c-share-links--stacked' if stacked %>" data-module="track-click">
+  <div class="gem-c-share-links <%= brand_helper.brand_class %> <%= 'gem-c-share-links--stacked' if stacked %>" data-module="track-click">
     <% if title %>
       <h2 class="gem-c-share-links__title"><%= title %></h2>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/share_links.yml
+++ b/app/views/govuk_publishing_components/components/docs/share_links.yml
@@ -127,13 +127,13 @@ examples:
           icon: 'linkedin'
         },
         {
+          href: '/other-share-link',
+          text: 'Anything else that might be included that could have quite a long name',
+          icon: 'other'
+        },
+        {
           href: '/youtube-share-link',
           text: 'YouTube',
           icon: 'youtube'
-        },
-        {
-          href: '/other-share-link',
-          text: 'Anything else',
-          icon: 'other'
-        },
+        }
       ]

--- a/spec/components/share_links_spec.rb
+++ b/spec/components/share_links_spec.rb
@@ -40,7 +40,7 @@ describe "ShareLinks", type: :view do
     assert_select ".gem-c-share-links .gem-c-share-links__link[href=\"/facebook\"]"
     assert_select ".gem-c-share-links .gem-c-share-links__link[href=\"/twitter\"]",
       false, "A twitter share link has not been provided so should not have been rendered"
-    assert_select ".gem-c-share-links .gem-c-share-links__link__icon--twitter",
+    assert_select ".gem-c-share-links .gem-c-share-links__link-icon--twitter",
       false, "A twitter share link has not been provided so a twitter icon should not have been rendered"
   end
 

--- a/spec/components/share_links_spec.rb
+++ b/spec/components/share_links_spec.rb
@@ -40,8 +40,6 @@ describe "ShareLinks", type: :view do
     assert_select ".gem-c-share-links .gem-c-share-links__link[href=\"/facebook\"]"
     assert_select ".gem-c-share-links .gem-c-share-links__link[href=\"/twitter\"]",
       false, "A twitter share link has not been provided so should not have been rendered"
-    assert_select ".gem-c-share-links .gem-c-share-links__link-icon--twitter",
-      false, "A twitter share link has not been provided so a twitter icon should not have been rendered"
   end
 
   it "adds social interactions tracking" do


### PR DESCRIPTION
Fix some small issues with the component ahead of using it in the new organisation pages. Specifically:

- added rel="external" to the links for tracking purposes
- removed the `dont-print` style and added specific print styles for this component
- removed the visually hidden 'share on' text as it no longer works in the context of providing custom text to the component, and where it's currently in use the links have a heading above them saying 'share on'
- stop long link names from wrapping beneath the icons

Trello card: https://trello.com/c/wPvE62vw/185-modify-share-links-component

---

Component guide for this PR:
https://govuk-publishing-compon-pr-276.herokuapp.com/component-guide/
