### PR TITLE
Update back link and panel components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@
 
 ## Unreleased
 
-- Add a readonly option to input component
-- Copy to clipboard is readonly and selects input on click
-- Copy to clipboard supports data attributes for the button element
+* Add a readonly option to input component
+* Copy to clipboard is readonly and selects input on click
+* Copy to clipboard supports data attributes for the button element
+* Update back link component to allow injection of custom text (PR #628)
+* Update panel component to only render div if description is provided (PR #628)
 
 ## 12.11.0
 

--- a/app/views/govuk_publishing_components/components/_back_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_back_link.html.erb
@@ -1,4 +1,7 @@
-<%= link_to t('components.back_link.back'),
+<%
+  text ||= t('components.back_link.back')
+%>
+<%= link_to text,
   href,
   class: %w(
     gem-c-back-link

--- a/app/views/govuk_publishing_components/components/_panel.html.erb
+++ b/app/views/govuk_publishing_components/components/_panel.html.erb
@@ -5,9 +5,9 @@
   <h2 class="govuk-panel__title">
     <%= title %>
   </h2>
-  <div class="govuk-panel__body">
-    <% if description %>
-      <%= description %>
-    <% end %>
-  </div>
+  <% if description %>
+    <div class="govuk-panel__body">
+      <%= description %> 
+    </div>
+  <% end %>
 </div>

--- a/app/views/govuk_publishing_components/components/docs/back_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/back_link.yml
@@ -10,3 +10,7 @@ examples:
   default:
     data:
       href: '#'
+  custom_text:
+    data:
+      text: 'Back to document list'
+      href: '#'

--- a/app/views/govuk_publishing_components/components/docs/panel.yml
+++ b/app/views/govuk_publishing_components/components/docs/panel.yml
@@ -11,3 +11,6 @@ examples:
       description: |
         Your reference number<br>
         <strong>HDJ2123F</strong>
+  no_description:
+    data:
+      title: Content has been published


### PR DESCRIPTION
We need to display custom text on the back link component and this
changes that to allow text to be injected.
The panel component should not render a div for the description if there
isn't one, this fixes that.

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-628.herokuapp.com/component-guide/
