### PR TITLE
Remove policies related code

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/related_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/related_navigation.yml
@@ -1,5 +1,5 @@
 name: Related Navigation
-description: Component showing related content, including topics, guidance, collections and policies (where applicable)
+description: Component showing related content, including topics, guidance and collections
 accessibility_criteria: |
   - Should have a role of 'navigation' on any navigation elements inside the component
   - Should be marked up as navigation and not as tangential content
@@ -41,16 +41,6 @@ examples:
           - title: The future of jobs and skills
             base_path: /government/collections/the-future-of-jobs-and-skills
             document_type: document_collection
-  with_policies:
-    data:
-      links:
-        related_policies:
-          - title: Further education and training
-            base_path: /government/policies/further-education-and-training
-            document_type: policy
-          - title: Primary school education
-            base_path: /government/policies/primary-school-education
-            document_type: policy
   with_topical_events:
     data:
       links:
@@ -151,10 +141,6 @@ examples:
           - title: The future of jobs and skills
             base_path: /government/collections/the-future-of-jobs-and-skills
             document_type: document_collection
-        related_policies:
-          - title: Further education and training
-            base_path: /government/policies/further-education-and-training
-            document_type: policy
         world_locations:
           - title: South Sudan
             base_path: /world/south-sudan/news

--- a/lib/govuk_publishing_components/presenters/content_item.rb
+++ b/lib/govuk_publishing_components/presenters/content_item.rb
@@ -90,10 +90,6 @@ module GovukPublishingComponents
         filter_link_type(content_store_response.dig("links", "organisations").to_a, "organisation")
       end
 
-      def related_policies
-        filter_link_type(content_store_response.dig("links", "related_policies").to_a, "policy")
-      end
-
       def related_statistical_data_sets
         filter_link_type(content_store_response.dig("links", "related_statistical_data_sets").to_a, "statistical_data_set")
       end

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -8,7 +8,6 @@ module GovukPublishingComponents
         related_guides
         topics
         collections
-        policies
         topical_events
         world_locations
         statistical_data_sets
@@ -24,7 +23,6 @@ module GovukPublishingComponents
           "related_guides" => related_guides,
           "collections" => related_collections,
           "topics" => related_topics,
-          "policies" => related_policies,
           "topical_events" => related_topical_events,
           "world_locations" => related_world_locations,
           "statistical_data_sets" => related_statistical_data_sets,
@@ -104,11 +102,6 @@ module GovukPublishingComponents
         links.select do |link|
           link["document_type"] == type
         end
-      end
-
-      def related_policies
-        policies = filter_link_type("related_policies", "policy")
-        build_links_for_sidebar(policies)
       end
 
       def related_statistical_data_sets

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,5 @@
 {
+  "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
     "govuk-frontend": {

--- a/spec/components/related_navigation_spec.rb
+++ b/spec/components/related_navigation_spec.rb
@@ -91,20 +91,6 @@ describe "Related navigation", type: :view do
     assert_select ".gem-c-related-navigation__section-link[href=\"/government/collections/the-future-of-jobs-and-skills\"]", text: 'The future of jobs and skills'
   end
 
-  it "renders policy section when passed policy items" do
-    content_item = {}
-    content_item["links"] = construct_links(
-      "related_policies",
-      "/government/policies/further-education-and-training",
-      "Further education and training",
-      "policy"
-    )
-    render_component(content_item)
-
-    assert_select ".gem-c-related-navigation__sub-heading", text: 'Policy'
-    assert_select ".gem-c-related-navigation__section-link[href=\"/government/policies/further-education-and-training\"]", text: 'Further education and training'
-  end
-
   it "renders topical events section when passed topical event items" do
     content_item = {}
     content_item["links"] = construct_links(
@@ -191,20 +177,11 @@ describe "Related navigation", type: :view do
     ordered_related_items = construct_links(
       "ordered_related_items", "/apprenticeships", "Apprenticeships"
     )
-    related_policies = construct_links(
-      "related_policies",
-      "/government/policies/further-education-and-training",
-      "Further education and training",
-      "policy"
-    )
-    content_item["links"] = ordered_related_items.merge(related_policies)
+    content_item["links"] = ordered_related_items
     render_component(content_item)
 
     assert_select ".gem-c-related-navigation__main-heading", text: 'Related content'
     assert_select ".gem-c-related-navigation__section-link--other[href=\"/apprenticeships\"]", text: 'Apprenticeships'
-
-    assert_select ".gem-c-related-navigation__sub-heading", text: 'Policy'
-    assert_select ".gem-c-related-navigation__section-link[href=\"/government/policies/further-education-and-training\"]", text: 'Further education and training'
   end
 
   it "link tracking is enabled" do

--- a/spec/dummy/app/controllers/welcome_controller.rb
+++ b/spec/dummy/app/controllers/welcome_controller.rb
@@ -9,7 +9,6 @@ class WelcomeController < ApplicationController
       "Travel advice Afghanistan" => "/foreign-travel-advice/afghanistan",
       "HMRC contact" => "/government/organisations/hm-revenue-customs/contact/agent-dedicated-line-self-assessment-or-paye-for-individuals",
       "AAIB report (specialist document)" => "/aaib-reports/aaib-investigation-to-airbus-helicopters-ec120b-colibri-g-swng",
-      "Guidance with a policy" => "/government/publications/helping-british-nationals-overseas-our-service-on-twitter-fcotravel--2",
     }
 
     if params[:base_path]

--- a/spec/lib/presenters/related_navigation_helper_spec.rb
+++ b/spec/lib/presenters/related_navigation_helper_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
         "related_guides" => [],
         "collections" => [],
         "topics" => [],
-        "policies" => [],
         "topical_events" => [],
         "world_locations" => [],
         "statistical_data_sets" => [],
@@ -104,15 +103,6 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
               "document_type" => "mainstream_browse_page"
             }
           ],
-          "related_policies" => [
-            {
-              "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
-              "locale" => "en",
-              "base_path" => "/related-policy",
-              "title" => "related policy",
-              "document_type" => "policy"
-            }
-          ],
           "world_locations" => [
             {
               "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
@@ -127,7 +117,6 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
         "related_guides" => [],
         "collections" => [{ path: "/related-collection", text: "related collection" }],
         "topics" => [{ path: "/browse/something", text: "A mainstream browse page" }, { path: "/related-topic", text: "related topic" }],
-        "policies" => [{ path: "/related-policy", text: "related policy" }],
         "related_contacts" => [],
         "related_external_links" => [],
         "topical_events" => [{ path: "/related-topical-event", text: "related topical event" }],


### PR DESCRIPTION
Remove code related to Policies

Trello card: 
https://trello.com/c/P9Fmi7wX/213-remove-now-unnecessary-code-relating-to-policies-and-policy-areas

As part of the work for the new Single Taxonomy, Policies are being
unpublished, therefore code related to Policies is not needed anymore.