### PR TITLE
Add govspeak-html-publication to _all_components

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -28,6 +28,7 @@
 @import "components/feedback";
 @import "components/fieldset";
 @import "components/file-upload";
+@import "components/govspeak-html-publication";
 @import "components/govspeak";
 @import "components/heading";
 @import "components/highlight-boxes";


### PR DESCRIPTION
Add govspeak-html-publication to _all_components

In some documents with document type `html_publication`, rendered by
`government-frontend`, the correct css styling was not applied because
we were not importing the `govspeak-html-publication` component.

Trello: https://trello.com/c/wPyyRRfH/634-table-styling-on-2018-budget-query-from-hm-treasury



Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-618.herokuapp.com/component-guide/
