### PR TITLE
Add translations translation for translations to .cy

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1,4 +1,6 @@
 cy:
+  common:
+    translations: "Cyfieithiadau"
   components:
     radio:
       or: 'neu'


### PR DESCRIPTION
This is used in (surprise surprise) the [translation-nav component](https://github.com/alphagov/govuk_publishing_components/blob/6dd1858c0dcd0dd48ba930b719db335d5c8186e4/app/views/govuk_publishing_components/components/_translation-nav.html.erb#L9)
