### PR TITLE
Don't include govuk-frontend/all in public frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix an issue that included govuk-frontend with the components (#569)
+
 ## 12.0.0
 
 * Append the product name to the browser title (PR #563)

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -1,10 +1,7 @@
 // This file contains the styles for the Component Guide.
 
 @import "govuk_publishing_components/components/helpers/govuk-frontend-settings";
-@import "govuk-frontend/settings/all";
-@import "govuk-frontend/tools/all";
-@import "govuk-frontend/helpers/all";
-@import "govuk-frontend/core/all";
+@import "govuk-frontend/all";
 
 .component-guide-wrapper {
   padding-bottom: $govuk-gutter * 1.5;

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -1,7 +1,3 @@
-// Include all of the GOV.UK Frontend styles. This includes fonts, and individual components.
-@import "components/helpers/govuk-frontend-settings";
-@import "govuk-frontend/all";
-
 // This is the file that the application needs to include in order to use
 // the components.
 

--- a/app/assets/stylesheets/govuk_publishing_components/admin_styles.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/admin_styles.scss
@@ -4,7 +4,3 @@
 
 // Include our GOV.UK components
 @import "govuk_publishing_components/all_components";
-
-// Components that are only available inside the admin layout
-@import "govuk_publishing_components/components/layout-footer";
-@import "govuk_publishing_components/components/layout-header";


### PR DESCRIPTION
https://github.com/alphagov/govuk_publishing_components/pull/558 accidentally included `govuk-frontend/all` in the components library. This means that frontends include the entirety of govuk-frontend including the font (which is huge).

