### PR TITLE
Update input component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -1,34 +1,6 @@
-// scss-lint:disable QualifyingElement
-.gem-c-input,
+// This component relies on styles from GOV.UK Frontend
 
-// Explicitly set the input type so that we have higher specificity than
-// https://github.com/alphagov/static/blob/79d29b6a4221874ead27e67d007704a6be166a57/app/assets/stylesheets/helpers/_buttons.scss#L91-L122
-// This can be removed once everything is using `core_layout`.
-input[type=text].gem-c-input {
-  @include core-19;
+// Specify the functions used to resolve assets paths in SCSS
+$govuk-font-url-function: "font-url";
 
-  box-sizing: border-box;
-  width: 100%;
-  height: 2.10526em;
-
-  margin: 0; // Override unwanted global cascaded styles
-  margin-bottom: 20px;
-
-  padding: $gem-spacing-scale-1;
-  // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
-  // as background-color and color need to always be set together, color should not be set either
-  border: $gem-border-width-form-element solid;
-  border-radius: 0;
-
-  // Disable inner shadow and remove rounded corners
-  appearance: none;
-
-  &.gem-c-input:focus {
-    outline: $gem-focus-width solid $gem-focus-colour;
-  }
-
-  &.gem-c-input--error {
-    border: $gem-border-width-error solid $gem-error-colour;
-  }
-}
-// scss-lint:enable QualifyingElement
+@import "../../../../node_modules/govuk-frontend/components/input/input";

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -1,35 +1,41 @@
 <%
   id ||= "input-#{SecureRandom.hex(4)}"
   hint_id ||= "hint-#{SecureRandom.hex(4)}"
-  value ||= false
+  value ||= nil
   error_message ||= false
   label ||= {}
   type ||= "text"
   describedby ||= false
+  ariadescribedby ||= nil
+  css_classes = %w(gem-c-input govuk-input)
+  css_classes << "govuk-input--error" if error_message
+
+  if error_message
+    ariadescribedby = hint_id
+  elsif describedby
+    ariadescribedby = describedby
+  end
 %>
 
-<%= render "govuk_publishing_components/components/label", {
-  text: label[:text],
-  html_for: id,
-  hint_text: error_message,
-  hint_text_classes: "gem-c-label__error",
-  hint_id: hint_id,
-  bold: error_message ? true : false,
-} %>
+<%= content_tag :div, class: "govuk-form-group" do %>
+  <%= render "govuk_publishing_components/components/label", {
+    text: label[:text],
+    html_for: id,
+    hint_text: error_message,
+    hint_text_classes: "gem-c-label__error",
+    hint_id: hint_id,
+    bold: error_message ? true : false,
+  } %>
 
-<input
-  class="gem-c-input <%= "gem-c-input--error" if error_message %>"
-  id="<%= id %>"
-  name="<%= name %>"
-  type="<%= type %>"
-
-  <% if error_message %>
-    aria-describedby="<%= hint_id %>"
-  <% elsif describedby %>
-    aria-describedby="<%= describedby %>"
-  <% end %>
-
-  <% if value %>
-    value="<%= value %>"
-  <% end %>
->
+  <%= text_field_tag name,
+    value,
+    {
+      class: css_classes,
+      id: id,
+      type: type,
+      aria: {
+        describedby: ariadescribedby
+      }
+    }
+  %>
+<% end %>

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -17,8 +17,8 @@ describe "Input", type: :view do
       name: "email-address",
     )
 
-    assert_select ".gem-c-input[type='text']"
-    assert_select ".gem-c-input[name='email-address']"
+    assert_select ".govuk-input[type='text']"
+    assert_select ".govuk-input[name='email-address']"
 
     assert_select ".gem-c-label", text: "What is your email address?"
   end
@@ -29,14 +29,14 @@ describe "Input", type: :view do
       type: "email",
     )
 
-    assert_select ".gem-c-input[type='email']"
-    assert_select ".gem-c-input[name='email-address']"
+    assert_select ".govuk-input[type='email']"
+    assert_select ".govuk-input[name='email-address']"
   end
 
   it "sets the 'for' on the label to the input id" do
     render_component(name: "email-address")
 
-    input = css_select(".gem-c-input")
+    input = css_select(".govuk-input")
     input_id = input.attr("id").text
 
     assert_select ".gem-c-label__text[for='#{input_id}']"
@@ -48,7 +48,7 @@ describe "Input", type: :view do
       value: "example@example.com",
     )
 
-    assert_select ".gem-c-input[value='example@example.com']"
+    assert_select ".govuk-input[value='example@example.com']"
   end
 
   it "renders inputs with an aria-describedby if provided" do
@@ -58,7 +58,7 @@ describe "Input", type: :view do
       describedby: "some-other-element"
     )
 
-    assert_select ".gem-c-input[aria-describedby='some-other-element']"
+    assert_select ".govuk-input[aria-describedby='some-other-element']"
   end
 
   context "when an error_message is provided" do
@@ -82,7 +82,7 @@ describe "Input", type: :view do
       hint = css_select(".gem-c-label__hint")
       hint_id = hint.attr("id").text
 
-      assert_select ".gem-c-input[aria-describedby='#{hint_id}']"
+      assert_select ".govuk-input[aria-describedby='#{hint_id}']"
     end
   end
 
@@ -98,7 +98,7 @@ describe "Input", type: :view do
     end
 
     it "does not set the 'aria-describedby' on the input" do
-      input = css_select(".gem-c-input")
+      input = css_select(".govuk-input")
       expect(input.attr("aria-describedby")).to be_nil
     end
   end


### PR DESCRIPTION
This PR:
 - updates the Form input component to use GOV.UK Frontend styles
 - uses Rails helpers to generate markup

---

Component guide for this PR:
https://govuk-publishing-compon-pr-442.herokuapp.com/component-guide/input
