### PR TITLE
Allow autofocus on inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * You can now use `GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment` to get the current environment, for use in the admin layout components (PR #548)
 * Update GOV.UK Frontend from 1.2.0 to 2.1.0 and manage breaking changes (PR #545)
 * Add navigation and meta links to footer component (PR #550)
-
+* Allow autofocus on input component (PR #552)
 
 ## 11.0.0
 

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -8,6 +8,8 @@
   label ||= nil
   hint ||= nil
   error_message ||= nil
+  autofocus ||= nil
+  tabindex ||= nil
   hint_id = "hint-#{SecureRandom.hex(4)}" if hint
   error_message_id = "error-message-#{SecureRandom.hex(4)}" if error_message
 
@@ -48,16 +50,16 @@
     } %>
   <% end %>
 
-  <%= text_field_tag name,
-    value,
-    {
+  <%= tag.input name: name,
+      value: value,
       class: css_classes,
       id: id,
       type: type,
       data: data,
+      tabindex: tabindex,
+      autofocus: autofocus,
       aria: {
         describedby: aria_described_by
       }
-    }
   %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -13,6 +13,8 @@ accessibility_criteria: |
   * be of the appropriate type for their use, e.g. password inputs should be of type 'password'
 
   Labels use the [label component](/component-guide/label).
+
+  Avoid using autofocus and tabindex unless you have user research to support this behaviour.
 govuk_frontend_components:
   - input
 examples:

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -56,3 +56,10 @@ examples:
         text: "Search for"
       name: "name"
       value: "moose"
+  autofocused:
+    data:
+      label:
+        text: "Username"
+      name: "username"
+      autofocus: true
+      tabindex: 0

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -73,6 +73,17 @@ describe "Input", type: :view do
     assert_select ".govuk-input[data-module='contextual-guidance']"
   end
 
+  it "renders autofocused input" do
+    render_component(
+      label: { text: "Username" },
+      name: "username",
+      autofocus: true,
+      tabindex: 0
+    )
+
+    assert_select ".govuk-input[autofocus][tabindex='0']"
+  end
+
   context "when a hint is provided" do
     before do
       render_component(


### PR DESCRIPTION
This attribute will be used for the login page to ease the authentication process. It shouldn't be used without user research to back this behaviour.

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-552.herokuapp.com/component-guide/input/autofocused/preview
