### PR TITLE
Extend accessible autocomplete onConfirm function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Extend accessible autocomplete onConfirm function (PR #718)
 * Add type option to button component (PR #711)
 
 ## 13.6.1

--- a/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
@@ -7,8 +7,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   "use strict";
 
   Modules.AccessibleAutocomplete = function () {
+    var $selectElem;
+
     this.start = function ($element) {
-      var $selectElem = $element.find('select');
+      $selectElem = $element.find('select');
 
       var configOptions = {
         selectElement: document.getElementById($selectElem.attr('id')),
@@ -18,20 +20,36 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         defaultValue: ""
       };
 
-      configOptions.onConfirm = function(label) {
-        if ($selectElem.data('track-category') !== undefined && $selectElem.data('track-action') !== undefined) {
-          track($selectElem.data('track-category'), $selectElem.data('track-action'), label, $selectElem.data('track-options'));
-        }
-        // This is to compensate for the fact that the accessible-autocomplete library will not
-        // update the hidden select if the onConfirm function is supplied
-        // https://github.com/alphagov/accessible-autocomplete/issues/322
-        var value = $selectElem.children("option").filter(function () { return $(this).html() == label; }).val();
-        if (typeof value !== 'undefined') {
-          $selectElem.val(value).trigger( "change" );
-        }
-      };
+      configOptions.onConfirm = this.onConfirm;
 
       new accessibleAutocomplete.enhanceSelectElement(configOptions);
+      //attach the onConfirm function to data attr, to call it in finder-frontend when clearing facet tags
+      $selectElem.data('onconfirm', this.onConfirm);
+    };
+
+    this.onConfirm = function(label, removeDropDown) {
+      if ($selectElem.data('track-category') !== undefined && $selectElem.data('track-action') !== undefined) {
+        track($selectElem.data('track-category'), $selectElem.data('track-action'), label, $selectElem.data('track-options'));
+      }
+      // This is to compensate for the fact that the accessible-autocomplete library will not
+      // update the hidden select if the onConfirm function is supplied
+      // https://github.com/alphagov/accessible-autocomplete/issues/322
+      var value = $selectElem.children("option").filter(function () { return $(this).html() == label; }).val();
+      if (typeof value !== 'undefined') {
+        $selectElem.val(value).trigger( "change" );
+      }
+
+      // used to clear the autocomplete when clicking on a facet tag in finder-frontend
+      // very brittle but menu visibility is determined by autocomplete after this function is called
+      // setting autocomplete val to '' causes menu to appear, we don't want that, this solves it
+      // ideally will rewrite autocomplete to have better hooks in future
+      if (removeDropDown) {
+        $selectElem.closest('.gem-c-accessible-autocomplete').addClass('gem-c-accessible-autocomplete--hide-menu');
+        setTimeout(function() {
+          $('.autocomplete__menu').remove(); // this element is recreated every time the user starts typing
+          $selectElem.closest('.gem-c-accessible-autocomplete').removeClass('gem-c-accessible-autocomplete--hide-menu');
+        }, 100);
+      }
     };
 
     function track (category, action, label, options) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
@@ -13,3 +13,9 @@
     @include govuk-font(19)
   }
 }
+
+.gem-c-accessible-autocomplete--hide-menu {
+  .autocomplete__menu {
+    display: none;
+  }
+}


### PR DESCRIPTION
In finder-frontend we have facet tags that appear above search results when users choose search options. The intended functionality is that clicking on these facet tags will remove them from the search, updating the search results and clearing the relevant input.

![screen shot 2019-01-23 at 11 01 45](https://user-images.githubusercontent.com/861310/51602210-50584780-1efe-11e9-865c-3f23837378b5.png)

This is complicated in the case of accessible autocompletes as the code is imported and doesn't have any hooks for doing this externally. Problems:

- externally clearing the value of the autocomplete causes the drop down of suggestions to appear and we can't access the code that controls that
- simulating a user click in the 0th drop down item would work, but it shifts the focus back to the autocomplete, which is confusing

Solution:

- attach our custom `onConfirm` function to the autocomplete's (hidden) select element, so it can be called by JS in finder-frontend
- update `onConfirm` to allow an extra parameter, only passed when clicking on a facet tag, to hide the menu
- if this parameter is passed, apply a class to the autocomplete parent to hide the menu, then call a short timeout to remove the menu from the dom then remove the hiding class, so the next time the autocomplete is used the menu will appear again (the menu element is recreated every time, so removing it is okay)

This is not an ideal solution to this problem. In the near future we intend to do something better.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-718.herokuapp.com/component-guide/accessible_autocomplete

Trello card: https://trello.com/c/Gk9FE0Sg/238-fix-finders-bugs