### PR TITLE
Bump version number to 12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 12.6.0
 
  * Adds separate tracking data for a link to the homepage on breadcrumbs (PR #610)
 

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '12.5.0'.freeze
+  VERSION = '12.6.0'.freeze
 end


### PR DESCRIPTION
Updates gem version to 12.6


---

Component guide for this PR:
https://govuk-publishing-compon-pr-612.herokuapp.com/component-guide/
