### PR TITLE
Allow custom tags in head for admin layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow custom tags in `<head>` for admin layout (PR #480)
+
 ## 9.12.2
 
 * Remove fixed 'name=button' attribute for buttons, to avoid them becoming a form param (PR #479)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (9.12.1)
+    govuk_publishing_components (9.12.2)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -339,4 +339,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -14,6 +14,7 @@
       <%= stylesheet_link_tag "govuk_publishing_components/admin_styles_ie8" %>
     <![endif]-->
     <%= javascript_include_tag "govuk_publishing_components/vendor/modernizr" %>
+    <%= yield :head %>
   </head>
   <body class="govuk-template__body">
     <script>


### PR DESCRIPTION
This PR allows custom tags in the `<head>` of admin layout. This is currently needed to load application styles in admin interfaces.

Updates gemfile.lock missed from #479 which makes Heroku fail on deploys

---

Example of usage in `app/views/layouts/application.html.erb`:
```
<% content_for :head do %>
<%= stylesheet_link_tag "application" %>
<% end %>

<%= render 'govuk_publishing_components/components/layout_for_admin', { ... } do %>
...
<% end %>
```

https://govuk-publishing-compon-pr-480.herokuapp.com/component-guide/layout_for_admin
