### PR TITLE
Fix the step by step title sizing and spacing on mobile when it appears as a footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Fix the step by step title sizing and spacing on mobile when it appears as a footer (PR #413)
+
 ## 9.5.0
 
 * Improve step nav 'remember open steps' code (PR #406)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
@@ -1,18 +1,26 @@
 .gem-c-step-nav-related {
   border-top: 2px solid $govuk-blue;
-  margin-bottom: $gutter * 1.5;
+  margin-bottom: $gutter-half;
 }
 
 .gem-c-step-nav-related__heading {
   margin-top: $gutter-half;
   margin-bottom: $gutter-one-third;
   @include bold-19;
+
+  @include media(mobile) {
+    @include bold-24;
+  }
 }
 
 .gem-c-step-nav-related__links {
   @include bold-16;
   margin: 0;
   padding: 0;
+
+  @include media(mobile) {
+    @include bold-24;
+  }
 }
 
 .gem-c-step-nav-related__pretitle {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
@@ -1,26 +1,18 @@
 .gem-c-step-nav-related {
   border-top: 2px solid $govuk-blue;
-  margin-bottom: $gutter-half;
+  margin-bottom: $gutter;
 }
 
 .gem-c-step-nav-related__heading {
   margin-top: $gutter-half;
   margin-bottom: $gutter-one-third;
   @include bold-19;
-
-  @include media(mobile) {
-    @include bold-24;
-  }
 }
 
 .gem-c-step-nav-related__links {
   @include bold-16;
   margin: 0;
   padding: 0;
-
-  @include media(mobile) {
-    @include bold-24;
-  }
 }
 
 .gem-c-step-nav-related__pretitle {


### PR DESCRIPTION
## Changes
- changes margin bottom on step by step nav related from $gutter * 1.5 to $gutter-half for both desktop and mobile
- adds font size bold-24 for mobile views

## What
On mobile when the step by step nav appears as a footer the sizing of the step by step title is too small and there's a lot of whitespace between the title and the steps beneath.

We should bump up the size of the title and close up the space a little. Check-in with Kate if you need guidance on sizing and spacing.

## Why
One of our goals this quarter is to optimise the user-facing step by step pattern.

Ticket: https://trello.com/c/zlQ0Go3P/700-fix-the-step-by-step-title-sizing-and-spacing-on-mobile-when-it-appears-as-a-footer

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-413.herokuapp.com/component-guide/step_by_step_nav_related
