### PR TITLE
Add data attributes to error alert and error summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Error alert supports data attributes on root element (PR #662)
+* Error summary supports data attributes on root element (PR #662)
+
 ## 12.19.0
 
 * Tabs supports data attributes on the tab element (PR #660)

--- a/app/views/govuk_publishing_components/components/_error_alert.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_alert.html.erb
@@ -1,6 +1,7 @@
 <% description ||= nil %>
+<% data_attributes ||= {} %>
 
-<%= tag.div class: "gem-c-error-alert", data: { module: "initial-focus" }, role: "alert", tabindex: "-1" do %>
+<%= tag.div class: "gem-c-error-alert", data: { module: "initial-focus" }.merge(data_attributes), role: "alert", tabindex: "-1" do %>
   <% if description.present? %>
     <%= tag.h2 message, class: "gem-c-error-summary__title" %>
     <%= tag.div description, class: "gem-c-error-summary__body" %>

--- a/app/views/govuk_publishing_components/components/_error_summary.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_summary.html.erb
@@ -2,20 +2,21 @@
   id ||= "error-summary-#{SecureRandom.hex(4)}"
   title ||= false
   description ||= false
+  data_attributes ||= {}
   items ||= []
   title_id ||= "error-summary-title-#{SecureRandom.hex(4)}"
   if items.empty? && !title
     raise ArgumentError, "The error_summary component needs at least one item or a title in order to render."
   end
 %>
-<div
-  class="gem-c-error-summary"
-  data-module="error-summary"
-  aria-labelledby="<%= title_id %>"
-  role="alert"
-  tabindex="-1"
-  id="<%= id %>"
->
+<%= tag.div(
+  class: "gem-c-error-summary",
+  data: { module: "error-summary" }.merge(data_attributes),
+  aria: { labelledby: title_id },
+  role: "alert",
+  tabindex: -1,
+  id: id,
+) do %>
   <% if title %>
     <h2 class="gem-c-error-summary__title" id="<%= title_id %>">
       <%= title %>
@@ -42,4 +43,4 @@
       </ul>
     <% end %>
   </div>
-</div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/error_alert.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_alert.yml
@@ -21,3 +21,9 @@ examples:
         orci. Proin semper porttitor ipsum, vel maximus justo rutrum vel.
         Morbi volutpat facilisis libero. Donec posuere eget odio non egestas.
         Nullam sed neque quis turpis.
+  with_data_attributes:
+    data:
+      message: Message to alert the user to a unsuccessful action goes here
+      description: A further description
+      data_attributes:
+        tracking: GTM-123AB

--- a/app/views/govuk_publishing_components/components/docs/error_summary.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_summary.yml
@@ -24,3 +24,11 @@ examples:
       - text: Descriptive link to the question with an error 2
         href: '#example-error-2'
       - text: Description of error without link
+  with_data_attributes:
+    data:
+      title: Message to alert the user to a problem goes here
+      description: Optional description of the errors and how to correct them
+      data_attributes:
+        tracking: GTM-123AB
+      items:
+      - text: Descriptive link to the question with an error 1


### PR DESCRIPTION
This is another that is hoped to be tracked by Google Tag Manager for
which we need to inject data attributes.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-662.herokuapp.com/component-guide/
