### PR TITLE
Use content_tag instead of button_tag for buttons

### DIFF
--- a/app/views/govuk_publishing_components/components/_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_button.html.erb
@@ -3,7 +3,7 @@
 <% if button.link? %>
   <%= link_to button.text, button.href, button.html_options %>
 <% else %>
-  <%= button_tag button.text, button.html_options %>
+  <%= content_tag :button, button.text, button.html_options %>
 <% end %>
 
 <% if button.info_text %>

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -24,6 +24,7 @@ module GovukPublishingComponents
       def html_options
         options = { class: css_classes }
         options[:role] = "button" if link?
+        options[:type] = "submit" unless link?
         options[:rel] = rel if rel
         options[:data] = data_attributes if data_attributes
         options[:title] = title if title

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -12,7 +12,7 @@ describe "Button", type: :view do
 
   it "renders the correct defaults" do
     render_component(text: "Submit")
-    assert_select ".govuk-button", text: "Submit"
+    assert_select ".govuk-button[type=submit]", text: "Submit"
     assert_select ".govuk-button--start", false
     assert_select ".gem-c-button__info-text", false
   end
@@ -24,7 +24,7 @@ describe "Button", type: :view do
 
   it "renders start now button" do
     render_component(text: "Start now", href: "#", start: true)
-    assert_select ".govuk-button", text: "Start now", href: "#"
+    assert_select ".govuk-button[href='#']", text: "Start now"
     assert_select ".govuk-button--start"
   end
 


### PR DESCRIPTION
When using a button to submit a GET form, the button element becomes an
unwanted parameter sent to the server. The button_tag helper sets two
attributes: name ('button') and type ('submit'), the former being the
cause of the issue and the latter being something we can set manually.

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-[THIS PR NUMBER].herokuapp.com/component-guide/
