### PR TITLE
allow navigation items to only show in collapsed menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* allow navigation items to only show in collapsed menu (PR #691)
+
 ## 13.5.3
 
 * Update error-summary component to use govuk-frontend styles (PR #692)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -54,3 +54,9 @@
   background-color: govuk-colour("yellow");
   color: govuk-colour("black");
 }
+
+.govuk-header__navigation-item--collapsed-menu-only {
+  @include govuk-media-query($from: desktop) {
+    display: none;
+  }
+}

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -40,7 +40,8 @@
     <nav>
       <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
         <% navigation_items.each_with_index do |item, index| %>
-          <li class="govuk-header__navigation-item <%= "govuk-header__navigation-item--active" if item[:active] %>">
+          <li class="govuk-header__navigation-item <%= "govuk-header__navigation-item--active" if item[:active] %>
+            <%= "govuk-header__navigation-item--collapsed-menu-only" if item[:show_only_in_collapsed_menu] %>">
             <%= link_to(
               item[:text],
               item[:href],

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -31,6 +31,9 @@ examples:
         active: true
       - text: Navigation item 2
         href: "#2"
+      - text: Hidden on desktop
+        href: "#3"
+        show_only_in_collapsed_menu: true
   full_width:
     description: |
       This is difficult to preview because the preview windows are constrained, but the header will stretch to the size of its container.

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -41,11 +41,13 @@ describe "Layout header", type: :view do
     navigation_items = [
       { text: "Foo", href: "/foo", active: true },
       { text: "Bar", href: "/bar" },
+      { text: "Hello", href: "/hello", show_only_in_collapsed_menu: true },
     ]
 
     render_component(environment: "staging", navigation_items: navigation_items)
 
     assert_select ".govuk-header__navigation-item.govuk-header__navigation-item--active", text: "Foo"
     assert_select ".govuk-header__navigation-item", text: "Bar"
+    assert_select ".govuk-header__navigation-item.govuk-header__navigation-item--collapsed-menu-only", text: "Hello"
   end
 end


### PR DESCRIPTION
Needed for https://github.com/alphagov/content-publisher/pull/647

## Why this is needed

On the content publisher app there are two navigations, primary (layout_header component) and secondary (phase banner component).

On mobile view the phase banner hides the navigation items, however, these still need to be accessible for mobile users. Therefore, we need to add them to the primary navigation bar and hide them unless it's on mobile.

## See screenshots for further information:

### Desktop
<img width="1065" alt="screen shot 2019-01-02 at 16 46 55" src="https://user-images.githubusercontent.com/4599889/50602003-f1c71d00-0ead-11e9-9a22-0aa66fe68edc.png">

### Mobile
<img width="744" alt="screen shot 2019-01-02 at 16 39 52" src="https://user-images.githubusercontent.com/4599889/50602013-fab7ee80-0ead-11e9-9268-6dc315798539.png">


---

Component guide for this PR:
https://govuk-publishing-compon-pr-691.herokuapp.com/component-guide/
