### PR TITLE
Active step by step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased changes
+
+* Show relevant step by step nav based on previous action (PR #491)
+
 ## 9.16.0
 
 * Allow target attribute for links generated with the button component (PR #488)

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -1,4 +1,7 @@
-<% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request.path) %>
+<%
+  active_step_nav_content_id = request.query_parameters['step-by-step-nav']
+  navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request.path, active_step_nav_content_id)
+%>
 <% prioritise_taxon_breadcrumbs ||= false %>
 
 <div class='gem-c-contextual-breadcrumbs'>

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -1,7 +1,4 @@
-<%
-  active_step_nav_content_id = request.query_parameters['step-by-step-nav']
-  navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request.path, active_step_nav_content_id)
-%>
+<% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request) %>
 <% prioritise_taxon_breadcrumbs ||= false %>
 
 <div class='gem-c-contextual-breadcrumbs'>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -3,13 +3,7 @@
 <div class="gem-c-contextual-sidebar">
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
     <!-- Rendering step by step related items because there are a few but not too many of them -->
-    <%
-      related_links_override = false
-      if navigation.step_nav_helper.get_active_step_nav 
-        related_links_override = [ navigation.step_nav_helper.get_active_step_nav ]
-      end
-    %>
-    <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links(related_links_override) %>
+    <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links %>
   <% end %>
   
   <% if navigation.content_tagged_to_single_step_by_step? or navigation.step_nav_helper.get_active_step_nav %>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -9,7 +9,7 @@
     <%
       related_links_override = false
       if navigation.step_nav_helper.get_active_step_nav 
-        related_links_override = [navigation.step_nav_helper.get_active_step_nav]
+        related_links_override = [ navigation.step_nav_helper.get_active_step_nav ]
       end
     %>
     <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links(related_links_override) %>
@@ -35,7 +35,7 @@
   <% if navigation.step_nav_helper.get_active_step_nav %>
     <%= render "govuk_publishing_components/components/step_by_step_nav_related", {
       pretitle: "Also part of",
-      links: navigation.step_nav_helper.related_links
+      links: navigation.step_nav_helper.also_part_of_step_nav
     } %>
   <% end %>
 </div>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -9,7 +9,7 @@
     <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links %>
   <% end %>
   
-  <% if navigation.content_tagged_to_single_step_by_step? or active_step_nav_content_id %>
+  <% if navigation.content_tagged_to_single_step_by_step? or navigation.step_nav_helper.get_active_step_nav %>
     <!-- Rendering step by step sidebar because there's 1 step by step list -->
     <%= render 'govuk_publishing_components/components/step_by_step_nav', navigation.step_nav_helper.sidebar %>
   <% elsif navigation.content_tagged_to_mainstream_browse_pages? %>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -1,12 +1,15 @@
-<% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request.path) %>
+<%
+  active_step_nav_content_id = request.query_parameters['step-by-step-nav']
+  navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request.path, active_step_nav_content_id) 
+%>
 
 <div class="gem-c-contextual-sidebar">
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
     <!-- Rendering step by step related items because there are a few but not too many of them -->
     <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links %>
   <% end %>
-
-  <% if navigation.content_tagged_to_single_step_by_step? %>
+  
+  <% if navigation.content_tagged_to_single_step_by_step? or active_step_nav_content_id %>
     <!-- Rendering step by step sidebar because there's 1 step by step list -->
     <%= render 'govuk_publishing_components/components/step_by_step_nav', navigation.step_nav_helper.sidebar %>
   <% elsif navigation.content_tagged_to_mainstream_browse_pages? %>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -1,7 +1,4 @@
-<%
-  active_step_nav_content_id = request.query_parameters['step-by-step-nav']
-  navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request.path, active_step_nav_content_id) 
-%>
+<% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request) %>
 
 <div class="gem-c-contextual-sidebar">
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -6,7 +6,13 @@
 <div class="gem-c-contextual-sidebar">
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
     <!-- Rendering step by step related items because there are a few but not too many of them -->
-    <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links %>
+    <%
+      related_links_override = false
+      if navigation.step_nav_helper.get_active_step_nav 
+        related_links_override = [navigation.step_nav_helper.get_active_step_nav]
+      end
+    %>
+    <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links(related_links_override) %>
   <% end %>
   
   <% if navigation.content_tagged_to_single_step_by_step? or navigation.step_nav_helper.get_active_step_nav %>
@@ -24,5 +30,12 @@
   <% else %>
     <!-- Rendering related navigation sidebar because no browse, no related links, no live taxons -->
     <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
+  <% end %>
+
+  <% if navigation.step_nav_helper.get_active_step_nav %>
+    <%= render "govuk_publishing_components/components/step_by_step_nav_related", {
+      pretitle: "Also part of",
+      links: navigation.step_nav_helper.related_links
+    } %>
   <% end %>
 </div>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
@@ -70,6 +70,7 @@
           <div class="gem-c-step-nav__panel js-panel" id="step-panel-<%= id %>-<%= step_index + 1 %>">
             <%
               in_substep = false
+              options[:content_id] = tracking_id
               options[:step_index] = step_index
               options[:link_index] = 0
             %>

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -6,9 +6,10 @@ module GovukPublishingComponents
 
       # @param content_item A content item hash with strings as keys
       # @param request_path `request.path`
-      def initialize(content_item, request_path)
+      def initialize(content_item, request_path, active_step_nav_content_id = false)
         @content_item = content_item
         @request_path = simple_smart_answer? ? content_item['base_path'] : request_path
+        @active_step_nav_content_id = active_step_nav_content_id
       end
 
       def simple_smart_answer?
@@ -65,7 +66,7 @@ module GovukPublishingComponents
       end
 
       def step_nav_helper
-        @step_nav_helper ||= PageWithStepByStepNavigation.new(content_item, request_path)
+        @step_nav_helper ||= PageWithStepByStepNavigation.new(content_item, request_path, @active_step_nav_content_id)
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -2,14 +2,14 @@ module GovukPublishingComponents
   module Presenters
     # @private
     class ContextualNavigation
-      attr_reader :content_item, :request_path
+      attr_reader :content_item, :request_path, :active_step_nav_content_id
 
       # @param content_item A content item hash with strings as keys
       # @param request_path `request.path`
-      def initialize(content_item, request_path, active_step_nav_content_id = false)
+      def initialize(content_item, request)
         @content_item = content_item
-        @request_path = simple_smart_answer? ? content_item['base_path'] : request_path
-        @active_step_nav_content_id = active_step_nav_content_id
+        @request_path = simple_smart_answer? ? content_item['base_path'] : request.path
+        @active_step_nav_content_id = request.query_parameters ? request.query_parameters['step-by-step-nav'] : nil
       end
 
       def simple_smart_answer?
@@ -66,7 +66,7 @@ module GovukPublishingComponents
       end
 
       def step_nav_helper
-        @step_nav_helper ||= PageWithStepByStepNavigation.new(content_item, request_path, @active_step_nav_content_id)
+        @step_nav_helper ||= PageWithStepByStepNavigation.new(content_item, request_path, active_step_nav_content_id)
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -3,7 +3,7 @@ module GovukPublishingComponents
     # @private
     # Only used by the step by step component
     class PageWithStepByStepNavigation
-      def initialize(content_store_response, current_path, active_step_nav_content_id = false)
+      def initialize(content_store_response, current_path, active_step_nav_content_id = nil)
         @content_item = content_store_response.to_h
         @current_path = current_path
         @active_step_nav_content_id = active_step_nav_content_id

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -41,6 +41,21 @@ module GovukPublishingComponents
         end
       end
 
+      def also_part_of_step_nav
+        active_step_nav = get_active_step_nav
+        if active_step_nav
+          step_navs.delete_if { |step_nav| step_nav.content_id == active_step_nav.content_id }
+        end
+
+        step_navs.map do |step_nav|
+          {
+            href: step_nav.base_path,
+            text: step_nav.title,
+            tracking_id: step_nav.content_id
+          }
+        end
+      end
+
       def sidebar
         if show_sidebar?
           @sidebar ||= first_or_active_step_nav.content.tap do |sb|

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -20,7 +20,7 @@ module GovukPublishingComponents
       end
 
       def show_header?
-        step_navs.count == 1 or @active_step_nav_content_id
+        step_navs.count == 1 || get_active_step_nav
       end
 
       def show_related_links?
@@ -58,16 +58,22 @@ module GovukPublishingComponents
         end
       end
 
+      def get_active_step_nav
+        if @active_step_nav_content_id
+          active_step_nav = step_navs.select { |step_nav| step_nav.content_id == @active_step_nav_content_id }
+          active_step_nav.first
+        else
+          false
+        end
+      end
+
     private
 
       attr_reader :content_item, :current_path
 
       def first_step_nav
-        if @active_step_nav_content_id
-          active_step_nav = step_navs.select { |step_nav| step_nav.content_id == @active_step_nav_content_id }
-          return active_step_nav.first
-        end
-
+        active_step_nav = get_active_step_nav
+        return active_step_nav if active_step_nav
         step_navs.first
       end
 

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -27,8 +27,11 @@ module GovukPublishingComponents
         step_navs.any? && step_navs.count < 5
       end
 
-      def related_links(step_by_step_navs = false)
-        if step_by_step_navs == false
+      def related_links
+
+        if get_active_step_nav
+          step_by_step_navs = [get_active_step_nav]
+        else
           step_by_step_navs = step_navs
         end
 

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -3,9 +3,10 @@ module GovukPublishingComponents
     # @private
     # Only used by the step by step component
     class PageWithStepByStepNavigation
-      def initialize(content_store_response, current_path)
+      def initialize(content_store_response, current_path, active_step_nav_content_id = false)
         @content_item = content_store_response.to_h
         @current_path = current_path
+        @active_step_nav_content_id = active_step_nav_content_id
       end
 
       def step_navs
@@ -19,7 +20,7 @@ module GovukPublishingComponents
       end
 
       def show_header?
-        step_navs.count == 1
+        step_navs.count == 1 or @active_step_nav_content_id
       end
 
       def show_related_links?
@@ -62,6 +63,11 @@ module GovukPublishingComponents
       attr_reader :content_item, :current_path
 
       def first_step_nav
+        if @active_step_nav_content_id
+          active_step_nav = step_navs.select { |step_nav| step_nav.content_id == @active_step_nav_content_id }
+          return active_step_nav.first
+        end
+
         step_navs.first
       end
 

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -27,8 +27,12 @@ module GovukPublishingComponents
         step_navs.any? && step_navs.count < 5
       end
 
-      def related_links
-        step_navs.map do |step_nav|
+      def related_links(step_by_step_navs = false)
+        if step_by_step_navs == false
+          step_by_step_navs = step_navs
+        end
+
+        step_by_step_navs.map do |step_nav|
           {
             href: step_nav.base_path,
             text: step_nav.title,

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -16,7 +16,7 @@ module GovukPublishingComponents
       end
 
       def show_sidebar?
-        show_header? && first_step_nav.steps.present?
+        show_header? && first_or_active_step_nav.steps.present?
       end
 
       def show_header?
@@ -43,9 +43,9 @@ module GovukPublishingComponents
 
       def sidebar
         if show_sidebar?
-          @sidebar ||= first_step_nav.content.tap do |sb|
+          @sidebar ||= first_or_active_step_nav.content.tap do |sb|
             configure_for_sidebar(sb)
-            sb.merge!(small: true, heading_level: 3, tracking_id: first_step_nav.content_id)
+            sb.merge!(small: true, heading_level: 3, tracking_id: first_or_active_step_nav.content_id)
           end
         end
       end
@@ -53,9 +53,9 @@ module GovukPublishingComponents
       def header
         if show_header?
           {
-            title: first_step_nav.title,
-            path: first_step_nav.base_path,
-            tracking_id: first_step_nav.content_id
+            title: first_or_active_step_nav.title,
+            path: first_or_active_step_nav.base_path,
+            tracking_id: first_or_active_step_nav.content_id
           }
         else
           {}
@@ -75,7 +75,7 @@ module GovukPublishingComponents
 
       attr_reader :content_item, :current_path
 
-      def first_step_nav
+      def first_or_active_step_nav
         active_step_nav = get_active_step_nav
         return active_step_nav if active_step_nav
         step_navs.first

--- a/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
+++ b/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
@@ -57,7 +57,7 @@ module GovukPublishingComponents
       def create_list_item_content(link)
         if link[:href]
           @link_index += 1
-          href = link_href(link[:active], link[:href])
+          href = link_href(link[:active], link[:href], "step-by-step-nav=#{@options[:content_id]}")
 
           text = capture do
             concat link_text(link[:active], link[:text])
@@ -92,7 +92,12 @@ module GovukPublishingComponents
         style == "choice" ? "ul" : "ol"
       end
 
-      def link_href(active, href)
+      def link_href(active, href, query_string = false)
+        
+        if query_string
+          href += "?#{query_string}"
+        end
+        
         active ? "#content" : href
       end
 

--- a/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
+++ b/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
@@ -93,11 +93,7 @@ module GovukPublishingComponents
       end
 
       def link_href(active, href, query_string = false)
-        
-        if query_string
-          href += "?#{query_string}"
-        end
-        
+        href += "?#{query_string}" if query_string
         active ? "#content" : href
       end
 

--- a/spec/components/step_by_step_nav_spec.rb
+++ b/spec/components/step_by_step_nav_spec.rb
@@ -176,23 +176,23 @@ describe "step nav", type: :view do
   end
 
   it "renders links and link attributes correctly" do
-    render_component(steps: stepnav)
+    render_component(steps: stepnav, tracking_id: "this-is-the-step-by-step-content-id")
 
-    assert_select step1 + " .gem-c-step-nav__link[href='/link1'][data-position='1.1']", text: "Link 1.1.1"
-    assert_select step1 + " .gem-c-step-nav__link[href='/link1'][rel='external']", false
-    assert_select step1 + " .gem-c-step-nav__link[href='http://www.gov.uk'][rel='external'][data-position='1.2']", text: "Link 1.1.2 £0 to £300"
-    assert_select step1 + " .gem-c-step-nav__link[href='http://www.gov.uk'] .gem-c-step-nav__context", text: "£0 to £300"
-    assert_select step1 + " .gem-c-step-nav__link[href='/link3'][data-position='1.3']", text: "Link 1.1.3"
-    assert_select step1 + " .gem-c-step-nav__link[href='/link4'][data-position='1.4']", text: "Link 1.1.4"
-    assert_select step2or + " .gem-c-step-nav__link[href='/link8'][data-position='4.2']", text: "Link 2.2.2"
+    assert_select step1 + " .gem-c-step-nav__link[href='/link1?step-by-step-nav=this-is-the-step-by-step-content-id'][data-position='1.1']", text: "Link 1.1.1"
+    assert_select step1 + " .gem-c-step-nav__link[href='/link1?step-by-step-nav=this-is-the-step-by-step-content-id'][rel='external']", false
+    assert_select step1 + " .gem-c-step-nav__link[href='http://www.gov.uk?step-by-step-nav=this-is-the-step-by-step-content-id'][rel='external'][data-position='1.2']", text: "Link 1.1.2 £0 to £300"
+    assert_select step1 + " .gem-c-step-nav__link[href='http://www.gov.uk?step-by-step-nav=this-is-the-step-by-step-content-id'] .gem-c-step-nav__context", text: "£0 to £300"
+    assert_select step1 + " .gem-c-step-nav__link[href='/link3?step-by-step-nav=this-is-the-step-by-step-content-id'][data-position='1.3']", text: "Link 1.1.3"
+    assert_select step1 + " .gem-c-step-nav__link[href='/link4?step-by-step-nav=this-is-the-step-by-step-content-id'][data-position='1.4']", text: "Link 1.1.4"
+    assert_select step2or + " .gem-c-step-nav__link[href='/link8?step-by-step-nav=this-is-the-step-by-step-content-id'][data-position='4.2']", text: "Link 2.2.2"
   end
 
   it "renders links without hrefs" do
-    render_component(steps: stepnav)
+    render_component(steps: stepnav, tracking_id: "this-is-the-step-by-step-content-id")
 
-    assert_select step2or + " .gem-c-step-nav__list-item .gem-c-step-nav__link[href='/link7'][data-position='4.1']", text: "Link 2.2.1"
+    assert_select step2or + " .gem-c-step-nav__list-item .gem-c-step-nav__link[href='/link7?step-by-step-nav=this-is-the-step-by-step-content-id'][data-position='4.1']", text: "Link 2.2.1"
     assert_select step2or + " .gem-c-step-nav__list-item", text: "or"
-    assert_select step2or + " .gem-c-step-nav__list-item .gem-c-step-nav__link[href='/link8'][data-position='4.2']", text: "Link 2.2.2"
+    assert_select step2or + " .gem-c-step-nav__list-item .gem-c-step-nav__link[href='/link8?step-by-step-nav=this-is-the-step-by-step-content-id'][data-position='4.2']", text: "Link 2.2.2"
   end
 
   it "renders optional steps" do

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -22,6 +22,12 @@ describe "Contextual navigation" do
     and_no_step_by_step_header
   end
 
+  scenario "I see the step by step I am currently interacting with" do
+    given_theres_are_two_step_by_step_lists
+    and_i_visit_that_page_by_clicking_on_a_step_by_step_link
+    then_i_see_the_step_by_step
+  end
+
   scenario "There's a mainstream browse page tagged" do
     given_theres_a_page_with_browse_page
     and_i_visit_that_page
@@ -131,6 +137,10 @@ describe "Contextual navigation" do
 
   def and_i_visit_that_page
     visit "/contextual-navigation/page-with-contextual-navigation"
+  end
+
+  def and_i_visit_that_page_by_clicking_on_a_step_by_step_link
+    visit "/contextual-navigation/page-with-contextual-navigation?step-by-step-nav=8ad782bd-8603-40eb-97c0-434cb22047cd"
   end
 
   def then_i_see_the_step_by_step

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -26,6 +26,7 @@ describe "Contextual navigation" do
     given_theres_are_two_step_by_step_lists
     and_i_visit_that_page_by_clicking_on_a_step_by_step_link
     then_i_see_the_step_by_step
+    and_the_step_by_step_header
   end
 
   scenario "There's a mainstream browse page tagged" do

--- a/spec/lib/components/step_by_step_nav_helper_spec.rb
+++ b/spec/lib/components/step_by_step_nav_helper_spec.rb
@@ -18,50 +18,50 @@ RSpec.describe GovukPublishingComponents::Presenters::StepByStepNavHelper do
 
     it "generates a basic list" do
       contents = [{ text: "Link 1", href: "/link1" }]
-      options = { link_index: 0, step_index: 0 }
+      options = { link_index: 0, step_index: 0, content_id: "this-is-the-step-by-step-content-id" }
       list = step_helper.render_step_nav_element({ type: "list", contents: contents }, options)
 
-      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="1"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1">Link 1 </a></li></ol>')
+      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="1"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1?step-by-step-nav=this-is-the-step-by-step-content-id">Link 1 </a></li></ol>')
     end
 
     it "generates a choice list" do
       contents = [{ text: "Link 1", href: "/link1" }]
-      options = { link_index: 0, step_index: 0 }
+      options = { link_index: 0, step_index: 0, content_id: "this-is-the-step-by-step-content-id" }
       list = step_helper.render_step_nav_element({ type: "list", contents: contents, style: "choice" }, options)
 
-      expect(list).to eql('<ul class="gem-c-step-nav__list gem-c-step-nav__list--choice" data-length="1"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1">Link 1 </a></li></ul>')
+      expect(list).to eql('<ul class="gem-c-step-nav__list gem-c-step-nav__list--choice" data-length="1"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1?step-by-step-nav=this-is-the-step-by-step-content-id">Link 1 </a></li></ul>')
     end
 
     it "generates a list with multiple items and correct link and step indexing attributes" do
       contents = [{ text: "Link 1", href: "/link1" }, { text: "Link 2", href: "/link2" }, { text: "Link 3", href: "/link3" }]
-      options = { link_index: 3, step_index: 2 }
+      options = { link_index: 3, step_index: 2, content_id: "this-is-the-step-by-step-content-id" }
       list = step_helper.render_step_nav_element({ type: "list", contents: contents }, options)
 
-      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="3"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="3.4" class="gem-c-step-nav__link js-link" href="/link1">Link 1 </a></li><li class="gem-c-step-nav__list-item js-list-item "><a data-position="3.5" class="gem-c-step-nav__link js-link" href="/link2">Link 2 </a></li><li class="gem-c-step-nav__list-item js-list-item "><a data-position="3.6" class="gem-c-step-nav__link js-link" href="/link3">Link 3 </a></li></ol>')
+      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="3"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="3.4" class="gem-c-step-nav__link js-link" href="/link1?step-by-step-nav=this-is-the-step-by-step-content-id">Link 1 </a></li><li class="gem-c-step-nav__list-item js-list-item "><a data-position="3.5" class="gem-c-step-nav__link js-link" href="/link2?step-by-step-nav=this-is-the-step-by-step-content-id">Link 2 </a></li><li class="gem-c-step-nav__list-item js-list-item "><a data-position="3.6" class="gem-c-step-nav__link js-link" href="/link3?step-by-step-nav=this-is-the-step-by-step-content-id">Link 3 </a></li></ol>')
     end
 
     it "generates a list with external links marked appropriately" do
       contents = [{ text: "Link 1", href: "https://www.gov.uk" }, { text: "Link 2", href: "/link2" }]
-      options = { link_index: 0, step_index: 0 }
+      options = { link_index: 0, step_index: 0, content_id: "this-is-the-step-by-step-content-id" }
       list = step_helper.render_step_nav_element({ type: "list", contents: contents }, options)
 
-      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="2"><li class="gem-c-step-nav__list-item js-list-item "><a rel="external" data-position="1.1" class="gem-c-step-nav__link js-link" href="https://www.gov.uk">Link 1 </a></li><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.2" class="gem-c-step-nav__link js-link" href="/link2">Link 2 </a></li></ol>')
+      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="2"><li class="gem-c-step-nav__list-item js-list-item "><a rel="external" data-position="1.1" class="gem-c-step-nav__link js-link" href="https://www.gov.uk?step-by-step-nav=this-is-the-step-by-step-content-id">Link 1 </a></li><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.2" class="gem-c-step-nav__link js-link" href="/link2?step-by-step-nav=this-is-the-step-by-step-content-id">Link 2 </a></li></ol>')
     end
 
     it "generates a list with contexts" do
       contents = [{ text: "Link 1", href: "/link1", context: "37p" }]
-      options = { link_index: 0, step_index: 0 }
+      options = { link_index: 0, step_index: 0, content_id: "this-is-the-step-by-step-content-id" }
       list = step_helper.render_step_nav_element({ type: "list", contents: contents }, options)
 
-      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="1"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1">Link 1 <span class="gem-c-step-nav__context">37p</span></a></li></ol>')
+      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="1"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1?step-by-step-nav=this-is-the-step-by-step-content-id">Link 1 <span class="gem-c-step-nav__context">37p</span></a></li></ol>')
     end
 
     it "generates a list with an active element" do
       contents = [{ text: "Link 1", href: "/link1" }, { text: "Link 2", href: "/link2", active: true }]
-      options = { link_index: 0, step_index: 0 }
+      options = { link_index: 0, step_index: 0, content_id: "this-is-the-step-by-step-content-id" }
       list = step_helper.render_step_nav_element({ type: "list", contents: contents }, options)
 
-      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="2"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1">Link 1 </a></li><li class="gem-c-step-nav__list-item js-list-item gem-c-step-nav__list-item--active"><a data-position="1.2" class="gem-c-step-nav__link js-link" href="#content"><span class="visuallyhidden">You are currently viewing: </span>Link 2 </a></li></ol>')
+      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="2"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1?step-by-step-nav=this-is-the-step-by-step-content-id">Link 1 </a></li><li class="gem-c-step-nav__list-item js-list-item gem-c-step-nav__list-item--active"><a data-position="1.2" class="gem-c-step-nav__link js-link" href="#content"><span class="visuallyhidden">You are currently viewing: </span>Link 2 </a></li></ol>')
     end
   end
 end


### PR DESCRIPTION
Spike on showing relevant step by step nav based on previous action

Part of this epic: https://trello.com/c/sPtieY54

## What
There are pages that are in more than one step by step journey. 
e.g. https://www.gov.uk/book-driving-test

For users arriving cold from Google we should show users the multiple journeys this content is part of.

But for users navigating using a specific step by step navigation e.g. Learn to drive a car. We should show that navigation expanded on the page. We should though give them a route into the alternative journey using a 'Part of' link.

## Why
We should show the relevant step by steps to users wherever possible.

## Before
![screenshot-frontend dev gov uk-2018 09 03-10-42-52](https://user-images.githubusercontent.com/4599889/44979985-7b012e00-af66-11e8-9f85-70c8c7300ce8.png)


## After
![screenshot-frontend dev gov uk-2018 09 03-10-39-37](https://user-images.githubusercontent.com/4599889/44979996-82c0d280-af66-11e8-8d94-2d083b20183e.png)


---

Component guide for this PR:
https://govuk-publishing-compon-pr-491.herokuapp.com/component-guide/
