### PR TITLE
Make layout footer support spawning new windows for links

### DIFF
--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -18,15 +18,11 @@
                 <% item[:items].each do |item| %>
                   <% if item[:href] && item[:text] %>
                     <li class="govuk-footer__list-item">
-                      <% if item[:target].nil? %>
-                        <%= link_to item[:text], item[:href], target: '',
-                          class: "govuk-footer__link"
-                        %>
-                      <% else %>
-                        <%= link_to item[:text], item[:href], target: item[:target],
-                          class: "govuk-footer__link"
-                        %>
-                      <% end %>
+                      <%
+                        attributes = { class: "govuk-footer__link" }.merge(item.fetch(:attributes, {}))
+                        attributes[:rel] = "noopener" if attributes[:target] == "_blank" && !attributes[:rel]
+                      %>
+                      <%= link_to item[:text], item[:href], attributes %>
                     </li>
                   <% end %>
                 <% end %>

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -18,9 +18,15 @@
                 <% item[:items].each do |item| %>
                   <% if item[:href] && item[:text] %>
                     <li class="govuk-footer__list-item">
-                      <a class="govuk-footer__link" href="<%= item[:href] %>">
-                        <%= item[:text] %>
-                      </a>
+                      <% if item[:target].nil? %>
+                        <%= link_to item[:text], item[:href], target: '',
+                          class: "govuk-footer__link"
+                        %>
+                      <% else %>
+                        <%= link_to item[:text], item[:href], target: item[:target],
+                          class: "govuk-footer__link"
+                        %>
+                      <% end %>
                     </li>
                   <% end %>
                 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -124,7 +124,7 @@ examples:
           - href: '/government/organisations/government-digital-service'
             text: Government Digital Service
 
-  with_new_windows:
+  with_attributes_links:
     data:
       navigation:
         - title: Test Links
@@ -132,6 +132,11 @@ examples:
           items:
             - href: 'https://www.gov.uk/government/collections/organisation'
               text: Shows a page in a new window
-              target: '_blank'
+              attributes:
+                target: _blank
+                rel: noopener
             - href: 'https://www.gov.uk/corporation-tax'
               text: Shows page in the same window
+              attributes:
+                data:
+                  tracking: GTM-123AB

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -123,3 +123,15 @@ examples:
             text: Rhestr o Wasanaethau Cymraeg
           - href: '/government/organisations/government-digital-service'
             text: Government Digital Service
+
+  with_new_windows:
+    data:
+      navigation:
+        - title: Test Links
+          columns: 1
+          items:
+            - href: 'https://www.gov.uk/government/collections/organisation'
+              text: Shows a page in a new window
+              target: '_blank'
+            - href: 'https://www.gov.uk/corporation-tax'
+              text: Shows page in the same window

--- a/spec/components/layout_footer_spec.rb
+++ b/spec/components/layout_footer_spec.rb
@@ -37,7 +37,7 @@ describe "Layout footer", type: :view do
     assert_select ".govuk-footer__navigation .govuk-footer__list--columns-2 .govuk-footer__link[href='/browse/benefits']", text: "Benefits"
   end
 
-  it "renders links that can either spawn a new window or use the same window" do
+  it "renders the footer with attributes" do
     render_component(
       navigation: [
         {
@@ -47,14 +47,20 @@ describe "Layout footer", type: :view do
             {
               href: "/browse/benefits",
               text: "Benefits",
-              target: "_blank"
+              attributes: { title: "A title" }
             }
           ]
         }
       ]
     )
-    assert_select ".govuk-footer__navigation .govuk-footer__list--columns-2 .govuk-footer__link[target='_blank']", text: "Benefits"
 
+    assert_select 'a' do |link|
+      expect(link.attr('class').to_s).to eq "govuk-footer__link"
+      expect(link.attr('title').to_s).to eq "A title"
+    end
+  end
+
+  it "renders the footer with attributes but will set the rel attribute if target is blank" do
     render_component(
       navigation: [
         {
@@ -63,12 +69,18 @@ describe "Layout footer", type: :view do
           items: [
             {
               href: "/browse/benefits",
-              text: "Benefits"
+              text: "Benefits",
+              attributes: { target: "_blank" }
             }
           ]
         }
       ]
     )
-    assert_select ".govuk-footer__navigation .govuk-footer__list--columns-2 .govuk-footer__link[target='']", text: "Benefits"
+
+    assert_select 'a' do |link|
+      expect(link.attr('class').to_s).to eq "govuk-footer__link"
+      expect(link.attr('target').to_s).to eq "_blank"
+      expect(link.attr('rel').to_s).to eq "noopener"
+    end
   end
 end

--- a/spec/components/layout_footer_spec.rb
+++ b/spec/components/layout_footer_spec.rb
@@ -36,4 +36,39 @@ describe "Layout footer", type: :view do
     assert_select ".govuk-footer__navigation .govuk-footer__heading", text: "Services and information"
     assert_select ".govuk-footer__navigation .govuk-footer__list--columns-2 .govuk-footer__link[href='/browse/benefits']", text: "Benefits"
   end
+
+  it "renders links that can either spawn a new window or use the same window" do
+    render_component(
+      navigation: [
+        {
+          title: "Services and information",
+          columns: 2,
+          items: [
+            {
+              href: "/browse/benefits",
+              text: "Benefits",
+              target: "_blank"
+            }
+          ]
+        }
+      ]
+    )
+    assert_select ".govuk-footer__navigation .govuk-footer__list--columns-2 .govuk-footer__link[target='_blank']", text: "Benefits"
+
+    render_component(
+      navigation: [
+        {
+          title: "Services and information",
+          columns: 2,
+          items: [
+            {
+              href: "/browse/benefits",
+              text: "Benefits"
+            }
+          ]
+        }
+      ]
+    )
+    assert_select ".govuk-footer__navigation .govuk-footer__list--columns-2 .govuk-footer__link[target='']", text: "Benefits"
+  end
 end


### PR DESCRIPTION
https://trello.com/c/TiZgaPxw/537-open-support-links-in-a-new-tab

Enhancing the layout footer component so that it can make pressing a link open a new window
or change the page of the current window.
- Making use of link_to in _layout_footer.html.erb to handle the target attribute and
  explicitly setting target to '' if no target attribute is passed to the component.
- Adding a new example to layout_footer.yml so users can see examples of using the
  layout footer component to open links in either the same or a new window.

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

