### PR TITLE
Move all commonly used imports into _all_components.scss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Move all commonly used imports into all_components.scss (PR #683)
+
 ## 13.5.0
 
 * Allow heading on single checkbox (PR #686)

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -1,18 +1,27 @@
-// Include all of the GOV.UK Frontend styles. This includes fonts, and individual components.
-@import "components/helpers/govuk-frontend-settings";
-
 // This is the file that the application needs to include in order to use
 // the components.
+
+// Include all of the GOV.UK Frontend styles. This includes fonts, and individual components.
+
+@import "components/helpers/govuk-frontend-settings";
+
+// Include common imports used by many components
+@import "govuk-frontend/all";
 
 // `govuk_frontend_toolkit`
 @import "measurements";
 @import "grid_layout";
 @import "typography";
 @import "colours";
+@import "css3";
+
 @import "components/helpers/variables";
 @import "components/helpers/brand-colours";
 @import "components/mixins/media-down";
+@import "components/mixins/margins";
+@import "components/mixins/clearfix";
 
+// components
 @import "components/accessible-autocomplete";
 @import "components/back-link";
 @import "components/breadcrumbs";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
@@ -1,8 +1,3 @@
-@import "helpers/govuk-frontend-settings";
-@import "govuk-frontend/settings/all";
-@import "govuk-frontend/tools/all";
-@import "govuk-frontend/helpers/all";
-
 @import url(asset-path("accessible-autocomplete/dist/accessible-autocomplete.min.css"));
 
 .gem-c-accessible-autocomplete {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_back-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_back-link.scss
@@ -1,2 +1,1 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/back-link/back-link";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -1,4 +1,3 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/breadcrumbs/breadcrumbs";
 
 .gem-c-breadcrumbs--inverse .govuk-breadcrumbs__list-item .govuk-breadcrumbs__link {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -1,5 +1,3 @@
-@import "helpers/govuk-frontend-settings";
-@import "mixins/margins";
 @import "govuk-frontend/components/button/button";
 
 $gem-secondary-button-colour: #00823b;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_character-count.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_character-count.scss
@@ -1,3 +1,1 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/character-count/character-count";
-@import "govuk-frontend/objects/form-group";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
@@ -1,4 +1,3 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/checkboxes/checkboxes";
 
 .gem-c-checkbox.gem-c-checkbox--margin-bottom:last-child,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_details.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_details.scss
@@ -1,2 +1,1 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/details/details";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -1,6 +1,3 @@
-// `govuk_frontend_toolkit`
-@import "typography";
-
 .gem-c-document-list {
   @include govuk-text-colour;
   @include core-19;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-message.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-message.scss
@@ -1,2 +1,1 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/error-message/error-message";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -1,6 +1,3 @@
-// govuk_frontend_toolkit
-@import "grid_layout";
-
 .gem-c-feedback {
   max-width: 960px;
   margin: 0 auto;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_fieldset.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_fieldset.scss
@@ -1,6 +1,3 @@
-@import "helpers/variables";
-@import "mixins/clearfix";
-
 .gem-c-fieldset {
   margin: 0 0 $gem-spacing-scale-4;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_file-upload.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_file-upload.scss
@@ -1,3 +1,1 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/file-upload/file-upload";
-@import "govuk-frontend/objects/form-group";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_hint.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_hint.scss
@@ -1,2 +1,1 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/hint/hint";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -1,5 +1,3 @@
-@import 'grid_layout';
-
 .gem-c-image-card {
   // if this extends grid-row a margin-bottom can't
   // be applied as the extend overrides it

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -1,3 +1,1 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/input/input";
-@import "govuk-frontend/objects/form-group";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inset-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inset-text.scss
@@ -1,2 +1,1 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/inset-text/inset-text";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_label.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_label.scss
@@ -1,2 +1,1 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/label/label";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
@@ -1,2 +1,1 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/footer/footer";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-admin.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-admin.scss
@@ -1,2 +1,1 @@
-@import "helpers/govuk-frontend-settings";
-@import "govuk-frontend/all";
+// uses govuk-frontend/all

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -1,4 +1,3 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/header/header";
 @import "govuk-frontend/components/tag/tag";
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_lead-paragraph.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_lead-paragraph.scss
@@ -1,5 +1,3 @@
-@import "mixins/margins";
-
 .gem-c-lead-paragraph {
   @include govuk-text-colour;
   @include core-24;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_panel.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_panel.scss
@@ -1,2 +1,1 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/panel/panel";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
@@ -1,4 +1,3 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/phase-banner/phase-banner";
 
 .gem-c-phase-banner {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
@@ -1,6 +1,4 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/radios/radios";
-@import "govuk-frontend/objects/form-group";
 
 // This is here as it seems to have been missed from govuk-frontend
 // @FIXME if a colour has been added to govuk-radios__divider remove this

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
@@ -1,2 +1,1 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/select/select";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_skip-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_skip-link.scss
@@ -1,2 +1,1 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/skip-link/skip-link";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -1,6 +1,3 @@
-// govuk_frontend_toolkit
-@import 'css3';
-
 $stroke-width: 2px;
 $stroke-width-large: 3px;
 $number-circle-size: 26px;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_table.scss
@@ -1,8 +1,4 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/table/table";
-@import "govuk-frontend/core/links";
-@import "govuk-frontend/helpers/shape-arrow";
-@import "govuk-frontend/helpers/focusable";
 
 $table-border-width: 1px;
 $table-border-colour: govuk-colour("grey-2");

--- a/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
@@ -1,4 +1,3 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/tabs/tabs";
 
 .js-enabled {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
@@ -1,6 +1,4 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/textarea/textarea";
-@import "govuk-frontend/objects/form-group";
 
 .gem-c-textarea {
   margin-bottom: govuk-spacing(1);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_translation-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_translation-nav.scss
@@ -1,5 +1,3 @@
-@import "mixins/margins";
-
 .gem-c-translation-nav {
   @include responsive-top-margin;
   @include govuk-text-colour;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
@@ -1,4 +1,3 @@
-@import "helpers/govuk-frontend-settings";
 @import "govuk-frontend/components/warning-text/warning-text";
 
 .gem-c-warning-text__text--no-indent {


### PR DESCRIPTION
This is an experimental PR to move duplicate import lines such as `@import "components/helpers/govuk-frontend-settings";` out of individual SASS files and into the main application.scss file.

Advantages:

- no duplication
- easier to see in one place all of the things we import
- might compile fractionally quicker?

Disadvantages:

- doesn't impact overall compiled CSS size (actually it seems to have reduced it by 1KB, but that's probably immaterial as that saving is likely already achieved through gzipping)
- can't easily see which files use which imports, so if we stop using an import we might not know to remove it from application.scss

Would be good to get some feedback on whether people think this worth doing or not.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-683.herokuapp.com/component-guide/
