### PR TITLE
Add secondary and secondary quiet modifiers to button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Updates the tabs component to make the heading inside the panel optional and to add a modifier for panel without border (PR #485)
+* Add secondary and secondary quiet modifiers to button component (PR #484)
 
 ## 9.14.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -4,6 +4,13 @@
 $govuk-image-url-function: "image-url";
 $govuk-font-url-function: "font-url";
 
+$gem-secondary-button-colour: #00823b;
+$gem-secondary-button-hover-colour: darken($gem-secondary-button-colour, 5%);
+$gem-secondary-button-background-colour: govuk-colour("white");
+$gem-secondary-button-hover-background-colour: govuk-colour("grey-4");
+$gem-quiet-button-colour: govuk-colour("grey-1");
+$gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
+
 @import "../../../../node_modules/govuk-frontend/components/button/button";
 
 @import "mixins/margins";
@@ -26,4 +33,78 @@ $govuk-font-url-function: "font-url";
   display: block;
   max-width: 14em;
   margin-top: .5em;
+}
+
+.gem-c-button--secondary {
+  padding: (govuk-spacing(2) - $govuk-border-width-form-element) govuk-spacing(2); // s1
+  border-color: $gem-secondary-button-colour;
+  color: $gem-secondary-button-colour;
+  background-color: $gem-secondary-button-background-colour;
+  box-shadow: none;
+
+  &:link,
+  &:visited,
+  &:active {
+    color: $gem-secondary-button-colour;
+    background-color: $gem-secondary-button-background-colour;
+    text-decoration: none;
+  }
+
+  &:link:focus {
+    color: $gem-secondary-button-colour;
+  }
+
+  &:hover {
+    border-color: $gem-secondary-button-hover-colour;
+    color: $gem-secondary-button-hover-colour;
+    background-color: $gem-secondary-button-hover-background-colour;
+    text-decoration: none;
+  }
+
+  &:before {
+    content: none;
+  }
+}
+
+.gem-c-button--secondary-quiet {
+  padding: (govuk-spacing(2) - $govuk-border-width-form-element) govuk-spacing(2); // s1
+  border-color: $gem-quiet-button-colour;
+  color: $gem-quiet-button-colour;
+  background-color: $gem-secondary-button-background-colour;
+  box-shadow: none;
+
+  &:link,
+  &:visited,
+  &:active {
+    color: $gem-quiet-button-colour;
+    background-color: $gem-secondary-button-background-colour;
+    text-decoration: none;
+  }
+
+  &:link:focus {
+    color: $gem-quiet-button-colour;
+  }
+
+  &:hover {
+    border-color: $gem-quiet-button-hover-colour;
+    color: $gem-quiet-button-hover-colour;
+    background-color: $gem-secondary-button-hover-background-colour;
+    text-decoration: none;
+  }
+
+  &:before {
+    content: none;
+  }
+}
+
+// Begin adjustments for font baseline offset
+// These should be removed when the font is updated with the correct baseline
+// For the 1px addition please see https://github.com/alphagov/govuk-frontend/pull/365#discussion_r154349428
+
+$offset: 2;
+
+.gem-c-button--secondary,
+.gem-c-button--secondary-quiet {
+  padding-top: (govuk-spacing(2) - $govuk-border-width-form-element + $offset); // s1
+  padding-bottom: (govuk-spacing(2) - $govuk-border-width-form-element - $offset + 1); // s1
 }

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -34,6 +34,18 @@ examples:
       href: "#"
       start: true
       rel: "external"
+  secondary_button:
+    data:
+      text: "Secondary button"
+      href: "#"
+      secondary: true
+      rel: "external"
+  secondary_quiet_button:
+    data:
+      text: "Secondary quiet button"
+      href: "#"
+      secondary_quiet: true
+      rel: "external"
   start_now_button_with_info_text:
     data:
       text: "Start now"

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
   module Presenters
     class ButtonHelper
       attr_reader :href, :text, :title, :info_text, :rel, :data_attributes,
-        :start, :margin_bottom
+        :start, :secondary, :secondary_quiet, :margin_bottom
 
       def initialize(local_assigns)
         @href = local_assigns[:href]
@@ -14,6 +14,8 @@ module GovukPublishingComponents
         @rel = local_assigns[:rel]
         @data_attributes = local_assigns[:data_attributes]
         @start = local_assigns[:start]
+        @secondary = local_assigns[:secondary]
+        @secondary_quiet = local_assigns[:secondary_quiet]
         @margin_bottom = local_assigns[:margin_bottom]
       end
 
@@ -36,6 +38,8 @@ module GovukPublishingComponents
       def css_classes
         classes = %w(gem-c-button govuk-button)
         classes << "govuk-button--start" if start
+        classes << "gem-c-button--secondary" if secondary
+        classes << "gem-c-button--secondary-quiet" if secondary_quiet
         classes << "gem-c-button--bottom-margin" if margin_bottom
         classes.join(" ")
       end

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -28,6 +28,18 @@ describe "Button", type: :view do
     assert_select ".govuk-button--start"
   end
 
+  it "renders secondary button" do
+    render_component(text: "Secondary", href: "#", secondary: true)
+    assert_select ".gem-c-button--secondary[href='#']", text: "Secondary"
+    assert_select ".gem-c-button--secondary"
+  end
+
+  it "renders secondary quiet button" do
+    render_component(text: "Secondary quiet", href: "#", secondary_quiet: true)
+    assert_select ".gem-c-button--secondary-quiet[href='#']", text: "Secondary quiet"
+    assert_select ".gem-c-button--secondary-quiet"
+  end
+
   it "renders an anchor if href set" do
     render_component(text: "Start now", href: "#")
     assert_select "a.govuk-button"


### PR DESCRIPTION
This PR adds secondary and secondary quiet modifiers to button component needed for the admin interfaces.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-484.herokuapp.com/component-guide/button
