### PR TITLE
Make h1 in legend optional

### DIFF
--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -8,6 +8,7 @@
   heading ||= nil
   hint_text ||= "Select all that apply."
   items ||= []
+  is_page_heading ||= false
 
   # check if any item is set as being conditional
   has_conditional = items.any? { |item| item.is_a?(Hash) && item[:conditional] }
@@ -18,8 +19,12 @@
   <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": "#{id}-hint #{"#{id}-error" if error}" do %>
 
     <% if heading.present? %>
-      <%= tag.legend class: "govuk-fieldset__legend govuk-fieldset__legend--xl" do %>
-        <%= tag.h1 heading, class: "govuk-fieldset__heading" %>
+      <% if is_page_heading %>
+        <%= tag.legend class: "govuk-fieldset__legend govuk-fieldset__legend--xl gem-c-title gem-c-title--margin-bottom-5" do %>
+          <%= tag.h1 heading, class: "gem-c-title__text" %>
+        <% end %>
+      <% else %>
+        <%= tag.legend heading, class: "govuk-fieldset__legend govuk-fieldset__legend--m" %>
       <% end %>
     <% end %>
 

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -26,6 +26,18 @@ examples:
           value: "green"
         - label: "Blue"
           value: "blue"
+  with_legend_as_page_heading:
+    data:
+      name: "favourite_colour"
+      heading: "What is your favourite colour?"
+      is_page_heading: true
+      items:
+        - label: "Red"
+          value: "red"
+        - label: "Green"
+          value: "green"
+        - label: "Blue"
+          value: "blue"
   custom_hint_text:
     data:
       name: "favourite_skittle"

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -20,6 +20,23 @@ describe "Checkboxes", type: :view do
     assert_select "label[for='favourite-colour-0']", text: "Red"
     assert_select "label[for='favourite-colour-1']", text: "Green"
     assert_select "label[for='favourite-colour-2']", text: "Blue"
+    assert_select "legend", text: "What is your favourite colour?"
+    assert_select "legend h1", false
+  end
+
+  it "renders checkboxes with the legend as the page heading" do
+    render_component(
+      name: "favourite-skittle",
+      heading: "What is your favourite skittle?",
+      is_page_heading: true,
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+        { label: "Blue", value: "blue" }
+      ]
+    )
+    assert_select ".govuk-checkboxes"
+    assert_select "legend h1", "What is your favourite skittle?"
   end
 
   it "renders checkboxes with custom hint text" do


### PR DESCRIPTION
The legend in the checkboxes' fieldset should contain plaintext unless specified, to match the pattern in the GOV.UK Design System:

<img width="995" alt="new_default_legend_example" src="https://user-images.githubusercontent.com/87140/48788328-83097800-ece2-11e8-8682-3ebfb24c9d03.png">

<img width="988" alt="legend_as_page_heading_example" src="https://user-images.githubusercontent.com/87140/48788337-8ac91c80-ece2-11e8-9dc9-61e05a58b65e.png">

---

Component guide for this PR:
https://govuk-publishing-compon-pr-630.herokuapp.com/component-guide/
