### PR TITLE
Add footer component

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -50,6 +50,16 @@ $border-color: #ccc;
   }
 }
 
+.component-warning {
+  border: 3px solid $orange;
+  margin: 0 0 $gutter;
+  padding: $gutter $gutter 0 $gutter;
+
+  .component-warning__title {
+    @include bold-24;
+  }
+}
+
 .component-doc-h2 {
   @include bold-27;
   margin: ($gutter * 1.5) 0 $gutter;

--- a/app/assets/stylesheets/govuk_publishing_components/admin_styles.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/admin_styles.scss
@@ -9,3 +9,5 @@ $govuk-font-url-function: 'font-url';
 // Include our GOV.UK components
 @import "govuk_publishing_components/all_components";
 
+// Components that are only available inside the admin layout
+@import "govuk_publishing_components/components/layout-footer";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
@@ -1,0 +1,1 @@
+// This component relies on styles from GOV.UK Frontend

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -46,6 +46,10 @@ module GovukPublishingComponents
       component[:display_preview].nil? ? true : component[:display_preview]
     end
 
+    def part_of_admin_layout?
+      component[:part_of_admin_layout]
+    end
+
     def html_body
       govspeak_to_html(body) if body.present?
     end

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -1,6 +1,15 @@
 <% content_for :title, "#{@component_doc.name} component" %>
 <%= render 'govuk_publishing_components/components/title', title: @component_doc.name, context: "Component" %>
 
+<% if @component_doc.part_of_admin_layout? %>
+<div class="component-warning">
+  <h2 class="component-warning__title">Admin layout only</h2>
+  <p>
+    This component uses the Design System, so only works inside the <%= link_to "admin layout", "/component-guide/layout_for_admin" %>
+  </p>
+</div>
+<% end %>
+
 <div class="component-show">
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -1,0 +1,26 @@
+<footer class="govuk-footer " role="contentinfo">
+  <div class="govuk-width-container ">
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+        <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+          <path
+            fill="currentColor"
+            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+          />
+        </svg>
+        <span class="govuk-footer__licence-description">
+          All content is available under the
+          <a
+            class="govuk-footer__link"
+            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+            rel="license"
+          >Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -1,0 +1,12 @@
+name: Layout footer (experimental)
+description: The footer provides copyright, licensing and other information
+part_of_admin_layout: true
+govuk_frontend_components:
+  - footer
+examples:
+  default:
+    data: {}
+accessibility_criteria: |
+  The component must:
+
+  * implement accessible links

--- a/app/views/govuk_publishing_components/components/docs/layout_for_admin.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_admin.yml
@@ -12,7 +12,9 @@ body: |
 
   Because it is an entire layout, this component can only be [previewed on a separate page](/admin).
 
-  Typically you'll use this together with a footer and header.
+  Typically you'll use this together with:
+
+  - the [layout footer component](/component-guide/layout_footer)
 
 display_preview: false
 display_html: true

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -16,6 +16,11 @@
   <% if GovukPublishingComponents::Config.application_print_stylesheet %>
     <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_print_stylesheet}", media: "print" %>
   <% end %>
+
+  <% if @component_doc && @component_doc.part_of_admin_layout? %>
+    <%= stylesheet_link_tag "govuk_publishing_components/admin_styles" %>
+  <% end %>
+
   <%= javascript_include_tag "component_guide/application" %>
   <%= javascript_include_tag "#{GovukPublishingComponents::Config.application_javascript}" %>
   <%= csrf_meta_tags %>

--- a/spec/components/layout_footer_spec.rb
+++ b/spec/components/layout_footer_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe "Layout footer", type: :view do
+  def component_name
+    "layout_footer"
+  end
+
+  it "renders the footer" do
+    render_component({})
+
+    assert_select ".govuk-footer"
+  end
+end


### PR DESCRIPTION
This implements the footer component from GOV.UK Frontend.

Things of note:

- Even though we don't have custom CSS, we still create a CSS file for this component. This is mainly so it's easy to discover for a developer where the styles come from.
- When the component is `part_of_admin_layout`, we'll show a warning banner. This hopefully makes it clear that the component can't be used on the public frontend (because GOV.UK Frontend isn't available).

[View in component guide](https://govuk-publishing-compon-pr-404.herokuapp.com/component-guide/layout_footer)

https://trello.com/c/k5agy6jw