### PR TITLE
Modify warning text component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Modify warning text component (PR #655)
+
 ## 12.17.0
 
 * Add data attributes to select component (PR #650)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
@@ -5,3 +5,7 @@
   padding-left: 0;
   margin-left: 0;
 }
+
+.gem-c-warning-text__text--large {
+  @include govuk-font($size: 24, $weight: bold);
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
@@ -1,2 +1,7 @@
 @import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/warning-text/warning-text";
+
+.gem-c-warning-text__text--no-indent {
+  padding-left: 0;
+  margin-left: 0;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
@@ -9,3 +9,7 @@
 .gem-c-warning-text__text--large {
   @include govuk-font($size: 24, $weight: bold);
 }
+
+.gem-c-warning-text__text--highlight {
+  color: $govuk-error-colour;
+}

--- a/app/views/govuk_publishing_components/components/_warning_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_warning_text.html.erb
@@ -1,15 +1,18 @@
 <%
   id ||= "warning-text-#{SecureRandom.hex(4)}"
   classes ||= ''
-  css_classes = %w(gem-c-warning-text govuk-warning-text)
-  css_classes << classes if classes
   text_assistive ||= 'Warning'
   text_icon ||= '!'
+
+  css_classes = %w(gem-c-warning-text govuk-warning-text)
+  css_classes << classes if classes
 %>
 
 <%= tag.div id: id, class: css_classes do %>
-  <%= tag.span text_icon, class: "govuk-warning-text__icon", "aria-hidden": "true" %>
-  <%= tag.strong class: "govuk-warning-text__text" do %>
+  <% unless text_icon.empty? %>
+    <%= tag.span text_icon, class: "govuk-warning-text__icon", "aria-hidden": "true" %>
+  <% end %>
+  <%= tag.strong class: "govuk-warning-text__text #{'gem-c-warning-text__text--no-indent' if text_icon.empty?}" do %>
     <%= tag.span text_assistive, class: "govuk-warning-text__assistive" %>
     <%= text %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/_warning_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_warning_text.html.erb
@@ -4,6 +4,7 @@
   text_assistive ||= 'Warning'
   text_icon ||= '!'
   large_font ||= false
+  highlight_text ||= false
 
   css_classes = %w(gem-c-warning-text govuk-warning-text)
   css_classes << classes if classes
@@ -11,6 +12,7 @@
   text_classes = %w(govuk-warning-text__text)
   text_classes << "gem-c-warning-text__text--no-indent" if text_icon.empty?
   text_classes << "gem-c-warning-text__text--large" if large_font
+  text_classes << "gem-c-warning-text__text--highlight" if highlight_text
 %>
 
 <%= tag.div id: id, class: css_classes do %>

--- a/app/views/govuk_publishing_components/components/_warning_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_warning_text.html.erb
@@ -3,16 +3,21 @@
   classes ||= ''
   text_assistive ||= 'Warning'
   text_icon ||= '!'
+  large_font ||= false
 
   css_classes = %w(gem-c-warning-text govuk-warning-text)
   css_classes << classes if classes
+
+  text_classes = %w(govuk-warning-text__text)
+  text_classes << "gem-c-warning-text__text--no-indent" if text_icon.empty?
+  text_classes << "gem-c-warning-text__text--large" if large_font
 %>
 
 <%= tag.div id: id, class: css_classes do %>
   <% unless text_icon.empty? %>
     <%= tag.span text_icon, class: "govuk-warning-text__icon", "aria-hidden": "true" %>
   <% end %>
-  <%= tag.strong class: "govuk-warning-text__text #{'gem-c-warning-text__text--no-indent' if text_icon.empty?}" do %>
+  <%= tag.strong class: text_classes do %>
     <%= tag.span text_assistive, class: "govuk-warning-text__assistive" %>
     <%= text %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/docs/warning_text.yml
+++ b/app/views/govuk_publishing_components/components/docs/warning_text.yml
@@ -21,3 +21,7 @@ examples:
     data:
       text_icon: ""
       text: "You can be fined up to £320 if you don't register."
+  with_larger_font:
+    data:
+      text: "This content was updated on the 24th of November 2018"
+      large_font: true

--- a/app/views/govuk_publishing_components/components/docs/warning_text.yml
+++ b/app/views/govuk_publishing_components/components/docs/warning_text.yml
@@ -17,3 +17,7 @@ examples:
     data:
       text_icon: "£"
       text: "You can be fined up to £5,000 if you don’t register."
+  without_icon:
+    data:
+      text_icon: ""
+      text: "You can be fined up to £320 if you don't register."

--- a/app/views/govuk_publishing_components/components/docs/warning_text.yml
+++ b/app/views/govuk_publishing_components/components/docs/warning_text.yml
@@ -25,3 +25,7 @@ examples:
     data:
       text: "This content was updated on the 24th of November 2018"
       large_font: true
+  with_red_font:
+    data:
+      text: "This content has changed"
+      highlight_text: true

--- a/spec/components/warning_text_spec.rb
+++ b/spec/components/warning_text_spec.rb
@@ -32,4 +32,14 @@ describe "warning text", type: :view do
     render_component(large_font: true, text: "You can be fined up to £5,000 if you don’t register.")
     assert_select(".govuk-warning-text__text.gem-c-warning-text__text--large", text: /You can be fined up to £5,000 if you don’t register/i)
   end
+
+  it "renders highlighted text" do
+    render_component(highlight_text: true, text: "You can be fined up to £5,000 if you don’t register.")
+    assert_select(".govuk-warning-text__text.gem-c-warning-text__text--highlight", text: /You can be fined up to £5,000 if you don’t register/i)
+  end
+
+  it "renders highlighted and large text together" do
+    render_component(highlight_text: true, large_font: true, text: "Because")
+    assert_select(".govuk-warning-text__text.gem-c-warning-text__text--highlight.gem-c-warning-text__text--large", text: /Because/i)
+  end
 end

--- a/spec/components/warning_text_spec.rb
+++ b/spec/components/warning_text_spec.rb
@@ -27,4 +27,9 @@ describe "warning text", type: :view do
     assert_select(".govuk-warning-text__icon", false)
     assert_select(".gem-c-warning-text__text--no-indent", text: /You can be fined up to £5,000 if you don’t register/i)
   end
+
+  it "renders large warning text" do
+    render_component(large_font: true, text: "You can be fined up to £5,000 if you don’t register.")
+    assert_select(".govuk-warning-text__text.gem-c-warning-text__text--large", text: /You can be fined up to £5,000 if you don’t register/i)
+  end
 end

--- a/spec/components/warning_text_spec.rb
+++ b/spec/components/warning_text_spec.rb
@@ -21,4 +21,10 @@ describe "warning text", type: :view do
     render_component(text_icon: ":(", text: "You can be fined up to £5,000 if you don’t register.")
     assert_select(".govuk-warning-text__icon", text: ":(")
   end
+
+  it "renders no icon" do
+    render_component(text_icon: "", text: "You can be fined up to £5,000 if you don’t register.")
+    assert_select(".govuk-warning-text__icon", false)
+    assert_select(".gem-c-warning-text__text--no-indent", text: /You can be fined up to £5,000 if you don’t register/i)
+  end
 end


### PR DESCRIPTION
Modify the warning text component so that it:

- doesn't have to have an icon
- has an option to have larger text
- has an option to have highlighted (i.e. red) text

---

Component guide for this PR:
https://govuk-publishing-compon-pr-655.herokuapp.com/component-guide/warning_text
