### PR TITLE
Update feedback component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -1,6 +1,5 @@
 // govuk_frontend_toolkit
-@import 'grid_layout';
-@import 'design-patterns/buttons';
+@import "grid_layout";
 
 .gem-c-feedback {
   max-width: 960px;
@@ -178,6 +177,11 @@
   }
 }
 
-.gem-c-feedback__submit {
-  @include button;
+// static.css on GOV.UK overwrites the component styles using input[type="text"]
+// so we need to apply  govuk-input styles using a stronger selector
+.gem-c-feedback input[type="text"] {
+  // scss-lint:disable PlaceholderInExtend
+  @extend .govuk-input;
+  // scss-lint:enable PlaceholderInExtend
+  margin: 0;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -4,3 +4,4 @@
 $govuk-font-url-function: "font-url";
 
 @import "../../../../node_modules/govuk-frontend/components/input/input";
+@import "../../../../node_modules/govuk-frontend/objects/form-group";

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -93,8 +93,9 @@
           name: "what_wrong"
         } %>
 
-        <%# TODO: use button component once available in gem %>
-        <input class="gem-c-feedback__submit" type="submit" value="Send">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Send"
+        } %>
       </div>
     </div>
   </form>
@@ -136,8 +137,9 @@
           describedby: "survey_explanation"
         } %>
 
-        <%# TODO: use button component once available in gem %>
-        <input class="gem-c-feedback__submit" type="submit" value="Send me the survey">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Send me the survey"
+        } %>
         <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=<%= stripped_url -%>&amp;gcl=1627485790.1515403243" class="gem-c-feedback__email-link" id="take-survey" target="_blank" rel="noopener noreferrer">Don’t have an email address?</a>
       </div>
     </div>


### PR DESCRIPTION
This PR:
 - updates the feedback component to use the button components
 - applies a stronger selector for inputs; static overwrites the input styles coming from GOV.UK Frontend using `input[type="text"]` as selector, so we need to apply `.govuk-input` styles with a stronger selector until the styles from static will be removed.

Below is an example of how this component is rendered in gov.uk and how it's rendered after the update. While the styles overwrite could be done in the applications I consider it's better to be done here since there are strong chances that this component will be loaded with static styles in other projects.

### Before
<img width="962" alt="screen shot 2018-07-30 at 09 54 29" src="https://user-images.githubusercontent.com/788096/43387637-d8bfba50-93de-11e8-8b3d-eec1f57d027b.png">

### After
<img width="963" alt="screen shot 2018-07-30 at 09 55 28" src="https://user-images.githubusercontent.com/788096/43387642-dc80df98-93de-11e8-8fd2-91e3c6c79ec7.png">


---

Component guide for this PR:
https://govuk-publishing-compon-pr-447.herokuapp.com/component-guide/feedback
