### PR TITLE
Improve metadata positioning in doc list for right to left layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Improve metadata positioning in document list for rtl layouts (PR #429)
+
 ## 9.5.2
 
 * Attempt to improve Google snippet display (PR #424)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -17,6 +17,11 @@
 
 .gem-c-document-list__item-title--context {
   margin-right: $gutter-one-third;
+
+  .direction-rtl & {
+    margin-right: 0;
+    margin-left: $gutter-one-third;
+  }
 }
 
 .gem-c-document-list__item-context {
@@ -29,9 +34,14 @@
 
 .gem-c-document-list__attribute {
   @include core-14;
-  float: left;
+  display: inline-block;
   list-style: none;
   padding-right: $gutter-two-thirds;
+
+  .direction-rtl & {
+    padding-right: 0;
+    padding-left: $gutter-two-thirds;
+  }
 }
 
 .gem-c-document-list--bottom-margin {

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -116,3 +116,22 @@ examples:
           path: '/government/organisations/advisory-committee-on-the-microbiological-safety-of-food'
           context: 'moving to GOV.UK'
           description: "Works with 4 agencies and public bodies"
+  right_to_left:
+    data:
+      items:
+      - link:
+          text: 'School behaviour and attendance: parental responsibility measures'
+          path: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+          description: "Statutory guidance for schools, local authorities and the police on dealing with poor attendance and behaviour in school"
+        metadata:
+          public_updated_at: 2017-01-05 14:50:33
+          document_type: 'Statutory guidance'
+      - link:
+          text: 'Forestry Commission'
+          path: '/government/organisations/forestry-commission'
+          context: 'separate website'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Organisation'
+    context:
+      right_to_left: true


### PR DESCRIPTION
Move the metadata to the right when on a right to left layout. Otherwise it's difficult to see how the metadata is related to the document list item heading

## Before
<img width="929" alt="screen shot 2018-07-17 at 13 33 52" src="https://user-images.githubusercontent.com/29889908/42817449-0fa98d16-89c6-11e8-9521-2131149bda8c.png">

## After
<img width="919" alt="screen shot 2018-07-17 at 13 39 13" src="https://user-images.githubusercontent.com/29889908/42817709-d1a21686-89c6-11e8-9230-cb845713d7fe.png">

Component guide: https://govuk-publishing-compon-pr-429.herokuapp.com/component-guide/document_list
