### PR TITLE
Add tabs component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## Unreleased
 
 * Step by step component, Google snippet improvement (PR #461)
+* Add tabs component (PR #455)
+
 
 ## 9.8.0
 
@@ -21,6 +23,8 @@
 * Add reset styles to document list component (PR #451)
 * Add tests for contextual breadcrumbs (PR #457)
 * Allow prioritising taxonomy breadcrumbs (PR #457)
+* Contextual breadcrumbs will show taxon based breadcrumbs if prioritise_taxon_breadcrumbs is true (defaults to false if not passed) (PR #457)
+
 
 ## 9.7.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
@@ -1,0 +1,1 @@
+// This component relies on styles from GOV.UK Frontend

--- a/app/views/govuk_publishing_components/components/_tabs.html.erb
+++ b/app/views/govuk_publishing_components/components/_tabs.html.erb
@@ -1,0 +1,31 @@
+<%
+  tabs ||= []
+%>
+<% if tabs.count > 1 %>
+  <div class="govuk-tabs gem-c-tabs" data-module="tabs">
+    <h2 class="govuk-tabs__title">
+      Contents
+    </h2>
+    <ul class="govuk-tabs__list">
+      <% tabs.each do |tab| %>
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="#<%= tab[:id] %>">
+            <%= tab[:title] %>
+          </a>
+      </li>
+      <% end %>
+    </ul>
+    <% tabs.each do |tab| %>
+      <section class="govuk-tabs__panel" id="<%= tab[:id] %>">
+        <h2 class="govuk-heading-l"><%= tab[:title] %></h2>
+          <%= tab[:content] %>
+      </section>
+      <% end %>
+  </div>
+<% end %>
+<% if tabs.count == 1 %>
+    <section id="<%= tabs[0][:id] %>">
+      <h2 class="govuk-heading-l"><%= tabs[0][:title] %></h2>
+      <%= tabs[0][:content] %>
+    </section>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -4,7 +4,6 @@ part_of_admin_layout: true
 govuk_frontend_components:
   - select
 accessibility_criteria: |
-The component must:
   - accept focus
   - be focusable with a keyboard
   - be usable with a keyboard

--- a/app/views/govuk_publishing_components/components/docs/tabs.yml
+++ b/app/views/govuk_publishing_components/components/docs/tabs.yml
@@ -1,0 +1,42 @@
+name: "Tabs (experimental)"
+description: "The tabs component lets users toggle between related sections of content."
+part_of_admin_layout: true
+body: |
+  This component is based on the [design system tabs component](https://design-system.service.gov.uk/components/tabs/)
+  and is currently experimental. If using this component, please feed back any research findings to the
+  design team.
+
+  The tabs component lets users navigate between related sections of content on a single page,
+  displaying one section at a time. Note that they are not intended to be used to navigate
+  between different pages.
+
+  The content block MUST be passed as a block to avoid the risk of unsanitised HTML.
+accessibility_criteria: |
+  - Tabs must:
+    * accept focus
+    * be usable with a keyboard
+    * indicate when they have focus
+    * be usable with touch
+    * be usable with voice commands
+    * have visible text
+
+examples:
+  default:
+    data:
+      tabs:
+        - id: "tab1"
+          title: "First section"
+          content: |
+            <p>Fusce at dictum tellus, ac accumsan est. Nulla vitae turpis in nulla gravida tincidunt. Duis lectus felis, tempus id bibendum sit amet, posuere ut elit. Donec enim odio, eleifend in urna a, sagittis egestas est. Proin id ex ultricies, porta eros id, vehicula quam. Morbi non sagittis velit.</p>
+        - id: "tab2"
+          title: "Second section"
+          content: |
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam congue elementum commodo. Vestibulum elit turpis, efficitur quis posuere vitae, commodo vitae augue. Donec ut pharetra ligula. Phasellus ac mauris eu felis bibendum dapibus rutrum sed quam. Pellentesque posuere ante id consequat pretium.</p>
+  single_item:
+    description: If only an individual item is supplied to the component (if the list is created dynamically, for example) it will be rendered without tabs.
+    data:
+      tabs:
+        - id: "singletab"
+          title: "Single piece of content"
+          content: |
+            Here is a single piece of content, there should be no tabs.

--- a/spec/components/tabs_spec.rb
+++ b/spec/components/tabs_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe "Tabs", type: :view do
+  def component_name
+    "tabs"
+  end
+
+  it "does not render anything if no data is passed" do
+    assert_empty render_component({})
+  end
+
+  it "renders tabs and sections" do
+    render_component(
+      tabs: [
+          {
+            id: "tab1",
+            title: "First section",
+            content: "<p>Fusce at dictum tellus, ac accumsan est. Nulla vitae turpis in nulla gravida tincidunt. Duis lectus felis, tempus id bibendum sit amet, posuere ut elit. Donec enim odio, eleifend in urna a, sagittis egestas est. Proin id ex ultricies, porta eros id, vehicula quam. Morbi non sagittis velit.</p>"
+          },
+          {
+            id: "tab2",
+            title: "Second section",
+            content: "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam congue elementum commodo. Vestibulum elit turpis, efficitur quis posuere vitae, commodo vitae augue. Donec ut pharetra ligula. Phasellus ac mauris eu felis bibendum dapibus rutrum sed quam. Pellentesque posuere ante id consequat pretium.</p>"
+          }
+        ]
+    )
+    assert_select ".govuk-tabs"
+    assert_select ".govuk-tabs__tab", 2
+    assert_select ".govuk-tabs__panel", 2
+    assert_select "#tab1"
+    assert_select "#tab1"
+  end
+end

--- a/spec/dummy/app/controllers/welcome_controller.rb
+++ b/spec/dummy/app/controllers/welcome_controller.rb
@@ -21,4 +21,9 @@ class WelcomeController < ApplicationController
     response.headers[Slimmer::Headers::SKIP_HEADER] = "true"
     render 'admin_example', layout: 'dummy_admin_layout'
   end
+
+  def tabsexample
+    response.headers[Slimmer::Headers::SKIP_HEADER] = "true"
+    render 'tabs_example', layout: 'dummy_admin_layout'
+  end
 end

--- a/spec/dummy/app/views/welcome/tabs_example.html.erb
+++ b/spec/dummy/app/views/welcome/tabs_example.html.erb
@@ -1,0 +1,22 @@
+<h1>A test page in the dummy app</h1>
+<p>This is for testing the tabs component</p>
+<% tab1content = capture do %>
+  <p>Fusce at dictum tellus, ac accumsan est. Nulla vitae turpis in nulla gravida tincidunt. Duis lectus felis, tempus id bibendum sit amet, posuere ut elit. Donec enim odio, eleifend in urna a, sagittis egestas est. Proin id ex ultricies, porta eros id, vehicula quam. Morbi non sagittis velit.</p>
+<% end %>
+<% tab2content = capture do %>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam congue elementum commodo. Vestibulum elit turpis, efficitur quis posuere vitae, commodo vitae augue. Donec ut pharetra ligula. Phasellus ac mauris eu felis bibendum dapibus rutrum sed quam. Pellentesque posuere ante id consequat pretium.</p>
+<% end %>
+  <%= render "govuk_publishing_components/components/tabs", {
+    tabs: [
+      {
+        id: "tab1",
+        title: "First section",
+        content: tab1content
+      },
+      {
+        id: "tab2",
+        title: "Second section",
+        content: tab2content
+      }
+    ]
+  } %>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   get 'contextual-navigation', to: 'welcome#contextual_navigation'
   get 'contextual-navigation/*base_path', to: 'welcome#contextual_navigation'
   get 'admin', to: 'welcome#admin'
+  get 'tabsexample', to: 'welcome#tabsexample'
 end

--- a/spec/features/tabs_spec.rb
+++ b/spec/features/tabs_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe "Tabs component", js: true do
+  scenario "Tabs load" do
+    given_i_visit_a_page_with_the_tabs_component
+    then_the_tabs_load
+    only_the_first_tab_is_selected
+    when_i_click_the_second_tab
+    then_only_the_second_tab_is_selected
+  end
+
+  def given_i_visit_a_page_with_the_tabs_component
+    visit "/tabsexample"
+  end
+
+  def then_the_tabs_load
+    expect(page).to have_css(".govuk-tabs__list")
+  end
+
+  def only_the_first_tab_is_selected
+    expect(page).to have_css("#tab_tab1[aria-selected=true]")
+    expect(page).not_to have_css("#tab_tab2[aria-selected=true]")
+  end
+
+  def when_i_click_the_second_tab
+    find("#tab_tab2").click
+  end
+
+  def then_only_the_second_tab_is_selected
+    expect(page).to have_css("#tab_tab2[aria-selected=true]")
+    expect(page).not_to have_css("#tab_tab1[aria-selected=true]")
+  end
+end


### PR DESCRIPTION
Tabs component added, brought in from the design system. Also implements
a test page containing an example of the component for testing purposes.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-455.herokuapp.com/component-guide/
