### PR TITLE
Version 9.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 9.7.0
 
 * Update radio component to use GOV.UK Frontend styles (PR #433)
 * Update button component to use GOV.UK Frontend styles (PR #439)
 * Update back-link component to use GOV.UK Frontend styles (PR #440)
 * Add conditional reveal support for radios using GOV.UK Frontend scripts (PR #441)
+* Update input component to use GOV.UK Frontend styles (PR #442)
+* Update label component to use GOV.UK Frontend styles (PR #443)
 * Upgrade to the latest version of the Design System (PR #444)
 
 ## 9.6.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (9.6.0)
+    govuk_publishing_components (9.7.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -116,7 +116,7 @@ GEM
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
       unicorn (~> 5.4.0)
-    govuk_frontend_toolkit (7.5.0)
+    govuk_frontend_toolkit (7.6.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_schemas (3.1.0)
@@ -260,7 +260,7 @@ GEM
       rubocop (>= 0.51.0)
     ruby-progressbar (1.9.0)
     safe_yaml (1.0.4)
-    sanitize (4.6.5)
+    sanitize (4.6.6)
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
       nokogumbo (~> 1.4)
@@ -307,7 +307,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     unicode-display_width (1.3.0)
-    unicorn (5.4.0)
+    unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     webmock (3.0.1)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '9.6.0'.freeze
+  VERSION = '9.7.0'.freeze
 end


### PR DESCRIPTION
## 9.7.0

* Update radio component to use GOV.UK Frontend styles (PR #433)
* Update button component to use GOV.UK Frontend styles (PR #439)
* Update back-link component to use GOV.UK Frontend styles (PR #440)
* Add conditional reveal support for radios using GOV.UK Frontend scripts (PR #441)
* Update input component to use GOV.UK Frontend styles (PR #442)
* Update label component to use GOV.UK Frontend styles (PR #443)
* Upgrade to the latest version of the Design System (PR #444)
