### PR TITLE
Add component for the basic page HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add experimental Admin layout (PR #371)
 * Add the [GOV.UK Frontend](https://design-system.service.gov.uk/) library to the gem (PR #398)
 
 ## 9.3.6

--- a/app.json
+++ b/app.json
@@ -23,5 +23,12 @@
   },
   "formation": {},
   "addons": [],
-  "buildpacks": []
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "heroku/ruby"
+    }
+  ]
 }

--- a/app/assets/stylesheets/govuk_publishing_components/admin_styles.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/admin_styles.scss
@@ -1,0 +1,11 @@
+// Include all of the GOV.UK Frontend styles. This includes global styles, fonts,
+// and individual components.
+$govuk-global-styles: true;
+$govuk-image-url-function: 'image-url';
+$govuk-font-url-function: 'font-url';
+
+@import "../../../node_modules/govuk-frontend/all";
+
+// Include our GOV.UK components
+@import "govuk_publishing_components/all_components";
+

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-admin.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-admin.scss
@@ -1,0 +1,1 @@
+// This component relies on styles from GOV.UK Frontend

--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title><%= browser_title %></title>
+    <%= stylesheet_link_tag 'govuk_publishing_components/admin_styles' %>
+  </head>
+  <body class="govuk-template__body">
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/govuk_publishing_components/components/docs/layout_for_admin.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_admin.yml
@@ -1,0 +1,26 @@
+name: Admin layout (experimental)
+description: A layout to be used by admin applications
+body: |
+  This component uses [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend),
+  part of the GOV.UK Design System.
+
+  It also includes the styles for the other components in this gem, so that you can use
+  these components as well.
+
+  This component is experimental. Breaking changes are likely and we'll not release
+  major version of the gem for these changes.
+
+  Because it is an entire layout, this component can only be [previewed on a separate page](/admin).
+
+  Typically you'll use this together with a footer and header.
+
+display_preview: false
+display_html: true
+accessibility_criteria: |
+  TBD
+examples:
+  default:
+    data:
+      browser_title: 'A page title'
+      block: |
+        <!-- You probably want to use the header, main & footer components here -->

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,4 +1,5 @@
 Rails.application.config.assets.precompile += %w(
+  govuk_publishing_components/admin_styles.css
   govuk_publishing_components/component_guide.css
   component_guide/all_components.css
   component_guide/all_components_print.css
@@ -12,4 +13,15 @@ Rails.application.config.assets.precompile += %w(
   govuk_publishing_components/govuk-schema-placeholder-1x1.png
   govuk_publishing_components/govuk-schema-placeholder-4x3.png
   govuk_publishing_components/govuk-schema-placeholder-16x9.png
+)
+
+# Add GOV.Frontend assets
+
+Rails.application.config.assets.precompile += %w(
+  govuk-logotype-crown.png
+)
+
+Rails.application.config.assets.paths += %W(
+  #{__dir__}/../../node_modules/govuk-frontend/assets/images
+  #{__dir__}/../../node_modules/govuk-frontend/assets/fonts
 )

--- a/spec/components/layout_for_admin_spec.rb
+++ b/spec/components/layout_for_admin_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe "Layout for admin", type: :view do
+  def component_name
+    "layout_for_admin"
+  end
+
+  it "adds the <title> tag" do
+    render_component(browser_title: "Hello, admin page", environment: "production")
+
+    assert_select "title", visible: false, text: "Hello, admin page"
+  end
+end

--- a/spec/dummy/app/controllers/welcome_controller.rb
+++ b/spec/dummy/app/controllers/welcome_controller.rb
@@ -16,4 +16,9 @@ class WelcomeController < ApplicationController
       @content_item = Services.content_store.content_item("/" + params[:base_path])
     end
   end
+
+  def admin
+    response.headers[Slimmer::Headers::SKIP_HEADER] = "true"
+    render 'admin_example', layout: 'dummy_admin_layout'
+  end
 end

--- a/spec/dummy/app/views/layouts/dummy_admin_layout.html.erb
+++ b/spec/dummy/app/views/layouts/dummy_admin_layout.html.erb
@@ -1,0 +1,3 @@
+<%= render 'govuk_publishing_components/components/layout_for_admin', browser_title: 'Example admin page' do %>
+  <%= yield %>
+<% end %>

--- a/spec/dummy/app/views/welcome/admin_example.html.erb
+++ b/spec/dummy/app/views/welcome/admin_example.html.erb
@@ -1,0 +1,5 @@
+<%= render 'govuk_publishing_components/components/title', title: "Hello! I am an example admin page" %>
+
+<p class="govuk-body">
+  Pages with the admin layout can use GOV.UK styles directly.
+</p>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   get 'step-nav/:slug', to: 'step_nav#show'
   get 'contextual-navigation', to: 'welcome#contextual_navigation'
   get 'contextual-navigation/*base_path', to: 'welcome#contextual_navigation'
+  get 'admin', to: 'welcome#admin'
 end


### PR DESCRIPTION
This component outputs just the basic HTML for a page. It has `<head>` and `<body>` tags, title tag and includes its own CSS. So preview the whole thing, there's also a special page on /admin in the component guide.

In future PRs we'll add a header, footer and the rest of the page furniture.

https://trello.com/c/R7Ija8dR