### PR TITLE
Make Product name customisable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ## Unreleased
 
 * Fix toggle behaviour in related navigation and taxonomy navigation when JS disabled (PR #551)
+* Make "GOV.UK Publishing" the default product name (PR #557 #561)
+* Change the colour of production to red (PR #557)
+* Add environment tag in the header for all environments (PR #557)
 
 ## 11.1.0
 

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -1,4 +1,5 @@
 <%
+  product_name ||= "Publishing"
   navigation_items ||= []
 %>
 <header class="gem-c-layout-header govuk-header gem-c-layout-header--<%= environment %>" role="banner" data-module="header">
@@ -19,7 +20,7 @@
         </span>
 
         <span class="govuk-header__product-name">
-          Publishing
+          <%= product_name %>
         </span>
 
         <span class="gem-c-environment-tag govuk-tag gem-c-environment-tag--<%= environment %>">

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -19,6 +19,10 @@ examples:
   development_environment:
     data:
       environment: development
+  with_product_name:
+    data:
+      environment: production
+      product_name: Product
   with_navigation:
     data:
       environment: production

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -17,6 +17,12 @@ describe "Layout header", type: :view do
     assert_select ".govuk-header.gem-c-layout-header--staging"
   end
 
+  it "renders the product name" do
+    render_component(environment: "staging", product_name: "Product name")
+
+    assert_select ".govuk-header__product-name", text: "Product name"
+  end
+
   it "renders the header with navigation items" do
     navigation_items = [
       { text: "Foo", href: "/foo", active: true },


### PR DESCRIPTION
This is to allow Signon to be called "Signon" again. We'll still use "Publishing" as the default.

Follow up to https://github.com/alphagov/govuk_publishing_components/pull/557.

cc @alex-ju 

https://trello.com/c/05wMNlxg