### PR TITLE
Bump to version 12.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 12.14.0
 
 * Add accessible autocomplete component. (PR #621)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (12.13.0)
+    govuk_publishing_components (12.14.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '12.13.0'.freeze
+  VERSION = '12.14.0'.freeze
 end


### PR DESCRIPTION
Update changelog to reflect release of new autocomplete component.

Version number is updated from `12.13.0` to `12.14.0`.