### PR TITLE
Add resets to document list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Update feedback component to use GOV.UK Frontend styles (PR #447)
 * Remove brackets from show/hide links (PR #448)
 * Add experimental inset text component based on GOV.UK Frontend (PR #449)
+* Add reset styles to document list component (PR #451)
 
 ## 9.7.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -1,3 +1,12 @@
+// `govuk_frontend_toolkit`
+@import "typography";
+
+.gem-c-document-list {
+  @include core-19;
+  margin: 0;
+  padding: 0;
+}
+
 .gem-c-document-list__item {
   overflow: hidden;
   margin-bottom: $gutter-one-third;
@@ -30,6 +39,10 @@
 
 .gem-c-document-list__item-description {
   margin-bottom: 5px;
+}
+
+.gem-c-document-list__item-metadata {
+  padding: 0;
 }
 
 .gem-c-document-list__attribute {

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -35,7 +35,7 @@
         <% end %>
 
         <% if item[:metadata] %>
-          <ul>
+          <ul class="gem-c-document-list__item-metadata">
             <% item[:metadata].each do |item_metadata_key, item_metadata_value| %>
               <li class="gem-c-document-list__attribute">
                 <% if item_metadata_key.to_s.eql?("public_updated_at") %>


### PR DESCRIPTION
This PR adds resets paddings and margins and adds font styles without having the component rely on the reset CSS.

Here is an example of how the component looks like without reset CSS.

### Before
<img width="880" alt="screen shot 2018-07-30 at 15 47 42" src="https://user-images.githubusercontent.com/788096/43404869-6b6efe98-9410-11e8-888d-21383c63ec5b.png">

### After
<img width="880" alt="screen shot 2018-07-30 at 15 47 01" src="https://user-images.githubusercontent.com/788096/43404877-6f81bb6a-9410-11e8-96a3-a1948bbea5fa.png">

---

Component guide for this PR:
https://govuk-publishing-compon-pr-451.herokuapp.com/component-guide/document_list
