### PR TITLE
Add bottom margin to success alert component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add a bottom margin to the success-alert component (should of been added by default)
+
 ## 12.0.0
 
 * Append the product name to the browser title (PR #563)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
@@ -2,6 +2,7 @@
   color: $gem-text-colour;
   padding: $gem-spacing-scale-3;
   border: $gem-border-width-mobile solid $gem-success-colour;
+  margin-bottom: $gem-spacing-scale-4;
 
   @include media(tablet) {
     padding: $gem-spacing-scale-4;


### PR DESCRIPTION
This adds a bottom margin by default to the success alert component.

## Before
<img width="671" alt="screen shot 2018-10-11 at 11 06 25" src="https://user-images.githubusercontent.com/24479188/46797118-2f505a00-cd46-11e8-9c2a-704d0f5aade3.png">

## After
<img width="684" alt="screen shot 2018-10-11 at 11 05 54" src="https://user-images.githubusercontent.com/24479188/46797127-35ded180-cd46-11e8-909e-524b6ab3189a.png">
 
Trello:
https://trello.com/c/DYwko3da/313-no-margin-below-the-flash-banner-and-the-content-block-below