### PR TITLE
Don't send the `user_agent` in survey form

### DIFF
--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -141,7 +141,6 @@
         <div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>
 
         <input type="hidden" name="url" value="<%= utf_encode(stripped_path) -%>">
-        <input type="hidden" name="user_agent" value="<%= utf_encode(user_agent) -%>">
 
         <input name="email_survey_signup[survey_id]" type="hidden" value="footer_satisfaction_survey">
         <input name="email_survey_signup[survey_source]" type="hidden" value="<%= utf_encode(stripped_path) -%>">

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -54,7 +54,6 @@ describe("Feedback component", function () {
             '<div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>' +
 
             '<input type="hidden" name="url" value="http://example.com/path/to/page">' +
-            '<input type="hidden" name="user_agent" value="Safari">' +
 
             '<h2 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h2>' +
             '<p class="gem-c-feedback__form-paragraph">To help us improve GOV.UK, we\'d like to know more about your visit today. We\'ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don\'t worry we won\'t send you spam or share your email address with anyone.</p>' +
@@ -473,8 +472,7 @@ describe("Feedback component", function () {
       expect(request.method).toBe('POST');
       expect(request.data()).toEqual({
         url: ["http://example.com/path/to/page"],
-        'email_survey_signup[email_address]': ["test@test.com"],
-        user_agent: ["Safari"]
+        'email_survey_signup[email_address]': ["test@test.com"]
       });
     });
 


### PR DESCRIPTION
We're currently adding the `user_agent` when the page is first requested. This is wrong because the page will be cached, so that any subsequent page requests will return the same HTML with the same form fields - and the previous request's user agent.

This commit removes the user agent, because we don't actually seem to be using it in the feedback application where it's sent to: the EmailSurveySignupController creates a `EmailSurveySignup` object, which sends the actual email. There's no usage of this `user_agent` anywhere.