### PR TITLE
Remove line-height on description and list

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -81,13 +81,13 @@
 }
 
 .gem-c-image-card__description {
-  @include govuk-font($size: 16, $line-height: 1.5);
+  @include govuk-font($size: 16);
   padding-top: $gutter-one-quarter;
   word-wrap: break-word;
 }
 
 .gem-c-image-card__list {
-  @include govuk-font($size: 16, $line-height: 1.5);
+  @include govuk-font($size: 16);
   position: relative;
   z-index: 2;
   padding: $gutter-one-quarter 0 0 0;


### PR DESCRIPTION
Spoke with @markhurrell and we don't want a custom `line-height` for these elements on image-card. I'm fine with the change.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-665.herokuapp.com/component-guide/image_card
