### PR TITLE
Bump gem to version 13.8.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (13.8.0)
+    govuk_publishing_components (13.8.1)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '13.8.0'.freeze
+  VERSION = '13.8.1'.freeze
 end


### PR DESCRIPTION
Bumping gem for bugfix on ampersands in the Accessible Autocomplete. Updated changelog on previous commit.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-730.herokuapp.com/component-guide/
