### PR TITLE
Extend the double dot problem solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Change breadcrumb class name (PR #435)
 * Add admin component for select (PR #434)
+* Extend the double dot problem solution (PR #432)
 
 ## 9.5.3
 

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
@@ -340,18 +340,19 @@ examples:
       ]
   solve_the_double_dot_problem:
     description: |
-      If a page is in a step by step navigation more than once and a user is viewing that URL, both links to it will be highlighted as the site has no way to know which link the user is currently viewing (highlighted links should only occur when the step by step navigation is in the sidebar).
+      If a page is in a step by step navigation more than once and a user is viewing that URL, both links to it will be highlighted as the backend has no way to know which link the user is currently viewing (links should only be highlighted when the step by step navigation is in the sidebar).
 
-      JavaScript is included in the component to solve this. It uses sessionStorage to capture the data-position attribute of non-external links when clicked, and then uses this value to decide which link to highlight when the new page loads. This session storage data is immediately deleted after it is read on page load, mainly to prevent problems with highlighting if the user were to move between different step by step navigations.
+      JavaScript is included in the component to solve this. It uses sessionStorage to capture the data-position attribute of non-external links when clicked, and then uses this value to decide which link (and parent step) to highlight and expand when the new page loads. Note that it uses the tracking_id attribute to uniquely identify the current step nav. If tracking_id is not set this may result in other step navs having the wrong link highlighted.
 
       If a user has not clicked a link (i.e. has visited the page without first clicking on a step by step navigation) the first active link in the first active step will be highlighted. If there is no active step, the first active link will be highlighted (but there should always be an active step).
 
       The current page in the step by step navigation is an anchor link to the top of the page. If there are more than one of these and the user clicks one that is not currently highlighted, that one will be highlighted.
 
-      The example below will show all links highlighted if JS is disabled, in the real world no more than two or three links are likely to be highlighted at once.
+      The example below will show all non-external links highlighted if JS is disabled. In the real world no more than two or three links are likely to be highlighted at once.
     data:
       highlight_step: 2
       show_step: 2
+      tracking_id: "example-id"
       steps: [
         {
           title: "Not the active step",

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -83,7 +83,6 @@ module GovukPublishingComponents
                 link[:active] = true
                 step_nav_content[:show_step] = step_index + 1
                 step_nav_content[:highlight_step] = step_index + 1
-                return step_nav_content
               end
             end
           end

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -48,6 +48,9 @@ describe('A stepnav module', function () {
               <li class="gem-c-step-nav__list-item js-list-item">\
                 <a href="/link3" class="gem-c-step-nav__link js-link" data-position="2.2">Link 3</a>\
               </li>\
+              <li class="gem-c-step-nav__list-item gem-c-step-nav__list-item--active js-list-item">\
+                <a href="#content" class="gem-c-step-nav__link js-link" data-position="2.3">Link 4</a>\
+              </li>\
             </ol>\
           </div>\
         </li>\
@@ -67,19 +70,19 @@ describe('A stepnav module', function () {
           <div class="gem-c-step-nav__panel js-panel" id="step-panel-topic-step-three-1">\
             <ol class="gem-c-step-nav__list" data-length="5">\
               <li class="gem-c-step-nav__list-item gem-c-step-nav__list-item--active js-list-item">\
-                <a href="/link4" class="gem-c-step-nav__link js-link" data-position="3.1">Link 4</a>\
+                <a href="/link4" class="gem-c-step-nav__link js-link" data-position="3.1">Link 5</a>\
               </li>\
               <li class="gem-c-step-nav__list-item gem-c-step-nav__list-item--active js-list-item">\
-                <a href="/link5" class="gem-c-step-nav__link js-link" data-position="3.2">Link 5</a>\
+                <a href="/link5" class="gem-c-step-nav__link js-link" data-position="3.2">Link 6</a>\
               </li>\
               <li class="gem-c-step-nav__list-item js-list-item">\
-                <a href="http://www.gov.uk" class="gem-c-step-nav__link js-link" data-position="3.3" rel="external">Link 6</a>\
+                <a href="http://www.gov.uk" class="gem-c-step-nav__link js-link" data-position="3.3" rel="external">Link 7</a>\
               </li>\
               <li class="gem-c-step-nav__list-item gem-c-step-nav__list-item--active js-list-item">\
-                <a href="#content" class="gem-c-step-nav__link js-link" data-position="3.4">Link 7</a>\
+                <a href="#content" class="gem-c-step-nav__link js-link" data-position="3.4">Link 8</a>\
               </li>\
               <li class="gem-c-step-nav__list-item gem-c-step-nav__list-item--active js-list-item">\
-                <a href="#content" class="gem-c-step-nav__link js-link" data-position="3.5">Link 8</a>\
+                <a href="#content" class="gem-c-step-nav__link js-link" data-position="3.5">Link 9</a>\
               </li>\
             </ol>\
           </div>\
@@ -758,7 +761,7 @@ describe('A stepnav module', function () {
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavShown', {
       label: '3 - Topic Step Three - Elsewhere click: Small ; optional',
       dimension26: '3',
-      dimension27: '8',
+      dimension27: '9',
       dimension28: '5',
       dimension96: 'unique-id'
     });
@@ -771,36 +774,44 @@ describe('A stepnav module', function () {
       stepnav.start($element);
     });
 
+    afterEach(function () {
+      sessionStorage.removeItem('govuk-step-nav-active-link_unique-id');
+    });
+
     it("puts a clicked link in session storage", function () {
       $element.find('.js-link[data-position="3.1"]').click();
-      expect(sessionStorage.getItem('govuk-step-nav-active-link')).toBe('3.1');
+      expect(sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe('3.1');
     });
 
     it("does not put an external clicked link in session storage", function () {
       $element.find('.js-link[data-position="3.3"]').click();
-      expect(sessionStorage.getItem('govuk-step-nav-active-link')).toBe(null);
+      expect(sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe(null);
     });
 
     it("highlights the first active link in the first active step if no sessionStorage value is set", function () {
-      expect(sessionStorage.getItem('govuk-step-nav-active-link')).toBe(null);
+      expect(sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe(null);
       expect($element.find('.js-link[data-position="3.1"]').closest('.js-list-item')).toHaveClass('gem-c-step-nav__list-item--active');
       expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1);
     });
 
-    it("highlights a clicked #content link and removes other highlights", function () {
+    it("highlights a clicked #content link and its parent step, and removes other highlighting", function () {
       expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1);
 
       var $firstLink = $element.find('.js-link[data-position="3.4"]');
       $firstLink.click();
-      expect(sessionStorage.getItem('govuk-step-nav-active-link')).toBe('3.4');
+      expect(sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe('3.4');
       expect($firstLink.closest('.js-list-item')).toHaveClass('gem-c-step-nav__list-item--active');
+      expect($firstLink.closest('.js-step')).toHaveClass('gem-c-step-nav__step--active');
       expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1);
+      expect($element.find(('.gem-c-step-nav__step--active')).length).toBe(1);
 
       var $secondLink = $element.find('.js-link[data-position="3.5"]');
       $secondLink.click();
-      expect(sessionStorage.getItem('govuk-step-nav-active-link')).toBe('3.5');
+      expect(sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe('3.5');
       expect($secondLink.closest('.js-list-item')).toHaveClass('gem-c-step-nav__list-item--active');
+      expect($secondLink.closest('.js-step')).toHaveClass('gem-c-step-nav__step--active');
       expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1);
+      expect($element.find(('.gem-c-step-nav__step--active')).length).toBe(1);
     });
   });
 
@@ -820,17 +831,48 @@ describe('A stepnav module', function () {
 
       stepnav = new GOVUK.Modules.Gemstepnav();
       $element = $(html);
-      sessionStorage.setItem('govuk-step-nav-active-link', '3.5');
+      sessionStorage.setItem('govuk-step-nav-active-link_unique-id', '3.5');
       stepnav.start($element);
     });
 
     afterEach(function () {
-      sessionStorage.removeItem('govuk-step-nav-active-link');
+      sessionStorage.removeItem('govuk-step-nav-active-link_unique-id');
     });
 
     it("highlights only one link", function () {
-      expect(sessionStorage.getItem('govuk-step-nav-active-link')).toBe('3.5');
+      expect(sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe('3.5');
       expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1);
+      expect($element.find(('.gem-c-step-nav__step--active')).length).toBe(1);
+    });
+  });
+
+  describe('in a double dot situation where a clicked link that is not highlighted is already stored on page load', function() {
+    beforeEach(function () {
+      var store = {};
+
+      spyOn(sessionStorage, 'getItem').and.callFake(function (key) {
+        return store[key];
+      });
+      spyOn(sessionStorage, 'setItem').and.callFake(function (key, value) {
+        return store[key] = value + '';
+      });
+      spyOn(sessionStorage, 'clear').and.callFake(function () {
+        store = {};
+      });
+
+      stepnav = new GOVUK.Modules.Gemstepnav();
+      $element = $(html);
+      sessionStorage.setItem('govuk-step-nav-active-link_unique-id', 'definitelynotvalid');
+      stepnav.start($element);
+    });
+
+    afterEach(function () {
+      sessionStorage.removeItem('govuk-step-nav-active-link_unique-id');
+    });
+
+    it("highlights only one link", function () {
+      expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1);
+      expect($element.find(('.gem-c-step-nav__step--active')).length).toBe(1);
     });
   });
 
@@ -843,7 +885,7 @@ describe('A stepnav module', function () {
     });
 
     it("highlights the first active link if no sessionStorage value is set", function () {
-      expect(sessionStorage.getItem('govuk-step-nav-active-link')).toBe(null);
+      expect(sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe(null);
       expect($element.find('.js-link[data-position="2.1"]').closest('.js-list-item')).toHaveClass('gem-c-step-nav__list-item--active');
       expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1);
     });


### PR DESCRIPTION
The double dot problem occurs where a page occurs more than once in a single step by step navigation. The backend doesn't know which link was clicked, so we use JS to store the clicked link in sessionStorage, then work out which link and step to highlight when the page loads again based on that. The aims are:

- to ensure that no more than one link and one step are highlighted
- to ensure that the last link the user clicked on (assuming it is still in a step by step navigation) is the one that is highlighted

![screen shot 2018-07-17 at 16 24 41](https://user-images.githubusercontent.com/861310/42827295-f19e712a-89dd-11e8-99b2-23085b7adaa8.png)

This solution was previously implemented only to handle highlighting of the links themselves, but has been expanded to include the highlighting of the steps as well.

- now handles highlighting of both the links and the steps
- uses the step nav id to create a unique session store attribute, so cannot conflict with another step nav

---

- Trello card: https://trello.com/c/U3bgGMWy/722-incorrect-step-opened-by-default-when-same-link-appear-multiple-times-in-single-step-by-step
- Component guide for this PR:
https://govuk-publishing-compon-pr-432.herokuapp.com/component-guide/step_by_step_nav/solve_the_double_dot_problem
