### PR TITLE
Allow target to be specified for button components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow target attribute for links generated with the button component (PR #488)
+
 ## 9.15.0
 
 * Update tabs component to make the heading inside the panel optional and to add a modifier for panel without border (PR #485)

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -28,6 +28,11 @@ examples:
     data:
       text: "I'm really a link sssh"
       href: "#"
+  link_button_target_blank:
+    data:
+      text: "I'm really a link sssh"
+      href: "http://www.gov.uk"
+      target: "_blank"
   start_now_button:
     data:
       text: "Start now"

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
   module Presenters
     class ButtonHelper
       attr_reader :href, :text, :title, :info_text, :rel, :data_attributes,
-        :start, :secondary, :secondary_quiet, :margin_bottom
+        :start, :secondary, :secondary_quiet, :margin_bottom, :target
 
       def initialize(local_assigns)
         @href = local_assigns[:href]
@@ -17,6 +17,7 @@ module GovukPublishingComponents
         @secondary = local_assigns[:secondary]
         @secondary_quiet = local_assigns[:secondary_quiet]
         @margin_bottom = local_assigns[:margin_bottom]
+        @target = local_assigns[:target]
       end
 
       def link?
@@ -30,6 +31,7 @@ module GovukPublishingComponents
         options[:rel] = rel if rel
         options[:data] = data_attributes if data_attributes
         options[:title] = title if title
+        options[:target] = target if target
         options
       end
 

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -66,6 +66,12 @@ describe "Button", type: :view do
     assert_select ".govuk-button[rel='nofollow preload']", text: "Start now"
   end
 
+  it "renders target attribute correctly" do
+    render_component(text: "Start now", href: "#", target: "_blank")
+    assert_select "a.govuk-button[target='_blank']"
+    assert_select "button.govuk-button", false
+  end
+
   it "renders margin bottom class correctly" do
     render_component(text: "Submit")
     assert_select ".govuk-button", text: "Submit"


### PR DESCRIPTION
Allow target attribute on links styled as buttons for opening in a new tab.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-488.herokuapp.com/component-guide/button
