### PR TITLE
Clarify variable names for feedback component

### DIFF
--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -7,12 +7,12 @@
   end
 
   email_regex = /[^\s=\/?&]+(?:@|%40)[^\s=\/?&]+/
-  path_without_pii = utf_encode(request.original_url.gsub(email_regex, '[email]'))
-  url_without_pii = utf_encode(request.fullpath.gsub(email_regex, '[email]'))
+  url_without_pii = utf_encode(request.original_url.gsub(email_regex, '[email]'))
+  path_without_pii = utf_encode(request.fullpath.gsub(email_regex, '[email]'))
 %>
 
 <div class="gem-c-feedback <%= margin_top_class %>" data-module="feedback">
   <%= render "govuk_publishing_components/components/feedback/yes_no_banner" %>
-  <%= render "govuk_publishing_components/components/feedback/problem_form", path_without_pii: path_without_pii %>
-  <%= render "govuk_publishing_components/components/feedback/survey_signup_form", path_without_pii: path_without_pii, url_without_pii: url_without_pii %>
+  <%= render "govuk_publishing_components/components/feedback/problem_form", url_without_pii: url_without_pii %>
+  <%= render "govuk_publishing_components/components/feedback/survey_signup_form", url_without_pii: url_without_pii, path_without_pii: path_without_pii %>
 </div>

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -16,7 +16,7 @@
     <div class="gem-c-feedback__column-two-thirds">
       <div class="gem-c-feedback__error-summary gem-c-feedback__js-show js-hidden js-errors" tabindex="-1"></div>
 
-      <input type="hidden" name="url" value="<%= path_without_pii %>">
+      <input type="hidden" name="url" value="<%= url_without_pii %>">
 
       <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
       <p id="feedback_explanation" class="gem-c-feedback__form-paragraph">Don’t include personal or financial information like your National Insurance number or credit card details.</p>

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -17,7 +17,7 @@
       <div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>
 
       <input name="email_survey_signup[survey_id]" type="hidden" value="footer_satisfaction_survey">
-      <input name="email_survey_signup[survey_source]" type="hidden" value="<%= path_without_pii %>">
+      <input name="email_survey_signup[survey_source]" type="hidden" value="<%= url_without_pii %>">
       <input name="email_survey_signup[ga_client_id]" type="hidden" value="1627485790.1515403243">
 
       <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
@@ -35,7 +35,7 @@
       <%= render "govuk_publishing_components/components/button", {
         text: "Send me the survey"
       } %>
-      <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=<%= url_without_pii %>&amp;gcl=1627485790.1515403243" class="gem-c-feedback__email-link govuk-link" id="take-survey" target="_blank" rel="noopener noreferrer">Don’t have an email address?</a>
+      <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=<%= path_without_pii %>&amp;gcl=1627485790.1515403243" class="gem-c-feedback__email-link govuk-link" id="take-survey" target="_blank" rel="noopener noreferrer">Don’t have an email address?</a>
     </div>
   </div>
 </form>


### PR DESCRIPTION
These were actually misnamed in the original PR: the `url_without_pii` was the `path_without_pii`, and the reverse.