### PR TITLE
Remove special casing for Static

### DIFF
--- a/app/assets/javascripts/component_guide/visual-regression.js
+++ b/app/assets/javascripts/component_guide/visual-regression.js
@@ -47,11 +47,6 @@
 
     if (href.includes('dev.gov.uk/component-guide')) {
       var appName = host.split('.')[0];
-
-      if (appName === 'static') {
-        appName = 'govuk-static';
-      }
-
       return _forceHTTPS(href.replace(host, appName + '.herokuapp.com'));
     } else if (href.includes('dev.gov.uk')) {
       return _forceHTTPS(href.replace(host, 'www.gov.uk'));

--- a/app/assets/stylesheets/component_guide/all_components.scss
+++ b/app/assets/stylesheets/component_guide/all_components.scss
@@ -1,1 +1,0 @@
-@import "../govuk_publishing_components/all_components";

--- a/app/assets/stylesheets/component_guide/all_components_print.scss
+++ b/app/assets/stylesheets/component_guide/all_components_print.scss
@@ -1,1 +1,0 @@
-@import "../govuk_publishing_components/all_components_print";

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -1,5 +1,5 @@
 // Govspeak attachment
-// https://govuk-static.herokuapp.com/component-guide/govspeak/block_attachments
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/block_attachments
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss
@@ -1,5 +1,5 @@
 // Govspeak call to action
-// https://govuk-static.herokuapp.com/component-guide/govspeak/call_to_action
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/call_to_action
 //
 // Support:
 //

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -1,5 +1,5 @@
 // Govspeak charts
-// https://govuk-static.herokuapp.com/component-guide/govspeak/charts
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/charts
 // Uses Magna Charta (https://github.com/alphagov/magna-charta)
 //
 // Support:

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
@@ -1,5 +1,5 @@
 // Govspeak contact
-// https://govuk-static.herokuapp.com/component-guide/govspeak/contact
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/contact
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_example.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_example.scss
@@ -1,5 +1,5 @@
 // Govspeak example callout
-// https://govuk-static.herokuapp.com/component-guide/govspeak/example
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/example
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
@@ -1,5 +1,5 @@
 // Govspeak footnotes callout
-// https://govuk-static.herokuapp.com/component-guide/govspeak/footnotes
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/footnotes
 //
 // Support:
 //

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_fraction.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_fraction.scss
@@ -1,6 +1,6 @@
 // Govspeak fractions
-// https://govuk-static.herokuapp.com/component-guide/govspeak/image_fractions
-// https://govuk-static.herokuapp.com/component-guide/govspeak/text_fractions
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/image_fractions
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/text_fractions
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_information-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_information-callout.scss
@@ -1,5 +1,5 @@
 // Govspeak information callout
-// https://govuk-static.herokuapp.com/component-guide/govspeak/information_callout
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/information_callout
 //
 // Support:
 //

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_legislative-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_legislative-list.scss
@@ -1,5 +1,5 @@
 // Govspeak legislative list
-// https://govuk-static.herokuapp.com/component-guide/govspeak/legislative_lists
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/legislative_lists
 
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_media-player.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_media-player.scss
@@ -1,5 +1,5 @@
 // Govspeak media player
-// https://govuk-static.herokuapp.com/component-guide/govspeak/with_youtube_embed
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/with_youtube_embed
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_stat-headline.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_stat-headline.scss
@@ -1,5 +1,5 @@
 // Govspeak statistic headline
-// https://govuk-static.herokuapp.com/component-guide/govspeak/statistic_headlines
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/statistic_headlines
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -1,5 +1,5 @@
 // Govspeak tables
-// https://govuk-static.herokuapp.com/component-guide/govspeak/tables
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/tables
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -1,8 +1,8 @@
 // Govspeak typography
-// https://govuk-static.herokuapp.com/component-guide/govspeak/heading_levels
-// https://govuk-static.herokuapp.com/component-guide/govspeak/lists
-// https://govuk-static.herokuapp.com/component-guide/govspeak/nested_lists
-// https://govuk-static.herokuapp.com/component-guide/govspeak/blockquote
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/heading_levels
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/lists
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/nested_lists
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/blockquote
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
@@ -1,5 +1,5 @@
 // Govspeak warning callout
-// https://govuk-static.herokuapp.com/component-guide/govspeak/warning_callout
+// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/warning_callout
 //
 // Support:
 //

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -8,7 +8,7 @@ body: |
   Note: We do not consume GOV.UK Elements directly due to the naming conventions being leaky,
   in time this component will be a wrapper for the [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) project's button component.
 
-  This component is also [extended for use in govspeak](https://govuk-static.herokuapp.com/component-guide/govspeak/button).
+  This component is also [extended for use in govspeak](https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/button).
 
   These instances of buttons are added by Content Designers, ideally this duplication would not exist but we currently don't have shared markup
   via our components within the generated [govspeak](https://github.com/alphagov/govspeak).

--- a/app/views/govuk_publishing_components/components/docs/contextual_breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_breadcrumbs.yml
@@ -15,7 +15,7 @@ body: |
   [preview]: https://govuk-publishing-components.herokuapp.com/contextual-navigation
   [header]: /component-guide/step_by_step_nav_header
   [sidebar]: /component-guide/contextual_sidebar
-  [breadcrumbs]: https://govuk-static.herokuapp.com/component-guide/breadcrumbs
+  [breadcrumbs]: https://govuk-publishing-components.herokuapp.com/component-guide/breadcrumbs
 accessibility_criteria: |
   Components called by this component must be accessible
 examples:

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -16,7 +16,7 @@ body: |
   [preview]: https://govuk-publishing-components.herokuapp.com/contextual-navigation
   [step-by-step]: /component-guide/step_by_step_nav
   [related_navigation]: /component-guide/related_navigation
-  [taxonomy-sidebar]: https://govuk-static.herokuapp.com/component-guide/taxonomy_sidebar
+  [taxonomy-sidebar]: https://govuk-publishing-components.herokuapp.com/component-guide/taxonomy_sidebar
   [contextual_breadcrumbs]: /component-guide/contextual_breadcrumbs
 accessibility_criteria: |
   Components called by this component must be accessible

--- a/app/views/govuk_publishing_components/components/docs/fieldset.yml
+++ b/app/views/govuk_publishing_components/components/docs/fieldset.yml
@@ -18,7 +18,7 @@ examples:
         <input type="radio" id="default-no" name="default"t>
         <label for="default-no">No</label>
   with_html_legend:
-    description: 'If you only have one fieldset on the page you might want to include the title of the page as the legend text. Used with a [captured](http://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-capture) [title](http://govuk-static.herokuapp.com/component-guide/title)'
+    description: 'If you only have one fieldset on the page you might want to include the title of the page as the legend text. Used with a [captured](http://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-capture) [title](http://govuk-publishing-components.herokuapp.com/component-guide/title)'
     data:
       legend_text: |
         <!-- Use the title component, this is hardcoded only for this example -->

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -13,11 +13,6 @@
   <%= stylesheet_link_tag "component_guide/application", media: "screen" %>
   <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_stylesheet}" %>
 
-  <% if GovukPublishingComponents::Config.static %>
-    <%= stylesheet_link_tag "component_guide/all_components", media: "screen" %>
-    <%= stylesheet_link_tag "component_guide/all_components_print", media: "print" %>
-  <% end %>
-
   <% if GovukPublishingComponents::Config.application_print_stylesheet %>
     <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_print_stylesheet}", media: "print" %>
   <% end %>

--- a/docs/use-components.md
+++ b/docs/use-components.md
@@ -1,17 +1,11 @@
 # Use a component
 
-Components are included in templates in slightly different ways depending on whether the component is in the application itself, in static, or in the gem.
+Components are included in templates in slightly different ways depending on whether the component is in the application itself or in the gem.
 
 A component from the application would be included in a template like this:
 
 ```erb
 <%= render "components/back-to-top", href: "#contents" %>
-```
-
-A component from static would be included like this:
-
-```erb
-<%= render "govuk_publishing_components/components/lead_paragraph", text: "A description is one or two leading sentences." %>
 ```
 
 A component from the gem would be included like this:

--- a/lib/generators/govuk_publishing_components/component_generator.rb
+++ b/lib/generators/govuk_publishing_components/component_generator.rb
@@ -6,10 +6,8 @@ module GovukPublishingComponents
     source_root File.expand_path('../templates', __FILE__)
 
     def copy_component_files
-      static = GovukPublishingComponents::Config.static
-
       @public_name = file_name.dasherize
-      @component_prefix = static ? 'pub-c-' : 'app-c-'
+      @component_prefix = 'app-c-'
       component_directory_name = GovukPublishingComponents::Config.component_directory_name
 
       template_dir = "app/views/#{component_directory_name}/"
@@ -20,14 +18,8 @@ module GovukPublishingComponents
       create_directory_if_not_exists(docs_dir)
       create_directory_if_not_exists(scss_dir)
 
-      if static
-        template '_component.html.erb', "#{template_dir}#{@public_name.underscore}.raw.html.erb"
-        template 'component.yml.erb', "#{docs_dir}#{@public_name.underscore}.yml"
-      else
-        template '_component.html.erb', "#{template_dir}_#{@public_name}.html.erb"
-        template 'component.yml.erb', "#{docs_dir}#{@public_name}.yml"
-      end
-
+      template '_component.html.erb', "#{template_dir}_#{@public_name}.html.erb"
+      template 'component.yml.erb', "#{docs_dir}#{@public_name}.yml"
       template '_component.scss', "#{scss_dir}_#{@public_name}.scss"
     end
 

--- a/lib/govuk_publishing_components/config.rb
+++ b/lib/govuk_publishing_components/config.rb
@@ -4,7 +4,6 @@ module GovukPublishingComponents
   end
 
   module Config
-    STATIC_COMPONENT_DIRECTORY = "govuk_component".freeze
     APP_COMPONENT_DIRECTORY = "components".freeze
 
     mattr_accessor :component_guide_title
@@ -19,11 +18,8 @@ module GovukPublishingComponents
     mattr_accessor :application_javascript
     self.application_javascript = "application"
 
-    mattr_accessor :static
-    self.static = false
-
     def self.component_directory_name
-      static ? STATIC_COMPONENT_DIRECTORY : APP_COMPONENT_DIRECTORY
+      APP_COMPONENT_DIRECTORY
     end
 
     def self.gem_directory

--- a/spec/dummy/app/views/govuk_component/docs/test-static-component.yml
+++ b/spec/dummy/app/views/govuk_component/docs/test-static-component.yml
@@ -1,5 +1,0 @@
-name: Test static component
-description: A test static component for the dummy app
-examples:
-  default:
-    data: {}

--- a/spec/dummy/app/views/govuk_component/test-static-component.raw.html.erb
+++ b/spec/dummy/app/views/govuk_component/test-static-component.raw.html.erb
@@ -1,3 +1,0 @@
-<div class="a-test-static-component">
-  This component lives in `govuk_component`, the folder used by static to store components.
-</div>

--- a/spec/javascripts/govuk_publishing_components/VisualRegressionSpec.js
+++ b/spec/javascripts/govuk_publishing_components/VisualRegressionSpec.js
@@ -63,7 +63,7 @@ describe('VisualDiffTool', function () {
 
       VisualDiffTool(windowLocation);
 
-      expect(console.log.calls.mostRecent().args[0]).toContain("https://govuk-static.herokuapp.com/component-guide/title");
+      expect(console.log.calls.mostRecent().args[0]).toContain("https://govuk-publishing-components.herokuapp.com/component-guide/title");
     });
   });
 });

--- a/spec/javascripts/govuk_publishing_components/VisualRegressionSpec.js
+++ b/spec/javascripts/govuk_publishing_components/VisualRegressionSpec.js
@@ -54,16 +54,5 @@ describe('VisualDiffTool', function () {
 
       expect(console.log.calls.mostRecent().args[0]).toContain("https://government-frontend.herokuapp.com");
     });
-
-    it('compares local static url to live static deploy', function() {
-      windowLocation = {
-        href: 'https://static.dev.gov.uk/component-guide/title',
-        host: 'static.dev.gov.uk'
-      };
-
-      VisualDiffTool(windowLocation);
-
-      expect(console.log.calls.mostRecent().args[0]).toContain("https://govuk-publishing-components.herokuapp.com/component-guide/title");
-    });
   });
 });

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -5,35 +5,16 @@ describe GovukPublishingComponents::Config do
     it "configures the application" do
       GovukPublishingComponents.configure do |config|
         config.component_guide_title = "My component guide"
-        config.static = true
-
         config.application_stylesheet = "custom_stylesheet"
         config.application_print_stylesheet = "custom_print_stylesheet"
         config.application_javascript = "custom_javascript"
       end
 
       expect(GovukPublishingComponents::Config.component_guide_title).to eql("My component guide")
-      expect(GovukPublishingComponents::Config.static).to eql(true)
-
       expect(GovukPublishingComponents::Config.application_stylesheet).to eql("custom_stylesheet")
       expect(GovukPublishingComponents::Config.application_print_stylesheet).to eql("custom_print_stylesheet")
       expect(GovukPublishingComponents::Config.application_javascript).to eql("custom_javascript")
-    end
-
-    it "uses a default component directory" do
-      GovukPublishingComponents.configure do |config|
-        config.static = false
-      end
-
       expect(GovukPublishingComponents::Config.component_directory_name).to eql('components')
-    end
-
-    it "uses a different component directory for static" do
-      GovukPublishingComponents.configure do |config|
-        config.static = true
-      end
-
-      expect(GovukPublishingComponents::Config.component_directory_name).to eql('govuk_component')
     end
   end
 end


### PR DESCRIPTION
We've moved all the components to the gem, so we can start removing some of the special cases that were needed to render static's components in the component guide in static. See commits for the details.

https://trello.com/c/pU7YINt1/45-move-all-components-from-static-into-the-gem