### PR TITLE
Allow passing in govspeak into notice component 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* The Notice component now accepts blocks (PR #407)
+
 ## 9.4.0
 
 * Add experimental Admin layout (PR #371)

--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -1,11 +1,11 @@
 <% if defined?(title) %>
   <%
     description_text ||= false
-    description_govspeak ||= false
+    description_govspeak ||= yield || false
     margin_bottom_class = " gem-c-notice--bottom-margin" unless local_assigns[:margin_bottom]
   %>
   <section class="gem-c-notice<%= margin_bottom_class %>" aria-label="Notice" role="region">
-    <% if description_text || description_govspeak %>
+    <% if description_text.present? || description_govspeak.present? %>
       <h2 class="gem-c-notice__title"><%= title %></h2>
     <% else %>
       <span class="gem-c-notice__title"><%= title %></span>

--- a/app/views/govuk_publishing_components/components/docs/notice.yml
+++ b/app/views/govuk_publishing_components/components/docs/notice.yml
@@ -21,6 +21,10 @@ examples:
     data:
       title: 'Statistics release update'
       description_govspeak: '<p>The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p>This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a rel="external" href="https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/">www.ogauthority.co.uk</a></p>'
+  with_govspeak_from_a_block:
+    data:
+      title: 'Statistics release update'
+      block: '<p>The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p>This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a rel="external" href="https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/">www.ogauthority.co.uk</a></p>'
   with_markup_in_the_title:
     description: In some circumstances it may be necessary to include simple markup in the title, such as a link. Note that this will be wrapped in a H2 tag if there is no description included, so be sure that any markup inserted is valid inside that tag (e.g. another heading tag inside a H2 would be invalid).
     data:

--- a/spec/components/inverse_header_spec.rb
+++ b/spec/components/inverse_header_spec.rb
@@ -1,9 +1,5 @@
 require 'rails_helper'
 
-def component_path
-  "govuk_publishing_components/components/inverse_header"
-end
-
 def block
   "<div class=\"gem-c-title gem-c-title--inverse\">
   <p class=\"gem-c-title__context\">
@@ -25,20 +21,20 @@ describe "Inverse header", type: :view do
   end
 
   it "renders content within a wrapper when content is provided" do
-    render(component_path, {}) { block }
+    render_component({}) { block }
 
     assert_select ".gem-c-inverse-header div.gem-c-title"
     assert_select ".gem-c-inverse-header h1", text: "HTML publication page title"
   end
 
   it "renders correct css class when header is to be full page width" do
-    render(component_path, full_width: true) { block }
+    render_component(full_width: true) { block }
 
     assert_select ".gem-c-inverse-header--full-width"
   end
 
   it "renders correct css class when padding_top flag is set to false" do
-    render(component_path, padding_top: false) { block }
+    render_component(padding_top: false) { block }
 
     assert_select ".gem-c-inverse-header--padding-top", false
   end

--- a/spec/components/notice_spec.rb
+++ b/spec/components/notice_spec.rb
@@ -26,6 +26,15 @@ describe "Notice", type: :view do
     assert_select ".gem-c-notice__description", text: "Duplicate, added in error"
   end
 
+  it "renders a notice with a title and description text from a block" do
+    render_component(title: "Statistics release cancelled") do
+      "Duplicate, added in error"
+    end
+
+    assert_select ".gem-c-notice__title", text: "Statistics release cancelled"
+    assert_select ".govuk-govspeak", text: "Duplicate, added in error"
+  end
+
   it "renders a notice with a title and description govspeak" do
     render_component(title: "Statistics release update", description_govspeak: "<p>The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p>This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a rel=\"external\" href=\"https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/\">www.ogauthority.co.uk</a></p>".html_safe)
 

--- a/spec/support/components_helper.rb
+++ b/spec/support/components_helper.rb
@@ -5,7 +5,11 @@ module Helpers
     end
 
     def render_component(locals)
-      render partial: "govuk_publishing_components/components/#{component_name}", locals: locals
+      if block_given?
+        render("govuk_publishing_components/components/#{component_name}", locals) { yield }
+      else
+        render "govuk_publishing_components/components/#{component_name}", locals
+      end
     end
   end
 end


### PR DESCRIPTION
We currently don't support passing in a block to this component like we do for other components. It'll make it easier to pass in safe HTML to the component.

Also updates the test helper to make this possible.

https://trello.com/c/k5agy6jw