### PR TITLE
Update components for finders

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/checkbox.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkbox.js
@@ -1,0 +1,17 @@
+window.GOVUK = window.GOVUK || {};
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  'use strict';
+
+   Modules.Checkbox = function () {
+    this.start = function ($element) {
+      var controls = $element.attr('data-aria-controls');
+
+      if (controls) {
+        $element.find('.govuk-checkboxes__input').attr('aria-controls', controls);
+      }
+    };
+
+  };
+})(window.GOVUK.Modules);

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -18,6 +18,7 @@
 @import "components/breadcrumbs";
 @import "components/button";
 @import "components/character-count";
+@import "components/checkbox";
 @import "components/checkboxes";
 @import "components/contents-list";
 @import "components/copy-to-clipboard";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkbox.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkbox.scss
@@ -1,3 +1,6 @@
+@import "helpers/govuk-frontend-settings";
+@import "govuk-frontend/components/checkboxes/checkboxes";
+
 .gem-c-checkbox.gem-c-checkbox--margin-bottom:last-child,
 .gem-c-checkbox.gem-c-checkbox--margin-bottom:last-of-type {
   margin-bottom: $gutter-two-thirds;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkbox.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkbox.scss
@@ -1,2 +1,8 @@
-@import "helpers/govuk-frontend-settings";
-@import "govuk-frontend/components/checkboxes/checkboxes";
+.gem-c-checkbox.gem-c-checkbox--margin-bottom:last-child,
+.gem-c-checkbox.gem-c-checkbox--margin-bottom:last-of-type {
+  margin-bottom: $gutter-two-thirds;
+
+  @include media(tablet) {
+    margin-bottom: $gutter;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
@@ -1,6 +1,3 @@
-@import "helpers/govuk-frontend-settings";
-@import "govuk-frontend/components/checkboxes/checkboxes";
-
 .govuk-checkboxes--nested {
   margin-left: (govuk-spacing(3) + 3px);
   padding-left: govuk-spacing(4);

--- a/app/views/govuk_publishing_components/components/_checkbox.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkbox.html.erb
@@ -6,7 +6,7 @@
   name = item[:name].present? ? item[:name] : name
 %>
 
-<%= tag.div class: "gem-c-checkbox govuk-checkboxes__item" do %>
+<%= tag.div class: "gem-c-checkbox govuk-checkboxes__item", data: { module: "checkbox", 'aria-controls': controls }  do %>
   <%= tag.input id: id,
     name: name,
     type: "checkbox",
@@ -15,8 +15,7 @@
     checked: item[:checked].present? ? "checked" : nil,
     data: item[:data_attributes],
     aria: {
-      describedby: item[:hint].present? ? "#{id}-item-hint" : nil,
-      controls: controls
+      describedby: item[:hint].present? ? "#{id}-item-hint" : nil
     }
   %>
   <%= tag.label item[:label], class: "govuk-label govuk-checkboxes__label", for: id %>

--- a/app/views/govuk_publishing_components/components/_checkbox.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkbox.html.erb
@@ -1,22 +1,27 @@
 <%
+  index ||= false
   id ||= "checkbox-#{SecureRandom.hex(4)}"
-  index ||= rand(1..100)
+  id = "#{id}-#{index}" if index
   name = item[:name].present? ? item[:name] : name
 %>
 
 <%= tag.div class: "gem-c-checkbox govuk-checkboxes__item" do %>
-  <%= tag.input id: "#{id}-#{index}",
+  <%= tag.input id: id,
     name: name,
     type: "checkbox",
     value: item[:value],
     class: "govuk-checkboxes__input",
     checked: item[:checked].present? ? "checked" : nil,
+    data: item[:data_attributes],
     aria: {
-      describedby: item[:hint].present? ? "#{id}-#{index}-item-hint" : nil,
+      describedby: item[:hint].present? ? "#{id}-item-hint" : nil,
       controls: item[:conditional].present? ? "#{id}-conditional-#{index}" : nil
-  } %>
-  <%= tag.label item[:label], class: "govuk-label govuk-checkboxes__label", for: "#{id}-#{index}" %>
+    }
+  %>
+  <%= tag.label item[:label], class: "govuk-label govuk-checkboxes__label", for: id %>
   <% if item[:hint].present? %>
-    <%= tag.span item[:hint], id: "#{id}-#{index}-item-hint", class: "govuk-hint govuk-checkboxes__hint" %>
+    <%= tag.span item[:hint], id: "#{id}-item-hint", class: "govuk-hint govuk-checkboxes__hint" %>
   <% end %>
 <% end %>
+
+

--- a/app/views/govuk_publishing_components/components/_checkbox.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkbox.html.erb
@@ -2,6 +2,7 @@
   index ||= false
   id ||= "checkbox-#{SecureRandom.hex(4)}"
   id = "#{id}-#{index}" if index
+  controls ||= item[:conditional].present? ? "#{id}-conditional-#{index || rand(1..100)}" : nil
   name = item[:name].present? ? item[:name] : name
 %>
 
@@ -15,7 +16,7 @@
     data: item[:data_attributes],
     aria: {
       describedby: item[:hint].present? ? "#{id}-item-hint" : nil,
-      controls: item[:conditional].present? ? "#{id}-conditional-#{index}" : nil
+      controls: controls
     }
   %>
   <%= tag.label item[:label], class: "govuk-label govuk-checkboxes__label", for: id %>

--- a/app/views/govuk_publishing_components/components/_checkbox.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkbox.html.erb
@@ -4,9 +4,11 @@
   id = "#{id}-#{index}" if index
   controls ||= item[:conditional].present? ? "#{id}-conditional-#{index || rand(1..100)}" : nil
   name = item[:name].present? ? item[:name] : name
+  margin_bottom ||= false
+  margin_bottom_class = "gem-c-checkbox--margin-bottom" if margin_bottom
 %>
 
-<%= tag.div class: "gem-c-checkbox govuk-checkboxes__item", data: { module: "checkbox", 'aria-controls': controls }  do %>
+<%= tag.div class: "gem-c-checkbox govuk-checkboxes__item #{margin_bottom_class}", data: { module: "checkbox", 'aria-controls': controls }  do %>
   <%= tag.input id: id,
     name: name,
     type: "checkbox",
@@ -23,5 +25,3 @@
     <%= tag.span item[:hint], id: "#{id}-item-hint", class: "govuk-hint govuk-checkboxes__hint" %>
   <% end %>
 <% end %>
-
-

--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -46,7 +46,7 @@
           index: index,
         } %>
         <% if item[:conditional] %>
-          <%= tag.div item[:conditional], id: "#{id}-conditional-#{index}", class: "govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" %>
+          <%= tag.div item[:conditional], id: "#{id}-#{index}-conditional-#{index}", class: "govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" %>
         <% end %>
 
         <% if item[:items].present? %>

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -2,7 +2,8 @@
   id ||= "input-#{SecureRandom.hex(4)}"
   value ||= nil
   type ||= "text"
-  describedby ||= false
+  describedby ||= nil
+  controls ||= nil
   data ||= nil
 
   label ||= nil
@@ -29,7 +30,6 @@
     aria_described_by << describedby if describedby
     aria_described_by = aria_described_by.join(" ")
   end
-
 %>
 
 <%= content_tag :div, class: form_group_css_classes do %>
@@ -68,7 +68,8 @@
       autofocus: autofocus,
       readonly: readonly,
       aria: {
-        describedby: aria_described_by
+        describedby: aria_described_by,
+        controls: controls
       }
   %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/checkbox.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkbox.yml
@@ -63,3 +63,15 @@ examples:
             dimension29: "Tracked"
           }
         }
+  checkbox_with_aria_controls:
+    description: |
+      A value for aria-controls can be passed to the checkbox.
+
+      If a value is not passed, and a value for conditional has been passed, a value is generated based on the id of the checkbox and the passed index. This is used in the [form checkboxes component](/component-guide/checkboxes/checkbox_items_with_conditional_reveal).
+    data:
+      name: "happy"
+      controls: "wrapper"
+      item:
+        label: "Are you happy?"
+        value: "happy"
+

--- a/app/views/govuk_publishing_components/components/docs/checkbox.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkbox.yml
@@ -65,7 +65,7 @@ examples:
         }
   checkbox_with_aria_controls:
     description: |
-      A value for aria-controls can be passed to the checkbox.
+      A value for aria-controls can be passed to the checkbox. This is applied using Javascript.
 
       If a value is not passed, and a value for conditional has been passed, a value is generated based on the id of the checkbox and the passed index. This is used in the [form checkboxes component](/component-guide/checkboxes/checkbox_items_with_conditional_reveal).
     data:

--- a/app/views/govuk_publishing_components/components/docs/checkbox.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkbox.yml
@@ -1,5 +1,5 @@
 name: Checkbox
-description: Let users select one or more options by using the checkboxes component. 
+description: Let users select one or more options by using the checkboxes component.
 body: This component is used by [Form checkboxes component](/component-guide/checkboxes).
 govuk_frontend_components:
   - checkboxes
@@ -35,3 +35,31 @@ examples:
         label: "Red"
         value: "red_colour"
         checked: true
+  checkbox_with_identifier:
+    description: |
+      If no ID is given, a unique ID is generated for the checkbox automatically.
+
+      If an index is given, this is appended onto the end of the ID (given or generated). This is used in the checkboxes component where multiple checkboxes are output.
+    data:
+      name: "with_id"
+      id: "moose"
+      index: 10
+      item:
+        label: "With an id of 'moose-10'"
+        value: "with_id"
+  checkbox_with_data_attributes:
+    description: Data attributes such as tracking can be applied if required. Note that for a checkbox this will not fire tracking events automatically, so if you want your tracking to work you'll need to write some tracking Javascript in the app around the component to detect it.
+    data:
+      name: "With tracking"
+      item:
+        label: "Tracked"
+        value: "tracked"
+        data_attributes: {
+          track_category: "checkboxClicked",
+          track_label: "/news-and-communications",
+          track_action: "news",
+          track_options: {
+            dimension28: 2,
+            dimension29: "Tracked"
+          }
+        }

--- a/app/views/govuk_publishing_components/components/docs/checkbox.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkbox.yml
@@ -74,4 +74,13 @@ examples:
       item:
         label: "Are you happy?"
         value: "happy"
+  checkbox_with_bottom_margin:
+    description: By default the component has no bottom margin, this option adds it.
+    data:
+      name: "behold_my_bottom_margin"
+      margin_bottom: true
+      item:
+        label: "Do you like my bottom margin?"
+        value: "bottom_margin"
+
 

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -90,6 +90,7 @@ examples:
           value: "irish"
         - label: "Other"
           value: "other"
+          conditional: "Sorry this isn't more specific"
   checkbox_items_with_checked_items:
     data:
       name: "nationality"

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -44,9 +44,16 @@ examples:
       The example below uses the ID of the main container for demonstration purposes as there aren't any useful elements with IDs in the component guide. In real use this would be passed the ID of an element that correctly described the input.
     data:
       label:
-        text: "This might not work"
+        text: "This is an example only and may not work with a screen reader"
       name: "labelledby"
       describedby: "wrapper"
+  aria_controls:
+    description: Allows the addition of an aria-controls attribute, for use in places like the finders where the page is updated dynamically after value changes to the input.
+    data:
+      label:
+        text: "This is an example only and will not work with a screen reader as intended"
+      name: "controls"
+      controls: "wrapper"
   with_hint:
     data:
       label:

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -30,6 +30,13 @@ examples:
         text: "What is your email address?"
       name: "address"
       type: "email"
+  with_an_identifier:
+    description: Give the input a specific ID.
+    data:
+      label:
+        text: "Has an id"
+      name: "hasid"
+      id: "hasid"
   aria_described_by:
     description: |
       Allows the addition of an aria-describedby attribute. Note that this will be overridden in the event of an error, where the error will be used for the describedby attribute value.

--- a/spec/components/checkbox_spec.rb
+++ b/spec/components/checkbox_spec.rb
@@ -89,4 +89,14 @@ describe "Checkbox", type: :view do
     render_component(item: item, id: "myid", index: 10)
     assert_select ".govuk-checkboxes__input#myid-10"
   end
+
+  it "renders a checkbox with bottom margin" do
+    item = {
+      label: "With id",
+      value: "id",
+    }
+
+    render_component(item: item, margin_bottom: true)
+    assert_select ".gem-c-checkbox.gem-c-checkbox--margin-bottom"
+  end
 end

--- a/spec/components/checkbox_spec.rb
+++ b/spec/components/checkbox_spec.rb
@@ -16,6 +16,7 @@ describe "Checkbox", type: :view do
       }
     )
     assert_select ".govuk-checkboxes__item"
+    assert_select ".govuk-checkboxes__input[aria-controls]", false
     assert_select "label[for='favourite_colour_default-1']", text: "Red"
     assert_select "input[name='favourite_colour_default']", value: "red_colour"
   end
@@ -87,36 +88,5 @@ describe "Checkbox", type: :view do
 
     render_component(item: item, id: "myid", index: 10)
     assert_select ".govuk-checkboxes__input#myid-10"
-  end
-
-  it "renders a checkbox without aria-controls" do
-    item = {
-      label: "Without controls",
-      value: "controls"
-    }
-
-    render_component(item: item)
-    assert_select ".govuk-checkboxes__input[aria-controls]", false
-  end
-
-  it "renders a checkbox with aria-controls" do
-    item = {
-      label: "With controls",
-      value: "controls"
-    }
-
-    render_component(item: item, controls: "nothing")
-    assert_select ".govuk-checkboxes__input[aria-controls='nothing']"
-  end
-
-  it "renders a checkbox with a generated aria-controls" do
-    item = {
-      label: "With generated controls",
-      value: "controls",
-      conditional: "This is a thing"
-    }
-
-    render_component(item: item, id: "id", index: 2)
-    assert_select ".govuk-checkboxes__input[aria-controls='id-2-conditional-2']"
   end
 end

--- a/spec/components/checkbox_spec.rb
+++ b/spec/components/checkbox_spec.rb
@@ -49,4 +49,43 @@ describe "Checkbox", type: :view do
     assert_select ".govuk-checkboxes__item"
     assert_select "input[checked]", value: "red_colour"
   end
+
+  it "renders a checkbox with data attributes" do
+    render_component(
+      id: "with_tracking",
+      name: "with_tracking",
+      index: 4,
+      item: {
+        label: "Tracked",
+        value: "tracked",
+        data_attributes: {
+          track_category: "checkboxClicked",
+          track_label: "/news-and-communications",
+          track_options: {
+            dimension28: 2,
+            dimension29: "Tracked"
+          }
+        }
+      }
+    )
+    assert_select ".govuk-checkboxes__input[data-track-category='checkboxClicked']"
+    assert_select ".govuk-checkboxes__input[data-track-label='/news-and-communications']"
+    assert_select ".govuk-checkboxes__input[data-track-options='{\"dimension28\":2,\"dimension29\":\"Tracked\"}']"
+  end
+
+  it "renders a checkbox with an id" do
+    item = {
+      label: "With id",
+      value: "id",
+    }
+
+    render_component(item: item)
+    assert_select ".govuk-checkboxes__input"
+
+    render_component(item: item, id: "myid")
+    assert_select ".govuk-checkboxes__input#myid"
+
+    render_component(item: item, id: "myid", index: 10)
+    assert_select ".govuk-checkboxes__input#myid-10"
+  end
 end

--- a/spec/components/checkbox_spec.rb
+++ b/spec/components/checkbox_spec.rb
@@ -88,4 +88,35 @@ describe "Checkbox", type: :view do
     render_component(item: item, id: "myid", index: 10)
     assert_select ".govuk-checkboxes__input#myid-10"
   end
+
+  it "renders a checkbox without aria-controls" do
+    item = {
+      label: "Without controls",
+      value: "controls"
+    }
+
+    render_component(item: item)
+    assert_select ".govuk-checkboxes__input[aria-controls]", false
+  end
+
+  it "renders a checkbox with aria-controls" do
+    item = {
+      label: "With controls",
+      value: "controls"
+    }
+
+    render_component(item: item, controls: "nothing")
+    assert_select ".govuk-checkboxes__input[aria-controls='nothing']"
+  end
+
+  it "renders a checkbox with a generated aria-controls" do
+    item = {
+      label: "With generated controls",
+      value: "controls",
+      conditional: "This is a thing"
+    }
+
+    render_component(item: item, id: "id", index: 2)
+    assert_select ".govuk-checkboxes__input[aria-controls='id-2-conditional-2']"
+  end
 end

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -99,11 +99,12 @@ describe "Checkboxes", type: :view do
       items: [
         { label: "British", value: "british", conditional: "including English, Scottish, Welsh and Northern Irish" },
         { label: "Irish", value: "irish" },
-        { label: "Other", value: "other" }
+        { label: "Other", value: "other", conditional: "Sorry this is so vague" }
       ]
     )
     assert_select ".govuk-checkboxes"
-    assert_select("#nationality-conditional-0", text: "including English, Scottish, Welsh and Northern Irish")
+    assert_select("#nationality-0-conditional-0", text: "including English, Scottish, Welsh and Northern Irish")
+    assert_select("#nationality-2-conditional-2", text: "Sorry this is so vague")
   end
 
   it "renders checkboxes with preselected items" do

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -74,6 +74,16 @@ describe "Input", type: :view do
     assert_select ".govuk-input[aria-describedby='some-other-element']"
   end
 
+  it "renders inputs with an aria-controls if provided" do
+    render_component(
+      label: { text: "What is your postcode?" },
+      name: "postcode",
+      controls: "another-element"
+    )
+
+    assert_select ".govuk-input[aria-controls='another-element']"
+  end
+
   it "renders input with a data attributes" do
     render_component(
       data: { module: "contextual-guidance" },

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -33,6 +33,16 @@ describe "Input", type: :view do
     assert_select ".govuk-input[name='email-address']"
   end
 
+  it "renders an input with a given id" do
+    render_component(
+      label: { text: "What is your email address?" },
+      name: "email-address",
+      id: "test"
+    )
+
+    assert_select ".govuk-input#test"
+  end
+
   it "sets the 'for' on the label to the input id" do
     render_component(
       label: { text: "What is your email address?" },

--- a/spec/javascripts/components/checkbox-spec.js
+++ b/spec/javascripts/components/checkbox-spec.js
@@ -1,0 +1,20 @@
+describe("Checkbox component", function () {
+  var FIXTURE = '<div class="gem-c-checkbox govuk-checkboxes__item" data-aria-controls="wrapper" data-module="checkbox">' +
+    '<input id="checkbox-ba4e102e" name="happy" type="checkbox" value="happy" class="govuk-checkboxes__input">' +
+    '<label class="govuk-label govuk-checkboxes__label" for="checkbox-ba4e102e">Are you happy?</label>' +
+  '</div>';
+
+  beforeEach(function () {
+    setFixtures(FIXTURE);
+    loadCheckbox();
+  });
+
+  it("adds aria controls if the data-aria-controls attribute is set", function () {
+    expect($('.gem-c-checkbox .govuk-checkboxes__input').attr('aria-controls')).toBe('wrapper');
+  });
+
+  function loadCheckbox () {
+    var checkbox = new GOVUK.Modules.Checkbox();
+    checkbox.start($('.gem-c-checkbox'));
+  }
+});

--- a/spec/javascripts/components/checkboxes-spec.js
+++ b/spec/javascripts/components/checkboxes-spec.js
@@ -1,7 +1,7 @@
 describe("Checkboxes component", function () {
   function loadCheckboxesComponent () {
-      var checkboxes = new GOVUK.Modules.Checkboxes();
-      checkboxes.start($('.gem-c-checkboxes'));
+    var checkboxes = new GOVUK.Modules.Checkboxes();
+    checkboxes.start($('.gem-c-checkboxes'));
   }
 
   var FIXTURE = '\


### PR DESCRIPTION
We want to use components for form fields in finders, which requires some changes to components to support this. Specifically:

- input component needs `aria-controls` attribute option
- input component needs `id` option (turns out this was already present, but not documented)
- change how `id` option works in checkbox
- add `data-attributes` option to checkbox
- add `aria-controls` option to checkbox using Javascript to apply
- add `margin-bottom` option to checkbox

---

Trello card: https://trello.com/c/fhhTwfLo/178-use-form-element-components-in-finders
Component guide for this PR:
https://govuk-publishing-compon-pr-643.herokuapp.com/component-guide/
