### PR TITLE
bump version to 12.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased changes
+## 12.12.1
 
 * Corrects name for checkboxes documentation (PR #638)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (12.12.0)
+    govuk_publishing_components (12.12.1)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '12.12.0'.freeze
+  VERSION = '12.12.1'.freeze
 end


### PR DESCRIPTION
* Corrects name for checkboxes documentation (PR #638)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-639.herokuapp.com/component-guide/
