### PR TITLE
Remove redundant styles from contents list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove redundant styles from contents list (PR #436)
 * Add admin component for select (PR #434)
 
 ## 9.5.3

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -1,13 +1,7 @@
 @import "helpers/contents-list-helper";
 
 .gem-c-contents-list {
-  // Always render the contents list above a
-  // back to contents link
-  position: relative;
   margin-bottom: $gutter-two-thirds;
-  z-index: 1;
-  background: $white;
-  box-shadow: 0 20px 15px -10px $white;
 }
 
 .gem-c-contents-list--no-underline {


### PR DESCRIPTION
These styles (white background, box shadow and z index) were added prior to universal layout to ensure position fixed back to top link disappeared beneath the contents list in the left hand column. Both the layout and the contents list have now changed, so this CSS is no longer needed

---

Component guide for this PR:
https://govuk-publishing-compon-pr-436.herokuapp.com/component-guide/
