### PR TITLE
Make displaying the preview optional

### DIFF
--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -42,6 +42,10 @@ module GovukPublishingComponents
       component[:display_html]
     end
 
+    def display_preview?
+      component[:display_preview].nil? ? true : component[:display_preview]
+    end
+
     def html_body
       govspeak_to_html(body) if body.present?
     end

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_preview.html.erb
@@ -1,8 +1,10 @@
-<div data-module="test-a11y" data-excluded-rules="<%= @component_doc.accessibility_excluded_rules %>">
-  <%= render "govuk_publishing_components/component_guide/component_doc/component", component_doc: @component_doc, example: example, preview_page: false %>
-  <div class="component-guide-preview component-guide-preview--violation" data-module="test-a11y-violation" data-content="Accessibility Issues"></div>
-  <div class="component-guide-preview component-guide-preview--warning" data-module="test-a11y-warning" data-content="Potential accessibility issues: need manual check"></div>
-</div>
+<% if component_doc.display_preview? %>
+  <div data-module="test-a11y" data-excluded-rules="<%= @component_doc.accessibility_excluded_rules %>">
+    <%= render "govuk_publishing_components/component_guide/component_doc/component", component_doc: @component_doc, example: example, preview_page: false %>
+    <div class="component-guide-preview component-guide-preview--violation" data-module="test-a11y-violation" data-content="Accessibility Issues"></div>
+    <div class="component-guide-preview component-guide-preview--warning" data-module="test-a11y-warning" data-content="Potential accessibility issues: need manual check"></div>
+  </div>
+<% end %>
 
 <% if component_doc.display_html? %>
   <div class="component-guide-preview component-call component-highlight component-output" data-content="HTML OUTPUT">

--- a/app/views/govuk_publishing_components/components/docs/metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/metadata.yml
@@ -9,6 +9,7 @@ accessibility_criteria: |
 
 shared_accessibility_criteria:
   - link
+display_preview: false
 examples:
   from_only:
     data:


### PR DESCRIPTION
We'll use this to create a layout component. We can't preview that on the component guide page because it will crash slimmer, which doesn't allow elements like `<head>` to appear in the body.

https://trello.com/c/R7Ija8dR