### PR TITLE
Add a maybe button to the feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+* Add a hidden 'Maybe' option to the feedback component. (PR #608)
+
 ## 12.4.0
 
 * Updates current breadcrumbs components to be based on GOV.UK Frontend (PR #593)

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -13,6 +13,20 @@
       <h2 class="gem-c-feedback__prompt-question">Is this page useful?</h2>
 
       <%= link_to contact_govuk_path, {
+        class: 'gem-c-feedback__prompt-link',
+        data: {
+          'track-category' => 'yesNoFeedbackForm',
+          'track-action' => 'ffMaybeClick'
+        },
+        style: 'display: none;',
+        hidden: 'hidden',
+        'aria-hidden': 'true',
+        'aria-expanded': false,
+      } do %>
+        Maybe
+      <% end %>
+
+      <%= link_to contact_govuk_path, {
         class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful',
         data: {
           'track-category' => 'yesNoFeedbackForm',

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -18,10 +18,11 @@
           'track-category' => 'yesNoFeedbackForm',
           'track-action' => 'ffMaybeClick'
         },
+        'aria-expanded': false,
+        role: 'button',
         style: 'display: none;',
         hidden: 'hidden',
         'aria-hidden': 'true',
-        'aria-expanded': false,
       } do %>
         Maybe
       <% end %>
@@ -31,9 +32,11 @@
         data: {
           'track-category' => 'yesNoFeedbackForm',
           'track-action' => 'ffYesClick'
-          },
-        } do %>
-          Yes <span class="visually-hidden">this page is useful</span>
+        },
+        'aria-expanded': false,
+        role: 'button',
+      } do %>
+        Yes <span class="visually-hidden">this page is useful</span>
       <% end %>
 
       <%= link_to contact_govuk_path, {
@@ -41,12 +44,12 @@
         data: {
           'track-category' => 'yesNoFeedbackForm',
           'track-action' => 'ffNoClick'
-          },
-          'aria-controls': 'page-is-not-useful',
-          'aria-expanded': false,
-          'role': 'button'
-        } do %>
-          No <span class="visually-hidden">this page is not useful</span>
+        },
+        'aria-controls': 'page-is-not-useful',
+        'aria-expanded': false,
+        role: 'button',
+      } do %>
+        No <span class="visually-hidden">this page is not useful</span>
       <% end %>
 
       <%= link_to contact_govuk_path, {
@@ -54,12 +57,12 @@
         data: {
           'track-category' => 'Onsite Feedback',
           'track-action' => 'GOV.UK Open Form'
-          },
-          'aria-controls': 'something-is-wrong',
-          'aria-expanded': false,
-          'role': 'button'
-        } do %>
-          Is there anything wrong with this page?
+        },
+        'aria-controls': 'something-is-wrong',
+        'aria-expanded': false,
+        role: 'button',
+      } do %>
+        Is there anything wrong with this page?
       <% end %>
     </div>
 


### PR DESCRIPTION
We have a problem where bots are filling in the feedback component and skewing the results. The theory here is that they are clicking on the first link, so we're introducing a new hidden first link called 'Maybe'.

I haven't added support for JavaScript so if a user were to click it, it would always make a normal browser request. I figure this is fine since we're targeting bots.

Component guide for this PR:
https://govuk-publishing-compon-pr-608.herokuapp.com/component-guide/

[Trello Card](https://trello.com/c/4Yo6hC5c/592-set-up-a-honeypot-to-catch-link-clicking-bots)