### PR TITLE
Fix heading structure in feedback component

### DIFF
--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -7,7 +7,7 @@
 <div class="gem-c-feedback <%= margin_top_class %>" data-module="feedback">
   <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
     <div class="js-prompt-questions">
-      <h3 class="gem-c-feedback__prompt-question">Is this page useful?</h3>
+      <h2 class="gem-c-feedback__prompt-question">Is this page useful?</h2>
 
       <%= link_to contact_govuk_path, {
         class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful',
@@ -72,7 +72,7 @@
         <input type="hidden" name="url" value="<%= request.original_url -%>">
         <input type="hidden" name="user_agent" value="<%= request.user_agent -%>">
 
-        <h2 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h2>
+        <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
         <p id="feedback_explanation" class="gem-c-feedback__form-paragraph">Don’t include personal or financial information like your National Insurance number or credit card details.</p>
 
         <%= render "govuk_publishing_components/components/input", {
@@ -121,7 +121,7 @@
         <input name="email_survey_signup[survey_source]" type="hidden" value="<%= request.original_url -%>">
         <input name="email_survey_signup[ga_client_id]" type="hidden" value="1627485790.1515403243">
 
-        <h2 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h2>
+        <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
         <p id="survey_explanation" class="gem-c-feedback__form-paragraph">To help us improve GOV.UK, we’d like to know more about your visit today. We’ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don’t worry we won’t send you spam or share your email address with anyone.</p>
 
         <%= render "govuk_publishing_components/components/input", {


### PR DESCRIPTION
The heading structure of the feedback component began with a H3 and then included two H2s, so it looked like this:

<img width="237" alt="screen shot 2018-06-25 at 12 16 17" src="https://user-images.githubusercontent.com/861310/41847343-96de543a-7871-11e8-9742-71cdc0447e84.png">

This PR makes it looks like this: 

<img width="261" alt="screen shot 2018-06-25 at 12 16 44" src="https://user-images.githubusercontent.com/861310/41847366-a6575e52-7871-11e8-9ef5-9e52335ed346.png">

It's not ideal that the H2s have duplicate text, but this issue is outside of the scope of this PR.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-385.herokuapp.com/component-guide/feedback
