### PR TITLE
Update back-link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Update radio component to use GOV.UK Frontend styles (PR #433)
 * Update button component to use GOV.UK Frontend styles (PR #439)
+* Update back-link component to use GOV.UK Frontend styles (PR #440)
 
 ## 9.6.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -6,7 +6,7 @@
 @import "grid_layout";
 @import "typography";
 @import "colours";
-
+@import "components/helpers/variables";
 @import "components/helpers/brand-colours";
 
 @import "components/back-link";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_back-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_back-link.scss
@@ -1,33 +1,6 @@
-@import "helpers/variables";
+// This component relies on styles from GOV.UK Frontend
 
-.gem-c-back-link {
-  position: relative;
-  display: inline-block;
-  margin-top: $gem-spacing-scale-3;
-  margin-bottom: $gem-spacing-scale-3;
-  font-size: 16px;
-  line-height: 1.25;
+// Specify the functions used to resolve assets paths in SCSS
+$govuk-font-url-function: "font-url";
 
-  text-decoration: none;
-  border-bottom: 1px solid currentColor;
-
-  &:link,
-  &:link:focus,
-  &:visited,
-  &:active {
-    color: currentColor;
-  }
-
-  &:hover {
-    color: $link-colour;
-  }
-
-  &::before {
-    content: "";
-    display: inline-block;
-    margin-right: .3em;
-    border-top: 0.3125em solid transparent;
-    border-right: 0.375em solid currentColor;
-    border-bottom: 0.3125em solid transparent;
-  }
-}
+@import "../../../../node_modules/govuk-frontend/components/back-link/back-link";

--- a/app/views/govuk_publishing_components/components/_back_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_back_link.html.erb
@@ -1,6 +1,7 @@
-<a
-  class="gem-c-back-link"
-  href="<%= href %>"
->
-  <%= t('components.back_link.back') %>
-</a>
+<%= link_to t('components.back_link.back'),
+  href,
+  class: %w(
+    gem-c-back-link
+    govuk-back-link
+  )
+ %>

--- a/spec/components/back_link_spec.rb
+++ b/spec/components/back_link_spec.rb
@@ -13,11 +13,11 @@ describe "Back Link", type: :view do
 
   it "renders a back link correctly" do
     render_component(href: '/back-me')
-    assert_select ".gem-c-back-link[href=\"/back-me\"]", text: "Back"
+    assert_select ".govuk-back-link[href=\"/back-me\"]", text: "Back"
   end
 
   it "can render in welsh" do
     I18n.with_locale(:cy) { render_component(href: '/back-me') }
-    assert_select ".gem-c-back-link[href=\"/back-me\"]", text: "Yn ôl"
+    assert_select ".govuk-back-link[href=\"/back-me\"]", text: "Yn ôl"
   end
 end


### PR DESCRIPTION
The font style for this component is currently coming from govuk_template. This PR updates the component to use GOV.UK Frontend styles which also extends component's compatibility (the left chevron) down to IE8.

### Before
&nbsp;&nbsp;<img width="71" alt="screen shot 2018-07-25 at 12 35 39" src="https://user-images.githubusercontent.com/788096/43198645-4f1352b0-9007-11e8-95df-d567d27d70ed.png">

### After
<img width="74" alt="screen shot 2018-07-25 at 12 36 28" src="https://user-images.githubusercontent.com/788096/43198673-5f353fb4-9007-11e8-8e60-4cc7806398d4.png">

---

Component guide for this PR:
https://govuk-publishing-compon-pr-440.herokuapp.com/component-guide/back-link
