### PR TITLE
Release 12.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 12.1.0
 
 * Add option to send the `user_organisation` in admin analytics component (PR #577)
 * Add a bottom margin to the error-alert component (PR #578)
 * Update the way we include Javascript and Stylesheets in the admin layout
   component. Make sure to follow the [installation instructions](docs/install-and-use.md) (PR #571) if your using the admin layout component.
+* Fix background colour for focused buttons (PR #579)
 
 ## 12.0.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (12.0.1)
+    govuk_publishing_components (12.1.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '12.0.1'.freeze
+  VERSION = '12.1.0'.freeze
 end


### PR DESCRIPTION
## 12.1.0

* Add option to send the `user_organisation` in admin analytics component (PR #577)
* Add a bottom margin to the error-alert component (PR #578)
* Update the way we include Javascript and Stylesheets in the admin layout
  component. Make sure to follow the [installation instructions](docs/install-and-use.md) (PR #571) if your using the admin layout component.
* Fix background colour for focused buttons (PR #579)

---
