### PR TITLE
Adds warning text from design systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Replace error summary script with the GOV.UK Frontend one and add example page to test error summary with inputs (PR #585)
+* Adds warning text from design systems (PR #588)
 
 ## 12.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -63,3 +63,4 @@
 @import "components/textarea";
 @import "components/title";
 @import "components/translation-nav";
+@import "components/warning-text";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
@@ -1,0 +1,2 @@
+@import "helpers/govuk-frontend-settings";
+@import "govuk-frontend/components/warning-text/warning-text";

--- a/app/views/govuk_publishing_components/components/_warning_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_warning_text.html.erb
@@ -1,0 +1,16 @@
+<%
+  id ||= "warning-text-#{SecureRandom.hex(4)}"
+  classes ||= ''
+  css_classes = %w(gem-c-warning-text govuk-warning-text)
+  css_classes << classes if classes
+  text_assistive ||= 'Warning'
+  text_icon ||= '!'
+%>
+
+<%= tag.div id: id, class: css_classes do %>
+  <%= tag.span text_icon, class: "govuk-warning-text__icon", "aria-hidden": "true" %>
+  <%= tag.strong class: "govuk-warning-text__text" do %>
+    <%= tag.span text_assistive, class: "govuk-warning-text__assistive" %>
+    <%= text %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/warning_text.yml
+++ b/app/views/govuk_publishing_components/components/docs/warning_text.yml
@@ -1,0 +1,19 @@
+name: Warning text
+description: |
+  Use the warning text component when you need to warn users about something important, such as legal consequences of an action, or lack of action, that they might take.
+govuk_frontend_components:
+  - warning-text
+accessibility_criteria: |
+  All text must have a contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+examples:
+  default:
+    data:
+      text: "You can be fined up to £5,000 if you don’t register."
+  custom_assistive_text:
+    data:
+      text_assistive: "Danger"
+      text: "You can be fined up to £5,000 if you don’t register."
+  custom_icon_text:
+    data:
+      text_icon: "£"
+      text: "You can be fined up to £5,000 if you don’t register."

--- a/spec/components/warning_text_spec.rb
+++ b/spec/components/warning_text_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe "warning text", type: :view do
+  def component_name
+    "warning_text"
+  end
+
+  it "renders warning text" do
+    render_component(text: "You can be fined up to £5,000 if you don’t register.")
+    assert_select(".govuk-warning-text__assistive", text: "Warning")
+    assert_select(".govuk-warning-text__text", text: /You can be fined up to £5,000 if you don’t register?/i)
+  end
+
+  it "renders custom assistive text" do
+    render_component(text_assistive: "Danger", text: "You can be fined up to £5,000 if you don’t register.")
+    assert_select(".govuk-warning-text__assistive", text: "Danger")
+    assert_select(".govuk-warning-text__text", text: /You can be fined up to £5,000 if you don’t register?/i)
+  end
+
+  it "renders custom icon text" do
+    render_component(text_icon: ":(", text: "You can be fined up to £5,000 if you don’t register.")
+    assert_select(".govuk-warning-text__icon", text: ":(")
+  end
+end


### PR DESCRIPTION
## User need
Part of:

https://trello.com/c/UrJYOEVF

## Background
Design System has a [warning text component](https://design-system.service.gov.uk/components/warning-text/). We should add this component in the shared library (govuk_publishing_components).

Ticket: https://trello.com/c/lJ9w813f/351-add-warning-text-component

![screenshot-govuk-publishing-components dev gov uk-3212-2018 10 25-10-57-54](https://user-images.githubusercontent.com/4599889/47492494-0c916b80-d845-11e8-97b6-85a218a2feea.png)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-588.herokuapp.com/component-guide/
