### PR TITLE
Allow image card component to not have main link

### DIFF
--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -3,7 +3,7 @@
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
   card_helper = GovukPublishingComponents::Presenters::ImageCardHelper.new(local_assigns)
 %>
-<% if card_helper.href %>
+<% if card_helper.href || card_helper.extra_links.any? %>
   <div class="gem-c-image-card <%= "gem-c-image-card--large" if card_helper.large %> <%= brand_helper.brand_class %>"
     <%= "data-module=track-click" if card_helper.is_tracking? %>
   >
@@ -15,16 +15,20 @@
       <% if card_helper.heading_text %>
         <%= content_tag(card_helper.heading_tag,
           class: "gem-c-image-card__title") do %>
-            <%= link_to card_helper.heading_text, card_helper.href,
-              class: "gem-c-image-card__title-link #{brand_helper.color_class}",
-              data: card_helper.href_data_attributes
-            %>
+            <% if card_helper.href %>
+              <%= link_to card_helper.heading_text, card_helper.href,
+                class: "gem-c-image-card__title-link #{brand_helper.color_class}",
+                data: card_helper.href_data_attributes
+              %>
+            <% else %>
+              <%= card_helper.heading_text %>
+            <% end %>
         <% end %>
       <% end %>
 
       <%= card_helper.description %>
 
-      <% if card_helper.extra_links %>
+      <% if card_helper.extra_links.any? %>
         <ul class="gem-c-image-card__list <%= "gem-c-image-card__list--indented" if not card_helper.extra_links_no_indent %>">
           <% card_helper.extra_links.each do |link| %>
             <li class="gem-c-image-card__list-item">

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -1,7 +1,7 @@
 name: Image card
 description: Image and associated text with a link
 body: |
-  An image and an associated link, meant for use for news articles and people. Includes optional paragraph and additional links.
+  An image and links, meant for use for news articles and people. Includes optional paragraph and additional links.
 
   The component is generally to be used within a grid column but has no grid of its own, so the text and the images in the examples below may not always line up. This will normally look tidier, for example [on pages like this](https://www.gov.uk/government/organisations/attorney-generals-office).
 accessibility_criteria: |
@@ -70,6 +70,22 @@ examples:
         }
       ]
       extra_links_no_indent: true
+  extra_links_with_no_main_link:
+    description: If extra links are included, the main link is not needed. Note that in this configuration the image is not a link as no link has been supplied.
+    data:
+      image_src: "http://placekitten.com/215/140"
+      image_alt: "some meaningful alt text please"
+      heading_text: "John Whiskers MP"
+      extra_links: [
+        {
+          text: "Minister for Cats",
+          href: "/government/ministers/"
+        },
+        {
+          text: "Head of Tuna Operations",
+          href: "/government/ministers/"
+        }
+      ]
   without_heading_text:
     description: |
       The only required parameter to the component is href but if no heading_text is supplied the link will not appear. This is to allow the component to use only extra links as shown.

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -9,7 +9,7 @@ module GovukPublishingComponents
       def initialize(local_assigns)
         @href = local_assigns[:href]
         @href_data_attributes = local_assigns[:href_data_attributes]
-        @extra_links = local_assigns[:extra_links]
+        @extra_links = local_assigns[:extra_links] || []
         @image_src = local_assigns[:image_src]
         @image_alt = local_assigns[:image_alt] || ""
         @context = local_assigns[:context]

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -43,6 +43,11 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card__list.gem-c-image-card__list--indented", false
   end
 
+  it "renders extra links without a main link" do
+    render_component(extra_links: [{ href: '/1', text: 'link1' }])
+    assert_select ".gem-c-image-card__title a", false
+  end
+
   it "applies branding" do
     render_component(href: '#', heading_text: 'test', extra_links: [{ href: '/1', text: 'link1' }], brand: 'attorney-generals-office')
     assert_select ".gem-c-image-card.brand--attorney-generals-office"


### PR DESCRIPTION
- as long as extra links are supplied
- required for organisation pages

We need to be able to do this:

<img width="266" alt="screen shot 2018-06-22 at 15 41 52" src="https://user-images.githubusercontent.com/861310/41782687-d7698204-7632-11e8-9b45-98e18a36550d.png">

---

Component guide for this PR:
https://govuk-publishing-compon-pr-382.herokuapp.com/component-guide/image_card
