### PR TITLE
Use notice component

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -50,16 +50,6 @@ $border-color: #ccc;
   }
 }
 
-.component-warning {
-  border: 3px solid $orange;
-  margin: 0 0 $gutter;
-  padding: $gutter $gutter 0 $gutter;
-
-  .component-warning__title {
-    @include bold-24;
-  }
-}
-
 .component-doc-h2 {
   @include bold-27;
   margin: ($gutter * 1.5) 0 $gutter;

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -2,12 +2,9 @@
 <%= render 'govuk_publishing_components/components/title', title: @component_doc.name, context: "Component" %>
 
 <% if @component_doc.part_of_admin_layout? %>
-<div class="component-warning">
-  <h2 class="component-warning__title">Admin layout only</h2>
-  <p>
-    This component uses the Design System, so only works inside the <%= link_to "admin layout", "/component-guide/layout_for_admin" %>
-  </p>
-</div>
+  <%= render "govuk_publishing_components/components/notice", title: "Admin layout only" do %>
+    <p>This component only works inside the <%= link_to "layout for admin component", "/component-guide/layout_for_admin" %>.</p>
+  <% end %>
 <% end %>
 
 <div class="component-show">


### PR DESCRIPTION
This uses the notice component on the component guide page, instead of a home grown warning block. As suggested by @alex-ju.

https://trello.com/c/k5agy6jw/6-create-a-footer-component