### PR TITLE
Add javascript support for admin layout components

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/admin_scripts.js
+++ b/app/assets/javascripts/govuk_publishing_components/admin_scripts.js
@@ -1,0 +1,4 @@
+//= require all.js
+
+// Initialise all GOVUKFrontend components
+window.GOVUKFrontend.initAll()

--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -7,5 +7,6 @@
   </head>
   <body class="govuk-template__body">
     <%= yield %>
+    <%= javascript_include_tag "govuk_publishing_components/admin_scripts" %>
   </body>
 </html>

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -43,5 +43,8 @@
 
       <%= yield %>
     </main>
+    <% if @component_doc && @component_doc.part_of_admin_layout? %>
+      <%= javascript_include_tag "govuk_publishing_components/admin_scripts" %>
+    <% end %>
 </body>
 </html>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,4 +1,5 @@
 Rails.application.config.assets.precompile += %w(
+  govuk_publishing_components/admin_scripts.js
   govuk_publishing_components/admin_styles.css
   govuk_publishing_components/component_guide.css
   component_guide/all_components.css
@@ -24,4 +25,5 @@ Rails.application.config.assets.precompile += %w(
 Rails.application.config.assets.paths += %W(
   #{__dir__}/../../node_modules/govuk-frontend/assets/images
   #{__dir__}/../../node_modules/govuk-frontend/assets/fonts
+  #{__dir__}/../../node_modules/govuk-frontend/
 )


### PR DESCRIPTION
Add JavaScript support for admin layout and review app components that are flagged as part_of_admin_layout.

[Trello card](https://trello.com/c/FKQqvGsp)

---
Component guide for this PR:
https://govuk-publishing-compon-pr-415.herokuapp.com/component-guide/
