### PR TITLE
Bump version to 12.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 12.4.0
 
 * Updates current breadcrumbs components to be based on GOV.UK Frontend (PR #593)
 * Expands image card component to handle smaller images gracefully (PR #605)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (12.3.0)
+    govuk_publishing_components (12.4.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '12.3.0'.freeze
+  VERSION = '12.4.0'.freeze
 end


### PR DESCRIPTION
Includes the following changes:

* Updates current breadcrumbs components to be based on GOV.UK Frontend (PR #593)
* Expands image card component to handle smaller images gracefully (PR #605)

Component guide for this PR:
https://govuk-publishing-compon-pr-607.herokuapp.com/component-guide/
