### PR TITLE
Add govuk-frontend spacing scale to hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add govuk-frontend spacing scale to hint (PR #724)
 * Increase focus contrast of feedback links (PR #731)
 
 ## 13.8.1

--- a/app/views/govuk_publishing_components/components/_hint.html.erb
+++ b/app/views/govuk_publishing_components/components/_hint.html.erb
@@ -1,8 +1,9 @@
 <%
   id ||= "hint-#{SecureRandom.hex(4)}"
-  classes ||= ''
+  margin_bottom ||= 3
+
   css_classes = %w( gem-c-hint govuk-hint )
-  css_classes << classes if classes
+  css_classes << ([*0..9].include?(margin_bottom) ? "govuk-!-margin-bottom-#{margin_bottom}" : "govuk-!-margin-bottom-3")
 %>
 
 <%= tag.span id: id, class: css_classes do %>

--- a/app/views/govuk_publishing_components/components/docs/hint.yml
+++ b/app/views/govuk_publishing_components/components/docs/hint.yml
@@ -14,3 +14,8 @@ examples:
   default:
     data:
       text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+  with_margin_bottom:
+    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](http://govuk-frontend-review.herokuapp.com/docs/#settings/spacing-variable-govuk-spacing-points). It defaults to a margin bottom of 3 (15px).
+    data:
+      text: "You qualify if you were born in the UK before June 1960."
+      margin_bottom: 9

--- a/spec/components/hint_spec.rb
+++ b/spec/components/hint_spec.rb
@@ -8,6 +8,24 @@ describe "Hint", type: :view do
   it "renders hint" do
     render_component(text: "For example, ‘QQ 12 34 56 C’.")
 
-    assert_select(".govuk-hint", text: "For example, ‘QQ 12 34 56 C’.")
+    assert_select '.govuk-hint.govuk-\!-margin-bottom-3', text: "For example, ‘QQ 12 34 56 C’."
+  end
+
+  it "applies a specified bottom margin" do
+    render_component(text: "For example, ‘QQ 12 34 56 C’.", margin_bottom: 7)
+
+    assert_select '.govuk-hint.govuk-\!-margin-bottom-7'
+  end
+
+  it "applies zero bottom margin" do
+    render_component(text: "For example, ‘QQ 12 34 56 C’.", margin_bottom: 0)
+
+    assert_select '.govuk-hint.govuk-\!-margin-bottom-0'
+  end
+
+  it "defaults to the initial bottom margin if an incorrect value is passed" do
+    render_component(text: "For example, ‘QQ 12 34 56 C’.", margin_bottom: 12)
+
+    assert_select '.govuk-hint.govuk-\!-margin-bottom-3'
   end
 end


### PR DESCRIPTION
**This PR cannot be merged until finder-frontend has been updated to use this new option, [coming soon](https://github.com/alphagov/finder-frontend/pull/833)**

This PR removes the option to pass an arbitrary class to the hint component and replaces it with an option to pass a number between 0 and 9 to provide variable bottom margin using the [govuk-frontend spacing classes](http://govuk-frontend-review.herokuapp.com/docs/#settings/spacing-variable-govuk-spacing-points).

![screen shot 2019-01-29 at 08 50 17](https://user-images.githubusercontent.com/861310/51895841-07dbd680-23a3-11e9-9eed-9171fc7b1c8d.png)

This removes the potential loss of isolation for the component and replaces it with an option that provides the functionality for which the class option was intended. 

Places where hint is used:

- finder-frontend (where it is given a a govuk-frontend spacing class)
- file upload component, using the default margin
- textarea component, using default
- radio component, using default
- input component, using default

---

Component guide for this PR:
https://govuk-publishing-compon-pr-724.herokuapp.com/component-guide/hint
