### PR TITLE
[Do not merge] Enable bold text in govspeak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add tabs component (PR #455)
 * Adds styling for singular related step by step navs (PR #458)
 * Add schema.org `isPartOf` links from articles to step by steps (PR #384)
+* Enables bold styling in govspeak blocks, removes rich govspeak feature (PR #463)
 
 ## 9.8.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -186,14 +186,6 @@
 
   // Text styles
 
-  // rich-govspeak is a modifier for the govspeak component
-  // that allows bold text. Used by the highway code manual.
-  &.rich-govspeak {
-    strong {
-      font-weight: bold;
-    }
-  }
-
   em,
   i {
     font-style: normal;

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -186,10 +186,6 @@
 
   // Text styles
 
-  strong {
-    font-weight: 400;
-  }
-
   // rich-govspeak is a modifier for the govspeak component
   // that allows bold text. Used by the highway code manual.
   &.rich-govspeak {

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -1,11 +1,9 @@
 <%
   direction_class = "direction-#{direction}" if local_assigns.include?(:direction)
-  rich_govspeak = local_assigns.fetch(:rich_govspeak) if local_assigns.include?(:rich_govspeak)
   disable_youtube_expansions = local_assigns.fetch(:disable_youtube_expansions) if local_assigns.include?(:disable_youtube_expansions)
 
   classes = []
   classes << direction_class if direction_class
-  classes << "rich-govspeak" if rich_govspeak
   classes << "disable-youtube" if disable_youtube_expansions
 %>
 

--- a/app/views/govuk_publishing_components/components/_govspeak_html_publication.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak_html_publication.html.erb
@@ -2,7 +2,6 @@
   govspeak_locals = {}
   govspeak_locals[:content] = local_assigns.fetch(:content) if local_assigns.include?(:content)
   govspeak_locals[:direction] = local_assigns.fetch(:direction) if local_assigns.include?(:direction)
-  govspeak_locals[:rich_govspeak] = local_assigns.fetch(:rich_govspeak) if local_assigns.include?(:rich_govspeak)
   govspeak_locals[:disable_youtube_expansions] = local_assigns.fetch(:disable_youtube_expansions) if local_assigns.include?(:disable_youtube_expansions)
 %>
 <div class="gem-c-govspeak-html-publication">

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -283,11 +283,6 @@ examples:
     data:
       block: |
         <p>This content has <strong>text in strong tags</strong>, but they are not styled as bold</p>
-  with_rich_govspeak:
-    data:
-      rich_govspeak: true
-      block: |
-        <p>This content uses rich govspeak and has <strong>text in strong tags</strong> that are styled as bold</p>
   with_youtube_embed:
     data:
       block: |

--- a/spec/components/govspeak_html_publication_spec.rb
+++ b/spec/components/govspeak_html_publication_spec.rb
@@ -30,15 +30,6 @@ describe "Govspeak for HTML publications", type: :view do
     assert_select ".disable-youtube h2", text: "youtube"
   end
 
-  it "can enable rich govspeak" do
-    render_component(
-      rich_govspeak: true,
-      content: "<strong>boldly go</strong>".html_safe
-    )
-
-    assert_select ".rich-govspeak strong", text: 'boldly go'
-  end
-
   it "accepts a block" do
     render "govuk_publishing_components/components/#{component_name}" do
       "content-via-block"

--- a/spec/components/govspeak_spec.rb
+++ b/spec/components/govspeak_spec.rb
@@ -30,15 +30,6 @@ describe "Govspeak", type: :view do
     assert_select ".disable-youtube h2", text: "youtube"
   end
 
-  it "can enable rich govspeak" do
-    render_component(
-      rich_govspeak: true,
-      content: "<strong>boldly go</strong>".html_safe
-    )
-
-    assert_select ".rich-govspeak strong", text: 'boldly go'
-  end
-
   it "accepts a block" do
     render "govuk_publishing_components/components/#{component_name}" do
       "content-via-block"

--- a/spec/dummy/app/views/welcome/contextual_navigation.html.erb
+++ b/spec/dummy/app/views/welcome/contextual_navigation.html.erb
@@ -30,7 +30,7 @@
       </ul>
     <% end %>
 
-    <%= render 'govuk_publishing_components/components/govspeak', content: content, rich_govspeak: true %>
+    <%= render 'govuk_publishing_components/components/govspeak', content: content %>
   </div>
 
   <div class="column-one-third">


### PR DESCRIPTION
https://trello.com/c/BUij6N3Y/361-turn-on-bold-for-whitehall

Do not merge because we'd like to see how this works in various formats in a preview app.

We've been asked to enable bold text for a specific format which tested favourably.
(eg. https://www.gov.uk/guidance/connect-to-govwifi-using-an-android-device)

Instead of enabling bold text by exception this PR enables it entirely for govspeak text containing `<strong>` tags.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-463.herokuapp.com/component-guide/
