### PR TITLE
Add explicit Civil Service branding

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -26,6 +26,9 @@
 
 @include organisation-brand-colour;
 
+// colours for the prime ministers office are not included in the toolkit
+// so are written out here for our use
+
 .brand--prime-ministers-office-10-downing-street {
   .brand__color {
     color: $fuschia;
@@ -35,6 +38,17 @@
     }
   }
 
+  &.brand__border-color,
+  .brand__border-color {
+    border-color: $black;
+  }
+}
+
+// in the toolkit, civil service has red for the text and borders
+// but the required border colour is black, ideally would fix this in
+// the toolkit but other things are using it
+
+.brand--civil-service {
   &.brand__border-color,
   .brand__border-color {
     border-color: $black;


### PR DESCRIPTION
- branding in the toolkit uses red for both the border and link colour and then whitehall ignores the border colour to use black instead
- in our model this meant the red was being used for the border colour, so this addition sets the border colour correctly to black

Fixes this problem:

![screen shot 2018-06-25 at 11 47 35](https://user-images.githubusercontent.com/861310/41851332-71123678-787f-11e8-82d8-ad55d72f3d38.png)

Trello card: https://trello.com/c/lxiL4E81/211-promotional-orgs-and-their-branding

---

Component guide for this PR:
https://govuk-publishing-compon-pr-387.herokuapp.com/component-guide/
