### PR TITLE
Remove brackets from show/hide links

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -51,11 +51,8 @@
       bindComponentLinkClicks(stepNavTracker);
 
       function getTextForInsertedElements() {
-        var openBracket = '<span class="visuallyhidden">(</span>';
-        var closeBracket = '<span class="visuallyhidden">)</span>';
-
-        actions.showText = openBracket + $element.attr('data-show-text') + closeBracket;
-        actions.hideText = openBracket + $element.attr('data-hide-text') + closeBracket;
+        actions.showText = $element.attr('data-show-text');
+        actions.hideText = $element.attr('data-hide-text');
         actions.showAllText = $element.attr('data-show-all-text');
         actions.hideAllText = $element.attr('data-hide-all-text');
       }

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -451,7 +451,7 @@ describe('A stepnav module', function () {
 
     it("sets the show/hide link text to 'hide'", function () {
       var $step1 = $element.find('#topic-step-one');
-      expect($step1.find('.js-toggle-link')).toHaveText("(Hide)");
+      expect($step1.find('.js-toggle-link')).toHaveText("Hide");
     });
 
     it("sets the show all/hide all button text correctly", function () {


### PR DESCRIPTION
- this reverts a change that was intended to make the Google snippet for a step by step page more readable (but didn't work)
- changes '(show)' and '(hide)' links back to just 'show' and 'hide'
- neither of these changes altered the appearance of the component

---

Component guide for this PR:
https://govuk-publishing-compon-pr-448.herokuapp.com/component-guide/
