### PR TITLE
Add robots rules

### DIFF
--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta name="robots" content="noindex,nofollow,noimageindex">
     <title><%= browser_title %></title>
     <%= stylesheet_link_tag 'govuk_publishing_components/admin_styles' %>
   </head>

--- a/spec/components/layout_for_admin_spec.rb
+++ b/spec/components/layout_for_admin_spec.rb
@@ -10,4 +10,10 @@ describe "Layout for admin", type: :view do
 
     assert_select "title", visible: false, text: "Hello, admin page"
   end
+
+  it "adds the robots metatag" do
+    render_component(browser_title: "Hello, admin page", environment: "production")
+
+    assert_select 'meta[name="robots"][content="noindex,nofollow,noimageindex"]', visible: false
+  end
 end


### PR DESCRIPTION
As this component is intended for admin apps this metatag asks google and
other robots that respect it to not index the page, not index the images
in the page, and not follow the links for indexing.
---

Component guide for this PR:
https://govuk-publishing-compon-pr-409.herokuapp.com/component-guide/
