### PR TITLE
Support data attributes on copy-to-clipboard, details and tabs components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Details supports data attributes on root element (PR #660)
 * Copy to clipboard supports data attributes for the input element (PR #660)
 
 ## 12.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Copy to clipboard supports data attributes for the input element (PR #660)
+
 ## 12.18.0
 
 * Add inverse option to metadata component (PR #657)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Tabs supports data attributes on the tab element (PR #660)
 * Details supports data attributes on root element (PR #660)
 * Copy to clipboard supports data attributes for the input element (PR #660)
 

--- a/app/views/govuk_publishing_components/components/_copy_to_clipboard.html.erb
+++ b/app/views/govuk_publishing_components/components/_copy_to_clipboard.html.erb
@@ -1,5 +1,6 @@
 <%
   button_data_attributes ||= nil
+  input_data_attributes ||= nil
 %>
 <div class="gem-c-copy-to-clipboard" data-module="copy-to-clipboard">
   <%= render "govuk_publishing_components/components/input", {
@@ -8,6 +9,7 @@
     },
     name: SecureRandom.hex,
     value: copyable_content,
+    data: input_data_attributes,
     readonly: true,
   } %>
 

--- a/app/views/govuk_publishing_components/components/_details.html.erb
+++ b/app/views/govuk_publishing_components/components/_details.html.erb
@@ -1,4 +1,5 @@
-<details class="gem-c-details govuk-details">
+<% data_attributes ||= nil %>
+<%= tag.details class: "gem-c-details govuk-details", data: data_attributes do %>
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
       <%= title %>
@@ -7,4 +8,4 @@
   <div class="govuk-details__text">
     <%= yield %>
   </div>
-</details>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_tabs.html.erb
+++ b/app/views/govuk_publishing_components/components/_tabs.html.erb
@@ -13,9 +13,10 @@
     <ul class="govuk-tabs__list">
       <% tabs.each do |tab| %>
       <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="#<%= tab[:id] %>">
-          <%= tab[:label] %>
-        </a>
+        <%= link_to(tab[:label],
+                    "##{tab[:id]}",
+                    class: "govuk-tabs__tab",
+                    data: tab[:tab_data_attributes]) %>
       </li>
       <% end %>
     </ul>

--- a/app/views/govuk_publishing_components/components/docs/copy_to_clipboard.yml
+++ b/app/views/govuk_publishing_components/components/docs/copy_to_clipboard.yml
@@ -6,10 +6,12 @@ examples:
       label: Copy and send this link to someone and they’ll be able to preview your draft on GOV.UK.
       copyable_content: http://www.example.org
       button_text: Copy link
-  with_button_data_attributes:
+  with_data_attributes:
     data:
       label: Copy and send this link to someone and they’ll be able to preview your draft on GOV.UK.
       copyable_content: http://www.example.org
+      input_data_attributes:
+        "tracking-code": GA-123ABC
       button_text: Copy link
       button_data_attributes:
         "tracking-code": GA-123ABC

--- a/app/views/govuk_publishing_components/components/docs/details.yml
+++ b/app/views/govuk_publishing_components/components/docs/details.yml
@@ -21,3 +21,10 @@ examples:
       title: Help with nationality
       block: |
         We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
+  with_data_attributes:
+    data:
+      title: Help with nationality
+      data_attributes:
+        tracking: GTM-123AB
+      block: |
+        We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.

--- a/app/views/govuk_publishing_components/components/docs/tabs.yml
+++ b/app/views/govuk_publishing_components/components/docs/tabs.yml
@@ -64,3 +64,20 @@ examples:
           label: "Single piece of content"
           content: |
             <p class="govuk-body-m">Here is a single piece of content, there should be no tabs.</p>
+  with_data_attributes:
+    data:
+      tabs:
+        - id: "tab-with-data-attributes-1"
+          label: "First section"
+          title: "First section"
+          tab_data_attributes:
+            tracking: GTM-123AB
+          content: |
+            <p class="govuk-body-m">Fusce at dictum tellus, ac accumsan est. Nulla vitae turpis in nulla gravida tincidunt. Duis lectus felis, tempus id bibendum sit amet, posuere ut elit. Donec enim odio, eleifend in urna a, sagittis egestas est. Proin id ex ultricies, porta eros id, vehicula quam. Morbi non sagittis velit.</p>
+        - id: "tab-with-data-attributes-2"
+          label: "Second section"
+          title: "Second section"
+          tab_data_attributes:
+            tracking: GTM-123AB
+          content: |
+            <p class="govuk-body-m">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam congue elementum commodo. Vestibulum elit turpis, efficitur quis posuere vitae, commodo vitae augue. Donec ut pharetra ligula. Phasellus ac mauris eu felis bibendum dapibus rutrum sed quam. Pellentesque posuere ante id consequat pretium.</p>


### PR DESCRIPTION
Trello: https://trello.com/c/yRnJfrDN/487-deployment-of-remaining-data-attributes-for-consistent-event-tracking-in-gtm

These have been requested by the PA on Publishing Workflow, Andy, for
integrating with google-tag-manager.

Component guide for this PR:
https://govuk-publishing-compon-pr-660.herokuapp.com/component-guide/
