### PR TITLE
Add search filter to component guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add search to component guide (PR #706)
+
 ## 13.5.4
 
 * Allow navigation items to only show in collapsed menu (PR #691)
@@ -16,7 +20,6 @@
 
 * Update error-summary component to use govuk-frontend styles (PR #692)
 * Fix issues with data submission in the Feedback component (#698, #699, #700)
-=======
 
 ## 13.5.2
 

--- a/app/assets/javascripts/component_guide/filter-components.js
+++ b/app/assets/javascripts/component_guide/filter-components.js
@@ -1,0 +1,32 @@
+(function() {
+  window.GOVUK = window.GOVUK || {};
+
+  window.GOVUK.FilterComponents = function filterList(searchTerm) {
+    var itemsToFilter = document.querySelectorAll('.component-list li');
+
+    for (var i = 0; i < itemsToFilter.length; i++ ) {
+      var currentComponent = itemsToFilter[i];
+      var componentText = currentComponent.innerText.toLowerCase();
+
+      if (componentText.includes(searchTerm.toLowerCase())) {
+        currentComponent.classList.remove('component-guide-hidden');
+      } else {
+        currentComponent.classList.add('component-guide-hidden');
+      }
+    }
+  };
+
+  var formElement = document.querySelector('[data-module=filter-components]');
+
+  if (formElement) {
+    var searchField = formElement.querySelector('input');
+
+    // We don't want the form to submit/refresh the page on enter key
+    formElement.addEventListener('submit', function(e) { e.preventDefault(); });
+
+    searchField.addEventListener('input', function(e) {
+      var searchTerm = searchField.value;
+      window.GOVUK.FilterComponents(searchTerm);
+    });
+  }
+})();

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -24,8 +24,21 @@
   }
 }
 
+.component-search {
+  display: none;
+
+  .js-enabled & {
+    display: block;
+    margin-top: $govuk-gutter * 2;
+  }
+}
+
 .component-body {
   margin-bottom: $govuk-gutter * 1.5;
+}
+
+.component-guide-hidden {
+  display: none;
 }
 
 .component-doc {

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -10,6 +10,12 @@
   <p>See the <a href="https://github.com/alphagov/govuk_publishing_components">govuk_publishing_components gem</a> for further details, or <a href="https://docs.publishing.service.gov.uk/manual/components.html#component-guides">a list of all component guides</a>.</p>
 </div>
 
+<form role="search" data-module="filter-components" class="component-search">
+  <%= render "govuk_publishing_components/components/search", {
+    label_text: "Search components"
+  } %>
+</form>
+
 <h2 class="component-doc-h2">Components in this application</h2>
 
 <ul class="component-list">

--- a/spec/javascripts/govuk_publishing_components/FilterComponentsSpec.js
+++ b/spec/javascripts/govuk_publishing_components/FilterComponentsSpec.js
@@ -1,0 +1,72 @@
+/* global describe, afterEach, it, expect */
+
+var FilterComponents = window.GOVUK.FilterComponents;
+
+function addFormInput() {
+  var form = document.createElement('form');
+  form.setAttribute('data-module', 'filter-components');
+  document.body.appendChild(form);
+};
+
+function addComponents() {
+  var list = document.createElement('ul');
+  list.classList.add("component-list");
+
+  // Set up accordion component
+  var accordionLi = document.createElement('li');
+  var accordionLink = document.createElement('a');
+  var accordionP = document.createElement('p');
+  accordionLink.innerText = "Accordion";
+  accordionP.innerText = "A group of expanding/collapsing sections";
+  accordionLi.setAttribute('id', 'accordion');
+  accordionLi.appendChild(accordionP);
+  accordionLi.appendChild(accordionLink);
+
+  // Set up back link component
+  var backLinkLi = document.createElement('li');
+  var backLink = document.createElement('a');
+  var backLinkP = document.createElement('p');
+  backLink.innerText = "Back link";
+  backLinkP.innerText = "A link used to help users get back, useful when not using other navigation such as breadcrumbs";
+  backLinkLi.setAttribute('id', 'back-link');
+  backLinkLi.appendChild(backLinkP);
+  backLinkLi.appendChild(backLink);
+
+  list.appendChild(accordionLi);
+  list.appendChild(backLinkLi);
+
+  document.body.appendChild(list);
+};
+
+describe('FilterComponents', function() {
+  beforeAll(function() {
+    addFormInput();
+    addComponents();
+  });
+
+  it('hides all components that do not match search criteria', function() {
+    FilterComponents("Accordion");
+
+    expect(document.getElementById('back-link').classList.toString()).toBe('component-guide-hidden');
+  });
+
+  it('shows all components that match search criteria', function() {
+    FilterComponents("Accordion");
+
+    expect(document.getElementById('accordion').classList.toString()).toBe('');
+  });
+
+  it('searches both the component name and description', function() {
+    FilterComponents("navigation");
+
+    expect(document.getElementById('back-link').classList.toString()).toBe('');
+    expect(document.getElementById('accordion').classList.toString()).toBe('component-guide-hidden');
+  });
+
+  it('the search is not case-sensitive', function() {
+    FilterComponents("ACCORDION");
+
+    expect(document.getElementById('accordion').classList.toString()).toBe('');
+    expect(document.getElementById('back-link').classList.toString()).toBe('component-guide-hidden');
+  });
+});

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -23,6 +23,7 @@ src_files:
   - assets/component_guide/vendor/axe.min.js
   - assets/component_guide/visual-regression.js
   - assets/component_guide/accessibility-test.js
+  - assets/component_guide/filter-components.js
 
 # stylesheets
 #


### PR DESCRIPTION
Adds a search box to the component guide which allows users to filter the list of components underneath.

## How it looks
<img width="977" alt="screen shot 2019-01-08 at 10 13 09" src="https://user-images.githubusercontent.com/29889908/50824287-1a2b9d00-132e-11e9-8870-331ae34f5c8b.png">

## How it looks with search term
<img width="987" alt="screen shot 2019-01-08 at 11 00 51" src="https://user-images.githubusercontent.com/29889908/50826832-af319480-1334-11e9-8ed6-e40ad6e49d99.png">

Component guide for this PR:
https://govuk-publishing-compon-pr-706.herokuapp.com/component-guide/
