### PR TITLE
Add textarea component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Update feedback component to use GOV.UK Frontend styles (PR #447)
 * Remove brackets from show/hide links (PR #448)
 * Add experimental inset text component based on GOV.UK Frontend (PR #449)
+* Add experimental textarea component based on GOV.UK Frontend (PR #450)
 * Add reset styles to document list component (PR #451)
 * Add tests for contextual breadcrumbs (PR #457)
 * Contextual breadcrumbs will show taxon based breadcrumbs if prioritise_taxon_breadcrumbs is true (defaults to false if not passed) (PR #457)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
@@ -1,0 +1,1 @@
+// This component relies on styles from GOV.UK Frontend

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -1,0 +1,56 @@
+<%
+  id ||= "textarea-#{SecureRandom.hex(4)}"
+  value ||= nil
+  rows ||= 5
+
+  label ||= nil
+  hint ||= nil
+  error_message ||= nil
+  hint_id = "hint-#{SecureRandom.hex(4)}" if hint
+  error_message_id = "error-message-#{SecureRandom.hex(4)}" if error_message
+
+  css_classes = %w(gem-c-textarea govuk-textarea)
+  css_classes << "govuk-textarea--error" if error_message
+  form_group_css_classes = %w(govuk-form-group)
+  form_group_css_classes << "govuk-form-group--error" if error_message
+
+  aria_described_by ||= nil
+  if hint || error_message
+    aria_described_by = []
+    aria_described_by << hint_id if hint
+    aria_described_by << error_message_id if error_message
+    aria_described_by = aria_described_by.join(" ")
+  end
+%>
+
+<%= content_tag :div, class: form_group_css_classes do %>
+  <% if label %>
+    <%= render "govuk_publishing_components/components/label", {
+      text: label[:text],
+      html_for: id
+    } %>
+  <% end %>
+
+  <% if hint %>
+    <%= render "govuk_publishing_components/components/hint", {
+      id: hint_id,
+      text: hint
+    } %>
+  <% end %>
+
+  <% if error_message %>
+    <%= render "govuk_publishing_components/components/error_message", {
+      id: error_message_id,
+      text: error_message
+    } %>
+  <% end %>
+
+  <%= tag.textarea name: name,
+    value: value,
+    class: css_classes,
+    id: id,
+    rows: rows,
+    aria: {
+      describedby: aria_described_by
+    } do %><%= value %><% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/textarea.yml
+++ b/app/views/govuk_publishing_components/components/docs/textarea.yml
@@ -1,0 +1,48 @@
+name: Form textarea (experimental)
+description: A textarea field and an associated label
+part_of_admin_layout: true
+govuk_frontend_components:
+  - textarea
+accessibility_criteria: |
+  The component must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - be usable with touch
+  - indicate when they have focus
+  - be recognisable as form textarea elements
+  - have correctly associated labels
+
+  Labels use the [label component](/component-guide/label).
+examples:
+  default:
+    data:
+      label:
+        text: "Can you provide more detail?"
+      name: "more-detail"
+  specific_rows:
+    description: Textarea with 10 rows
+    data:
+      label:
+        text: "Can you provide more detail?"
+      name: "more-detail-rows"
+      rows: 10
+  with_hint:
+    data:
+      label:
+        text: "Can you provide more detail?"
+      name: "with-hint"
+      hint: "Please include as much information as possible."
+  with_error:
+    data:
+      label:
+        text: "Can you provide more detail?"
+      name: "more-detail-error"
+      error_message: "Please could you provide more detail"
+  with_value:
+    data:
+      label:
+        text: "Can you provide more detail?"
+      name: "more-detail-value"
+      value: "More detail"

--- a/spec/components/textarea_spec.rb
+++ b/spec/components/textarea_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+describe "Textarea", type: :view do
+  def component_name
+    "textarea"
+  end
+
+  it "fails to render when no data is given" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  it "renders textarea with name and label text" do
+    render_component(
+      label: { text: "Can you provide more detail?" },
+      name: "more-details",
+    )
+
+    assert_select ".govuk-textarea"
+    assert_select ".govuk-textarea[name='more-details']"
+
+    assert_select ".govuk-label", text: "Can you provide more detail?"
+  end
+
+  it "renders textarea with a custom number of rows" do
+    render_component(
+      name: "custom-rows",
+      rows: 10,
+    )
+
+    assert_select ".govuk-textarea"
+    assert_select ".govuk-textarea[rows='10']"
+  end
+
+  it "sets the 'for' on the label to the textarea id" do
+    render_component(
+      label: { text: "Can you provide more detail?" },
+      name: "more-detail-label"
+    )
+
+    textarea = css_select(".govuk-textarea")
+    textarea_id = textarea.attr("id").text
+
+    assert_select ".govuk-label[for='#{textarea_id}']"
+  end
+
+  it "sets the value when provided" do
+    render_component(
+      name: "more-detail-value",
+      value: "More detail provided",
+    )
+
+    assert_select ".govuk-textarea", text: "More detail provided"
+  end
+
+  context "when a hint is provided" do
+    before do
+      render_component(
+        name: "more-detail-hint",
+        hint: "Don’t include personal or financial information, eg your National Insurance number or credit card details.",
+      )
+    end
+
+    it "renders the hint" do
+      assert_select ".govuk-hint", text: "Don’t include personal or financial information, eg your National Insurance number or credit card details."
+    end
+
+    it "has 'aria-describedby' the hint id" do
+      hint_id = css_select(".govuk-hint").attr("id")
+
+      assert_select ".govuk-textarea[aria-describedby='#{hint_id}']"
+    end
+  end
+
+  context "when an error_message is provided" do
+    before do
+      render_component(
+        name: "more-detail-hint-error-message",
+        error_message: "Please enter more detail",
+      )
+    end
+
+    it "renders the error message" do
+      assert_select ".govuk-error-message", text: "Please enter more detail"
+    end
+
+    it "has 'aria-describedby' the error message id" do
+      error_message_id = css_select(".govuk-error-message").attr("id")
+
+      assert_select ".govuk-textarea[aria-describedby='#{error_message_id}']"
+    end
+  end
+end


### PR DESCRIPTION
Add experimental textarea component based on GOVUK Frontend.

This is dependent on #446.
All unnecessary commits will be removed at rebase.
The only commit that this PR will bring is [7a1013c](https://github.com/alphagov/govuk_publishing_components/pull/450/commits/7a1013c66384d430cc9bdf3c0b546914c25d8d71).

[Trello card](https://trello.com/c/1kjXetZW)

---
Component guide for this PR:
https://govuk-publishing-compon-pr-450.herokuapp.com/component-guide/textarea
