### PR TITLE
Add data attributes to select component

### DIFF
--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -2,6 +2,8 @@
   options ||= []
   id ||= false
   label ||= false
+
+  select_helper = GovukPublishingComponents::Presenters::SelectHelper.new(options)
 %>
 <% if options.any? && id && label %>
   <div class="govuk-form-group gem-c-select">
@@ -9,9 +11,7 @@
       <%= label %>
     </label>
     <select class="govuk-select" id="<%= id %>" name="<%= id %>">
-      <% options.each do |option| %>
-        <option value="<%= option[:value] %>" <% if option[:selected] %>selected<% end %>><%= option[:text] %></option>
-      <% end %>
+      <%= options_for_select(select_helper.option_markup, select_helper.selected_option) %>
     </select>
   </div>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -22,7 +22,7 @@ examples:
   with_preselect:
     data:
       id: 'dropdown2'
-      label: 'My Dropdown'
+      label: 'Option 2 preselected'
       options:
       - text: 'Option one'
         value: 'option1'
@@ -31,3 +31,25 @@ examples:
         selected: true
       - text: 'Option three'
         value: 'option3'
+  with_data_attributes:
+    description: Data attributes can be added to the option elements of the select. Note that the component will not do anything with them - Javascript will have to be added in the application that uses the component, for example to fire tracking events.
+    data:
+      id: 'dropdown3'
+      label: 'With data attributes'
+      options:
+      - text: 'Option one'
+        value: 'option1'
+        data_attributes:
+          track_category: "hello"
+          something_else: "moo"
+      - text: 'Option two'
+        value: 'option2'
+      - text: 'Option three'
+        value: 'option3'
+        data_attributes:
+          track_category: 'navDocumentCollectionLinkClicked'
+          track_action: 1.1
+          track_label: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+          track_options:
+            dimension28: 2
+            dimension29: 'School behaviour and attendance: parental responsibility measures'

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -9,6 +9,7 @@ require "govuk_publishing_components/presenters/page_with_step_by_step_navigatio
 require "govuk_publishing_components/presenters/content_breadcrumbs_based_on_parent"
 require "govuk_publishing_components/presenters/content_breadcrumbs_based_on_taxons"
 require "govuk_publishing_components/presenters/services"
+require "govuk_publishing_components/presenters/select"
 require "govuk_publishing_components/presenters/meta_tags"
 require "govuk_publishing_components/presenters/taxonomy_navigation"
 require "govuk_publishing_components/presenters/curated_taxonomy_sidebar_links"

--- a/lib/govuk_publishing_components/presenters/select.rb
+++ b/lib/govuk_publishing_components/presenters/select.rb
@@ -1,0 +1,38 @@
+module GovukPublishingComponents
+  module Presenters
+    class SelectHelper
+      attr_reader :options, :option_markup, :selected_option
+
+      def initialize(options)
+        @options = options
+        @option_markup = get_options
+      end
+
+    private
+
+      def get_options
+        return if options.nil?
+
+        options.map { |option|
+          @selected_option = option[:value] if option[:selected]
+          [
+            option[:text],
+            option[:value],
+            options_data_attribute(option[:data_attributes])
+          ]
+        }
+      end
+
+      def options_data_attribute(attributes)
+        return {} if attributes.nil?
+
+        attrs = {}
+        attributes.each do |key, value|
+          key_name = "data-#{key.to_s.split('_').join('-')}"
+          attrs[key_name] = value.is_a?(Hash) ? value.to_json : value
+        end
+        attrs
+      end
+    end
+  end
+end

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -10,23 +10,27 @@ describe "Select", type: :view do
   end
 
   it "does not render if items are passed but no id is passed" do
-    assert_empty render_component(label: 'My label',
-        options: [
+    assert_empty render_component(
+      label: 'My label',
+      options: [
         {
           value: "government-gateway",
           text: "Use Government Gateway"
         }
-      ])
+      ]
+    )
   end
 
   it "does not render if items are passed but no label is passed" do
-    assert_empty render_component(id: 'mydropdown',
-        options: [
+    assert_empty render_component(
+      id: 'mydropdown',
+      options: [
         {
           value: "government-gateway",
           text: "Use Government Gateway"
         }
-      ])
+      ]
+    )
   end
 
 
@@ -98,5 +102,28 @@ describe "Select", type: :view do
     )
 
     assert_select ".govuk-select option[value=medium][selected]"
+  end
+
+  it "renders a select with data attributes" do
+    render_component(
+      id: "mydropdown",
+      label: "attributes",
+      options: [
+        {
+          value: 1,
+          text: "One",
+          data_attributes: {
+            track_category: "category",
+            track_action: "action",
+            track_options: {
+              dimension28: 28,
+              dimension29: "twentynine"
+            }
+          }
+        }
+      ]
+    )
+
+    assert_select ".govuk-select option[value=1][data-track-category='category'][data-track-action='action'][data-track-options='{\"dimension28\":28,\"dimension29\":\"twentynine\"}']"
   end
 end


### PR DESCRIPTION
Adds the ability to pass arbitrary data attributes to the select component, that will be applied to the individual options.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-650.herokuapp.com/component-guide/select
Trello card: https://trello.com/c/CF6DmPXk/137-add-sorting-to-the-news-and-communications-finder