### PR TITLE
Changes required when there are only one "part of" step by step navs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 * Step by step component, Google snippet improvement (PR #461)
 * Add tabs component (PR #455)
-
+* Adds styling for singular related step by step navs (PR #458)
 
 ## 9.8.0
 
@@ -24,7 +24,6 @@
 * Add tests for contextual breadcrumbs (PR #457)
 * Allow prioritising taxonomy breadcrumbs (PR #457)
 * Contextual breadcrumbs will show taxon based breadcrumbs if prioritise_taxon_breadcrumbs is true (defaults to false if not passed) (PR #457)
-
 
 ## 9.7.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
@@ -15,6 +15,19 @@
   padding: 0;
 }
 
+.gem-c-step-nav-related--singular {
+  margin-bottom: $gutter-one-third + 3;
+
+  .gem-c-step-nav-related__heading {
+    @include _core-font-generator(19px, 19px, 19px, 1.4, 1.4, false, bold);
+    margin-top: $gutter-two-thirds;
+  }
+
+  .gem-c-step-nav-related__pretitle {
+    margin-bottom: $gutter-one-quarter;
+  }
+}
+
 .gem-c-step-nav-related__pretitle {
   display: block;
   margin-bottom: $gutter-half;

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -3,7 +3,9 @@
   pretitle ||= t("govuk_component.step_by_step_nav_related.part_of", default: "Part of")
 %>
 <% if links.any? %>
-  <div class="gem-c-step-nav-related" data-module="track-click">
+  <div 
+    class="gem-c-step-nav-related <%= "gem-c-step-nav-related--singular" if links.length == 1 %>" 
+    data-module="track-click">
     <h2 class="gem-c-step-nav-related__heading">
       <span class="gem-c-step-nav-related__pretitle"><%= pretitle %></span>
       <% if links.length == 1 %>


### PR DESCRIPTION
## Adds styling for singular related step by step navs

## Changes
- Increase size of font to be the same size as the step by step headings
- Increase the margin-top for the "part of" text to $gutter-two-third
- Decrease the margin-bottom for the "part of" text to $gutter-one-quarter
- Decrease the margin-bottom of step by step title to $gutter-one-third + 3

## Notes:
Change number 4 is being done as there is a padding of 7px on the show all button which makes the margin-bottom seem much larger.

This should not affect cases where there are multiple step by steps.

Ticket: https://trello.com/c/zlQ0Go3P/700-fix-the-step-by-step-title-sizing-and-spacing-on-mobile-when-it-appears-as-a-footer-s

## Screenshot
<img width="386" alt="screen shot 2018-07-31 at 14 16 11" src="https://user-images.githubusercontent.com/4599889/43462170-495d46b2-94cd-11e8-82c1-4623ee4430da.png">

---

Component guide for this PR:
https://govuk-publishing-compon-pr-458.herokuapp.com/component-guide/step_by_step_nav_related
