### PR TITLE
Update version to 12.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 12.0.1
 
-* Add a bottom margin to the success-alert component (should of been added by default)
+* Add a bottom margin to the success-alert component - should of been added by default (PR #573)
 
 ## 12.0.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (12.0.0)
+    govuk_publishing_components (12.0.1)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '12.0.0'.freeze
+  VERSION = '12.0.1'.freeze
 end


### PR DESCRIPTION
This fixes a bug where there was no bottom margin on the success-alert
component (PR #573)

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-[THIS PR NUMBER].herokuapp.com/component-guide/
