### PR TITLE
Use ERB comments not HTML comments in template markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use ERB comments not HTML comments in template markup (PR #667)
+
 ## 12.20.0
 
 * Error alert supports data attributes on root element (PR #662)

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -3,30 +3,30 @@
 
 <div class='gem-c-contextual-breadcrumbs'>
   <% if navigation.content_tagged_to_current_step_by_step? %>
-    <!-- Rendering step by step nav breadcrumbs because there's 1 step by step -->
+    <%# Rendering step by step nav breadcrumbs because there's 1 step by step %>
     <%= render 'govuk_publishing_components/components/step_by_step_nav_header',
       navigation.step_nav_helper.header %>
   <% elsif navigation.content_is_tagged_to_a_live_taxon? && prioritise_taxon_breadcrumbs %>
-    <!-- Rendering taxonomy breadcrumbs because the page is tagged to live taxons
-          and we want to prioritise them over all other breadcrumbs -->
+    <%# Rendering taxonomy breadcrumbs because the page is tagged to live taxons
+          and we want to prioritise them over all other breadcrumbs %>
     <%= render 'govuk_publishing_components/components/breadcrumbs',
                breadcrumbs: navigation.taxon_breadcrumbs[:breadcrumbs],
                collapse_on_mobile: true %>
   <% elsif navigation.content_tagged_to_mainstream_browse_pages? %>
-    <!-- Rendering parent-based breadcrumbs because the page is tagged to mainstream browse -->
+    <%# Rendering parent-based breadcrumbs because the page is tagged to mainstream browse %>
     <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
   <% elsif navigation.content_has_curated_related_items? %>
-    <!-- Rendering parent-based breadcrumbs because the page has curated related links -->
+    <%# Rendering parent-based breadcrumbs because the page has curated related links %>
     <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
   <% elsif navigation.content_is_tagged_to_a_live_taxon? %>
-    <!-- Rendering taxonomy breadcrumbs because the page is tagged to live taxons -->
+    <%# Rendering taxonomy breadcrumbs because the page is tagged to live taxons %>
     <%= render 'govuk_publishing_components/components/breadcrumbs',
       breadcrumbs: navigation.taxon_breadcrumbs[:breadcrumbs],
       collapse_on_mobile: true %>
   <% elsif navigation.breadcrumbs.any? %>
-    <!-- Rendering parent-based breadcrumbs because no browse, no related links, no live taxons -->
+    <%# Rendering parent-based breadcrumbs because no browse, no related links, no live taxons %>
     <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
   <% else %>
-    <!-- Not rendering any breadcrumbs because there aren't any -->
+    <%# Not rendering any breadcrumbs because there aren't any %>
   <% end %>
 </div>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -2,29 +2,29 @@
 
 <div class="gem-c-contextual-sidebar">
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
-    <!-- Rendering step by step related items because there are a few but not too many of them -->
+    <%# Rendering step by step related items because there are a few but not too many of them %>
     <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links %>
   <% end %>
 
   <% if navigation.content_tagged_to_current_step_by_step? %>
-    <!-- Rendering step by step sidebar because there's 1 step by step list -->
+    <%# Rendering step by step sidebar because there's 1 step by step list %>
     <%= render 'govuk_publishing_components/components/step_by_step_nav', navigation.step_nav_helper.sidebar %>
   <% elsif navigation.content_tagged_to_mainstream_browse_pages? %>
-    <!-- Rendering related navigation sidebar because the page is tagged to mainstream browse -->
+    <%# Rendering related navigation sidebar because the page is tagged to mainstream browse %>
     <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
   <% elsif navigation.content_has_curated_related_items? %>
-    <!-- Rendering related navigation sidebar because the page has curated related links -->
+    <%# Rendering related navigation sidebar because the page has curated related links %>
     <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
   <% elsif navigation.content_is_tagged_to_a_live_taxon? %>
-    <!-- Rendering taxonomy sidebar because the page is tagged to live taxons -->
+    <%# Rendering taxonomy sidebar because the page is tagged to live taxons %>
     <%= render 'govuk_publishing_components/components/taxonomy_navigation', navigation.taxonomy_sidebar %>
   <% else %>
-    <!-- Rendering related navigation sidebar because no browse, no related links, no live taxons -->
+    <%# Rendering related navigation sidebar because no browse, no related links, no live taxons %>
     <%= render 'govuk_publishing_components/components/related_navigation', content_item %>
   <% end %>
 
   <% if navigation.content_tagged_to_other_step_by_steps? %>
-    <!-- Rendering step by step related items because there are a few but not too many of them -->
+    <%# Rendering step by step related items because there are a few but not too many of them %>
     <%= render 'govuk_publishing_components/components/step_by_step_nav_related', {
       pretitle: "Also part of", 
       links: navigation.step_nav_helper.also_part_of_step_nav,

--- a/spec/dummy/app/views/layouts/dummy_admin_layout.html.erb
+++ b/spec/dummy/app/views/layouts/dummy_admin_layout.html.erb
@@ -13,7 +13,7 @@
     ]
   }%>
   <div class="govuk-width-container">
-    <!-- breadcrumbs, backlink, phasebanner goes here-->
+    <%# breadcrumbs, backlink, phasebanner goes here %>
     <main class="govuk-main-wrapper " id="main-content" role="main">
       <%= yield %>
     </main>


### PR DESCRIPTION
Comments are only needed to help comprehension of the template code,
they're not needed when templates are used to render HTML view code.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-667.herokuapp.com/component-guide/
