### PR TITLE
Add organisation structure schema.org info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add parentOrganization and subOrganization properties to org schemas.
+
 ## 9.26.0
 
 * Add table component (PR #531)

--- a/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
@@ -54,3 +54,17 @@ examples:
         base_path: "/foo"
         details: {}
       schema: :organisation
+  organisation_schema_with_related_orgs:
+    data:
+      content_item:
+        title: "Magical Artefacts Agency"
+        base_path: "/foo"
+        details: {}
+        links:
+          ordered_parent_organisations:
+            - title: "Ministry of Magic"
+              base_path: "/ministry-of-magic"
+          ordered_child_organisations:
+            - title: "Dodgy Wands Commission"
+              base_path: "/dodgy-wands-commission"
+      schema: :organisation

--- a/lib/govuk_publishing_components/presenters/machine_readable/organisation_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/organisation_schema.rb
@@ -18,6 +18,39 @@ module GovukPublishingComponents
           },
           "name" => page.title,
           "description" => page.body
+        }.merge(parent_organisations).merge(sub_organisations)
+      end
+
+    private
+
+      def parent_organisations
+        related_organisations("ordered_parent_organisations", "parentOrganization")
+      end
+
+      def sub_organisations
+        related_organisations("ordered_child_organisations", "subOrganization")
+      end
+
+      def related_organisations(link_type, schema_name)
+        organisations = page.content_item.dig("links", link_type)
+
+        return {} unless organisations.present?
+
+        related_orgs = organisations.map do |org|
+          page = Page.new(content_item: org)
+          linked_org(page.canonical_url)
+        end
+
+        {
+          schema_name => related_orgs
+        }
+      end
+
+      def linked_org(url)
+        {
+          "@context" => "http://schema.org",
+          "@type" => "GovernmentOrganization",
+          "sameAs" => url
         }
       end
     end

--- a/spec/lib/presenters/schema_org_spec.rb
+++ b/spec/lib/presenters/schema_org_spec.rb
@@ -44,6 +44,24 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
       expect(structured_data['@type']).to eql("Person")
     end
 
+    it "generates schema.org GovernmentOrganization" do
+      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "organisation") do |org|
+        org.merge(
+          "base_path" => "/ministry-of-magic",
+          "title" => "Ministry of Magic"
+        )
+      end
+
+      structured_data = generate_structured_data(
+        content_item: content_item,
+        schema: :organisation
+      ).structured_data
+
+      expect(structured_data["@type"]).to eq("GovernmentOrganization")
+      expect(structured_data["name"]).to eq("Ministry of Magic")
+      expect(structured_data["mainEntityOfPage"]["@id"]).to eq("http://www.dev.gov.uk/ministry-of-magic")
+    end
+
     it "allows override of the URL" do
       content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "answer") do |random_item|
         random_item.merge(


### PR DESCRIPTION
Adds [parent][1] and [child][2] organisations (if present) to the GovernmentOrganization schema.org information rendered on org pages.

Organisations like [Defra][3] have only child orgs (no parent), [BCMS][4] only have a parent (no children) and some, like [Rural Payments Agency][5] have both.

https://trello.com/c/aoP7LQGh/180-add-parent-and-child-orgs-to-the-governmentorganization-schema

Rural payments agency schema with parent and sub-Organization properties
![screen shot 2018-09-24 at 13 09 10](https://user-images.githubusercontent.com/773037/45951374-1ed87980-bffb-11e8-8fdc-071031a9dab1.png)


[1]: https://schema.org/parentOrganization
[2]: https://schema.org/subOrganization
[3]: https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs
[4]: https://www.gov.uk/government/organisations/rural-payments-agency
[5]: https://www.gov.uk/government/organisations/british-cattle-movement-service

---

Component guide for updated machine readable metadata on this PR:
https://govuk-publishing-compon-pr-533.herokuapp.com/component-guide/machine_readable_metadata
