### PR TITLE
Version 11.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 11.2.0
 
 * Fix toggle behaviour in related navigation and taxonomy navigation when JS disabled (PR #551)
 * Make "GOV.UK Publishing" the default product name (PR #557 #561)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (11.1.0)
+    govuk_publishing_components (11.2.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -119,7 +119,7 @@ GEM
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
       unicorn (~> 5.4.0)
-    govuk_frontend_toolkit (8.0.0)
+    govuk_frontend_toolkit (8.1.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_schemas (3.2.0)
@@ -165,8 +165,8 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    money (6.12.0)
-      i18n (>= 0.6.4, < 1.1)
+    money (6.13.0)
+      i18n (>= 0.6.4, <= 2)
     multipart-post (2.0.0)
     netrc (0.11.0)
     nio4r (2.3.1)
@@ -234,7 +234,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.2.1)
+    rouge (3.3.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.1)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '11.1.0'.freeze
+  VERSION = '11.2.0'.freeze
 end


### PR DESCRIPTION
## Version 11.2.0
- Fix toggle behaviour in related navigation and taxonomy navigation when JS disabled (PR #551)
- Make "GOV.UK Publishing" the default product name (PR #557 #561)
- Change the colour of production to red (PR #557)
- Add environment tag in the header for all environments (PR #557)
