### PR TITLE
[DO NOT MERGE] Do not disable italic text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Enables italic styling in govspeak blocks (PR #487)
+
 ## 9.15.0
 
 * Update tabs component to make the heading inside the panel optional and to add a modifier for panel without border (PR #485)

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -188,7 +188,6 @@
 
   em,
   i {
-    font-style: normal;
     font-weight: inherit;
   }
 


### PR DESCRIPTION
I did some investigation, and this will affect 2974 editions in the live content store.  A bit of break-down:

```
   9 /aaib-reports/
   1 /corporation-tax-rates
 443 /dfid-research-outputs/
   2 /drug-device-alerts/
   3 /drug-safety-update/
1790 /government/
  51 /guidance/
 672 /hmrc-internal-manuals/
   1 /individual-savings-accounts
   1 /junior-individual-savings-accounts
   1 /vat-rates
```

And the /government pages:

```
   2 /government/case-studies/
   1 /government/collections/
  25 /government/consultations/
   5 /government/fatalities/
1060 /government/news/
   2 /government/organisations/
 489 /government/publications/
 194 /government/speeches/
   1 /government/statistical-data-sets/
  11 /government/statistics/
```

There's a full list in the trello card.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-487.herokuapp.com/component-guide/

---

[Trello card](https://trello.com/c/cVWRl9tm/404-investigate-adding-italics-to-whitehall-publisher-including-html-attachments)