### PR TITLE
Bump version to 10.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@
 - Don't include changes that are purely internal. The CHANGELOG should be a
   useful summary for people upgrading their application, not a replication
   of the commit log.
-  
+
+## 10.2.0
+
+* Add data-tracking-url for radio inputs for the purposes of cross domain tracking (PR #539)
+
 ## 10.1.0
 
 * Add isPartOf schema to content with document collections (PR #542)
-
-## Unreleased
-
-* Add data-tracking-url for radio inputs for the purposes of cross domain tracking (PR #539)
 
 ## 10.0.0
 

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '10.1.0'.freeze
+  VERSION = '10.2.0'.freeze
 end


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

v10.2.0

* Add data-tracking-url for radio inputs for the purposes of cross domain tracking (PR #539)

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-[THIS PR NUMBER].herokuapp.com/component-guide/
