### PR TITLE
Limit hint styles to checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Put margin bottom on autocomplete (PR #680)
 * Adds hidden class to conditional reveals for radio to resolve flicker issue (PR #679)
+* Limit hint styles to checkboxes (PR #681)
 
 ## 13.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
@@ -43,9 +43,11 @@
   }
 }
 
-// this is complex but needed to override the govuk-frontend styles in
-// https://github.com/alphagov/govuk-frontend/blob/b8058640b9602ecb6e1f66f887553190cbae7b46/src/components/hint/_hint.scss#L16
-// our elements are wrapped in list items that already provide a margin-bottom
-.govuk-label:not(.govuk-label--m):not(.govuk-label--l):not(.govuk-label--xl) + .govuk-hint {
-  margin-bottom: 0;
+.gem-c-checkboxes {
+  // this is complex but needed to override the govuk-frontend styles in
+  // https://github.com/alphagov/govuk-frontend/blob/b8058640b9602ecb6e1f66f887553190cbae7b46/src/components/hint/_hint.scss#L16
+  // our elements are wrapped in list items that already provide a margin-bottom
+  .govuk-label:not(.govuk-label--m):not(.govuk-label--l):not(.govuk-label--xl) + .govuk-hint {
+    margin-bottom: 0;
+  }
 }


### PR DESCRIPTION
This changes a style in the checkboxes component relating to hints to limit it to just the checkboxes component. Previously it was too generic and was affecting the text input component as well.

--------

This rule was used in checkboxes in this context...

![screen shot 2018-12-19 at 09 15 45](https://user-images.githubusercontent.com/861310/50210736-ce10bc80-036e-11e9-8063-67959e5f0421.png)

Here the default margin bottom of 10px on the hints was needed to be removed because these nested checkboxes are already wrapped in a list item that has its own 10px margin bottom. Without this rule if the last nested checkbox had a hint the margin on it gave an extra 10px to the overall margin of the component, changing it from 30px to 40px.

Unfortunately this rule wasn't scoped to the checkboxes component, so it affected the text input as well, making it look like this:

![screen shot 2018-12-19 at 09 16 05](https://user-images.githubusercontent.com/861310/50210848-162fdf00-036f-11e9-970f-89d18be2f8c6.png)

...when it's supposed to look like this:

![screen shot 2018-12-19 at 09 16 18](https://user-images.githubusercontent.com/861310/50210859-1e881a00-036f-11e9-9339-728c50436af3.png)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-681.herokuapp.com/component-guide/
