### PR TITLE
Version 9.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 9.12.1
 
 * Renames the publishing-app metatag to publishing-application, to be consistent with rendering-application (PR #475)
 

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '9.12.0'.freeze
+  VERSION = '9.12.1'.freeze
 end


### PR DESCRIPTION
Renames the publishing-app metatag to publishing-application, to be consistent with rendering-application (PR #471)

https://trello.com/c/vhfMGngX/239-investigate-and-correct-smart-answer-google-analytics-tracking