### PR TITLE
Use time element in image card component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* BREAKING: Use time element in image card component, breaking change.
+This will require an update to usages of the image card component.
+The way in which context information is passed to the component has changed from `context: "some context"` to `context: {text: "some context", date: "2017-06-14"`}
+
 ## 10.2.0
 
 * Add data-tracking-url for radio inputs for the purposes of cross domain tracking (PR #539)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (10.1.0)
+    govuk_publishing_components (10.2.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -39,7 +39,9 @@ examples:
       href: "/also-not-a-page"
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
       image_alt: "some meaningful alt text please"
-      context: "10 May 2018 - Press release"
+      context:
+        date: 2016-06-27 10:29:44
+        text: "Press release"
       heading_text: "Government does things"
       description: "Following a thorough review of existing procedure, a government body has today announced that further work is necessary."
   with_extra_links:
@@ -69,7 +71,8 @@ examples:
       href: "/government/people/"
       image_src: "http://placekitten.com/215/140"
       image_alt: "some meaningful alt text please"
-      context: "The Rt Hon"
+      context:
+        text: "The Rt Hon"
       heading_text: "John Whiskers MP"
       extra_links: [
         {
@@ -149,7 +152,9 @@ examples:
       href: "/still-not-a-page"
       image_src: "https://assets.publishing.service.gov.uk/frontend/homepage/leaving-the-eu-bc9992ee672a30d8e8a3e195c9afa750e618748130a4e073a593ba36dfc29af9.jpg"
       image_alt: "some meaningful alt text please"
-      context: "14 Jun 2017 - Announcement"
+      context:
+        date: 2017-06-14 11:30:00
+        text: "Announcement"
       heading_text: "Something has happened nearby possibly"
       description: "Following a news report that something has happened, further details are emerging of the thing that has happened and what that means for you."
   with_tracking:
@@ -188,7 +193,8 @@ examples:
       href: "/government/people/"
       image_src: "http://placekitten.com/215/140"
       image_alt: "some meaningful alt text please"
-      context: "The Rt Hon"
+      context:
+        text: "The Rt Hon"
       heading_text: "John Whiskers MP"
       metadata: "Unpaid"
       extra_links: [

--- a/app/views/govuk_publishing_components/components/docs/taxonomy_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/taxonomy_list.yml
@@ -67,7 +67,8 @@ examples:
           image:
             url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
             alt: some meaningful alt text please
-            context: The Rt Hon
+            context:
+              text: The Rt Hon
         - link:
             path: /not-a-page
             text: News headline
@@ -75,7 +76,8 @@ examples:
           image:
             url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
             alt: some meaningful alt text please
-            context: The Rt Hon
+            context:
+              text: The Rt Hon
         - link:
             path: /not-a-page
             text: News headline
@@ -83,7 +85,8 @@ examples:
           image:
             url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
             alt: some meaningful alt text please
-            context: The Rt Hon
+            context:
+              text: The Rt Hon
         - link:
             path: /not-a-page
             text: News headline
@@ -91,7 +94,9 @@ examples:
           image:
             url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG
             alt: some meaningful alt text please
-            context: The Rt Hon
+            context:
+              text: This is a document
+              date: 2016-06-27 10:29:44
       document_list:
         items:
         - link:

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -40,7 +40,22 @@ module GovukPublishingComponents
       end
 
       def context
-        content_tag(:p, @context, class: "gem-c-image-card__context") if @context
+        return unless @context
+
+        content_tag(:p, class: 'gem-c-image-card__context') do
+          if @context[:date]
+            date = content_tag(:time, l(@context[:date], format: '%e %B %Y'), datetime: @context[:date].iso8601)
+            dash = content_tag(:span, ' — ', 'aria-hidden': true)
+
+            if @context[:text]
+              date.concat(dash).concat(@context[:text])
+            else
+              date
+            end
+          else
+            @context[:text]
+          end
+        end
       end
 
       def heading_tag

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -31,10 +31,26 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card h2.gem-c-image-card__title", false
   end
 
-  it "shows context and description" do
-    render_component(href: '#', context: 'some context', description: 'description')
-    assert_select ".gem-c-image-card .gem-c-image-card__context", text: 'some context'
+  it "shows description" do
+    render_component(href: '#', description: 'description')
     assert_select ".gem-c-image-card .gem-c-image-card__description", text: 'description'
+  end
+
+  it "shows text context" do
+    render_component(href: '#', context: { text: "press release" })
+    assert_select ".gem-c-image-card .gem-c-image-card__context", text: 'press release'
+  end
+
+  it "shows date context" do
+    render_component(href: '#', context: { date: Time.zone.parse("2017-06-14 14:50:33 +0000") })
+    assert_select ".gem-c-image-card .gem-c-image-card__context time[datetime='2017-06-14T14:50:33Z']", text: "14 June 2017"
+  end
+
+  it "shows date and text context together" do
+    render_component(href: '#', context: { date: Time.zone.parse("2017-06-14 14:50:33 +0000"), text: "Press Release" })
+    assert_select ".gem-c-image-card .gem-c-image-card__context", text: '14 June 2017 — Press Release'
+    assert_select ".gem-c-image-card .gem-c-image-card__context time[datetime='2017-06-14T14:50:33Z']", text: "14 June 2017"
+    assert_select ".gem-c-image-card .gem-c-image-card__context span[aria-hidden=true]", text: "—"
   end
 
   it "renders extra links" do


### PR DESCRIPTION
Trello: https://trello.com/c/8UGqW1fT/184-use-time-elements-in-the-image-card-component

**This is a BREAKING CHANGE.**

This PR introduces the following changes:

- Context is now passed to the image component as a hash with a `date` and `text`, rather than a String. These are both optional.
- If a date is passed, it is rendered within a `<time>` element
- If a date and text is passed, the `<time>` element is rendered within a `<p>`, and an `aria-hidden` dash is introduced between the two.

This now matches how we render dates in other components, e.g: [document list](https://govuk-publishing-components.herokuapp.com/component-guide/document_list)

## Before
<img width="868" alt="screen shot 2018-09-27 at 11 31 07" src="https://user-images.githubusercontent.com/29889908/46140516-3c9b1e00-c249-11e8-8103-4547c23f5651.png">

## After
<img width="868" alt="screen shot 2018-09-27 at 11 31 11" src="https://user-images.githubusercontent.com/29889908/46140385-e1692b80-c248-11e8-8347-c3bfdd826684.png">

Component guide for this PR:
https://govuk-publishing-compon-pr-541.herokuapp.com/component-guide/image_card
