### PR TITLE
Adds custom event category for checkbox change events. Any app with it's own tracking logic for checkboxes will need to remove it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* `BREAKING:` Adds custom event category for checkbox change events. Any app with it's own tracking logic for checkboxes will need to remove it (PR #729)
+
 ## 14.0.0
 
 * BREAKING: Add govuk-frontend spacing scale to hint (PR #724)

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -23,6 +23,28 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
       });
 
+      $(scope).find('input[type=checkbox]').on('change', function(e) {
+        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+          var $checkbox = $(e.target);
+          var category = $checkbox.data("track-category");
+          if (typeof category !== "undefined") {
+            var isChecked = $checkbox.is(":checked");
+            var uncheckTrackCategory = $checkbox.data("uncheck-track-category");
+            if (!isChecked && typeof uncheckTrackCategory !== "undefined") {
+              category = uncheckTrackCategory;
+            }
+            var action = $checkbox.data("track-action");
+            var options = $checkbox.data("track-options");
+            if (typeof options !== 'object' || options === null) {
+              options = {};
+            }
+            options['value'] = $checkbox.data("track-value");
+            options['label'] = $checkbox.data("track-label");
+            GOVUK.analytics.trackEvent(category, action, options);
+          }
+        }
+      });
+
     };
 
     this.toggleNestedCheckboxes = function(scope, checkbox) {

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -114,7 +114,7 @@ examples:
         - label: "Blue"
           value: "blue"
   checkboxes_with_data_attributes:
-    description: Data attributes such as tracking can be applied if required. Note that for a checkbox this will not fire tracking events automatically, so if you want your tracking to work you'll need to write some tracking Javascript in the app around the component to detect it.
+    description: Data attributes such as tracking can be applied if required. This will fire tracking identical tracking events on check and uncheck. See below to send different events on uncheck.
     data:
       name: "With tracking"
       items:
@@ -122,6 +122,23 @@ examples:
           value: "tracked"
           data_attributes: {
             track_category: "checkboxClicked",
+            track_label: "/news-and-communications",
+            track_action: "news",
+            track_options: {
+              dimension28: 2,
+              dimension29: "Tracked"
+            }
+          }
+  checkboxes_with_data_attributes_and_custom_uncheck_event_category:
+    description: It can send a different tracking event category for an uncheck. This is handled automatically
+    data:
+      name: "With tracking and a custom uncheck category"
+      items:
+        - label: "Tracked"
+          value: "tracked"
+          data_attributes: {
+            track_category: "checkboxClicked",
+            untrack_category: "checkboxUnchecked",
             track_label: "/news-and-communications",
             track_action: "news",
             track_options: {

--- a/spec/javascripts/components/checkboxes-spec.js
+++ b/spec/javascripts/components/checkboxes-spec.js
@@ -13,7 +13,7 @@ describe("Checkboxes component", function () {
         <span id="checkboxes-1ac8e5cf-hint" class="govuk-hint">Select all that apply.</span>\
         <div class="govuk-checkboxes" data-nested="true">\
            <div class="gem-c-checkbox govuk-checkboxes__item">\
-              <input id="checkboxes-1ac8e5cf-0" name="favourite_colour" type="checkbox" value="red" class="govuk-checkboxes__input">\
+              <input id="checkboxes-1ac8e5cf-0" name="favourite_colour" type="checkbox" value="red" class="govuk-checkboxes__input" data-track-category="choseFavouriteColour" data-track-action="favourite-color" data-track-label="red" data-track-value="1" data-track-options='{"dimension28": "wubbalubbadubdub","dimension29": "Pickle Rick"}'>\
               <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-0">Red</label>\
            </div>\
            <div id="checkboxes-1ac8e5cf-nested-0" class="govuk-checkboxes govuk-checkboxes--nested" data-parent="checkboxes-1ac8e5cf-0">\
@@ -27,7 +27,7 @@ describe("Checkboxes component", function () {
               </div>\
            </div>\
            <div class="gem-c-checkbox govuk-checkboxes__item">\
-              <input id="checkboxes-1ac8e5cf-1" name="favourite_colour" type="checkbox" value="blue" class="govuk-checkboxes__input">\
+              <input id="checkboxes-1ac8e5cf-1" name="favourite_colour" type="checkbox" value="blue" class="govuk-checkboxes__input" data-track-category="choseFavouriteColour" data-uncheck-track-category="unselectedFavouriteColour" data-track-action="favourite-color" data-track-label="blue" data-track-value="2" data-track-options='{"dimension28":"Get schwifty","dimension29":"Squanch"}'>\
               <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-1">Blue</label>\
            </div>\
            <div id="checkboxes-1ac8e5cf-nested-1" class="govuk-checkboxes govuk-checkboxes--nested" data-parent="checkboxes-1ac8e5cf-1">\
@@ -51,6 +51,9 @@ describe("Checkboxes component", function () {
   var $parentCheckboxWrapper;
   var $parentCheckbox;
   var $nestedChildren;
+  var $checkboxesWrapper;
+  var expectedRedOptions;
+  var expectedBlueOptions;
 
   beforeEach(function() {
     setFixtures(FIXTURE);
@@ -59,6 +62,15 @@ describe("Checkboxes component", function () {
     $parentCheckboxWrapper = $('.govuk-checkboxes--nested:eq(0)').prev('.govuk-checkboxes__item');
     $parentCheckbox = $parentCheckboxWrapper.find('.govuk-checkboxes__input');
     $nestedChildren = $parentCheckboxWrapper.next('.govuk-checkboxes--nested').find('.govuk-checkboxes__input');
+    $checkboxesWrapper = $(".gem-c-checkboxes");
+    expectedRedOptions =  {label: "red", value: 1, dimension28: "wubbalubbadubdub", dimension29: "Pickle Rick"};
+    expectedBlueOptions = {label: "blue", value: 2, dimension28: "Get schwifty", dimension29: "Squanch"};
+
+    GOVUK.analytics = {
+      trackEvent: function(){}
+    }
+
+    spyOn(GOVUK.analytics, 'trackEvent');
   });
 
   it('checking a parent checkbox checks all its children', function () {
@@ -88,5 +100,37 @@ describe("Checkboxes component", function () {
     expect($('#checkboxes-1ac8e5cf-0-0.govuk-checkboxes__input').attr('aria-controls')).toBe('thing');
     expect($('#checkboxes-1ac8e5cf-1-0.govuk-checkboxes__input').attr('aria-controls')).toBe('thing2');
     expect($('#checkboxes-1ac8e5cf-0.govuk-checkboxes__input').attr('aria-controls')).toBe(undefined);
+  });
+
+  it('fires a Google analytics event when it is checked', function () {
+    $checkbox = $checkboxesWrapper.find(":input[value='red']");
+    $checkbox.trigger("click");
+    expect($checkbox.is(":checked")).toBe(true);
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith("choseFavouriteColour", "favourite-color", expectedRedOptions);
+  });
+
+  it('fires a Google analytics event when it is unchecked and there is no uncheck track category', function () {
+    $checkbox = $checkboxesWrapper.find(":input[value='red']");
+    $checkbox.trigger("click");
+    expect($checkbox.is(":checked")).toBe(true);
+
+    GOVUK.analytics.trackEvent.calls.reset();
+
+    $checkbox.trigger("click");
+    expect($checkbox.is(":checked")).toBe(false);
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith("choseFavouriteColour", "favourite-color", expectedRedOptions);
+  });
+
+  it('fires a Google analytics event when it is unchecked and there is an uncheck track category', function () {
+    $checkbox = $checkboxesWrapper.find(":input[value='blue']");
+    $checkbox.trigger("click");
+    expect($checkbox.is(":checked")).toBe(true);
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith("choseFavouriteColour", "favourite-color", expectedBlueOptions);
+
+    $checkbox.trigger("click");
+    expect($checkbox.is(":checked")).toBe(false);
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith("unselectedFavouriteColour", "favourite-color", expectedBlueOptions);
   });
 });


### PR DESCRIPTION
As checkboxes fire their own tracking event it will be necessary to
remove any custom logic in apps that listens for change events
otherwise it will fire twice.

Trello: https://trello.com/c/l6kGfBhh/230-add-missing-facet-tag-email-alert-tracking-and-checkbox-issue

Component guide for this PR:
https://govuk-publishing-compon-pr-729.herokuapp.com/component-guide/
