### PR TITLE
Add value check to accessible autocomplete custom onConfirm function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add value check to accessible autocomplete custom onConfirm function (PR #693)
 * Move all commonly used imports into all_components.scss (PR #683)
 
 ## 13.5.0

--- a/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
@@ -26,7 +26,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         // update the hidden select if the onConfirm function is supplied
         // https://github.com/alphagov/accessible-autocomplete/issues/322
         var value = $selectElem.children("option").filter(function () { return $(this).html() == label; }).val();
-        $selectElem.val(value).trigger( "change" );
+        if (typeof value !== 'undefined') {
+          $selectElem.val(value).trigger( "change" );
+        }
       };
 
       new accessibleAutocomplete.enhanceSelectElement(configOptions);


### PR DESCRIPTION
Use of the accessible autocomplete component in finders required a custom onConfirm function, which was [causing this problem](https://github.com/alphagov/accessible-autocomplete/issues/322).

However, this change was causing the value of the hidden select to be reset to nothing when the blur event occurred on the autocomplete. This PR adds a check to only update the value of the select if the value is not undefined.

This change is necessary for https://github.com/alphagov/finder-frontend/pull/740

---

Component guide for this PR:
https://govuk-publishing-compon-pr-693.herokuapp.com/component-guide/accessible_autocomplete
