### PR TITLE
Update textarea component

### DIFF
--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -3,6 +3,7 @@
   value ||= nil
   rows ||= 5
   data ||= nil
+  spellcheck ||= "true"
 
   label ||= nil
   hint ||= nil
@@ -52,6 +53,7 @@
     id: id,
     rows: rows,
     data: data,
+    spellcheck: spellcheck,
     aria: {
       describedby: aria_described_by
     } do %><%= value %><% end %>

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -2,6 +2,7 @@
   id ||= "textarea-#{SecureRandom.hex(4)}"
   value ||= nil
   rows ||= 5
+  data ||= nil
 
   label ||= nil
   hint ||= nil
@@ -50,6 +51,7 @@
     class: css_classes,
     id: id,
     rows: rows,
+    data: data,
     aria: {
       describedby: aria_described_by
     } do %><%= value %><% end %>

--- a/spec/components/textarea_spec.rb
+++ b/spec/components/textarea_spec.rb
@@ -33,6 +33,15 @@ describe "Textarea", type: :view do
     assert_select ".govuk-textarea[rows='10']"
   end
 
+  it "renders textarea with a data attributes" do
+    render_component(
+      data: { module: "contextual-guidance" },
+      name: "with-data-attributes"
+    )
+
+    assert_select ".govuk-textarea[data-module='contextual-guidance']"
+  end
+
   it "sets the 'for' on the label to the textarea id" do
     render_component(
       label: { text: "Can you provide more detail?" },

--- a/spec/components/textarea_spec.rb
+++ b/spec/components/textarea_spec.rb
@@ -42,6 +42,15 @@ describe "Textarea", type: :view do
     assert_select ".govuk-textarea[data-module='contextual-guidance']"
   end
 
+  it "renders textarea with disabled spellcheck" do
+    render_component(
+      spellcheck: "false",
+      name: "with-disabled-spellcheck"
+    )
+
+    assert_select ".govuk-textarea[spellcheck='false']"
+  end
+
   it "sets the 'for' on the label to the textarea id" do
     render_component(
       label: { text: "Can you provide more detail?" },


### PR DESCRIPTION
This PR adds the following to the textarea component:
-  data attributes (for JavaScript module initialisation - e.g. `data-module`; analytics tracking - e.g. `data-track`)
 - spellcheck so we can disable so we can disable browser spell check when needed.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-468.herokuapp.com/component-guide/textarea
