### PR TITLE
Add character count component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix regression for buttons in govspeak section (PR #582)
+* Add character count component based on GOV.UK Frontend (PR #583)
 
 ## 12.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/character-count.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/character-count.js
@@ -1,0 +1,2 @@
+// This component relies on JavaScript from GOV.UK Frontend
+//= require govuk-frontend/components/character-count/character-count.js

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -15,6 +15,7 @@
 @import "components/back-link";
 @import "components/breadcrumbs";
 @import "components/button";
+@import "components/character-count";
 @import "components/contents-list";
 @import "components/copy-to-clipboard";
 @import "components/details";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_character-count.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_character-count.scss
@@ -1,0 +1,3 @@
+@import "helpers/govuk-frontend-settings";
+@import "govuk-frontend/components/character-count/character-count";
+@import "govuk-frontend/objects/form-group";

--- a/app/views/govuk_publishing_components/components/_character_count.html.erb
+++ b/app/views/govuk_publishing_components/components/_character_count.html.erb
@@ -1,0 +1,80 @@
+<%
+  id ||= "character-count-#{SecureRandom.hex(4)}"
+  value ||= nil
+  rows ||= 5
+  data ||= nil
+  spellcheck ||= "true"
+
+  label ||= nil
+  hint ||= nil
+  error_message ||= nil
+  hint_id = "hint-#{SecureRandom.hex(4)}" if hint
+  error_message_id = "error-message-#{SecureRandom.hex(4)}" if error_message
+
+  css_classes = %w(gem-c-textarea govuk-textarea js-character-count)
+  css_classes << "govuk-textarea--error" if error_message
+  form_group_css_classes = %w(govuk-form-group)
+  form_group_css_classes << "govuk-form-group--error" if error_message
+
+  aria_described_by ||= nil
+  if hint || error_message
+    aria_described_by = []
+    aria_described_by << hint_id if hint
+    aria_described_by << error_message_id if error_message
+    aria_described_by = aria_described_by.join(" ")
+  end
+
+  maxlength ||= nil
+  maxwords ||= nil
+  threshold ||= nil
+%>
+
+<%= content_tag :div,
+  class: "govuk-character-count",
+  data: {
+    module: "character-count",
+    maxlength: maxlength,
+    maxwords: maxwords,
+    threshold: threshold
+  } do %>
+
+  <%= render "govuk_publishing_components/components/hint", {
+    id: hint_id,
+    text: hint
+  } %>
+
+
+  <%= content_tag :div, class: form_group_css_classes do %>
+    <% if label %>
+      <%= render "govuk_publishing_components/components/label", { html_for: id }.merge(label.symbolize_keys) %>
+    <% end %>
+
+    <% if hint %>
+      <%= render "govuk_publishing_components/components/hint", {
+        id: hint_id,
+        text: hint
+      } %>
+    <% end %>
+
+    <% if error_message %>
+      <%= render "govuk_publishing_components/components/error_message", {
+        id: error_message_id,
+        text: error_message
+      } %>
+    <% end %>
+
+    <%= tag.textarea name: name,
+      value: value,
+      class: css_classes,
+      id: id,
+      rows: rows,
+      data: data,
+      spellcheck: spellcheck,
+      aria: {
+        describedby: aria_described_by
+      } do %><%= value %><% end %>
+  <% end %>
+  <span id="<%= id %>-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
+    You can enter up to <%= maxlength || maxwords %> <%= maxwords ? 'words' : 'characters' %>
+  </span>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_character_count.html.erb
+++ b/app/views/govuk_publishing_components/components/_character_count.html.erb
@@ -1,36 +1,13 @@
 <%
   id ||= "character-count-#{SecureRandom.hex(4)}"
-  value ||= nil
-  rows ||= 5
-  data ||= nil
-  spellcheck ||= "true"
-
-  label ||= nil
-  hint ||= nil
-  error_message ||= nil
-  hint_id = "hint-#{SecureRandom.hex(4)}" if hint
-  error_message_id = "error-message-#{SecureRandom.hex(4)}" if error_message
-
-  css_classes = %w(gem-c-textarea govuk-textarea js-character-count)
-  css_classes << "govuk-textarea--error" if error_message
-  form_group_css_classes = %w(govuk-form-group)
-  form_group_css_classes << "govuk-form-group--error" if error_message
-
-  aria_described_by ||= nil
-  if hint || error_message
-    aria_described_by = []
-    aria_described_by << hint_id if hint
-    aria_described_by << error_message_id if error_message
-    aria_described_by = aria_described_by.join(" ")
-  end
-
   maxlength ||= nil
   maxwords ||= nil
   threshold ||= nil
+  textarea ||= {}
 %>
 
 <%= content_tag :div,
-  class: "govuk-character-count",
+  class: "gem-c-character-count govuk-character-count",
   data: {
     module: "character-count",
     maxlength: maxlength,
@@ -38,42 +15,8 @@
     threshold: threshold
   } do %>
 
-  <%= render "govuk_publishing_components/components/hint", {
-    id: hint_id,
-    text: hint
-  } %>
+  <%= render "govuk_publishing_components/components/textarea", { id: id, character_count: true }.merge(textarea.symbolize_keys) %>
 
-
-  <%= content_tag :div, class: form_group_css_classes do %>
-    <% if label %>
-      <%= render "govuk_publishing_components/components/label", { html_for: id }.merge(label.symbolize_keys) %>
-    <% end %>
-
-    <% if hint %>
-      <%= render "govuk_publishing_components/components/hint", {
-        id: hint_id,
-        text: hint
-      } %>
-    <% end %>
-
-    <% if error_message %>
-      <%= render "govuk_publishing_components/components/error_message", {
-        id: error_message_id,
-        text: error_message
-      } %>
-    <% end %>
-
-    <%= tag.textarea name: name,
-      value: value,
-      class: css_classes,
-      id: id,
-      rows: rows,
-      data: data,
-      spellcheck: spellcheck,
-      aria: {
-        describedby: aria_described_by
-      } do %><%= value %><% end %>
-  <% end %>
   <span id="<%= id %>-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
     You can enter up to <%= maxlength || maxwords %> <%= maxwords ? 'words' : 'characters' %>
   </span>

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -8,10 +8,12 @@
   label ||= nil
   hint ||= nil
   error_message ||= nil
+  character_count ||= nil
   hint_id = "hint-#{SecureRandom.hex(4)}" if hint
   error_message_id = "error-message-#{SecureRandom.hex(4)}" if error_message
 
   css_classes = %w(gem-c-textarea govuk-textarea)
+  css_classes << "js-character-count" if character_count
   css_classes << "govuk-textarea--error" if error_message
   form_group_css_classes = %w(govuk-form-group)
   form_group_css_classes << "govuk-form-group--error" if error_message

--- a/app/views/govuk_publishing_components/components/docs/character_count.yml
+++ b/app/views/govuk_publishing_components/components/docs/character_count.yml
@@ -19,31 +19,35 @@ accessibility_criteria: |
 examples:
   default:
     data:
-      label:
-        text: "Can you provide more detail?"
-      name: "more-detail"
+      textarea:
+        label:
+          text: "Can you provide more detail?"
+        name: "more-detail"
       maxlength: 10
   with_hint:
     data:
-      label:
-        text: "Can you provide more detail?"
-      name: "with-hint"
-      hint: "Please include as much information as possible."
+      textarea:
+        label:
+          text: "Can you provide more detail?"
+        name: "with-hint"
+        hint: "Please include as much information as possible."
       maxlength: 10
   with_error:
     data:
-      label:
-        text: "Can you provide more detail?"
-      name: "more-detail-error"
-      error_message: "Detail must be 10 characters or less"
-      value: |
-        221B Baker Street
-        London
-        NW1 6XE
+      textarea:
+        label:
+          text: "Can you provide more detail?"
+        name: "more-detail-error"
+        error_message: "Detail must be 10 characters or less"
+        value: |
+          221B Baker Street
+          London
+          NW1 6XE
       maxlength: 10
   with_word_count:
     data:
-      label:
-        text: "Can you provide more detail?"
-      name: "more-detail-value"
+      textarea:
+        label:
+          text: "Can you provide more detail?"
+        name: "more-detail-value"
       maxwords: 10

--- a/app/views/govuk_publishing_components/components/docs/character_count.yml
+++ b/app/views/govuk_publishing_components/components/docs/character_count.yml
@@ -1,0 +1,49 @@
+name: Form character count
+description: Help users enter text when there is a limit on the number of characters they can type
+govuk_frontend_components:
+  - character-count
+accessibility_criteria: |
+  The component must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - be usable with touch
+  - indicate when they have focus
+  - be recognisable as form textarea elements
+  - have correctly associated labels
+  - inform the user about the character limit
+  - inform the user as the number of left characters changes
+
+  Labels use the [label component](/component-guide/label).
+examples:
+  default:
+    data:
+      label:
+        text: "Can you provide more detail?"
+      name: "more-detail"
+      maxlength: 10
+  with_hint:
+    data:
+      label:
+        text: "Can you provide more detail?"
+      name: "with-hint"
+      hint: "Please include as much information as possible."
+      maxlength: 10
+  with_error:
+    data:
+      label:
+        text: "Can you provide more detail?"
+      name: "more-detail-error"
+      error_message: "Detail must be 10 characters or less"
+      value: |
+        221B Baker Street
+        London
+        NW1 6XE
+      maxlength: 10
+  with_word_count:
+    data:
+      label:
+        text: "Can you provide more detail?"
+      name: "more-detail-value"
+      maxwords: 10

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,9 +3,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "govuk-frontend": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.1.0.tgz",
-      "integrity": "sha512-6wYIANvYAi3aLdJQXBbvgtEeZG6KOvLlul2uwpA4Ow5BdgmSyDVUAB0PLR5MVFaiqlyvMhGTAMa38AiFHwVqgA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.2.0.tgz",
+      "integrity": "sha512-vNiUIp8EQACARNTyOwmE110HcQd+zJvkgbKv+gmY28QxqQGGd2DEJ35nblnjElsRJpSgbxwa85iqlNtbR3Q5tA=="
     },
     "jquery": {
       "version": "1.12.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "jquery": "1.12.4",
-    "govuk-frontend": "^2.1.0"
+    "govuk-frontend": "^2.2.0"
   }
 }

--- a/spec/components/character_count_spec.rb
+++ b/spec/components/character_count_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe "Character count", type: :view do
+  def component_name
+    "character_count"
+  end
+
+  it "renders character count with textarea" do
+    render_component(
+      name: "character-count",
+      textarea: {
+        label: { text: "Can you provide more detail?" },
+        name: "more-details"
+      },
+      data: {
+        module: "character-count",
+        maxlength: "100",
+      }
+    )
+
+    assert_select ".govuk-character-count .govuk-textarea"
+
+    assert_select ".govuk-character-count .govuk-label", text: "Can you provide more detail?"
+  end
+
+  it "renders character count with data attributes" do
+    render_component(
+      name: "character-count",
+      textarea: {
+        label: { text: "Can you provide more detail?" },
+        name: "more-details"
+      },
+      data: {
+        module: "character-count"
+      },
+      maxlength: "100",
+    )
+
+    assert_select ".govuk-character-count[data-module='character-count']"
+    assert_select ".govuk-character-count[data-maxlength='100']"
+  end
+end


### PR DESCRIPTION
This PR:
- updates the gem to use govuk-frontend 2.2.0
- adds the new character count component from govuk-frontend


---

Component guide for this PR:
https://govuk-publishing-compon-pr-583.herokuapp.com/component-guide/character_count
