### PR TITLE
Bump version from 9.7.0 to 9.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-# Unreleased
+## Unreleased
+
+## 9.8.0
 
 * Add error message and hint components based on GOV.UK Frontend (PR #446)
 * Update feedback component to use GOV.UK Frontend styles (PR #447)
@@ -16,7 +18,7 @@
 * Add experimental textarea component based on GOV.UK Frontend (PR #450)
 * Add reset styles to document list component (PR #451)
 * Add tests for contextual breadcrumbs (PR #457)
-* Contextual breadcrumbs will show taxon based breadcrumbs if prioritise_taxon_breadcrumbs is true (defaults to false if not passed) (PR #457)
+* Allow prioritising taxonomy breadcrumbs (PR #457)
 
 ## 9.7.0
 

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '9.7.0'.freeze
+  VERSION = '9.8.0'.freeze
 end


### PR DESCRIPTION
This release contains a number of new components as per the changelog.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-460.herokuapp.com/component-guide/
