### PR TITLE
Add back environment variables needed for Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,6 +8,12 @@
     "BUNDLE_WITHOUT": {
       "value": "test"
     },
+    "PLEK_SERVICE_CONTENT_STORE_URI": {
+      "value": "https://www.gov.uk/api"
+    },
+    "PLEK_SERVICE_RUMMAGER_URI": {
+      "value": "https://www.gov.uk/api"
+    },
     "GOVUK_WEBSITE_ROOT": {
       "value": "https://www.gov.uk"
     }


### PR DESCRIPTION
This partially reverts commit 857e187bd1af1d0955c0b40df0dd38b7053decab.

Only `PLEK_SERVICE_STATIC_URI` should have been removed, as `PLEK_SERVICE_CONTENT_STORE_URI` and `PLEK_SERVICE_RUMMAGER_URI` are still used by the navigation components.