### PR TITLE
T143 accessible autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add accessible autocomplete component. (PR #621)
 * Add 'error_items' option for input, radio, textarea and file upload components (PR #615)
 * Update layout header to allow a full width option (PR #616)
 

--- a/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
@@ -1,0 +1,37 @@
+//= require accessible-autocomplete/dist/accessible-autocomplete.min.js
+
+window.GOVUK = window.GOVUK || {};
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  "use strict";
+
+  Modules.AccessibleAutocomplete = function () {
+    this.start = function ($element) {
+      var $selectElem = $element.find('select');
+
+      var configOptions = {
+        selectElement: document.getElementById($selectElem.attr('id')),
+        showAllValues: true,
+        confirmOnBlur: false
+      };
+
+      if ($selectElem.data('track-category') !== undefined && $selectElem.data('track-action') !== undefined) {
+        configOptions.onConfirm = function(val) {
+          track($selectElem.data('track-category'), $selectElem.data('track-action'), val, $selectElem.data('track-options'));
+        };
+      }
+
+      new accessibleAutocomplete.enhanceSelectElement(configOptions);
+    };
+
+    function track (category, action, label, options) {
+      if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+        options = options || {};
+        options.label = label;
+
+        GOVUK.analytics.trackEvent(category, action, options);
+      }
+    }
+  };
+})(window.GOVUK.Modules);

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -13,6 +13,7 @@
 @import "components/helpers/brand-colours";
 @import "components/mixins/media-down";
 
+@import "components/accessible-autocomplete";
 @import "components/back-link";
 @import "components/breadcrumbs";
 @import "components/button";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
@@ -1,0 +1,16 @@
+@import "helpers/govuk-frontend-settings";
+@import "govuk-frontend/settings/all";
+@import "govuk-frontend/tools/all";
+@import "govuk-frontend/helpers/all";
+
+@import url(asset-path("accessible-autocomplete/dist/accessible-autocomplete.min.css"));
+
+.gem-c-accessible-autocomplete {
+  .autocomplete__input {
+    background: govuk-colour("white");
+  }
+
+  .autocomplete__option {
+    @include govuk-font(19)
+  }
+}

--- a/app/views/govuk_publishing_components/components/_accessible_autocomplete.html.erb
+++ b/app/views/govuk_publishing_components/components/_accessible_autocomplete.html.erb
@@ -1,0 +1,24 @@
+<%
+  id ||= "autocomplete-#{SecureRandom.hex(4)}"
+  label ||= nil
+  data_attributes ||= nil
+  options ||= []
+  selected_option ||= nil
+%>
+<% if label && options.any? %>
+  <%=
+    render "govuk_publishing_components/components/label", {
+      html_for: id
+    }.merge(label.symbolize_keys)
+  %>
+
+  <div class="gem-c-accessible-autocomplete" data-module="accessible-autocomplete">
+    <%=
+      select_tag(
+        id,
+        options_for_select(options, selected_option),
+        data: data_attributes
+      )
+    %>
+  </div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
+++ b/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
@@ -1,0 +1,42 @@
+name: Accessible autocomplete
+description: An autocomplete component, built to be accessible.
+body: |
+  This component uses the [Accessible Autocomplete](https://github.com/alphagov/accessible-autocomplete) code to create an accessible autocomplete element. The autocomplete is created with the `showAllValues`
+  option set to `true` and the `confirmOnBlur` option set to `false` (see [Autocomplete examples](https://alphagov.github.io/accessible-autocomplete/examples) here). It also depends upon the
+  [label component](https://github.com/component-guide/label).
+
+  If Javascript is disabled, the component appears as a select box, so the user can still select an option.
+accessibility_criteria: |
+  [Accessibility acceptance criteria](https://github.com/alphagov/accessible-autocomplete/blob/master/accessibility-criteria.md)
+examples:
+  default:
+    data:
+      label:
+        text: 'Countries'
+      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us']]
+  with_unique_identifier:
+    data:
+      id: 'unique-autocomplete'
+      label:
+        text: 'Countries'
+      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us']]
+  with_selected_option_chosen:
+    data:
+      id: 'selected-option-chosen-autocomplete'
+      label:
+        text: 'Countries'
+      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us']]
+      selected_option: ['United Kingdom', 'gb']
+  with_tracking_enabled:
+    description: |
+     This example shows tracking enabled on an autocomplete. Tracking will be enabled automatically when `track_category` and `track_action` are specified in `data_attributes`.
+    data:
+      id: 'tracking-enabled-autocomplete'
+      label:
+        text: 'Countries'
+      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us']]
+      data_attributes:
+        track_category: 'chosen_category'
+        track_action: 'chosen_action'
+        track_option:
+          custom_dimension: 'your_custom_dimension'

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -22,6 +22,7 @@ Rails.application.config.assets.precompile += %w(
 # Add GOV.Frontend assets
 
 Rails.application.config.assets.precompile += %w(
+  accessible-autocomplete/dist/accessible-autocomplete.min.css
   govuk-logotype-crown.png
 )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,14 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "accessible-autocomplete": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-1.6.2.tgz",
+      "integrity": "sha512-7S+6Vi82LQFSSd5feKedu46tiY2/DShpdXiRp0NY3cLwc+DKe1ayWd66mb3JVi8LTQubRM7jco+u92e6w0bbvg==",
+      "requires": {
+        "preact": "^8.3.1"
+      }
+    },
     "govuk-frontend": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.2.0.tgz",
@@ -11,6 +19,11 @@
       "version": "1.12.4",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.4.tgz",
       "integrity": "sha1-AeHfuikP5z3rp3zurLD5ui/sngw="
+    },
+    "preact": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.3.1.tgz",
+      "integrity": "sha512-s8H1Y8O9e+mOBo3UP1jvWqArPmjCba2lrrGLlq/0kN1XuIINUbYtf97iiXKxCuG3eYwmppPKnyW2DBrNj/TuTg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "jquery": "1.12.4",
-    "govuk-frontend": "^2.2.0"
+    "accessible-autocomplete": "^1.6.2",
+    "govuk-frontend": "^2.2.0",
+    "jquery": "1.12.4"
   }
 }

--- a/spec/components/accessible_autocomplete_spec.rb
+++ b/spec/components/accessible_autocomplete_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe "AccessibleAutocomplete", type: :view do
+  def component_name
+    "accessible_autocomplete"
+  end
+
+  it 'renders select element' do
+    render_component(
+      id: 'basic-autocomplete',
+      label: { text: "Countries" },
+      options: [['United Kingdom', 'gb'], ['United States', 'us']]
+    )
+
+    assert_select ".govuk-label", text: "Countries", for: "basic-autocomplete"
+    assert_select "select#basic-autocomplete"
+    assert_select "select#basic-autocomplete option[value=gb]"
+    assert_select "select#basic-autocomplete option[value=gb]", text: 'United Kingdom'
+    assert_select "select#basic-autocomplete option[value=us]"
+    assert_select "select#basic-autocomplete option[value=us]", text: 'United States'
+  end
+
+  it 'renders select element with selected value' do
+    render_component(
+      id: 'basic-autocomplete',
+      label: { text: "Countries" },
+      options: [['United Kingdom', 'gb'], ['United States', 'us']],
+      selected_option: ['United States', 'us']
+    )
+
+    assert_select ".govuk-label", text: "Countries", for: "basic-autocomplete"
+    assert_select "select#basic-autocomplete"
+    assert_select "select#basic-autocomplete option[value=gb]"
+    assert_select "select#basic-autocomplete option[value=us][selected]"
+  end
+
+  it 'does not render when no data is specified' do
+    assert_empty render_component({})
+  end
+
+  it 'does not render when no label is specified' do
+    assert_empty render_component(
+      id: 'basic-autocomplete',
+      options: [['United Kingdom', 'gb'], ['United States', 'us']]
+    )
+  end
+
+  it 'does not render when no options are specified' do
+    assert_empty render_component(
+      id: 'basic-autocomplete',
+      label: { text: "Countries" }
+    )
+  end
+end


### PR DESCRIPTION
This PR adds a new _accessible autocomplete_ component to the publishing components, using the existing accessible autocomplete at https://alphagov.github.io/accessible-autocomplete. 

The new component here adds a label alongside the autocomplete, in addition to support for tracking _if this is specifically enabled_ when creating the component.

No JS tests are included as they would be testing the functionality which has already been tested by the existing autocomplete component, and which can be seen at https://github.com/alphagov/accessible-autocomplete/tree/master/test.

This PR has been demoed to @alex-ju (before the PR was created). It was mentioned that the module system will be retired in the future, but until then the new module created in this PR can remain.

Co-authored-by: Mahmud Hussain <mahmud.hussain@digital.cabinet-office.gov.uk>

---

Component guide for this PR:
https://govuk-publishing-compon-pr-621.herokuapp.com/component-guide/
