### PR TITLE
Create "copy to clipboard" component

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/copy-to-clipboard.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/copy-to-clipboard.js
@@ -11,17 +11,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       copyButton.addEventListener('click', function (event) {
         event.preventDefault()
         var input = element[0].querySelector('.gem-c-input')
-        copyToClipboard(input.value)
+        input.select()
+        document.execCommand('copy')
       })
-    }
-
-    function copyToClipboard (text) {
-      var temp = document.createElement('input')
-      temp.value = text
-      document.body.appendChild(temp)
-      temp.select()
-      document.execCommand('copy')
-      document.body.removeChild(temp)
     }
   }
 })(window, window.GOVUK)

--- a/app/assets/javascripts/govuk_publishing_components/components/copy-to-clipboard.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/copy-to-clipboard.js
@@ -2,24 +2,26 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (global, GOVUK) {
-  "use strict"
-
-  var $ = global.jQuery
+  'use strict'
 
   GOVUK.Modules.CopyToClipboard = function () {
     this.start = function (element) {
-      element.on("click", "button", function (event) {
+      var copyButton = element[0].querySelector('.gem-c-button')
+
+      copyButton.addEventListener('click', function (event) {
         event.preventDefault()
-        copyToClipboard(element.find("input").val())
+        var input = element[0].querySelector('.gem-c-input')
+        copyToClipboard(input.value)
       })
     }
 
-    function copyToClipboard(text) {
-      var $temp = $("<input>");
-      $("body").append($temp);
-      $temp.val(text).select();
-      document.execCommand("copy");
-      $temp.remove();
+    function copyToClipboard (text) {
+      var temp = document.createElement('input')
+      temp.value = text
+      document.body.appendChild(temp)
+      temp.select()
+      document.execCommand('copy')
+      document.body.removeChild(temp)
     }
   }
 })(window, window.GOVUK)

--- a/app/assets/javascripts/govuk_publishing_components/components/copy-to-clipboard.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/copy-to-clipboard.js
@@ -1,0 +1,25 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (global, GOVUK) {
+  "use strict"
+
+  var $ = global.jQuery
+
+  GOVUK.Modules.CopyToClipboard = function () {
+    this.start = function (element) {
+      element.on("click", "button", function (event) {
+        event.preventDefault()
+        copyToClipboard(element.find("input").val())
+      })
+    }
+
+    function copyToClipboard(text) {
+      var $temp = $("<input>");
+      $("body").append($temp);
+      $temp.val(text).select();
+      document.execCommand("copy");
+      $temp.remove();
+    }
+  }
+})(window, window.GOVUK)

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -13,6 +13,7 @@
 @import "components/breadcrumbs";
 @import "components/button";
 @import "components/contents-list";
+@import "components/copy-to-clipboard";
 @import "components/document-list";
 @import "components/error-summary";
 @import "components/feedback";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_copy-to-clipboard.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_copy-to-clipboard.scss
@@ -1,0 +1,1 @@
+// No styles, this component just uses subcomponents

--- a/app/views/govuk_publishing_components/components/_copy_to_clipboard.html.erb
+++ b/app/views/govuk_publishing_components/components/_copy_to_clipboard.html.erb
@@ -1,0 +1,14 @@
+<div class="gem-c-copy-to-clipboard" data-module="copy-to-clipboard">
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: label,
+    },
+    name: SecureRandom.hex,
+    value: copyable_content
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: button_text,
+    secondary_quiet: true,
+  } %>
+</div>

--- a/app/views/govuk_publishing_components/components/docs/copy_to_clipboard.yml
+++ b/app/views/govuk_publishing_components/components/docs/copy_to_clipboard.yml
@@ -1,0 +1,10 @@
+name: Copy to clipboard
+description: Content that a user is intended to copy, like a URL
+examples:
+  default:
+    data:
+      label: Copy and send this link to someone and they’ll be able to preview your draft on GOV.UK.
+      copyable_content: http://www.example.org
+      button_text: Copy link
+accessibility_criteria: |
+  - should be usable with keyboard

--- a/spec/components/copy_to_clipboard_spec.rb
+++ b/spec/components/copy_to_clipboard_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe "Copy to clipboard", type: :view do
+  def component_name
+    "copy_to_clipboard"
+  end
+
+  it "renders the component" do
+    render_component(
+      label: "Some label",
+      copyable_content: "https://www.example.org",
+      button_text: "Copy link"
+    )
+
+    assert_select "label", text: "Some label"
+    assert_select "input", value: "https://www.example.org"
+    assert_select "button", value: "Copy link"
+  end
+end


### PR DESCRIPTION
This component will initially be used in the page preview in content publisher to allow users to copy a URL. Once we have it we can then use it to improve the [Subscription links component](https://govuk-publishing-components.herokuapp.com/component-guide/subscription-links/with_copyable_feed_link), which would benefit from the same functionality.

<img width="1002" alt="screen shot 2018-08-31 at 17 30 39" src="https://user-images.githubusercontent.com/233676/44924575-9c360480-ad43-11e8-8708-63215d64110d.png">

Preview: https://govuk-publishing-compon-pr-494.herokuapp.com/component-guide/copy_to_clipboard

https://trello.com/c/hAfZNnxt/183-add-copy-to-clipboard-component