### PR TITLE
[WIP] Adds toggle tips components

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/tooltip.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/tooltip.js
@@ -1,0 +1,72 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  'use strict'
+
+  window.GOVUK = window.GOVUK || {};
+
+  Modules.Tooltip = function () {
+    this.start = function (tooltip) {
+        var initiator = $(tooltip).attr('data-initiator');
+        var trigger = $(tooltip).attr('data-trigger');
+        var hideOnBlur = $(tooltip).attr('data-hide-on-blur');
+        var overlay = $(tooltip).find('#tooltip-overlay');
+        var closeBtn = $(tooltip).find('.tooltip-close--button');
+        var _this = this;
+
+        if (initiator && trigger) {
+            $(initiator).on(trigger, function(e){
+                _this._initiator = $(e.target);
+                _this.initiatorZIndex = _this._initiator.css('z-index');
+                _this.show(tooltip, _this._initiator);
+            });
+            if (hideOnBlur == 'true') {
+                $(initiator).on('blur mouseout', function(e){
+                    _this.hide(tooltip, _this._initiator);
+                });
+            }
+
+            $(overlay).on('click', function(e) {
+                _this.hide(tooltip, _this._initiator);
+            });
+
+            $(closeBtn).on('click', function(e) {
+                _this.hide(tooltip, _this._initiator);
+            });
+        }
+    }
+
+    this.setPosition = function(tooltip, initiator) {
+        var _initiator = $(initiator);
+        var _tooltipContent = $(tooltip).find('.tooltip-content');
+        var initiatorPosition = _initiator.position();
+        initiatorPosition.top += _initiator.outerHeight() + 10;
+        if (initiatorPosition.left > ($(document).width() / 2) ) {
+            initiatorPosition.left -= ( $(tooltip).width() / 2 ) + 20;
+            _tooltipContent.addClass('right');
+        } else {
+            initiatorPosition.left += 5;
+            _tooltipContent.removeClass('right');
+        }
+        $(tooltip).css(initiatorPosition);
+    }
+
+    this.show = function(tooltip, initiator) {
+        this.setPosition(tooltip, initiator);
+        $(tooltip).removeClass('gem-c-tooltip--hidden');
+
+        var blur = $(tooltip).attr('data-blur-background');
+        if (blur == "true") {
+            $('#tooltip-overlay').addClass('gem-c-tooltip-background-blur');
+            $(initiator).css('z-index', 40);
+        }
+    }
+
+    this.hide = function(tooltip, initiator) {
+        $(tooltip).addClass('gem-c-tooltip--hidden');
+        $(tooltip).find('#tooltip-overlay').removeClass('gem-c-tooltip-background-blur');
+        $(initiator).css('z-index', this.initiatorZIndex);
+    }
+  }
+})(window.GOVUK.Modules);

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -64,5 +64,6 @@
 @import "components/taxonomy-navigation";
 @import "components/textarea";
 @import "components/title";
+@import "components/tooltip";
 @import "components/translation-nav";
 @import "components/warning-text";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_tooltip.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_tooltip.scss
@@ -1,0 +1,85 @@
+$background-blur-color: rgba(0, 0, 0, 0.5);
+$tooltip-shadow-colour: rgba(0, 0, 0, 0.1);
+
+.gem-c-tooltip {
+  display: inline-block;
+  position: absolute;
+
+  &.gem-c-tooltip--hidden {
+    display: none;
+  }
+}
+
+.gem-c-tooltip-background-blur {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 10;
+  background-color: $background-blur-color;
+}
+
+.gem-c-tooltip .tooltip-content {
+  display: inline-block;
+  position: relative;
+  font-family: "nta", sans-serif;
+  background: govuk-colour('black');
+  font-size: 16px;
+  line-height: 30px;
+  color: govuk-colour('white');
+  padding: 11px 55px 9px 15px;
+  box-shadow: 0 5px 0 $tooltip-shadow-colour;
+  z-index: 30;
+
+  &:after {
+    content: ".";
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    background: govuk-colour('black');
+    color: transparent;
+    overflow: hidden;
+    top: -5px;
+    left: 20px;
+    transform: rotate(45deg);
+  }
+
+  &.right:after {
+    left: auto;
+    right: 20px;
+  }
+}
+
+.gem-c-tooltip .tooltip-content .tooltip-close--button {
+  position: absolute;
+  overflow: hidden;
+  width: 40px;
+  height: 30px;
+  padding: 9px 0;
+  top: 0;
+  right: 0;
+  color: govuk-colour('white');
+  font-size: 30px;
+  text-decoration: none;
+  text-align: center;
+  line-height: 30px;
+  z-index: 40;
+
+  &:hover {
+    background: govuk-colour('blue');
+  }
+
+  &:focus {
+    background: govuk-colour('yellow');
+    outline: none;
+  }
+
+  .tooltip-close--button-text {
+    position: absolute;
+    top: -100px;
+    left: -1000%;
+  }
+}
+
+

--- a/app/views/govuk_publishing_components/components/_tooltip.html.erb
+++ b/app/views/govuk_publishing_components/components/_tooltip.html.erb
@@ -1,0 +1,27 @@
+<%
+    initiator ||= '' # id or class
+    trigger ||= "click" # click | hover | focus
+    hidden ||= false
+    hide_close_button ||= false
+    hide_on_blur ||= false
+    blur_background ||= false
+    css_classes = "gem-c-tooltip"
+    css_classes << " gem-c-tooltip--hidden " if hidden
+%>
+
+<%= tag.div class: css_classes, 
+    "data-module": "tooltip",
+    "data-initiator": initiator,
+    "data-trigger": trigger,
+    "data-blur-background": blur_background,
+    "data-hide-on-blur": hide_on_blur do %>
+    <%= tag.div id: "tooltip-overlay" %>
+    <%= tag.div class: "tooltip-content" do %>
+        <%= text %>
+        <% if !hide_close_button %>
+            <%= tag.a class: "tooltip-close--button", href: "#" do %>
+                x <%= tag.span "Close", class: "tooltip-close--button-text" %>
+            <% end %>
+        <% end %>
+    <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/tooltip.yml
+++ b/app/views/govuk_publishing_components/components/docs/tooltip.yml
@@ -1,0 +1,47 @@
+name: Tooltip
+description: |
+  Hi I'm a tool tip
+examples:
+  default:
+    data:
+      hidden: false
+      initiator: "#button1"
+      trigger: "click mouseover focus"
+      text: "You can be fined up to £5,000 if you don’t register."
+  mouseover:
+    data:
+      hidden: false
+      initiator: "#button2"
+      trigger: "mouseover"
+      text: "You can be fined up to £5,000 if you don’t register."
+  click:
+    data:
+      hidden: false
+      initiator: "#button3"
+      trigger: "click"
+      text: "You can be fined up to £5,000 if you don’t register."
+  focus:
+    data:
+      hidden: false
+      initiator: "#button4"
+      trigger: "focus"
+      text: "You can be fined up to £5,000 if you don’t register."
+  mouseover_click_or_focus:
+    data:
+      hidden: false
+      initiator: "#button5"
+      trigger: "hover click focus"
+      text: "You can be fined up to £5,000 if you don’t register."
+  hidden_by_default:
+    data:
+      hidden: true
+      initiator: "#button6"
+      trigger: "click"
+      text: "You can be fined up to £5,000 if you don’t register."
+  hide_close_button:
+    data:
+      hidden: false
+      initiator: "#button7"
+      trigger: "mouseover"
+      close_button: "hide"
+      text: "You can be fined up to £5,000 if you don’t register."


### PR DESCRIPTION
**As a** user
**I want** to be able to get help on confusing data
**So that** I can better understand it

Build pop-out tips to be used in table headers. This will comprise a hit spot that launches a panel of information, and blurring out the background whilst the help info is on screen.

To support users in understanding what the table data means

Ideally for data informed private beta.

Ticket: https://trello.com/c/DJaLf2kT/376-5-build-toggle-tips-functionality

## Screenshot
![nov-05-2018 11-21-48](https://user-images.githubusercontent.com/4599889/47995410-28222f00-e0ed-11e8-8fd1-e1f9264f63a6.gif)

----

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-609.herokuapp.com/component-guide/tooltip
