### PR TITLE
Refactor header component to provide options for head or list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+
+## Unreleased
+
+* Refactor header component to provide options for head or list (PR #516)
+
 ## 9.21.0
 
 * Add file upload component based on GOV.UK Frontend (PR #515)

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -27,7 +27,8 @@
     <!-- Rendering step by step related items because there are a few but not too many of them -->
     <%= render 'govuk_publishing_components/components/step_by_step_nav_related', {
       pretitle: "Also part of", 
-      links: navigation.step_nav_helper.also_part_of_step_nav 
+      links: navigation.step_nav_helper.also_part_of_step_nav,
+      always_display_as_list: true
     } %>
   <% end %>
 </div>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -1,6 +1,7 @@
 <%
   links ||= []
   pretitle ||= t("govuk_component.step_by_step_nav_related.part_of", default: "Part of")
+  always_display_as_list ||= false
 %>
 <% if links.any? %>
   <div 
@@ -8,7 +9,7 @@
     data-module="track-click">
     <h2 class="gem-c-step-nav-related__heading">
       <span class="gem-c-step-nav-related__pretitle"><%= pretitle %></span>
-      <% if links.length == 1 %>
+      <% if links.length == 1 && !always_display_as_list %>
           <a href="<%= links[0][:href] %>"
             class="gem-c-step-nav-related__link"
             data-track-category="stepNavPartOfClicked"

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav_related.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav_related.yml
@@ -62,3 +62,17 @@ examples:
           tracking_id: 'this-is-the-tracking-id'
         }
       ]
+  always_display_as_a_list:
+    description: |
+      when this component is rendered alongside an expanded step by step, we want it to render as a heading. 
+      However, in some cases the component will not be followed by a step by step, for example [Book Driving Test](https://www.gov.uk/book-driving-test).
+      In these cases, the heading is not followed by any content, so it should be rendered as a list instead.
+    data:
+      pretitle: 'Also part of'
+      always_display_as_list: true
+      links: [
+        {
+          href: '/learn-to-drive-a-motorbike',
+          text: 'Learn to drive a motorbike: step by step'
+        }
+      ]

--- a/spec/components/step_by_step_nav_related_spec.rb
+++ b/spec/components/step_by_step_nav_related_spec.rb
@@ -104,4 +104,11 @@ describe "Step by step navigation related", type: :view do
     assert_select ".gem-c-step-nav-related .gem-c-step-nav-related__link-item:nth-child(1) .gem-c-step-nav-related__link[data-track-options='{\"dimension96\" : \"peter\" }']"
     assert_select ".gem-c-step-nav-related .gem-c-step-nav-related__link-item:nth-child(2) .gem-c-step-nav-related__link[data-track-options='{\"dimension96\" : \"paul\" }']"
   end
+
+  it "displays as a list when always_display_as_list is passed in" do
+    render_component(links: one_link, always_display_as_list: true)
+
+    assert_select ".gem-c-step-nav-related .gem-c-step-nav-related__heading .gem-c-step-nav-related__pretitle", text: 'Part of'
+    assert_select ".gem-c-step-nav-related .gem-c-step-nav-related__links .gem-c-step-nav-related__link[href='/link1']", text: 'Link 1'
+  end
 end


### PR DESCRIPTION
When you're on a page that is part of two step by steps and one is expanded the other is displayed underneath as a heading but has no associated content.

When this happens the current orphaned header should be render as a list.

We should provide the option to display this as a list.

Ticket: https://trello.com/c/ul9DX8yu/856-refactor-header-component-to-provide-options-for-head-or-list

# Just component

## Before
<img width="1018" alt="screen shot 2018-09-13 at 11 33 36" src="https://user-images.githubusercontent.com/4599889/45483468-eb6b3480-b748-11e8-90b3-21687e141a07.png">

## After
<img width="1004" alt="screen shot 2018-09-13 at 11 33 07" src="https://user-images.githubusercontent.com/4599889/45483485-f7ef8d00-b748-11e8-9a9e-e9cefd6c8dbb.png">

# Within context

## Before
<img width="258" alt="screen shot 2018-09-13 at 11 35 24" src="https://user-images.githubusercontent.com/4599889/45483585-44d36380-b749-11e8-8343-61081dd84cfb.png">

## After
<img width="295" alt="screen shot 2018-09-13 at 11 35 03" src="https://user-images.githubusercontent.com/4599889/45483569-3ab16500-b749-11e8-91d5-1a94e384092f.png">


---

Component guide for this PR:
https://govuk-publishing-compon-pr-516.herokuapp.com/component-guide/step_by_step_nav_related/always_display_as_a_list
