### PR TITLE
Improve step nav 'remember open steps' code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * The Notice component now accepts blocks (PR #407)
+* Improve step nav 'remember open steps' code (PR #406)
 
 ## 9.4.0
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/history-support.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/history-support.js
@@ -1,8 +1,0 @@
-// used by the step by step navigation component
-
-if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
-if(typeof window.GOVUK.support === 'undefined'){ window.GOVUK.support = {}; }
-
-window.GOVUK.support.history = function() {
-  return window.history && window.history.pushState && window.history.replaceState;
-}

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
@@ -164,9 +164,7 @@ examples:
       ]
   remember_last_opened_step:
     description: |
-      If a step is opened its ID is appended to the end of the URL, so that if the URL is shared or the 'back' button is used, that step will be opened on page load. This was historically part of the behaviour of the accordion. By default this is turned off and cannot be used together with the option to open a step by default.
-
-      This behaviour is used with the 'links to more information' option.
+      If steps are opened their IDs are added to an array in sessionStorage, so that if the user returns to this page in the same session, those steps will be opened on page load. This option can technically be used together with the option to open a step by default, but this is not recommended as it could confuse users.
     data:
       remember_last_step: true
       steps: [

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -531,6 +531,28 @@ describe('A stepnav module', function () {
     });
   });
 
+  describe('when a step is supposed to be shown by default', function() {
+    beforeEach(function () {
+      stepnav = new GOVUK.Modules.Gemstepnav();
+      $element = $(html);
+      $element.find('#topic-step-two').attr('data-show', '');
+      stepnav.start($element);
+    });
+
+    it("shows the step it's supposed to", function () {
+      var $openStep = $element.find('#topic-step-two');
+      expect($openStep).toHaveClass('step-is-shown');
+    });
+
+    it("leaves the other steps closed", function () {
+      var $closedStep1 = $element.find('#topic-step-one');
+      var $closedStep3 = $element.find('#topic-step-three');
+
+      expect($closedStep1).not.toHaveClass('step-is-shown');
+      expect($closedStep3).not.toHaveClass('step-is-shown');
+    });
+  });
+
   describe('When tracking a big step nav', function () {
     beforeEach(function () {
       stepnav = new GOVUK.Modules.Gemstepnav();


### PR DESCRIPTION
- use sessionStorage, not URL
- can now remember more than one open step
- remove a lot of redundant code (relating to this and not relating to this)

Trello card: https://trello.com/c/pjEOb2FO/702-spike-options-for-remembering-opened-steps

Removes dependence on history.js, fixes https://github.com/alphagov/govuk_publishing_components/issues/396

---

Component guide for this PR:
https://govuk-publishing-compon-pr-406.herokuapp.com/component-guide/
