### PR TITLE
Version 9.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 9.3.6
+
+* Make heading tag optional on image card (PR #394)
+
 ## 9.3.5
 
 * Extend image card to support html description (PR #392)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (9.3.5)
+    govuk_publishing_components (9.3.6)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '9.3.5'.freeze
+  VERSION = '9.3.6'.freeze
 end


### PR DESCRIPTION
* Make heading tag optional on image card (PR #394)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-395.herokuapp.com/component-guide/
