### PR TITLE
Add prioritise_taxon_breadcrumbs flag to contextual breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * Remove brackets from show/hide links (PR #448)
 * Add experimental inset text component based on GOV.UK Frontend (PR #449)
 * Add reset styles to document list component (PR #451)
+* Add tests for contextual breadcrumbs (PR #457)
+* Contextual breadcrumbs will show taxon based breadcrumbs if prioritise_taxon_breadcrumbs is true (defaults to false if not passed) (PR #457)
 
 ## 9.7.0
 

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -1,10 +1,17 @@
 <% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request.path) %>
+<% prioritise_taxon_breadcrumbs ||= false %>
 
 <div class='gem-c-contextual-breadcrumbs'>
   <% if navigation.content_tagged_to_single_step_by_step? %>
     <!-- Rendering step by step nav breadcrumbs because there's 1 step by step -->
     <%= render 'govuk_publishing_components/components/step_by_step_nav_header',
       navigation.step_nav_helper.header %>
+  <% elsif navigation.content_is_tagged_to_a_live_taxon? && prioritise_taxon_breadcrumbs %>
+    <!-- Rendering taxonomy breadcrumbs because the page is tagged to live taxons
+          and we want to prioritise them over all other breadcrumbs -->
+    <%= render 'govuk_publishing_components/components/breadcrumbs',
+               breadcrumbs: navigation.taxon_breadcrumbs[:breadcrumbs],
+               collapse_on_mobile: true %>
   <% elsif navigation.content_tagged_to_mainstream_browse_pages? %>
     <!-- Rendering parent-based breadcrumbs because the page is tagged to mainstream browse -->
     <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>

--- a/spec/components/contextual_breadcrumbs_spec.rb
+++ b/spec/components/contextual_breadcrumbs_spec.rb
@@ -1,0 +1,123 @@
+require "rails_helper"
+
+describe "ContextualBreadcrumbs", type: :view do
+  def component_name
+    "contextual_breadcrumbs"
+  end
+
+  def example_document_for(schema_name, example_name)
+    GovukSchemas::Example.find(schema_name, example_name: example_name)
+  end
+
+  def remove_mainstream_browse(content_item)
+    content_item["links"]["mainstream_browse_pages"] = nil
+    content_item
+  end
+
+  def remove_curated_related_item(content_item)
+    content_item["links"]["ordered_related_items"] = nil
+    content_item
+  end
+
+  def set_parent_titles_to_businesses(content_item)
+    content_item["links"]["parent"][0]["title"] = "Business and self-employed"
+    content_item["links"]["parent"][0]["links"]["parent"][0]["title"] = "Licences and licence applications"
+    content_item
+  end
+
+  def set_live_taxons(content_item)
+    content_item["links"]["taxons"][0]["phase"] = "live"
+    content_item["links"]["taxons"][0]["links"]["parent_taxons"][0]["phase"] = "live"
+    content_item
+  end
+
+  it "renders step by step breadcrumbs and step by step header if the content item is tagged to step by step" do
+    render_component(content_item: example_document_for("guide", "guide-with-step-navs"))
+    assert_select(".gem-c-step-nav-header")
+    assert_select "a", text: "Learn to drive a car: step by step"
+  end
+
+  it "renders parent-based breadcrumbs if the content_item is tagged to mainstream browse" do
+    render_component(content_item: example_document_for("place", "find-regional-passport-office"))
+    assert_no_selector(".gem-c-step-nav-header")
+    assert_select "a", text: "Home"
+    assert_select "a", text: "Passports, travel and living abroad"
+    assert_select "a", text: "Passports"
+  end
+
+  it "renders curated related items breadcrumbs if the content_item has curated related items" do
+    content_item = example_document_for("licence", "licence_without_continuation_link")
+    content_item = remove_mainstream_browse(content_item)
+    render_component(content_item: content_item)
+    assert_no_selector(".gem-c-step-nav-header")
+    assert_select "a", text: "Home"
+    assert_select "a", text: "Business and self-employed"
+    assert_select "a", text: "Licences and licence applications"
+  end
+
+  it "renders taxon breadcrumbs if there are some and no mainstream or curated_content" do
+    content_item = example_document_for("guide", "guide")
+    content_item = remove_mainstream_browse(content_item)
+    content_item = remove_curated_related_item(content_item)
+    content_item = set_live_taxons(content_item)
+    render_component(content_item: content_item)
+    assert_no_selector(".gem-c-step-nav-header")
+    assert_select "a", text: "Home"
+    assert_select "a", text: "School curriculum"
+    assert_select "a", text: "Education, training and skills"
+  end
+
+  it "renders no taxon breadcrumbs if they are not live" do
+    content_item = example_document_for("guide", "guide")
+    content_item = remove_mainstream_browse(content_item)
+    content_item = remove_curated_related_item(content_item)
+    content_item["links"]["taxons"].each { |taxon| taxon["phase"] = "draft" }
+    assert_no_selector(".gem-c-step-nav-header")
+    assert_no_selector(".gem-c-breadcrumbs")
+  end
+
+  it "renders no breadcrumbs if there aren't any" do
+    content_item = example_document_for("guide", "guide")
+    content_item = remove_mainstream_browse(content_item)
+    content_item = remove_curated_related_item(content_item)
+    content_item["links"]["taxons"] = nil
+    assert_no_selector(".gem-c-step-nav-header")
+    assert_no_selector(".gem-c-breadcrumbs")
+  end
+
+  it "renders taxon breadcrumbs even if there are mainstream browse pages if prioritise_taxon_breadcrumbs is true" do
+    content_item = example_document_for("guide", "guide")
+    content_item = set_parent_titles_to_businesses(content_item)
+    content_item = set_live_taxons(content_item)
+    render_component(content_item: content_item, prioritise_taxon_breadcrumbs: true)
+    assert_select "a", text: "Home"
+    assert_no_selector "a", text: "Business and self-employed"
+    assert_no_selector "a", text: "Licences and licence applications"
+    assert_select "a", text: "School curriculum"
+    assert_select "a", text: "Education, training and skills"
+  end
+
+  it "renders mainstream browse pages if prioritise_taxon_breadcrumbs is false and there are live taxons" do
+    content_item = example_document_for("guide", "guide")
+    content_item = set_parent_titles_to_businesses(content_item)
+    content_item = set_live_taxons(content_item)
+    render_component(content_item: content_item, prioritise_taxon_breadcrumbs: false)
+    assert_select "a", text: "Home"
+    assert_select "a", text: "Business and self-employed"
+    assert_select "a", text: "Licences and licence applications"
+    assert_no_selector "a", text: "School curriculum"
+    assert_no_selector "a", text: "Education, training and skills"
+  end
+
+  it "renders mainstream browse pages if prioritise_taxon_breadcrumbs is not passed and are live taxons" do
+    content_item = example_document_for("guide", "guide")
+    content_item = set_parent_titles_to_businesses(content_item)
+    content_item = set_live_taxons(content_item)
+    render_component(content_item: content_item)
+    assert_select "a", text: "Home"
+    assert_select "a", text: "Business and self-employed"
+    assert_select "a", text: "Licences and licence applications"
+    assert_no_selector "a", text: "School curriculum"
+    assert_no_selector "a", text: "Education, training and skills"
+  end
+end


### PR DESCRIPTION
Contextual breadcrumbs will show taxon based breadcrumbs if prioritise_taxon_breadcrumbs is true (defaults to false if not passed) 

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-457.herokuapp.com/component-guide/
https://govuk-publishing-compon-pr-457.herokuapp.com/component-guide/contextual_breadcrumbs

Trello card
https://trello.com/c/yZfYuiJp/84-use-taxons-breadcrumb-in-b-sample
