### PR TITLE
Add select dropdown component based on design system select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add admin component for select (PR #434)
+
 ## 9.5.3
 
 * Improve metadata positioning in document list for rtl layouts (PR #429)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
@@ -1,0 +1,1 @@
+// This component relies on styles from GOV.UK Frontend

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -1,0 +1,17 @@
+<%
+  options ||= []
+  id ||= false
+  label ||= false
+%>
+<% if options.any? && id && label %>
+  <div class="govuk-form-group gem-c-select">
+    <label class="govuk-label" for="<%= id %>">
+      <%= label %>
+    </label>
+    <select class="govuk-select" id="<%= id %>" name="<%= id %>">
+      <% options.each do |option| %>
+        <option value="<%= option[:value] %>" <% if option[:selected] %>selected<% end %>><%= option[:text] %></option>
+      <% end %>
+    </select>
+  </div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -1,0 +1,35 @@
+name: Select (experimental)
+description: A dropdown select
+part_of_admin_layout: true
+govuk_frontend_components:
+  - select
+accessibility_criteria: |
+The component must:
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - indicate when it has focus
+examples:
+  default:
+    data:
+      id: 'dropdown1'
+      label: 'My Dropdown'
+      options:
+      - text: 'Option one'
+        value: 'option1'
+      - text: 'Option two'
+        value: 'option2'
+      - text: 'Option three'
+        value: 'option3'
+  with_preselect:
+    data:
+      id: 'dropdown2'
+      label: 'My Dropdown'
+      options:
+      - text: 'Option one'
+        value: 'option1'
+      - text: 'Option two'
+        value: 'option2'
+        selected: true
+      - text: 'Option three'
+        value: 'option3'

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+describe "Select", type: :view do
+  def component_name
+    "select"
+  end
+
+  it "does not render anything if no data is passed" do
+    assert_empty render_component({})
+  end
+
+  it "does not render if items are passed but no id is passed" do
+    assert_empty render_component(label: 'My label',
+        options: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        }
+      ])
+  end
+
+  it "does not render if items are passed but no label is passed" do
+    assert_empty render_component(id: 'mydropdown',
+        options: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        }
+      ])
+  end
+
+
+  it "does not render if no items are passed" do
+    assert_empty render_component(id: 'mydropdown', label: "My label", options: [])
+  end
+
+  it "renders a select box with one item" do
+    render_component(
+      id: "mydropdown",
+      label: "My dropdown",
+      options: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        }
+      ]
+    )
+
+    assert_select "select[name=mydropdown]"
+    assert_select ".govuk-label[for=mydropdown]", text: "My dropdown"
+    assert_select ".govuk-select option[value=government-gateway]"
+  end
+
+  it "renders a select box with multiple items" do
+    render_component(
+      id: "mydropdown",
+      label: "My dropdown",
+      options: [
+        {
+          value: "big",
+          text: "Big"
+        },
+        {
+          value: "medium",
+          text: "Medium"
+        },
+        {
+          value: "small",
+          text: "Small"
+        }
+      ]
+    )
+
+    assert_select ".govuk-select option[value=big]"
+    assert_select ".govuk-select option[value=small]"
+    assert_select ".govuk-select option[value=medium]"
+  end
+
+  it "renders a select a preselected item" do
+    render_component(
+      id: "mydropdown",
+      label: "My dropdown",
+      options: [
+        {
+          value: "big",
+          text: "Big"
+        },
+        {
+          value: "medium",
+          text: "Medium",
+          selected: true
+        },
+        {
+          value: "small",
+          text: "Small"
+        }
+      ]
+    )
+
+    assert_select ".govuk-select option[value=medium][selected]"
+  end
+end


### PR DESCRIPTION
Only works in admin layout
https://trello.com/c/zW7BT3w9/28-add-select-dropdown-component

---

Component guide for this PR:
https://govuk-publishing-compon-pr-434.herokuapp.com/component-guide/select
