### PR TITLE
Stop populating meta tags with outdated supertypes

### DIFF
--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -29,13 +29,6 @@ module GovukPublishingComponents
         meta_tags["govuk:format"] = content_item[:document_type] if content_item[:document_type]
         meta_tags["govuk:publishing-application"] = content_item[:publishing_app] if content_item[:publishing_app]
         meta_tags["govuk:schema-name"] = content_item[:schema_name] if content_item[:schema_name]
-
-        user_journey_stage = content_item[:user_journey_document_supertype]
-        meta_tags["govuk:user-journey-stage"] = user_journey_stage if user_journey_stage
-
-        navigation_document_type = content_item[:navigation_document_supertype]
-        meta_tags["govuk:navigation-document-type"] = navigation_document_type if navigation_document_type
-
         meta_tags["govuk:content-id"] = content_item[:content_id] if content_item[:content_id]
         meta_tags["govuk:withdrawn"] = "withdrawn" if content_item[:withdrawn_notice].present?
         meta_tags["govuk:content-has-history"] = "true" if has_content_history?

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -76,16 +76,6 @@ describe "Meta tags", type: :view do
     assert_empty render_component(content_item: { details: { political: true } }).strip
   end
 
-  it "renders user journey stage when user journey supertype is included" do
-    render_component(content_item: { user_journey_document_supertype: 'some-stage-of-journey' })
-    assert_meta_tag('govuk:user-journey-stage', 'some-stage-of-journey')
-  end
-
-  it "renders navigation document type when content item has navigation document supertype" do
-    render_component(content_item: { navigation_document_supertype: 'guidance' })
-    assert_meta_tag('govuk:navigation-document-type', 'guidance')
-  end
-
   it "renders 'political' political status when political content and government is current" do
     current = true
     political = true


### PR DESCRIPTION
These 2 supertypes aren't used anymore, and are out of date because we're no longer using the supertypes from the content item anymore.

https://trello.com/c/hp5BJD2i