### PR TITLE
Add the ability for the layout header to go full width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update layout header to allow a full width option (PR #616)
+
 ## 12.7.0
 
 * Update phase banner component to use GOV.UK Frontend styles (PR #613)

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -1,10 +1,15 @@
 <%
+  full_width ||= false
   product_name ||= "Publishing"
   navigation_items ||= []
+  if full_width
+    width_class = "govuk-header__container--full-width"
+  else
+    width_class = "govuk-width-container"
+  end
 %>
 <header class="gem-c-layout-header govuk-header gem-c-layout-header--<%= environment %>" role="banner" data-module="header">
-  <div class="govuk-header__container govuk-width-container">
-
+  <div class="govuk-header__container <%= width_class %>">
     <div class="govuk-header__logo">
       <a href="/" class="govuk-header__link govuk-header__link--homepage">
         <span class="govuk-header__logotype">

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -31,6 +31,12 @@ examples:
         active: true
       - text: Navigation item 2
         href: "#2"
+  full_width:
+    description: |
+      This is difficult to preview because the preview windows are constrained, but the header will stretch to the size of its container.
+    data:
+      environment: production
+      full_width: true
 
 accessibility_criteria: |
   The component must:

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -23,6 +23,20 @@ describe "Layout header", type: :view do
     assert_select ".govuk-header__product-name", text: "Product name"
   end
 
+  it "renders at a constrained width by default" do
+    render_component(environment: "staging", product_name: "Product name")
+
+    assert_select ".govuk-width-container"
+  end
+
+  it "renders at full width when requested to" do
+    render_component(environment: "staging", product_name: "Product name", full_width: true)
+
+    assert_select ".govuk-header__container--full-width"
+  end
+
+
+
   it "renders the header with navigation items" do
     navigation_items = [
       { text: "Foo", href: "/foo", active: true },


### PR DESCRIPTION
Allows layout header to go full width when passed a parameter.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-616.herokuapp.com/component-guide/
