### PR TITLE
Add error message and hint

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-message.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-message.scss
@@ -1,0 +1,6 @@
+// This component relies on styles from GOV.UK Frontend
+
+// Specify the functions used to resolve assets paths in SCSS
+$govuk-font-url-function: "font-url";
+
+@import "../../../../node_modules/govuk-frontend/components/error-message/error-message";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_hint.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_hint.scss
@@ -1,0 +1,6 @@
+// This component relies on styles from GOV.UK Frontend
+
+// Specify the functions used to resolve assets paths in SCSS
+$govuk-font-url-function: "font-url";
+
+@import "../../../../node_modules/govuk-frontend/components/hint/hint";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -4,3 +4,4 @@
 $govuk-font-url-function: "font-url";
 
 @import "../../../../node_modules/govuk-frontend/components/input/input";
+@import "../../../../node_modules/govuk-frontend/objects/form-group";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
@@ -5,3 +5,4 @@ $govuk-image-url-function: "image-url";
 $govuk-font-url-function: "font-url";
 
 @import "../../../../node_modules/govuk-frontend/components/radios/radios";
+@import "../../../../node_modules/govuk-frontend/objects/form-group";

--- a/app/views/govuk_publishing_components/components/_error_message.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_message.html.erb
@@ -1,0 +1,10 @@
+<%
+  id ||= "error-message-#{SecureRandom.hex(4)}"
+  classes ||= ''
+  css_classes = %w( gem-c-error-message govuk-error-message )
+  css_classes << classes if classes
+%>
+
+<%= tag.span id: id, class: css_classes do %>
+  <%= text %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_hint.html.erb
+++ b/app/views/govuk_publishing_components/components/_hint.html.erb
@@ -1,0 +1,10 @@
+<%
+  id ||= "hint-#{SecureRandom.hex(4)}"
+  classes ||= ''
+  css_classes = %w( gem-c-hint govuk-hint )
+  css_classes << classes if classes
+%>
+
+<%= tag.span id: id, class: css_classes do %>
+  <%= text %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -1,32 +1,52 @@
 <%
   id ||= "input-#{SecureRandom.hex(4)}"
-  hint_id ||= "hint-#{SecureRandom.hex(4)}"
   value ||= nil
-  error_message ||= false
-  label ||= {}
   type ||= "text"
   describedby ||= false
-  ariadescribedby ||= nil
+
+  label ||= nil
+  hint ||= nil
+  error_message ||= nil
+  hint_id = "hint-#{SecureRandom.hex(4)}" if hint
+  error_message_id = "error-message-#{SecureRandom.hex(4)}" if error_message
+
   css_classes = %w(gem-c-input govuk-input)
   css_classes << "govuk-input--error" if error_message
-  hint_text_css_classes = "govuk-error-message" if error_message
+  form_group_css_classes = %w(govuk-form-group)
+  form_group_css_classes << "govuk-form-group--error" if error_message
 
-  if error_message
-    ariadescribedby = hint_id
-  elsif describedby
-    ariadescribedby = describedby
+  aria_described_by ||= nil
+  if hint || error_message || describedby
+    aria_described_by = []
+    aria_described_by << hint_id if hint
+    aria_described_by << error_message_id if error_message
+    aria_described_by << describedby if describedby
+    aria_described_by = aria_described_by.join(" ")
   end
+
 %>
 
-<%= content_tag :div, class: "govuk-form-group" do %>
-  <%= render "govuk_publishing_components/components/label", {
-    text: label[:text],
-    html_for: id,
-    hint_text: error_message,
-    hint_text_classes: hint_text_css_classes,
-    hint_id: hint_id,
-    bold: error_message ? true : false,
-  } %>
+<%= content_tag :div, class: form_group_css_classes do %>
+  <% if label %>
+    <%= render "govuk_publishing_components/components/label", {
+      text: label[:text],
+      html_for: id
+    } %>
+  <% end %>
+
+  <% if hint %>
+    <%= render "govuk_publishing_components/components/hint", {
+      id: hint_id,
+      text: hint
+    } %>
+  <% end %>
+
+  <% if error_message %>
+    <%= render "govuk_publishing_components/components/error_message", {
+      id: error_message_id,
+      text: error_message
+    } %>
+  <% end %>
 
   <%= text_field_tag name,
     value,
@@ -35,7 +55,7 @@
       id: id,
       type: type,
       aria: {
-        describedby: ariadescribedby
+        describedby: aria_described_by
       }
     }
   %>

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -2,10 +2,34 @@
   id_prefix ||= "radio-#{SecureRandom.hex(4)}"
   items ||= []
 
+  label ||= nil
+  hint ||= nil
+  error_message ||= nil
+  hint_id = "hint-#{SecureRandom.hex(4)}" if hint
+  error_message_id = "error-message-#{SecureRandom.hex(4)}" if error_message
+
+  form_group_css_classes = %w(govuk-form-group)
+  form_group_css_classes << "govuk-form-group--error" if error_message
+
   # check if any item is set as being conditional
   has_conditional = items.any? { |item| item["conditional"] }
 %>
-<%= content_tag :div, class: "govuk-form-group" do %>
+<%= content_tag :div, class: form_group_css_classes do %>
+
+  <% if hint %>
+    <%= render "govuk_publishing_components/components/hint", {
+      id: hint_id,
+      text: hint
+    } %>
+  <% end %>
+
+  <% if error_message %>
+    <%= render "govuk_publishing_components/components/error_message", {
+      id: error_message_id,
+      text: error_message
+    } %>
+  <% end %>
+
   <%= content_tag :div, class: "govuk-radios",
     data: {
       module: ('radios' if has_conditional)

--- a/app/views/govuk_publishing_components/components/docs/back_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/back_link.yml
@@ -4,6 +4,8 @@ accessibility_criteria: |
   - has a touch area easy for users to touch
 shared_accessibility_criteria:
 - link
+govuk_frontend_components:
+  - back-link
 examples:
   default:
     data:

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -3,11 +3,6 @@ description: Use buttons to move though a transaction, aim to use only one butto
 body: |
   Button text should be short and describe the action the button performs.
 
-  [GOV.UK Elements has more information](https://govuk-elements.herokuapp.com/buttons/) on how buttons should be used.
-
-  Note: We do not consume GOV.UK Elements directly due to the naming conventions being leaky,
-  in time this component will be a wrapper for the [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) project's button component.
-
   This component is also [extended for use in govspeak](https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/button).
 
   These instances of buttons are added by Content Designers, ideally this duplication would not exist but we currently don't have shared markup
@@ -23,6 +18,8 @@ accessibility_criteria: |
   - activate when focused and enter is pressed
   - have a role of button
   - have an accessible label
+govuk_frontend_components:
+  - button
 examples:
   default:
     data:

--- a/app/views/govuk_publishing_components/components/docs/error_message.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_message.yml
@@ -1,0 +1,16 @@
+name: Form error message
+description: Use error messages for any form fields.
+govuk_frontend_components:
+  - error-message
+accessibility_criteria: |
+  All text must have a contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+
+  Error message must:
+
+  - be associated with an input. The `error_message_id` must match the `aria-describedby` property on the input your label is associated with.
+
+  If error message is within a label it will be announced in its entirety by screen readers. By associating error messages with inputs using `aria-describedby`, then screen readers will read the label, describe the type of input (eg radio) and then read additional text. It means users of screen readers can scan and skip options as easy as people making choices with sight.
+examples:
+  default:
+    data:
+      text: "Please enter your National Insurance Number"

--- a/app/views/govuk_publishing_components/components/docs/hint.yml
+++ b/app/views/govuk_publishing_components/components/docs/hint.yml
@@ -1,0 +1,16 @@
+name: Form hint text
+description: Use hints for any form fields.
+govuk_frontend_components:
+  - hint
+accessibility_criteria: |
+  All text must have a contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+
+  Hint text must:
+
+  - be associated with an input. The `hint_id` must match the `aria-describedby` property on the input your label is associated with.
+
+  If hint text is within a label it will be announced in its entirety by screen readers. By associating hints with inputs using `aria-describedby`, then screen readers will read the label, describe the type of input (eg radio) and then read additional text. It means users of screen readers can scan and skip options as easy as people making choices with sight.
+examples:
+  default:
+    data:
+      text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -1,7 +1,5 @@
 name: Form input
 description: A form input field and an associated label.
-body: |
-  [Forked from GOV.UK Frontend](https://govuk-frontend-review.herokuapp.com/components/input)
 accessibility_criteria: |
   Inputs in the component must:
 
@@ -15,6 +13,8 @@ accessibility_criteria: |
   * be of the appropriate type for their use, e.g. password inputs should be of type 'password'
 
   Labels use the [label component](/component-guide/label).
+govuk_frontend_components:
+  - input
 examples:
   default:
     data:
@@ -38,6 +38,12 @@ examples:
         text: "This might not work"
       name: "labelledby"
       describedby: "wrapper"
+  with_hint:
+    data:
+      label:
+        text: "What is your name?"
+      name: "name"
+      hint: "Please provide your first and last name"
   with_error:
     data:
       label:

--- a/app/views/govuk_publishing_components/components/docs/label.yml
+++ b/app/views/govuk_publishing_components/components/docs/label.yml
@@ -2,8 +2,6 @@ name: Form label
 description: Use labels for all form fields.
 body: |
   For use with other form inputs e.g. [Radio buttons](/component-guide/radio)
-
-  Forked from the upcoming [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend), when GOV.UK Frontend release we can replace these source files.
 accessibility_criteria: |
   All text must have a contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
 
@@ -16,6 +14,8 @@ accessibility_criteria: |
   - be associated with an input. The `hint_id` must match the `aria-describedby` property on the input your label is associated with.
 
   If hint text is within a label it will be announced in its entirity by screen readers. By putting the hint alongside labels and associating hints with inputs using `aria-describedby`, then screen readers will read the label, describe the type of input (eg radio) and then read additional text. It means users of screen readers can scan and skip options as easy as people making choices with sight. [A discussion of this approach](https://github.com/alphagov/govuk_elements/issues/574).
+govuk_frontend_components:
+  - label
 examples:
   default:
     data:

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -1,5 +1,5 @@
-name: Radio button
-description: A radio button is a GOV.UK element that allows users to answer a question by selecting an option. If you have a question with more than one option you should stack radio buttons.
+name: Form radio button
+description: A radio button is an element that allows users to answer a question by selecting an option. If you have a question with more than one option you should stack radio buttons.
 body: |
   You can also use 'or' as an item to break up radios.
 
@@ -33,6 +33,8 @@ accessibility_criteria: |
 accessibility_excluded_rules:
 - radiogroup # Since this is in isolation we don't want to wrap a fieldset here.
 - aria-expanded # We use aria expanded to reflect the state of a conditionally revealed radio content even if this attribute is not officially supported on this element.
+govuk_frontend_components:
+  - radios
 examples:
   default:
     data:
@@ -118,6 +120,26 @@ examples:
         hint_text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sapien justo, lobortis elementum tortor in, luctus interdum turpis. Nam sit amet nulla nec arcu condimentum dapibus quis varius metus. Suspendisse cursus tristique diam et vestibulum. Proin nec lacinia tortor. Morbi at nisi id lorem aliquam ullamcorper. Pellentesque laoreet sit amet leo sodales ultricies. Suspendisse maximus efficitur odio in tristique."
         text: "Quisque tincidunt venenatis bibendum. Morbi volutpat magna euismod ipsum consequat cursus. Etiam bibendum interdum ultricies."
         bold: true
+  with_hint_on_form_group:
+    data:
+      name: "radio-group-error"
+      id_prefix: "hint"
+      hint: "You’ll need to prove your identity using one of the following methods"
+      items:
+      - value: "government-gateway"
+        text: "Use Government Gateway"
+      - value: "govuk-verify"
+        text: "Use GOV.UK Verify"
+  with_error_on_form_group:
+    data:
+      name: "radio-group-error"
+      id_prefix: "error"
+      error_message: "Please select one option"
+      items:
+      - value: "government-gateway"
+        text: "Use Government Gateway"
+      - value: "govuk-verify"
+        text: "Use GOV.UK Verify"
   conditional:
     data:
       name: "radio-group-conditional"

--- a/spec/components/error_message_spec.rb
+++ b/spec/components/error_message_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe "Error message", type: :view do
+  def component_name
+    "error_message"
+  end
+
+  it "renders error message" do
+    render_component(text: "Please enter your National Insurance number")
+
+    assert_select(".govuk-error-message", text: "Please enter your National Insurance number")
+  end
+end

--- a/spec/components/hint_spec.rb
+++ b/spec/components/hint_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe "Hint", type: :view do
+  def component_name
+    "hint"
+  end
+
+  it "renders hint" do
+    render_component(text: "For example, ‘QQ 12 34 56 C’.")
+
+    assert_select(".govuk-hint", text: "For example, ‘QQ 12 34 56 C’.")
+  end
+end

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -34,7 +34,10 @@ describe "Input", type: :view do
   end
 
   it "sets the 'for' on the label to the input id" do
-    render_component(name: "email-address")
+    render_component(
+      label: { text: "What is your email address?" },
+      name: "email-address"
+    )
 
     input = css_select(".govuk-input")
     input_id = input.attr("id").text
@@ -61,45 +64,41 @@ describe "Input", type: :view do
     assert_select ".govuk-input[aria-describedby='some-other-element']"
   end
 
-  context "when an error_message is provided" do
+  context "when a hint is provided" do
     before do
       render_component(
         name: "email-address",
-        error_message: "Please enter a valid email address",
-        describedby: "some-other-element"
+        hint: "Please enter a valid email address",
       )
     end
 
-    it "renders the error message as the label's hint" do
+    it "renders the hint" do
       assert_select ".govuk-hint", text: "Please enter a valid email address"
     end
 
-    it "makes the label bold" do
-      assert_select ".govuk-label--s"
-    end
-
-    it "sets the 'aria-describedby' on the input to the hint id and overrides a describedby parameter" do
-      hint = css_select(".govuk-hint")
-      hint_id = hint.attr("id").text
+    it "has 'aria-describedby' the hint id" do
+      hint_id = css_select(".govuk-hint").attr("id")
 
       assert_select ".govuk-input[aria-describedby='#{hint_id}']"
     end
   end
 
-  context "when an error_message is not provided" do
-    before { render_component(name: "email-address") }
-
-    it "does not render the label's hint" do
-      assert_select ".govuk-hint", count: 0
+  context "when an error_message is provided" do
+    before do
+      render_component(
+        name: "email-address",
+        error_message: "Please enter a valid email address",
+      )
     end
 
-    it "does not make the label bold" do
-      assert_select ".govuk-label--s", count: 0
+    it "renders the error message" do
+      assert_select ".govuk-error-message", text: "Please enter a valid email address"
     end
 
-    it "does not set the 'aria-describedby' on the input" do
-      input = css_select(".govuk-input")
-      expect(input.attr("aria-describedby")).to be_nil
+    it "has 'aria-describedby' the error message id" do
+      error_message_id = css_select(".govuk-error-message").attr("id")
+
+      assert_select ".govuk-input[aria-describedby='#{error_message_id}']"
     end
   end
 end

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -72,7 +72,7 @@ describe "Radio", type: :view do
     assert_select ".govuk-radios__item .govuk-label--s"
   end
 
-  it "renders radio-group with hint text" do
+  it "renders radio items with hint text" do
     render_component(
       name: "radio-group-hint-text",
       items: [
@@ -179,6 +179,44 @@ describe "Radio", type: :view do
     )
 
     assert_select ".govuk-radios__conditional", text: "You’ll need to prove your identity using Government Gateway"
+  end
+
+  it "renders radio-group with hint text" do
+    render_component(
+      name: "radio-group-conditional",
+      hint: "You’ll need to prove your identity using one of the following methods",
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        },
+        {
+          value: "govuk-verify",
+          text: "Use GOV.UK Verify"
+        }
+      ]
+    )
+
+    assert_select ".govuk-hint", text: "You’ll need to prove your identity using one of the following methods"
+  end
+
+  it "renders radio-group with error message" do
+    render_component(
+      name: "radio-group-conditional",
+      error_message: "Please select one option",
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        },
+        {
+          value: "govuk-verify",
+          text: "Use GOV.UK Verify"
+        }
+      ]
+    )
+
+    assert_select ".govuk-error-message", text: "Please select one option"
   end
 
   it "renders radio-group with welsh translated 'or'" do


### PR DESCRIPTION
This PR adds error message and hint as components and updates the two components using them (input and radio).

The reason for having these as separate components instead of being part of the label component is that they should also be able to be used for fieldsets in legends so decoupling them allows them to be used in other circumstances.

---
[Trello card](https://trello.com/c/4iwUWRwz)
Component guide for this PR:
https://govuk-publishing-compon-pr-446.herokuapp.com/component-guide/
