### PR TITLE
Version gem 9.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 9.5.3
 
 * Improve metadata positioning in document list for rtl layouts (PR #429)
+* Add favicon to admin layout (PR #426)
+* Disable GOV.UK Frontend global styles (PR #427)
+* Replace the location URL sent to Google Analytics with one that masks email addresses (PR #428)
 
 ## 9.5.2
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (9.5.2)
+    govuk_publishing_components (9.5.3)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -111,7 +111,7 @@ GEM
       rubocop (~> 0.51.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
-    govuk_app_config (1.6.0)
+    govuk_app_config (1.7.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
@@ -162,7 +162,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    money (6.11.3)
+    money (6.12.0)
       i18n (>= 0.6.4, < 1.1)
     multipart-post (2.0.0)
     netrc (0.11.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '9.5.2'.freeze
+  VERSION = '9.5.3'.freeze
 end


### PR DESCRIPTION
This version includes:

* Improve metadata positioning in document list for rtl layouts (PR #429)
* Add favicon to admin layout (PR #426)
* Disable govuk-frontend global styles (PR #427)
* Mask email addresses from the URL submitted with feedback responses (PR #428)


