### PR TITLE
Add accordion component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
   of the commit log.
 
 ## Unreleased
-
 * Extend accessible autocomplete onConfirm function (PR #718)
+* Add Accordion component based on GOV.UK Frontend (PR #714)
 * Add type option to button component (PR #711)
 
 ## 13.6.1

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -1,0 +1,2 @@
+// This component relies on JavaScript from GOV.UK Frontend
+//= require govuk-frontend/components/accordion/accordion.js

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -23,6 +23,7 @@
 
 // components
 @import "components/accessible-autocomplete";
+@import "components/accordion";
 @import "components/back-link";
 @import "components/breadcrumbs";
 @import "components/button";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -7,6 +7,7 @@
 @import "typography";
 @import "colours";
 
+@import "components/print/accordion";
 @import "components/print/contents-list";
 @import "components/print/feedback";
 @import "components/print/govspeak-html-publication";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
@@ -1,0 +1,15 @@
+@import "govuk-frontend/components/accordion/accordion";
+
+.govuk-accordion--condensed {
+  .govuk-accordion__section-button {
+    @include govuk-media-query($from: tablet) {
+      @include govuk-font($size: 19, $weight: bold);
+    }
+  }
+
+  .govuk-accordion__section-summary {
+    @include govuk-media-query($from: tablet) {
+      @include govuk-font($size: 16);
+    }
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_accordion.scss
@@ -1,0 +1,31 @@
+// This is in place until a proper fix comes through from GOV.UK Frontend.
+//
+// TODO: Replace with the print styles that will come from GOV.UK Frontend.
+
+@import "../accordion";
+
+// Open all of the accordion sections.
+.govuk-accordion__section-content {
+  display: block !important;
+}
+
+// Change the colour from the blue link colour to black.
+.govuk-accordion__section-button {
+  color: govuk-colour('black') !important;
+}
+
+// Change the summary subheading size.
+.govuk-accordion__section-summary {
+  @include govuk-typography-common();
+  @include govuk-typography-responsive($size: 16, $important: true);
+
+  .govuk-accordion--condensed & {
+    @include govuk-typography-responsive($size: 14, $important: true);
+  }
+}
+
+// Hide the unusable 'Open all' button and the '+' icons.
+.govuk-accordion__open-all,
+.govuk-accordion__icon {
+  display: none !important;
+}

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -1,0 +1,45 @@
+<%
+  heading_helper = GovukPublishingComponents::Presenters::AccordionHelper.new(local_assigns)
+
+  id ||= "default-id-#{SecureRandom.hex(4)}"
+  items ||= []
+  condensed ||= false
+  accordion_classes = %w(gem-c-accordion govuk-accordion)
+  accordion_classes << 'govuk-accordion--condensed' if condensed
+
+  data_attributes ||= {}
+  data_attributes[:module] = 'accordion'
+%>
+<% if items.any? %>
+  <%= tag.div(class: accordion_classes, id: id, data: data_attributes) do %>
+    <% items.each_with_index do |item, i| %>
+      <%
+        # Nunjucks starts a loop on 1 and the client side JavaScript also
+        # adopts this behaviour. To prevent things from breaking, the index
+        # here also need to be increase by one. (Nunjucks is used by GOV.UK
+        # Frontend, which this component is based on.)
+        index = i + 1
+
+        item[:data_attributes] ||= nil
+
+        section_classes = %w(govuk-accordion__section)
+        section_classes << 'govuk-accordion__section--expanded' if item[:expanded]
+
+        summary_classes = %w(govuk-accordion__section-summary govuk-body)
+      %>
+      <%= tag.div(class: section_classes) do %>
+        <div class="govuk-accordion__section-header">
+          <%=
+            content_tag(
+              heading_helper.heading_tag,
+              content_tag('span', item[:heading][:text], class: "govuk-accordion__section-button", id: "#{id}-heading-#{index}", data: item[:data_attributes]),
+              class: 'govuk-accordion__section-heading'
+            )
+          %>
+          <%= tag.div(item[:summary][:text], id: "#{id}-summary-#{index}", class: summary_classes) if item[:summary].present? %>
+        </div>
+        <%= tag.div(item[:content][:html], id: "#{id}-content-#{index}", class: "govuk-accordion__section-content", 'aria-labelledby': "#{id}-heading-#{index}") %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -1,0 +1,351 @@
+name: Accordion (experimental)
+description: The accordion component lets users show and hide sections of related content on a page.
+govuk_frontend_components:
+  - accordion
+body: |
+  This component is based on the [design system accordion component](https://design-system.service.gov.uk/components/accordion/) and is currently experimental. If using this component, please feed back any research findings to the design team.
+
+accessibility_criteria: |
+  The accordion must:
+
+    * accept focus
+    * be usable with a keyboard
+    * indicate when they have focus
+    * be usable with touch
+    * be usable with voice commands
+    * have visible text
+    * indicate to users that each section can be expanded and collapsed
+    * inform the user when a step has been expanded or collapsed
+    * be readable when only the text of the page is zoomed in
+
+  Section headings must use a button element:
+
+    * so that sections can be toggled with the space and enter keys
+    * so that sections can't be opened in a new tab or window
+
+  When JavaScript is unavailable the component must:
+
+  * be fully expanded
+  * not be marked as expandable
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      items:
+        - heading:
+            text: "Writing well for the web"
+          content:
+            html: "<p class='govuk-body'>This is the content for Writing well for the web.</p>"
+        - heading:
+            text: "Writing well for specialists"
+          content:
+            html: "<p class='govuk-body'>This is the content for Writing well for specialists.</p>"
+        - heading:
+            text: "Know your audience"
+          content:
+            html: "<p class='govuk-body'>This is the content for Know your audience.</p>"
+        - heading:
+            text: "How people read"
+          content:
+            html: "<p class='govuk-body'>This is the content for How people read.</p>"
+  with_supplied_identification:
+    description: |
+      An `id` is optional as it's automatically generated, but it can be supplied if a specific `id` is required.
+
+      The `id` must be **unique** across the domain of your service - this is because as the open / closed state of individual instances of the accordion persists across page loads using `localStorage`.
+
+      Used as an `id` in the HTML for the accordion as a whole, and also as a prefix for the `id`s of the section contents and the buttons that open them, so that those `id`s can be the target of `aria-labelledby` and `aria-control` attributes.
+    data:
+      id: with-supplied-id-thats-unique-across-the-domain
+      items:
+        - heading:
+            text: "Writing well for the web"
+          content:
+            html: "<p class='govuk-body'>This is the content for Writing well for the web.</p>"
+        - heading:
+            text: "Writing well for specialists"
+          content:
+            html: "<p class='govuk-body'>This is the content for Writing well for specialists.</p>"
+        - heading:
+            text: "Know your audience"
+          content:
+            html: "<p class='govuk-body'>This is the content for Know your audience.</p>"
+        - heading:
+            text: "How people read"
+          content:
+            html: "<p class='govuk-body'>This is the content for How people read.</p>"
+  with_summary:
+    description: Adds a subheading below each section heading.
+    data:
+      items:
+        - heading:
+            text: "Understanding agile project management"
+          summary:
+            text: "Introductions, methods, core features."
+          content:
+            html:
+              '<ul class="govuk-list">
+                  <li>
+                    <a class="govuk-link" href="#">Agile and government services: an introduction</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">Agile methods: an introduction</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">Core principles of agile</a>
+                  </li>
+              </ul>'
+        - heading:
+            text: "Working with agile methods"
+          summary:
+            text: "Workspaces, tools and techniques, user stories, planning."
+          content:
+            html:
+              '<ul class="govuk-list">
+                  <li>
+                    <a class="govuk-link" href="#">Creating an agile working environment</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">Agile tools and techniques</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">Set up a team wall</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">Writing user stories</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">Planning in agile</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">Deciding on priorities</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">Developing a roadmap</a>
+                  </li>
+              </ul>'
+        - heading:
+            text: "Governing agile services"
+          summary:
+            text: "Principles, measuring progress, spending money."
+          content:
+            html:
+              '<ul class="govuk-list">
+                  <li>
+                    <a class="govuk-link" href="#">Governance principles for agile service delivery</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">Measuring and reporting progress</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">Spend controls: check if you need approval to spend money on a service</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">Spend controls: apply for approval to spend money on a service</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">Spend controls: the new pipeline process</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">Working across organisational boundaries</a>
+                  </li>
+              </ul>'
+        - heading:
+            text: "Phases of an agile project"
+          summary:
+            text: "Discovery, alpha, beta, live and retirement."
+          content:
+            html:
+              '<ul class="govuk-list">
+                  <li>
+                    <a class="govuk-link" href="#">How the discovery phase works</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">How the alpha phase works</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">How the beta phase works</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">How the live phase works</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link" href="#">Retiring your service</a>
+                  </li>
+              </ul>'
+  with_data_attributes:
+    description: |
+      Adds custom data attributes to the accordion to each section. Accepts an hash, so multiple attributes can be added.
+
+      The `data_attributes` hash is for the outermost element in the accordion.
+
+      Each item can also have a `data_attributes` hash. This is placed on the `button` that triggers the opening and closing - useful for differentiating between each section of the accordion.
+
+    data:
+      data_attributes:
+          gtm: 'gtm-accordion'
+          ga: 'ga-accordion'
+      items:
+        - heading:
+            text: "Writing well for the web"
+          content:
+            html: "<p class='govuk-body'>This is the content for Writing well for the web.</p>"
+          data_attributes:
+            gtm: 'gtm-accordion-item-1'
+        - heading:
+            text: "Writing well for specialists"
+          content:
+            html: "<p class='govuk-body'>This is the content for Writing well for specialists.</p>"
+          data_attributes:
+            gtm: 'gtm-accordion-item-2'
+        - heading:
+            text: "Know your audience"
+          content:
+            html: "<p class='govuk-body'>This is the content for Know your audience.</p>"
+          data_attributes:
+            gtm: 'gtm-accordion-item-3'
+        - heading:
+            text: "How people read"
+          content:
+            html: "<p class='govuk-body'>This is the content for How people read.</p>"
+          data_attributes:
+            gtm: 'gtm-accordion-item-4'
+  different_heading_level:
+    description: This will alter the level of the heading, not the appearance of the heading.
+    data:
+      heading_level: 5
+      items:
+        - heading:
+            text: "Writing well for the web"
+          content:
+            html: "<p class='govuk-body'>This is the content for Writing well for the web.</p>"
+        - heading:
+            text: "Writing well for specialists"
+          content:
+            html: "<p class='govuk-body'>This is the content for Writing well for specialists.</p>"
+        - heading:
+            text: "Know your audience"
+          content:
+            html: "<p class='govuk-body'>This is the content for Know your audience.</p>"
+        - heading:
+            text: "How people read"
+          content:
+            html: "<p class='govuk-body'>This is the content for How people read.</p>"
+  with_section_open:
+    description: |
+      Adding `expanded: true` to the item will mean the section will default to being open, rather than closed. Once a user has opened or closed a section, the state of each section will be remembered - this can override a section's default.
+    data:
+      items:
+        - heading:
+            text: "Writing well for the web"
+          content:
+            html: "<p class='govuk-body'>This is the content for Writing well for the web.</p>"
+          expanded: true
+        - heading:
+            text: "Writing well for specialists"
+          content:
+            html: "<p class='govuk-body'>This is the content for Writing well for specialists.</p>"
+        - heading:
+            text: "Know your audience"
+          content:
+            html: "<p class='govuk-body'>This is the content for Know your audience.</p>"
+        - heading:
+            text: "How people read"
+          content:
+            html: "<p class='govuk-body'>This is the content for How people read.</p>"
+  condensed_layout:
+    description: |
+      This is for when a smaller accordion is required. Since smaller screens trigger a single column layout, this modifier only makes the accordion smaller when viewed on large screens.
+    data:
+      condensed: true
+      items:
+        - heading:
+            text: "Understanding agile project management"
+          content:
+            html:
+              '<ul class="govuk-list">
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Agile and government services: an introduction</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Agile methods: an introduction</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Core principles of agile</a>
+                  </li>
+              </ul>'
+        - heading:
+            text: "Working with agile methods"
+          summary:
+            text: "Workspaces, tools and techniques, user stories, planning."
+          content:
+            html:
+              '<ul class="govuk-list">
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Creating an agile working environment</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Agile tools and techniques</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Set up a team wall</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Writing user stories</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Planning in agile</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Deciding on priorities</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Developing a roadmap</a>
+                  </li>
+              </ul>'
+        - heading:
+            text: "Governing agile services"
+          content:
+            html:
+              '<ul class="govuk-list">
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Governance principles for agile service delivery</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Measuring and reporting progress</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Spend controls: check if you need approval to spend money on a service</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Spend controls: apply for approval to spend money on a service</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Spend controls: the new pipeline process</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Working across organisational boundaries</a>
+                  </li>
+              </ul>'
+        - heading:
+            text: "Phases of an agile project"
+          content:
+            html:
+              '<ul class="govuk-list">
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">How the discovery phase works</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">How the alpha phase works</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">How the beta phase works</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">How the live phase works</a>
+                  </li>
+                  <li>
+                    <a class="govuk-link govuk-body-s" href="#">Retiring your service</a>
+                  </li>
+              </ul>'

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -1,5 +1,6 @@
 require "govuk_publishing_components/config"
 require "govuk_publishing_components/engine"
+require "govuk_publishing_components/presenters/accordion_helper"
 require "govuk_publishing_components/presenters/breadcrumbs"
 require "govuk_publishing_components/presenters/button_helper"
 require "govuk_publishing_components/presenters/contextual_navigation"

--- a/lib/govuk_publishing_components/presenters/accordion_helper.rb
+++ b/lib/govuk_publishing_components/presenters/accordion_helper.rb
@@ -1,0 +1,12 @@
+module GovukPublishingComponents
+  module Presenters
+    class AccordionHelper
+      attr_reader :heading_tag
+
+      def initialize(options)
+        @heading_tag = "h2"
+        @heading_tag = "h#{options[:heading_level]}" if [1, 2, 3, 4, 5, 6].include? options[:heading_level]
+      end
+    end
+  end
+end

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,13 +7,13 @@
       "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-1.6.2.tgz",
       "integrity": "sha512-7S+6Vi82LQFSSd5feKedu46tiY2/DShpdXiRp0NY3cLwc+DKe1ayWd66mb3JVi8LTQubRM7jco+u92e6w0bbvg==",
       "requires": {
-        "preact": "8.3.1"
+        "preact": "^8.3.1"
       }
     },
     "govuk-frontend": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.4.0.tgz",
-      "integrity": "sha512-WSecWLGM1qZ48UD0YGGWOfaBqrWtwf39cOUAuC8+SMNh7kkZ6Ou2Y7+d3Bt8OEPaFNFR2N2vZO2WRnT2gaCjMg=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.5.1.tgz",
+      "integrity": "sha512-DDi1HGRTNRH/UmqOYACOR01V+aae36pnHHf5/g08spscJO5AazA/BQTenlNm8WFJ4UAeikb1TrCbgGWJE4Vypw=="
     },
     "jquery": {
       "version": "1.12.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "accessible-autocomplete": "^1.6.2",
-    "govuk-frontend": "^2.4.0",
+    "govuk-frontend": "^2.5.1",
     "jquery": "1.12.4"
   }
 }

--- a/spec/components/accordion_spec.rb
+++ b/spec/components/accordion_spec.rb
@@ -1,0 +1,230 @@
+require 'rails_helper'
+
+describe 'Accordion', type: :view do
+  def component_name
+    'accordion'
+  end
+
+  it "does not render anything if no data is passed" do
+    test_data = {}
+    assert_empty render_component(test_data)
+  end
+
+  it 'places the title and content correctly' do
+    test_data = {
+      id: 'test-for-heading-and-content',
+      items: [{
+                heading: { text: 'Heading 1' },
+                content: { html: '<p>Content 1.</p>' }
+              },
+              {
+                heading: { text: 'Heading 2' },
+                content: { html: '<p>Content 2.</p>' }
+              },
+              {
+                heading: { text: 'Heading 3' },
+                content: { html: '<p>Content 3.</p>' }
+              }]
+    }
+
+    render_component(test_data)
+
+    assert_select '.govuk-accordion__section-button', text: 'Heading 1', count: 1
+    assert_select '.govuk-accordion__section-content', text: /Content 1./, count: 1
+
+    assert_select '.govuk-accordion__section-button', text: 'Heading 2', count: 1
+    assert_select '.govuk-accordion__section-content', text: /Content 2./, count: 1
+
+    assert_select '.govuk-accordion__section-button', text: 'Heading 3', count: 1
+    assert_select '.govuk-accordion__section-content', text: /Content 3./, count: 1
+  end
+
+  it 'uses the correct id, and interpolates it correctly' do
+    test_data = {
+      id: 'test-for-id',
+      items: [{
+                heading: { text: 'Heading 1' },
+                summary: { text: "Summary 1." },
+                content: { html: '<p>Content 1.</p>' }
+              },
+              {
+                heading: { text: 'Heading 2' },
+                summary: { text: "Summary 2." },
+                content: { html: '<p>Content 2.</p>' }
+              }]
+    }
+
+    render_component(test_data)
+
+    assert_select '#test-for-id', count: 1
+    assert_select "[id^='test-for-id-heading-']", count: 2
+    assert_select "[id^='test-for-id-summary-']", count: 2
+    assert_select "[id^='test-for-id-content-']", count: 2
+  end
+
+  it 'an id is created when no id is set' do
+    test_data = {
+      items: [{
+                heading: { text: 'Heading 1' },
+                summary: { text: "Summary 1." },
+                content: { html: '<p>Content 1.</p>' }
+              }]
+    }
+
+    render_component(test_data)
+
+    # Default id is `default-id-{XXXXXXXX}`. This is using CSS selectors
+    # to check the start and the end of the id.
+    assert_select "[id^='default-id-']", count: 4
+
+    assert_select "[id$='-heading-1']", count: 1
+    assert_select "[id$='-summary-1']", count: 1
+    assert_select "[id$='-content-1']", count: 1
+  end
+
+  it 'the heading level is changed when heading_level is set' do
+    test_data = {
+      id: 'heading-level-change',
+      heading_level: 5,
+      items: [{
+                heading: { text: 'Heading 1' },
+                summary: { text: "Summary 1." },
+                content: { html: '<p>Content 1.</p>' }
+              }]
+    }
+    render_component(test_data)
+    assert_select "h5", count: 1
+  end
+
+  it 'default heading level is used when heading_level is not set' do
+    test_data = {
+      id: 'heading-level-default',
+      items: [{
+                heading: { text: 'Heading 1' },
+                summary: { text: "Summary 1." },
+                content: { html: '<p>Content 1.</p>' }
+              }]
+    }
+
+    render_component(test_data)
+    assert_select "h2", count: 1
+  end
+
+  it 'data attribute is present when required' do
+    test_data = {
+      id: 'test-for-data-attributes',
+      items: [{
+                heading: { text: 'Heading 1' },
+                content: { html: '<p>Content 1.</p>' },
+                data_attributes: { gtm: "google-tag-manager" }
+              },
+              {
+                heading: { text: 'Heading 2' },
+                content: { html: '<p>Content 2.</p>' },
+                data_attributes: { gtm: "google-tag-manager" }
+              }]
+    }
+
+    render_component(test_data)
+
+    assert_select "[data-gtm]", count: 2
+    assert_select "[data-gtm='google-tag-manager']", count: 2
+  end
+
+  it '`data-module="accordion"` attribute is present when no custom data attributes given' do
+    test_data = {
+      id: 'test-for-module-data-attributes',
+      items: [{
+                heading: { text: 'Heading 1' },
+                content: { html: '<p>Content 1.</p>' },
+              },
+              {
+                heading: { text: 'Heading 2' },
+                content: { html: '<p>Content 2.</p>' },
+              }]
+    }
+    render_component(test_data)
+    assert_select "[data-module='accordion']", count: 1
+  end
+
+  it '`data-module="accordion"` attribute is present when custom data attributes given' do
+    test_data = {
+      id: 'test-for-module-data-attributes',
+      data_attributes: {
+        accordion: 'first'
+      },
+      items: [{
+                data_attributes: {
+                  gtm: 'this-is-gtm'
+                },
+                heading: { text: 'Heading 1' },
+                content: { html: '<p>Content 1.</p>' },
+              },
+              {
+                data_attributes: {
+                  gtm: 'this-is-a-second-gtm'
+                },
+                heading: { text: 'Heading 2' },
+                content: { html: '<p>Content 2.</p>' },
+              }]
+    }
+    render_component(test_data)
+    assert_select "[data-module='accordion']", count: 1
+    assert_select "[data-gtm]", count: 2
+    assert_select "[data-gtm='this-is-gtm']", count: 1
+    assert_select "[data-gtm='this-is-a-second-gtm']", count: 1
+    assert_select "[data-accordion='first']", count: 1
+  end
+
+  it 'section has class added when expanded flag is present' do
+    test_data = {
+      id: 'condensed-layout',
+      condensed: true,
+      items: [{
+                heading: { text: 'Heading 1' },
+                summary: { text: "Summary 1." },
+                content: { html: '<p>Content 1.</p>' },
+                expanded: true
+              },
+              {
+                heading: { text: 'Heading 2' },
+                summary: { text: "Summary 2." },
+                content: { html: '<p>Content 2.</p>' }
+              }]
+    }
+    render_component(test_data)
+    assert_select '.govuk-accordion__section.govuk-accordion__section--expanded', count: 1
+    assert_select '.govuk-accordion__section', count: 2
+  end
+
+  it 'condensed class added correctly' do
+    test_data = {
+      id: 'condensed-layout',
+      condensed: true,
+      items: [{
+                heading: { text: 'Heading 1' },
+                summary: { text: "Summary 1." },
+                content: { html: '<p>Content 1.</p>' }
+              }]
+    }
+    render_component(test_data)
+    assert_select '.govuk-accordion.govuk-accordion--condensed', count: 1
+  end
+
+  it 'loop index starts at one, not zero (thanks Nunjucks.)' do
+    test_data = {
+      id: 'thanks-nunjucks',
+      items: [{
+                heading: { text: 'Heading 1' },
+                summary: { text: "Summary 1." },
+                content: { html: '<p>Content 1.</p>' }
+              }]
+    }
+
+    render_component(test_data)
+
+    assert_select '#thanks-nunjucks-heading-1', count: 1
+    assert_select '#thanks-nunjucks-summary-1', count: 1
+    assert_select '#thanks-nunjucks-content-1', count: 1
+  end
+end


### PR DESCRIPTION
Adds the Accordion component based on GOV.UK Frontend.

[Card](https://trello.com/c/9KTI0qjV/577-add-accordion-component-as-a-component-and-use-it-for-markdown-styleguide).

This component is required by Content Publisher to hide and show the Govspeak guidance.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-714.herokuapp.com/component-guide/accordion/
