### PR TITLE
Upgrade to GOV.UK Frontend 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Update button component to use GOV.UK Frontend styles (PR #439)
 * Update back-link component to use GOV.UK Frontend styles (PR #440)
 * Add conditional reveal support for radios using GOV.UK Frontend scripts (PR #441)
+* Upgrade to the latest version of the Design System (PR #444)
 
 ## 9.6.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -10,14 +10,6 @@
   border-bottom-color: govuk-colour("grey-1");
 }
 
-// Fix header component's reliance on markup whitespace
-// https://github.com/alphagov/govuk-frontend/pull/884/files
-//
-// Remove this fix after updating to GOV.UK Frontend 1.1.0
-.govuk-header__container {
-  @include govuk-clearfix;
-}
-
 .govuk-header__logo {
   @include mq ($from: desktop) {
     float: left;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
@@ -5,26 +5,3 @@ $govuk-image-url-function: "image-url";
 $govuk-font-url-function: "font-url";
 
 @import "../../../../node_modules/govuk-frontend/components/radios/radios";
-
-// Radios divider support
-// https://github.com/alphagov/govuk-frontend/pull/849/files
-//
-// Remove this after updating to GOV.UK Frontend 1.2.0
-.govuk-radios__divider {
-  $govuk-radios-size: govuk-spacing(7);
-  $govuk-divider-size: $govuk-radios-size !default;
-  @include govuk-font($size: 19);
-  width: $govuk-divider-size;
-  margin-bottom: govuk-spacing(2);
-  text-align: center;
-}
-
-// Hint for radios support
-// https://github.com/alphagov/govuk-frontend/pull/846/files
-//
-// Remove this after updating to GOV.UK Frontend 1.2.0
-.govuk-radios__hint {
-  display: block;
-  padding-right: 15px;
-  padding-left: 15px;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "govuk-frontend": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-1.0.0.tgz",
-      "integrity": "sha512-4qCRrwGEcDC0ybjb5lls3P8tDgM8/hpTy2Mesgp1wa1/HdtlXtShj0E0H41lkXNrX7ZQOoDCc4gUEoOgZD+QfA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-1.2.0.tgz",
+      "integrity": "sha512-pHKghu9J1nB7F/MKpiYaimPoJXUJdmMZUGuORv9K1Ek1sVNdTRlEKR+rogpfR4GkroS0tS1LMwQJrQkiCvxIIw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "govuk-frontend": "^1.0.0"
+    "govuk-frontend": "^1.2.0"
   }
 }


### PR DESCRIPTION
Changes:

- https://github.com/alphagov/govuk-frontend/releases/tag/v1.1.0
- https://github.com/alphagov/govuk-frontend/releases/tag/v1.1.1
- https://github.com/alphagov/govuk-frontend/releases/tag/v1.2.0