### PR TITLE
Step by step component, Google snippet improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Step by step component, Google snippet improvement (PR #461)
+
 ## 9.8.0
 
 * Add error message and hint components based on GOV.UK Frontend (PR #446)

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
@@ -55,7 +55,7 @@
                       <%= logic %>
                     <% else %>
                       <% step_number += 1 %>
-                      <span class="visuallyhidden">Step</span> <%= step_number %>
+                      <span class="visuallyhidden">Step</span> <%= step_number %><span class="visuallyhidden" aria-hidden="true">:</span>
                     <% end %>
                   </span>
                 </span>

--- a/spec/components/step_by_step_nav_spec.rb
+++ b/spec/components/step_by_step_nav_spec.rb
@@ -204,9 +204,9 @@ describe "step nav", type: :view do
   it "displays step numbering and step logic correctly" do
     render_component(steps: stepnav)
 
-    assert_select step1 + " .gem-c-step-nav__circle--number .gem-c-step-nav__circle-inner .gem-c-step-nav__circle-background", text: "Step 1"
+    assert_select step1 + " .gem-c-step-nav__circle--number .gem-c-step-nav__circle-inner .gem-c-step-nav__circle-background", text: "Step 1:"
     assert_select step1and + " .gem-c-step-nav__circle--logic .gem-c-step-nav__circle-inner .gem-c-step-nav__circle-background", text: "and"
-    assert_select step2 + " .gem-c-step-nav__circle--number .gem-c-step-nav__circle-inner .gem-c-step-nav__circle-background", text: "Step 2"
+    assert_select step2 + " .gem-c-step-nav__circle--number .gem-c-step-nav__circle-inner .gem-c-step-nav__circle-background", text: "Step 2:"
     assert_select step2or + " .gem-c-step-nav__circle--logic .gem-c-step-nav__circle-inner .gem-c-step-nav__circle-background", text: "or"
   end
 


### PR DESCRIPTION
- hopefully this will add a colon between the words 'Step x' and the title of the step, so the google snippet will look more like: "Step 1: Buy a car"
- should not impact accessibility as the colon has aria hidden on it, voiceover ignores it

---

Trello card: https://trello.com/c/n74CIkZ8/524-review-the-effects-of-the-google-snippet-changes
Component guide for this PR:
https://govuk-publishing-compon-pr-461.herokuapp.com/component-guide/
