### PR TITLE
Add 'about' to schema.org article schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Don't include changes that are purely internal. The CHANGELOG should be a
   useful summary for people upgrading their application, not a replication
   of the commit log.
+  
+# Unreleased
+
+* Add the 'about' property for the schema.org schema for an Article with live taxons (PR #482)
 
 ## 9.13.0
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 GovukPublishingComponents::Engine.routes.draw do
-  root :to => 'component_guide#index', as: :component_guide
+  root to: 'component_guide#index', as: :component_guide
   get ':component/preview' => 'component_guide#preview', as: :component_preview_all
   get ':component/:example/preview' => 'component_guide#preview', as: :component_preview
   get ':component' => 'component_guide#show', as: :component_doc

--- a/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
@@ -29,7 +29,7 @@ module GovukPublishingComponents
               "url" => page.logo_url,
             }
           }
-        }.merge(image_schema).merge(author_schema).merge(body).merge(is_part_of)
+        }.merge(image_schema).merge(author_schema).merge(body).merge(is_part_of).merge(about)
       end
 
     private
@@ -97,6 +97,29 @@ module GovukPublishingComponents
           logo_url: page.logo_url,
           image_placeholders: page.image_placeholders
         )
+      end
+
+      def about
+        return {} unless live_taxons.any?
+        {
+            "about" => linked_taxons
+        }
+      end
+
+      def live_taxons
+        taxons = page.content_item.dig("links", "taxons")
+        return [] unless taxons
+        taxons.select { |taxon| taxon["phase"] == "live" }
+      end
+
+      def linked_taxons
+        live_taxons.map do |taxon|
+          {
+              "@context" => "http://schema.org",
+              "@type" => "CreativeWork",
+              "sameAs" => taxon["web_url"]
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
Adds the 'about' property for the schema.org schema for an Article with live taxons

Uses the live taxonomies to which content is tagged to generate an about section for the article schema. This is so 


---

Component guide for this PR:
https://govuk-publishing-compon-pr-482.herokuapp.com/component-guide/

Trello
https://trello.com/c/tiEHCuAA/123-implement-adding-about-to-schemaorg-article-schema