### PR TITLE
Extend toggle module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Extend toggle module (PR #712)
+
 ## 13.6.0
 
 * Add search to component guide (PR #706)

--- a/app/assets/javascripts/govuk_publishing_components/dependencies.js
+++ b/app/assets/javascripts/govuk_publishing_components/dependencies.js
@@ -4,12 +4,12 @@
 //= require govuk/modules
 
 $(document).ready(function () {
-  'use strict'
+  'use strict';
 
-  GOVUK.modules.start()
+  GOVUK.modules.start();
 
   // Static has a Toggle module in here we have a GemToggle module, we can't
   // easily change govspeak to use GemToggle but we can use the GemToggle module
   var gemToggle = new GOVUK.Modules.GemToggle();
   gemToggle.start($("[data-module=toggle]"));
-})
+});

--- a/app/assets/javascripts/govuk_publishing_components/lib/toggle.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/toggle.js
@@ -1,12 +1,35 @@
 /*
   Toggle the display of elements
 
-  This is a straight copy of the same file from static.
+  Use as follows:
+
+  <div data-module="gem-toggle">
+    <a href="#" data-controls="target" data-expanded="true">
+      Show more
+    </a>
+    <div id="target">
+      Content to be toggled
+    </div>
+  </div>
 
   Use `data-controls` and `data-expanded` to indicate the
   starting state and the IDs of the elements that the toggle
   controls. This is synonymous with ARIA attributes, which
   get added when starting.
+
+  If you want to set `data-expanded` to false, you must add
+  the `js-hidden` class to the element you wish to hide in
+  your template, the module will not do this for you.
+
+  `data-controls` can contain more than one element, space
+  separated.
+
+  Use `data-toggle-class` on the parent element to set the
+  class that is toggled. Defaults to `js-hidden`.
+
+  Use `data-toggled-text` on the trigger element to set the
+  text shown when the element is toggled. Defaults to not
+  changing.
 */
 
 window.GOVUK.Modules = window.GOVUK.Modules || {};

--- a/app/assets/javascripts/govuk_publishing_components/lib/toggle.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/toggle.js
@@ -12,58 +12,58 @@
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  'use strict'
+  'use strict';
 
   Modules.GemToggle = function () {
     this.start = function ($el) {
-      var toggleSelector = '[data-controls][data-expanded]'
+      var toggleSelector = '[data-controls][data-expanded]';
 
-      $el.on('click', toggleSelector, toggle)
-      $el.find(toggleSelector).each(addAriaAttrs)
+      $el.on('click', toggleSelector, toggle);
+      $el.find(toggleSelector).each(addAriaAttrs);
 
       // Add the ARIA attributes with JavaScript
       // If the JS fails and there's no interactive elements, having
       // no aria attributes is an accurate representation.
       function addAriaAttrs () {
-        var $toggle = $(this)
-        $toggle.attr('role', 'button')
-        $toggle.attr('aria-controls', $toggle.data('controls'))
-        $toggle.attr('aria-expanded', $toggle.data('expanded'))
+        var $toggle = $(this);
+        $toggle.attr('role', 'button');
+        $toggle.attr('aria-controls', $toggle.data('controls'));
+        $toggle.attr('aria-expanded', $toggle.data('expanded'));
 
-        var $targets = getTargetElements($toggle)
-        $targets.attr('aria-live', 'polite')
-        $targets.attr('role', 'region')
-        $toggle.data('$targets', $targets)
+        var $targets = getTargetElements($toggle);
+        $targets.attr('aria-live', 'polite');
+        $targets.attr('role', 'region');
+        $toggle.data('$targets', $targets);
       }
 
       function toggle (event) {
         var $toggle = $(event.target),
           expanded = $toggle.attr('aria-expanded') === 'true',
-          $targets = $toggle.data('$targets')
+          $targets = $toggle.data('$targets');
 
         if (expanded) {
-          $toggle.attr('aria-expanded', false)
-          $targets.addClass('js-hidden')
+          $toggle.attr('aria-expanded', false);
+          $targets.addClass('js-hidden');
         } else {
-          $toggle.attr('aria-expanded', true)
-          $targets.removeClass('js-hidden')
+          $toggle.attr('aria-expanded', true);
+          $targets.removeClass('js-hidden');
         }
 
-        var toggledText = $toggle.data('toggled-text')
+        var toggledText = $toggle.data('toggled-text');
         if (typeof toggledText === 'string') {
-          $toggle.data('toggled-text', $toggle.text())
-          $toggle.text(toggledText)
+          $toggle.data('toggled-text', $toggle.text());
+          $toggle.text(toggledText);
         }
 
-        event.preventDefault()
+        event.preventDefault();
       }
 
       function getTargetElements ($toggle) {
         var ids = $toggle.attr('aria-controls').split(' '),
-          selector = '#' + ids.join(', #')
+          selector = '#' + ids.join(', #');
 
-        return $el.find(selector)
+        return $el.find(selector);
       }
-    }
-  }
-})(window.GOVUK.Modules)
+    };
+  };
+})(window.GOVUK.Modules);

--- a/app/assets/javascripts/govuk_publishing_components/lib/toggle.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/toggle.js
@@ -17,6 +17,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   Modules.GemToggle = function () {
     this.start = function ($el) {
       var toggleSelector = '[data-controls][data-expanded]';
+      var toggleClass = $el.attr('data-toggle-class') || 'js-hidden';
 
       $el.on('click', toggleSelector, toggle);
       $el.find(toggleSelector).each(addAriaAttrs);
@@ -43,10 +44,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
         if (expanded) {
           $toggle.attr('aria-expanded', false);
-          $targets.addClass('js-hidden');
+          $targets.addClass(toggleClass);
         } else {
           $toggle.attr('aria-expanded', true);
-          $targets.removeClass('js-hidden');
+          $targets.removeClass(toggleClass);
         }
 
         var toggledText = $toggle.data('toggled-text');

--- a/spec/javascripts/components/toggle-spec.js
+++ b/spec/javascripts/components/toggle-spec.js
@@ -83,4 +83,20 @@ describe('A toggle module', function () {
       expect(element.find('#another-target').is('.js-hidden')).toBe(true);
     });
   });
+
+  describe('when a custom class is given', function () {
+    var element = $('\
+      <div data-toggle-class="myclass">\
+        <a href="#" class="my-toggle" data-expanded="true" data-controls="target">Toggle</a>\
+        <div id="target">Target</div>\
+      </div>');
+
+    it('toggles the given class', function () {
+      toggle.start(element);
+
+      expect(element.find('#target').is('.myclass')).toBe(false);
+      element.find('.my-toggle').trigger('click');
+      expect(element.find('#target').is('.myclass')).toBe(true);
+    });
+  });
 });

--- a/spec/javascripts/components/toggle-spec.js
+++ b/spec/javascripts/components/toggle-spec.js
@@ -1,65 +1,65 @@
 describe('A toggle module', function () {
-  'use strict'
+  'use strict';
 
   var toggle,
-    element
+    element;
 
   beforeEach(function () {
-    toggle = new GOVUK.Modules.GemToggle()
-  })
+    toggle = new GOVUK.Modules.GemToggle();
+  });
 
   describe('when starting', function () {
     var element = $('\
       <div>\
         <a href="#" class="my-toggle" data-expanded="false" data-controls="target">Toggle</a>\
         <div id="target">Target</div>\
-      </div>')
+      </div>');
 
     it('adds aria attributes to toggles', function () {
-      toggle.start(element)
+      toggle.start(element);
 
-      var $toggle = element.find('.my-toggle')
-      expect($toggle.attr('role')).toBe('button')
-      expect($toggle.attr('aria-expanded')).toBe('false')
-      expect($toggle.attr('aria-controls')).toBe('target')
-    })
-  })
+      var $toggle = element.find('.my-toggle');
+      expect($toggle.attr('role')).toBe('button');
+      expect($toggle.attr('aria-expanded')).toBe('false');
+      expect($toggle.attr('aria-controls')).toBe('target');
+    });
+  });
 
   describe('when clicking a toggle', function () {
-    var element
+    var element;
 
     beforeEach(function () {
       element = $('\
         <div>\
           <a href="#" class="my-toggle" data-expanded="false" data-controls="target" data-toggled-text="Show fewer">Toggle</a>\
           <div id="target" class="js-hidden">Target</div>\
-        </div>')
+        </div>');
 
-      toggle.start(element)
-      element.find('.my-toggle').trigger('click')
-    })
+      toggle.start(element);
+      element.find('.my-toggle').trigger('click');
+    });
 
     it('toggles the display of a target', function () {
-      expect(element.find('#target').is('.js-hidden')).toBe(false)
-      element.find('.my-toggle').trigger('click')
-      expect(element.find('#target').is('.js-hidden')).toBe(true)
-    })
+      expect(element.find('#target').is('.js-hidden')).toBe(false);
+      element.find('.my-toggle').trigger('click');
+      expect(element.find('#target').is('.js-hidden')).toBe(true);
+    });
 
     it('updates the aria-expanded attribute on the toggle', function () {
-      expect(element.find('.my-toggle').attr('aria-expanded')).toBe('true')
+      expect(element.find('.my-toggle').attr('aria-expanded')).toBe('true');
 
-      element.find('.my-toggle').trigger('click')
-      expect(element.find('.my-toggle').attr('aria-expanded')).toBe('false')
-    })
+      element.find('.my-toggle').trigger('click');
+      expect(element.find('.my-toggle').attr('aria-expanded')).toBe('false');
+    });
 
     it('updates the text shown in the toggle link when expanded if such text is supplied', function () {
-      expect(element.find('.my-toggle').data('toggled-text')).toBe('Toggle')
-      expect(element.find('.my-toggle').text()).toBe('Show fewer')
-      element.find('.my-toggle').trigger('click')
-      expect(element.find('.my-toggle').data('toggled-text')).toBe('Show fewer')
-      expect(element.find('.my-toggle').text()).toBe('Toggle')
-    })
-  })
+      expect(element.find('.my-toggle').data('toggled-text')).toBe('Toggle');
+      expect(element.find('.my-toggle').text()).toBe('Show fewer');
+      element.find('.my-toggle').trigger('click');
+      expect(element.find('.my-toggle').data('toggled-text')).toBe('Show fewer');
+      expect(element.find('.my-toggle').text()).toBe('Toggle');
+    });
+  });
 
   describe('when clicking a toggle that controls multiple targets', function () {
     it('toggles the display of each target', function () {
@@ -68,19 +68,19 @@ describe('A toggle module', function () {
           <a href="#" class="my-toggle" data-expanded="false" data-controls="target another-target">Toggle</a>\
           <div id="target" class="js-hidden">Target</div>\
           <div id="another-target" class="js-hidden">Another target</div>\
-        </div>')
+        </div>');
 
-      toggle.start(element)
-      expect(element.find('#target').is('.js-hidden')).toBe(true)
-      expect(element.find('#another-target').is('.js-hidden')).toBe(true)
+      toggle.start(element);
+      expect(element.find('#target').is('.js-hidden')).toBe(true);
+      expect(element.find('#another-target').is('.js-hidden')).toBe(true);
 
-      element.find('.my-toggle').trigger('click')
-      expect(element.find('#target').is('.js-hidden')).toBe(false)
-      expect(element.find('#another-target').is('.js-hidden')).toBe(false)
+      element.find('.my-toggle').trigger('click');
+      expect(element.find('#target').is('.js-hidden')).toBe(false);
+      expect(element.find('#another-target').is('.js-hidden')).toBe(false);
 
-      element.find('.my-toggle').trigger('click')
-      expect(element.find('#target').is('.js-hidden')).toBe(true)
-      expect(element.find('#another-target').is('.js-hidden')).toBe(true)
-    })
-  })
-})
+      element.find('.my-toggle').trigger('click');
+      expect(element.find('#target').is('.js-hidden')).toBe(true);
+      expect(element.find('#another-target').is('.js-hidden')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Adds a new option to the `gem-toggle` Javascript module, allowing a class to be passed that will be used in the toggle, in place of the default `js-hidden` class. 

Needed for [finders](https://trello.com/c/HeKk9mpK/192-add-progressive-disclosure-to-facets-on-mobile), where I need to toggle the display of facets, but only on mobile. If we use the default `js-hidden` class, the toggle functionality is there on desktop as well, and we don't want that.

Also linted some files, recommend this be reviewed commit by commit.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-712.herokuapp.com/component-guide/
