### PR TITLE
Handle smaller images in image card large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Updates current breadcrumbs components to be based on GOV.UK Frontend (PR #593)
+* Expands image card component to handle smaller images gracefully (PR #605)
 
 ## 12.3.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -113,18 +113,26 @@
   }
 }
 
+.gem-c-image-card--large.gem-c-image-card {
+  margin: 0 0 30px 0;
+}
+
 .gem-c-image-card--large {
   .gem-c-image-card__image-wrapper {
-    @include grid-column( 2 / 3, tablet );
+    padding: 0 $gutter-one-third 0 0;
+    margin: 0;
+    float: left;
+    max-width: 66.66%;
   }
 
   .gem-c-image-card__text-wrapper {
-    @include grid-column( 1 / 3, tablet );
+    overflow: hidden;
   }
 
   .gem-c-image-card__image-wrapper {
     @include media(mobile) {
       margin-bottom: $gutter-one-third;
+      padding: 0;
     }
   }
 
@@ -133,6 +141,7 @@
     @include media(mobile) {
       float: none;
       width: auto;
+      max-width: 100%;
     }
   }
 


### PR DESCRIPTION
Trello: https://trello.com/c/QT5ZEcF7/124-bug-expand-image-card-component-to-handle-smaller-images

This tweaks the CSS for the image card large example so that it now handles smaller images more gracefully. This is needed for [one of the topic page MV variants](https://trello.com/c/5hFNt9yn/43-build-in-page-navigation-element). Previously, there would have been a large gap between the small image and the text. Now, the text expands to fill the rest of the space not taken up by the image.

## Before
<img width="926" alt="screen shot 2018-11-01 at 12 23 59" src="https://user-images.githubusercontent.com/29889908/47851884-de2a0800-ddd1-11e8-84b9-c19d2688c8cc.png">

## After
<img width="938" alt="screen shot 2018-11-01 at 12 24 19" src="https://user-images.githubusercontent.com/29889908/47851891-e4b87f80-ddd1-11e8-8cb8-bd108436f163.png">

This was tested on an organisation page to ensure it behaves in the same way where the component has already been used.

## Before
<img width="977" alt="screen shot 2018-11-01 at 13 39 38" src="https://user-images.githubusercontent.com/29889908/47855133-98723d00-dddb-11e8-95fa-d64f39cf668c.png">

## After
<img width="967" alt="screen shot 2018-11-01 at 13 39 27" src="https://user-images.githubusercontent.com/29889908/47855142-9f994b00-dddb-11e8-9a9b-59bc2b138679.png">

Component Guide: https://govuk-publishing-compon-pr-605.herokuapp.com/component-guide/image_card/large_version