### PR TITLE
Attempt to improve Google snippet display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Attempt to improve Google snippet display (PR #424)
 * Add JavaScript detection, HTML5 shim and IE8 stylesheet to admin layout (PR #419)
 
 ## 9.5.1

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -45,8 +45,11 @@
       bindComponentLinkClicks(stepNavTracker);
 
       function getTextForInsertedElements() {
-        actions.showText = $element.attr('data-show-text');
-        actions.hideText = $element.attr('data-hide-text');
+        var openBracket = '<span class="visuallyhidden">(</span>';
+        var closeBracket = '<span class="visuallyhidden">)</span>';
+
+        actions.showText = openBracket + $element.attr('data-show-text') + closeBracket;
+        actions.hideText = openBracket + $element.attr('data-hide-text') + closeBracket;
         actions.showAllText = $element.attr('data-show-all-text');
         actions.hideAllText = $element.attr('data-hide-all-text');
       }
@@ -64,7 +67,9 @@
           }
 
           if (!$(this).find('.js-toggle-link').length) {
-            $(this).find('.js-step-title-button').append('<span class="gem-c-step-nav__toggle-link js-toggle-link" aria-hidden="true">' + linkText + '</span>');
+            $(this).find('.js-step-title-button').append(
+              '<span class="gem-c-step-nav__toggle-link js-toggle-link" aria-hidden="true" hidden></span>'
+            );
           }
         });
       }
@@ -250,7 +255,7 @@
 
           if ($showOrHideAllButton.text() == actions.showAllText) {
             $showOrHideAllButton.text(actions.hideAllText);
-            $element.find('.js-toggle-link').text(actions.hideText);
+            $element.find('.js-toggle-link').html(actions.hideText);
             shouldshowAll = true;
 
             stepNavTracker.track('pageElementInteraction', 'stepNavAllShown', {
@@ -258,7 +263,7 @@
             });
           } else {
             $showOrHideAllButton.text(actions.showAllText);
-            $element.find('.js-toggle-link').text(actions.showText);
+            $element.find('.js-toggle-link').html(actions.showText);
             shouldshowAll = false;
 
             stepNavTracker.track('pageElementInteraction', 'stepNavAllHidden', {
@@ -316,7 +321,7 @@
         $stepElement.toggleClass('step-is-shown', isShown);
         $stepContent.toggleClass('js-hidden', !isShown);
         $titleLink.attr("aria-expanded", isShown);
-        $stepElement.find('.js-toggle-link').text(isShown ? actions.hideText : actions.showText);
+        $stepElement.find('.js-toggle-link').html(isShown ? actions.hideText : actions.showText);
       }
 
       function isShown() {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -263,6 +263,8 @@ $top-border: solid 2px $grey-3;
   @include _core-font-generator(14px, 14px, 14px, 1.2, 1.2, false);
   display: block;
   color: $link-colour;
+  // core-font-generator sets this to none, so we need to override
+  text-transform: capitalize !important;
 
   .gem-c-step-nav--large & {
     @include _core-font-generator(16px, 14px, 16px, 1.2, 1.2, false);

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
@@ -21,8 +21,8 @@
     class="gem-c-step-nav js-hidden <% unless small %>gem-c-step-nav--large<% end %>"
     <%= "data-remember" if remember_last_step %>
     <%= "data-id=#{tracking_id}" if tracking_id %>
-    data-show-text="<%= t("govuk_component.step_by_step_nav.show", default: "Show") %>"
-    data-hide-text="<%= t("govuk_component.step_by_step_nav.hide", default: "Hide") %>"
+    data-show-text="<%= t("govuk_component.step_by_step_nav.show", default: "show") %>"
+    data-hide-text="<%= t("govuk_component.step_by_step_nav.hide", default: "hide") %>"
     data-show-all-text="<%= t("govuk_component.step_by_step_nav.show_all", default: "Show all") %>"
     data-hide-all-text="<%= t("govuk_component.step_by_step_nav.hide_all", default: "Hide all") %>"
   >
@@ -54,9 +54,7 @@
                     <% if logic %>
                       <%= logic %>
                     <% else %>
-                      <%
-                        step_number += 1
-                      %>
+                      <% step_number += 1 %>
                       <span class="visuallyhidden">Step</span> <%= step_number %>
                     <% end %>
                   </span>

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -448,7 +448,7 @@ describe('A stepnav module', function () {
 
     it("sets the show/hide link text to 'hide'", function () {
       var $step1 = $element.find('#topic-step-one');
-      expect($step1.find('.js-toggle-link')).toHaveText("Hide");
+      expect($step1.find('.js-toggle-link')).toHaveText("(Hide)");
     });
 
     it("sets the show all/hide all button text correctly", function () {


### PR DESCRIPTION
Google is currently displaying snippets for some of our step by step pages like this:

![screen shot 2018-07-12 at 13 27 02](https://user-images.githubusercontent.com/861310/42757691-d3ac988a-88f8-11e8-981e-083388448e58.png)

This PR attempts to improve the snippet display by:

- wrapping the 'show' elements in brackets (hidden to users, both visually and with aria)
- lowercasing the 'show' elements (using CSS to capitalize, don't know if this will actually work)

This hopefully will produce a snippet more like this:

"Step 2 Update your vehicle's log book (V5C) (show). ... "

---

Trello card: https://trello.com/c/xTkNr64l/712-fix-google-snippet-display
Component guide for this PR:
https://govuk-publishing-compon-pr-424.herokuapp.com/component-guide/
