### PR TITLE
Add GOV.UK Frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ doc
 .yardoc
 
 tmp/failures.txt
+node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add the [GOV.UK Frontend](https://design-system.service.gov.uk/) library to the gem (PR #398)
+
 ## 9.3.6
 
 * Make heading tag optional on image card (PR #394)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,9 @@
 library("govuk")
 
 node {
-  govuk.buildProject()
+  govuk.buildProject(
+    beforeTest: {
+      sh("npm install")
+    }
+  )
 }

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ There are 2 types of helper classes in this app:
 - [AppHelpers](lib/govuk_publishing_components/app_helpers). Are exposed to the applications using this gem. They should be documented using RDoc.
 - [Component Presenters](lib/govuk_publishing_components/presenters). Anything in these classes is only for use within the components. They should be marked `@private`.
 
+## GOV.UK Frontend
+
+This gem is the way GOV.UK consumes [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend), part of the GOV.UK Design System.
+
+We use NPM to pull in the GOV.UK Frontend styles and Javascript, but we don't commit
+the `node_modules` directory. To install GOV.UK Frontend on your machine, run:
+
+```
+npm install
+```
+
+You'll need to have installed Node and NPM for this.
+
 ## Documentation
 
 [See the rubydoc.info documentation](http://www.rubydoc.info/gems/govuk_publishing_components)

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/alphagov/govuk_publishing_components"
   s.license     = "MIT"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "DEVELOPMENT.md", "LICENCE.md", "Rakefile", "README.md"]
+  s.files = Dir["{node_modules,app,config,db,lib}/**/*", "DEVELOPMENT.md", "LICENCE.md", "Rakefile", "README.md"]
 
   s.add_dependency "govuk_app_config"
   s.add_dependency "rails", ">= 5.0.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "lockfileVersion": 1,
+  "dependencies": {
+    "govuk-frontend": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-1.0.0.tgz",
+      "integrity": "sha512-4qCRrwGEcDC0ybjb5lls3P8tDgM8/hpTy2Mesgp1wa1/HdtlXtShj0E0H41lkXNrX7ZQOoDCc4gUEoOgZD+QfA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "govuk-frontend": "^1.0.0"
+  }
+}

--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+npm install
 bundle install
 
 if [[ $1 == "--live" ]] ; then


### PR DESCRIPTION
This commit adds GOV.UK Frontend (https://design-system.service.gov.uk/) to the gem.

When we run `npm install` npm will install the library into `node_modules`. This is ignored in git to avoid us having to commit the entire 15.000 lines of code in govuk_frontend. To include it in the distributed version of the gem, the node_modules directory is added to `s.files` in the gemspec. To make the files available during build, we run `npm install` before the tests (see Jenkinsfile).

PRs that actually make use of GOV.UK Frontend will come separately (see https://github.com/alphagov/govuk_publishing_components/pull/371 for how we intend to use it).

https://trello.com/c/R7Ija8dR/16-create-layout-system-for-admin-applications