### PR TITLE
add checkboxes from design systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Replace error summary script with the GOV.UK Frontend one and add example page to test error summary with inputs (PR #585)
 * Expose a high resolution image in meta tags (PR #592)
 * Adds warning text from design systems (PR #588)
+* Add checkboxes from design systems (PR #590)
 
 ## 12.2.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -1,0 +1,2 @@
+// This component relies on JavaScript from GOV.UK Frontend
+//= require govuk-frontend/components/checkboxes/checkboxes.js

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -16,6 +16,7 @@
 @import "components/breadcrumbs";
 @import "components/button";
 @import "components/character-count";
+@import "components/checkboxes";
 @import "components/contents-list";
 @import "components/copy-to-clipboard";
 @import "components/details";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
@@ -1,0 +1,2 @@
+@import "helpers/govuk-frontend-settings";
+@import "govuk-frontend/components/checkboxes/checkboxes";

--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -1,0 +1,55 @@
+<%
+  id ||= "checkboxes-#{SecureRandom.hex(4)}"
+  classes ||= ''
+  css_classes = %w( gem-c-checkboxes govuk-form-group )
+  css_classes << classes if classes
+  error ||= nil
+  css_classes << "govuk-form-group--error" if error
+  hint_text ||= "Select all that apply."
+  items ||= []
+
+  # check if any item is set as being conditional
+  has_conditional = items.any? { |item| item.is_a?(Hash) && item[:conditional] }
+%>
+
+<%= tag.div id: id, class: css_classes do %>
+  <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": "#{id}-hint #{"#{id}-error" if error}" do %>
+
+    <%= tag.legend class: "govuk-fieldset__legend govuk-fieldset__legend--xl" do %>
+      <%= tag.h1 heading, class: "govuk-fieldset__heading" %>
+    <% end %>
+
+    <%= tag.span hint_text, id: "#{id}-hint", class: "govuk-hint" %>
+
+    <% if error.present? %>
+      <%= tag.span error, id: "#{id}-error", class: "govuk-error-message" %>
+    <% end %>
+
+    <%= tag.div class: "govuk-checkboxes", data: {
+      module: ('checkboxes' if has_conditional)
+    } do %>
+      <% items.each_with_index do |item, index| %>
+        <%= tag.div class: "govuk-checkboxes__item" do %>
+          <%= tag.input id: "#{id}-#{index}",
+            name: name,
+            type: "checkbox",
+            value: item[:value],
+            class: "govuk-checkboxes__input",
+            aria: {
+              describedby: item[:hint].present? ? "#{id}-#{index}-item-hint" : nil,
+              controls: item[:conditional].present? ? "#{id}-conditional-#{index}" : nil
+            } do %>
+            <%= tag.label item[:label], class: "govuk-label govuk-checkboxes__label", for: "#{id}-#{index}" %>
+            <% if item[:hint].present? %>
+              <%= tag.span item[:hint], id: "#{id}-#{index}-item-hint", class: "govuk-hint govuk-checkboxes__hint" %>
+            <% end %>
+          <% end %>
+        <% end %>
+        <% if item[:conditional] %>
+          <%= tag.div item[:conditional], id: "#{id}-conditional-#{index}", class: "govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -1,0 +1,82 @@
+name: Form checkboxes
+description: Help users enter text when there is a limit on the number of characters they can type
+govuk_frontend_components:
+  - checkboxes
+accessibility_criteria: |
+  The component must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - be usable with touch
+  - indicate when they have focus
+  - be recognisable as form textarea elements
+  - have correctly associated labels
+  - inform the user about the character limit
+  - inform the user as the number of left characters changes
+
+  Labels use the [label component](/component-guide/label).
+examples:
+  default:
+    data:
+      name: "favourite_colour"
+      heading: "What is your favourite colour?"
+      items:
+        - label: "Red"
+          value: "red"
+        - label: "Green"
+          value: "green"
+        - label: "Blue"
+          value: "blue"
+  custom_hint_text:
+    data:
+      name: "favourite_skittle"
+      heading: "What is your favourite skittle?"
+      hint_text: "Taste the rainbow"
+      items:
+        - label: "Red"
+          value: "red"
+        - label: "Green"
+          value: "green"
+        - label: "Blue"
+          value: "blue"
+  checkbox_items_with_hint:
+    data:
+      name: "nationality"
+      heading: "What is your nationality?"
+      hint_text: "If you have dual nationality, select all options that are relevant to you."
+      items:
+        - label: "British"
+          value: "british"
+          hint: "including English, Scottish, Welsh and Northern Irish"
+        - label: "Irish"
+          value: "irish"
+        - label: "Other"
+          value: "other"
+  checkbox_items_with_error:
+    data:
+      name: "nationality"
+      heading: "What is your nationality?"
+      error: "Select if you are British, Irish or a citizen of a different country"
+      hint_text: "If you have dual nationality, select all options that are relevant to you."
+      items:
+        - label: "British"
+          value: "british"
+          hint: "including English, Scottish, Welsh and Northern Irish"
+        - label: "Irish"
+          value: "irish"
+        - label: "Other"
+          value: "other"
+  checkbox_items_with_conditional_reveal:
+    data:
+      name: "nationality"
+      heading: "What is your nationality?"
+      hint_text: "If you have dual nationality, select all options that are relevant to you."
+      items:
+        - label: "British"
+          value: "british"
+          conditional: "including English, Scottish, Welsh and Northern Irish"
+        - label: "Irish"
+          value: "irish"
+        - label: "Other"
+          value: "other"

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+describe "Checkboxes", type: :view do
+  def component_name
+    "checkboxes"
+  end
+
+  it "renders checkboxes" do
+    render_component(
+      id: "favourite-colour",
+      name: "favourite_colour",
+      heading: "What is your favourite colour?",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+        { label: "Blue", value: "blue" }
+      ]
+    )
+    assert_select ".govuk-checkboxes"
+    assert_select "label[for='favourite-colour-0']", text: "Red"
+    assert_select "label[for='favourite-colour-1']", text: "Green"
+    assert_select "label[for='favourite-colour-2']", text: "Blue"
+  end
+
+  it "renders checkboxes with custom hint text" do
+    render_component(
+      name: "favourite-skittle",
+      heading: "What is your favourite skittle?",
+      hint_text: "Taste the rainbow",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+        { label: "Blue", value: "blue" }
+      ]
+    )
+    assert_select ".govuk-checkboxes"
+    assert_select(".govuk-hint", text: "Taste the rainbow")
+  end
+
+  it "renders checkboxes with hint text for checkbox item" do
+    render_component(
+      id: "nationality",
+      name: "nationality",
+      heading: "What is your nationality?",
+      hint_text: "If you have dual nationality, select all options that are relevant to you.",
+      items: [
+        { label: "British", value: "british", hint: "including English, Scottish, Welsh and Northern Irish" },
+        { label: "Irish", value: "irish" },
+        { label: "Other", value: "other" }
+      ]
+    )
+    assert_select ".govuk-checkboxes"
+    assert_select "label[for='nationality-0']", text: "British"
+    assert_select "label[for='nationality-1']", text: "Irish"
+    assert_select "label[for='nationality-2']", text: "Other"
+    assert_select("#nationality-0-item-hint", text: "including English, Scottish, Welsh and Northern Irish")
+  end
+
+  it "renders checkboxes with error message" do
+    render_component(
+      id: "nationality",
+      name: "nationality",
+      heading: "What is your nationality?",
+      error: "Select if you are British, Irish or a citizen of a different country",
+      hint_text: "If you have dual nationality, select all options that are relevant to you.",
+      items: [
+        { label: "British", value: "british", hint: "including English, Scottish, Welsh and Northern Irish" },
+        { label: "Irish", value: "irish" },
+        { label: "Other", value: "other" }
+      ]
+    )
+    assert_select ".govuk-checkboxes"
+    assert_select("#nationality-error", text: "Select if you are British, Irish or a citizen of a different country")
+  end
+
+  it "renders checkboxes with conditional reveal" do
+    render_component(
+      id: "nationality",
+      name: "nationality",
+      heading: "What is your nationality?",
+      hint_text: "If you have dual nationality, select all options that are relevant to you.",
+      items: [
+        { label: "British", value: "british", conditional: "including English, Scottish, Welsh and Northern Irish" },
+        { label: "Irish", value: "irish" },
+        { label: "Other", value: "other" }
+      ]
+    )
+    assert_select ".govuk-checkboxes"
+    assert_select("#nationality-conditional-0", text: "including English, Scottish, Welsh and Northern Irish")
+  end
+end


### PR DESCRIPTION
# Add checkboxes component to support attachment and taxonomy workflow
## User need
https://trello.com/c/V91W6SoB/350-add-checkboxes-component-to-support-attachment-and-taxonomy-workflow

Part of:

https://trello.com/c/Rzd8bdIp

https://trello.com/c/UrJYOEVF

## Background
Design System has a [checkboxes component](https://design-system.service.gov.uk/components/checkboxes/). We should add this component in the shared library (govuk_publishing_components) and automatically initialise it using `data-module` attribute.

## Screenshot

![screenshot-govuk-publishing-components dev gov uk-3212-2018 10 26-11-16-03](https://user-images.githubusercontent.com/4599889/47560607-a540ed80-d910-11e8-9ad8-68761ca927e1.png)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-590.herokuapp.com/component-guide/
