### PR TITLE
Make heading tag optional on image card

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -26,6 +26,14 @@ examples:
       image_alt: "some meaningful alt text please"
       heading_text: "I am a heading level 3"
       heading_level: 3
+  without_a_heading:
+    description: The heading tag can be removed if the heading_level parameter is passed as 0.
+    data:
+      href: "/really-not-a-page"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      image_alt: "some meaningful alt text please"
+      heading_text: "I am not a heading"
+      heading_level: 0
   with_more_information:
     data:
       href: "/also-not-a-page"

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -16,7 +16,7 @@ module GovukPublishingComponents
         @description = local_assigns[:description]
         @large = local_assigns[:large]
         @heading_text = local_assigns[:heading_text]
-        @heading_level = local_assigns[:heading_level]
+        @heading_level = local_assigns[:heading_level] || 2
         @extra_links_no_indent = local_assigns[:extra_links_no_indent]
         @metadata = local_assigns[:metadata]
       end
@@ -45,7 +45,7 @@ module GovukPublishingComponents
 
       def heading_tag
         return "h#{@heading_level}" if [1, 2, 3, 4, 5, 6].include? @heading_level
-        "h2"
+        return "span" if @heading_level.zero?
       end
 
       def description

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -25,6 +25,12 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card h1.gem-c-image-card__title", text: 'heading 1'
   end
 
+  it "can have no heading tag" do
+    render_component(href: '#', heading_text: 'no heading', heading_level: 0)
+    assert_select ".gem-c-image-card span.gem-c-image-card__title", text: 'no heading'
+    assert_select ".gem-c-image-card h2.gem-c-image-card__title", false
+  end
+
   it "shows context and description" do
     render_component(href: '#', context: 'some context', description: 'description')
     assert_select ".gem-c-image-card .gem-c-image-card__context", text: 'some context'


### PR DESCRIPTION
This change allows the heading tag to be removed from an image card, by passing the `heading_level` parameter as `0`. Note that this does not change the appearance of the component in any way.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-394.herokuapp.com/component-guide/
