### PR TITLE
Reinstate previews on metadata component and hide for machine-readable metadata.

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
@@ -6,6 +6,7 @@ body: |
 accessibility_criteria: |
   The HTML should not be visible.
 display_html: true
+display_preview: false
 examples:
   default:
     data:

--- a/app/views/govuk_publishing_components/components/docs/metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/metadata.yml
@@ -9,7 +9,6 @@ accessibility_criteria: |
 
 shared_accessibility_criteria:
   - link
-display_preview: false
 examples:
   from_only:
     data:


### PR DESCRIPTION
In [this PR](https://github.com/alphagov/govuk_publishing_components/pull/400/files#diff-58fe188b00b5e8007bc3deb55a4d728dR12), we mistakenly hid previews for the wrong metadata component. We meant to hide them for the machine-readable metadata component as it has no visible changes.

Should have previews: https://govuk-publishing-compon-pr-559.herokuapp.com/component-guide/metadata

Should only have HTML previews: https://govuk-publishing-compon-pr-559.herokuapp.com/component-guide/machine_readable_metadata