### PR TITLE
Add option to checkboxes to allow preselected items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Add option to checkboxes to allow preselected items (PR #623)
+
 ## 12.8.0
 
 * Add 'error_items' option for input, radio, textarea and file upload components (PR #615)

--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -35,6 +35,7 @@
             type: "checkbox",
             value: item[:value],
             class: "govuk-checkboxes__input",
+            checked: item[:checked].present? ? "checked" : nil,
             aria: {
               describedby: item[:hint].present? ? "#{id}-#{index}-item-hint" : nil,
               controls: item[:conditional].present? ? "#{id}-conditional-#{index}" : nil

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -80,3 +80,16 @@ examples:
           value: "irish"
         - label: "Other"
           value: "other"
+  checkbox_items_with_checked_items:
+    data:
+      name: "nationality"
+      heading: "What is your nationality?"
+      hint_text: "If you have dual nationality, select all options that are relevant to you."
+      items:
+        - label: "British"
+          value: "british"
+          checked: true
+        - label: "Irish"
+          value: "irish"
+        - label: "Other"
+          value: "other"

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -88,4 +88,20 @@ describe "Checkboxes", type: :view do
     assert_select ".govuk-checkboxes"
     assert_select("#nationality-conditional-0", text: "including English, Scottish, Welsh and Northern Irish")
   end
+
+  it "renders checkboxes with preselected items" do
+    render_component(
+      id: "nationality",
+      name: "nationality",
+      heading: "What is your nationality?",
+      hint_text: "If you have dual nationality, select all options that are relevant to you.",
+      items: [
+        { label: "British", value: "british", checked: true },
+        { label: "Irish", value: "irish" },
+        { label: "Other", value: "other" }
+      ]
+    )
+    assert_select ".govuk-checkboxes"
+    assert_select ".govuk-checkboxes__input[checked]", value: "british"
+  end
 end


### PR DESCRIPTION
Add option to checkboxes to allow preselected items

# Screenshot

<img width="1026" alt="screen shot 2018-11-19 at 12 30 27" src="https://user-images.githubusercontent.com/4599889/48707314-f8981a00-ebf6-11e8-9173-6a7797e26765.png">


---

Component guide for this PR:
https://govuk-publishing-compon-pr-623.herokuapp.com/component-guide/checkboxes/checkbox_items_with_checked_items