### PR TITLE
Update label component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_label.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_label.scss
@@ -1,26 +1,6 @@
-@import "helpers/variables";
+// This component relies on styles from GOV.UK Frontend
 
-.gem-c-label {
-  display: block;
-  color: $gem-text-colour;
-  @include core-19;
-}
+// Specify the functions used to resolve assets paths in SCSS
+$govuk-font-url-function: "font-url";
 
-.gem-c-label--bold,
-.gem-c-label__text--bold {
-  font-weight: 700;
-}
-
-// Hint text sits inside a label, to be read by AT
-.gem-c-label__hint {
-  display: block;
-  color: $gem-secondary-text-colour;
-  font-weight: 400;
-}
-
-// TODO: Replace this with the error message component.
-.gem-c-label__error {
-  font-weight: bold;
-  color: $gem-error-colour;
-  padding-top: 4px;
-}
+@import "../../../../node_modules/govuk-frontend/components/label/label";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
@@ -18,3 +18,13 @@ $govuk-font-url-function: "font-url";
   margin-bottom: govuk-spacing(2);
   text-align: center;
 }
+
+// Hint for radios support
+// https://github.com/alphagov/govuk-frontend/pull/846/files
+//
+// Remove this after updating to GOV.UK Frontend 1.2.0
+.govuk-radios__hint {
+  display: block;
+  padding-right: 15px;
+  padding-left: 15px;
+}

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -9,6 +9,7 @@
   ariadescribedby ||= nil
   css_classes = %w(gem-c-input govuk-input)
   css_classes << "govuk-input--error" if error_message
+  hint_text_css_classes = "govuk-error-message" if error_message
 
   if error_message
     ariadescribedby = hint_id
@@ -22,7 +23,7 @@
     text: label[:text],
     html_for: id,
     hint_text: error_message,
-    hint_text_classes: "gem-c-label__error",
+    hint_text_classes: hint_text_css_classes,
     hint_id: hint_id,
     bold: error_message ? true : false,
   } %>

--- a/app/views/govuk_publishing_components/components/_label.html.erb
+++ b/app/views/govuk_publishing_components/components/_label.html.erb
@@ -1,40 +1,21 @@
 <%
   classes ||= ''
-  text_classes ||= ''
-  hint_text_classes ||= ''
   hint_text ||= ''
+  hint_text_classes ||= ''
   bold ||= false
+  css_classes = %w( gem-c-label govuk-label )
+  css_classes << "govuk-label--s" if bold
+  css_classes << classes if classes
+  hint_text_css_classes = %w( govuk-hint )
+  hint_text_css_classes << hint_text_classes if hint_text_classes
 %>
 
+<%= tag.label for: html_for, class: css_classes do %>
+  <%= text %>
+<% end %>
 
-<div
-  class="
-    gem-c-label
-    <%= "gem-c-label--bold" if bold %>
-    <%= classes if classes %>
-  "
->
-  <label
-    class="
-      gem-c-label__text
-      <%= "gem-c-label__text--bold" if bold %>
-      <%= text_classes if text_classes %>
-    "
-    <% if html_for %>
-      for="<%= html_for %>"
-    <% end %>
-  >
-    <%= text %>
-  </label>
-  <% if hint_text.present? %>
-    <span
-      class="
-        gem-c-label__hint
-        <%= hint_text_classes if hint_text_classes %>
-      "
-      id="<%= hint_id %>"
-    >
-      <%= hint_text %>
-    </span>
+<% if hint_text.present? %>
+  <%= tag.span id: hint_id, class: hint_text_css_classes do %>
+    <%= hint_text %>
   <% end %>
-</div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -22,10 +22,7 @@
           label_hint_id = "label-hint-#{SecureRandom.hex(4)}" if item[:hint_text].present?
           conditional_id = "conditional-#{SecureRandom.hex(4)}" if item[:conditional].present?
         %>
-        <%= tag.div class: %w(
-          gem-c-radio
-          govuk-radios__item
-        ) do %>
+        <%= tag.div class: %w( gem-c-radio govuk-radios__item ) do %>
           <%= check_box_tag name,
             item[:value],
             item[:checked],
@@ -44,9 +41,8 @@
           <%= render "govuk_publishing_components/components/label", {
             hint_id: label_hint_id,
             html_for: label_id,
-            classes: "govuk-label govuk-radios__label",
-            text_classes: "gem-c-radio__label__text",
-            hint_text_classes: "gem-c-radio__label__hint",
+            classes: "govuk-radios__label",
+            hint_text_classes: "govuk-radios__hint",
             hint_text: item[:hint_text],
             text: item[:text],
             bold: item[:bold]

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -20,7 +20,7 @@ describe "Input", type: :view do
     assert_select ".govuk-input[type='text']"
     assert_select ".govuk-input[name='email-address']"
 
-    assert_select ".gem-c-label", text: "What is your email address?"
+    assert_select ".govuk-label", text: "What is your email address?"
   end
 
   it "renders inputs with a configurable type" do
@@ -39,7 +39,7 @@ describe "Input", type: :view do
     input = css_select(".govuk-input")
     input_id = input.attr("id").text
 
-    assert_select ".gem-c-label__text[for='#{input_id}']"
+    assert_select ".govuk-label[for='#{input_id}']"
   end
 
   it "sets the value when provided" do
@@ -71,15 +71,15 @@ describe "Input", type: :view do
     end
 
     it "renders the error message as the label's hint" do
-      assert_select ".gem-c-label__hint", text: "Please enter a valid email address"
+      assert_select ".govuk-hint", text: "Please enter a valid email address"
     end
 
     it "makes the label bold" do
-      assert_select ".gem-c-label--bold"
+      assert_select ".govuk-label--s"
     end
 
     it "sets the 'aria-describedby' on the input to the hint id and overrides a describedby parameter" do
-      hint = css_select(".gem-c-label__hint")
+      hint = css_select(".govuk-hint")
       hint_id = hint.attr("id").text
 
       assert_select ".govuk-input[aria-describedby='#{hint_id}']"
@@ -90,11 +90,11 @@ describe "Input", type: :view do
     before { render_component(name: "email-address") }
 
     it "does not render the label's hint" do
-      assert_select ".gem-c-label__hint", count: 0
+      assert_select ".govuk-hint", count: 0
     end
 
     it "does not make the label bold" do
-      assert_select ".gem-c-label--bold", count: 0
+      assert_select ".govuk-label--s", count: 0
     end
 
     it "does not set the 'aria-describedby' on the input" do

--- a/spec/components/label_spec.rb
+++ b/spec/components/label_spec.rb
@@ -18,7 +18,7 @@ describe "Label", type: :view do
     )
 
     assert_select(
-      ".gem-c-label__text[for='id-that-matches-input']",
+      ".govuk-label[for='id-that-matches-input']",
       text: "National Insurance number"
     )
   end
@@ -32,11 +32,11 @@ describe "Label", type: :view do
     )
 
     assert_select(
-      ".gem-c-label__text[for='id-that-matches-input']",
+      ".govuk-label[for='id-that-matches-input']",
       text: "National Insurance number"
     )
-    assert_select ".gem-c-label__hint", text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
-    assert_select ".gem-c-label__hint[id=should-match-aria-describedby-input]"
+    assert_select ".govuk-hint", text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    assert_select ".govuk-hint[id=should-match-aria-describedby-input]"
   end
 
   it "renders label with bold text" do
@@ -47,9 +47,9 @@ describe "Label", type: :view do
     )
 
     assert_select(
-      ".gem-c-label__text[for='id-that-matches-input']",
+      ".govuk-label[for='id-that-matches-input']",
       text: "National Insurance number"
     )
-    assert_select ".gem-c-label__text--bold"
+    assert_select ".govuk-label--s"
   end
 end

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -28,7 +28,7 @@ describe "Radio", type: :view do
     )
 
     assert_select ".govuk-radios__input[name=radio-group-one-item]"
-    assert_select ".govuk-radios__item:first-child .gem-c-radio__label__text", text: "Use Government Gateway"
+    assert_select ".govuk-radios__item:first-child .govuk-radios__label", text: "Use Government Gateway"
   end
 
   it "renders radio-group with multiple items" do
@@ -47,8 +47,8 @@ describe "Radio", type: :view do
     )
 
     assert_select ".govuk-radios__input[name=radio-group-multiple-items]"
-    assert_select ".govuk-radios__item:first-child .gem-c-radio__label__text", text: "Use Government Gateway"
-    assert_select ".govuk-radios__item:last-child .gem-c-radio__label__text", text: "Use GOV.UK Verify"
+    assert_select ".govuk-radios__item:first-child .govuk-radios__label", text: "Use Government Gateway"
+    assert_select ".govuk-radios__item:last-child .govuk-radios__label", text: "Use GOV.UK Verify"
   end
 
   it "renders radio-group with bold labels" do
@@ -69,7 +69,7 @@ describe "Radio", type: :view do
     )
 
     assert_select ".govuk-radios__input[name=radio-group-bold-labels]"
-    assert_select ".govuk-radios__item .gem-c-label--bold"
+    assert_select ".govuk-radios__item .govuk-label--s"
   end
 
   it "renders radio-group with hint text" do
@@ -90,10 +90,10 @@ describe "Radio", type: :view do
     )
 
     assert_select ".govuk-radios__input[name=radio-group-hint-text]"
-    assert_select ".govuk-radios__item:first-child .gem-c-radio__label__text", text: "Use Government Gateway"
-    assert_select ".govuk-radios__item:first-child .gem-c-label__hint", text: "You'll have a user ID if you've signed up to do things like sign up Self Assessment tax return online."
-    assert_select ".govuk-radios__item:last-child .gem-c-radio__label__text", text: "Use GOV.UK Verify"
-    assert_select ".govuk-radios__item:last-child .gem-c-label__hint", text: "You'll have an account if you've already proved your identity with a certified company, such as the Post Office."
+    assert_select ".govuk-radios__item:first-child .govuk-radios__label", text: "Use Government Gateway"
+    assert_select ".govuk-radios__item:first-child .govuk-hint", text: "You'll have a user ID if you've signed up to do things like sign up Self Assessment tax return online."
+    assert_select ".govuk-radios__item:last-child .govuk-radios__label", text: "Use GOV.UK Verify"
+    assert_select ".govuk-radios__item:last-child .govuk-hint", text: "You'll have an account if you've already proved your identity with a certified company, such as the Post Office."
   end
 
   it "renders radio-group with checked option" do
@@ -134,9 +134,9 @@ describe "Radio", type: :view do
 
     assert_select ".govuk-radios__input[name=radio-group-custom-id-prefix]"
     assert_select ".govuk-radios__input[id=custom-0]", value: "government-gateway"
-    assert_select ".gem-c-radio__label__text[for=custom-0]", text: "Use Government Gateway"
+    assert_select ".govuk-radios__label[for=custom-0]", text: "Use Government Gateway"
     assert_select ".govuk-radios__input[id=custom-1]", value: "govuk-verify"
-    assert_select ".gem-c-radio__label__text[for=custom-1]", text: "Use GOV.UK Verify"
+    assert_select ".govuk-radios__label[for=custom-1]", text: "Use GOV.UK Verify"
   end
 
   it "renders radio-group with or divider" do
@@ -156,9 +156,9 @@ describe "Radio", type: :view do
     )
 
     assert_select ".govuk-radios__input[name=radio-group-or-divider]"
-    assert_select ".govuk-radios__item:first-child .gem-c-radio__label__text", text: "Use Government Gateway"
+    assert_select ".govuk-radios__item:first-child .govuk-radios__label", text: "Use Government Gateway"
     assert_select ".govuk-radios__divider", text: "or"
-    assert_select ".govuk-radios__item:last-child .gem-c-radio__label__text", text: "Use GOV.UK Verify"
+    assert_select ".govuk-radios__item:last-child .govuk-radios__label", text: "Use GOV.UK Verify"
   end
 
   it "renders radio-group with conditionally revealed content" do


### PR DESCRIPTION
This PR:
- updates the [label component](https://govuk-publishing-compon-pr-443.herokuapp.com/component-guide/label) to use GOV.UK Frontend styles
- updates the [radio component](https://govuk-publishing-compon-pr-443.herokuapp.com/component-guide/radio) to use the new label component
- updates the [input component](https://govuk-publishing-compon-pr-443.herokuapp.com/component-guide/input) to use the new label component

Notes:
This PR does not handle the hint and error message updates which will be part of a new PR.
Recommend review commit-by-commit.

[Trello card](https://trello.com/c/nONqbbzg)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-443.herokuapp.com/component-guide/