### PR TITLE
Add header component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/admin_styles.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/admin_styles.scss
@@ -1,8 +1,8 @@
 // Include all of the GOV.UK Frontend styles. This includes global styles, fonts,
 // and individual components.
 $govuk-global-styles: true;
-$govuk-image-url-function: 'image-url';
-$govuk-font-url-function: 'font-url';
+$govuk-image-url-function: "image-url";
+$govuk-font-url-function: "font-url";
 
 @import "../../../node_modules/govuk-frontend/all";
 
@@ -11,3 +11,4 @@ $govuk-font-url-function: 'font-url';
 
 // Components that are only available inside the admin layout
 @import "govuk_publishing_components/components/layout-footer";
+@import "govuk_publishing_components/components/layout-header";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -1,11 +1,11 @@
 // This component relies on styles from GOV.UK Frontend
 
-.gem-c-header--integration .govuk-header__container,
-.gem-c-header--staging .govuk-header__container {
+.gem-c-layout-header--integration .govuk-header__container,
+.gem-c-layout-header--staging .govuk-header__container {
   border-bottom-color: govuk-colour("yellow");
 }
 
-.gem-c-header--development .govuk-header__container {
+.gem-c-layout-header--development .govuk-header__container {
   border-bottom-color: govuk-colour("grey-1");
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -1,0 +1,30 @@
+// This component relies on styles from GOV.UK Frontend
+
+.gem-c-header--integration .govuk-header__container,
+.gem-c-header--staging .govuk-header__container {
+  border-bottom-color: govuk-colour("yellow");
+}
+
+.gem-c-header--development .govuk-header__container {
+  border-bottom-color: govuk-colour("grey-1");
+}
+
+// Fix header component's reliance on markup whitespace
+// https://github.com/alphagov/govuk-frontend/pull/884/files
+//
+// Remove this fix after updating to GOV.UK Frontend 1.1.0
+.govuk-header__container {
+  @include govuk-clearfix;
+}
+
+.govuk-header__logo {
+  @include mq ($from: desktop) {
+    float: left;
+  }
+}
+
+.govuk-header__content {
+  @include mq ($from: desktop) {
+    float: left;
+  }
+}

--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -3,10 +3,19 @@
   <head>
     <meta name="robots" content="noindex,nofollow,noimageindex">
     <title><%= browser_title %></title>
-    <%= stylesheet_link_tag 'govuk_publishing_components/admin_styles' %>
+    <%= stylesheet_link_tag "govuk_publishing_components/admin_styles" %>
   </head>
   <body class="govuk-template__body">
+    <%= render "govuk_publishing_components/components/layout_header", {
+      environment: "production",
+      product_name: "Admin",
+      navigation_items: [
+        {:text => "John Doe", :href => "#profile"},
+        {:text => "Log out", :href => "#logout"}
+      ]
+    }%>
     <%= yield %>
+    <%= render "govuk_publishing_components/components/layout_footer" %>
     <%= javascript_include_tag "govuk_publishing_components/admin_scripts" %>
   </body>
 </html>

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -1,0 +1,60 @@
+<%
+navigation_classes ||= ''
+  navigation_items ||= []
+  css_classes ||= ''
+  container_classes ||= ''
+  homepage_url ||= '/'
+  product_name ||= nil
+  service_name ||= nil
+  service_url ||= nil
+%>
+<header class="gem-c-header govuk-header gem-c-header--<%= environment %>" role="banner" data-module="header">
+  <div class="govuk-header__container <%= container_classes.present? || 'govuk-width-container' %>">
+
+    <div class="govuk-header__logo">
+      <a href="<%= homepage_url %>" class="govuk-header__link govuk-header__link--homepage">
+        <span class="govuk-header__logotype">
+          <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
+            <path fill="currentColor" fill-rule="evenodd"
+              d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+            ></path>
+            <image src="<%= asset_path('govuk-logotype-crown.png') %>" class="govuk-header__logotype-crown-fallback-image"></image>
+          </svg>
+          <span class="govuk-header__logotype-text">
+            GOV.UK
+          </span>
+        </span>
+        <% if product_name %>
+        <span class="govuk-header__product-name">
+          <%= product_name %>
+        </span>
+        <% end %>
+      </a>
+    </div><div class="govuk-header__content">
+
+    <% if service_name %>
+    <a href="<%= service_url %>" class="govuk-header__link govuk-header__link--service-name">
+      <%= service_name %>
+    </a>
+    <% end %>
+
+    <% if navigation_items.any? %>
+    <button role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+    <nav>
+      <ul id="navigation" class="govuk-header__navigation <%= navigation_classes.present? || 'govuk-header__navigation--end' %>" aria-label="Top Level Navigation">
+        <% navigation_items.each_with_index do |item, index| %>
+          <li class="govuk-header__navigation-item <%= "govuk-header__navigation-item--active" if item[:active] %>">
+            <%= link_to(
+              item[:text],
+              item[:href],
+              class: 'govuk-header__link',
+              ) %>
+          </li>
+        <% end %>
+      </ul>
+    </nav>
+    <% end %>
+
+    </div>
+  </div>
+</header>

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -1,18 +1,12 @@
 <%
-navigation_classes ||= ''
+  product_name ||= false
   navigation_items ||= []
-  css_classes ||= ''
-  container_classes ||= ''
-  homepage_url ||= '/'
-  product_name ||= nil
-  service_name ||= nil
-  service_url ||= nil
 %>
 <header class="gem-c-header govuk-header gem-c-header--<%= environment %>" role="banner" data-module="header">
-  <div class="govuk-header__container <%= container_classes.present? || 'govuk-width-container' %>">
+  <div class="govuk-header__container govuk-width-container">
 
     <div class="govuk-header__logo">
-      <a href="<%= homepage_url %>" class="govuk-header__link govuk-header__link--homepage">
+      <a href="/" class="govuk-header__link govuk-header__link--homepage">
         <span class="govuk-header__logotype">
           <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
             <path fill="currentColor" fill-rule="evenodd"
@@ -32,16 +26,10 @@ navigation_classes ||= ''
       </a>
     </div><div class="govuk-header__content">
 
-    <% if service_name %>
-    <a href="<%= service_url %>" class="govuk-header__link govuk-header__link--service-name">
-      <%= service_name %>
-    </a>
-    <% end %>
-
     <% if navigation_items.any? %>
     <button role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
     <nav>
-      <ul id="navigation" class="govuk-header__navigation <%= navigation_classes.present? || 'govuk-header__navigation--end' %>" aria-label="Top Level Navigation">
+      <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
         <% navigation_items.each_with_index do |item, index| %>
           <li class="govuk-header__navigation-item <%= "govuk-header__navigation-item--active" if item[:active] %>">
             <%= link_to(

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -2,7 +2,7 @@
   product_name ||= false
   navigation_items ||= []
 %>
-<header class="gem-c-header govuk-header gem-c-header--<%= environment %>" role="banner" data-module="header">
+<header class="gem-c-layout-header govuk-header gem-c-layout-header--<%= environment %>" role="banner" data-module="header">
   <div class="govuk-header__container govuk-width-container">
 
     <div class="govuk-header__logo">

--- a/app/views/govuk_publishing_components/components/docs/layout_for_admin.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_admin.yml
@@ -14,6 +14,7 @@ body: |
 
   Typically you'll use this together with:
 
+  - the [layout header component](/component-guide/layout_header)
   - the [layout footer component](/component-guide/layout_footer)
 
 display_preview: false

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -1,0 +1,57 @@
+name: Layout header (experimental)
+description: The header provides the crown logo, product or service name and navigation
+body: |
+  Requires the specification of the environment (development, integration,
+  staging or production).
+part_of_admin_layout: true
+govuk_frontend_components:
+  - header
+examples:
+  default:
+    data:
+      environment: production
+  staging_environment:
+    data:
+      environment: staging
+  integration_environment:
+    data:
+      environment: integration
+  development_environment:
+    data:
+      environment: development
+  with_product_name:
+    data:
+      environment: production
+      product_name: Product
+  with_navigation:
+    data:
+      environment: production
+      navigation_items:
+      - text: Navigation item 1
+        href: "#1"
+        active: true
+      - text: Navigation item 2
+        href: "#2"
+
+accessibility_criteria: |
+  The component must:
+
+  - have a text contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+
+  Links in the Header must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - indicate when they have focus
+  - change in appearance when touched (in the touch-down state)
+  - change in appearance when hovered
+  - have visible text
+
+  Images in the Header must:
+
+  - be presentational when linked to from accompanying text (crown icon).
+
+  Landmarks and Roles in the Header should:
+
+  - have a role of `banner` at the root of the component (<header>) ([ARIA 1.1](https://www.w3.org/TR/wai-aria-1.1/#banner))

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -14,7 +14,7 @@ describe "Layout header", type: :view do
   it "renders the header with environment modifier class" do
     render_component(environment: "staging")
 
-    assert_select ".govuk-header.gem-c-header--staging"
+    assert_select ".govuk-header.gem-c-layout-header--staging"
   end
 
   it "renders the product name" do

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe "Layout header", type: :view do
+  def component_name
+    "layout_header"
+  end
+
+  it "renders the header" do
+    render_component(environment: "staging")
+
+    assert_select ".govuk-header"
+  end
+
+  it "renders the header with environment modifier class" do
+    render_component(environment: "staging")
+
+    assert_select ".govuk-header.gem-c-header--staging"
+  end
+
+  it "renders the product name" do
+    render_component(environment: "staging", product_name: "Product name")
+
+    assert_select ".govuk-header__product-name", text: "Product name"
+  end
+
+  it "renders the header with navigation items" do
+    navigation_items = [
+      { text: "Foo", href: "/foo", active: true },
+      { text: "Bar", href: "/bar" },
+    ]
+
+    render_component(environment: "staging", navigation_items: navigation_items)
+
+    assert_select ".govuk-header__navigation-item.govuk-header__navigation-item--active", text: "Foo"
+    assert_select ".govuk-header__navigation-item", text: "Bar"
+  end
+end


### PR DESCRIPTION
This implements the header component from GOV.UK Frontend exemplifying with environment, product name and navigation items.

## Notes
- Contains [a CSS fix](https://github.com/alphagov/govuk_publishing_components/pull/408/files#diff-e9749171eb74b1f0e663c2b759893bf5R16) that should be removed after [updating to the next govuk-frontend release](https://github.com/alphagov/govuk-frontend/pull/884).
- JavaScript needed for the navigation on mobile devices not added yet, will be part of the admin layout. (l.e. added in https://github.com/alphagov/govuk_publishing_components/pull/415)

[View in component guide](https://govuk-publishing-compon-pr-408.herokuapp.com/component-guide/layout_header)

[Trello card](https://trello.com/c/faHdZDk2)