### PR TITLE
Add support for nested check boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased changes
+
+* Add support to checkboxes to allow nested checkboxes and add new checkbox component (PR #626)
+
 ## 12.9.1
 
 * Fix showing multiple error items in a form field (PR #625)

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -1,2 +1,44 @@
 // This component relies on JavaScript from GOV.UK Frontend
 //= require govuk-frontend/components/checkboxes/checkboxes.js
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+ (function (Modules) {
+  'use strict'
+   Modules.Checkboxes = function () {
+    this.start = function (scope) {
+      var _this = this;
+
+      $(scope).find('[data-nested=true] input[type=checkbox]').on('change', function(e) {
+        var checkbox = e.target;
+        var isNested = $(checkbox).closest('.govuk-checkboxes--nested');
+        var hasNested = $('.govuk-checkboxes--nested[data-parent=' + checkbox.id + ']');
+
+        if (hasNested.length) {
+          _this.toggleNestedCheckboxes(hasNested, checkbox);
+        } else if (isNested.length) {
+          _this.toggleParentCheckbox(isNested, checkbox);
+        }
+      });
+    };
+
+    this.toggleNestedCheckboxes = function(scope, checkbox) {
+      if (checkbox.checked) {
+        scope.find('input[type=checkbox]').prop("checked", true);
+      } else {
+        scope.find('input[type=checkbox]').prop("checked", false);
+      }
+    };
+
+    this.toggleParentCheckbox = function(scope, checkbox) {
+      var siblings = $(checkbox).parent('.govuk-checkboxes__item').siblings();
+      var parent_id = scope.data('parent');
+
+      if (checkbox.checked && siblings.length == siblings.find(':checked').length) {
+        $('#' + parent_id).prop("checked", true);
+      } else {
+        $('#' + parent_id).prop("checked", false);
+      }
+    };
+  }
+})(window.GOVUK.Modules);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkbox.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkbox.scss
@@ -1,0 +1,2 @@
+@import "helpers/govuk-frontend-settings";
+@import "govuk-frontend/components/checkboxes/checkboxes";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
@@ -1,2 +1,13 @@
 @import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/checkboxes/checkboxes";
+
+.govuk-checkboxes--nested {
+  margin-left: (govuk-spacing(3) + 3px);
+  padding-left: govuk-spacing(4);
+  box-sizing: border-box;
+  border-left-style: solid;
+  border-left-width: 4px;
+  border-color: govuk-colour('grey-2');
+  padding: govuk-spacing(2) govuk-spacing(4);
+  margin-bottom: govuk-spacing(3);
+}

--- a/app/views/govuk_publishing_components/components/_checkbox.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkbox.html.erb
@@ -1,0 +1,22 @@
+<%
+  id ||= "checkbox-#{SecureRandom.hex(4)}"
+  index ||= rand(1..100)
+%>
+
+<%= tag.div class: "gem-c-checkbox govuk-checkboxes__item" do %>
+  <%= tag.input id: "#{id}-#{index}",
+    name: name,
+    type: "checkbox",
+    value: item[:value],
+    class: "govuk-checkboxes__input",
+    checked: item[:checked].present? ? "checked" : nil,
+    aria: {
+      describedby: item[:hint].present? ? "#{id}-#{index}-item-hint" : nil,
+      controls: item[:conditional].present? ? "#{id}-conditional-#{index}" : nil
+  } do %>
+    <%= tag.label item[:label], class: "govuk-label govuk-checkboxes__label", for: "#{id}-#{index}" %>
+    <% if item[:hint].present? %>
+      <%= tag.span item[:hint], id: "#{id}-#{index}-item-hint", class: "govuk-hint govuk-checkboxes__hint" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_checkbox.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkbox.html.erb
@@ -1,6 +1,7 @@
 <%
   id ||= "checkbox-#{SecureRandom.hex(4)}"
   index ||= rand(1..100)
+  name = item[:name].present? ? item[:name] : name
 %>
 
 <%= tag.div class: "gem-c-checkbox govuk-checkboxes__item" do %>

--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -5,18 +5,22 @@
   css_classes << classes if classes
   error ||= nil
   css_classes << "govuk-form-group--error" if error
+  heading ||= nil
   hint_text ||= "Select all that apply."
   items ||= []
 
   # check if any item is set as being conditional
   has_conditional = items.any? { |item| item.is_a?(Hash) && item[:conditional] }
+  has_nested = items.any? { |item| item.is_a?(Hash) && item[:items] }
 %>
 
-<%= tag.div id: id, class: css_classes do %>
+<%= tag.div id: id, class: css_classes, data: { module: "checkboxes" } do %>
   <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": "#{id}-hint #{"#{id}-error" if error}" do %>
 
-    <%= tag.legend class: "govuk-fieldset__legend govuk-fieldset__legend--xl" do %>
-      <%= tag.h1 heading, class: "govuk-fieldset__heading" %>
+    <% if heading.present? %>
+      <%= tag.legend class: "govuk-fieldset__legend govuk-fieldset__legend--xl" do %>
+        <%= tag.h1 heading, class: "govuk-fieldset__heading" %>
+      <% end %>
     <% end %>
 
     <%= tag.span hint_text, id: "#{id}-hint", class: "govuk-hint" %>
@@ -26,28 +30,31 @@
     <% end %>
 
     <%= tag.div class: "govuk-checkboxes", data: {
-      module: ('checkboxes' if has_conditional)
+      module: ('checkboxes' if has_conditional),
+      nested: ('true' if has_nested),
     } do %>
       <% items.each_with_index do |item, index| %>
-        <%= tag.div class: "govuk-checkboxes__item" do %>
-          <%= tag.input id: "#{id}-#{index}",
-            name: name,
-            type: "checkbox",
-            value: item[:value],
-            class: "govuk-checkboxes__input",
-            checked: item[:checked].present? ? "checked" : nil,
-            aria: {
-              describedby: item[:hint].present? ? "#{id}-#{index}-item-hint" : nil,
-              controls: item[:conditional].present? ? "#{id}-conditional-#{index}" : nil
-            } do %>
-            <%= tag.label item[:label], class: "govuk-label govuk-checkboxes__label", for: "#{id}-#{index}" %>
-            <% if item[:hint].present? %>
-              <%= tag.span item[:hint], id: "#{id}-#{index}-item-hint", class: "govuk-hint govuk-checkboxes__hint" %>
-            <% end %>
-          <% end %>
-        <% end %>
+        <%= render 'govuk_publishing_components/components/checkbox', {
+          id: id,
+          name: name,
+          item: item,
+          index: index,
+        } %>
         <% if item[:conditional] %>
           <%= tag.div item[:conditional], id: "#{id}-conditional-#{index}", class: "govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" %>
+        <% end %>
+
+        <% if item[:items].present? %>
+          <%= tag.div id: "#{id}-nested-#{index}", class: "govuk-checkboxes govuk-checkboxes--nested", data: { parent: "#{id}-#{index}" } do %>
+            <% item[:items].each_with_index do |nested_item, nested_index| %>
+              <%= render 'govuk_publishing_components/components/checkbox', {
+                id: id,
+                name: name,
+                item: nested_item,
+                index: "#{index}-#{nested_index}",
+              } %>
+            <% end %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/checkbox.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkbox.yml
@@ -1,0 +1,39 @@
+name: Checkbox
+description: Let users select one or more options by using the checkboxes component.
+govuk_frontend_components:
+  - checkboxes
+accessibility_criteria: |
+  The component must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - be usable with touch
+  - indicate when they have focus
+  - be recognisable as form textarea elements
+  - have correctly associated labels
+  - inform the user about the character limit
+  - inform the user as the number of left characters changes
+
+  Labels use the [label component](/component-guide/label).
+examples:
+  default:
+    data:
+      name: "favourite_colour_default"
+      item:
+        label: "Red"
+        value: "red_colour"
+  checkbox_with_hint:
+    data:
+      name: "favourite_colour_checkbox_with_hint"
+      item:
+        label: "Red"
+        value: "red_colour"
+        hint: "This is the colour red."
+  checkbox_with_checked:
+    data:
+      name: "favourite_colour_checkbox_with_checked"
+      item:
+        label: "Red"
+        value: "red_colour"
+        checked: true

--- a/app/views/govuk_publishing_components/components/docs/checkbox.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkbox.yml
@@ -1,5 +1,6 @@
 name: Checkbox
-description: Let users select one or more options by using the checkboxes component.
+description: Let users select one or more options by using the checkboxes component. 
+body: This component is used by [Form checkboxes component](/component-guide/checkboxes).
 govuk_frontend_components:
   - checkboxes
 accessibility_criteria: |
@@ -10,10 +11,7 @@ accessibility_criteria: |
   - be usable with a keyboard
   - be usable with touch
   - indicate when they have focus
-  - be recognisable as form textarea elements
   - have correctly associated labels
-  - inform the user about the character limit
-  - inform the user as the number of left characters changes
 
   Labels use the [label component](/component-guide/label).
 examples:

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -1,5 +1,6 @@
 name: Form checkboxes
 description: Let users select one or more options by using the checkboxes component.
+body: This component uses [Checkbox component](/component-guide/checkbox).
 govuk_frontend_components:
   - checkboxes
 accessibility_criteria: |
@@ -10,10 +11,7 @@ accessibility_criteria: |
   - be usable with a keyboard
   - be usable with touch
   - indicate when they have focus
-  - be recognisable as form textarea elements
   - have correctly associated labels
-  - inform the user about the character limit
-  - inform the user as the number of left characters changes
 
   Labels use the [label component](/component-guide/label).
 examples:

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -1,5 +1,5 @@
 name: Form checkboxes
-description: Help users enter text when there is a limit on the number of characters they can type
+description: Let users select one or more options by using the checkboxes component.
 govuk_frontend_components:
   - checkboxes
 accessibility_criteria: |
@@ -91,5 +91,26 @@ examples:
           checked: true
         - label: "Irish"
           value: "irish"
+        - label: "Other"
+          value: "other"
+  checkbox_items_with_checked_items:
+    data:
+      name: "favourite_colour"
+      heading: "What is your favourite colour?"
+      items:
+        - label: "Red"
+          value: "red"
+          items:
+            - label: "Light Red"
+              value: "light_red"
+            - label: "Dark Red"
+              value: "dark_red"
+        - label: "Blue"
+          value: "blue"
+          items:
+            - label: "Light blue"
+              value: "light_blue"
+            - label: "Dark blue"
+              value: "dark_blue"
         - label: "Other"
           value: "other"

--- a/spec/components/checkbox_spec.rb
+++ b/spec/components/checkbox_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe "Checkbox", type: :view do
+  def component_name
+    "checkbox"
+  end
+
+  it "renders checkbox" do
+    render_component(
+      id: "favourite_colour_default",
+      name: "favourite_colour_default",
+      index: 1,
+      item: {
+        label: "Red",
+        value: "red_colour"
+      }
+    )
+    assert_select ".govuk-checkboxes__item"
+    assert_select "label[for='favourite_colour_default-1']", text: "Red"
+    assert_select "input[name='favourite_colour_default']", value: "red_colour"
+  end
+
+  it "renders checkbox with custom hint text" do
+    render_component(
+      id: "favourite_colour_checkbox_with_hint",
+      name: "favourite_colour_checkbox_with_hint",
+      index: 2,
+      item: {
+        label: "Red",
+        value: "red_colour",
+        hint: "This is the colour red."
+      }
+    )
+    assert_select ".govuk-checkboxes__item"
+    assert_select(".govuk-hint.govuk-checkboxes__hint", text: "This is the colour red.")
+  end
+
+  it "renders preselected checkbox" do
+    render_component(
+      id: "favourite_colour_checkbox_with_checked",
+      name: "favourite_colour_checkbox_with_checked",
+      index: 3,
+      item: {
+        label: "Red",
+        value: "red_colour",
+        checked: true
+      }
+    )
+    assert_select ".govuk-checkboxes__item"
+    assert_select "input[checked]", value: "red_colour"
+  end
+end

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -104,4 +104,27 @@ describe "Checkboxes", type: :view do
     assert_select ".govuk-checkboxes"
     assert_select ".govuk-checkboxes__input[checked]", value: "british"
   end
+
+  it "renders checkboxes with nested items" do
+    render_component(
+      id: "favourite_colour_nested",
+      name: "favourite_colour_nested",
+      heading: "What is your favourite colour?",
+      items: [
+        {
+          label: "Red",
+          value: "red",
+          items: [
+            { label: "Light Red", value: "light_red" },
+            { label: "Dark Red", value: "dark_red" }
+          ]
+        },
+        { label: "Blue", value: "blue" },
+        { label: "Other", value: "other" }
+      ]
+    )
+    assert_select ".govuk-checkboxes"
+    assert_select ".govuk-checkboxes.govuk-checkboxes--nested"
+    assert_select ".govuk-checkboxes.govuk-checkboxes--nested input[value=light_red]"
+  end
 end

--- a/spec/javascripts/components/checkboxes-spec.js
+++ b/spec/javascripts/components/checkboxes-spec.js
@@ -1,0 +1,69 @@
+function loadCheckboxesComponent () {
+    var checkboxes = new GOVUK.Modules.Checkboxes();
+    checkboxes.start($('.gem-c-checkboxes'));
+}
+
+var FIXTURE = `
+<div id="checkboxes-1ac8e5cf" class="gem-c-checkboxes govuk-form-group " data-module="checkboxes">
+   <fieldset class="govuk-fieldset" aria-describedby="checkboxes-1ac8e5cf-hint ">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+         <h1 class="govuk-fieldset__heading">What is your favourite colour?</h1>
+      </legend>
+      <span id="checkboxes-1ac8e5cf-hint" class="govuk-hint">Select all that apply.</span>
+      <div class="govuk-checkboxes" data-nested="true">
+         <div class="gem-c-checkbox govuk-checkboxes__item">
+            <input id="checkboxes-1ac8e5cf-0" name="favourite_colour" type="checkbox" value="red" class="govuk-checkboxes__input">
+            <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-0">Red</label>
+         </div>
+         <div id="checkboxes-1ac8e5cf-nested-0" class="govuk-checkboxes govuk-checkboxes--nested" data-parent="checkboxes-1ac8e5cf-0">
+            <div class="gem-c-checkbox govuk-checkboxes__item">
+               <input id="checkboxes-1ac8e5cf-0-0" name="favourite_colour" type="checkbox" value="light_red" class="govuk-checkboxes__input">
+               <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-0-0">Light Red</label>
+            </div>
+            <div class="gem-c-checkbox govuk-checkboxes__item">
+               <input id="checkboxes-1ac8e5cf-0-1" name="favourite_colour" type="checkbox" value="dark_red" class="govuk-checkboxes__input">
+               <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-0-1">Dark Red</label>
+            </div>
+         </div>
+         <div class="gem-c-checkbox govuk-checkboxes__item">
+            <input id="checkboxes-1ac8e5cf-1" name="favourite_colour" type="checkbox" value="blue" class="govuk-checkboxes__input">
+            <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-1">Blue</label>
+         </div>
+         <div id="checkboxes-1ac8e5cf-nested-1" class="govuk-checkboxes govuk-checkboxes--nested" data-parent="checkboxes-1ac8e5cf-1">
+            <div class="gem-c-checkbox govuk-checkboxes__item">
+               <input id="checkboxes-1ac8e5cf-1-0" name="favourite_colour" type="checkbox" value="light_blue" class="govuk-checkboxes__input">
+               <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-1-0">Light blue</label>
+            </div>
+            <div class="gem-c-checkbox govuk-checkboxes__item">
+               <input id="checkboxes-1ac8e5cf-1-1" name="favourite_colour" type="checkbox" value="dark_blue" class="govuk-checkboxes__input">
+               <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-1-1">Dark blue</label>
+            </div>
+         </div>
+         <div class="gem-c-checkbox govuk-checkboxes__item">
+            <input id="checkboxes-1ac8e5cf-2" name="favourite_colour" type="checkbox" value="other" class="govuk-checkboxes__input">
+            <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-2">Other</label>
+         </div>
+      </div>
+   </fieldset>
+</div>
+`;
+
+describe("selecting a parent checkbox", function () {
+  beforeEach(function() {
+    setFixtures(FIXTURE);
+    loadCheckboxesComponent();
+  });
+
+  it('checks all child when a parent is selected', function () { });
+  it('unchecks all child when a parent is deselected', function () { });
+});
+
+describe("selecting a child checkbox", function () {
+  beforeEach(function() {
+    setFixtures(FIXTURE);
+    loadCheckboxesComponent();
+  });
+
+  it('checks parent when all children are selected', function () { });
+  it('unchecks parent when one or more children are deselected', function () { });
+});

--- a/spec/javascripts/components/checkboxes-spec.js
+++ b/spec/javascripts/components/checkboxes-spec.js
@@ -54,8 +54,12 @@ describe("selecting a parent checkbox", function () {
     loadCheckboxesComponent();
   });
 
-  it('checks all child when a parent is selected', function () { });
-  it('unchecks all child when a parent is deselected', function () { });
+  it('checks all child when a parent is selected', function () {
+     // TODO - NEEDS TO BE WRITTEN
+   });
+  it('unchecks all child when a parent is deselected', function () {
+     // TODO - NEEDS TO BE WRITTEN
+   });
 });
 
 describe("selecting a child checkbox", function () {
@@ -64,6 +68,10 @@ describe("selecting a child checkbox", function () {
     loadCheckboxesComponent();
   });
 
-  it('checks parent when all children are selected', function () { });
-  it('unchecks parent when one or more children are deselected', function () { });
+  it('checks parent when all children are selected', function () {
+    // TODO - NEEDS TO BE WRITTEN
+  });
+  it('unchecks parent when one or more children are deselected', function () {
+    // TODO - NEEDS TO BE WRITTEN
+  });
 });


### PR DESCRIPTION
# Changes
- Adds functionality to allow nested checkboxes
- Separates out checkboxes into their own component.

Component guide for this PR:
https://govuk-publishing-compon-pr-626.herokuapp.com/component-guide/checkbox
https://govuk-publishing-compon-pr-626.herokuapp.com/component-guide/checkboxes