### PR TITLE
Triggers select changed event when onConfirm is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Accessible autocomplete triggers change if tracking data is supplied (PR #666) 
+
 ## 13.0.0
 
 * Encode feedback component to ensure UTF-8 characters are rendered (PR #673)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,5 +332,8 @@ DEPENDENCIES
   webmock (~> 3.0.1)
   yard
 
+RUBY VERSION
+   ruby 2.5.3p105
+
 BUNDLED WITH
    1.17.1

--- a/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
@@ -16,11 +16,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         confirmOnBlur: false
       };
 
-      if ($selectElem.data('track-category') !== undefined && $selectElem.data('track-action') !== undefined) {
-        configOptions.onConfirm = function(val) {
-          track($selectElem.data('track-category'), $selectElem.data('track-action'), val, $selectElem.data('track-options'));
-        };
-      }
+      configOptions.onConfirm = function(label) {
+        if ($selectElem.data('track-category') !== undefined && $selectElem.data('track-action') !== undefined) {
+          track($selectElem.data('track-category'), $selectElem.data('track-action'), label, $selectElem.data('track-options'));
+        }
+        var value = $selectElem.children("option").filter(function () { return $(this).html() == label; }).val();
+        $element.trigger( "accessibleAutocompleteChanged", [$element, value, label] );
+      };
 
       new accessibleAutocomplete.enhanceSelectElement(configOptions);
     };

--- a/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
@@ -13,15 +13,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var configOptions = {
         selectElement: document.getElementById($selectElem.attr('id')),
         showAllValues: true,
-        confirmOnBlur: false
+        confirmOnBlur: true,
+        preserveNullOptions: true, // https://github.com/alphagov/accessible-autocomplete#null-options
+        defaultValue: ""
       };
 
       configOptions.onConfirm = function(label) {
         if ($selectElem.data('track-category') !== undefined && $selectElem.data('track-action') !== undefined) {
           track($selectElem.data('track-category'), $selectElem.data('track-action'), label, $selectElem.data('track-options'));
         }
+        // This is to compensate for the fact that the accessible-autocomplete library will not
+        // update the hidden select if the onConfirm function is supplied
+        // https://github.com/alphagov/accessible-autocomplete/issues/322
         var value = $selectElem.children("option").filter(function () { return $(this).html() == label; }).val();
-        $element.trigger( "accessibleAutocompleteChanged", [$element, value, label] );
+        $selectElem.val(value).trigger( "change" );
       };
 
       new accessibleAutocomplete.enhanceSelectElement(configOptions);


### PR DESCRIPTION
This is necessary for us to use the accessible-autocomplete component in finder-frontend (related PR: https://github.com/alphagov/finder-frontend/pull/740)

For more details see [finder-frontend PR #740](https://github.com/alphagov/finder-frontend/pull/740)

Trello: https://trello.com/c/fkbJr5kX/173-add-autocomplete-to-finders

---

Component guide for this PR:
https://govuk-publishing-compon-pr-666.herokuapp.com/component-guide/
