### PR TITLE
Improve autocomplete appearance without js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Improve autocomplete appearance without js (PR #695)
+
 ## 13.5.1
 
 * Add value check to accessible autocomplete custom onConfirm function (PR #693)

--- a/app/views/govuk_publishing_components/components/_accessible_autocomplete.html.erb
+++ b/app/views/govuk_publishing_components/components/_accessible_autocomplete.html.erb
@@ -18,6 +18,7 @@
         select_tag(
           id,
           options_for_select(options, selected_option),
+          class: "govuk-select",
           data: data_attributes
         )
       %>

--- a/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
+++ b/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
@@ -13,7 +13,7 @@ examples:
     data:
       label:
         text: 'Countries'
-      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us']]
+      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us'], ['The Separate Customs Territory of Taiwan, Penghu, Kinmen, and Matsu (Chinese Taipei)', 'tw']]
   with_unique_identifier:
     data:
       id: 'unique-autocomplete'


### PR DESCRIPTION
The accessible autocomplete component is now being used in finders. When Javascript is disabled it falls back to displaying a standard select element. Unfortunately this is unstyled, so it can look like this...

**Before**

![screen shot 2019-01-03 at 11 37 00](https://user-images.githubusercontent.com/861310/50635967-3c977200-0f4c-11e9-824e-0ccf30608a67.png)

This PR adds the `govuk-select` style to these selects, so they look a lot better when JS is disabled:

**After**

![screen shot 2019-01-03 at 11 36 32](https://user-images.githubusercontent.com/861310/50635986-533dc900-0f4c-11e9-9011-19fbc5e630cb.png)

I tried to use the existing select component inside the autocomplete component to achieve this, but the options available on that component weren't compatible, so it seemed simpler to just add the class, as I've done.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-695.herokuapp.com/component-guide/accessible_autocomplete
