### PR TITLE
Version 11.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 11.0.0
 
 * BREAKING: Use time element in image card component, breaking change.
 This will require an update to usages of the image card component.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (10.2.0)
+    govuk_publishing_components (11.0.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '10.2.0'.freeze
+  VERSION = '11.0.0'.freeze
 end


### PR DESCRIPTION
Includes a __breaking change__ to the image card component.

* This will require an update to usages of the image card component.
 The way in which context information is passed to the component has changed from `context: "some context"` to `context: {text: "some context", date: "2017-06-14"`}

Component guide for this PR:
https://govuk-publishing-compon-pr-547.herokuapp.com/component-guide/
