### PR TITLE
Change heading/legend/hint options on checkboxes component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change heading/legend/hint options on checkboxes component (PR #684)
+
 ## 13.3.0
 
 * Put margin bottom on autocomplete (PR #680)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
@@ -50,4 +50,8 @@
   .govuk-label:not(.govuk-label--m):not(.govuk-label--l):not(.govuk-label--xl) + .govuk-hint {
     margin-bottom: 0;
   }
+
+  .gem-c-checkboxes__legend--hidden {
+    @include govuk-visually-hidden();
+  }
 }

--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -8,43 +8,45 @@
     <%= cb_helper.checkbox_markup(cb_helper.items[0], 0) %>
 
   <% else %>
-    <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": cb_helper.fieldset_describedby do %>
-      <%= cb_helper.heading_markup %>
+    <% if cb_helper.heading_markup %>
+      <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": cb_helper.fieldset_describedby do %>
+        <%= cb_helper.heading_markup %>
 
-      <% if cb_helper.hint_text %>
-        <%= tag.span cb_helper.hint_text, id: "#{id}-hint", class: "govuk-hint" %>
-      <% end %>
+        <% if cb_helper.hint_text %>
+          <%= tag.span cb_helper.hint_text, id: "#{id}-hint", class: "govuk-hint" %>
+        <% end %>
 
-      <% if cb_helper.error %>
-        <%= tag.span error, id: "#{id}-error", class: "govuk-error-message" %>
-      <% end %>
+        <% if cb_helper.error %>
+          <%= tag.span error, id: "#{id}-error", class: "govuk-error-message" %>
+        <% end %>
 
-      <%= tag.ul class: "govuk-checkboxes gem-c-checkboxes__list", data: {
-        module: ('checkboxes' if cb_helper.has_conditional),
-        nested: ('true' if cb_helper.has_nested),
-      } do %>
-        <% cb_helper.items.each_with_index do |item, index| %>
-          <%= tag.li class: "gem-c-checkboxes__list-item" do %>
-            <%= cb_helper.checkbox_markup(item, index) %>
+        <%= tag.ul class: "govuk-checkboxes gem-c-checkboxes__list", data: {
+          module: ('checkboxes' if cb_helper.has_conditional),
+          nested: ('true' if cb_helper.has_nested),
+        } do %>
+          <% cb_helper.items.each_with_index do |item, index| %>
+            <%= tag.li class: "gem-c-checkboxes__list-item" do %>
+              <%= cb_helper.checkbox_markup(item, index) %>
 
-            <% if item[:conditional] %>
-              <%= tag.div item[:conditional], id: "#{id}-#{index}-conditional-#{index}", class: "govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" %>
-            <% end %>
+              <% if item[:conditional] %>
+                <%= tag.div item[:conditional], id: "#{id}-#{index}-conditional-#{index}", class: "govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" %>
+              <% end %>
 
-            <% if item[:items].present? %>
-              <%= tag.ul id: "#{id}-nested-#{index}", class: "govuk-checkboxes govuk-checkboxes--nested", data: { parent: "#{id}-#{index}" } do %>
-                <% item[:items].each_with_index do |nested_item, nested_index| %>
-                  <%= tag.li class: "gem-c-checkboxes__list-item" do %>
-                    <%= cb_helper.checkbox_markup(nested_item, "#{index}-#{nested_index}") %>
+              <% if item[:items].present? %>
+                <%= tag.ul id: "#{id}-nested-#{index}", class: "govuk-checkboxes govuk-checkboxes--nested", data: { parent: "#{id}-#{index}" } do %>
+                  <% item[:items].each_with_index do |nested_item, nested_index| %>
+                    <%= tag.li class: "gem-c-checkboxes__list-item" do %>
+                      <%= cb_helper.checkbox_markup(nested_item, "#{index}-#{nested_index}") %>
+                    <% end %>
                   <% end %>
                 <% end %>
               <% end %>
-            <% end %>
 
+            <% end %>
           <% end %>
         <% end %>
-      <% end %>
 
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -71,6 +71,17 @@ examples:
           value: "green"
         - label: "Blue"
           value: "blue"
+  without_hint_text:
+    description: Hint text defaults to 'Select all that apply'. This can be removed entirely with this option.
+    data:
+      name: "favourite_skittle"
+      heading: "What is your favourite skittle?"
+      no_hint_text: true
+      items:
+        - label: "Mauve"
+          value: "mauve"
+        - label: "Sunset orange"
+          value: "sunsetorange"
   with_legend_as_page_heading:
     description: Since the legend/heading is required, if the checkboxes are alone on a page it makes sense to use this element as the H1 on the page rather than duplicate text.
     data:

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -35,6 +35,19 @@ examples:
           value: "green"
         - label: "Blue"
           value: "blue"
+  with_a_hidden_heading:
+    description: If the heading/legend on the checkboxes is not required, it can be visually hidden using this option. It will still be visible to screen readers.
+    data:
+      name: "favourite_colour"
+      heading: "What is your favourite colour?"
+      visually_hide_heading: true
+      items:
+        - label: "Red"
+          value: "red"
+        - label: "Green"
+          value: "green"
+        - label: "Blue"
+          value: "blue"
   with_a_custom_id_attribute:
     description: Note that if an id is not given one is generated automatically. In either case, the id is applied to the parent element of the checkboxes, and each checkbox is given the same id with an incremented number at the end, e.g. the checkboxes below have ids of potatoes-0 and potatoes-1.
     data:
@@ -59,7 +72,7 @@ examples:
         - label: "Purple"
           value: "purple"
   with_custom_hint_text:
-    description: Note that a hint (and a heading) is only displayed if there is more than one checkbox.
+    description: Hint text defaults to 'Select all that apply' but can be overridden with this option. Note that a hint (and a heading) is only displayed if there is more than one checkbox.
     data:
       name: "favourite_skittle"
       heading: "What is your favourite skittle?"
@@ -72,10 +85,11 @@ examples:
         - label: "Blue"
           value: "blue"
   without_hint_text:
-    description: Hint text defaults to 'Select all that apply'. This can be removed entirely with this option.
+    description: Hint text can be removed entirely with this option. Note that this option can be combined with the visually_hide_heading option, as shown.
     data:
       name: "favourite_skittle"
       heading: "What is your favourite skittle?"
+      visually_hide_heading: true
       no_hint_text: true
       items:
         - label: "Mauve"

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
       include ActionView::Helpers
       include ActionView::Context
 
-      attr_reader :items, :name, :css_classes, :error, :has_conditional, :has_nested, :id, :hint_text, :no_hint_text
+      attr_reader :items, :name, :css_classes, :error, :has_conditional, :has_nested, :id, :hint_text
 
       def initialize(options)
         @items = options[:items] || []
@@ -22,15 +22,16 @@ module GovukPublishingComponents
         @is_page_heading = options[:is_page_heading]
         @no_hint_text = options[:no_hint_text]
         @hint_text = options[:hint_text] || "Select all that apply." unless @no_hint_text
+        @visually_hide_heading = options[:visually_hide_heading]
       end
 
       def fieldset_describedby
-        return if @no_hint_text
-
-        text = %w()
-        text << "#{id}-hint" if @hint_text
-        text << "#{id}-error" if @error
-        text
+        unless @no_hint_text
+          text = %w()
+          text << "#{id}-hint" if @hint_text
+          text << "#{id}-error" if @error
+          text
+        end
       end
 
       def heading_markup
@@ -44,7 +45,10 @@ module GovukPublishingComponents
             content_tag(:h1, @heading, class: "gem-c-title__text")
           end
         else
-          content_tag(:legend, @heading, class: "govuk-fieldset__legend govuk-fieldset__legend--m")
+          classes = %w(govuk-fieldset__legend govuk-fieldset__legend--m)
+          classes << "gem-c-checkboxes__legend--hidden" if @visually_hide_heading
+
+          content_tag(:legend, @heading, class: classes)
         end
       end
 

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
       include ActionView::Helpers
       include ActionView::Context
 
-      attr_reader :items, :name, :css_classes, :error, :has_conditional, :has_nested, :id, :hint_text
+      attr_reader :items, :name, :css_classes, :error, :has_conditional, :has_nested, :id, :hint_text, :no_hint_text
 
       def initialize(options)
         @items = options[:items] || []
@@ -20,10 +20,13 @@ module GovukPublishingComponents
         @id = options[:id] || "checkboxes-#{SecureRandom.hex(4)}"
         @heading = options[:heading]
         @is_page_heading = options[:is_page_heading]
-        @hint_text = options[:hint_text] || "Select all that apply."
+        @no_hint_text = options[:no_hint_text]
+        @hint_text = options[:hint_text] || "Select all that apply." unless @no_hint_text
       end
 
       def fieldset_describedby
+        return if @no_hint_text
+
         text = %w()
         text << "#{id}-hint" if @hint_text
         text << "#{id}-error" if @error

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -36,6 +36,34 @@ describe "Checkboxes", type: :view do
     assert_select ".govuk-label", text: "Green"
   end
 
+  it "renders nothing if no heading is supplied" do
+    render_component(
+      name: "favourite_colour",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+      ]
+    )
+    assert_select "fieldset.govuk-fieldset", false
+    assert_select "legend", false
+    assert_select "legend h1", false
+    assert_select ".govuk-hint", false
+    assert_select ".govuk-checkboxes", false
+  end
+
+  it "renders a hidden heading/legend" do
+    render_component(
+      name: "favourite_colour",
+      heading: "What is your favourite colour?",
+      visually_hide_heading: true,
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+      ]
+    )
+    assert_select ".govuk-fieldset__legend.gem-c-checkboxes__legend--hidden", text: "What is your favourite colour?"
+  end
+
   it "renders checkboxes with a given id" do
     render_component(
       id: "favourite-colour",
@@ -54,6 +82,7 @@ describe "Checkboxes", type: :view do
     assert_select ".govuk-checkboxes__label[for='favourite-colour-1']", text: "Green"
     assert_select ".govuk-checkboxes__input#favourite-colour-2"
     assert_select ".govuk-checkboxes__label[for='favourite-colour-2']", text: "Blue"
+    assert_select ".govuk-fieldset[aria-describedby='favourite-colour-hint']"
   end
 
   it "renders checkboxes with individual ids" do
@@ -79,6 +108,7 @@ describe "Checkboxes", type: :view do
   it "renders checkboxes with a custom hint" do
     render_component(
       name: "favourite_colour",
+      heading: "What is your favourite skittle?",
       hint_text: "Choose carefully",
       items: [
         { label: "Red", value: "red" },

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -88,6 +88,19 @@ describe "Checkboxes", type: :view do
     assert_select ".govuk-hint", text: "Choose carefully"
   end
 
+  it "renders checkboxes with no hint" do
+    render_component(
+      name: "favourite_colour",
+      no_hint_text: true,
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+      ]
+    )
+    assert_select ".govuk-hint", false
+    assert_select ".govuk-fieldset[aria-describedby]", false
+  end
+
   it "does not render a hint or heading if there is only one checkbox" do
     render_component(
       name: "favourite_colour",


### PR DESCRIPTION
This PR changes the checkboxes component as follows:

- makes the heading (legend) text option mandatory, without which the component will fail to render, as this is an accessibility violation
- provides an option to make the heading (legend) visually hidden if not required
- provides an option to make hint text optional

---

Component guide for this PR:
https://govuk-publishing-compon-pr-684.herokuapp.com/component-guide/checkboxes
