### PR TITLE
Updates current breadcrumbs to use design systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Updates current breadcrumbs components to be based on GOV.UK Frontend (PR #593)
+
 ## 12.3.0
 
 * Expose a high resolution image in meta tags (PR #592)

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -11,6 +11,7 @@
 @import "colours";
 @import "components/helpers/variables";
 @import "components/helpers/brand-colours";
+@import "components/mixins/media-down";
 
 @import "components/back-link";
 @import "components/breadcrumbs";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -1,64 +1,19 @@
-@import "design-patterns/breadcrumbs";
-@import "mixins/back-arrow";
-@import "mixins/media-down";
+@import "helpers/govuk-frontend-settings";
+@import "govuk-frontend/components/breadcrumbs/breadcrumbs";
 
-.gem-c-breadcrumbs {
-  // reset the default browser styles
-  ol {
-    padding: 0;
-    margin: 0;
-  }
-
-  @include breadcrumbs;
-
-  .gem-c-breadcrumbs__item {
-    @include govuk-text-colour;
-  }
-
-  .gem-c-breadcrumbs__link {
-    @include govuk-link-common;
-    @include govuk-link-style-text;
-  }
-
-  .gem-c-breadcrumbs--current {
-    &:link,
-    &:visited,
-    &:hover,
-    &:active {
-      color: $secondary-text-colour;
-      text-decoration: none;
-    }
-
-    &:focus {
-      text-decoration: none;
-    }
-  }
-
-  @include media-down(mobile) {
-    &.gem-c-breadcrumbs--collapse-on-mobile .gem-c-breadcrumbs__item {
-      display: none;
-
-      &.gem-c-breadcrumbs--parent {
-        background-image: none;
-        display: block;
-        margin-left: 0;
-        padding-left: 14px;
-        position: relative;
-
-        &:before {
-          @include back-arrow;
-        }
-      }
-    }
-  }
-}
-
-.gem-c-breadcrumbs--current.gem-c-breadcrumbs--inverse,
-.gem-c-breadcrumbs .gem-c-breadcrumbs--inverse {
+.gem-c-breadcrumbs--inverse .govuk-breadcrumbs__list-item .govuk-breadcrumbs__link {
   &:link,
   &:visited,
   &:hover,
   &:active {
-    color: $white;
+    color: govuk-colour('white');
   }
+}
+
+.gem-c-breadcrumbs--inverse .govuk-breadcrumbs__list-item {
+  color: govuk-colour('white');
+}
+
+.gem-c-breadcrumbs--inverse .govuk-breadcrumbs__list-item:before {
+  border-color: govuk-colour('white');
 }

--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -11,39 +11,37 @@
   <%= raw structured_data.to_json %>
 </script>
 
-<div class="gem-c-breadcrumbs <%= collapse_class %>" data-module="track-click">
-  <ol>
-  <% breadcrumbs.each_with_index do |crumb, index| %>
-    <%
-      is_link = crumb[:url].present? || crumb[:is_current_page]
-      path = crumb[:is_current_page] ? '#content' : crumb[:url]
-      aria_current = crumb[:is_current_page] ? 'page' : 'false'
-      css_class = "gem-c-breadcrumbs__link " + invert_class.concat(crumb[:is_current_page] ? ' gem-c-breadcrumbs--current ' : '')
-    %>
-
-    <li class='gem-c-breadcrumbs__item <%= "gem-c-breadcrumbs--parent" if crumb[:is_page_parent] %>'>
-      <% if is_link %>
-        <%= link_to(
-          crumb[:title],
-          path,
-          data: {
-            track_category: 'breadcrumbClicked',
-            track_action: index + 1,
-            track_label: path,
-            track_options: {
-              dimension28: breadcrumbs.length.to_s,
-              dimension29: crumb[:title]
+<div class="gem-c-breadcrumbs govuk-breadcrumbs <%= invert_class %>" data-module="track-click">
+  <ol class="govuk-breadcrumbs__list">
+    <% breadcrumbs.each_with_index do |crumb, index| %>
+      <%
+        is_link = crumb[:url].present? || crumb[:is_current_page]
+        path = crumb[:is_current_page] ? '#content' : crumb[:url]
+        aria_current = crumb[:is_current_page] ? 'page' : 'false'
+      %>
+      <li class="govuk-breadcrumbs__list-item" aria-current="<%= aria_current %>">
+        <% if is_link %>
+          <%= link_to(
+            crumb[:title],
+            path,
+            data: {
+              track_category: 'breadcrumbClicked',
+              track_action: index + 1,
+              track_label: path,
+              track_options: {
+                dimension28: breadcrumbs.length.to_s,
+                dimension29: crumb[:title]
+              }
+            },
+            class: "govuk-breadcrumbs__link",
+            aria: {
+              current: aria_current,
             }
-          },
-          class: css_class,
-          aria: {
-            current: aria_current,
-          }
-        ) %>
-      <% else %>
-        <%= crumb[:title] %>
-      <% end %>
-    </li>
-  <% end %>
+          ) %>
+        <% else %>
+          <%= crumb[:title] %>
+        <% end %>
+      </li>
+    <% end %>
   </ol>
 </div>

--- a/spec/components/breadcrumbs_spec.rb
+++ b/spec/components/breadcrumbs_spec.rb
@@ -17,7 +17,7 @@ describe "Breadcrumbs", type: :view do
   it "renders a single breadcrumb" do
     render_component(breadcrumbs: [{ title: 'Section', url: '/section' }])
 
-    assert_link_with_text_in('.gem-c-breadcrumbs__item:first-child', '/section', 'Section')
+    assert_link_with_text_in('.govuk-breadcrumbs__list-item:first-child', '/section', 'Section')
   end
 
   it "renders schema data" do
@@ -26,9 +26,7 @@ describe "Breadcrumbs", type: :view do
       { title: 'Section 2', url: '/section-2' },
       { title: 'Section 3', is_current_page: true },
     ]
-
     structured_data = GovukPublishingComponents::Presenters::Breadcrumbs.new(breadcrumbs, "/section-3").structured_data
-
     expect(structured_data["@type"]).to eq("BreadcrumbList")
     expect(structured_data["itemListElement"].first["@type"]).to eq("ListItem")
     expect(structured_data["itemListElement"].first["position"]).to eq(1)
@@ -49,10 +47,10 @@ describe "Breadcrumbs", type: :view do
     }
 
     assert_select '.gem-c-breadcrumbs[data-module="track-click"]', 1
-    assert_select '.gem-c-breadcrumbs__item:first-child a[data-track-action="1"]', 1
-    assert_select '.gem-c-breadcrumbs__item:first-child a[data-track-label="/section"]', 1
-    assert_select '.gem-c-breadcrumbs__item:first-child a[data-track-category="breadcrumbClicked"]', 1
-    assert_select ".gem-c-breadcrumbs__item:first-child a[data-track-options='#{expected_tracking_options.to_json}']", 1
+    assert_select '.govuk-breadcrumbs__list-item:first-child a[data-track-action="1"]', 1
+    assert_select '.govuk-breadcrumbs__list-item:first-child a[data-track-label="/section"]', 1
+    assert_select '.govuk-breadcrumbs__list-item:first-child a[data-track-category="breadcrumbClicked"]', 1
+    assert_select ".govuk-breadcrumbs__list-item:first-child a[data-track-options='#{expected_tracking_options.to_json}']", 1
   end
 
   it "tracks the total breadcrumb count on each breadcrumb" do
@@ -69,9 +67,9 @@ describe "Breadcrumbs", type: :view do
       { dimension28: "3", dimension29: "Section 3" },
     ]
 
-    assert_select ".gem-c-breadcrumbs__item:nth-child(1) a[data-track-options='#{expected_tracking_options[0].to_json}']", 1
-    assert_select ".gem-c-breadcrumbs__item:nth-child(2) a[data-track-options='#{expected_tracking_options[1].to_json}']", 1
-    assert_select ".gem-c-breadcrumbs__item:nth-child(3) a[data-track-options='#{expected_tracking_options[2].to_json}']", 1
+    assert_select ".govuk-breadcrumbs__list-item:nth-child(1) a[data-track-options='#{expected_tracking_options[0].to_json}']", 1
+    assert_select ".govuk-breadcrumbs__list-item:nth-child(2) a[data-track-options='#{expected_tracking_options[1].to_json}']", 1
+    assert_select ".govuk-breadcrumbs__list-item:nth-child(3) a[data-track-options='#{expected_tracking_options[2].to_json}']", 1
   end
 
   it "renders a list of breadcrumbs" do
@@ -81,9 +79,9 @@ describe "Breadcrumbs", type: :view do
         { title: 'Sub-section', url: '/sub-section' },
       ])
 
-    assert_link_with_text_in('.gem-c-breadcrumbs__item:first-child', '/', 'Home')
-    assert_link_with_text_in('.gem-c-breadcrumbs__item:first-child + li', '/section', 'Section')
-    assert_link_with_text_in('.gem-c-breadcrumbs__item:last-child', '/sub-section', 'Sub-section')
+    assert_link_with_text_in('.govuk-breadcrumbs__list-item:first-child', '/', 'Home')
+    assert_link_with_text_in('.govuk-breadcrumbs__list-item:first-child + li', '/section', 'Section')
+    assert_link_with_text_in('.govuk-breadcrumbs__list-item:last-child', '/sub-section', 'Sub-section')
   end
 
   it "renders inverted breadcrumbs when passed a flag" do
@@ -102,6 +100,6 @@ describe "Breadcrumbs", type: :view do
         { title: 'Current Page' },
       ]
     )
-    assert_select('.gem-c-breadcrumbs__item:last-child', 'Current Page')
+    assert_select('.govuk-breadcrumbs__list-item:last-child', 'Current Page')
   end
 end


### PR DESCRIPTION
Part of:

https://trello.com/c/UrJYOEVF

The breadcrumbs component in govuk_publishing_components need to be updated to use govuk-frontend code

Ticket: https://trello.com/c/PXQahpcq/357-update-breadcrumb-component

## IMPORTANT
The only difference between the current component and this update is that previously there was no underline for items which had a link to `#content` on the current page. The new design systems standards show all links with an underline styling.

Also important to notice that I've had to include media-down mixin globally as it was being used by a lot of govspeak helpers but not actually required in these files.

## Screenshot

### Before
![screenshot-govuk-publishing-components herokuapp com-2018 10 29-10-19-58](https://user-images.githubusercontent.com/4599889/47643964-d6196080-db64-11e8-9b63-b13cbc66f8ee.png)

### After
![screenshot-meet google com-2018 10 29-10-22-08 1](https://user-images.githubusercontent.com/4599889/47643978-df0a3200-db64-11e8-8d48-a43081542d87.png)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-593.herokuapp.com/component-guide/
