### PR TITLE
Fix accessible autocomplete so it can handle HTML entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 13.8.1
+
+* Fix autocomplete to allow it to handle HTML entities in the select list (PR #728)
+
 ## 13.8.0
 
-* Update contextual breadcrumbs to not show taxonomy breadcrumbs when showing specialist documents (PR #725)  
+* Update contextual breadcrumbs to not show taxonomy breadcrumbs when showing specialist documents (PR #725)
 
 ## 13.7.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
@@ -28,13 +28,18 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     };
 
     this.onConfirm = function(label, removeDropDown) {
+
+      function escapeHTML(str){
+        return new Option(str).innerHTML;
+      }
+
       if ($selectElem.data('track-category') !== undefined && $selectElem.data('track-action') !== undefined) {
         track($selectElem.data('track-category'), $selectElem.data('track-action'), label, $selectElem.data('track-options'));
       }
       // This is to compensate for the fact that the accessible-autocomplete library will not
       // update the hidden select if the onConfirm function is supplied
       // https://github.com/alphagov/accessible-autocomplete/issues/322
-      var value = $selectElem.children("option").filter(function () { return $(this).html() == label; }).val();
+      var value = $selectElem.children("option").filter(function () { return $(this).html() == escapeHTML(label); }).val();
       if (typeof value !== 'undefined') {
         $selectElem.val(value).change();
       }


### PR DESCRIPTION
Fix autocomplete js:
This fixes an issue where ampersands (and other characters) could not be
matched in the select box, resulting in an empty selection. This failed
silently in the background so the user was submitting blank choices they
were not aware of.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-728.herokuapp.com/component-guide/
