### PR TITLE
Support html description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Extend image card to support html description (PR #392)
+
 ## 9.3.4
 
 * Adjust metadata spacing in image card (PR #390)

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -49,7 +49,7 @@ module GovukPublishingComponents
       end
 
       def description
-        content_tag(:p, @description, class: "gem-c-image-card__description") if @description
+        content_tag(:div, @description, class: "gem-c-image-card__description") if @description
       end
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/HxtPYK4o/91-urls-are-not-rendered-as-links-in-news-items

Changes image card description from using a p tag to a div tag, so it can support html.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-392.herokuapp.com/component-guide/
