### PR TITLE
Add isPartOf to articles that are in a step by step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Step by step component, Google snippet improvement (PR #461)
 * Add tabs component (PR #455)
 * Adds styling for singular related step by step navs (PR #458)
+* Add schema.org `isPartOf` links from articles to step by steps (PR #384)
 
 ## 9.8.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (9.7.0)
+    govuk_publishing_components (9.8.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -71,7 +71,7 @@ GEM
       xpath (~> 2.0)
     cliver (0.3.2)
     coderay (1.1.2)
-    commander (4.4.5)
+    commander (4.4.6)
       highline (~> 1.7.2)
     concurrent-ruby (1.0.5)
     crack (0.4.3)

--- a/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
@@ -29,7 +29,7 @@ module GovukPublishingComponents
               "url" => page.logo_url,
             }
           }
-        }.merge(image_schema).merge(author_schema).merge(body)
+        }.merge(image_schema).merge(author_schema).merge(body).merge(is_part_of)
       end
 
     private
@@ -66,6 +66,37 @@ module GovukPublishingComponents
 
       def publishing_organisation
         page.content_item.dig("links", "primary_publishing_organisation").to_a.first
+      end
+
+      def is_part_of
+        return {} unless linked_step_by_steps.any?
+        {
+          "isPartOf" => step_by_step_schemas
+        }
+      end
+
+      def linked_step_by_steps
+        # We could include `related_to_step_navs` eventually too, but initially
+        # link to those that we render in the "step_by_step_nav_related" component
+        @step_by_steps ||= page.content_item.dig("links", "part_of_step_navs").to_a
+      end
+
+      def step_by_step_schemas
+        linked_step_by_steps.map do |step_by_step|
+          step_by_step_page = linked_page(step_by_step)
+          structured_data = HowToSchema.new(step_by_step_page.canonical_url).structured_data
+
+          structured_data.merge(image_schema)
+        end
+      end
+
+      def linked_page(step_by_step)
+        Page.new(
+          content_item: step_by_step,
+          schema: :article,
+          logo_url: page.logo_url,
+          image_placeholders: page.image_placeholders
+        )
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/machine_readable/how_to_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/how_to_schema.rb
@@ -1,0 +1,20 @@
+module GovukPublishingComponents
+  module Presenters
+    class HowToSchema
+      attr_reader :how_to_url
+
+      def initialize(how_to_url)
+        @how_to_url = how_to_url
+      end
+
+      def structured_data
+        # http://schema.org/HowTo - minimal
+        {
+          "@context" => "http://schema.org",
+          "@type" => "HowTo",
+          "sameAs" => how_to_url
+        }
+      end
+    end
+  end
+end

--- a/lib/govuk_publishing_components/presenters/machine_readable/page.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/page.rb
@@ -16,7 +16,7 @@ module GovukPublishingComponents
       end
 
       def body
-        local_assigns[:body] || content_item["details"]["body"]
+        local_assigns[:body] || content_item.dig("details", "body")
       end
 
       def title

--- a/lib/govuk_publishing_components/presenters/schema_org.rb
+++ b/lib/govuk_publishing_components/presenters/schema_org.rb
@@ -1,5 +1,6 @@
 require 'govuk_publishing_components/presenters/machine_readable/page'
 require 'govuk_publishing_components/presenters/machine_readable/article_schema'
+require 'govuk_publishing_components/presenters/machine_readable/how_to_schema'
 require 'govuk_publishing_components/presenters/machine_readable/news_article_schema'
 require 'govuk_publishing_components/presenters/machine_readable/organisation_schema'
 require 'govuk_publishing_components/presenters/machine_readable/person_schema'

--- a/spec/lib/presenters/schema_org_spec.rb
+++ b/spec/lib/presenters/schema_org_spec.rb
@@ -103,6 +103,48 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
       expect(structured_data['author']['name']).to eql("Foo org")
     end
 
+    it "links to step by steps that it belongs to" do
+      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "answer") do |random_item|
+        random_item.merge(
+          "first_published_at" => "2017-09-04T13:50:49.000+00:00",
+          "links" => {
+            "part_of_step_navs" => [
+              {
+                "api_path" => "/api/content/employ-someone",
+                "base_path" => "/employ-someone",
+                "content_id" => "47bcdf4c-9df9-48ff-b1ad-2381ca819464",
+                "description" => "Employ someone: agree a contract, right to work checks, DBS checks, workplace pensions, set up PAYE, tell HMRC",
+                "details" => {},
+                "document_type" => "step_by_step_nav",
+                "locale" => "en",
+                "public_updated_at" => "2018-06-22T12:12:38Z",
+                "schema_name" => "step_by_step_nav",
+                "title" => "Employ someone: step by step",
+                "api_url" => "https://www.gov.uk/api/content/employ-someone",
+                "web_url" => "https://www.gov.uk/employ-someone"
+              }
+            ],
+            "primary_publishing_organisation" => [
+              {
+                "content_id" => "d944229b-a5ad-453d-8e16-cb5dcfcdb866",
+                "title" => "Foo org",
+                "locale" => "en",
+                "base_path" => "/orgs/foo",
+              }
+            ]
+          }
+        )
+      end
+
+      structured_data = generate_structured_data(
+        content_item: content_item,
+        schema: :article
+      ).structured_data
+
+      expect(structured_data['isPartOf'][0]['@type']).to eq('HowTo')
+      expect(structured_data['isPartOf'][0]['sameAs']).to eq('http://www.dev.gov.uk/employ-someone')
+    end
+
     it "adds an image if it's available" do
       content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "news_article") do |random_item|
         random_item["details"]["image"] = { "url" => "/foo" }


### PR DESCRIPTION
- Adds a `HowTo` schema to more accurately (than using `Article`) represent the semantics of this relationship.
- Links content that should show things in a `step-by-step-related` component to those pages by using the [`isPartOf` property](https://schema.org/isPartOf).

The `HowTo` schema implemented here is minimal because we link using [`sameAs`](https://schema.org/sameAs) to the step by step page which has a [fuller schema implemented in collections](https://github.com/alphagov/collections/blob/7e0134d150916d37cef679980a7d13400c583b71/app/models/step_nav.rb#L31-L65).

It seems valid (at least the Google structured data testing tool doesn't object) to be "isPartOf" many things. This fits quite well with what we want to do with step by steps.

We could easily add the step by steps that are in the `related_to_step_nav` links array, but this seems a step too far at this point as it's not exactly certain how this will affect search rankings, snippets, etc.

## Structured data test

This was tested by pasting the json generated for https://www.gov.uk/employer-preventing-discrimination (which is part of two step by steps) into https://search.google.com/structured-data/testing-tool/u/0/

![screen shot 2018-08-02 at 15 58 24](https://user-images.githubusercontent.com/773037/43592201-ed6fc87e-966c-11e8-8584-ad7d1d2bbb13.png)

