### PR TITLE
Fix focus colour for buttons

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -45,7 +45,8 @@ $gem-destructive-button-border-colour: govuk-colour("black");
 
   &:link,
   &:visited,
-  &:active {
+  &:active,
+  &:focus {
     color: $gem-secondary-button-colour;
     background-color: $gem-secondary-button-background-colour;
     text-decoration: none;
@@ -76,7 +77,8 @@ $gem-destructive-button-border-colour: govuk-colour("black");
 
   &:link,
   &:visited,
-  &:active {
+  &:active,
+  &:focus {
     color: $gem-quiet-button-colour;
     background-color: $gem-secondary-button-background-colour;
     text-decoration: none;
@@ -104,7 +106,8 @@ $gem-destructive-button-border-colour: govuk-colour("black");
 
   &:link,
   &:visited,
-  &:active {
+  &:active,
+  &:focus {
     background-color: $gem-destructive-button-background-colour;
   }
 

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -42,21 +42,15 @@ examples:
   secondary_button:
     data:
       text: "Secondary button"
-      href: "#"
       secondary: true
-      rel: "external"
   secondary_quiet_button:
     data:
       text: "Secondary quiet button"
-      href: "#"
       secondary_quiet: true
-      rel: "external"
   destructive_button:
     data:
       text: "Destructive button"
-      href: "#"
       destructive: true
-      rel: "external"
   start_now_button_with_info_text:
     data:
       text: "Start now"


### PR DESCRIPTION
This PR sets the appropriate background colour when buttons are being focused and updates the examples to use the `<button>` element by default (instead of `<a>`), as it's the recommended way.

### Before
<img width="232" alt="screen shot 2018-10-12 at 12 15 48" src="https://user-images.githubusercontent.com/788096/46866282-a524f600-ce18-11e8-8d31-666e0ce1ed41.png">


### After
<img width="238" alt="screen shot 2018-10-12 at 12 13 26" src="https://user-images.githubusercontent.com/788096/46866288-a9511380-ce18-11e8-85d0-30de1e76635a.png">

[Trello card](https://trello.com/c/fJPJoRJm)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-579.herokuapp.com/component-guide/button
