### PR TITLE
Remove classes option from components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove classes option from components (PR #727)
+
 ## 15.3.0
 
 * Update skip-link to allow custom link text (PR #755)

--- a/app/views/govuk_publishing_components/components/_inset_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_inset_text.html.erb
@@ -1,10 +1,7 @@
 <%
   id ||= "inset-text-#{SecureRandom.hex(4)}"
-  classes ||= ''
-  css_classes = %w( gem-c-inset-text govuk-inset-text )
-  css_classes << classes if classes
 %>
 
-<%= tag.div id: id, class: css_classes do %>
+<%= tag.div id: id, class: "gem-c-inset-text govuk-inset-text" do %>
   <%= text %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_label.html.erb
+++ b/app/views/govuk_publishing_components/components/_label.html.erb
@@ -1,13 +1,14 @@
 <%
-  classes ||= ''
   hint_text ||= ''
-  hint_text_classes ||= ''
+  is_radio_label ||= false
   bold ||= false
+
   css_classes = %w( gem-c-label govuk-label )
   css_classes << "govuk-label--s" if bold
-  css_classes << classes if classes
+  css_classes << "govuk-radios__label" if is_radio_label
+
   hint_text_css_classes = %w( govuk-hint )
-  hint_text_css_classes << hint_text_classes if hint_text_classes
+  hint_text_css_classes << "govuk-radios__hint" if is_radio_label
 %>
 
 <%= tag.label for: html_for, class: css_classes do %>

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -89,8 +89,7 @@
             <%= render "govuk_publishing_components/components/label", {
               hint_id: label_hint_id,
               html_for: label_id,
-              classes: "govuk-radios__label",
-              hint_text_classes: "govuk-radios__hint",
+              is_radio_label: true,
               hint_text: item[:hint_text],
               text: item[:text],
               bold: item[:bold]
@@ -98,9 +97,9 @@
           <% end %>
 
           <% if item[:conditional] %>
-          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="<%= conditional_id %>">
-            <%= item[:conditional] %>
-          </div>
+            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="<%= conditional_id %>">
+              <%= item[:conditional] %>
+            </div>
           <% end %>
 
         <% end %>

--- a/app/views/govuk_publishing_components/components/_warning_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_warning_text.html.erb
@@ -1,13 +1,9 @@
 <%
   id ||= "warning-text-#{SecureRandom.hex(4)}"
-  classes ||= ''
   text_assistive ||= 'Warning'
   text_icon ||= '!'
   large_font ||= false
   highlight_text ||= false
-
-  css_classes = %w(gem-c-warning-text govuk-warning-text)
-  css_classes << classes if classes
 
   text_classes = %w(govuk-warning-text__text)
   text_classes << "gem-c-warning-text__text--no-indent" if text_icon.empty?
@@ -15,7 +11,7 @@
   text_classes << "gem-c-warning-text__text--highlight" if highlight_text
 %>
 
-<%= tag.div id: id, class: css_classes do %>
+<%= tag.div id: id, class: "gem-c-warning-text govuk-warning-text" do %>
   <% unless text_icon.empty? %>
     <%= tag.span text_icon, class: "govuk-warning-text__icon", "aria-hidden": "true" %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/docs/label.yml
+++ b/app/views/govuk_publishing_components/components/docs/label.yml
@@ -34,3 +34,12 @@ examples:
       html_for: "id-that-matches-input"
       hint_id: "should-match-aria-describedby-input-bold"
       hint_text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+  inside_a_radio_component:
+    description: Then the label is used inside the [radio component](/component-guide/radio) additional classes are required on the radio, which are added by this option. This is already handled by the radio component and is a specific use case, but is worth documenting.
+    data:
+      text: "National Insurance number"
+      html_for: "id-that-matches-input"
+      is_radio_label: true
+      html_for: "id-radio"
+      hint_id: "id-radio"
+      hint_text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."

--- a/spec/components/label_spec.rb
+++ b/spec/components/label_spec.rb
@@ -52,4 +52,17 @@ describe "Label", type: :view do
     )
     assert_select ".govuk-label--s"
   end
+
+  it "renders label when required to be inside the radio component" do
+    render_component(
+      is_radio_label: true,
+      text: "A label for the radio component",
+      html_for: "id-radio",
+      hint_id: "should-match-aria-describedby-input",
+      hint_text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    )
+
+    assert_select ".gem-c-label.govuk-label.govuk-radios__label"
+    assert_select ".govuk-hint.govuk-radios__hint"
+  end
 end


### PR DESCRIPTION
**This PR should not be merged before https://github.com/alphagov/govuk_publishing_components/pull/724 (now merged, so we're okay)**

Removing the ability to pass arbitrary classes to several components, which was potentially damaging to component isolation. Specifically:

- inset text (only appears to be [used in email-alert-frontend](https://github.com/search?q=org%3Aalphagov+govuk_publishing_components%2Fcomponents%2Finset_text&type=Code) where the `classes` option is not used)
- warning text ([doesn't appear to be used anywhere?](https://github.com/search?q=org%3Aalphagov+govuk_publishing_components%2Fcomponents%2Fwarning_text&type=Code))
- label ([used in](https://github.com/search?p=1&q=org%3Aalphagov+govuk_publishing_components%2Fcomponents%2Flabel&type=Code) content publisher without classes, used throughout govuk_publishing_components but only in the radio component to add classes, have replaced with a `is_radio_label` option that adds the classes inside the component instead of passing them) 

In all of these cases the `classes` option was undocumented and untested. It has been used previously in the hint component to allow the app to add bottom margin, but this has been replaced with a specific option to provide the same functionality.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-727.herokuapp.com/component-guide/
