### PR TITLE
Tweak "about" in Article schema

### DIFF
--- a/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
@@ -141,7 +141,7 @@ module GovukPublishingComponents
         live_taxons.map do |taxon|
           {
               "@context" => "http://schema.org",
-              "@type" => "CreativeWork",
+              "@type" => "Thing",
               "sameAs" => taxon["web_url"]
           }
         end

--- a/spec/lib/presenters/schema_org_spec.rb
+++ b/spec/lib/presenters/schema_org_spec.rb
@@ -234,12 +234,12 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
       expect(structured_data['about']).to eql([
                                                  {
                                                      "@context" => "http://schema.org",
-                                                     "@type" => "CreativeWork",
+                                                     "@type" => "Thing",
                                                      "sameAs" => "https://www.gov.uk/education/becoming-an-apprentice"
                                                  },
                                                  {
                                                      "@context" => "http://schema.org",
-                                                     "@type" => "CreativeWork",
+                                                     "@type" => "Thing",
                                                      "sameAs" => "https://www.gov.uk/employment/finding-job"
                                                  }
                                              ])
@@ -260,7 +260,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
       expect(structured_data['about']).to eql([
                                                   {
                                                       "@context" => "http://schema.org",
-                                                      "@type" => "CreativeWork",
+                                                      "@type" => "Thing",
                                                       "sameAs" => "https://www.gov.uk/education/becoming-an-apprentice"
                                                   }
                                               ])


### PR DESCRIPTION
A topic is more of a "Thing" than it is a "CreativeWork". I'm not sure what difference this will actually make, but it seems conceptually better to me.

I think this is small enough to not need an entry in the change log