### PR TITLE
Move javascript initialistation to footer of component guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Insert component guide script elements before closing body element (PR #525)
+
 ## 9.23.0
 
 * Add half_width flag for higlight boxes (PR #520)

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -27,8 +27,6 @@
     <%= javascript_include_tag "govuk_publishing_components/vendor/modernizr" %>
   <% end %>
 
-  <%= javascript_include_tag "component_guide/application" %>
-  <%= javascript_include_tag "#{GovukPublishingComponents::Config.application_javascript}" %>
   <%= csrf_meta_tags %>
 </head>
 <body class="<%= 'hide-header-and-footer' if @preview %>">
@@ -52,5 +50,7 @@
     <% if @component_doc && @component_doc.part_of_admin_layout? %>
       <%= javascript_include_tag "govuk_publishing_components/admin_scripts" %>
     <% end %>
+    <%= javascript_include_tag "component_guide/application" %>
+    <%= javascript_include_tag "#{GovukPublishingComponents::Config.application_javascript}" %>
 </body>
 </html>


### PR DESCRIPTION
This moves the script elements from the HTML head to be just before the
closing body tag.

The reasons for this change are:

- This is a standard practice for not hindering a web page rendering
  with blocking scripts
- This allows to embrace the script initialisation approach used by
  [GOV.UK Frontend][1]

The need for this is triggered by Content Publisher using the GOV.UK
Frontend initialisation approach and thus the components do not work.

As far as I can tell this shouldn't cause any problems for existing apps
as all of their JS is initialised within `$(document).ready` functions
so will still execute at the same time.

[1]: https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-from-dist.md#2-include-resources

An alternative to this may be to include overwritable view files in component guide so that apps can insert JS / CSS in places that suit the application. 

As a follow up to this I think it'd be good to go through and move JS to just before body in our various frontend apps which should help prepare us for moving towards embracing GOV.UK Frontend.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-525.herokuapp.com/component-guide/
