### PR TITLE
Version 13.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 13.0.0
 
+* Encode feedback component to ensure UTF-8 characters are rendered (PR #673)
 * Fix autocomplete styles (PR #671)
 * BREAKING: Merge checkbox components (PR #659)
 * Accept a maxlength attribute for input (PR #670)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (12.21.0)
+    govuk_publishing_components (13.0.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '12.21.0'.freeze
+  VERSION = '13.0.0'.freeze
 end


### PR DESCRIPTION
**Note that this version contains a potentially breaking change, the removal of the checkbox component.**

## 13.0.0

* Encode feedback component to ensure UTF-8 characters are rendered (PR #673)
* Fix autocomplete styles (PR #671)
* BREAKING: Merge checkbox components (PR #659)
* Accept a maxlength attribute for input (PR #670)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-674.herokuapp.com/component-guide/
