### PR TITLE
Add `autocomplete` attribute to feedback form and use it on feedback component's survey signup form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add `autocomplete` attribute option to input component and use it on feedback component's survey signup form (PR #733)
+
 ## 16.3.0
 
 * Fix issue embedding videos in govspeak after YouTube API is loaded (PR #775)

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -5,6 +5,7 @@
   describedby ||= nil
   controls ||= nil
   data ||= nil
+  autocomplete ||= nil
 
   label ||= nil
   hint ||= nil
@@ -65,6 +66,7 @@
       id: id,
       type: type,
       data: data,
+      autocomplete: autocomplete,
       tabindex: tabindex,
       autofocus: autofocus,
       readonly: readonly,

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -103,3 +103,10 @@ examples:
       name: "name"
       value: "You can't type more"
       maxlength: 10
+  with_autocomplete:
+    data:
+      label:
+        text: "Automatically complete the field with a user's email address (in supporting browsers)"
+      name: "name"
+      type: "email"
+      autocomplete: "email"

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -29,6 +29,7 @@
         },
         name: "email_survey_signup[email_address]",
         type: "email",
+        autocomplete: "email",
         describedby: "survey_explanation"
       } %>
 

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -84,6 +84,16 @@ describe "Input", type: :view do
     assert_select ".govuk-input[aria-controls='another-element']"
   end
 
+  it "renders inputs with an autocomplete attribute if provided" do
+    render_component(
+      label: { text: "What is your name?" },
+      name: "name",
+      autocomplete: "name"
+    )
+
+    assert_select ".govuk-input[autocomplete='name']"
+  end
+
   it "renders input with a data attributes" do
     render_component(
       data: { module: "contextual-guidance" },


### PR DESCRIPTION
* Add `autocomplete` attribute option to input component
* Use `autocomplete=email` on feedback component's survey signup form to conform with WCAG criterion 1.3.5 (Identify Input Purpose)

I'm not sure if it also makes sense to add the `autocomplete` attribute option to other form components? Checkboxes and radio buttons probably don't make sense, but selects and textareas might, not sure about file upload.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-[733].herokuapp.com/component-guide/
