### PR TITLE
Iterate textarea component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Support embedding content inside textarea formgroup (PR #649)
+* Accept a maxlength attribute for textarea (PR #649)
+
 ## 12.14.1
 
 * Edit ERB view to prevent invalid HTML generation. (PR #647)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
@@ -1,3 +1,7 @@
 @import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/textarea/textarea";
 @import "govuk-frontend/objects/form-group";
+
+.gem-c-textarea {
+  margin-bottom: govuk-spacing(1);
+}

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -62,4 +62,7 @@
     aria: {
       describedby: aria_described_by
     } do %><%= value %><% end %>
+  <% if block_given? %>
+    <%= yield %>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -54,7 +54,6 @@
   <% end %>
 
   <%= tag.textarea name: name,
-    value: value,
     class: css_classes,
     id: id,
     rows: rows,

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -10,6 +10,7 @@
   error_message ||= nil
   error_items ||= nil
   character_count ||= nil
+  maxlength ||= nil
   hint_id = "hint-#{SecureRandom.hex(4)}"
   has_error ||= error_message || error_items&.any?
   error_id = "error-#{SecureRandom.hex(4)}"
@@ -57,6 +58,7 @@
     class: css_classes,
     id: id,
     rows: rows,
+    maxlength: maxlength,
     data: data,
     spellcheck: spellcheck,
     aria: {

--- a/app/views/govuk_publishing_components/components/docs/textarea.yml
+++ b/app/views/govuk_publishing_components/components/docs/textarea.yml
@@ -62,3 +62,10 @@ examples:
       name: "more-elements"
       block: |
         <span class="govuk-hint">Here's a hint</span>
+  with_maxlength:
+    data:
+      label:
+        text: "A textarea that doesn't allow many characters"
+      name: "maxlength"
+      value: "You can't type more"
+      maxlength: 19

--- a/app/views/govuk_publishing_components/components/docs/textarea.yml
+++ b/app/views/govuk_publishing_components/components/docs/textarea.yml
@@ -55,3 +55,10 @@ examples:
         text: "Can you provide more detail?"
       name: "more-detail-value"
       value: "More detail"
+  with_extra_elements:
+    data:
+      label:
+        text: "How about a hint below?"
+      name: "more-elements"
+      block: |
+        <span class="govuk-hint">Here's a hint</span>


### PR DESCRIPTION
Trello: https://trello.com/c/M3d7G6YG/501-iterate-character-count-text-and-rules

This adds two new features to the textarea component:

- [Ability to embed extra content into the textarea component formgroup](https://govuk-publishing-compon-pr-649.herokuapp.com/component-guide/textarea/with_extra_elements)
- [Set a maxlength on the textarea](https://govuk-publishing-compon-pr-649.herokuapp.com/component-guide/textarea/with_maxlength)

We intend to use these in content-publisher like so:

```
      <%= render "govuk_publishing_components/components/textarea", {
        label: {
          text: t("documents.edit.form_labels.summary"),
          bold: true
        },
        id: "document_summary",
        name: "document[summary]",
        value: @document.summary,
        rows: 4,
        maxlength: 600,
        data: {
          "contextual-guidance": "document-summary-guidance"
        }
      } do %>
        <%= render "components/input_length_suggester", {
          for_id: "document_summary",
          show_from: 130,
          message: "Summary should be under 140 characters. Current length: {count}"
        } %>
      <% end %>
```

It also fixes some issues, see commits for more details.

Marked as WIP while I finish off the related content publisher work

---

Component guide for this PR:
https://govuk-publishing-compon-pr-649.herokuapp.com/component-guide/
