### PR TITLE
Add guard for user agent and url being nil in feedback

### DIFF
--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -3,9 +3,13 @@
   margin_top ||= 1
   margin_top_class = "gem-c-feedback--top-margin" if margin_top == 1
   email_regex = /[^\s=\/?&]+(?:@|%40)[^\s=\/?&]+/
-  stripped_path = request.original_url.gsub(email_regex, '[email]').encode
-  stripped_url = request.fullpath.gsub(email_regex, '[email]').encode
-  user_agent = request.user_agent.encode
+  stripped_path = request.original_url.gsub(email_regex, '[email]')
+  stripped_url = request.fullpath.gsub(email_regex, '[email]')
+  user_agent = request.user_agent
+
+  def utf_encode element
+    element.is_a?(String) ? element.encode : element
+  end
 %>
 
 <div class="gem-c-feedback <%= margin_top_class %>" data-module="feedback">
@@ -90,8 +94,8 @@
       <div class="gem-c-feedback__column-two-thirds">
         <div class="gem-c-feedback__error-summary gem-c-feedback__js-show js-hidden js-errors" tabindex="-1"></div>
 
-        <input type="hidden" name="url" value="<%= stripped_path -%>">
-        <input type="hidden" name="user_agent" value="<%= user_agent -%>">
+        <input type="hidden" name="url" value="<%= utf_encode(stripped_path) -%>">
+        <input type="hidden" name="user_agent" value="<%= utf_encode(user_agent) -%>">
 
         <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
         <p id="feedback_explanation" class="gem-c-feedback__form-paragraph">Don’t include personal or financial information like your National Insurance number or credit card details.</p>
@@ -136,11 +140,11 @@
       <div class="gem-c-feedback__column-two-thirds">
         <div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>
 
-        <input type="hidden" name="url" value="<%= stripped_path -%>">
-        <input type="hidden" name="user_agent" value="<%= user_agent -%>">
+        <input type="hidden" name="url" value="<%= utf_encode(stripped_path) -%>">
+        <input type="hidden" name="user_agent" value="<%= utf_encode(user_agent) -%>">
 
         <input name="email_survey_signup[survey_id]" type="hidden" value="footer_satisfaction_survey">
-        <input name="email_survey_signup[survey_source]" type="hidden" value="<%= stripped_path -%>">
+        <input name="email_survey_signup[survey_source]" type="hidden" value="<%= utf_encode(stripped_path) -%>">
         <input name="email_survey_signup[ga_client_id]" type="hidden" value="1627485790.1515403243">
 
         <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
@@ -158,7 +162,7 @@
         <%= render "govuk_publishing_components/components/button", {
           text: "Send me the survey"
         } %>
-        <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=<%= stripped_url -%>&amp;gcl=1627485790.1515403243" class="gem-c-feedback__email-link govuk-link" id="take-survey" target="_blank" rel="noopener noreferrer">Don’t have an email address?</a>
+        <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=<%= utf_encode(stripped_url) -%>&amp;gcl=1627485790.1515403243" class="gem-c-feedback__email-link govuk-link" id="take-survey" target="_blank" rel="noopener noreferrer">Don’t have an email address?</a>
       </div>
     </div>
   </form>

--- a/spec/components/feedback_spec.rb
+++ b/spec/components/feedback_spec.rb
@@ -33,15 +33,24 @@ describe "Feedback", type: :view do
     before do
       allow_any_instance_of(ActionDispatch::Request).to receive(:user_agent).and_return(ascii_agent)
       allow_any_instance_of(ActionDispatch::Request).to receive(:original_url).and_return(ascii_url)
-      render_component({})
     end
 
     it "encodes user-agents to UTF-8" do
+      render_component({})
+
       expect(response.body).to include(utf8_agent)
     end
 
     it "encodes URL params to UTF-8" do
+      render_component({})
+
       expect(response.body).to include(utf8_url)
+    end
+
+    it "doesn't encode if the user-agent is nil" do
+      allow_any_instance_of(ActionDispatch::Request).to receive(:user_agent).and_return(nil)
+
+      expect { render_component({}) }.to_not raise_error
     end
   end
 end


### PR DESCRIPTION
There is some potential, especially in tests, for these to be nil
which would throw errors when attempting to encode them to UTF-8.

Now we only encode if we are sure they are strings.

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

Paired with @Rosa-Fox 

---

Component guide for this PR:
https://govuk-publishing-compon-pr-677.herokuapp.com/component-guide/
