### PR TITLE
Support multiple errors in form fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add 'error_items' option for input, radio, textarea and file upload components (PR #615)
 * Update layout header to allow a full width option (PR #616)
 
 ## 12.7.1

--- a/app/views/govuk_publishing_components/components/_error_summary.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_summary.html.erb
@@ -1,4 +1,5 @@
 <%
+  id ||= "error-summary-#{SecureRandom.hex(4)}"
   title ||= false
   description ||= false
   items ||= []
@@ -13,6 +14,7 @@
   aria-labelledby="<%= title_id %>"
   role="alert"
   tabindex="-1"
+  id="<%= id %>"
 >
   <% if title %>
     <h2 class="gem-c-error-summary__title" id="<%= title_id %>">

--- a/app/views/govuk_publishing_components/components/_file_upload.html.erb
+++ b/app/views/govuk_publishing_components/components/_file_upload.html.erb
@@ -7,19 +7,21 @@
   label ||= nil
   hint ||= nil
   error_message ||= nil
-  hint_id = "hint-#{SecureRandom.hex(4)}" if hint
-  error_message_id = "error-message-#{SecureRandom.hex(4)}" if error_message
+  error_items ||= nil
+  has_error = error_message || error_items&.any?
+  hint_id = "hint-#{SecureRandom.hex(4)}"
+  error_id = "error-#{SecureRandom.hex(4)}"
 
   css_classes = %w(gem-c-file-upload govuk-file-upload)
-  css_classes << "govuk-file-upload--error" if error_message
+  css_classes << "govuk-file-upload--error" if has_error
   form_group_css_classes = %w(govuk-form-group)
-  form_group_css_classes << "govuk-form-group--error" if error_message
+  form_group_css_classes << "govuk-form-group--error" if has_error
 
   aria_described_by ||= nil
-  if hint || error_message
+  if hint || has_error
     aria_described_by = []
     aria_described_by << hint_id if hint
-    aria_described_by << error_message_id if error_message
+    aria_described_by << error_id if has_error
     aria_described_by = aria_described_by.join(" ")
   end
 %>
@@ -38,8 +40,13 @@
 
   <% if error_message %>
     <%= render "govuk_publishing_components/components/error_message", {
-      id: error_message_id,
+      id: error_id,
       text: error_message
+    } %>
+  <% elsif error_items %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      id: error_id,
+      items: error_items
     } %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -8,21 +8,23 @@
   label ||= nil
   hint ||= nil
   error_message ||= nil
+  error_items ||= nil
   autofocus ||= nil
   tabindex ||= nil
-  hint_id = "hint-#{SecureRandom.hex(4)}" if hint
-  error_message_id = "error-message-#{SecureRandom.hex(4)}" if error_message
+  has_error = error_message || error_items&.any?
+  hint_id = "hint-#{SecureRandom.hex(4)}"
+  error_id = "error-#{SecureRandom.hex(4)}"
 
   css_classes = %w(gem-c-input govuk-input)
-  css_classes << "govuk-input--error" if error_message
+  css_classes << "govuk-input--error" if has_error
   form_group_css_classes = %w(govuk-form-group)
-  form_group_css_classes << "govuk-form-group--error" if error_message
+  form_group_css_classes << "govuk-form-group--error" if has_error
 
   aria_described_by ||= nil
-  if hint || error_message || describedby
+  if hint || has_error || describedby
     aria_described_by = []
     aria_described_by << hint_id if hint
-    aria_described_by << error_message_id if error_message
+    aria_described_by << error_id if has_error
     aria_described_by << describedby if describedby
     aria_described_by = aria_described_by.join(" ")
   end
@@ -45,8 +47,13 @@
 
   <% if error_message %>
     <%= render "govuk_publishing_components/components/error_message", {
-      id: error_message_id,
+      id: error_id,
       text: error_message
+    } %>
+  <% elsif error_items %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      id: error_id,
+      items: error_items
     } %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -5,11 +5,13 @@
   label ||= nil
   hint ||= nil
   error_message ||= nil
-  hint_id = "hint-#{SecureRandom.hex(4)}" if hint
-  error_message_id = "error-message-#{SecureRandom.hex(4)}" if error_message
+  error_items ||= nil
+  has_error = error_message || error_items&.any?
+  hint_id = "hint-#{SecureRandom.hex(4)}"
+  error_id = "error-#{SecureRandom.hex(4)}"
 
   form_group_css_classes = %w(govuk-form-group)
-  form_group_css_classes << "govuk-form-group--error" if error_message
+  form_group_css_classes << "govuk-form-group--error" if has_error
 
   # check if any item is set as being conditional
   has_conditional = items.any? { |item| item.is_a?(Hash) && item[:conditional] }
@@ -25,8 +27,13 @@
 
   <% if error_message %>
     <%= render "govuk_publishing_components/components/error_message", {
-      id: error_message_id,
+      id: error_id,
       text: error_message
+    } %>
+  <% elsif error_items %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      id: error_id,
+      items: error_items
     } %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -8,21 +8,23 @@
   label ||= nil
   hint ||= nil
   error_message ||= nil
+  error_items ||= nil
   character_count ||= nil
-  hint_id = "hint-#{SecureRandom.hex(4)}" if hint
-  error_message_id = "error-message-#{SecureRandom.hex(4)}" if error_message
+  hint_id = "hint-#{SecureRandom.hex(4)}"
+  has_error ||= error_message || error_items&.any?
+  error_id = "error-#{SecureRandom.hex(4)}"
 
   css_classes = %w(gem-c-textarea govuk-textarea)
   css_classes << "js-character-count" if character_count
-  css_classes << "govuk-textarea--error" if error_message
+  css_classes << "govuk-textarea--error" if has_error
   form_group_css_classes = %w(govuk-form-group)
-  form_group_css_classes << "govuk-form-group--error" if error_message
+  form_group_css_classes << "govuk-form-group--error" if has_error
 
   aria_described_by ||= nil
-  if hint || error_message
+  if hint || has_error
     aria_described_by = []
     aria_described_by << hint_id if hint
-    aria_described_by << error_message_id if error_message
+    aria_described_by << error_id if has_error
     aria_described_by = aria_described_by.join(" ")
   end
 %>
@@ -41,8 +43,13 @@
 
   <% if error_message %>
     <%= render "govuk_publishing_components/components/error_message", {
-      id: error_message_id,
+      id: error_id,
       text: error_message
+    } %>
+  <% elsif error_items %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      id: error_id,
+      items: error_items
     } %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/docs/error_summary.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_summary.yml
@@ -8,6 +8,7 @@ shared_accessibility_criteria:
 examples:
   default:
     data:
+      id: error-summary
       title: Message to alert the user to a problem goes here
       description: Optional description of the errors and how to correct them
       items:

--- a/app/views/govuk_publishing_components/components/docs/file_upload.yml
+++ b/app/views/govuk_publishing_components/components/docs/file_upload.yml
@@ -32,6 +32,14 @@ examples:
         text: "Upload a file"
       name: "file-upload-with-error"
       error_message: "Please upload a file"
+  with_error_items:
+    data:
+      label:
+        text: "Upload a file"
+      name: "file-upload-with-error"
+      error_items:
+      - text: Descriptive link to the question with an error 1
+        href: '#example-error-1'
   with_file_accept:
     data:
       label:

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -52,6 +52,14 @@ examples:
         text: "What is your name?"
       name: "name"
       error_message: "Please could you provide your name"
+  with_error_items:
+    data:
+      label:
+        text: "What is your name?"
+      name: "name"
+      error_items:
+      - text: Descriptive link to the question with an error 1
+        href: '#example-error-1'
   with_value:
     data:
       label:

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -140,6 +140,18 @@ examples:
         text: "Use Government Gateway"
       - value: "govuk-verify"
         text: "Use GOV.UK Verify"
+  with_error_items_on_form_group:
+    data:
+      name: "radio-group-error"
+      id_prefix: "error"
+      error_items:
+      - text: Descriptive link to the question with an error 1
+        href: '#example-error-1'
+      items:
+      - value: "government-gateway"
+        text: "Use Government Gateway"
+      - value: "govuk-verify"
+        text: "Use GOV.UK Verify"
   conditional:
     data:
       name: "radio-group-conditional"

--- a/app/views/govuk_publishing_components/components/docs/textarea.yml
+++ b/app/views/govuk_publishing_components/components/docs/textarea.yml
@@ -39,6 +39,14 @@ examples:
         text: "Can you provide more detail?"
       name: "more-detail-error"
       error_message: "Please could you provide more detail"
+  with_error_items:
+    data:
+      label:
+        text: "Can you provide more detail?"
+      name: "more-detail-error"
+      error_items:
+      - text: Descriptive link to the question with an error 1
+        href: '#example-error-1'
   with_value:
     data:
       label:

--- a/spec/components/error_summary_spec.rb
+++ b/spec/components/error_summary_spec.rb
@@ -13,6 +13,7 @@ describe "Error summary", type: :view do
 
   it "renders error items when no title is set" do
     render_component(
+      id: 'error-summary-id',
       items: [
         {
           text: 'Descriptive link to the question with an error',
@@ -20,6 +21,8 @@ describe "Error summary", type: :view do
         }
       ]
     )
+
+    assert_select ".gem-c-error-summary[id='error-summary-id']"
     assert_select(
       "ul li a.gem-c-error-summary__link:first-of-type[href='#example-error-1']",
       text: 'Descriptive link to the question with an error'
@@ -28,6 +31,7 @@ describe "Error summary", type: :view do
 
   it "renders an error summary with title and aria-labelledby set correctly" do
     render_component(
+      id: 'error-summary-id',
       title: 'Message to alert the user to a problem goes here'
     )
 
@@ -36,6 +40,7 @@ describe "Error summary", type: :view do
       aria_labelledby_id = element.css('.gem-c-error-summary').first.attributes["aria-labelledby"].value
     end
 
+    assert_select ".gem-c-error-summary[id='error-summary-id']"
     assert_select ".gem-c-error-summary__title[id='#{aria_labelledby_id}']", text: 'Message to alert the user to a problem goes here'
     assert_select ".gem-c-error-summary__text", count: 0
     assert_select ".gem-c-error-summary__list", count: 0
@@ -52,6 +57,7 @@ describe "Error summary", type: :view do
         }
       ]
     )
+
     assert_select ".gem-c-error-summary__title", text: 'Message to alert the user to a problem goes here'
     assert_select ".gem-c-error-summary__text", text: 'Optional description of the errors and how to correct them'
     assert_select(

--- a/spec/components/file_upload_spec.rb
+++ b/spec/components/file_upload_spec.rb
@@ -94,9 +94,32 @@ describe "File upload", type: :view do
     end
 
     it "has 'aria-describedby' the error message id" do
-      error_message_id = css_select(".govuk-error-message").attr("id")
+      error_id = css_select(".govuk-error-message").attr("id")
 
-      assert_select ".govuk-file-upload[aria-describedby='#{error_message_id}']"
+      assert_select ".govuk-file-upload[aria-describedby='#{error_id}']"
+    end
+  end
+
+  context "when error_items are provided" do
+    before do
+      render_component(
+        name: "file-upload-hint-error-message",
+        error_items: [
+          {
+            text: "Error item 1"
+          }
+        ]
+      )
+    end
+
+    it "renders the error message" do
+      assert_select ".gem-c-error-summary li", text: "Error item 1"
+    end
+
+    it "has 'aria-describedby' the error message id" do
+      error_id = css_select(".gem-c-error-summary").attr("id")
+
+      assert_select ".govuk-file-upload[aria-describedby='#{error_id}']"
     end
   end
 end

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -116,9 +116,32 @@ describe "Input", type: :view do
     end
 
     it "has 'aria-describedby' the error message id" do
-      error_message_id = css_select(".govuk-error-message").attr("id")
+      error_id = css_select(".govuk-error-message").attr("id")
 
-      assert_select ".govuk-input[aria-describedby='#{error_message_id}']"
+      assert_select ".govuk-input[aria-describedby='#{error_id}']"
+    end
+  end
+
+  context "when error_items are provided" do
+    before do
+      render_component(
+        name: "email-address",
+        error_items: [
+          {
+            text: "Error item 1"
+          }
+        ]
+      )
+    end
+
+    it "renders the error message" do
+      assert_select ".gem-c-error-summary li", text: "Error item 1"
+    end
+
+    it "has 'aria-describedby' the error message id" do
+      error_id = css_select(".gem-c-error-summary").attr("id")
+
+      assert_select ".govuk-input[aria-describedby='#{error_id}']"
     end
   end
 end

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -220,6 +220,29 @@ describe "Radio", type: :view do
     assert_select ".govuk-error-message", text: "Please select one option"
   end
 
+  it "renders radio-group with error items" do
+    render_component(
+      name: "radio-group-conditional",
+      error_items: [
+        {
+          text: "Error item 1"
+        }
+      ],
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        },
+        {
+          value: "govuk-verify",
+          text: "Use GOV.UK Verify"
+        }
+      ]
+    )
+
+    assert_select ".gem-c-error-summary li", text: "Error item 1"
+  end
+
   it "renders radio-group with welsh translated 'or'" do
     I18n.with_locale(:cy) do
       render_component(

--- a/spec/components/textarea_spec.rb
+++ b/spec/components/textarea_spec.rb
@@ -104,9 +104,32 @@ describe "Textarea", type: :view do
     end
 
     it "has 'aria-describedby' the error message id" do
-      error_message_id = css_select(".govuk-error-message").attr("id")
+      error_id = css_select(".govuk-error-message").attr("id")
 
-      assert_select ".govuk-textarea[aria-describedby='#{error_message_id}']"
+      assert_select ".govuk-textarea[aria-describedby='#{error_id}']"
+    end
+  end
+
+  context "when error_items are provided" do
+    before do
+      render_component(
+        name: "more-detail-hint-error-message",
+        error_items: [
+          {
+            text: "Error item 1"
+          }
+        ]
+      )
+    end
+
+    it "renders the error message" do
+      assert_select ".gem-c-error-summary li", text: "Error item 1"
+    end
+
+    it "has 'aria-describedby' the error message id" do
+      error_id = css_select(".gem-c-error-summary").attr("id")
+
+      assert_select ".govuk-textarea[aria-describedby='#{error_id}']"
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/4iKDzhBY/417-separate-saving-a-change-from-the-creation-of-a-preview

Currently we support an 'error_message' on a form field, but sometimes a
field can have multiple errors. This adds an alternative 'error_items'
option to the input, textarea, radio and file upload components to
support multiple errors as items of the error summary component.

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-[THIS PR NUMBER].herokuapp.com/component-guide/
