### PR TITLE
Upgrade to 13.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 13.8.0
 
 * Update contextual breadcrumbs to not show taxonomy breadcrumbs when showing specialist documents (PR #725)  
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (13.7.0)
+    govuk_publishing_components (13.8.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '13.7.0'.freeze
+  VERSION = '13.8.0'.freeze
 end


### PR DESCRIPTION
Includes:
- Stop showing taxonomy breadcrumbs when viewing specialist documents (#725)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-726.herokuapp.com/component-guide/
