### PR TITLE
Add tracking to select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Improve autocomplete appearance without js (PR #695)
+* Adds tracking to select component (PR #690)
 
 ## 13.5.1
 

--- a/app/assets/javascripts/govuk_publishing_components/components/select.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/select.js
@@ -1,0 +1,50 @@
+window.GOVUK = window.GOVUK || {};
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  'use strict';
+
+  Modules.TrackSelectChange = function () {
+    this.start = function (element) {
+      element.change(function(e) {
+        var selectedOption = $(this).find(":selected");
+        var trackable = '[data-track-category][data-track-action]';
+
+        if (selectedOption.is(trackable)) {
+          fireTrackingChange(selectedOption);
+        }
+      });
+
+      function fireTrackingChange(element) {
+        var options = {transport: 'beacon'},
+            category = element.attr('data-track-category'),
+            action = element.attr('data-track-action'),
+            label = element.attr('data-track-label'),
+            value = element.attr('data-track-value'),
+            dimension = element.attr('data-track-dimension'),
+            dimensionIndex = element.attr('data-track-dimension-index'),
+            extraOptions = element.attr('data-track-options');
+
+        if (label) {
+          options.label = label;
+        }
+
+        if (value) {
+          options.value = value;
+        }
+
+        if (dimension && dimensionIndex) {
+          options['dimension' + dimensionIndex] = dimension;
+        }
+
+        if (extraOptions) {
+          $.extend(options, JSON.parse(extraOptions));
+        }
+
+        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+          GOVUK.analytics.trackEvent(category, action, options);
+        }
+      };
+    };
+  };
+})(window.GOVUK.Modules);

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -4,13 +4,14 @@
   label ||= false
 
   select_helper = GovukPublishingComponents::Presenters::SelectHelper.new(options)
+  data_module = "data-module=track-select-change" unless select_helper.data_tracking?.eql?(false)
 %>
 <% if options.any? && id && label %>
   <div class="govuk-form-group gem-c-select">
     <label class="govuk-label" for="<%= id %>">
       <%= label %>
     </label>
-    <select class="govuk-select" id="<%= id %>" name="<%= id %>">
+    <select class="govuk-select" id="<%= id %>" name="<%= id %>" <%= data_module %> >
       <%= options_for_select(select_helper.option_markup, select_helper.selected_option) %>
     </select>
   </div>

--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -31,25 +31,52 @@ examples:
         selected: true
       - text: 'Option three'
         value: 'option3'
-  with_data_attributes:
-    description: Data attributes can be added to the option elements of the select. Note that the component will not do anything with them - Javascript will have to be added in the application that uses the component, for example to fire tracking events.
+  with_tracking:
+    description: 'Tracking can be enabled on the select component by passing a minimum of data_track_category and data_track_action. Other tracking attributes are optional. Note: tracking events do not currently fire within the component guide.'
     data:
       id: 'dropdown3'
+      label: 'With tracking enabled'
+      options:
+      - text: 'Option one'
+        value: 'option1'
+        data_attributes:
+          track_category: 'relatedLinkClicked'
+          track_action: 1.1
+          track_label: '/link-1'
+          track_options:
+            dimension28: 1
+            dimension29: 'Link 1'
+      - text: 'Option two'
+        value: 'option2'
+        data_attributes:
+          track_category: 'relatedLinkClicked'
+          track_action: 1.2
+          track_label: '/link-2'
+          track_options:
+            dimension28: 2
+            dimension29: 'Link 2'
+      - text: 'Option three'
+        value: 'option3'
+        data_attributes:
+          track_category: 'relatedLinkClicked'
+          track_action: 1.3
+          track_label: '/link-3'
+          track_options:
+            dimension28: 3
+            dimension29: 'Link 3'
+  with_data_attributes:
+    description: Other data attributes can be passed to the component if needed.
+    data:
+      id: 'dropdown4'
       label: 'With data attributes'
       options:
       - text: 'Option one'
         value: 'option1'
         data_attributes:
-          track_category: "hello"
-          something_else: "moo"
+          another_attribute: "attribute 1"
+          something_else: "attribute 2"
       - text: 'Option two'
         value: 'option2'
       - text: 'Option three'
         value: 'option3'
-        data_attributes:
-          track_category: 'navDocumentCollectionLinkClicked'
-          track_action: 1.1
-          track_label: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
-          track_options:
-            dimension28: 2
-            dimension29: 'School behaviour and attendance: parental responsibility measures'
+

--- a/lib/govuk_publishing_components/presenters/select.rb
+++ b/lib/govuk_publishing_components/presenters/select.rb
@@ -8,6 +8,10 @@ module GovukPublishingComponents
         @option_markup = get_options
       end
 
+      def data_tracking?
+        @options.any? { |item| item[:data_attributes] && item[:data_attributes][:track_category] && item[:data_attributes][:track_action] }
+      end
+
     private
 
       def get_options
@@ -31,6 +35,7 @@ module GovukPublishingComponents
           key_name = "data-#{key.to_s.split('_').join('-')}"
           attrs[key_name] = value.is_a?(Hash) ? value.to_json : value
         end
+
         attrs
       end
     end

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -104,6 +104,29 @@ describe "Select", type: :view do
     assert_select ".govuk-select option[value=medium][selected]"
   end
 
+  it "enables tracking if track_category and track_action passed" do
+    render_component(
+      id: "mydropdown",
+      label: "attributes",
+      options: [
+        {
+          value: 1,
+          text: "One",
+          data_attributes: {
+            track_category: "category",
+            track_action: "action",
+            track_options: {
+              dimension28: 28,
+              dimension29: "twentynine"
+            }
+          }
+        }
+      ]
+    )
+
+    assert_select ".gem-c-select [data-module=track-select-change]"
+  end
+
   it "renders a select with data attributes" do
     render_component(
       id: "mydropdown",
@@ -125,5 +148,26 @@ describe "Select", type: :view do
     )
 
     assert_select ".govuk-select option[value=1][data-track-category='category'][data-track-action='action'][data-track-options='{\"dimension28\":28,\"dimension29\":\"twentynine\"}']"
+  end
+
+  it "does not enable tracking for other data attributes" do
+    render_component(
+      id: "mydropdown",
+      label: "attributes",
+      options: [
+        {
+          value: 1,
+          text: "One",
+          data_attributes: {
+            another_attribute: "test1",
+            second_item: "item1",
+            option: "option1"
+          }
+        }
+      ]
+    )
+
+    assert_select ".gem-c-select [data-module=track-select-change]", false
+    assert_select ".gem-c-select [data-another-attribute=test1][data-second-item=item1][data-option=option1]"
   end
 end

--- a/spec/javascripts/components/select-spec.js
+++ b/spec/javascripts/components/select-spec.js
@@ -1,0 +1,43 @@
+describe('Track select change', function () {
+
+  var GOVUK = window.GOVUK || {};
+  var tracker;
+  var $element;
+
+  GOVUK.analytics = {
+    trackEvent: function () {}
+  };
+
+  beforeEach(function () {
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    $element = $(
+      '<select id="taxon-list" name="taxon-list" data-module="track-select-change"' +
+        '<option value="">All topics</option>' +
+        '<option data-track-category="filterClicked" data-track-action="taxon-list" data-track-label="Social care" value="7d67047c-bf22-4c34-b566-b46d6973f961">Social care</option>' +
+        '<option data-track-label="Social care" value="no-data-attributes">No data attributes</option>' +
+      '</select>'
+    );
+
+    tracker = new GOVUK.Modules.TrackSelectChange();
+    tracker.start($element);
+  });
+
+  afterEach(function () {
+    GOVUK.analytics.trackEvent.calls.reset();
+  });
+
+  it('tracks when the selected value is changed', function () {
+    $element.val("7d67047c-bf22-4c34-b566-b46d6973f961").change();
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'filterClicked', 'taxon-list', { transport: 'beacon', label: "Social care" }
+    )
+  });
+
+  it('does not fire an event if track category and track action are not present', function() {
+    $element.val("no-data-attributes").change();
+
+    expect(GOVUK.analytics.trackEvent.calls.count()).toEqual(0)
+  });
+})


### PR DESCRIPTION
Trello: https://trello.com/c/5iPpo7IR/193-add-tracking-to-topic-subtopic-facet

Enables tracking on the select component if track_category and track_action passed.

Component guide for this PR:
https://govuk-publishing-compon-pr-690.herokuapp.com/component-guide/select
