### PR TITLE
Add conditional reveal support for radios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update radio component to use GOV.UK Frontend styles (PR #433)
 * Update button component to use GOV.UK Frontend styles (PR #439)
 * Update back-link component to use GOV.UK Frontend styles (PR #440)
+* Add conditional reveal support for radios using GOV.UK Frontend scripts (PR #441)
 
 ## 9.6.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/radio.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/radio.js
@@ -1,0 +1,32 @@
+// This component relies on JavaScript from GOV.UK Frontend
+//= require components/radios/radios.js
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.FrontendModules = window.GOVUK.FrontendModules || {};
+
+(function (global, GOVUK) {
+  'use strict'
+
+  /**
+   * TODO: Ideally this would be a NodeList.prototype.forEach polyfill
+   *
+   * See: https://github.com/imagitama/nodelist-foreach-polyfill
+   * but the polyfill doesn't work in IE8 and needs more investigation
+   */
+  function nodeListForEach (nodes, callback) {
+    if (window.NodeList.prototype.forEach) {
+      return nodes.forEach(callback)
+    }
+    for (var i = 0; i < nodes.length; i++) {
+      callback.call(window, nodes[i], i, nodes)
+    }
+  }
+
+  GOVUK.FrontendModules.Radios = window.GOVUKFrontend
+
+  var $radios = document.querySelectorAll('[data-module="radios"]')
+
+  nodeListForEach($radios, function ($radio) {
+    new GOVUK.FrontendModules.Radios($radio).init()
+  })
+})(window, window.GOVUK)

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -1,9 +1,15 @@
 <%
   id_prefix ||= "radio-#{SecureRandom.hex(4)}"
   items ||= []
+
+  # check if any item is set as being conditional
+  has_conditional = items.any? { |item| item["conditional"] }
 %>
 <%= content_tag :div, class: "govuk-form-group" do %>
-  <%= content_tag :div, class: "govuk-radios" do %>
+  <%= content_tag :div, class: "govuk-radios",
+    data: {
+      module: ('radios' if has_conditional)
+    } do %>
     <% items.each_with_index do |item, index| %>
       <% if item === :or %>
         <div class="govuk-radios__divider">
@@ -14,6 +20,7 @@
           item_next = items[index + 1] unless index === items.size - 1
           label_id = item[:id] ? item[:id] : "#{id_prefix}-#{index}"
           label_hint_id = "label-hint-#{SecureRandom.hex(4)}" if item[:hint_text].present?
+          conditional_id = "conditional-#{SecureRandom.hex(4)}" if item[:conditional].present?
         %>
         <%= tag.div class: %w(
           gem-c-radio
@@ -28,6 +35,9 @@
               type: "radio",
               aria: {
                 describedby: label_hint_id
+              },
+              data: {
+                "aria-controls": conditional_id
               }
             }
           %>
@@ -42,6 +52,13 @@
             bold: item[:bold]
           } %>
         <% end %>
+
+        <% if item[:conditional] %>
+        <div class="govuk-radios__conditional" id="<%= conditional_id %>">
+          <%= item[:conditional] %>
+        </div>
+        <% end %>
+
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -1,9 +1,9 @@
 name: Radio button
 description: A radio button is a GOV.UK element that allows users to answer a question by selecting an option. If you have a question with more than one option you should stack radio buttons.
 body: |
-  Forked from the upcoming [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend), when GOV.UK Frontend release we can replace these source files.
+  You can also use 'or' as an item to break up radios.
 
-  You can also use 'or' as an item to [break up radios](https://www.gov.uk/service-manual/design/writing-for-user-interfaces#ask-questions-that-users-can-understand)
+  If JavaScript is disabled a conditionally revealed content expands fully. All of the functionality (including aria attributes) are added using JavaScript.
 accessibility_criteria: |
   Radio buttons should
 
@@ -32,6 +32,7 @@ accessibility_criteria: |
 
 accessibility_excluded_rules:
 - radiogroup # Since this is in isolation we don't want to wrap a fieldset here.
+- aria-expanded # We use aria expanded to reflect the state of a conditionally revealed radio content even if this attribute is not officially supported on this element.
 examples:
   default:
     data:
@@ -117,3 +118,14 @@ examples:
         hint_text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sapien justo, lobortis elementum tortor in, luctus interdum turpis. Nam sit amet nulla nec arcu condimentum dapibus quis varius metus. Suspendisse cursus tristique diam et vestibulum. Proin nec lacinia tortor. Morbi at nisi id lorem aliquam ullamcorper. Pellentesque laoreet sit amet leo sodales ultricies. Suspendisse maximus efficitur odio in tristique."
         text: "Quisque tincidunt venenatis bibendum. Morbi volutpat magna euismod ipsum consequat cursus. Etiam bibendum interdum ultricies."
         bold: true
+  conditional:
+    data:
+      name: "radio-group-conditional"
+      id_prefix: "conditional"
+      items:
+      - value: "government-gateway"
+        text: "Use Government Gateway"
+        conditional: "You’ll need to prove your identity using Government Gateway"
+      - value: "govuk-verify"
+        text: "Use GOV.UK Verify"
+        conditional: "You’ll need to prove your identity using GOV.UK Verify"

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -161,6 +161,26 @@ describe "Radio", type: :view do
     assert_select ".govuk-radios__item:last-child .gem-c-radio__label__text", text: "Use GOV.UK Verify"
   end
 
+  it "renders radio-group with conditionally revealed content" do
+    render_component(
+      name: "radio-group-conditional",
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway",
+          conditional: "You’ll need to prove your identity using Government Gateway"
+        },
+        {
+          value: "govuk-verify",
+          text: "Use GOV.UK Verify",
+          conditional: "You’ll need to prove your identity using GOV.UK Verify"
+        }
+      ]
+    )
+
+    assert_select ".govuk-radios__conditional", text: "You’ll need to prove your identity using Government Gateway"
+  end
+
   it "renders radio-group with welsh translated 'or'" do
     I18n.with_locale(:cy) do
       render_component(


### PR DESCRIPTION
This PR adds conditional reveal support for radios using GOV.UK Frontend scripts.

### Integration
Because GOV.UK Frontend components are not compatible (they are being initialised differently) with the `GOVUK.Modules` script, I attached them to a `GOVUK.FrontendModules` global.

For example the Radios script can be accessed via `GOVUK.FrontendModules.Radios`.

### Cross-browser support
This PR also contains a `nodeListForEach` utility function to iterate through each module instance on the page (if multiple). This could potentially be replaced by a Polyfill and placed at a higher lever to be shared between components.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-441.herokuapp.com/component-guide/radio/conditional/preview
