### PR TITLE
Allow heading on single checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow heading on single checkbox (PR #686)
+
 ## 13.4.0
 
 * Change heading/legend/hint options on checkboxes component (PR #684)

--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -4,10 +4,7 @@
 %>
 
 <%= tag.div id: id, class: cb_helper.css_classes, data: { module: "checkboxes" } do %>
-  <% if cb_helper.items.length == 1 %>
-    <%= cb_helper.checkbox_markup(cb_helper.items[0], 0) %>
-
-  <% else %>
+  <% if cb_helper.should_have_fieldset %>
     <% if cb_helper.heading_markup %>
       <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": cb_helper.fieldset_describedby do %>
         <%= cb_helper.heading_markup %>
@@ -41,12 +38,13 @@
                   <% end %>
                 <% end %>
               <% end %>
-
             <% end %>
           <% end %>
         <% end %>
-
       <% end %>
     <% end %>
+
+  <% else %>
+    <%= cb_helper.checkbox_markup(cb_helper.items[0], 0) %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -11,11 +11,8 @@ accessibility_criteria: |
   - be usable with touch
   - indicate when they have focus
   - have correctly associated labels
-  - have a legend (see below)
 
   Labels use the [label component](/component-guide/label).
-
-  Checkboxes in a fieldset require a legend. The text of the legend is passed using the 'heading' option. If no heading is passed, no legend is shown, which causes an accessibility error. You must pass a heading when using this component, or provide other measures to ensure accessibility.
 examples:
   default:
     data:
@@ -35,6 +32,38 @@ examples:
           value: "green"
         - label: "Blue"
           value: "blue"
+  with_a_heading_on_one_checkbox:
+    description: One checkbox does not require a fieldset and therefore does not require a legend. However, if a heading is supplied, a fieldset will be included in the component and the heading used as the legend, as shown.
+    data:
+      name: "agree"
+      heading: "Please tick the box to agree"
+      items:
+        - label: "I agree"
+          value: "agree"
+  with_custom_hint_text:
+    description: Hint text defaults to 'Select all that apply' but can be overridden with this option. Note that a hint (and a heading) is only displayed if there is more than one checkbox.
+    data:
+      name: "favourite_skittle"
+      heading: "What is your favourite skittle?"
+      hint_text: "Taste the rainbow"
+      items:
+        - label: "Red"
+          value: "red"
+        - label: "Green"
+          value: "green"
+        - label: "Blue"
+          value: "blue"
+  without_hint_text:
+    description: Hint text can be removed entirely with this option. Note that this option can be combined with the visually_hide_heading option.
+    data:
+      name: "favourite_skittle"
+      heading: "What is your favourite skittle?"
+      no_hint_text: true
+      items:
+        - label: "Mauve"
+          value: "mauve"
+        - label: "Sunset orange"
+          value: "sunsetorange"
   with_a_hidden_heading:
     description: If the heading/legend on the checkboxes is not required, it can be visually hidden using this option. It will still be visible to screen readers.
     data:
@@ -71,31 +100,6 @@ examples:
           id: "custom-orange-id"
         - label: "Purple"
           value: "purple"
-  with_custom_hint_text:
-    description: Hint text defaults to 'Select all that apply' but can be overridden with this option. Note that a hint (and a heading) is only displayed if there is more than one checkbox.
-    data:
-      name: "favourite_skittle"
-      heading: "What is your favourite skittle?"
-      hint_text: "Taste the rainbow"
-      items:
-        - label: "Red"
-          value: "red"
-        - label: "Green"
-          value: "green"
-        - label: "Blue"
-          value: "blue"
-  without_hint_text:
-    description: Hint text can be removed entirely with this option. Note that this option can be combined with the visually_hide_heading option, as shown.
-    data:
-      name: "favourite_skittle"
-      heading: "What is your favourite skittle?"
-      visually_hide_heading: true
-      no_hint_text: true
-      items:
-        - label: "Mauve"
-          value: "mauve"
-        - label: "Sunset orange"
-          value: "sunsetorange"
   with_legend_as_page_heading:
     description: Since the legend/heading is required, if the checkboxes are alone on a page it makes sense to use this element as the H1 on the page rather than duplicate text.
     data:

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -18,11 +18,17 @@ module GovukPublishingComponents
         @has_nested = options[:items].any? { |item| item.is_a?(Hash) && item[:items] }
 
         @id = options[:id] || "checkboxes-#{SecureRandom.hex(4)}"
-        @heading = options[:heading]
+        @heading = options[:heading] || nil
         @is_page_heading = options[:is_page_heading]
         @no_hint_text = options[:no_hint_text]
         @hint_text = options[:hint_text] || "Select all that apply." unless @no_hint_text
         @visually_hide_heading = options[:visually_hide_heading]
+      end
+
+      # should have a fieldset if there's a heading, or if more than one checkbox
+      # separate check is in the view for if more than one checkbox and no heading, in which case fail
+      def should_have_fieldset
+        @items.length > 1 || @heading
       end
 
       def fieldset_describedby

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -51,6 +51,17 @@ describe "Checkboxes", type: :view do
     assert_select ".govuk-checkboxes", false
   end
 
+  it "shows a heading/legend if supplied with only one checkbox" do
+    render_component(
+      name: "favourite_colour",
+      heading: "Favourite colour?",
+      items: [
+        { label: "Red", value: "red" },
+      ]
+    )
+    assert_select ".govuk-fieldset__legend", text: "Favourite colour?"
+  end
+
   it "renders a hidden heading/legend" do
     render_component(
       name: "favourite_colour",
@@ -134,14 +145,12 @@ describe "Checkboxes", type: :view do
   it "does not render a hint or heading if there is only one checkbox" do
     render_component(
       name: "favourite_colour",
-      heading: "What is your favourite colour?",
-      hint_text: "Choose carefully",
       items: [
         { label: "Red", value: "red" },
       ]
     )
-    assert_select ".govuk-hint", false
     assert_select ".govuk-fieldset__legend", false
+    assert_select ".govuk-hint", false
   end
 
   it "renders checkboxes with the legend as the page heading" do


### PR DESCRIPTION
- there is a requirement to have a heading/legend on a single checkbox, so if a heading is passed, render it

---

Component guide for this PR:
https://govuk-publishing-compon-pr-686.herokuapp.com/component-guide/checkboxes
