### PR TITLE
Avoid using an optional block in success alert component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix bug in success alert component (PR #503)
+
 ## 9.17
 
 * Support a description for Success Alert component (PR #499)  

--- a/app/views/govuk_publishing_components/components/_success_alert.html.erb
+++ b/app/views/govuk_publishing_components/components/_success_alert.html.erb
@@ -1,4 +1,4 @@
-<% description = yield %>
+<% description ||= nil %>
 
 <div
   class="gem-c-success-alert"

--- a/app/views/govuk_publishing_components/components/docs/success_alert.yml
+++ b/app/views/govuk_publishing_components/components/docs/success_alert.yml
@@ -9,10 +9,10 @@ examples:
   default:
     data:
       message: Message to alert the user to a successful action goes here
-  with_message_and_block:
+  with_message_and_description:
     data:
       message: Message to alert the user to a successful action goes here
-      block: A further description
+      description: A further description
   long_example:
     data:
       message: |

--- a/spec/components/success_alert_spec.rb
+++ b/spec/components/success_alert_spec.rb
@@ -11,9 +11,7 @@ describe "Success Alert", type: :view do
   end
 
   it "allows a block to be given for description" do
-    render_component(message: "Foo") do
-      "Bar"
-    end
+    render_component(message: "Foo", description: "Bar")
 
     assert_select ".gem-c-success-summary__title", text: "Foo"
     assert_select ".gem-c-success-summary__body", text: "Bar"


### PR DESCRIPTION
We currently have a really good bug blocking https://github.com/alphagov/content-publisher/pull/220 from being merged.

The success alert component intends to check if there's a block given to the alert component. It does so by checking `yield`. This works in tests, but in the real world there will *always* be a return value of `yield` - either the given block, or the *entire layout of the application*. Which leads to this beauty of a bug, which dupes the entire page inside the success alert:

![screencapture-content-publisher-dev-gov-uk-documents-fc421bc9-f2ce-4888-ab84-be73363b8894-en-2018-09-05-16_43_59](https://user-images.githubusercontent.com/233676/45105916-4ee3d980-b12d-11e8-93d0-b58c869d9fd7.png)

Unfortunately, we have no way of determining which `yield` we're talking to (`block_given?` is always true), so I think we won't be able to have optional blocks.

https://trello.com/c/i2Fi5qNQ