### PR TITLE
Adjust metadata spacing in image card

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -59,6 +59,7 @@
 }
 
 .gem-c-image-card__context,
+.gem-c-image-card__metadata,
 .gem-c-image-card__description {
   position: relative;
   z-index: 2;
@@ -67,11 +68,17 @@
 .gem-c-image-card__context,
 .gem-c-image-card__metadata {
   @include core-14;
+  margin-bottom: $gutter-one-quarter;
   color: $grey-1;
+
+  @include media(tablet) {
+    margin-bottom: 0;
+  }
 }
 
 .gem-c-image-card__description {
   padding-top: $gutter-one-quarter;
+  word-wrap: break-word;
 }
 
 .gem-c-image-card__list {


### PR DESCRIPTION
Change only applies on mobile.

Before:

![screen shot 2018-06-26 at 12 40 29](https://user-images.githubusercontent.com/861310/41909128-266667ec-793e-11e8-81cd-79c034ceb172.png)

After:

![screen shot 2018-06-26 at 12 40 04](https://user-images.githubusercontent.com/861310/41909138-2c953242-793e-11e8-92e2-aa09aa06b4d2.png)


---

Trello card: https://trello.com/c/QIV37tWx/218-font-size-spacing-of-featured-news-stories-on-mobile
Component guide for this PR:
https://govuk-publishing-compon-pr-[THIS PR NUMBER].herokuapp.com/component-guide/
