### PR TITLE
Make the related navigation helper compatible with the component guide

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/related_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/related_navigation.yml
@@ -10,238 +10,253 @@ accessibility_excluded_rules:
 examples:
   default:
     data:
-      links:
-        ordered_related_items:
-          - title: Find an apprenticeship
-            base_path: /apply-apprenticeship
-          - title: Training and study at work
-            base_path: /training-study-work-your-rights
-          - title: Careers helpline for teenagers
-            base_path: /careers-helpline-for-teenagers
+      content_item:
+        links:
+          ordered_related_items:
+            - title: Find an apprenticeship
+              base_path: /apply-apprenticeship
+            - title: Training and study at work
+              base_path: /training-study-work-your-rights
+            - title: Careers helpline for teenagers
+              base_path: /careers-helpline-for-teenagers
   with_curated_topics:
     data:
-      links:
-        topics:
-          - title: Apprenticeships, 14 to 19 education and training for work
-            base_path: /browse/education/find-course
-            document_type: topic
-          - title: Finding a job
-            base_path: /browse/working/finding-job
-            document_type: topic
-          - title: Apprenticeships
-            base_path: /topic/further-education-skills/apprenticeships
-            document_type: topic
+      content_item:
+        links:
+          topics:
+            - title: Apprenticeships, 14 to 19 education and training for work
+              base_path: /browse/education/find-course
+              document_type: topic
+            - title: Finding a job
+              base_path: /browse/working/finding-job
+              document_type: topic
+            - title: Apprenticeships
+              base_path: /topic/further-education-skills/apprenticeships
+              document_type: topic
   with_mainstream_browse_pages:
     data:
-      links:
-        mainstream_browse_pages:
-        - title: Driving licences
-          base_path: /browse/driving/driving-licences
-          document_type: mainstream_browse_page
-        - title: Driving tests and learning to drive or ride
-          base_path: /browse/driving/learning-to-drive
-          document_type: mainstream_browse_page
+      content_item:
+        links:
+          mainstream_browse_pages:
+          - title: Driving licences
+            base_path: /browse/driving/driving-licences
+            document_type: mainstream_browse_page
+          - title: Driving tests and learning to drive or ride
+            base_path: /browse/driving/learning-to-drive
+            document_type: mainstream_browse_page
   with_taxons:
     data:
-      links:
-        taxons:
-        - title: Driving instruction and driving lessons
-          base_path: /transport/driving-instruction-and-driving-lessons
-          phase: live
-          document_type: taxon
+      content_item:
+        links:
+          taxons:
+          - title: Driving instruction and driving lessons
+            base_path: /transport/driving-instruction-and-driving-lessons
+            phase: live
+            document_type: taxon
   with_curated_topics_and_mainstream_browse_pages:
     description: Currated topics and mainstream browse pages are combined.
     data:
-      links:
-        mainstream_browse_pages:
-        - title: Driving licences
-          base_path: /browse/driving/driving-licences
-          document_type: mainstream_browse_page
-        - title: Driving tests and learning to drive or ride
-          base_path: /browse/driving/learning-to-drive
-          document_type: mainstream_browse_page
-        topics:
-        - title: Cars
-          base_path: /topic/driving-tests-and-learning-to-drive/car
-          document_type: topic
+      content_item:
+        links:
+          mainstream_browse_pages:
+          - title: Driving licences
+            base_path: /browse/driving/driving-licences
+            document_type: mainstream_browse_page
+          - title: Driving tests and learning to drive or ride
+            base_path: /browse/driving/learning-to-drive
+            document_type: mainstream_browse_page
+          topics:
+          - title: Cars
+            base_path: /topic/driving-tests-and-learning-to-drive/car
+            document_type: topic
   with_curated_topics_and_mainstream_browse_pages_and_taxons:
     description: Currated topics and mainstream browse pages take precedence over the sidewide topic taxonomy.
     data:
-      links:
-        mainstream_browse_pages:
-        - title: Driving licences
-          base_path: /browse/driving/driving-licences
-          document_type: mainstream_browse_page
-        - title: Driving tests and learning to drive or ride
-          base_path: /browse/driving/learning-to-drive
-          document_type: mainstream_browse_page
-        taxons:
-        - title: Driving instruction and driving lessons
-          base_path: /transport/driving-instruction-and-driving-lessons
-          phase: live
-          document_type: taxon
-        topics:
-        - title: Cars
-          base_path: /topic/driving-tests-and-learning-to-drive/car
-          document_type: topic
+      content_item:
+        links:
+          mainstream_browse_pages:
+          - title: Driving licences
+            base_path: /browse/driving/driving-licences
+            document_type: mainstream_browse_page
+          - title: Driving tests and learning to drive or ride
+            base_path: /browse/driving/learning-to-drive
+            document_type: mainstream_browse_page
+          taxons:
+          - title: Driving instruction and driving lessons
+            base_path: /transport/driving-instruction-and-driving-lessons
+            phase: live
+            document_type: taxon
+          topics:
+          - title: Cars
+            base_path: /topic/driving-tests-and-learning-to-drive/car
+            document_type: topic
   with_collections:
     data:
-      links:
-        document_collections:
-          - title: Recruit an apprentice (formerly apprenticeship vacancies)
-            base_path: /government/collections/apprenticeship-vacancies
-            document_type: document_collection
-          - title: The future of jobs and skills
-            base_path: /government/collections/the-future-of-jobs-and-skills
-            document_type: document_collection
+      content_item:
+        links:
+          document_collections:
+            - title: Recruit an apprentice (formerly apprenticeship vacancies)
+              base_path: /government/collections/apprenticeship-vacancies
+              document_type: document_collection
+            - title: The future of jobs and skills
+              base_path: /government/collections/the-future-of-jobs-and-skills
+              document_type: document_collection
   with_topical_events:
     data:
-      links:
-        topical_events:
-          - title: UK-China High-Level People to People Dialogue 2017
-            base_path: /government/topical-events/uk-china-high-level-people-to-people-dialogue-2017
-            document_type: topical_event
+      content_item:
+        links:
+          topical_events:
+            - title: UK-China High-Level People to People Dialogue 2017
+              base_path: /government/topical-events/uk-china-high-level-people-to-people-dialogue-2017
+              document_type: topical_event
   with_world_locations:
     data:
-      links:
-        world_locations:
-          - title: South Sudan
-            base_path: /world/south-sudan/news
-          - title: USA
-            base_path: /world/usa/news
+      content_item:
+        links:
+          world_locations:
+            - title: South Sudan
+              base_path: /world/south-sudan/news
+            - title: USA
+              base_path: /world/usa/news
   with_external_related_links:
     description: The component can accept other related links, such as external links or other contacts.
     data:
-      details:
-        external_related_links:
-          - url: "http://media.slc.co.uk/sfe/1718/ft/sfe_terms_and_conditions_guide_1718_d.pdf"
-            title: "Student loans: terms and conditions 2017 to 2018 (PDF, 136KB)"
-          - url: "https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan"
-            title: "The Student Room: repaying your student loan"
+      content_item:
+        details:
+          external_related_links:
+            - url: "http://media.slc.co.uk/sfe/1718/ft/sfe_terms_and_conditions_guide_1718_d.pdf"
+              title: "Student loans: terms and conditions 2017 to 2018 (PDF, 136KB)"
+            - url: "https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan"
+              title: "The Student Room: repaying your student loan"
   with_extensive_world_locations:
     description: The component handles having a long list of content passed to it, by only showing the first few items and hiding the rest behind a Show More toggle.
     data:
-      links:
-        world_locations:
-          - title: Algeria
-            base_path: /world/algeria/news
-          - title: Austria
-            base_path: /world/austria/news
-          - title: Belarus
-            base_path: /world/belarus/news
-          - title: Belgium
-            base_path: /world/belgium/news
-          - title: Bolivia
-            base_path: /world/bolivia/news
-          - title: Brazil
-            base_path: /world/brazil/news
-          - title: Canada
-            base_path: /world/canada/news
-          - title: Chile
-            base_path: /world/chile/news
-          - title: China
-            base_path: /world/China/news
-          - title: Cuba
-            base_path: /world/cuba/news
-          - title: Denmark
-            base_path: /world/denmark/news
-          - title: Egypt
-            base_path: /world/egypt/news
-          - title: Fiji
-            base_path: /world/fiji/news
-          - title: Finland
-            base_path: /world/finland/news
-          - title: France
-            base_path: /world/france/news
-          - title: Germany
-            base_path: /world/germany/news
-          - title: Greece
-            base_path: /world/greece/news
-          - title: Norway
-            base_path: /world/norway/news
-          - title: Russia
-            base_path: /world/russia/news
-          - title: Sweden
-            base_path: /world/sweden/news
-          - title: United Kingdom
-            base_path: /world/united-kingdom/news
-          - title: USA
-            base_path: /world/usa/news
+      content_item:
+        links:
+          world_locations:
+            - title: Algeria
+              base_path: /world/algeria/news
+            - title: Austria
+              base_path: /world/austria/news
+            - title: Belarus
+              base_path: /world/belarus/news
+            - title: Belgium
+              base_path: /world/belgium/news
+            - title: Bolivia
+              base_path: /world/bolivia/news
+            - title: Brazil
+              base_path: /world/brazil/news
+            - title: Canada
+              base_path: /world/canada/news
+            - title: Chile
+              base_path: /world/chile/news
+            - title: China
+              base_path: /world/China/news
+            - title: Cuba
+              base_path: /world/cuba/news
+            - title: Denmark
+              base_path: /world/denmark/news
+            - title: Egypt
+              base_path: /world/egypt/news
+            - title: Fiji
+              base_path: /world/fiji/news
+            - title: Finland
+              base_path: /world/finland/news
+            - title: France
+              base_path: /world/france/news
+            - title: Germany
+              base_path: /world/germany/news
+            - title: Greece
+              base_path: /world/greece/news
+            - title: Norway
+              base_path: /world/norway/news
+            - title: Russia
+              base_path: /world/russia/news
+            - title: Sweden
+              base_path: /world/sweden/news
+            - title: United Kingdom
+              base_path: /world/united-kingdom/news
+            - title: USA
+              base_path: /world/usa/news
   with_quick_links:
     data:
-      details:
-        quick_links:
-          - title: "Money Laundering Regulations: introduction"
-            url: "https://www.gov.uk/money-laundering-regulations-introduction"
-          - title: "Money Laundering Regulations: report suspicious activities"
-            url: "https://www.gov.uk/money-laundering-regulations-report-suspicious-activities"
+      content_item:
+        details:
+          quick_links:
+            - title: "Money Laundering Regulations: introduction"
+              url: "https://www.gov.uk/money-laundering-regulations-introduction"
+            - title: "Money Laundering Regulations: report suspicious activities"
+              url: "https://www.gov.uk/money-laundering-regulations-report-suspicious-activities"
   with_related_statistical_data_sets:
     data:
-      links:
-        related_statistical_data_sets:
-        - title: International road fuel prices
-          base_path: /government/statistical-data-sets/comparisons-of-industrial-and-domestic-energy-prices-monthly-figures
-          document_type: statistical_data_set
-        - title: Weekly road fuel prices
-          base_path: /government/statistical-data-sets/oil-and-petroleum-products-weekly-statistics
-          document_type: statistical_data_set
-  with_related_contacts:
-    data:
-      links:
-        related:
-          - title: Pest Control
-            base_path: /pest-control
-            document_type: contact
-  with_all_related-content:
-    data:
-      links:
-        ordered_related_items:
-          - title: Find an apprenticeship
-            base_path: /apply-apprenticeship
-          - title: Training and study at work
-            base_path: /training-study-work-your-rights
-          - title: Careers helpline for teenagers
-            base_path: /careers-helpline-for-teenagers
-        topics:
-          - title: Apprenticeships, 14 to 19 education and training for work
-            base_path: /browse/education/find-course
-            document_type: topic
-          - title: Finding a job
-            base_path: /browse/working/finding-job
-            document_type: topic
-          - title: Apprenticeships
-            base_path: /topic/further-education-skills/apprenticeships
-            document_type: topic
-        topical_events:
-          - title: UK-China High-Level People to People Dialogue 2017
-            base_path: /government/topical-events/uk-china-high-level-people-to-people-dialogue-2017
-            document_type: topical_event
-        related:
-          - title: Pest Control
-            base_path: /pest-control
-            document_type: contact
-        related_statistical_data_sets:
+      content_item:
+        links:
+          related_statistical_data_sets:
           - title: International road fuel prices
             base_path: /government/statistical-data-sets/comparisons-of-industrial-and-domestic-energy-prices-monthly-figures
             document_type: statistical_data_set
           - title: Weekly road fuel prices
             base_path: /government/statistical-data-sets/oil-and-petroleum-products-weekly-statistics
             document_type: statistical_data_set
-        document_collections:
-          - title: Recruit an apprentice (formerly apprenticeship vacancies)
-            base_path: /government/collections/apprenticeship-vacancies
-            document_type: document_collection
-          - title: The future of jobs and skills
-            base_path: /government/collections/the-future-of-jobs-and-skills
-            document_type: document_collection
-        world_locations:
-          - title: South Sudan
-            base_path: /world/south-sudan/news
-          - title: USA
-            base_path: /world/usa/news
-      details:
-        external_related_links:
-          - url: "http://media.slc.co.uk/sfe/1718/ft/sfe_terms_and_conditions_guide_1718_d.pdf"
-            title: "Student loans: terms and conditions 2017 to 2018 (PDF, 136KB)"
-          - title: The Student Room repaying your student loan
-            url: https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan
+  with_related_contacts:
+    data:
+      content_item:
+        links:
+          related:
+            - title: Pest Control
+              base_path: /pest-control
+              document_type: contact
+  with_all_related-content:
+    data:
+      content_item:
+        links:
+          ordered_related_items:
+            - title: Find an apprenticeship
+              base_path: /apply-apprenticeship
+            - title: Training and study at work
+              base_path: /training-study-work-your-rights
+            - title: Careers helpline for teenagers
+              base_path: /careers-helpline-for-teenagers
+          topics:
+            - title: Apprenticeships, 14 to 19 education and training for work
+              base_path: /browse/education/find-course
+              document_type: topic
+            - title: Finding a job
+              base_path: /browse/working/finding-job
+              document_type: topic
+            - title: Apprenticeships
+              base_path: /topic/further-education-skills/apprenticeships
+              document_type: topic
+          topical_events:
+            - title: UK-China High-Level People to People Dialogue 2017
+              base_path: /government/topical-events/uk-china-high-level-people-to-people-dialogue-2017
+              document_type: topical_event
+          related:
+            - title: Pest Control
+              base_path: /pest-control
+              document_type: contact
+          related_statistical_data_sets:
+            - title: International road fuel prices
+              base_path: /government/statistical-data-sets/comparisons-of-industrial-and-domestic-energy-prices-monthly-figures
+              document_type: statistical_data_set
+            - title: Weekly road fuel prices
+              base_path: /government/statistical-data-sets/oil-and-petroleum-products-weekly-statistics
+              document_type: statistical_data_set
+          document_collections:
+            - title: Recruit an apprentice (formerly apprenticeship vacancies)
+              base_path: /government/collections/apprenticeship-vacancies
+              document_type: document_collection
+            - title: The future of jobs and skills
+              base_path: /government/collections/the-future-of-jobs-and-skills
+              document_type: document_collection
+          world_locations:
+            - title: South Sudan
+              base_path: /world/south-sudan/news
+            - title: USA
+              base_path: /world/usa/news
+        details:
+          external_related_links:
+            - url: "http://media.slc.co.uk/sfe/1718/ft/sfe_terms_and_conditions_guide_1718_d.pdf"
+              title: "Student loans: terms and conditions 2017 to 2018 (PDF, 136KB)"
+            - title: The Student Room repaying your student loan
+              url: https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -13,9 +13,9 @@ module GovukPublishingComponents
         statistical_data_sets
       ).freeze
 
-      def initialize(content_item:, context: nil)
-        @content_item = content_item
-        @context = context
+      def initialize(options = {})
+        @content_item = options.fetch(:content_item) { raise ArgumentError, 'missing argument: content_item' }
+        @context = options.fetch(:context, nil)
       end
 
       def related_navigation


### PR DESCRIPTION
The use of keyword arguments was preventing the component guide working.
This was introduced in #606

---

Component guide for this PR:
https://govuk-publishing-compon-pr-710.herokuapp.com/component-guide/