### PR TITLE
Improve the accessibility of the previous/next arrows on mainstream guides

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
@@ -20,7 +20,7 @@
 .gem-c-pagination__item {
   @include core-16($line-height: (20 / 16));
   list-style: none;
-  text-align: right;
+  text-align: left;
   margin: 0;
   padding: 0;
 }
@@ -29,6 +29,8 @@
   display: block;
   padding: $gutter-half;
   text-decoration: none;
+  background-color: $canvas-colour;
+  border-top: 1px solid $border-colour;
 
   &:visited {
     color: $link-colour;
@@ -41,29 +43,18 @@
 }
 
 .gem-c-pagination__link-title {
-  @include core-27($line-height: (33.75 / 27));
   display: block;
-}
-
-.gem-c-pagination__item--previous {
   text-align: left;
-
-  @include media(tablet) {
-    float: left;
-    width: 50%;
-  }
+  width: 100%;
 }
 
-.gem-c-pagination__item--next {
-  text-align: right;
-
-  @include media(tablet) {
-    float: right;
-    width: 50%;
-  }
+.gem-c-pagination__link-title-text {
+  @include core-19($font-weight: bold);
+  margin-left: $gutter / 3;
 }
 
 .gem-c-pagination__link-icon {
+  @include core-24($line-height: (33.75 / 27));
   display: inline-block;
   margin-bottom: 1px;
   height: .482em;
@@ -74,4 +65,9 @@
   display: inline-block;
   margin-top: 0.1em;
   text-decoration: underline;
+  margin-left: $gutter;
+
+  @include media(mobile) {
+    margin-left: $gutter-half + 9;
+  }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
@@ -6,32 +6,18 @@
   margin-right: -$gutter-half;
 }
 
-.gem-c-pagination__list {
-  margin: 0;
-  padding: 0;
-
-  &:after {
-    content: "";
-    display: block;
-    clear: both;
-  }
-}
-
 .gem-c-pagination__item {
   @include core-16($line-height: (20 / 16));
   list-style: none;
-  text-align: left;
-  margin: 0;
-  padding: 0;
 }
 
 .gem-c-pagination__link {
   display: block;
   padding: $gutter-half;
   text-decoration: none;
-  background-color: $canvas-colour;
-  border-top: 1px solid $border-colour;
 
+  &:hover,
+  &:active,
   &:visited {
     color: $link-colour;
   }
@@ -44,12 +30,10 @@
 
 .gem-c-pagination__link-title {
   display: block;
-  text-align: left;
-  width: 100%;
 }
 
-.gem-c-pagination__link-title-text {
-  @include core-19($font-weight: bold);
+.gem-c-pagination__link-text {
+  @include bold-19;
   margin-left: $gutter / 3;
 }
 

--- a/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
@@ -20,7 +20,7 @@
             <svg class="gem-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
               <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"/>
             </svg>
-            <span class="gem-c-pagination__link-title-text">
+            <span class="gem-c-pagination__link-text">
               <%= previous_page[:title] %>
             </span>
           </span>
@@ -46,7 +46,7 @@
             <svg class="gem-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
               <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"/>
             </svg>
-            <span class="gem-c-pagination__link-title-text">
+            <span class="gem-c-pagination__link-text">
               <%= next_page[:title] %>
             </span>
           </span>

--- a/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
@@ -20,7 +20,9 @@
             <svg class="gem-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
               <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"/>
             </svg>
-            <%= previous_page[:title] %>
+            <span class="gem-c-pagination__link-title-text">
+              <%= previous_page[:title] %>
+            </span>
           </span>
           <% if previous_page[:label].present? %>
             <span class="visually-hidden">:</span>
@@ -41,10 +43,12 @@
           data-track-dimension-index="29"
         >
           <span class="gem-c-pagination__link-title">
-            <%= next_page[:title] %>
             <svg class="gem-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
               <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"/>
             </svg>
+            <span class="gem-c-pagination__link-title-text">
+              <%= next_page[:title] %>
+            </span>
           </span>
           <% if next_page[:label].present? %>
             <span class="visually-hidden">:</span>


### PR DESCRIPTION
## Changes
- Link title text size changed from core-27 to core-19 with font-weight of bold.
- Link label offset to match position of link title text.
- All text and icon now left aligned

## What
We know from our user research that the current next / previous arrows on mainstream guides can be improved.

There's two problems:
- They point to the sidebar content (particularly step by steps) which is confusing
- Users zooming into the page can only see one at a time

## Why

One of our goals this quarter is to optimise the user-facing step by step pattern.

Ticket: https://trello.com/c/IELXDsqb/701-improve-the-accessibility-of-the-previous-next-arrows-on-mainstream-guides

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-410.herokuapp.com/component-guide/previous_and_next_navigation