### PR TITLE
Update to govuk-frontend 2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,13 +7,13 @@
       "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-1.6.2.tgz",
       "integrity": "sha512-7S+6Vi82LQFSSd5feKedu46tiY2/DShpdXiRp0NY3cLwc+DKe1ayWd66mb3JVi8LTQubRM7jco+u92e6w0bbvg==",
       "requires": {
-        "preact": "^8.3.1"
+        "preact": "8.3.1"
       }
     },
     "govuk-frontend": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.2.0.tgz",
-      "integrity": "sha512-vNiUIp8EQACARNTyOwmE110HcQd+zJvkgbKv+gmY28QxqQGGd2DEJ35nblnjElsRJpSgbxwa85iqlNtbR3Q5tA=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.4.0.tgz",
+      "integrity": "sha512-WSecWLGM1qZ48UD0YGGWOfaBqrWtwf39cOUAuC8+SMNh7kkZ6Ou2Y7+d3Bt8OEPaFNFR2N2vZO2WRnT2gaCjMg=="
     },
     "jquery": {
       "version": "1.12.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "accessible-autocomplete": "^1.6.2",
-    "govuk-frontend": "^2.2.0",
+    "govuk-frontend": "^2.4.0",
     "jquery": "1.12.4"
   }
 }


### PR DESCRIPTION
Update to govuk-frontend 2.4
See [GOV.UK Frontend changelog](https://github.com/alphagov/govuk-frontend/releases) for details.

Can someone with access to dependabot account help me setup an integration or webhook for govuk-frontend on this repository?

https://govuk-publishing-compon-pr-656.herokuapp.com/component-guide