### PR TITLE
Phase banner now uses design systems and adds app name support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased changes
+
+* Update phase banner component to use GOV.UK Frontend styles (PR #613)
+* Update phase banner component to support application name (PR #613)
+
 ## 12.6.0
 
- * Adds separate tracking data for a link to the homepage on breadcrumbs (PR #610)
+* Adds separate tracking data for a link to the homepage on breadcrumbs (PR #610)
 
 ## 12.5.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
@@ -1,9 +1,9 @@
-@import "design-patterns/alpha-beta";
+@import "helpers/govuk-frontend-settings";
+@import "govuk-frontend/components/phase-banner/phase-banner";
 
 .gem-c-phase-banner {
-  @include phase-banner;
-
-  a {
-    @extend %govuk-link;
+  .govuk-phase-banner__content__app-name {
+    display: inline-block;
+    margin-right: govuk-spacing(2);
   }
 }

--- a/app/views/govuk_publishing_components/components/_phase_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_phase_banner.html.erb
@@ -1,22 +1,25 @@
 <%
+app_name ||= nil
 phase ||= nil
+message ||= nil 
 
 unless phase.in?(%w[alpha beta])
   raise ArgumentError, "The phase banner component expects a `phase` (`beta` or `alpha`), #{phase.inspect} given"
 end
+
+unless message.present?
+  if phase == "beta"
+    message = raw("This part of GOV.UK is being rebuilt &ndash; <a href=\"/help/beta\">find out what beta means</a>")
+  elsif phase == "alpha"
+    message = raw("This part of GOV.UK is being built &ndash; <a href=\"/service-manual/phases/ideal-alphas\">find out what alpha means</a>")
+  end
+end 
 %>
 
-<div class="gem-c-phase-banner">
-  <p>
-    <strong class="phase-tag"><%= phase %></strong>
-    <span>
-      <% if local_assigns[:message] %>
-        <%= local_assigns[:message] %>
-      <% elsif phase == "beta" %>
-        This part of GOV.UK is being rebuilt &ndash; <a href="/help/beta">find out what beta means</a>
-      <% elsif phase == "alpha" %>
-        This part of GOV.UK is being built &ndash; <a href="/service-manual/phases/ideal-alphas">find out what alpha means</a>
-      <% end %>
-    </span>
-  </p>
-</div>
+<%= tag.div class: "gem-c-phase-banner govuk-phase-banner" do %>
+  <%= tag.p class: "govuk-phase-banner__content" do %>
+    <%= tag.strong app_name, class: "govuk-phase-banner__content__app-name" if app_name %>
+    <%= tag.strong phase, class: "govuk-tag govuk-phase-banner__content__tag" %>
+    <%= tag.span message, class: "govuk-phase-banner__text" if message %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/phase_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/phase_banner.yml
@@ -19,3 +19,7 @@ examples:
       phase: beta
       message: This is an optional different message to explain what the state means in this
         context which can take <a href='https://www.gov.uk'>HTML</a>
+  with_app_name:
+    data:
+      app_name: Skittles Maker
+      phase: beta

--- a/spec/components/phase_banner_spec.rb
+++ b/spec/components/phase_banner_spec.rb
@@ -20,24 +20,31 @@ describe "Phase banner", type: :view do
   it "shows a custom message" do
     render_component(phase: "alpha", message: "custom message")
 
-    assert_select ".gem-c-phase-banner span", text: "custom message"
+    assert_select ".gem-c-phase-banner .govuk-phase-banner__text", text: "custom message"
   end
 
   it "allows custom message HTML" do
     render_component(phase: "beta", message: "custom <strong>message</strong>".html_safe)
 
-    assert_select ".gem-c-phase-banner strong", text: "message"
+    assert_select ".gem-c-phase-banner .govuk-phase-banner__text strong", text: "message"
   end
 
   it "shows the alpha phase" do
     render_component(phase: "alpha")
 
-    assert_select ".phase-tag", text: "alpha"
+    assert_select ".govuk-phase-banner__content__tag", text: "alpha"
   end
 
   it "shows the beta phase" do
     render_component(phase: "beta")
 
-    assert_select ".phase-tag", text: "beta"
+    assert_select ".govuk-phase-banner__content__tag", text: "beta"
+  end
+
+  it "shows the app name" do
+    render_component(app_name: "Skittles Maker", phase: "beta")
+
+    assert_select ".govuk-phase-banner__content__app-name", text: "Skittles Maker"
+    assert_select ".govuk-phase-banner__content__tag", text: "beta"
   end
 end


### PR DESCRIPTION
Phase banner now uses design systems and adds app name support

https://design-system.service.gov.uk/components/phase-banner/

Needed for:
https://trello.com/c/6hvQZTVK/259-update-navigation-header

---

Component guide for this PR:
https://govuk-publishing-compon-pr-613.herokuapp.com/component-guide/phase_banner