### PR TITLE
Rename publishing-app metatag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Renames the publishing-app metatag to publishing-application, to be consistent with rendering-application (PR #475)
+
 ## 9.12.0
 
 * Adds publishing-app metatag (PR #470)

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -27,7 +27,7 @@ module GovukPublishingComponents
 
       def add_core_tags(meta_tags)
         meta_tags["govuk:format"] = content_item[:document_type] if content_item[:document_type]
-        meta_tags["govuk:publishing-app"] = content_item[:publishing_app] if content_item[:publishing_app]
+        meta_tags["govuk:publishing-application"] = content_item[:publishing_app] if content_item[:publishing_app]
         meta_tags["govuk:schema-name"] = content_item[:schema_name] if content_item[:schema_name]
 
         user_journey_stage = content_item[:user_journey_document_supertype]

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -12,7 +12,7 @@ describe "Meta tags", type: :view do
   it "renders with an example case study" do
     render_component(content_item: example_document_for('case_study', 'case_study'))
     assert_meta_tag('govuk:format', 'case_study')
-    assert_meta_tag('govuk:publishing-app', 'whitehall')
+    assert_meta_tag('govuk:publishing-application', 'whitehall')
     assert_meta_tag('govuk:analytics:organisations', '<L2><W4>')
     assert_meta_tag('govuk:analytics:world-locations', '<WL3>')
   end


### PR DESCRIPTION
There is a GA custom dimension called "rendering-application" so it makes sense
to call this metatag "publishing-application".

https://trello.com/b/16mTLUnP/platform-health-doing