### PR TITLE
Add test that components have the correct class

### DIFF
--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -1,23 +1,25 @@
 <% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request.path) %>
 
-<% if navigation.content_tagged_to_single_step_by_step? %>
-  <!-- Rendering step by step nav breadcrumbs because there's 1 step by step -->
-  <%= render 'govuk_publishing_components/components/step_by_step_nav_header',
-    navigation.step_nav_helper.header %>
-<% elsif navigation.content_tagged_to_mainstream_browse_pages? %>
-  <!-- Rendering parent-based breadcrumbs because the page is tagged to mainstream browse -->
-  <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
-<% elsif navigation.content_has_curated_related_items? %>
-  <!-- Rendering parent-based breadcrumbs because the page has curated related links -->
-  <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
-<% elsif navigation.content_is_tagged_to_a_live_taxon? %>
-  <!-- Rendering taxonomy breadcrumbs because the page is tagged to live taxons -->
-  <%= render 'govuk_publishing_components/components/breadcrumbs',
-    breadcrumbs: navigation.taxon_breadcrumbs[:breadcrumbs],
-    collapse_on_mobile: true %>
-<% elsif navigation.breadcrumbs.any? %>
-  <!-- Rendering parent-based breadcrumbs because no browse, no related links, no live taxons -->
-  <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
-<% else %>
-  <!-- Not rendering any breadcrumbs because there aren't any -->
-<% end %>
+<div class='gem-c-contextual-breadcrumbs'>
+  <% if navigation.content_tagged_to_single_step_by_step? %>
+    <!-- Rendering step by step nav breadcrumbs because there's 1 step by step -->
+    <%= render 'govuk_publishing_components/components/step_by_step_nav_header',
+      navigation.step_nav_helper.header %>
+  <% elsif navigation.content_tagged_to_mainstream_browse_pages? %>
+    <!-- Rendering parent-based breadcrumbs because the page is tagged to mainstream browse -->
+    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
+  <% elsif navigation.content_has_curated_related_items? %>
+    <!-- Rendering parent-based breadcrumbs because the page has curated related links -->
+    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
+  <% elsif navigation.content_is_tagged_to_a_live_taxon? %>
+    <!-- Rendering taxonomy breadcrumbs because the page is tagged to live taxons -->
+    <%= render 'govuk_publishing_components/components/breadcrumbs',
+      breadcrumbs: navigation.taxon_breadcrumbs[:breadcrumbs],
+      collapse_on_mobile: true %>
+  <% elsif navigation.breadcrumbs.any? %>
+    <!-- Rendering parent-based breadcrumbs because no browse, no related links, no live taxons -->
+    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
+  <% else %>
+    <!-- Not rendering any breadcrumbs because there aren't any -->
+  <% end %>
+</div>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -1,23 +1,25 @@
 <% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request.path) %>
 
-<% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
-  <!-- Rendering step by step related items because there are a few but not too many of them -->
-  <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links %>
-<% end %>
+<div class="gem-c-contextual-sidebar">
+  <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
+    <!-- Rendering step by step related items because there are a few but not too many of them -->
+    <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links %>
+  <% end %>
 
-<% if navigation.content_tagged_to_single_step_by_step? %>
-  <!-- Rendering step by step sidebar because there's 1 step by step list -->
-  <%= render 'govuk_publishing_components/components/step_by_step_nav', navigation.step_nav_helper.sidebar %>
-<% elsif navigation.content_tagged_to_mainstream_browse_pages? %>
-  <!-- Rendering related navigation sidebar because the page is tagged to mainstream browse -->
-  <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
-<% elsif navigation.content_has_curated_related_items? %>
-  <!-- Rendering related navigation sidebar because the page has curated related links -->
-  <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
-<% elsif navigation.content_is_tagged_to_a_live_taxon? %>
-  <!-- Rendering taxonomy sidebar because the page is tagged to live taxons -->
-  <%= render 'govuk_publishing_components/components/taxonomy_navigation', navigation.taxonomy_sidebar %>
-<% else %>
-  <!-- Rendering related navigation sidebar because no browse, no related links, no live taxons -->
-  <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
-<% end %>
+  <% if navigation.content_tagged_to_single_step_by_step? %>
+    <!-- Rendering step by step sidebar because there's 1 step by step list -->
+    <%= render 'govuk_publishing_components/components/step_by_step_nav', navigation.step_nav_helper.sidebar %>
+  <% elsif navigation.content_tagged_to_mainstream_browse_pages? %>
+    <!-- Rendering related navigation sidebar because the page is tagged to mainstream browse -->
+    <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
+  <% elsif navigation.content_has_curated_related_items? %>
+    <!-- Rendering related navigation sidebar because the page has curated related links -->
+    <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
+  <% elsif navigation.content_is_tagged_to_a_live_taxon? %>
+    <!-- Rendering taxonomy sidebar because the page is tagged to live taxons -->
+    <%= render 'govuk_publishing_components/components/taxonomy_navigation', navigation.taxonomy_sidebar %>
+  <% else %>
+    <!-- Rendering related navigation sidebar because no browse, no related links, no live taxons -->
+    <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
+  <% end %>
+</div>

--- a/app/views/govuk_publishing_components/components/_government_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_government_navigation.html.erb
@@ -2,7 +2,7 @@
   active ||= nil
 %>
 
-<nav id="proposition-menu" class="no-proposition-name">
+<nav id="proposition-menu" class="no-proposition-name gem-c-government-navigation">
   <ul id="proposition-links">
     <li>
       <a class="<%= 'active' if active == 'departments' %>" href="/government/organisations">

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="govuk-footer " role="contentinfo">
+<footer class="gem-c-layout-footer govuk-footer" role="contentinfo">
   <div class="govuk-width-container ">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">

--- a/spec/components/all_components_spec.rb
+++ b/spec/components/all_components_spec.rb
@@ -21,6 +21,17 @@ describe "All components" do
         expect(yaml["accessibility_criteria"]).not_to be_nil
       end
 
+      it "has the correct class in the ERB template",
+        skip: component_name.in?(%w[step_by_step_nav_related step_by_step_nav_header step_by_step_nav previous_and_next_navigation]),
+        not_applicable: component_name.in?(%w[meta_tags machine_readable_metadata layout_for_admin]) do
+
+        erb = File.read(filename)
+
+        class_name = "gem-c-#{component_name.dasherize}"
+
+        expect(erb).to match(class_name), class_name
+      end
+
       it "has a correctly named spec file", skip: component_name.in?(%w[contextual_breadcrumbs contextual_sidebar success_alert taxonomy_navigation]) do
         rspec_file = "#{__dir__}/../../spec/components/#{component_name.tr('-', '_')}_spec.rb"
 


### PR DESCRIPTION
This adds a test to make sure that every component has  a specific formatted class name. This will encourage consistency and codifies that we'll also a d the `gem-c-` class to GOV.UK Frontend-powered components. This makes sure that the browser extension can highlight and link all of our components.

There are a couple of components that have weird class names, so I've added those to `skip` (meaning they should be fixed). For example, the class name for the previous_and_next_navigation component is `gem-c-pagination`, not `gem-c-previous-and-next-navigation` as one might expect.

There are 3 components that don't need a class name, they're in `not_applicable` (which means they will not be fixed).