### PR TITLE
Add Google Tag Manager script as component

### DIFF
--- a/app/views/govuk_publishing_components/components/_google_tag_manager_script.html.erb
+++ b/app/views/govuk_publishing_components/components/_google_tag_manager_script.html.erb
@@ -1,0 +1,14 @@
+<%
+  gtm_auth ||= nil
+  gtm_preview ||= nil
+%>
+<script>
+var doNotTrack = ( navigator.doNotTrack === '1' || navigator.doNotTrack === 'yes' || navigator.msDoNotTrack === '1' || window.doNotTrack === '1' )
+if (!doNotTrack) {
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl+'<%= "&gtm_auth="+gtm_auth if gtm_auth %><%= "&gtm_preview="+gtm_preview if gtm_preview %>&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer',<%= gtm_id %>);
+}
+</script>

--- a/app/views/govuk_publishing_components/components/docs/google_tag_manager_script.yml
+++ b/app/views/govuk_publishing_components/components/docs/google_tag_manager_script.yml
@@ -1,0 +1,13 @@
+name: Google Tag Manager script
+description: |
+  Google Tag Manager script for tracking user interaction:
+  - gtm_id is the ID for the Google Tag Manager account
+  - gtm_preview allows a tag to be previewed in the Google Tag Manager interface
+  - gtm_auth is the identifier of an environment for Google Tag Manager
+accessibility_criteria: |
+  The component should not be visible to any users.
+display_html: true
+examples:
+  default:
+    data:
+      gtm_id: GTM-XXXXXXX

--- a/spec/components/all_components_spec.rb
+++ b/spec/components/all_components_spec.rb
@@ -23,7 +23,7 @@ describe "All components" do
 
       it "has the correct class in the ERB template",
         skip: component_name.in?(%w[step_by_step_nav_related step_by_step_nav_header step_by_step_nav previous_and_next_navigation]),
-        not_applicable: component_name.in?(%w[meta_tags machine_readable_metadata layout_for_admin]) do
+        not_applicable: component_name.in?(%w[meta_tags machine_readable_metadata google_tag_manager_script layout_for_admin]) do
 
         erb = File.read(filename)
 
@@ -32,13 +32,13 @@ describe "All components" do
         expect(erb).to match(class_name), class_name
       end
 
-      it "has a correctly named spec file", skip: component_name.in?(%w[contextual_breadcrumbs contextual_sidebar success_alert taxonomy_navigation]) do
+      it "has a correctly named spec file", skip: component_name.in?(%w[contextual_breadcrumbs contextual_sidebar success_alert taxonomy_navigation machine_readable_metadata google_tag_manager_script]) do
         rspec_file = "#{__dir__}/../../spec/components/#{component_name.tr('-', '_')}_spec.rb"
 
         expect(File).to exist(rspec_file)
       end
 
-      it "has a correctly named SCSS file", not_applicable: component_name.in?(%w[contextual_breadcrumbs contextual_sidebar government_navigation machine_readable_metadata meta_tags]) do
+      it "has a correctly named SCSS file", not_applicable: component_name.in?(%w[contextual_breadcrumbs contextual_sidebar government_navigation machine_readable_metadata meta_tags google_tag_manager_script]) do
         css_file = "#{__dir__}/../../app/assets/stylesheets/govuk_publishing_components/components/_#{component_name.tr('_', '-')}.scss"
 
         expect(File).to exist(css_file)


### PR DESCRIPTION
Component to generate the Google Tag Manager script for a given `gtm_id` (mandatory), `gtm_auth` and `gtm_preview` (optional depending on the GTM setup).

This also contains [a cross browser implementation of `doNotTrack`](https://github.com/alphagov/govuk-design-system/pull/296), so users don't have to rely on obscure plugins to block tracking.

[Trello card](https://trello.com/c/wh7K3ul2)