### PR TITLE
Add multiple selection option to autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Increase focus contrast of feedback links (PR #731)
+* Add multiple selection option to autocomplete (PR #723)
 
 ## 13.8.1
 

--- a/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
@@ -27,8 +27,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       $selectElem.data('onconfirm', this.onConfirm);
     };
 
-    this.onConfirm = function(label, removeDropDown) {
-
+    this.onConfirm = function(label, value, removeDropDown) {
       function escapeHTML(str){
         return new Option(str).innerHTML;
       }
@@ -39,21 +38,30 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       // This is to compensate for the fact that the accessible-autocomplete library will not
       // update the hidden select if the onConfirm function is supplied
       // https://github.com/alphagov/accessible-autocomplete/issues/322
-      var value = $selectElem.children("option").filter(function () { return $(this).html() == escapeHTML(label); }).val();
-      if (typeof value !== 'undefined') {
-        $selectElem.val(value).change();
-      }
+      if (typeof label !== 'undefined') {
+        if (typeof value === 'undefined') {
+          value = $selectElem.children("option").filter(function () { return $(this).html() == escapeHTML(label); }).val();
+        }
 
-      // used to clear the autocomplete when clicking on a facet tag in finder-frontend
-      // very brittle but menu visibility is determined by autocomplete after this function is called
-      // setting autocomplete val to '' causes menu to appear, we don't want that, this solves it
-      // ideally will rewrite autocomplete to have better hooks in future
-      if (removeDropDown) {
-        $selectElem.closest('.gem-c-accessible-autocomplete').addClass('gem-c-accessible-autocomplete--hide-menu');
-        setTimeout(function() {
-          $('.autocomplete__menu').remove(); // this element is recreated every time the user starts typing
-          $selectElem.closest('.gem-c-accessible-autocomplete').removeClass('gem-c-accessible-autocomplete--hide-menu');
-        }, 100);
+        if (typeof value !== 'undefined') {
+          var $option = $selectElem.find('option[value=\'' + value + '\']');
+          // if removeDropDown we are clearing the selection from outside the component
+          var selectState = typeof removeDropDown === 'undefined' ? true : false;
+          $option.prop('selected', selectState);
+          $selectElem.change();
+        }
+
+        // used to clear the autocomplete when clicking on a facet tag in finder-frontend
+        // very brittle but menu visibility is determined by autocomplete after this function is called
+        // setting autocomplete val to '' causes menu to appear, we don't want that, this solves it
+        // ideally will rewrite autocomplete to have better hooks in future
+        if (removeDropDown) {
+          $selectElem.closest('.gem-c-accessible-autocomplete').addClass('gem-c-accessible-autocomplete--hide-menu');
+          setTimeout(function() {
+            $('.autocomplete__menu').remove(); // this element is recreated every time the user starts typing
+            $selectElem.closest('.gem-c-accessible-autocomplete').removeClass('gem-c-accessible-autocomplete--hide-menu');
+          }, 100);
+        }
       }
     };
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
@@ -10,12 +10,38 @@
   }
 
   .autocomplete__option {
-    @include govuk-font(19)
+    @include govuk-font(19);
+  }
+
+  // needed as frontend doesn't currently support select multiples
+  // hopefully will in future and this can be removed
+  .govuk-select[multiple] {
+    height: auto;
+  }
+
+  .js-enabled & .app-c-autocomplete__multiselect-instructions {
+    display: none;
+  }
+
+  .autocomplete__list .autocomplete__option {
+    padding: 5px 6px;
+
+    &:before {
+      position: relative;
+      top: 3px;
+      padding-top: 2px;
+    }
   }
 }
 
 .gem-c-accessible-autocomplete--hide-menu {
   .autocomplete__menu {
+    display: none;
+  }
+}
+
+.gem-c-accessible-autocomplete--hide-facets {
+  .autocomplete__list {
     display: none;
   }
 }

--- a/app/views/govuk_publishing_components/components/_accessible_autocomplete.html.erb
+++ b/app/views/govuk_publishing_components/components/_accessible_autocomplete.html.erb
@@ -4,6 +4,11 @@
   data_attributes ||= nil
   options ||= []
   selected_option ||= nil
+  multiple ||= false
+  hide_facets ||= false
+
+  classes = %w(gem-c-accessible-autocomplete)
+  classes << "gem-c-accessible-autocomplete--hide-facets" if hide_facets
 %>
 <% if label && options.any? %>
   <div class="govuk-form-group">
@@ -13,15 +18,20 @@
       }.merge(label.symbolize_keys)
     %>
 
-    <div class="gem-c-accessible-autocomplete" data-module="accessible-autocomplete">
+    <%= tag.div class: classes, data: { module: "accessible-autocomplete" } do %>
+      <% if multiple %>
+        <span class="govuk-hint app-c-autocomplete__multiselect-instructions"><%= t('components.autocomplete.multiselect') %></span>
+      <% end %>
+
       <%=
         select_tag(
           id,
           options_for_select(options, selected_option),
+          multiple: multiple,
           class: "govuk-select",
           data: data_attributes
         )
       %>
-    </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
+++ b/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
@@ -40,3 +40,18 @@ examples:
         track_action: 'chosen_action'
         track_option:
           custom_dimension: 'your_custom_dimension'
+  with_multiple_selections:
+    description: This parameter allows the user to choose more than one option from the autocomplete. The component generates a select multiple in place of a regular select, and the autocomplete Javascript detects this and provides the multiple selection functionality.
+    data:
+      multiple: true
+      label:
+        text: 'Countries'
+      options: [['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us'], ['The Separate Customs Territory of Taiwan, Penghu, Kinmen, and Matsu (Chinese Taipei)', 'tw']]
+  with_multiple_selections_hide_facets:
+    description: This parameter hides the facet tags shown by the component in multiple mode when options have been chosen. This seems counter to likely requirements but is needed for finders where the app generates its own facet tags.
+    data:
+      multiple: true
+      hide_facets: true
+      label:
+        text: 'Countries'
+      options: [['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us'], ['The Separate Customs Territory of Taiwan, Penghu, Kinmen, and Matsu (Chinese Taipei)', 'tw']]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,8 @@ en:
   common:
     translations: "Translations"
   components:
+    autocomplete:
+      multiselect: "To select multiple items in a list, hold down Ctrl (PC) or Cmd (Mac) key."
     back_link:
       back: 'Back'
     contents_list:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,9 +3,8 @@
   "lockfileVersion": 1,
   "dependencies": {
     "accessible-autocomplete": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-1.6.2.tgz",
-      "integrity": "sha512-7S+6Vi82LQFSSd5feKedu46tiY2/DShpdXiRp0NY3cLwc+DKe1ayWd66mb3JVi8LTQubRM7jco+u92e6w0bbvg==",
+      "version": "git://github.com/alphagov/accessible-autocomplete.git#50ac417911660b9e171af8b5d97ed2080e486e1d",
+      "from": "git://github.com/alphagov/accessible-autocomplete.git#add-multiselect-support",
       "requires": {
         "preact": "^8.3.1"
       }
@@ -21,9 +20,9 @@
       "integrity": "sha1-AeHfuikP5z3rp3zurLD5ui/sngw="
     },
     "preact": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.3.1.tgz",
-      "integrity": "sha512-s8H1Y8O9e+mOBo3UP1jvWqArPmjCba2lrrGLlq/0kN1XuIINUbYtf97iiXKxCuG3eYwmppPKnyW2DBrNj/TuTg=="
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.4.2.tgz",
+      "integrity": "sha512-TsINETWiisfB6RTk0wh3/mvxbGRvx+ljeBccZ4Z6MPFKgu/KFGyf2Bmw3Z/jlXhL5JlNKY6QAbA9PVyzIy9//A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "accessible-autocomplete": "^1.6.2",
+    "accessible-autocomplete": "git://github.com/alphagov/accessible-autocomplete.git#add-multiselect-support",
     "govuk-frontend": "^2.5.1",
     "jquery": "1.12.4"
   }

--- a/spec/components/accessible_autocomplete_spec.rb
+++ b/spec/components/accessible_autocomplete_spec.rb
@@ -14,6 +14,7 @@ describe "AccessibleAutocomplete", type: :view do
 
     assert_select ".govuk-label", text: "Countries", for: "basic-autocomplete"
     assert_select "select#basic-autocomplete"
+    assert_select "select[multiple]", false
     assert_select "select#basic-autocomplete option[value=gb]"
     assert_select "select#basic-autocomplete option[value=gb]", text: 'United Kingdom'
     assert_select "select#basic-autocomplete option[value=us]"
@@ -50,5 +51,27 @@ describe "AccessibleAutocomplete", type: :view do
       id: 'basic-autocomplete',
       label: { text: "Countries" }
     )
+  end
+
+  it 'renders the multiple selection version correctly' do
+    render_component(
+      multiple: true,
+      label: { text: "Countries" },
+      options: [['United Kingdom', 'gb'], ['United States', 'us']]
+    )
+
+    assert_select "select[multiple]"
+    assert_select ".gem-c-accessible-autocomplete.gem-c-accessible-autocomplete--hide-facets", false
+  end
+
+  it 'does not show facet tags for multiple when given the option' do
+    render_component(
+      multiple: true,
+      hide_facets: true,
+      label: { text: "Countries" },
+      options: [['United Kingdom', 'gb'], ['United States', 'us']]
+    )
+
+    assert_select ".gem-c-accessible-autocomplete.gem-c-accessible-autocomplete--hide-facets"
   end
 end

--- a/spec/javascripts/components/accessible-autocomplete-spec.js
+++ b/spec/javascripts/components/accessible-autocomplete-spec.js
@@ -7,6 +7,14 @@ describe("An accessible autocomplete component", function () {
     autocomplete.start($('.gem-c-accessible-autocomplete'));
   }
 
+  function loadAutocompleteMultiple() {
+    //var multipleHtml = html.replace('<select', '<select multiple ');
+    setFixtures(html);
+    var autocomplete = new GOVUK.Modules.AccessibleAutocomplete();
+    $('.gem-c-accessible-autocomplete').find('select').attr('multiple','multiple').find('option:first-child').remove();
+    autocomplete.start($('.gem-c-accessible-autocomplete'));
+  }
+
   var html = '\
     <div class="gem-c-accessible-autocomplete" data-module="accessible-autocomplete">\
       <select id="test" class="govuk-select" data-track-category="category" data-track-action="action">\
@@ -121,6 +129,48 @@ describe("An accessible autocomplete component", function () {
     it('when an input is cleared', function () {
       expect(GOVUK.analytics.trackEvent).
         toHaveBeenCalledWith('category', 'action', Object({ label: '' }));
+    });
+  });
+
+  describe('in multiple mode', function() {
+    beforeEach(function (done) {
+      loadAutocompleteMultiple();
+      // use the component api for this test
+      // as methods in previous tests don't seem to
+      // work in multiple mode
+      var onConfirm = $('select').data('onconfirm');
+
+      $('.autocomplete__input').val('Deer');
+      onConfirm('Deer', 'de');
+
+      testAsyncWithDeferredReturnValue().done(function () {
+        done();
+      });
+    });
+
+    it('selects one option in the select', function () {
+      expect($('select').val()).toEqual(['de']);
+    });
+  });
+
+  describe('in multiple mode', function() {
+    beforeEach(function (done) {
+      loadAutocompleteMultiple();
+      var onConfirm = $('select').data('onconfirm');
+
+      $('.autocomplete__input').val('Moose');
+      onConfirm('Moose', 'mo');
+
+      $('.autocomplete__input').val('Deer');
+      onConfirm('Deer', 'de');
+
+      testAsyncWithDeferredReturnValue().done(function () {
+        done();
+      });
+    });
+
+    it('selects multiple options in the select', function () {
+      expect($('select').val()).toEqual(['mo', 'de']);
     });
   });
 });


### PR DESCRIPTION
Adds multiple selections as an option to the accessible autocomplete.

![screen shot 2019-01-28 at 13 18 27](https://user-images.githubusercontent.com/861310/51838766-399b6180-22ff-11e9-8df4-fc38c9072feb.png)

This is based on a [branch of the autocomplete](https://github.com/alphagov/accessible-autocomplete/tree/add-multiselect-support) so we probably don't want to merge this PR until we've decided whether that's acceptable or if/how we can get this functionality into the main branch.

---

Trello card: https://trello.com/c/gpTK31dA/183-add-multiple-selection-functionality-to-accessible-autocomplete

Component guide for this PR:
https://govuk-publishing-compon-pr-723.herokuapp.com/component-guide/accessible_autocomplete
