### PR TITLE
Fix focus states in branding model

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -9,7 +9,8 @@
       .brand__color {
         color: nth($organisation, 3);
 
-        &:hover {
+        &:hover,
+        &:focus {
           color: darken( nth($organisation, 3), 10% );
         }
       }
@@ -33,7 +34,8 @@
   .brand__color {
     color: $fuschia;
 
-    &:hover {
+    &:hover,
+    &:focus {
       color: darken( $fuschia, 10% );
     }
   }


### PR DESCRIPTION
- was not defined, so fell back to blue, which looked a bit odd when you focus on a link that was previously a completely different colour

Fixes this:

![screen shot 2018-06-25 at 15 56 57](https://user-images.githubusercontent.com/861310/41857896-712f3758-7890-11e8-8c13-10f65684c4b3.png)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-389.herokuapp.com/component-guide/
