### PR TITLE
Skip full validation of an org schema

### DIFF
--- a/spec/lib/presenters/schema_org_spec.rb
+++ b/spec/lib/presenters/schema_org_spec.rb
@@ -407,8 +407,16 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
     end
 
     def generate_org(details)
-      GovukSchemas::RandomExample.for_schema(frontend_schema: "organisation") do |org|
-        org.merge(details)
+      # We're skipping validation of the example schema for now because content
+      # schemas expect a lot of linked items to have base paths.  This is not the
+      # case.  It appears that the full fix is not trivial, partly because lots
+      # of tests in other apps rely on generated examples having base paths in
+      # linked items.
+      # We're making this change to unblock development, but it should be addressed
+      # soon, particularly as we can no longer rely on the below example reflecting
+      # a real content item
+      GovukSchemas::RandomExample.for_schema(frontend_schema: "organisation").tap do |org|
+        org.merge!(details)
       end
     end
   end


### PR DESCRIPTION
This was causing downstream failures because govuk_schemas [validates random schemas that have a block applied](https://github.com/alphagov/govuk_schemas/blob/f709a10cd2af63b29c22288fc7e0ad6af426926a/lib/govuk_schemas/random_example.rb#L88).  We're only overriding simple things to assert against here, and the schema tests to validate examples are run elsewhere.

No changelog necessary for this as it affects tests only.