### PR TITLE
Create the "main" component for admin layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * The Notice component now accepts blocks (PR #407)
+* Add "Layout main" component (PR #414)
 
 ## 9.4.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/admin_styles.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/admin_styles.scss
@@ -11,4 +11,5 @@ $govuk-font-url-function: "font-url";
 
 // Components that are only available inside the admin layout
 @import "govuk_publishing_components/components/layout-footer";
+@import "govuk_publishing_components/components/layout-main";
 @import "govuk_publishing_components/components/layout-header";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-main.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-main.scss
@@ -1,0 +1,1 @@
+// This component relies on styles from GOV.UK Frontend

--- a/app/views/govuk_publishing_components/components/_layout_main.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_main.html.erb
@@ -1,0 +1,3 @@
+<div class="gem-c-layout-main govuk-width-container">
+  <%= yield %>
+</div>

--- a/app/views/govuk_publishing_components/components/docs/layout_for_admin.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_admin.yml
@@ -16,6 +16,7 @@ body: |
 
   - the [layout header component](/component-guide/layout_header)
   - the [layout footer component](/component-guide/layout_footer)
+  - the [layout main component](/component-guide/layout_main)
 
 display_preview: false
 display_html: true

--- a/app/views/govuk_publishing_components/components/docs/layout_main.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_main.yml
@@ -1,0 +1,16 @@
+name: Layout main section (experimental)
+description: The main section of the page. Includes support for some flash messages.
+body: |
+  This is the main section of a page. It has a single column layout using the [Design System layout helpers](https://design-system.service.gov.uk/styles/layout).
+
+  You can see this component in action on the [admin layout example page](/admin)
+accessibility_criteria: |
+  None
+shared_accessibility_criteria:
+  - links
+part_of_admin_layout: true
+examples:
+  default:
+    data:
+      block: |
+        <p>This is the content.</p>

--- a/spec/components/layout_main_spec.rb
+++ b/spec/components/layout_main_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe "Layout main", type: :view do
+  def component_name
+    "layout_main"
+  end
+
+  it "renders with a column" do
+    render_component({}) do
+      "Some content"
+    end
+
+    assert_select ".govuk-width-container", text: "Some content"
+  end
+end

--- a/spec/dummy/app/views/layouts/dummy_admin_layout.html.erb
+++ b/spec/dummy/app/views/layouts/dummy_admin_layout.html.erb
@@ -1,3 +1,3 @@
 <%= render 'govuk_publishing_components/components/layout_for_admin', browser_title: 'Example admin page' do %>
-  <%= yield %>
+  <%= render 'govuk_publishing_components/components/layout_main' %>
 <% end %>


### PR DESCRIPTION
This component adds the "Layout main" component. It currently only makes the content use the grid (a single column). In the future this component will also contain the flash messages and other page essentials.

https://trello.com/c/4Z5AAIPI/15-create-main-component