### PR TITLE
Bump to version 12.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 12.0.0
 
 * Append the product name to the browser title (PR #563)
 * BREAKING: Remove Slimmer as a dependency

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (11.2.0)
+    govuk_publishing_components (12.0.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -112,7 +112,7 @@ GEM
       rubocop (~> 0.52.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
-    govuk_app_config (1.9.3)
+    govuk_app_config (1.10.0)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '11.2.0'.freeze
+  VERSION = '12.0.0'.freeze
 end


### PR DESCRIPTION
* Append the product name to the browser title (PR #563)
* BREAKING: Remove Slimmer as a dependency
This comprises many minor changes to components so they no longer rely on
Static provided stylesheets.
- If your app uses Slimmer, the component guide will no longer use it and you
  can no longer rely on any resets/global rules provided
- If your app removes the Slimmer middleware this will now break as Slimmer
  will be an undefined constant
- Apps which the admin layout no longer need to include jQuery as this comes
  bundled in the admin scripts.
* Use a purple environment colour on Heroku (#566). Make sure to add a `HEROKU` environment variable to Heroku instances.
* Use a red favicon colour on production (#566)
