### PR TITLE
Add metadata to image card component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add metadata to image card component (PR #377)
+
 ## 9.2.2
 
 * Add no10 to the branding model (PR #372)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -58,7 +58,8 @@
   z-index: 2;
 }
 
-.gem-c-image-card__context {
+.gem-c-image-card__context,
+.gem-c-image-card__metadata {
   @include core-14;
   color: $grey-1;
 }

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -36,6 +36,10 @@
           <% end %>
         </ul>
       <% end %>
+
+      <% if card_helper.metadata %>
+        <p class="gem-c-image-card__metadata"><%= card_helper.metadata %></p>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -158,3 +158,20 @@ examples:
           }
         }
       ]
+  with_metadata:
+    description: Can be used for links to people pages to indicate payment type
+    data:
+      href: "/government/people/"
+      image_src: "http://placekitten.com/215/140"
+      image_alt: "some meaningful alt text please"
+      context: "The Rt Hon"
+      heading_text: "John Whiskers MP"
+      metadata: "Unpaid"
+      extra_links: [
+        {
+          text: "Minister for Cats",
+          href: "/government/ministers/"
+        }
+      ]
+      extra_links_no_indent: true
+

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
       include ActionView::Helpers
       include ActionView::Context
 
-      attr_reader :href, :href_data_attributes, :extra_links, :large, :extra_links_no_indent, :heading_text
+      attr_reader :href, :href_data_attributes, :extra_links, :large, :extra_links_no_indent, :heading_text, :metadata
 
       def initialize(local_assigns)
         @href = local_assigns[:href]
@@ -18,6 +18,7 @@ module GovukPublishingComponents
         @heading_text = local_assigns[:heading_text]
         @heading_level = local_assigns[:heading_level]
         @extra_links_no_indent = local_assigns[:extra_links_no_indent]
+        @metadata = local_assigns[:metadata]
       end
 
       def is_tracking?

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -66,4 +66,9 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card[data-module='track-click']"
     assert_select ".gem-c-image-card__list-item a[data-track-category='cat']"
   end
+
+  it "shows metadata" do
+    render_component(href: '#', metadata: "Unpaid")
+    assert_select ".gem-c-image-card__metadata", text: 'Unpaid'
+  end
 end


### PR DESCRIPTION
For use on links to people pages, e.g: https://www.gov.uk/government/organisations/department-for-international-trade (Baroness Fairhead CBE)

<img width="787" alt="screen shot 2018-06-14 at 14 00 45" src="https://user-images.githubusercontent.com/29889908/41413556-5bc82dec-6fdb-11e8-983a-4b98f4a14558.png">


Component guide for this PR:
https://govuk-publishing-compon-pr-377.herokuapp.com/component-guide/image_card
