### PR TITLE
Fix govspeak button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix regression for buttons in govspeak section (PR #582)
+
 ## 12.1.0
 
 * Add option to send the `user_organisation` in admin analytics component (PR #577)

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
@@ -2,11 +2,13 @@
 
 // scss-lint:disable PlaceholderInExtend
 .gem-c-govspeak {
-  .button {
+  .button,
+  .govuk-button {
     @extend .govuk-button;
   }
 
-  .button-start {
+  .button-start,
+  .govuk-button--start {
     @extend .govuk-button--start;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -76,7 +76,8 @@
 
   // Links
   a {
-    @extend %govuk-link;
+    @include govuk-link-style-default;
+    @include govuk-focusable-fill;
   }
 
   // Lists


### PR DESCRIPTION
This PR fixes the styles applied to a button inside a govspeak section and allows the button to be styled using the `govuk-frontend` selectors.

### Before

Default

<img width="226" alt="screen shot 2018-10-16 at 15 14 42" src="https://user-images.githubusercontent.com/788096/47022993-97dc7400-d156-11e8-8c7d-031e26262ef8.png">

Focus

<img width="221" alt="screen shot 2018-10-16 at 15 14 52" src="https://user-images.githubusercontent.com/788096/47022995-99a63780-d156-11e8-8b82-68010822cda3.png">


### After

Default

<img width="227" alt="screen shot 2018-10-16 at 15 15 07" src="https://user-images.githubusercontent.com/788096/47023007-a460cc80-d156-11e8-851c-df33f7e4e4d4.png">

Focus

<img width="228" alt="screen shot 2018-10-16 at 15 15 18" src="https://user-images.githubusercontent.com/788096/47023019-a88cea00-d156-11e8-85f4-55cb9f85b57c.png">

---

Component guide for this PR:
https://govuk-publishing-compon-pr-582.herokuapp.com/component-guide/govspeak
