### PR TITLE
Adds step by step content ID to links inside steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Show relevant step by step nav based on user journey (PR #501)
 * Add Error alert component (PR #503)
 * Add experimental panel component based on GOV.UK Frontend (PR #507)
+* Adds step by step content ID to links inside steps (PR #502)
 
 ## 9.17.1
 

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
@@ -9,6 +9,7 @@
   step_nav_url ||= false
   highlight_step ||= false
   tracking_id ||= false
+  step_nav_content_id ||= tracking_id
 
   step_count = 0
   step_number = 0
@@ -70,6 +71,7 @@
           <div class="gem-c-step-nav__panel js-panel" id="step-panel-<%= id %>-<%= step_index + 1 %>">
             <%
               in_substep = false
+              options[:step_nav_content_id] = step_nav_content_id
               options[:step_index] = step_index
               options[:link_index] = 0
             %>

--- a/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
+++ b/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
@@ -93,7 +93,23 @@ module GovukPublishingComponents
       end
 
       def link_href(active, href)
-        active ? "#content" : href
+        return "#content" if active
+        return href if external_url?(href)
+        link_with_step_nav_query_parameter(href)
+      end
+
+      def external_url?(href)
+        href.start_with?('http')
+      end
+
+      def link_with_step_nav_query_parameter(href)
+        step_nav_content_id = @options[:step_nav_content_id]
+        return href if step_nav_content_id.blank?
+        uri = URI.parse(href)
+        exisiting_query_params = uri.query.present? ? CGI.parse(uri.query) : {}
+        new_query_params = exisiting_query_params.merge("step-by-step-nav" => step_nav_content_id)
+        uri.query = new_query_params.to_query
+        uri.to_s
       end
 
       def link_text(active, text)

--- a/spec/components/step_by_step_nav_spec.rb
+++ b/spec/components/step_by_step_nav_spec.rb
@@ -176,6 +176,18 @@ describe "step nav", type: :view do
   end
 
   it "renders links and link attributes correctly" do
+    render_component(steps: stepnav, tracking_id: "this-is-the-step-by-step-content-id")
+
+    assert_select step1 + " .gem-c-step-nav__link[href='/link1?step-by-step-nav=this-is-the-step-by-step-content-id'][data-position='1.1']", text: "Link 1.1.1"
+    assert_select step1 + " .gem-c-step-nav__link[href='/link1?step-by-step-nav=this-is-the-step-by-step-content-id'][rel='external']", false
+    assert_select step1 + " .gem-c-step-nav__link[href='http://www.gov.uk'][rel='external'][data-position='1.2']", text: "Link 1.1.2 £0 to £300"
+    assert_select step1 + " .gem-c-step-nav__link[href='http://www.gov.uk'] .gem-c-step-nav__context", text: "£0 to £300"
+    assert_select step1 + " .gem-c-step-nav__link[href='/link3?step-by-step-nav=this-is-the-step-by-step-content-id'][data-position='1.3']", text: "Link 1.1.3"
+    assert_select step1 + " .gem-c-step-nav__link[href='/link4?step-by-step-nav=this-is-the-step-by-step-content-id'][data-position='1.4']", text: "Link 1.1.4"
+    assert_select step2or + " .gem-c-step-nav__link[href='/link8?step-by-step-nav=this-is-the-step-by-step-content-id'][data-position='4.2']", text: "Link 2.2.2"
+  end
+
+  it "renders links and link attributes correctly without tracking id" do
     render_component(steps: stepnav)
 
     assert_select step1 + " .gem-c-step-nav__link[href='/link1'][data-position='1.1']", text: "Link 1.1.1"
@@ -188,11 +200,11 @@ describe "step nav", type: :view do
   end
 
   it "renders links without hrefs" do
-    render_component(steps: stepnav)
+    render_component(steps: stepnav, tracking_id: "this-is-the-step-by-step-content-id")
 
-    assert_select step2or + " .gem-c-step-nav__list-item .gem-c-step-nav__link[href='/link7'][data-position='4.1']", text: "Link 2.2.1"
+    assert_select step2or + " .gem-c-step-nav__list-item .gem-c-step-nav__link[href='/link7?step-by-step-nav=this-is-the-step-by-step-content-id'][data-position='4.1']", text: "Link 2.2.1"
     assert_select step2or + " .gem-c-step-nav__list-item", text: "or"
-    assert_select step2or + " .gem-c-step-nav__list-item .gem-c-step-nav__link[href='/link8'][data-position='4.2']", text: "Link 2.2.2"
+    assert_select step2or + " .gem-c-step-nav__list-item .gem-c-step-nav__link[href='/link8?step-by-step-nav=this-is-the-step-by-step-content-id'][data-position='4.2']", text: "Link 2.2.2"
   end
 
   it "renders optional steps" do

--- a/spec/lib/components/step_by_step_nav_helper_spec.rb
+++ b/spec/lib/components/step_by_step_nav_helper_spec.rb
@@ -18,50 +18,50 @@ RSpec.describe GovukPublishingComponents::Presenters::StepByStepNavHelper do
 
     it "generates a basic list" do
       contents = [{ text: "Link 1", href: "/link1" }]
-      options = { link_index: 0, step_index: 0 }
+      options = { link_index: 0, step_index: 0, step_nav_content_id: "this-is-an-id" }
       list = step_helper.render_step_nav_element({ type: "list", contents: contents }, options)
 
-      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="1"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1">Link 1 </a></li></ol>')
+      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="1"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1?step-by-step-nav=this-is-an-id">Link 1 </a></li></ol>')
     end
 
     it "generates a choice list" do
       contents = [{ text: "Link 1", href: "/link1" }]
-      options = { link_index: 0, step_index: 0 }
+      options = { link_index: 0, step_index: 0, step_nav_content_id: "this-is-an-id" }
       list = step_helper.render_step_nav_element({ type: "list", contents: contents, style: "choice" }, options)
 
-      expect(list).to eql('<ul class="gem-c-step-nav__list gem-c-step-nav__list--choice" data-length="1"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1">Link 1 </a></li></ul>')
+      expect(list).to eql('<ul class="gem-c-step-nav__list gem-c-step-nav__list--choice" data-length="1"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1?step-by-step-nav=this-is-an-id">Link 1 </a></li></ul>')
     end
 
     it "generates a list with multiple items and correct link and step indexing attributes" do
       contents = [{ text: "Link 1", href: "/link1" }, { text: "Link 2", href: "/link2" }, { text: "Link 3", href: "/link3" }]
-      options = { link_index: 3, step_index: 2 }
+      options = { link_index: 3, step_index: 2, step_nav_content_id: "this-is-an-id" }
       list = step_helper.render_step_nav_element({ type: "list", contents: contents }, options)
 
-      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="3"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="3.4" class="gem-c-step-nav__link js-link" href="/link1">Link 1 </a></li><li class="gem-c-step-nav__list-item js-list-item "><a data-position="3.5" class="gem-c-step-nav__link js-link" href="/link2">Link 2 </a></li><li class="gem-c-step-nav__list-item js-list-item "><a data-position="3.6" class="gem-c-step-nav__link js-link" href="/link3">Link 3 </a></li></ol>')
+      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="3"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="3.4" class="gem-c-step-nav__link js-link" href="/link1?step-by-step-nav=this-is-an-id">Link 1 </a></li><li class="gem-c-step-nav__list-item js-list-item "><a data-position="3.5" class="gem-c-step-nav__link js-link" href="/link2?step-by-step-nav=this-is-an-id">Link 2 </a></li><li class="gem-c-step-nav__list-item js-list-item "><a data-position="3.6" class="gem-c-step-nav__link js-link" href="/link3?step-by-step-nav=this-is-an-id">Link 3 </a></li></ol>')
     end
 
     it "generates a list with external links marked appropriately" do
       contents = [{ text: "Link 1", href: "https://www.gov.uk" }, { text: "Link 2", href: "/link2" }]
-      options = { link_index: 0, step_index: 0 }
+      options = { link_index: 0, step_index: 0, step_nav_content_id: "this-is-an-id" }
       list = step_helper.render_step_nav_element({ type: "list", contents: contents }, options)
 
-      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="2"><li class="gem-c-step-nav__list-item js-list-item "><a rel="external" data-position="1.1" class="gem-c-step-nav__link js-link" href="https://www.gov.uk">Link 1 </a></li><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.2" class="gem-c-step-nav__link js-link" href="/link2">Link 2 </a></li></ol>')
+      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="2"><li class="gem-c-step-nav__list-item js-list-item "><a rel="external" data-position="1.1" class="gem-c-step-nav__link js-link" href="https://www.gov.uk">Link 1 </a></li><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.2" class="gem-c-step-nav__link js-link" href="/link2?step-by-step-nav=this-is-an-id">Link 2 </a></li></ol>')
     end
 
     it "generates a list with contexts" do
       contents = [{ text: "Link 1", href: "/link1", context: "37p" }]
-      options = { link_index: 0, step_index: 0 }
+      options = { link_index: 0, step_index: 0, step_nav_content_id: "this-is-an-id" }
       list = step_helper.render_step_nav_element({ type: "list", contents: contents }, options)
 
-      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="1"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1">Link 1 <span class="gem-c-step-nav__context">37p</span></a></li></ol>')
+      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="1"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1?step-by-step-nav=this-is-an-id">Link 1 <span class="gem-c-step-nav__context">37p</span></a></li></ol>')
     end
 
     it "generates a list with an active element" do
       contents = [{ text: "Link 1", href: "/link1" }, { text: "Link 2", href: "/link2", active: true }]
-      options = { link_index: 0, step_index: 0 }
+      options = { link_index: 0, step_index: 0, step_nav_content_id: "this-is-an-id" }
       list = step_helper.render_step_nav_element({ type: "list", contents: contents }, options)
 
-      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="2"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1">Link 1 </a></li><li class="gem-c-step-nav__list-item js-list-item gem-c-step-nav__list-item--active"><a data-position="1.2" class="gem-c-step-nav__link js-link" href="#content"><span class="visuallyhidden">You are currently viewing: </span>Link 2 </a></li></ol>')
+      expect(list).to eql('<ol class="gem-c-step-nav__list " data-length="2"><li class="gem-c-step-nav__list-item js-list-item "><a data-position="1.1" class="gem-c-step-nav__link js-link" href="/link1?step-by-step-nav=this-is-an-id">Link 1 </a></li><li class="gem-c-step-nav__list-item js-list-item gem-c-step-nav__list-item--active"><a data-position="1.2" class="gem-c-step-nav__link js-link" href="#content"><span class="visuallyhidden">You are currently viewing: </span>Link 2 </a></li></ol>')
     end
   end
 end


### PR DESCRIPTION
# User need
As a someone trying to do a thing
I want to see the steps in the step by step journey I am on
So that I know what I need to do next

# What
If a content page is in more than one step nav, we only show a link to all of the step navs. This makes it harder for the user to navigate to the next step in their journey.

Add a parameter to the querystring when the user clicks on a link in a step nav. Then add something to the component that reads this value, so when then the content page is loaded the sidebar component expands the step by step that the user is following.

# Why
To make it easier for users to complete the journey they are on. 

# Measurement
I think we should see more linear journeys, and less clicking of the back button.

# Impact for users or other teams
There are limitations to this solution:
1. If the user comes to a content page with multiple step navs "cold" (i.e. directly from Google),  only the link to the step navs will be displayed.

2. If the user "breaks" the journey by going to a service or completing a smartanswer, then the querystring parameter will be lost, and if the done page is on muliple step navs, only the link to the step navs will be displayed.

# Applications involved

govuk_publishing_components 
government_frontend, frontend and collections to bump the gem version

---

Component guide for this PR:
https://govuk-publishing-compon-pr-[THIS PR NUMBER].herokuapp.com/component-guide/
