### PR TITLE
Increase focus contrast of feedback links

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -84,7 +84,7 @@
   color: $white;
 
   &:focus {
-    color: $link-colour;
+    color: $govuk-focus-text-colour;
   }
 }
 


### PR DESCRIPTION
The contrast of the focused feedback links doesn't meet WCAG criterion 1.4.3 (minimum contrast).
This changes the contrast to use the same <del>slightly darker colour that is also used for other links, copied from [govuk_template](https://github.com/alphagov/govuk_template/blob/master/source/assets/stylesheets/_accessibility.scss#L62-L65)</del> <ins>black-ish colour that is also used for in the Design System and GOV.UK Frontend</ins>.

<img width="925" alt="feedback-focus-colour-contrast-issue" src="https://user-images.githubusercontent.com/108893/52480054-8e15cb00-2ba2-11e9-8ab5-b47d2906d4be.png">

Component guide for this PR:
https://govuk-publishing-compon-pr-731.herokuapp.com/component-guide/
