### PR TITLE
Fix toggle behaviour when JS disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix toggle behaviour in related navigation and taxonomy navigation when JS disabled (PR #551)
+
 ## 11.1.0
 
 * Add Admin analytics script (#555)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
@@ -36,6 +36,14 @@
   }
 }
 
+.gem-c-related-navigation__toggle {
+  display: none;
+
+  .js-enabled & {
+    display: block;
+   }
+}
+
 .gem-c-related-navigation__section-link {
   @include bold-16;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_taxonomy-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_taxonomy-navigation.scss
@@ -62,6 +62,14 @@
   text-decoration: none;
 }
 
+.gem-c-taxonomy-navigation__toggle {
+  display: none;
+
+  .js-enabled & {
+    display: block;
+   }
+}
+
 
 .gem-c-taxonomy-navigation__section-heading {
   border-top: 1px solid $border-colour;

--- a/app/views/govuk_publishing_components/components/_taxonomy_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_taxonomy_navigation.html.erb
@@ -92,6 +92,7 @@
               <% if hidden_links.any? %>
                 <li class="gem-c-taxonomy-navigation__link toggle-wrap">
                   <a href="#"
+                    class="gem-c-taxonomy-navigation__toggle"
                     data-controls="toggle_<%= section_name %>"
                     data-expanded="false"
                     data-toggled-text="<%= t("govuk_component.metadata.toggle_less", default: "Show fewer") %>">

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -44,6 +44,7 @@
     <% if links.length > section_link_limit %>
       <li class="gem-c-related-navigation__link toggle-wrap">
         <a href="#"
+          class="gem-c-related-navigation__toggle"
           data-controls="toggle_<%= section_title %>"
           data-expanded="false"
           data-toggled-text="<%= t("govuk_component.metadata.toggle_less", default: "Show fewer") %>">


### PR DESCRIPTION
Trello: https://trello.com/c/LQKpXVSw/186-audit-components-that-use-a-toggle-and-update-to-hide-the-toggle-link-when-js-is-disabled

Previously, these components would auto-expand all contents when JS was disabled (which is good), but also continue to show the toggle link which would be confusing to users. This PR only shows the toggle link if JS is enabled.

## Before (taxonomy navigation)
<img width="915" alt="screen shot 2018-10-01 at 15 13 29" src="https://user-images.githubusercontent.com/29889908/46293942-94f55700-c58c-11e8-97f5-b0ae961f1a5d.png">

## After (taxonomy navigation)
<img width="921" alt="screen shot 2018-10-01 at 15 12 47" src="https://user-images.githubusercontent.com/29889908/46293958-9b83ce80-c58c-11e8-857e-e0eaac3c3433.png">

## Before (related navigation)
<img width="912" alt="screen shot 2018-10-01 at 15 13 07" src="https://user-images.githubusercontent.com/29889908/46293961-9f175580-c58c-11e8-9f96-232cd024613d.png">

## After (related navigation)
<img width="912" alt="screen shot 2018-10-01 at 15 12 29" src="https://user-images.githubusercontent.com/29889908/46293964-a2124600-c58c-11e8-88f1-0e8707892d8d.png">


Links:
https://govuk-publishing-compon-pr-551.herokuapp.com/component-guide/related_navigation
https://govuk-publishing-compon-pr-551.herokuapp.com/component-guide/taxonomy_navigation
