### PR TITLE
Version 13.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 13.7.0
+
 * Extend accessible autocomplete onConfirm function (PR #718)
 * Add Accordion component based on GOV.UK Frontend (PR #714)
 * Add type option to button component (PR #711)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (13.6.1)
+    govuk_publishing_components (13.7.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '13.6.1'.freeze
+  VERSION = '13.7.0'.freeze
 end


### PR DESCRIPTION
Includes:

* Extend accessible autocomplete onConfirm function (PR #718)
* Add Accordion component based on GOV.UK Frontend (PR #714)
* Add type option to button component (PR #711)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-721.herokuapp.com/component-guide/
