### PR TITLE
Bump version to 12.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 12.13.0
 
 * Add heading options to radio component (PR #635)
-* Add tests for checkbox JS
+* Add tests for checkbox JS (PR# 636)
 
 ## 12.12.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (12.12.1)
+    govuk_publishing_components (12.13.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '12.12.1'.freeze
+  VERSION = '12.13.0'.freeze
 end


### PR DESCRIPTION
Brings in the following changes:

- https://github.com/alphagov/govuk_publishing_components/pull/635
- https://github.com/alphagov/govuk_publishing_components/pull/636

---

Component guide for this PR:
https://govuk-publishing-compon-pr-637.herokuapp.com/component-guide/
