### PR TITLE
Fix autocomplete styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@
 
 ## Unreleased
 
-- BREAKING: Merge checkbox components (PR #659)
+* Fix autocomplete styles (PR #671)
+* BREAKING: Merge checkbox components (PR #659)
 * Accept a maxlength attribute for input (PR #670)
 
 ## 12.21.0
+
 * Retires the taxonomy navigation component (PR #606)
 * Introduces a new contextual footer component (PR #606)
 * Use ERB comments not HTML comments in template markup (PR #667)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
@@ -7,7 +7,11 @@
 
 .gem-c-accessible-autocomplete {
   .autocomplete__input {
-    background: govuk-colour("white");
+    z-index: 1;
+  }
+
+  .autocomplete__dropdown-arrow-down {
+    z-index: 0;
   }
 
   .autocomplete__option {


### PR DESCRIPTION
Arrow was not appearing on autocomplete, even though we're using the `showAllValues` option - see [autocomplete examples](https://alphagov.github.io/accessible-autocomplete/examples/).

This change fixes this by increasing the z-index on both the arrow svg and the input, so the arrow is visible but does not overlap the click area of the input.

Fixes this:

![screen shot 2018-12-18 at 12 23 51](https://user-images.githubusercontent.com/861310/50153951-d4942b00-02bf-11e9-8e37-9f9cec69c411.png)

...to this:

![screen shot 2018-12-18 at 12 23 57](https://user-images.githubusercontent.com/861310/50153959-d9f17580-02bf-11e9-9b21-c8d98cee9c40.png)



---

Component guide for this PR:
https://govuk-publishing-compon-pr-671.herokuapp.com/component-guide/accessible_autocomplete
