### PR TITLE
Send the current user's organisation to GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add option to send the `user_organisation` in admin analytics component (PR #577)
 * Add a bottom margin to the error-alert component (PR #578)
 * Update the way we include Javascript and Stylesheets in the admin layout
   component. Make sure to follow the [installation instructions](docs/install-and-use.md) (PR #571) if your using the admin layout component.

--- a/app/views/govuk_publishing_components/components/_admin_analytics.html.erb
+++ b/app/views/govuk_publishing_components/components/_admin_analytics.html.erb
@@ -1,3 +1,5 @@
+<% user_organisation ||= nil %>
+
 <script class="analytics">
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -6,5 +8,10 @@
 
   ga('create', 'UA-26179049-6', '<%= ENV['GOVUK_APP_DOMAIN'] %>');
   ga('set', 'anonymizeIp', true);
+
+  <% if user_organisation %>
+    ga('set', 'dimension8', "<%= user_organisation.presence || '(not set)' %>");
+  <% end %>
+
   ga('send', 'pageview');
 </script>

--- a/app/views/govuk_publishing_components/components/docs/admin_analytics.yml
+++ b/app/views/govuk_publishing_components/components/docs/admin_analytics.yml
@@ -6,4 +6,5 @@ accessibility_criteria: |
 display_html: true
 examples:
   default:
-    data: {}
+    data:
+      user_organisation: "HMRC"


### PR DESCRIPTION
This is currently done in Signon, and I'm assuming that this is fine to happen in all admin applications.