### PR TITLE
Remove `Policies` from shared nav bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Remove 'Policies' link from government navbar (PR #529)
+
 ## 9.26.1
 
 * Add parentOrganization and subOrganization properties to org schemas (PR #533)

--- a/app/views/govuk_publishing_components/components/_government_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_government_navigation.html.erb
@@ -25,11 +25,6 @@
       </a>
     </li>
     <li class="clear-child">
-      <a class="<%= 'active' if active == 'policies' %>" href="/government/policies">
-        <%= t("govuk_component.government_navigation.policies", default: "Policies") %>
-      </a>
-    </li>
-    <li>
       <a class="<%= 'active' if active == 'publications' %>" href="/government/publications">
         <%= t("govuk_component.government_navigation.publications", default: "Publications") %>
       </a>


### PR DESCRIPTION
Remove `Policies` from the navigation as they are soon to be retired.

This is the governement navbar certain front-ends use (finder-frontend,
government-frontend) which is the same navigation bar whitehall-frontend
uses but the code for whitehalls is in whitehall.

Trello:
https://trello.com/c/e27ECoMb/209-remove-the-policies-link-from-the-content-page-header-applies-to-some-pages

## Before:
<img width="1028" alt="screen shot 2018-09-21 at 10 21 54" src="https://user-images.githubusercontent.com/24479188/45873414-5987ab00-bd8a-11e8-851f-ecd8743009c0.png">

## After:
<img width="1021" alt="screen shot 2018-09-21 at 10 21 14" src="https://user-images.githubusercontent.com/24479188/45873436-63111300-bd8a-11e8-8c2e-7da44a3306ba.png">
