### PR TITLE
Expand relevant step-by-step to show the journey the user is on 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased changes
+
+* Show relevant step by step nav based on user journey (PR #501)
+
 ## 9.17.1
 
 * Fix bug in success alert component (PR #503)

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -2,7 +2,7 @@
 <% prioritise_taxon_breadcrumbs ||= false %>
 
 <div class='gem-c-contextual-breadcrumbs'>
-  <% if navigation.content_tagged_to_single_step_by_step? %>
+  <% if navigation.content_tagged_to_current_step_by_step? %>
     <!-- Rendering step by step nav breadcrumbs because there's 1 step by step -->
     <%= render 'govuk_publishing_components/components/step_by_step_nav_header',
       navigation.step_nav_helper.header %>

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -1,4 +1,4 @@
-<% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request.path) %>
+<% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request) %>
 <% prioritise_taxon_breadcrumbs ||= false %>
 
 <div class='gem-c-contextual-breadcrumbs'>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -6,7 +6,7 @@
     <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links %>
   <% end %>
 
-  <% if navigation.content_tagged_to_single_step_by_step? %>
+  <% if navigation.content_tagged_to_current_step_by_step? %>
     <!-- Rendering step by step sidebar because there's 1 step by step list -->
     <%= render 'govuk_publishing_components/components/step_by_step_nav', navigation.step_nav_helper.sidebar %>
   <% elsif navigation.content_tagged_to_mainstream_browse_pages? %>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -1,4 +1,4 @@
-<% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request.path) %>
+<% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request) %>
 
 <div class="gem-c-contextual-sidebar">
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -22,4 +22,12 @@
     <!-- Rendering related navigation sidebar because no browse, no related links, no live taxons -->
     <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
   <% end %>
+
+  <% if navigation.content_tagged_to_other_step_by_steps? %>
+    <!-- Rendering step by step related items because there are a few but not too many of them -->
+    <%= render 'govuk_publishing_components/components/step_by_step_nav_related', {
+      pretitle: "Also part of", 
+      links: navigation.step_nav_helper.also_part_of_step_nav 
+    } %>
+  <% end %>
 </div>

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -2,13 +2,14 @@ module GovukPublishingComponents
   module Presenters
     # @private
     class ContextualNavigation
-      attr_reader :content_item, :request_path
+      attr_reader :content_item, :request_path, :query_parameters
 
       # @param content_item A content item hash with strings as keys
       # @param request_path `request.path`
       def initialize(content_item, request)
         @content_item = content_item
         @request_path = simple_smart_answer? ? content_item['base_path'] : request.path
+        @query_parameters = request.query_parameters
       end
 
       def simple_smart_answer?
@@ -55,7 +56,7 @@ module GovukPublishingComponents
         content_item.dig("links", "taxons").to_a.any? { |taxon| taxon["phase"] == "live" }
       end
 
-      def content_tagged_to_single_step_by_step?
+      def content_tagged_to_current_step_by_step?
         # TODO: remove indirection here
         step_nav_helper.show_header?
       end
@@ -65,7 +66,7 @@ module GovukPublishingComponents
       end
 
       def step_nav_helper
-        @step_nav_helper ||= PageWithStepByStepNavigation.new(content_item, request_path)
+        @step_nav_helper ||= PageWithStepByStepNavigation.new(content_item, request_path, query_parameters)
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -65,6 +65,10 @@ module GovukPublishingComponents
         step_nav_helper.show_related_links?
       end
 
+      def content_tagged_to_other_step_by_steps?
+        step_nav_helper.show_also_part_of_step_nav?
+      end
+
       def step_nav_helper
         @step_nav_helper ||= PageWithStepByStepNavigation.new(content_item, request_path, query_parameters)
       end

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -6,9 +6,9 @@ module GovukPublishingComponents
 
       # @param content_item A content item hash with strings as keys
       # @param request_path `request.path`
-      def initialize(content_item, request_path)
+      def initialize(content_item, request)
         @content_item = content_item
-        @request_path = simple_smart_answer? ? content_item['base_path'] : request_path
+        @request_path = simple_smart_answer? ? content_item['base_path'] : request.path
       end
 
       def simple_smart_answer?

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -28,7 +28,8 @@ module GovukPublishingComponents
       end
 
       def related_links
-        step_navs.map do |step_nav|
+        step_by_step_navs = active_step_by_step? ? [active_step_by_step] : step_navs 
+        step_by_step_navs.map do |step_nav|
           {
             href: step_nav.base_path,
             text: step_nav.title,

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -28,14 +28,13 @@ module GovukPublishingComponents
       end
 
       def related_links
-        step_by_step_navs = active_step_by_step? ? [active_step_by_step] : step_navs 
-        step_by_step_navs.map do |step_nav|
-          {
-            href: step_nav.base_path,
-            text: step_nav.title,
-            tracking_id: step_nav.content_id
-          }
-        end
+        step_by_step_navs = active_step_by_step? ? [active_step_by_step] : step_navs
+        format_related_links(step_by_step_navs)
+      end
+
+      def also_part_of_step_nav
+        step_by_step_navs = step_navs.delete_if { |step_nav| step_nav.content_id == active_step_by_step.content_id }
+        format_related_links(step_by_step_navs)
       end
 
       def sidebar
@@ -104,6 +103,16 @@ module GovukPublishingComponents
           end
         end
         step_nav_content
+      end
+
+      def format_related_links(step_by_step_navs)
+        step_by_step_navs.map do |step_nav|
+          {
+            href: step_nav.base_path,
+            text: step_nav.title,
+            tracking_id: step_nav.content_id
+          }
+        end
       end
     end
 

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -16,11 +16,11 @@ module GovukPublishingComponents
       end
 
       def show_sidebar?
-        show_header? && first_step_nav.steps.present?
+        show_header? && current_step_nav.steps.present?
       end
 
       def show_header?
-        step_navs.count == 1
+        step_navs.count == 1 || active_step_by_step?
       end
 
       def show_related_links?
@@ -39,9 +39,9 @@ module GovukPublishingComponents
 
       def sidebar
         if show_sidebar?
-          @sidebar ||= first_step_nav.content.tap do |sb|
+          @sidebar ||= current_step_nav.content.tap do |sb|
             configure_for_sidebar(sb)
-            sb.merge!(small: true, heading_level: 3, tracking_id: first_step_nav.content_id)
+            sb.merge!(small: true, heading_level: 3, tracking_id: current_step_nav.content_id)
           end
         end
       end
@@ -49,9 +49,9 @@ module GovukPublishingComponents
       def header
         if show_header?
           {
-            title: first_step_nav.title,
-            path: first_step_nav.base_path,
-            tracking_id: first_step_nav.content_id
+            title: current_step_nav.title,
+            path: current_step_nav.base_path,
+            tracking_id: current_step_nav.content_id
           }
         else
           {}
@@ -71,7 +71,8 @@ module GovukPublishingComponents
 
       attr_reader :content_item, :current_path
 
-      def first_step_nav
+      def current_step_nav
+        return active_step_by_step if active_step_by_step?
         step_navs.first
       end
 

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -27,6 +27,10 @@ module GovukPublishingComponents
         step_navs.any? && (step_navs.count < 5 || active_step_by_step?)
       end
 
+      def show_also_part_of_step_nav?
+        active_step_by_step? && also_part_of_step_nav.any?
+      end
+
       def related_links
         step_by_step_navs = active_step_by_step? ? [active_step_by_step] : step_navs
         format_related_links(step_by_step_navs)

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -3,9 +3,10 @@ module GovukPublishingComponents
     # @private
     # Only used by the step by step component
     class PageWithStepByStepNavigation
-      def initialize(content_store_response, current_path)
+      def initialize(content_store_response, current_path, query_parameters = {})
         @content_item = content_store_response.to_h
         @current_path = current_path
+        @query_parameters = query_parameters
       end
 
       def step_navs
@@ -57,12 +58,25 @@ module GovukPublishingComponents
         end
       end
 
+      def active_step_by_step?
+        active_step_nav_content_id.present? && active_step_by_step.present?
+      end
+
+      def active_step_by_step
+        @active_step_navs ||= step_navs.select { |step_nav| step_nav.content_id == active_step_nav_content_id }
+        @active_step_navs.first
+      end
+
     private
 
       attr_reader :content_item, :current_path
 
       def first_step_nav
         step_navs.first
+      end
+
+      def active_step_nav_content_id
+        @active_step_nav_content_id ||= @query_parameters['step-by-step-nav'].present? ? @query_parameters['step-by-step-nav'] : nil
       end
 
       def steps

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -24,7 +24,7 @@ module GovukPublishingComponents
       end
 
       def show_related_links?
-        step_navs.any? && step_navs.count < 5
+        step_navs.any? && (step_navs.count < 5 || active_step_by_step?)
       end
 
       def related_links

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -22,6 +22,13 @@ describe "Contextual navigation" do
     and_no_step_by_step_header
   end
 
+  scenario "I see the step by step I am currently interacting with" do
+    given_theres_are_two_step_by_step_lists
+    and_i_visit_that_page_by_clicking_on_a_step_by_step_link
+    then_i_see_the_step_by_step
+    and_the_step_by_step_header
+  end
+
   scenario "There's a mainstream browse page tagged" do
     given_theres_a_page_with_browse_page
     and_i_visit_that_page
@@ -131,6 +138,10 @@ describe "Contextual navigation" do
 
   def and_i_visit_that_page
     visit "/contextual-navigation/page-with-contextual-navigation"
+  end
+
+  def and_i_visit_that_page_by_clicking_on_a_step_by_step_link
+    visit "/contextual-navigation/page-with-contextual-navigation?step-by-step-nav=8ad782bd-8603-40eb-97c0-434cb22047cd"
   end
 
   def then_i_see_the_step_by_step

--- a/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
+++ b/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
@@ -298,6 +298,7 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
     it "returns true if there is an active step by step" do
       step_nav_helper = described_class.new(content_item, "/driving-lessons-learning-to-drive", "step-by-step-nav" => "e01e924b-9c7c-4c71-8241-66a575c2f61f")
       expect(step_nav_helper.active_step_by_step?).to eq(true)
+      expect(step_nav_helper.show_related_links?).to be true
     end
 
     it "return false if there isn't an active step by step" do

--- a/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
+++ b/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
@@ -301,6 +301,13 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
       expect(step_nav_helper.show_related_links?).to be true
     end
 
+    it "returns the active step nav in the related links if there is an active step by step" do
+      step_nav_helper = described_class.new(content_item, "/driving-lessons-learning-to-drive", "step-by-step-nav" => "e01e924b-9c7c-4c71-8241-66a575c2f61f")
+      expect(step_nav_helper.related_links.count).to eq(1)
+      expect(step_nav_helper.related_links.first['tracking_id']).to eq(content_item[:content_id])
+      expect(step_nav_helper.show_related_links?).to be true
+    end
+
     it "return false if there isn't an active step by step" do
       step_nav_helper = described_class.new(content_item, "/driving-lessons-learning-to-drive")
       expect(step_nav_helper.active_step_by_step?).to eq(false)

--- a/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
+++ b/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
@@ -1,6 +1,123 @@
 require "spec_helper"
 
 RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigation do
+  let(:content_item) {
+    payload_for(
+      "guide",
+      "links" => {
+        "part_of_step_navs" => [
+          {
+            "api_path": "/api/content/learn-to-drive-a-car",
+            "base_path": "/learn-to-drive-a-car",
+            "content_id": "e01e924b-9c7c-4c71-8241-66a575c2f61f",
+            "description": "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
+            "document_type": "step_by_step_nav",
+            "locale": "en",
+            "public_updated_at": "2018-02-20T12:37:16Z",
+            "schema_name": "step_by_step_nav",
+            "title": "Learn to drive a car: step by step",
+            "withdrawn": false,
+            "details": {
+              "step_by_step_nav": {
+                "title": "Learn to drive a car: step by step",
+                "introduction": [
+                  {
+                    "content_type": "text/govspeak",
+                    "content": "Check what you need to do to learn to drive."
+                  }
+                ],
+                "steps": [
+                  {
+                    "title": "Check you're allowed to drive",
+                    "contents": [
+                      {
+                        "type": "paragraph",
+                        "text": "Most people can start learning to drive when they’re 17."
+                      },
+                      {
+                        "type": "list",
+                        "style": "required",
+                        "contents": [
+                          {
+                            "href": "/vehicles-can-drive",
+                            "text": "Check what age you can drive"
+                          },
+                          {
+                            "href": "/legal-obligations-drivers-riders",
+                            "text": "Requirements for driving legally"
+                          },
+                          {
+                            "href": "/driving-eyesight-rules",
+                            "text": "Driving eyesight rules"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Driving lessons and practice",
+                    "contents": [
+                      {
+                        "type": "paragraph",
+                        "text": "You need a provisional driving licence to take lessons or practice."
+                      },
+                      {
+                        "type": "list",
+                        "style": "required",
+                        "contents": [
+                          {
+                            "href": "/guidance/the-highway-code",
+                            "text": "The Highway Code"
+                          },
+                          {
+                            "href": "/driving-lessons-learning-to-drive",
+                            "text": "Taking driving lessons"
+                          },
+                          {
+                            "href": "/find-driving-schools-and-lessons",
+                            "text": "Find driving schools, lessons and instructors"
+                          },
+                          {
+                            "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions",
+                            "text": "Practise vehicle safety questions"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Prepare for your theory test",
+                    "logic": "and",
+                    "contents": [
+                      {
+                        "type": "list",
+                        "style": "required",
+                        "contents": [
+                          {
+                            "href": "/theory-test/revision-and-practice",
+                            "text": "Theory test revision and practice"
+                          },
+                          {
+                            "href": "/take-practice-theory-test",
+                            "text": "Take a practice theory test"
+                          },
+                          {
+                            "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
+                            "text": "Theory and hazard perception test app"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    )
+  }
+
   context "rules for handling differing numbers of linked step navs" do
     let(:step_nav) do
       {
@@ -145,121 +262,6 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
   end
 
   context "configuring step by step content for a sidebar navigation element" do
-    let(:content_item) {
-      payload_for("guide",
-        "links" => {
-          "part_of_step_navs" => [
-            {
-              "api_path": "/api/content/learn-to-drive-a-car",
-              "base_path": "/learn-to-drive-a-car",
-              "content_id": "e01e924b-9c7c-4c71-8241-66a575c2f61f",
-              "description": "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
-              "document_type": "step_by_step_nav",
-              "locale": "en",
-              "public_updated_at": "2018-02-20T12:37:16Z",
-              "schema_name": "step_by_step_nav",
-              "title": "Learn to drive a car: step by step",
-              "withdrawn": false,
-              "details": {
-                "step_by_step_nav": {
-                  "title": "Learn to drive a car: step by step",
-                  "introduction": [
-                    {
-                      "content_type": "text/govspeak",
-                      "content": "Check what you need to do to learn to drive."
-                    }
-                  ],
-                  "steps": [
-                    {
-                      "title": "Check you're allowed to drive",
-                      "contents": [
-                        {
-                          "type": "paragraph",
-                          "text": "Most people can start learning to drive when they’re 17."
-                        },
-                        {
-                          "type": "list",
-                          "style": "required",
-                          "contents": [
-                            {
-                              "href": "/vehicles-can-drive",
-                              "text": "Check what age you can drive"
-                            },
-                            {
-                              "href": "/legal-obligations-drivers-riders",
-                              "text": "Requirements for driving legally"
-                            },
-                            {
-                              "href": "/driving-eyesight-rules",
-                              "text": "Driving eyesight rules"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "title": "Driving lessons and practice",
-                      "contents": [
-                        {
-                          "type": "paragraph",
-                          "text": "You need a provisional driving licence to take lessons or practice."
-                        },
-                        {
-                          "type": "list",
-                          "style": "required",
-                          "contents": [
-                            {
-                              "href": "/guidance/the-highway-code",
-                              "text": "The Highway Code"
-                            },
-                            {
-                              "href": "/driving-lessons-learning-to-drive",
-                              "text": "Taking driving lessons"
-                            },
-                            {
-                              "href": "/find-driving-schools-and-lessons",
-                              "text": "Find driving schools, lessons and instructors"
-                            },
-                            {
-                              "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions",
-                              "text": "Practise vehicle safety questions"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "title": "Prepare for your theory test",
-                      "logic": "and",
-                      "contents": [
-                        {
-                          "type": "list",
-                          "style": "required",
-                          "contents": [
-                            {
-                              "href": "/theory-test/revision-and-practice",
-                              "text": "Theory test revision and practice"
-                            },
-                            {
-                              "href": "/take-practice-theory-test",
-                              "text": "Take a practice theory test"
-                            },
-                            {
-                              "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
-                              "text": "Theory and hazard perception test app"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            }
-          ]
-        })
-    }
-
     it "sets up navigation appropriately" do
       step_nav_helper = described_class.new(content_item, "/random_url")
       expect(step_nav_helper.step_navs.count).to eq(1)
@@ -289,6 +291,23 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
 
       # sets the /driving-lessons-learning-to-drive link to active
       expect(sidebar[:steps][1][:contents][1][:contents][1][:active]).to be true
+    end
+  end
+
+  context("active step by step") do
+    it "returns true if there is an active step by step" do
+      step_nav_helper = described_class.new(content_item, "/driving-lessons-learning-to-drive", "step-by-step-nav" => "e01e924b-9c7c-4c71-8241-66a575c2f61f")
+      expect(step_nav_helper.active_step_by_step?).to eq(true)
+    end
+
+    it "return false if there isn't an active step by step" do
+      step_nav_helper = described_class.new(content_item, "/driving-lessons-learning-to-drive")
+      expect(step_nav_helper.active_step_by_step?).to eq(false)
+    end
+
+    it "return false if it's an invalid step by step" do
+      step_nav_helper = described_class.new(content_item, "/driving-lessons-learning-to-drive", "step-by-step-nav" => "i-dont-exist")
+      expect(step_nav_helper.active_step_by_step?).to eq(false)
     end
   end
 

--- a/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
+++ b/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
@@ -299,6 +299,7 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
       step_nav_helper = described_class.new(content_item, "/driving-lessons-learning-to-drive", "step-by-step-nav" => "e01e924b-9c7c-4c71-8241-66a575c2f61f")
       expect(step_nav_helper.active_step_by_step?).to eq(true)
       expect(step_nav_helper.show_related_links?).to be true
+      expect(step_nav_helper.show_also_part_of_step_nav?).to be false
     end
 
     it "returns the active step nav in the related links if there is an active step by step" do
@@ -342,6 +343,7 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
       step_nav_helper = described_class.new(content_item_in_two_step_navs, "/driving-lessons-learning-to-drive", "step-by-step-nav" => "cccc-dddd")
       expect(step_nav_helper.also_part_of_step_nav.count).to eq(1)
       expect(step_nav_helper.also_part_of_step_nav.first[:tracking_id]).to eq('aaaa-bbbb')
+      expect(step_nav_helper.show_also_part_of_step_nav?).to be true
     end
   end
 

--- a/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
+++ b/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
@@ -317,6 +317,32 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
       step_nav_helper = described_class.new(content_item, "/driving-lessons-learning-to-drive", "step-by-step-nav" => "i-dont-exist")
       expect(step_nav_helper.active_step_by_step?).to eq(false)
     end
+
+    it "shows the titles of the other step navs the content item is part of" do
+      step_nav = {
+        "content_id" => "cccc-dddd",
+        "title" => "Learn to spacewalk: small step by giant leap",
+        "base_path" => "/learn-to-spacewalk"
+      }
+
+      another_step_nav = {
+        "content_id" => "aaaa-bbbb",
+        "title" => "Lose your lunch: lurch by lurch",
+        "base_path" => "/lose-your-lunch"
+      }
+
+      content_item_in_two_step_navs = {
+        "title" => "Book a session in the vomit comet",
+        "document_type" => "transaction",
+        "links" => {
+          "part_of_step_navs" => [step_nav, another_step_nav],
+        }
+      }
+
+      step_nav_helper = described_class.new(content_item_in_two_step_navs, "/driving-lessons-learning-to-drive", "step-by-step-nav" => "cccc-dddd")
+      expect(step_nav_helper.also_part_of_step_nav.count).to eq(1)
+      expect(step_nav_helper.also_part_of_step_nav.first[:tracking_id]).to eq('aaaa-bbbb')
+    end
   end
 
   def payload_for(schema, content_item)


### PR DESCRIPTION
## Notes: This only does the reading of the query string, does not add query string to the links on step by step.

Trello: https://trello.com/c/VOB2ioxF/809-expand-relevant-step-by-step-in-the-sidebar-to-show-the-journey-the-user-is-on-m

# User need
As a someone trying to do a thing
I want to see the steps in the step by step journey I am on
So that I know what I need to do next

# What
If a content page is in more than one step nav, we only show a link to all of the step navs. This makes it harder for the user to navigate to the next step in their journey.

Add something to the component that reads this value, so when then the content page is loaded the sidebar component expands the step by step that the user is following.

# Why
To make it easier for users to complete the journey they are on. 

# Measurement
I think we should see more linear journeys, and less clicking of the back button.

# Impact for users or other teams
There are limitations to this solution:
1. If the user comes to a content page with multiple step navs "cold" (i.e. directly from Google),  only the link to the step navs will be displayed.

2. If the user "breaks" the journey by going to a service or completing a smartanswer, then the querystring parameter will be lost, and if the done page is on muliple step navs, only the link to the step navs will be displayed.

# Applications involved

govuk_publishing_components 
government_frontend, frontend and collections to bump the gem version

# Screenshot
## Before
<img width="1552" alt="screen shot 2018-09-05 at 14 13 48" src="https://user-images.githubusercontent.com/5793815/45095511-21d7fc80-b116-11e8-898d-600ed02b75a5.png">


## After
![screenshot-frontend dev gov uk-2018 09 05-14-00-04](https://user-images.githubusercontent.com/4599889/45095059-f7d20a80-b114-11e8-8c0e-6f6cedcebf00.png)


---

Component guide for this PR:
https://govuk-publishing-compon-pr-501.herokuapp.com/component-guide/
