### PR TITLE
Pass through label params from textarea component

### DIFF
--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -27,10 +27,7 @@
 
 <%= content_tag :div, class: form_group_css_classes do %>
   <% if label %>
-    <%= render "govuk_publishing_components/components/label", {
-      text: label[:text],
-      html_for: id
-    } %>
+    <%= render "govuk_publishing_components/components/label", { html_for: id }.merge(label) %>
   <% end %>
 
   <% if hint %>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,4 @@
 {
-  "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
     "govuk-frontend": {


### PR DESCRIPTION
Instead of manually passing through params for the label component, this just passes everything in the `label` param. This allows us to pass any argument to label, without having to update the textarea component. I'd like to use this in content publisher to make the label bold.

https://trello.com/c/NEQWHpoU