### PR TITLE
Show finder breadcrumb for specialist documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update contextual breadcrumbs to not show taxonomy breadcrumbs when showing specialist documents (PR #725)  
+
 ## 13.7.0
 
 * Extend accessible autocomplete onConfirm function (PR #718)

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -18,7 +18,7 @@
   <% elsif navigation.content_has_curated_related_items? %>
     <%# Rendering parent-based breadcrumbs because the page has curated related links %>
     <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
-  <% elsif navigation.content_is_tagged_to_a_live_taxon? %>
+  <% elsif navigation.content_is_tagged_to_a_live_taxon? && !navigation.content_is_a_specialist_document? %>
     <%# Rendering taxonomy breadcrumbs because the page is tagged to live taxons %>
     <%= render 'govuk_publishing_components/components/breadcrumbs',
       breadcrumbs: navigation.taxon_breadcrumbs[:breadcrumbs],

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -21,7 +21,7 @@ module GovukPublishingComponents
       end
 
       def breadcrumbs
-        if content_item["schema_name"] == "specialist_document"
+        if content_is_a_specialist_document?
           parent_finder = content_item.dig("links", "finder", 0)
           return [] unless parent_finder
 
@@ -50,6 +50,10 @@ module GovukPublishingComponents
 
       def content_is_tagged_to_a_live_taxon?
         content_item.dig("links", "taxons").to_a.any? { |taxon| taxon["phase"] == "live" }
+      end
+
+      def content_is_a_specialist_document?
+        content_item["schema_name"] == "specialist_document"
       end
 
       def content_tagged_to_current_step_by_step?

--- a/spec/components/contextual_breadcrumbs_spec.rb
+++ b/spec/components/contextual_breadcrumbs_spec.rb
@@ -76,6 +76,34 @@ describe "ContextualBreadcrumbs", type: :view do
     assert_no_selector(".gem-c-breadcrumbs")
   end
 
+  it "renders parent finder breadcrumb if content schema is a specialist document" do
+    content_item = example_document_for("specialist_document", "cma-cases")
+    content_item["links"]["taxons"] = [
+      {
+        api_path: "/api/content/business/competition",
+        base_path: "/business/competition",
+        document_type: "taxon",
+        phase: "live",
+        links: {
+          parent_taxons: [
+            {
+              api_path: "/api/content/business-and-industry/business-regulation",
+              base_path: "/business-and-industry/business-regulation",
+              document_type: "taxon",
+              phase: "live",
+              links: {}
+            }
+          ]
+        }
+      }
+    ]
+
+    render_component(content_item: content_item)
+
+    assert_select "a", text: "Home"
+    assert_select "a", text: "Competition and Markets Authority cases"
+  end
+
   it "renders no breadcrumbs if there aren't any" do
     content_item = example_document_for("guide", "guide")
     content_item = remove_mainstream_browse(content_item)


### PR DESCRIPTION
This PR stops the contextual breadcrumbs component from showing taxonomy breadcrumbs when the content being viewed is a specialist document. This allows the content item's finder to be displayed instead, for which the logic already exists in the `breadcrumbs` method of `contextual_navigation.rb`. By making this change, we allow users to more easily navigate to the correct specialist finder if they come from somewhere other than a specialist finder.

Note that if `prioritise_taxon_breadcrumbs` is specified and set to `true` as part of instantiating the contextual breadcrumbs component, it is possible to override the above behaviour.

Solo: @karlbaker02

Example: for a specialist doc at https://www.gov.uk/cma-cases/funerals-market-study

Before:

![screen shot 2019-01-31 at 15 22 09](https://user-images.githubusercontent.com/5422487/52064242-27722b00-256c-11e9-8551-f77aaba64370.png)

After:

![screen shot 2019-01-31 at 15 22 25](https://user-images.githubusercontent.com/5422487/52064253-2b9e4880-256c-11e9-89b2-e637f9b4f3f3.png)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-725.herokuapp.com/component-guide/
