### PR TITLE
Add details component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_details.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_details.scss
@@ -1,0 +1,1 @@
+// This component relies on styles from GOV.UK Frontend

--- a/app/views/govuk_publishing_components/components/_details.html.erb
+++ b/app/views/govuk_publishing_components/components/_details.html.erb
@@ -1,0 +1,10 @@
+<details class="gem-c-details govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      <%= title %>
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <%= yield %>
+  </div>
+</details>

--- a/app/views/govuk_publishing_components/components/docs/details.yml
+++ b/app/views/govuk_publishing_components/components/docs/details.yml
@@ -1,0 +1,24 @@
+name: Details
+description: Make a page easier to scan by letting users reveal more detailed information only if they need it
+shared_accessibility_criteria:
+  - link
+accessibility_criteria: |
+  The component must:
+
+  * accept focus
+  * be focusable with a keyboard
+  * be usable with a keyboard
+  * be usable with touch
+  * indicate when it has focus
+  * toggle the visibility of the details element's content when interacted with
+  * indicate the expanded state when details' content is visible
+  * indicate the collapsed state when details' content is hidden
+part_of_admin_layout: true
+govuk_frontend_components:
+  - header
+examples:
+  default:
+    data:
+      title: Help with nationality
+      block: |
+        We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.

--- a/spec/components/details_spec.rb
+++ b/spec/components/details_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe "Details", type: :view do
+  def component_name
+    "details"
+  end
+
+  it "renders a details element" do
+    render_component(title: "Some title") do
+      "This is more info"
+    end
+
+    assert_select "details.gem-c-details"
+    assert_select ".govuk-details__summary-text", text: "Some title"
+    assert_select ".govuk-details__text", text: "This is more info"
+  end
+end


### PR DESCRIPTION
The details component is useful to reveal more detailed information.

https://govuk-publishing-compon-pr-453.herokuapp.com/component-guide/details

https://trello.com/c/d1jqgiXk/54-add-details-component