### PR TITLE
Add organisation meta tag if current page is org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add experimental Admin layout (PR #371)
 * Add the [GOV.UK Frontend](https://design-system.service.gov.uk/) library to the gem (PR #398)
 * Allow linking to the Design System on component pages (PR #401)
+* Add govuk:analytics:organisations meta tag if the current page is an organisation (PR #397)
 
 ## 9.3.6
 

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -46,6 +46,7 @@ module GovukPublishingComponents
 
       def add_organisation_tags(meta_tags)
         organisations = []
+        organisations += [content_item] if content_item[:document_type] == "organisation"
         organisations += links[:organisations] || []
         organisations += links[:worldwide_organisations] || []
         organisations_content = organisations.map { |link| "<#{link[:analytics_identifier]}>" }.uniq.join

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -31,6 +31,11 @@ describe "Meta tags", type: :view do
     assert_meta_tag('govuk:schema-name', 'publication')
   end
 
+  it "renders organisation meta tag if current page is organisation" do
+    render_component(content_item: example_document_for('organisation', 'organisation'))
+    assert_meta_tag('govuk:analytics:organisations', '<D1197>')
+  end
+
   it "renders organisations in a meta tag with angle brackets" do
     content_item = {
       links: {


### PR DESCRIPTION
Trello: https://trello.com/c/cbRSHmA9/30-add-organisation-id-to-custom-dimensions-in-google-analytics

Adds the govuk:analytics:organisations meta tag if the current page is an org (has an analytics_identifier value in the content item)

Component guide for this PR:
https://govuk-publishing-compon-pr-397.herokuapp.com/component-guide
