### PR TITLE
Add a hasPart schema to collection pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add a hasPart schema to collection pages (PR #522)
+
 ## 9.24.0
 
 * Insert component guide script elements before closing body element (PR #525)

--- a/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
@@ -29,7 +29,7 @@ module GovukPublishingComponents
               "url" => page.logo_url,
             }
           }
-        }.merge(image_schema).merge(author_schema).merge(body).merge(is_part_of).merge(about)
+        }.merge(image_schema).merge(author_schema).merge(body).merge(is_part_of).merge(about).merge(has_part)
       end
 
     private
@@ -97,6 +97,21 @@ module GovukPublishingComponents
           logo_url: page.logo_url,
           image_placeholders: page.image_placeholders
         )
+      end
+
+      def has_part
+        return {} unless collection_pages.any?
+        {
+            "hasPart" => collection_pages.map { |document| HasPartSchema.new(document).structured_data }
+        }
+      end
+
+      def collection_pages
+        @pages ||= fetch_collection_pages
+      end
+
+      def fetch_collection_pages
+        page.content_item.dig("links", "documents").to_a.map { |document| document["web_url"] }
       end
 
       def about

--- a/lib/govuk_publishing_components/presenters/machine_readable/has_part_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/has_part_schema.rb
@@ -1,0 +1,20 @@
+module GovukPublishingComponents
+  module Presenters
+    class HasPartSchema
+      attr_reader :has_part_url
+
+      def initialize(has_part_url)
+        @has_part_url = has_part_url
+      end
+
+      def structured_data
+        # http://schema.org/hasPart - minimal
+        {
+          "@context" => "http://schema.org",
+          "@type" => "CreativeWork",
+          "sameAs" => has_part_url
+        }
+      end
+    end
+  end
+end

--- a/lib/govuk_publishing_components/presenters/schema_org.rb
+++ b/lib/govuk_publishing_components/presenters/schema_org.rb
@@ -1,6 +1,7 @@
 require 'govuk_publishing_components/presenters/machine_readable/page'
 require 'govuk_publishing_components/presenters/machine_readable/article_schema'
 require 'govuk_publishing_components/presenters/machine_readable/how_to_schema'
+require 'govuk_publishing_components/presenters/machine_readable/has_part_schema'
 require 'govuk_publishing_components/presenters/machine_readable/news_article_schema'
 require 'govuk_publishing_components/presenters/machine_readable/organisation_schema'
 require 'govuk_publishing_components/presenters/machine_readable/person_schema'

--- a/spec/lib/presenters/schema_org_spec.rb
+++ b/spec/lib/presenters/schema_org_spec.rb
@@ -235,6 +235,48 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
       expect(structured_data['about']).to eql(nil)
     end
 
+    it "links to items that belongs to the content" do
+      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "document_collection") do |random_item|
+        random_item.merge(
+          "first_published_at" => "2017-09-04T13:50:49.000+00:00",
+          "links" => {
+              "documents" => [
+                  {
+                      "api_path" => "/api/content/acetic-acid-properties-uses-and-incident-management",
+                      "base_path" => "/acetic-acid-properties-uses-and-incident-management",
+                      "content_id" => "47bcdf4c-9df9-48ff-b1ad-2381ca819464",
+                      "description" => "Guidance on acetic acid (also known as ethanoic acid) for use in responding to chemical incidents",
+                      "details" => {},
+                      "document_type" => "guidance",
+                      "locale" => "en",
+                      "public_updated_at" => "2018-06-22T12:12:38Z",
+                      "schema_name" => "publication",
+                      "title" => "Acetic acid: health effects and incident management",
+                      "api_url" => "/api/content/acetic-acid-properties-uses-and-incident-management",
+                      "web_url" => "https://www.gov.uk/acetic-acid-properties-uses-and-incident-management"
+                  }
+              ],
+              "primary_publishing_organisation" => [
+                  {
+                      "content_id" => "d944229b-a5ad-453d-8e16-cb5dcfcdb866",
+                      "title" => "Foo org",
+                      "locale" => "en",
+                      "base_path" => "/orgs/foo",
+                  }
+              ]
+          }
+        )
+      end
+
+      structured_data = generate_structured_data(
+        content_item: content_item,
+        schema: :article
+      ).structured_data
+
+      expect(structured_data['hasPart'][0]['@type']).to eq('CreativeWork')
+      expect(structured_data['hasPart'][0]['sameAs']).to eq('https://www.gov.uk/acetic-acid-properties-uses-and-incident-management')
+    end
+
     def live_taxons_links
       {
         "links" => {


### PR DESCRIPTION
- Adds hasPart schema to Article schema
- Indicates an item or CreativeWork that is part of this item

https://trello.com/c/Wbc2R5X6/165-add-haspart-schemaorg-property-to-collection-pages

The added schema has been validated by being tested in the Structured Data Testing Tool:

<img width="1429" alt="screen shot 2018-09-19 at 09 45 56" src="https://user-images.githubusercontent.com/6651749/45742191-51e0ce80-bbf1-11e8-8107-47673575d98c.png">

At present this is how the schema looks, when using the Structured Data Testing Tool, showing no errors:

<img width="1426" alt="screen shot 2018-09-19 at 16 10 57" src="https://user-images.githubusercontent.com/6651749/45763135-c9c9eb80-bc27-11e8-8373-8f3c7b412e04.png">


Once the hasPart is deployed, it will append a hasPart section in the Article schema, listing the documents that has been linked to it.

Having the hasPart schema implemented should improve the search results through Google search.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-522.herokuapp.com/component-guide/
