### PR TITLE
Fix label in component guide

### DIFF
--- a/app/views/govuk_publishing_components/components/_file_upload.html.erb
+++ b/app/views/govuk_publishing_components/components/_file_upload.html.erb
@@ -26,7 +26,7 @@
 
 <%= content_tag :div, class: form_group_css_classes do %>
   <% if label %>
-    <%= render "govuk_publishing_components/components/label", { html_for: id, text: label[:text] }.merge(label) %>
+    <%= render "govuk_publishing_components/components/label", { html_for: id, text: label[:text] }.merge(label.symbolize_keys) %>
   <% end %>
 
   <% if hint %>

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -31,7 +31,7 @@
   <% if label %>
     <%= render "govuk_publishing_components/components/label", {
       html_for: id
-    }.merge(label) %>
+    }.merge(label.symbolize_keys) %>
   <% end %>
 
   <% if hint %>

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -27,7 +27,7 @@
 
 <%= content_tag :div, class: form_group_css_classes do %>
   <% if label %>
-    <%= render "govuk_publishing_components/components/label", { html_for: id }.merge(label) %>
+    <%= render "govuk_publishing_components/components/label", { html_for: id }.merge(label.symbolize_keys) %>
   <% end %>
 
   <% if hint %>


### PR DESCRIPTION
The `label` attribute should be a hash with keys, but the component guide passes in strings.