### PR TITLE
Bump patch version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@
 
 ## Unreleased
 
-* Add parentOrganization and subOrganization properties to org schemas.
-* Remove RummagerTaxonomySidebarLinks from contextual navigation
+## 9.26.1
+
+* Add parentOrganization and subOrganization properties to org schemas (PR #533)
+* Remove RummagerTaxonomySidebarLinks from contextual navigation (PR #530)
 
 ## 9.26.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (9.26.0)
+    govuk_publishing_components (9.26.1)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -60,6 +60,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
+    aws-xray-sdk (0.10.2)
+      oj (~> 3.0)
     builder (3.2.3)
     byebug (10.0.2)
     capybara (2.14.4)
@@ -82,7 +84,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.1)
     execjs (2.7.0)
-    faraday (0.15.2)
+    faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     foreman (0.85.0)
@@ -111,7 +113,8 @@ GEM
       rubocop (~> 0.52.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
-    govuk_app_config (1.8.0)
+    govuk_app_config (1.9.1)
+      aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
@@ -152,7 +155,7 @@ GEM
       PriorityQueue (~> 0.1.2)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
-    marcel (0.3.2)
+    marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
     mime-types (3.1)
@@ -172,6 +175,7 @@ GEM
     nokogumbo (1.5.0)
       nokogiri
     null_logger (0.0.1)
+    oj (3.6.10)
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '9.26.0'.freeze
+  VERSION = '9.26.1'.freeze
 end


### PR DESCRIPTION
These changes are small:

- RummagerTaxonomySidebarLinks should not be directly used by anything external
- The org schema changes are minor additions and don't require any opt ins to use

https://trello.com/c/aoP7LQGh/180-add-parent-and-child-orgs-to-the-governmentorganization-schema

---

Component guide for this PR:
https://govuk-publishing-compon-pr-534.herokuapp.com/component-guide/
