### PR TITLE
Use error_message to render multiple field errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix showing multiple error items in a form field (PR #625)
 * Add option to checkboxes to allow preselected items (PR #623)
 
 ## 12.8.0

--- a/app/views/govuk_publishing_components/components/_file_upload.html.erb
+++ b/app/views/govuk_publishing_components/components/_file_upload.html.erb
@@ -44,9 +44,9 @@
       text: error_message
     } %>
   <% elsif error_items %>
-    <%= render "govuk_publishing_components/components/error_summary", {
+    <%= render "govuk_publishing_components/components/error_message", {
       id: error_id,
-      items: error_items
+      text: raw(error_items.map { |item| item[:text] }.join("<br/>"))
     } %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -51,9 +51,9 @@
       text: error_message
     } %>
   <% elsif error_items %>
-    <%= render "govuk_publishing_components/components/error_summary", {
+    <%= render "govuk_publishing_components/components/error_message", {
       id: error_id,
-      items: error_items
+      text: raw(error_items.map { |item| item[:text] }.join("<br/>"))
     } %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -31,9 +31,9 @@
       text: error_message
     } %>
   <% elsif error_items %>
-    <%= render "govuk_publishing_components/components/error_summary", {
+    <%= render "govuk_publishing_components/components/error_message", {
       id: error_id,
-      items: error_items
+      text: raw(error_items.map { |item| item[:text] }.join("<br/>"))
     } %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -47,9 +47,9 @@
       text: error_message
     } %>
   <% elsif error_items %>
-    <%= render "govuk_publishing_components/components/error_summary", {
+    <%= render "govuk_publishing_components/components/error_message", {
       id: error_id,
-      items: error_items
+      text: raw(error_items.map { |item| item[:text] }.join("<br/>"))
     } %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/docs/file_upload.yml
+++ b/app/views/govuk_publishing_components/components/docs/file_upload.yml
@@ -40,6 +40,8 @@ examples:
       error_items:
       - text: Descriptive link to the question with an error 1
         href: '#example-error-1'
+      - text: Descriptive link to the question with an error 2
+        href: '#example-error-2'
   with_file_accept:
     data:
       label:

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -60,6 +60,8 @@ examples:
       error_items:
       - text: Descriptive link to the question with an error 1
         href: '#example-error-1'
+      - text: Descriptive link to the question with an error 2
+        href: '#example-error-2'
   with_value:
     data:
       label:

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -147,6 +147,8 @@ examples:
       error_items:
       - text: Descriptive link to the question with an error 1
         href: '#example-error-1'
+      - text: Descriptive link to the question with an error 2
+        href: '#example-error-2'
       items:
       - value: "government-gateway"
         text: "Use Government Gateway"

--- a/app/views/govuk_publishing_components/components/docs/textarea.yml
+++ b/app/views/govuk_publishing_components/components/docs/textarea.yml
@@ -47,6 +47,8 @@ examples:
       error_items:
       - text: Descriptive link to the question with an error 1
         href: '#example-error-1'
+      - text: Descriptive link to the question with an error 2
+        href: '#example-error-2'
   with_value:
     data:
       label:

--- a/spec/components/file_upload_spec.rb
+++ b/spec/components/file_upload_spec.rb
@@ -107,17 +107,20 @@ describe "File upload", type: :view do
         error_items: [
           {
             text: "Error item 1"
+          },
+          {
+            text: "Error item 2"
           }
         ]
       )
     end
 
     it "renders the error message" do
-      assert_select ".gem-c-error-summary li", text: "Error item 1"
+      assert_select ".govuk-error-message", text: "Error item 1Error item 2"
     end
 
     it "has 'aria-describedby' the error message id" do
-      error_id = css_select(".gem-c-error-summary").attr("id")
+      error_id = css_select(".govuk-error-message").attr("id")
 
       assert_select ".govuk-file-upload[aria-describedby='#{error_id}']"
     end

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -129,17 +129,20 @@ describe "Input", type: :view do
         error_items: [
           {
             text: "Error item 1"
+          },
+          {
+            text: "Error item 2"
           }
         ]
       )
     end
 
     it "renders the error message" do
-      assert_select ".gem-c-error-summary li", text: "Error item 1"
+      assert_select ".govuk-error-message", text: "Error item 1Error item 2"
     end
 
     it "has 'aria-describedby' the error message id" do
-      error_id = css_select(".gem-c-error-summary").attr("id")
+      error_id = css_select(".govuk-error-message").attr("id")
 
       assert_select ".govuk-input[aria-describedby='#{error_id}']"
     end

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -226,6 +226,9 @@ describe "Radio", type: :view do
       error_items: [
         {
           text: "Error item 1"
+        },
+        {
+          text: "Error item 2"
         }
       ],
       items: [
@@ -240,7 +243,7 @@ describe "Radio", type: :view do
       ]
     )
 
-    assert_select ".gem-c-error-summary li", text: "Error item 1"
+    assert_select ".govuk-error-message", text: "Error item 1Error item 2"
   end
 
   it "renders radio-group with welsh translated 'or'" do

--- a/spec/components/textarea_spec.rb
+++ b/spec/components/textarea_spec.rb
@@ -117,17 +117,20 @@ describe "Textarea", type: :view do
         error_items: [
           {
             text: "Error item 1"
+          },
+          {
+            text: "Error item 2"
           }
         ]
       )
     end
 
     it "renders the error message" do
-      assert_select ".gem-c-error-summary li", text: "Error item 1"
+      assert_select ".govuk-error-message", text: "Error item 1Error item 2"
     end
 
     it "has 'aria-describedby' the error message id" do
-      error_id = css_select(".gem-c-error-summary").attr("id")
+      error_id = css_select(".govuk-error-message").attr("id")
 
       assert_select ".govuk-textarea[aria-describedby='#{error_id}']"
     end


### PR DESCRIPTION
Previously we used the error_summary component to render multiple error
items for form fields. Unfortunately this had the udesirable consequence
of showing a big red box around the errors. This changes the approach to
instead concatenate the errors into a single error_message, separated
with "\<br/\>" tags.
