### PR TITLE
Add data-tracking-url attribute to radio inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add data-tracking-url for radio inputs for the purposes of cross domain tracking (PR #539)
+
 ## 10.0.0
 
 * BREAKING: Code related to `Policies` has been removed, including the

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -45,6 +45,9 @@
           label_id = item[:id] ? item[:id] : "#{id_prefix}-#{index}"
           label_hint_id = "label-hint-#{SecureRandom.hex(4)}" if item[:hint_text].present?
           conditional_id = "conditional-#{SecureRandom.hex(4)}" if item[:conditional].present?
+
+          data_attrs = { "aria-controls": conditional_id }
+          data_attrs["tracking-url"] =  item[:url] if item.key?(:url)
         %>
         <%= tag.div class: %w( gem-c-radio govuk-radios__item ) do %>
           <%= check_box_tag name,
@@ -57,9 +60,7 @@
               aria: {
                 describedby: label_hint_id
               },
-              data: {
-                "aria-controls": conditional_id
-              }
+              data: data_attrs,
             }
           %>
           <%= render "govuk_publishing_components/components/label", {

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -151,3 +151,14 @@ examples:
       - value: "govuk-verify"
         text: "Use GOV.UK Verify"
         conditional: "You’ll need to prove your identity using GOV.UK Verify"
+  tracking-url:
+    data:
+      name: "radio-group-tracking-url"
+      id_prefix: "tracking-url"
+      items:
+      - value: "government-gateway"
+        text: "Use Government Gateway"
+        url: "https://www.tax.service.gov.uk/gg/sign-in?continue=%2Fcheck-your-state-pension"
+      - value: "govuk-verify"
+        text: "Use GOV.UK Verify"
+        url: "https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=uk_idp_sign_in"

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -240,6 +240,29 @@ describe "Radio", type: :view do
 
     assert_select ".govuk-radios__divider", text: "neu"
   end
+
+  it "renders a radio group with data-tracking-url attributes" do
+    gateway_url = "https://www.tax.service.gov.uk/gg/sign-in?continue=%2Fcheck-your-state-pension%2Faccount&origin=nisp-frontend&accountType=individual"
+    verify_url = "https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=eidas_sign_in"
+    render_component(
+      name: "radio-group-tracking-urls",
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway",
+          url: gateway_url,
+        },
+        {
+          value: "govuk-verify",
+          text: "Use GOV.UK Verify",
+          url: verify_url,
+        }
+      ]
+    )
+
+    assert_select ".govuk-radios input[data-tracking-url='#{gateway_url}']"
+    assert_select ".govuk-radios input[data-tracking-url='#{verify_url}']"
+  end
 end
 
 # This component can be interacted with, so use integration tests for these cases.


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

In order to track choices made in service sign in pages
across domains we need to expose the destination of the chosen
option.

Related: https://github.com/alphagov/govuk-content-schemas/pull/817

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-539.herokuapp.com/component-guide/
