### PR TITLE
Update error_summary to make title and hrefs optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+* Make 'title' optional on error_summary component (PR #510)
+* Make 'href' optional for items in the error_summary (PR #510)
+
+
 ## 9.18.0
 
 * Show relevant step by step nav based on user journey (PR #501)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-summary.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-summary.scss
@@ -48,6 +48,8 @@
 }
 
 .gem-c-error-summary__list__item {
+  color: $gem-error-colour;
+  font-weight: bold;
   margin-bottom: $gem-spacing-scale-2;
 
   &:last-child {

--- a/app/views/govuk_publishing_components/components/_error_summary.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_summary.html.erb
@@ -1,7 +1,11 @@
 <%
+  title ||= false
   description ||= false
   items ||= []
   title_id ||= "error-summary-title-#{SecureRandom.hex(4)}"
+  if items.empty? && !title
+    raise ArgumentError, "The error_summary component needs at least one item or a title in order to render."
+  end
 %>
 <div
   class="gem-c-error-summary"
@@ -10,9 +14,11 @@
   role="alert"
   tabindex="-1"
 >
-  <h2 class="gem-c-error-summary__title" id="<%= title_id %>">
-    <%= title %>
-  </h2>
+  <% if title %>
+    <h2 class="gem-c-error-summary__title" id="<%= title_id %>">
+      <%= title %>
+    </h2>
+  <% end %>
   <div class="gem-c-error-summary__body">
     <% if description %>
       <p class="gem-c-error-summary__text"><%= description %></p>

--- a/app/views/govuk_publishing_components/components/_error_summary.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_summary.html.erb
@@ -27,10 +27,14 @@
       <ul class="gem-c-error-summary__list">
         <% items.each_with_index do |item, index| %>
           <li class="gem-c-error-summary__list__item">
-            <a
-              class="js-error-summary__link gem-c-error-summary__link"
-              href="<%= item[:href] %>"
-            ><%= item[:text] %></a>
+            <% if item[:href] %>
+              <a
+                class="js-error-summary__link gem-c-error-summary__link"
+                href="<%= item[:href] %>"
+              ><%= item[:text] %></a>
+            <% else %>
+              <%= item[:text] %>
+            <% end %>
           </li>
         <% end %>
       </ul>

--- a/app/views/govuk_publishing_components/components/docs/error_summary.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_summary.yml
@@ -22,5 +22,4 @@ examples:
         href: '#example-error-1'
       - text: Descriptive link to the question with an error 2
         href: '#example-error-2'
-      - text: Descriptive link to the question with an error 3
-        href: '#example-error-3'
+      - text: Description of error without link

--- a/spec/components/error_summary_spec.rb
+++ b/spec/components/error_summary_spec.rb
@@ -11,6 +11,21 @@ describe "Error summary", type: :view do
     end
   end
 
+  it "renders error items when no title is set" do
+    render_component(
+      items: [
+        {
+          text: 'Descriptive link to the question with an error',
+          href: '#example-error-1'
+        }
+      ]
+    )
+    assert_select(
+      "ul li a.gem-c-error-summary__link:first-of-type[href='#example-error-1']",
+      text: 'Descriptive link to the question with an error'
+    )
+  end
+
   it "renders an error summary with title and aria-labelledby set correctly" do
     render_component(
       title: 'Message to alert the user to a problem goes here'

--- a/spec/components/error_summary_spec.rb
+++ b/spec/components/error_summary_spec.rb
@@ -76,6 +76,9 @@ describe "Error summary", type: :view do
         {
           text: 'Descriptive link to the question with an error 3',
           href: '#example-error-3'
+        },
+        {
+          text: 'Description for error 4 with no link'
         }
       ]
     )
@@ -94,6 +97,10 @@ describe "Error summary", type: :view do
     assert_select(
       "ul li a.gem-c-error-summary__link:last-of-type[href='#example-error-3']",
       text: 'Descriptive link to the question with an error 3'
+    )
+    assert_select(
+      "ul li:last-of-type",
+      text: 'Description for error 4 with no link'
     )
   end
 end


### PR DESCRIPTION
Allow error_summary to render without a 'title'. Now the error_summary requires either a title or at least one item in order to error. An ArgumentError is raised in the case where `{title: false, items: []}`

Previously each item in the error_summary required a href linking to more details for the errors, this change makes the href optional.

![screen shot 2018-09-07 at 17 10 19](https://user-images.githubusercontent.com/330135/45230521-fb09f980-b2c0-11e8-8f46-17faa57726c5.png)


---

Component guide for this PR:
https://govuk-publishing-compon-pr-[THIS PR NUMBER].herokuapp.com/component-guide/
