### PR TITLE
Update to version 14.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 14.0.0
 
-* Add govuk-frontend spacing scale to hint (PR #724)
+* BREAKING: Add govuk-frontend spacing scale to hint (PR #724)
 * Increase focus contrast of feedback links (PR #731)
 
 ## 13.8.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (13.8.1)
+    govuk_publishing_components (14.0.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '13.8.1'.freeze
+  VERSION = '14.0.0'.freeze
 end


### PR DESCRIPTION
## 14.0.0

* BREAKING: Add govuk-frontend spacing scale to hint (PR #724) (PR already in place to cope with this change, see https://github.com/alphagov/finder-frontend/pull/833)
* Increase focus contrast of feedback links (PR #731)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-735.herokuapp.com/component-guide/
