### PR TITLE
Remove hidden `url` input from survey feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix issues with data submission in the Feedback component (#698, #699, #700)
+
 ## 13.5.2
 
 * Improve autocomplete appearance without js (PR #695)

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -138,8 +138,6 @@
       <div class="gem-c-feedback__column-two-thirds">
         <div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>
 
-        <input type="hidden" name="url" value="<%= utf_encode(stripped_path) -%>">
-
         <input name="email_survey_signup[survey_id]" type="hidden" value="footer_satisfaction_survey">
         <input name="email_survey_signup[survey_source]" type="hidden" value="<%= utf_encode(stripped_path) -%>">
         <input name="email_survey_signup[ga_client_id]" type="hidden" value="1627485790.1515403243">

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -52,8 +52,6 @@ describe("Feedback component", function () {
           '<div class="column-two-thirds">' +
             '<div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>' +
 
-            '<input type="hidden" name="url" value="http://example.com/path/to/page">' +
-
             '<h2 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h2>' +
             '<p class="gem-c-feedback__form-paragraph">To help us improve GOV.UK, we\'d like to know more about your visit today. We\'ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don\'t worry we won\'t send you spam or share your email address with anyone.</p>' +
 
@@ -469,7 +467,6 @@ describe("Feedback component", function () {
       expect(request.url).toBe('/contact/govuk/email-survey-signup');
       expect(request.method).toBe('POST');
       expect(request.data()).toEqual({
-        url: ["http://example.com/path/to/page"],
         'email_survey_signup[email_address]': ["test@test.com"]
       });
     });


### PR DESCRIPTION
This field doesn't seem to be used once it's posted to the feedback application. The controller only uses the `params[:
email_survey_signup]` hash, and not `params[:url]`. The existence of this field is probably accidental, since it duplicates `email_survey_signup[survey_source]`.

Related to https://github.com/alphagov/govuk_publishing_components/pull/698 https://github.com/alphagov/govuk_publishing_components/pull/699.