### PR TITLE
Don't send user_agent in problem reports

### DIFF
--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -5,7 +5,6 @@
   email_regex = /[^\s=\/?&]+(?:@|%40)[^\s=\/?&]+/
   stripped_path = request.original_url.gsub(email_regex, '[email]')
   stripped_url = request.fullpath.gsub(email_regex, '[email]')
-  user_agent = request.user_agent
 
   def utf_encode element
     element.is_a?(String) ? element.encode : element
@@ -95,7 +94,6 @@
         <div class="gem-c-feedback__error-summary gem-c-feedback__js-show js-hidden js-errors" tabindex="-1"></div>
 
         <input type="hidden" name="url" value="<%= utf_encode(stripped_path) -%>">
-        <input type="hidden" name="user_agent" value="<%= utf_encode(user_agent) -%>">
 
         <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
         <p id="feedback_explanation" class="gem-c-feedback__form-paragraph">Don’t include personal or financial information like your National Insurance number or credit card details.</p>

--- a/spec/components/feedback_spec.rb
+++ b/spec/components/feedback_spec.rb
@@ -25,32 +25,17 @@ describe "Feedback", type: :view do
   end
 
   describe "ASCII characters" do
-    let(:ascii_agent)   { 'áscii_user_ágent%EE%90%80'.force_encoding('ASCII-8BIT') }
-    let(:utf8_agent)    { ascii_agent.encode }
     let(:ascii_url)     { 'http://www.test.com/test?áscii=%EE%90%80'.force_encoding('ASCII-8BIT') }
     let(:utf8_url)      { ascii_url.encode }
 
     before do
-      allow_any_instance_of(ActionDispatch::Request).to receive(:user_agent).and_return(ascii_agent)
       allow_any_instance_of(ActionDispatch::Request).to receive(:original_url).and_return(ascii_url)
-    end
-
-    it "encodes user-agents to UTF-8" do
-      render_component({})
-
-      expect(response.body).to include(utf8_agent)
     end
 
     it "encodes URL params to UTF-8" do
       render_component({})
 
       expect(response.body).to include(utf8_url)
-    end
-
-    it "doesn't encode if the user-agent is nil" do
-      allow_any_instance_of(ActionDispatch::Request).to receive(:user_agent).and_return(nil)
-
-      expect { render_component({}) }.to_not raise_error
     end
   end
 end

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -22,7 +22,6 @@ describe("Feedback component", function () {
             '<div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>' +
 
             '<input type="hidden" name="url" value="http://example.com/path/to/page">' +
-            '<input type="hidden" name="user_agent" value="Safari">' +
 
             '<h2 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h2>' +
             '<p class="gem-c-feedback__form-paragraph">Don\'t include personal or financial information like your National Insurance number or credit card details.</p>' +
@@ -372,7 +371,6 @@ describe("Feedback component", function () {
         url: ["http://example.com/path/to/page"],
         what_doing: ["I was looking for some information about local government."],
         what_wrong: ["The background should be green."],
-        user_agent: ["Safari"],
         referrer: ["unknown"],
         javascript_enabled: ["true"]
       });


### PR DESCRIPTION
This removes the `user_agent` from the problem report form that the user sees when clicking "Is there anything wrong with this page".

Like https://github.com/alphagov/govuk_publishing_components/pull/698, this is wrong because the page will be cached, so that any subsequent page requests will return the same HTML with the same form fields - and the previous request's user agent.

We can remove this field, because it turns out that the feedback application merges the sent `params` with `technical_attributes`, which [includes the correct user_agent](https://github.com/alphagov/feedback/blob/6f74a9a2887ceff3302a4e8f425aff715dbc3e4a/app/controllers/contact/govuk/problem_reports_controller.rb#L9).

I've confirmed this by creating a ticket with a spoofed UA and checking the support-api database for it.