### PR TITLE
Relevant step by step should now be open inside simple smart answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 * Add data attributes and spellcheck support for textarea component (PR #468)
 * Add data attributes support for input component (PR #469)
+* Relevant step by step should now be open inside simple smart answers (PR #472)
 
 ## 9.10.0
 

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -8,7 +8,11 @@ module GovukPublishingComponents
       # @param request_path `request.path`
       def initialize(content_item, request_path)
         @content_item = content_item
-        @request_path = request_path
+        @request_path = simple_smart_answer? ? content_item['base_path'] : request_path
+      end
+
+      def simple_smart_answer?
+        content_item['document_type'] === "simple_smart_answer"
       end
 
       def taxonomy_sidebar


### PR DESCRIPTION
This changes the assignment of requested path of document type
"simple_smart_answer" to use the base path of the content item rather
than the requested based path.

This change was done so that the active link would show correctly on
simple smart answers.

Ticket: https://trello.com/c/SaxKuvqK/726-relevant-step-by-step-should-be-open-inside-simple-smart-answers-showing-the-dot-on-the-task-m

---

Component guide for this PR:
https://govuk-publishing-compon-pr-472.herokuapp.com/component-guide/
