### PR TITLE
Add highlight boxes from Collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add the [GOV.UK Frontend](https://design-system.service.gov.uk/) library to the gem (PR #398)
 * Allow linking to the Design System on component pages (PR #401)
 * Add govuk:analytics:organisations meta tag if the current page is an organisation (PR #397)
+* Move the highlight box component from Collections to the gem (PR #403)
 
 ## 9.3.6
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -19,6 +19,7 @@
 @import "components/fieldset";
 @import "components/govspeak";
 @import "components/heading";
+@import "components/highlight-boxes";
 @import "components/image-card";
 @import "components/input";
 @import "components/inverse-header";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_highlight-boxes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_highlight-boxes.scss
@@ -1,0 +1,66 @@
+.gem-c-highlight-boxes {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: $gutter-half;
+
+  @include media(tablet) {
+    margin-right: -25px;
+  }
+}
+
+.gem-c-highlight-boxes__item-wrapper {
+  @include core-19;
+  @include box-sizing(border-box);
+  list-style-type: none;
+  padding: ($gutter / 6) $gutter-one-third ($gutter-half + $gutter-one-third) 0;
+  width: 100%;
+
+  @include media(tablet) {
+    width: 50%;
+    padding: ($gutter / 6) ($gutter-half + $gutter-one-third) ($gutter-half + $gutter-one-third) 0;
+  }
+
+  @include media(desktop) {
+    width: (1 / 3) * 100%;
+    padding: ($gutter / 6) ($gutter-half + $gutter-one-third) ($gutter-half + $gutter-one-third) 0;
+  }
+}
+
+.gem-c-highlight-boxes__item {
+  @include box-sizing(border-box);
+  border: 1px solid $grey-2;
+  padding: $gutter-half * 1.5;
+  height: 100%;
+  box-shadow: 7px 7px 0 $white, 8px 8px 0 $grey-2;
+}
+
+.gem-c-highlight-boxes--inverse {
+  background-color: $govuk-blue;
+  border: 0;
+  color: $white;
+}
+
+.gem-c-highlight-boxes--inverse .gem-c-highlight-boxes__title {
+  color: $white;
+}
+
+.gem-c-highlight-boxes__title {
+  @include bold-19;
+  display: block;
+  text-decoration: underline;
+  margin-bottom: 5px;
+}
+
+.gem-c-highlight-boxes__title--featured {
+  @include bold-24;
+}
+
+.gem-c-highlight-boxes__description {
+  margin-bottom: $gutter-one-third;
+}
+
+.gem-c-highlight-boxes__metadata {
+  @include core-16;
+  display: inline-block;
+  margin-right: $gutter-half;
+}

--- a/app/views/govuk_publishing_components/components/_highlight_boxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_highlight_boxes.html.erb
@@ -1,0 +1,39 @@
+<%
+  items ||= []
+  inverse ||= false
+  inverse_class = "gem-c-highlight-boxes--inverse" if inverse
+  highlight_boxes_helper = GovukPublishingComponents::Presenters::HighlightBoxesHelper.new(local_assigns)
+%>
+<% if items.any? %>
+  <ol class="gem-c-highlight-boxes" <%= "data-module=track-click" if highlight_boxes_helper.data_tracking? %>>
+    <% items.each do |content_item| %>
+      <li class="gem-c-highlight-boxes__item-wrapper">
+        <div class="gem-c-highlight-boxes__item <%= inverse_class %>">
+          <%= link_to(
+            content_item[:link].fetch(:text),
+            content_item[:link].fetch(:path),
+            class: "gem-c-highlight-boxes__title #{"gem-c-highlight-boxes__title--featured" if content_item[:link][:featured]}",
+            data: content_item[:link][:data_attributes]
+            )
+          %>
+
+          <% if content_item[:link][:description] %>
+            <p class="gem-c-highlight-boxes__description"><%= content_item[:link][:description] %></p>
+          <% end %>
+
+          <% if content_item[:metadata] %>
+            <% content_item[:metadata].each do |metadata_key, metadata_value| %>
+              <% if metadata_key.to_s.eql?("public_updated_at") %>
+                <time class="gem-c-highlight-boxes__metadata" datetime="<%= metadata_value.iso8601 %>">
+                  <%= l(metadata_value, format: '%e %B %Y') %>
+                </time>
+              <% else %>
+                <p class="gem-c-highlight-boxes__metadata"><%= metadata_value %></p>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+      </li>
+    <% end %>
+  </ol>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/highlight_boxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/highlight_boxes.yml
@@ -1,0 +1,142 @@
+name: Highlight boxes
+description: Displays content item details in a grid of highlight boxes, with a max of 3 items per row.
+body: |
+  The highlight boxes have several optional flags which can be set:
+
+  - Inverse - renders the highlight boxes as white text on a blue background
+  - Featured - renders a specific highlight box with larger font size
+accessibility_criteria: |
+  The highlight boxes must:
+
+  - be visually distinct from other content on the page
+  - have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      items:
+      - link:
+          text: If your child is taken into care
+          path: /child-into-care
+        metadata:
+          document_type: Detailed guide
+      - link:
+          text: High needs funding
+          path: /high-needs-funding
+        metadata:
+          document_type: Guide
+      - link:
+          text: Joint Statement of the 4th meeting of the UK-China High-Level People to People Dialogue
+          path: /government/publications/joint-statement-of-the-4th-meeting-of-the-uk-china-high-level-people-to-people-dialogue
+        metadata:
+          document_type: Policy paper
+  with_descriptions_and_metadata:
+    data:
+      items:
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+  inverse:
+    data:
+      inverse: true
+      items:
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+  featured_card:
+    description: "Used to highlight a specific content item within the highlight boxes, e.g: the most popular."
+    data:
+      items:
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+          featured: true
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+  with_data_tracking_attributes:
+    data:
+      items:
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+          data_attributes: {
+            track_category: "servicesHighlightBoxClicked",
+            track_action: 1,
+            track_label: "/becoming-an-apprentice"
+          }
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+          data_attributes: {
+            track_category: "servicesHighlightBoxClicked",
+            track_action: 2,
+            track_label: "/becoming-an-apprentice",
+            track_options: {
+              dimension28: 2,
+              dimension29: "Becoming an apprentice"
+            }
+          }
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -20,6 +20,7 @@ require "govuk_publishing_components/presenters/heading_helper"
 require "govuk_publishing_components/presenters/contents_list_helper"
 require "govuk_publishing_components/presenters/image_card_helper"
 require "govuk_publishing_components/presenters/organisation_logo_helper"
+require "govuk_publishing_components/presenters/highlight_boxes_helper"
 
 require "govuk_publishing_components/app_helpers/taxon_breadcrumbs"
 require "govuk_publishing_components/app_helpers/brand_helper"

--- a/lib/govuk_publishing_components/presenters/highlight_boxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/highlight_boxes_helper.rb
@@ -1,0 +1,13 @@
+module GovukPublishingComponents
+  module Presenters
+    class HighlightBoxesHelper
+      def initialize(options)
+        @items = options[:items]
+      end
+
+      def data_tracking?
+        @items.any? { |item| item[:link][:data_attributes] }
+      end
+    end
+  end
+end

--- a/spec/components/highlight_boxes_spec.rb
+++ b/spec/components/highlight_boxes_spec.rb
@@ -1,0 +1,227 @@
+require "rails_helper"
+
+describe "Highlight Box", type: :view do
+  def component_name
+    "highlight_boxes"
+  end
+
+  it "renders nothing if no items are provided" do
+    assert_empty render_component(
+      items: []
+    )
+  end
+
+  it "fails to render highlight boxes when no link text is provided" do
+    assert_raises do
+      render_component(
+        items: [
+          link: {
+            path: '/education'
+          },
+          metadata: {
+            organisation: "Department of Education"
+          }
+        ]
+      )
+    end
+  end
+
+  it "fails to render highlight boxes when no link path is provided" do
+    assert_raises do
+      render_component(
+        items: [
+          link: {
+            text: 'Department of Education'
+          },
+          metadata: {
+            organisation: "Department of Education"
+          }
+        ]
+      )
+    end
+  end
+
+  it "renders correct link text and path" do
+    render_component(
+      items: [
+        link: {
+          text: 'Become an apprentice',
+          path: '/become-an-apprentice'
+        }
+      ]
+    )
+
+    assert_select ".gem-c-highlight-boxes__title[href=\"/become-an-apprentice\"]", text: 'Become an apprentice'
+  end
+
+  it "renders a description if provided" do
+    render_component(
+      items: [
+        link: {
+          text: 'Become an apprentice',
+          path: '/become-an-apprentice',
+          description: "How to become an apprentice"
+        }
+      ]
+    )
+
+    assert_select ".gem-c-highlight-boxes__description", text: 'How to become an apprentice'
+  end
+
+  it "renders metadata if provided" do
+    render_component(
+      items: [
+        link: {
+          text: 'Become an apprentice',
+          path: '/become-an-apprentice',
+          description: "How to become an apprentice"
+        },
+        metadata: {
+          public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+          organisations: 'Department of Education',
+          document_type: 'Guide'
+        }
+      ]
+    )
+
+    assert_select ".gem-c-highlight-boxes__metadata", text: 'Guide'
+    assert_select "time[datetime='2017-01-05T14:50:33Z']"
+    assert_select ".gem-c-highlight-boxes__metadata", text: 'Department of Education'
+  end
+
+  it "renders multiple content items" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: 'Become an apprentice',
+            path: '/become-an-apprentice',
+            description: "How to become an apprentice"
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2016-06-27 14:50:33 +0000"),
+            organisations: 'Department of Education',
+            document_type: 'Guide'
+          }
+        },
+        {
+          link: {
+            text: 'Student finance',
+            path: '/student-finance',
+            description: "Student finance"
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("1994-11-21 14:50:33 +0000"),
+            organisations: 'Department of Education',
+            document_type: 'Detailed Guide'
+          }
+        }
+      ]
+    )
+
+    assert_select ".gem-c-highlight-boxes__item .gem-c-highlight-boxes__title[href=\"/become-an-apprentice\"]", text: 'Become an apprentice'
+    assert_select ".gem-c-highlight-boxes__item .gem-c-highlight-boxes__description", text: 'How to become an apprentice'
+    assert_select ".gem-c-highlight-boxes__metadata", text: 'Guide'
+    assert_select "time[datetime='2016-06-27T14:50:33Z']"
+    assert_select ".gem-c-highlight-boxes__metadata", text: 'Department of Education'
+
+    assert_select ".gem-c-highlight-boxes__item .gem-c-highlight-boxes__title[href=\"/student-finance\"]", text: 'Student finance'
+    assert_select ".gem-c-highlight-boxes__item .gem-c-highlight-boxes__description", text: 'Student finance'
+    assert_select ".gem-c-highlight-boxes__metadata", text: 'Detailed Guide'
+    assert_select "time[datetime='1994-11-21T14:50:33Z']"
+    assert_select ".gem-c-highlight-boxes__metadata", text: 'Department of Education'
+  end
+
+  it "adds inverse class when inverse flag passed" do
+    render_component(
+      inverse: true,
+      items: [
+        link: {
+          text: 'Become an apprentice',
+          path: '/become-an-apprentice',
+          description: "How to become an apprentice"
+        },
+        metadata: {
+          public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+          organisations: 'Department of Education',
+          document_type: 'Guide'
+        }
+      ]
+    )
+
+    assert_select ".gem-c-highlight-boxes__item.gem-c-highlight-boxes--inverse"
+  end
+
+  it "adds featured class when featured flag passed" do
+    render_component(
+      items: [
+        link: {
+          text: 'Become an apprentice',
+          path: '/become-an-apprentice',
+          description: "How to become an apprentice",
+          featured: true
+        },
+        metadata: {
+          public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+          organisations: 'Department of Education',
+          document_type: 'Guide'
+        }
+      ]
+    )
+
+    assert_select ".gem-c-highlight-boxes__title.gem-c-highlight-boxes__title--featured"
+  end
+
+  it "adds data tracking attributes when data_attributes provided" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: 'Become an apprentice',
+            path: '/become-an-apprentice',
+            description: "How to become an apprentice",
+            data_attributes: {
+              track_category: "servicesHighlightBoxClicked",
+              track_action: 1,
+              track_label: "/becoming-an-apprentice"
+            }
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2016-06-27 14:50:33 +0000"),
+            organisations: 'Department of Education',
+            document_type: 'Guide'
+          }
+        },
+        {
+          link: {
+            text: 'Student finance',
+            path: '/student-finance',
+            description: "Student finance",
+            data_attributes: {
+              track_category: "servicesHighlightBoxClicked",
+              track_action: 2,
+              track_label: "/student-finance",
+              track_options: {
+                dimension28: 2,
+                dimension29: "Student Finance"
+              }
+            }
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("1994-11-21 14:50:33 +0000"),
+            organisations: 'Department of Education',
+            document_type: 'Detailed Guide'
+          }
+        }
+      ]
+    )
+
+    assert_select ".gem-c-highlight-boxes__title[data-track-category='servicesHighlightBoxClicked']"
+    assert_select ".gem-c-highlight-boxes__title[data-track-action='1']"
+    assert_select ".gem-c-highlight-boxes__title[data-track-label='/becoming-an-apprentice']"
+
+    assert_select ".gem-c-highlight-boxes__title[data-track-action='2']"
+    assert_select ".gem-c-highlight-boxes__title[data-track-label='/student-finance']"
+    assert_select ".gem-c-highlight-boxes__title[data-track-options='{\"dimension28\":2,\"dimension29\":\"Student Finance\"}']"
+  end
+end


### PR DESCRIPTION
Moves the highlight boxes component from Collections so it can be used by Government Frontend.

<img width="990" alt="screen shot 2018-07-11 at 09 55 07" src="https://user-images.githubusercontent.com/29889908/42561235-91c3c648-84f0-11e8-9a3f-0714e721235a.png">
<img width="995" alt="screen shot 2018-07-11 at 09 55 20" src="https://user-images.githubusercontent.com/29889908/42561252-9a55934a-84f0-11e8-8ac5-7374b62e8e31.png">
<img width="992" alt="screen shot 2018-07-11 at 09 55 24" src="https://user-images.githubusercontent.com/29889908/42561257-9d6805ea-84f0-11e8-907c-afa71c55877b.png">

Component guide for this PR:
https://govuk-publishing-compon-pr-403.herokuapp.com/component-guide/
