### PR TITLE
Remove headings from document list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Stop document list rendering titles as headings (PR #465)
+
 ## 9.9.0
 
 * Step by step component, Google snippet improvement (PR #461)

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -11,9 +11,6 @@
   <ol class="gem-c-document-list<%= margin_bottom_class %><%= margin_top_class %> <%= brand_helper.brand_class %>">
     <% items.each do |item| %>
       <li class="gem-c-document-list__item">
-        <% if item[:link][:description] || item[:metadata] %>
-          <h3 class="gem-c-document-list__item-title">
-        <% end %>
         <%=
           link_to(
             item[:link][:text],
@@ -22,9 +19,6 @@
             class: "gem-c-document-list__item-title #{brand_helper.color_class} #{title_with_context_class if item[:link][:context]}"
           )
         %>
-        <% if item[:link][:description] || item[:metadata] %>
-          </h3>
-        <% end %>
 
         <% if item[:link][:context] %>
           <span class="gem-c-document-list__item-context"><%= item[:link][:context] %></span>

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -94,7 +94,6 @@ examples:
           public_updated_at: 2017-07-19 15:01:48
           document_type: 'Statutory guidance'
   with_only_link:
-    description: When only link text and path is provided to the component (no description or metadata), this will render the link without wrapping it in a heading element.
     data:
       items:
       - link:

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -63,12 +63,12 @@ describe "Document list", type: :view do
     li = ".gem-c-document-list__item-title"
     attribute = ".gem-c-document-list__attribute"
 
-    assert_select "#{li} a[href='/government/publications/parental-responsibility-measures-for-behaviour-and-attendance']", text: "School behaviour and attendance: parental responsibility measures"
+    assert_select "#{li}[href='/government/publications/parental-responsibility-measures-for-behaviour-and-attendance']", text: "School behaviour and attendance: parental responsibility measures"
     assert_select "#{attribute} time", text: "5 January 2017"
     assert_select "#{attribute} time[datetime='2017-01-05T14:50:33Z']"
     assert_select ".gem-c-document-list__attribute", text: "Statutory guidance"
 
-    assert_select "#{li} a[href='/become-an-apprentice']", text: "Become an apprentice"
+    assert_select "#{li}[href='/become-an-apprentice']", text: "Become an apprentice"
     assert_select ".gem-c-document-list__item-description", text: 'Becoming an apprentice - what to expect'
     assert_select "#{attribute} time", text: "19 July 2017"
     assert_select "#{attribute} time[datetime='2017-07-19T15:01:48Z']"
@@ -119,17 +119,17 @@ describe "Document list", type: :view do
     )
     li = ".gem-c-document-list__item-title"
 
-    assert_select "#{li} a[href='/link1']", text: "Link 1"
-    assert_select "#{li} a[data-track-category='navDocumentCollectionLinkClicked']", text: "Link 1"
-    assert_select "#{li} a[data-track-action='1.1']", text: "Link 1"
-    assert_select "#{li} a[data-track-label='/link1']", text: "Link 1"
-    assert_select "#{li} a[data-track-options='{\"dimension28\":\"2\",\"dimension29\":\"Link 1\"}']", text: "Link 1"
+    assert_select "#{li}[href='/link1']", text: "Link 1"
+    assert_select "#{li}[data-track-category='navDocumentCollectionLinkClicked']", text: "Link 1"
+    assert_select "#{li}[data-track-action='1.1']", text: "Link 1"
+    assert_select "#{li}[data-track-label='/link1']", text: "Link 1"
+    assert_select "#{li}[data-track-options='{\"dimension28\":\"2\",\"dimension29\":\"Link 1\"}']", text: "Link 1"
 
-    assert_select "#{li} a[href='/link2']", text: "Link 2"
-    assert_select "#{li} a[data-track-category='navDocumentCollectionLinkClicked']", text: "Link 2"
-    assert_select "#{li} a[data-track-action='1.2']", text: "Link 2"
-    assert_select "#{li} a[data-track-label='/link2']", text: "Link 2"
-    assert_select "#{li} a[data-track-options='{\"dimension28\":\"2\",\"dimension29\":\"Link 2\"}']", text: "Link 2"
+    assert_select "#{li}[href='/link2']", text: "Link 2"
+    assert_select "#{li}[data-track-category='navDocumentCollectionLinkClicked']", text: "Link 2"
+    assert_select "#{li}[data-track-action='1.2']", text: "Link 2"
+    assert_select "#{li}[data-track-label='/link2']", text: "Link 2"
+    assert_select "#{li}[data-track-options='{\"dimension28\":\"2\",\"dimension29\":\"Link 2\"}']", text: "Link 2"
   end
 
   it "adds branding correctly" do
@@ -150,7 +150,7 @@ describe "Document list", type: :view do
     )
 
     assert_select '.gem-c-document-list.brand--attorney-generals-office'
-    assert_select '.gem-c-document-list .gem-c-document-list__item-title .brand__color'
+    assert_select '.gem-c-document-list .gem-c-document-list__item-title.brand__color'
   end
 
   it "does not wrap link in heading element if no description or metadata provided" do


### PR DESCRIPTION
Trello: https://trello.com/c/dOhKVSbr/73-stop-document-list-component-using-headings-by-default

This stops rendering the document title as a heading. This was cluttering up pages with lots of H3s which is bad for accessibility.

There shouldn't be any visible difference to the component, but behind the scenes the title is now an <a> tag even if description and metadata are passed in.

Component guide for this PR:
https://govuk-publishing-compon-pr-465.herokuapp.com/component-guide/document_list
