### PR TITLE
Add optional maxlength to input fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 - BREAKING: Merge checkbox components (PR #659)
+* Accept a maxlength attribute for input (PR #670)
 
 ## 12.21.0
 * Retires the taxonomy navigation component (PR #606)

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -13,6 +13,7 @@
   autofocus ||= nil
   tabindex ||= nil
   readonly ||= nil
+  maxlength ||= nil
   has_error = error_message || error_items&.any?
   hint_id = "hint-#{SecureRandom.hex(4)}"
   error_id = "error-#{SecureRandom.hex(4)}"
@@ -67,6 +68,7 @@
       tabindex: tabindex,
       autofocus: autofocus,
       readonly: readonly,
+      maxlength: maxlength,
       aria: {
         describedby: aria_described_by,
         controls: controls

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -96,3 +96,10 @@ examples:
       name: "readonly"
       value: "You can't change me"
       readonly: true
+  with_maxlength:
+    data:
+      label:
+        text: "An input that doesn't allow many characters"
+      name: "name"
+      value: "You can't type more"
+      maxlength: 10

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -104,6 +104,15 @@ describe "Input", type: :view do
     assert_select ".govuk-input[autofocus][tabindex='0']"
   end
 
+  it "sets the maxlength when provided" do
+    render_component(
+      name: "email-address",
+      maxlength: 10
+    )
+
+    assert_select ".govuk-input[maxlength='10']"
+  end
+
   context "when a hint is provided" do
     before do
       render_component(


### PR DESCRIPTION
Trello: https://trello.com/c/hGmJ5BfV

## Motivation

Content Publisher allows publishers to add an image credit. The intention is to limit the number of characters publishers can use in the image credit.

Sets a maxlength attribute in a similar way to textarea.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-670.herokuapp.com/component-guide/
