### PR TITLE
Fix bug that prevents conditional content to be shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-# 9.16.1
+## Unreleased
+
+* Bugfix for Radios component (PR #496)
+
+## 9.16.1
 
 * Bugfix for Google Tag Manager component (PR #492)
 

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -12,7 +12,7 @@
   form_group_css_classes << "govuk-form-group--error" if error_message
 
   # check if any item is set as being conditional
-  has_conditional = items.any? { |item| item["conditional"] }
+  has_conditional = items.any? { |item| item.is_a?(Hash) && item[:conditional] }
 %>
 <%= content_tag :div, class: form_group_css_classes do %>
 

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -178,6 +178,7 @@ describe "Radio", type: :view do
       ]
     )
 
+    assert_select ".govuk-radios[data-module=radios]"
     assert_select ".govuk-radios__conditional", text: "You’ll need to prove your identity using Government Gateway"
   end
 


### PR DESCRIPTION
Currently, if `conditional` is a symbol, it will always show because this conditional doesn't add the `data-module=radios` attribute. Conversely, if `conditional` is a string it won't be displayed.