### PR TITLE
Add skip link component and main container to admin layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@
 
 ## Unreleased
 
-* The Notice component now accepts blocks (PR #407)
+* Add experimental layout-footer component based on GOV.UK Frontend (PR #404)
 * Improve step nav 'remember open steps' code (PR #406)
+* The Notice component now accepts blocks (PR #407)
+* Add experimental layout-header component based on GOV.UK Frontend (PR #408)
+* Import and initialise GOV.UK Frontend scripts in the admin layout (PR #415)
 * Remove unneeded options from step nav component (PR #416)
+* Add experimental skip link component based on GOV.UK Frontend (PR #417)
 
 ## 9.4.0
 
-* Add experimental Admin layout (PR #371)
+* Add experimental admin layout (PR #371)
 * Add the [GOV.UK Frontend](https://design-system.service.gov.uk/) library to the gem (PR #398)
 * Allow linking to the Design System on component pages (PR #401)
 * Add govuk:analytics:organisations meta tag if the current page is an organisation (PR #397)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_skip-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_skip-link.scss
@@ -1,0 +1,1 @@
+// This component relies on styles from GOV.UK Frontend

--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -1,21 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="govuk-template">
   <head>
     <meta name="robots" content="noindex,nofollow,noimageindex">
     <title><%= browser_title %></title>
     <%= stylesheet_link_tag "govuk_publishing_components/admin_styles" %>
   </head>
   <body class="govuk-template__body">
-    <%= render "govuk_publishing_components/components/layout_header", {
-      environment: "production",
-      product_name: "Admin",
-      navigation_items: [
-        {:text => "John Doe", :href => "#profile"},
-        {:text => "Log out", :href => "#logout"}
-      ]
-    }%>
     <%= yield %>
-    <%= render "govuk_publishing_components/components/layout_footer" %>
     <%= javascript_include_tag "govuk_publishing_components/admin_scripts" %>
   </body>
 </html>

--- a/app/views/govuk_publishing_components/components/_skip_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_skip_link.html.erb
@@ -1,0 +1,4 @@
+<%
+  href ||= '#main-content'
+%>
+<%= link_to("Skip to main content", href, class: "gem-c-skip-link govuk-skip-link") %>

--- a/app/views/govuk_publishing_components/components/docs/skip_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/skip_link.yml
@@ -1,0 +1,16 @@
+name: Skip link (experimental)
+description: Skip link component helps keyboard-only users skip to the main content on a page
+part_of_admin_layout: true
+govuk_frontend_components:
+  - skip-link
+accessibility_criteria: |
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - indicate when they have focus
+  - becomes visible when pressing tab
+  - is the first items that screen readers hear and that keyboard users tab to
+examples:
+  default:
+    data:
+      href: '#content'

--- a/spec/components/skip_link_spec.rb
+++ b/spec/components/skip_link_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe "Skip Link", type: :view do
+  def component_name
+    "skip_link"
+  end
+
+  it "renders a skip link correctly" do
+    render_component(href: '#main-content')
+    assert_select ".govuk-skip-link[href=\"#main-content\"]", text: "Skip to main content"
+  end
+end

--- a/spec/dummy/app/views/layouts/dummy_admin_layout.html.erb
+++ b/spec/dummy/app/views/layouts/dummy_admin_layout.html.erb
@@ -1,3 +1,18 @@
 <%= render 'govuk_publishing_components/components/layout_for_admin', browser_title: 'Example admin page' do %>
-  <%= yield %>
+  <%= render "govuk_publishing_components/components/skip_link" %>
+  <%= render "govuk_publishing_components/components/layout_header", {
+    environment: "production",
+    product_name: "Admin",
+    navigation_items: [
+      {:text => "John Doe", :href => "#profile"},
+      {:text => "Log out", :href => "#logout"}
+    ]
+  }%>
+  <div class="govuk-width-container">
+    <!-- breadcrumbs, backlink, phasebanner goes here-->
+    <main class="govuk-main-wrapper " id="main-content" role="main">
+      <%= yield %>
+    </main>
+  </div>
+  <%= render "govuk_publishing_components/components/layout_footer" %>
 <% end %>

--- a/spec/dummy/app/views/welcome/admin_example.html.erb
+++ b/spec/dummy/app/views/welcome/admin_example.html.erb
@@ -1,4 +1,4 @@
-<%= render 'govuk_publishing_components/components/title', title: "Hello! I am an example admin page" %>
+<h1 class="govuk-heading-xl">Hello! I am an example admin page</h1>
 
 <p class="govuk-body">
   Pages with the admin layout can use GOV.UK styles directly.


### PR DESCRIPTION
This PR:
- adds skip link component based on GOVUK Frontend
- fix: moves the header and footer from the admin layout published in gem to the dummy admin layout in spec
- adds container wrapper and main element to the admin layout
- updates changelog

---

Component guide for this PR:
https://govuk-publishing-compon-pr-417.herokuapp.com/admin
