### PR TITLE
Expose the high resolution image in meta tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add additional examples to related navigation documentation
 * Remove init from radios script as we auto-initialise all components from GOV.UK Frontend
 * Replace error summary script with the GOV.UK Frontend one and add example page to test error summary with inputs (PR #585)
+* Expose a high resolution image in meta tags (PR #592)
 * Adds warning text from design systems (PR #588)
 
 ## 12.2.0

--- a/lib/govuk_publishing_components/presenters/machine_readable/page.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/page.rb
@@ -32,7 +32,7 @@ module GovukPublishingComponents
       end
 
       def image_url
-        content_item.dig("details", "image", "url")
+        content_item.dig("details", "image", "high_resolution_url") || content_item.dig("details", "image", "url")
       end
 
       def image_alt_text

--- a/spec/components/machine_readable_metadata_spec.rb
+++ b/spec/components/machine_readable_metadata_spec.rb
@@ -22,4 +22,23 @@ describe "Machine readable metadata", type: :view do
 
     assert JSON.parse(json_linked_data)
   end
+
+  it "uses images if available" do
+    example = GovukSchemas::RandomExample.for_schema(frontend_schema: "news_article") do |item|
+      item["details"].merge!(
+        "image" => {
+          "url" => "https://example.org/low-res.jpg",
+        }
+      )
+      item
+    end
+
+    render_component(content_item: example, schema: :article)
+
+    assert_meta_tag "twitter:image", "https://example.org/low-res.jpg"
+  end
+
+  def assert_meta_tag(name, content)
+    assert_select "meta[name='#{name}'][content='#{content}']"
+  end
 end

--- a/spec/components/machine_readable_metadata_spec.rb
+++ b/spec/components/machine_readable_metadata_spec.rb
@@ -25,17 +25,29 @@ describe "Machine readable metadata", type: :view do
 
   it "uses images if available" do
     example = GovukSchemas::RandomExample.for_schema(frontend_schema: "news_article") do |item|
-      item["details"].merge!(
-        "image" => {
+      item["details"]["image"] = {
           "url" => "https://example.org/low-res.jpg",
         }
-      )
       item
     end
 
     render_component(content_item: example, schema: :article)
 
     assert_meta_tag "twitter:image", "https://example.org/low-res.jpg"
+  end
+
+  it "uses high resolution images if available" do
+    example = GovukSchemas::RandomExample.for_schema(frontend_schema: "news_article") do |item|
+      item["details"]["image"] = {
+          "url" => "https://example.org/low-res.jpg",
+          "high_resolution_url" => "https://example.org/high-res.jpg",
+        }
+      item
+    end
+
+    render_component(content_item: example, schema: :article)
+
+    assert_meta_tag "twitter:image", "https://example.org/high-res.jpg"
   end
 
   def assert_meta_tag(name, content)


### PR DESCRIPTION
As described in https://github.com/alphagov/govuk-content-schemas/pull/827, we currently expose the image from the page to social media scrapers using this component. This image is often quite small, and unsuitable for services like Twitter.

Whitehall will soon be sending a higher resolution image in `details.image`. This PR makes sure that we use it if it's present.

https://trello.com/c/eqcMykln