### PR TITLE
Org schemas: prefer description over body

### DIFF
--- a/lib/govuk_publishing_components/presenters/machine_readable/organisation_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/organisation_schema.rb
@@ -17,7 +17,7 @@ module GovukPublishingComponents
             "@id" => page.canonical_url,
           },
           "name" => page.title,
-          "description" => page.body
+          "description" => page.description || page.body
         }.merge(parent_organisations).merge(sub_organisations)
       end
 

--- a/spec/lib/presenters/schema_org_spec.rb
+++ b/spec/lib/presenters/schema_org_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
     it "generates schema.org GovernmentOrganization" do
       content_item = generate_org(
         "base_path" => "/ministry-of-magic",
-        "title" => "Ministry of Magic"
+        "title" => "Ministry of Magic",
+        "description" => "The magical ministry."
       )
 
       structured_data = generate_structured_data(
@@ -57,6 +58,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
 
       expect(structured_data["@type"]).to eq("GovernmentOrganization")
       expect(structured_data["name"]).to eq("Ministry of Magic")
+      expect(structured_data["description"]).to eq("The magical ministry.")
       expect(structured_data["mainEntityOfPage"]["@id"]).to eq("http://www.dev.gov.uk/ministry-of-magic")
     end
 


### PR DESCRIPTION
They contain the same text, but the body contains markup which is possibly best to avoid for schema text.

The description is not always populated at present, so we still allow fallback.

Related to https://github.com/alphagov/whitehall/pull/4569