### PR TITLE
Remove checkbox label from inside code block

### DIFF
--- a/app/views/govuk_publishing_components/components/_checkbox.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkbox.html.erb
@@ -14,10 +14,9 @@
     aria: {
       describedby: item[:hint].present? ? "#{id}-#{index}-item-hint" : nil,
       controls: item[:conditional].present? ? "#{id}-conditional-#{index}" : nil
-  } do %>
-    <%= tag.label item[:label], class: "govuk-label govuk-checkboxes__label", for: "#{id}-#{index}" %>
-    <% if item[:hint].present? %>
-      <%= tag.span item[:hint], id: "#{id}-#{index}-item-hint", class: "govuk-hint govuk-checkboxes__hint" %>
-    <% end %>
+  } %>
+  <%= tag.label item[:label], class: "govuk-label govuk-checkboxes__label", for: "#{id}-#{index}" %>
+  <% if item[:hint].present? %>
+    <%= tag.span item[:hint], id: "#{id}-#{index}-item-hint", class: "govuk-hint govuk-checkboxes__hint" %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Having the `label` tag inside a code block within the `input` tag makes
the generated html have the `label` element wrapped inside an `input`
element.

This occurs when running `bundle exec rake default` in `finder-frontend`
(which is the command the Jenkins runs). Running `bundle exec cucumber`
does not present the same issue.

The problematic `input` element has both an opening tag and a closing
tag, causing parsing errors in strict mode in this `slimmer` method:
```
def parse_html(html, description_for_error_message)
  doc = Nokogiri::HTML.parse(html)
  if strict
    errors = doc.errors.select {|e| e.error?}.reject {|e| ignorable?(e)}
    if errors.size > 0
      error = errors.first
      message = "In #{description_for_error_message}: '#{error.message}' 
at line #{error.line} col #{error.column} (code #{error.code}).\n"
      message << "Add ?skip_slimmer=1 to the url to show the raw backend 
request.\n\n"
      message << context(html, error)
      raise message
    end
  end

  doc
end
```

The error returned is:
```
In backend response: '66:9: ERROR: Unexpected end tag : input' at line 
66 col 9 (code 76).
Add ?skip_slimmer=1 to the url to show the raw backend request.

  61:     <div class="govuk-checkboxes">
  62:
  63: <div class="gem-c-checkbox govuk-checkboxes__item">
  64:   <input id="checkboxes-6088ba3d-0" name="aircraft_category[]" 
type="checkbox" value="commercial-fixed-wing" 
class="govuk-checkboxes__input">
  65:     <label class="govuk-label govuk-checkboxes__label" 
for="checkboxes-6088ba3d-0">Commercial - fixed wing</label>
        -----v
  66: </input></div>
  67:
```

Co-Authored-By: edwardkerry <edward.kerry@digital.cabinet-office.gov.uk>

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-[THIS PR NUMBER].herokuapp.com/component-guide/
