### PR TITLE
Add type option to button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add type option to button component (PR #711)
+
 ## 13.6.1
 
 * Extend toggle module (PR #712)

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -33,6 +33,11 @@ examples:
       text: "I'm really a link sssh"
       href: "http://www.gov.uk"
       target: "_blank"
+  with_type:
+    description: Buttons default to having a type of submit, but in some cases it may be desirable to have a different type.
+    data:
+      text: "Button type button"
+      type: "button"
   start_now_button:
     data:
       text: "Start now"

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
   module Presenters
     class ButtonHelper
       attr_reader :href, :text, :title, :info_text, :rel, :data_attributes,
-        :margin_bottom, :target, :start, :secondary, :secondary_quiet, :destructive
+        :margin_bottom, :target, :type, :start, :secondary, :secondary_quiet, :destructive
 
       def initialize(local_assigns)
         @href = local_assigns[:href]
@@ -15,6 +15,7 @@ module GovukPublishingComponents
         @data_attributes = local_assigns[:data_attributes]
         @margin_bottom = local_assigns[:margin_bottom]
         @target = local_assigns[:target]
+        @type = local_assigns[:type]
         @start = local_assigns[:start]
         @secondary = local_assigns[:secondary]
         @secondary_quiet = local_assigns[:secondary_quiet]
@@ -28,12 +29,16 @@ module GovukPublishingComponents
       def html_options
         options = { class: css_classes }
         options[:role] = "button" if link?
-        options[:type] = "submit" unless link?
+        options[:type] = button_type
         options[:rel] = rel if rel
         options[:data] = data_attributes if data_attributes
         options[:title] = title if title
         options[:target] = target if target
         options
+      end
+
+      def button_type
+        type || "submit" unless link?
       end
 
     private

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -22,6 +22,18 @@ describe "Button", type: :view do
     assert_select ".govuk-button", text: "Submit"
   end
 
+  it "renders with the correct types" do
+    render_component(text: "Submit")
+    assert_select ".govuk-button[type=submit]", text: "Submit"
+
+    render_component(text: "Link", href: "#", type: "button")
+    assert_select "a.govuk-button", text: "Link"
+    assert_select "a.govuk-button[type=submit]", false
+
+    render_component(text: "Button", type: "button")
+    assert_select ".govuk-button[type=button]"
+  end
+
   it "renders start now button" do
     render_component(text: "Start now", href: "#", start: true)
     assert_select ".govuk-button[href='#']", text: "Start now"


### PR DESCRIPTION
Add an option to the button component to specify the button `type`. Currently defaults to submit (unless it's a link).

---

Component guide for this PR:
https://govuk-publishing-compon-pr-711.herokuapp.com/component-guide/button
