### PR TITLE
Add anti-forgery meta tags

### DIFF
--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta name="robots" content="noindex,nofollow,noimageindex">
+    <%= csrf_meta_tags %>
     <title><%= browser_title %></title>
     <%= stylesheet_link_tag 'govuk_publishing_components/admin_styles' %>
   </head>


### PR DESCRIPTION
This has added the cross site forge request headers

However I can't work out how to test it. The required meta tags appear as expected in the example pages, but they aren't there in the context of the rspec test. I suspect this is related to forgery protection being off by default in a test environment, but can't work out how to switch it back on. Input welcome!

---

Component guide for this PR:
https://govuk-publishing-compon-pr-418.herokuapp.com/component-guide/
