### PR TITLE
Add data-attribute support to input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+* Add data attributes and spellcheck support for textarea component (PR #468)
+* Add data attributes support for input component (PR #469)
+
 ## 9.10.0
 
 * Enables bold styling in govspeak blocks, removes rich govspeak feature (PR #463)

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -3,6 +3,7 @@
   value ||= nil
   type ||= "text"
   describedby ||= false
+  data ||= nil
 
   label ||= nil
   hint ||= nil
@@ -54,6 +55,7 @@
       class: css_classes,
       id: id,
       type: type,
+      data: data,
       aria: {
         describedby: aria_described_by
       }

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -64,6 +64,15 @@ describe "Input", type: :view do
     assert_select ".govuk-input[aria-describedby='some-other-element']"
   end
 
+  it "renders input with a data attributes" do
+    render_component(
+      data: { module: "contextual-guidance" },
+      name: "with-data-attributes"
+    )
+
+    assert_select ".govuk-input[data-module='contextual-guidance']"
+  end
+
   context "when a hint is provided" do
     before do
       render_component(


### PR DESCRIPTION
This PR adds the following to the input component:
-  data attributes (for JavaScript module initialisation - e.g. `data-module`; analytics tracking - e.g. `data-track`)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-469.herokuapp.com/component-guide/input
