### PR TITLE
Show step by step when disabled but active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Show step by step when the navigation is disabled but a user is actively interacting with the step by step (PR #535)
+
 ## 9.26.1
 
 * Add parentOrganization and subOrganization properties to org schemas (PR #533)

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -15,6 +15,12 @@ module GovukPublishingComponents
         end
       end
 
+      def related_to_step_navs
+        @related_to_step_navs ||= parsed_related_to_step_navs.map do |step_nav|
+          StepByStepModel.new(step_nav)
+        end
+      end
+
       def show_sidebar?
         show_header? && current_step_nav.steps.present?
       end
@@ -90,6 +96,10 @@ module GovukPublishingComponents
 
       def parsed_step_navs
         content_item.dig("links", "part_of_step_navs").to_a
+      end
+
+      def parsed_related_to_step_navs
+        content_item.dig("links", "related_to_step_navs").to_a
       end
 
       def configure_for_sidebar(step_nav_content)

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -30,7 +30,8 @@ module GovukPublishingComponents
       end
 
       def show_related_links?
-        step_navs.any? && (step_navs.count < 5 || active_step_by_step?)
+        return true if active_step_by_step?
+        step_navs.any? && step_navs.count < 5
       end
 
       def show_also_part_of_step_nav?

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -73,7 +73,8 @@ module GovukPublishingComponents
       end
 
       def active_step_by_step
-        @active_step_navs ||= step_navs.select { |step_nav| step_nav.content_id == active_step_nav_content_id }
+        step_navs_list = step_navs_combined_list
+        @active_step_navs ||= step_navs_list.select { |step_nav| step_nav.content_id == active_step_nav_content_id }
         @active_step_navs.first
       end
 
@@ -92,6 +93,13 @@ module GovukPublishingComponents
 
       def steps
         @steps ||= step_nav[:steps]
+      end
+
+      def step_navs_combined_list
+        step_nav_list = []
+        step_nav_list += step_navs if step_navs.any?
+        step_nav_list += related_to_step_navs if related_to_step_navs.any?
+        step_nav_list
       end
 
       def parsed_step_navs

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -44,7 +44,8 @@ module GovukPublishingComponents
       end
 
       def also_part_of_step_nav
-        step_by_step_navs = step_navs.delete_if { |step_nav| step_nav.content_id == active_step_by_step.content_id }
+        step_navs_list = step_navs_combined_list
+        step_by_step_navs = step_navs_list.delete_if { |step_nav| step_nav.content_id == active_step_by_step.content_id }
         format_related_links(step_by_step_navs)
       end
 

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -35,7 +35,7 @@ module GovukPublishingComponents
       end
 
       def show_also_part_of_step_nav?
-        active_step_by_step? && also_part_of_step_nav.any?
+        active_step_by_step? && also_part_of_step_nav.any? && step_navs_combined_list.count < 5
       end
 
       def related_links

--- a/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
+++ b/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
@@ -381,6 +381,24 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
       expect(step_nav_helper.active_step_by_step?).to eq(false)
       expect(step_nav_helper.show_also_part_of_step_nav?).to be false
     end
+
+    it "shows header for related to step nav when a step by step is active" do
+      step_nav = {
+        "content_id" => "cccc-dddd",
+        "title" => "Learn to spacewalk: small step by giant leap",
+        "base_path" => "/learn-to-spacewalk"
+      }
+      content_item = {
+        "title" => "Book a session in the vomit comet",
+        "document_type" => "transaction",
+        "links" => {
+          "related_to_step_navs" => [step_nav],
+        }
+      }
+      step_nav_helper = described_class.new(content_item, "/driving-lessons-learning-to-drive", "step-by-step-nav" => "cccc-dddd")
+      expect(step_nav_helper.active_step_by_step?).to eq(true)
+      expect(step_nav_helper.show_header?).to eq(true)
+    end
   end
 
   def payload_for(schema, content_item)

--- a/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
+++ b/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
@@ -399,6 +399,30 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
       expect(step_nav_helper.active_step_by_step?).to eq(true)
       expect(step_nav_helper.show_header?).to eq(true)
     end
+
+    it "shows the titles of the other step navs the content item is part of" do
+      step_nav = {
+        "content_id" => "cccc-dddd",
+        "title" => "Learn to spacewalk: small step by giant leap",
+        "base_path" => "/learn-to-spacewalk"
+      }
+      another_step_nav = {
+        "content_id" => "aaaa-bbbb",
+        "title" => "Lose your lunch: lurch by lurch",
+        "base_path" => "/lose-your-lunch"
+      }
+      content_item_in_two_step_navs = {
+        "title" => "Book a session in the vomit comet",
+        "document_type" => "transaction",
+        "links" => {
+          "related_to_step_navs" => [step_nav, another_step_nav],
+        }
+      }
+      step_nav_helper = described_class.new(content_item_in_two_step_navs, "/driving-lessons-learning-to-drive", "step-by-step-nav" => "cccc-dddd")
+      expect(step_nav_helper.also_part_of_step_nav.count).to eq(1)
+      expect(step_nav_helper.also_part_of_step_nav.first[:tracking_id]).to eq('aaaa-bbbb')
+      expect(step_nav_helper.show_also_part_of_step_nav?).to be true
+    end
   end
 
   def payload_for(schema, content_item)

--- a/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
+++ b/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
@@ -423,6 +423,55 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
       expect(step_nav_helper.also_part_of_step_nav.first[:tracking_id]).to eq('aaaa-bbbb')
       expect(step_nav_helper.show_also_part_of_step_nav?).to be true
     end
+
+    it "does not show part of step navs if more than 5" do
+      step_nav = {
+        "content_id" => "cccc-dddd",
+        "title" => "Learn to spacewalk: small step by giant leap",
+        "base_path" => "/learn-to-spacewalk"
+      }
+      another_step_nav = {
+        "content_id" => "aaaa-bbbb",
+        "title" => "Lose your lunch: lurch by lurch",
+        "base_path" => "/lose-your-lunch"
+      }
+      another_step_nav2 = {
+        "content_id" => "aaaa-bbbb",
+        "title" => "Lose your lunch: lurch by lurch 2",
+        "base_path" => "/lose-your-lunch-2"
+      }
+      another_step_nav3 = {
+        "content_id" => "aaaa-bbbb",
+        "title" => "Lose your lunch: lurch by lurch 3",
+        "base_path" => "/lose-your-lunch-3"
+      }
+      another_step_nav4 = {
+        "content_id" => "aaaa-bbbb",
+        "title" => "Lose your lunch: lurch by lurch 4",
+        "base_path" => "/lose-your-lunch-4"
+      }
+      another_step_nav5 = {
+        "content_id" => "aaaa-bbbb",
+        "title" => "Lose your lunch: lurch by lurch 5",
+        "base_path" => "/lose-your-lunch-5"
+      }
+      content_item_in_six_step_navs = {
+        "title" => "Book a session in the vomit comet",
+        "document_type" => "transaction",
+        "links" => {
+          "related_to_step_navs" => [
+            step_nav,
+            another_step_nav,
+            another_step_nav2,
+            another_step_nav3,
+            another_step_nav4,
+            another_step_nav5,
+          ],
+        }
+      }
+      step_nav_helper = described_class.new(content_item_in_six_step_navs, "/driving-lessons-learning-to-drive", "step-by-step-nav" => "cccc-dddd")
+      expect(step_nav_helper.show_also_part_of_step_nav?).to eq(false)
+    end
   end
 
   def payload_for(schema, content_item)

--- a/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
+++ b/spec/lib/presenters/page_with_step_by_step_navigation_spec.rb
@@ -345,6 +345,42 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
       expect(step_nav_helper.also_part_of_step_nav.first[:tracking_id]).to eq('aaaa-bbbb')
       expect(step_nav_helper.show_also_part_of_step_nav?).to be true
     end
+
+    it "shows related to step nav when a step by step is active" do
+      step_nav = {
+        "content_id" => "cccc-dddd",
+        "title" => "Learn to spacewalk: small step by giant leap",
+        "base_path" => "/learn-to-spacewalk"
+      }
+      content_item = {
+        "title" => "Book a session in the vomit comet",
+        "document_type" => "transaction",
+        "links" => {
+          "related_to_step_navs" => [step_nav],
+        }
+      }
+      step_nav_helper = described_class.new(content_item, "/driving-lessons-learning-to-drive", "step-by-step-nav" => "cccc-dddd")
+      expect(step_nav_helper.active_step_by_step?).to eq(true)
+      expect(step_nav_helper.also_part_of_step_nav.count).to eq(0)
+    end
+
+    it "does not shows related to step nav when a step by step is not active" do
+      step_nav = {
+        "content_id" => "cccc-dddd",
+        "title" => "Learn to spacewalk: small step by giant leap",
+        "base_path" => "/learn-to-spacewalk"
+      }
+      content_item = {
+        "title" => "Book a session in the vomit comet",
+        "document_type" => "transaction",
+        "links" => {
+          "related_to_step_navs" => [step_nav],
+        }
+      }
+      step_nav_helper = described_class.new(content_item, "/driving-lessons-learning-to-drive")
+      expect(step_nav_helper.active_step_by_step?).to eq(false)
+      expect(step_nav_helper.show_also_part_of_step_nav?).to be false
+    end
   end
 
   def payload_for(schema, content_item)


### PR DESCRIPTION
## What 
We want change how 'Hide navigation' option works.

At the moment when navigation is hidden its hidden for all users. We want to change this so that if a user uses the step by step navigation to get to the page with hidden navigation, the navigation shows.

## Why
Lab research has shown the value of showing step by step navigation throughout the journey.

Ticket: https://trello.com/c/SsoemgHH/860-related-to-step-by-step

# Before
<img width="1074" alt="screen shot 2018-09-13 at 15 31 57" src="https://user-images.githubusercontent.com/4599889/45495000-42353600-b76a-11e8-9f88-1eb41496fdd7.png">

# After
<img width="1044" alt="screen shot 2018-09-13 at 15 31 38" src="https://user-images.githubusercontent.com/4599889/45495003-46f9ea00-b76a-11e8-94af-38613ecc0f08.png">


---

Component guide for this PR:
https://govuk-publishing-compon-pr-535.herokuapp.com/component-guide/
