### PR TITLE
Use a normal dash for the browser title

### DIFF
--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -4,7 +4,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8" />
-    <title><%= browser_title %> — GOV.UK <%= product_name %></title>
+    <title><%= browser_title %> - GOV.UK <%= product_name %></title>
     <meta name="robots" content="noindex,nofollow,noimageindex">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= csrf_meta_tags %>

--- a/spec/components/layout_for_admin_spec.rb
+++ b/spec/components/layout_for_admin_spec.rb
@@ -8,7 +8,7 @@ describe "Layout for admin", type: :view do
   it "adds the <title> tag" do
     render_component(browser_title: "Hello, admin page", environment: "production")
 
-    assert_select "title", visible: false, text: "Hello, admin page — GOV.UK Publishing"
+    assert_select "title", visible: false, text: "Hello, admin page - GOV.UK Publishing"
   end
 
   it "adds the robots metatag" do


### PR DESCRIPTION
The emdash is hysterically long, which looks weird.

## Before

<img width="248" alt="screen shot 2018-10-11 at 11 28 05" src="https://user-images.githubusercontent.com/233676/46798087-d33b0500-cd48-11e8-9bd4-191c2b42e037.png">

## After

<img width="254" alt="screen shot 2018-10-11 at 11 27 56" src="https://user-images.githubusercontent.com/233676/46798095-d8984f80-cd48-11e8-8af5-7a03c519b8da.png">

