### PR TITLE
Allow components to link to the Design System

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add the [GOV.UK Frontend](https://design-system.service.gov.uk/) library to the gem (PR #398)
+* Allow linking to the Design System on component pages (PR #401)
 
 ## 9.3.6
 

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -62,6 +62,10 @@ module GovukPublishingComponents
       end
     end
 
+    def govuk_frontend_components
+      component[:govuk_frontend_components].to_a
+    end
+
     def github_search_url
       params = { q: "org:alphagov #{partial_path}", type: "Code" }
       "https://github.com/search?#{params.to_query}"

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -28,6 +28,19 @@
 
   <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, example: @component_doc.example %>
 
+  <% if @component_doc.govuk_frontend_components.any? %>
+    <h2 class="component-doc-h2">GOV.UK Design System</h2>
+    <%= render 'govuk_publishing_components/components/govspeak' do %>
+      <p>This component incorporates components from the <%= link_to "GOV.UK Design System", "https://design-system.service.gov.uk" %>:</p>
+
+      <ul>
+      <% @component_doc.govuk_frontend_components.each do |component| %>
+        <li><%= link_to component.humanize, "https://design-system.service.gov.uk/components/#{component}" %></li>
+      <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+
   <% if @component_doc.accessibility_criteria.present? %>
     <div class="grid-row component-accessibility-criteria">
       <div class="column-two-thirds">


### PR DESCRIPTION
If a component uses a component from the design system, it can now specify so in the YAML file using the `govuk_frontend_components` key.

This will show links on the component page.

https://trello.com/c/R7Ija8dR