### PR TITLE
Reformat output accessibility error to avoid injections

### DIFF
--- a/app/assets/javascripts/component_guide/accessibility-test.js
+++ b/app/assets/javascripts/component_guide/accessibility-test.js
@@ -132,15 +132,53 @@
         var activeElParent = _findParent(activeEl, '[data-module="test-a11y"]')
         var wrapper = activeElParent.querySelector(resultContainerSelector)
 
-        if (wrapper) {
-          var resultHTML = '<h3>(' + result.id + ') ' + result.summary + ' <a href="' + result.url + '">(see guidance)</a></h3>' +
-          '<p>' + selectorObj.reasons.join('<br />') + '</p>' +
-          '<p>Element can be found using the selector:<br /><span class="selector">' +
-          selectorObj.selector +
-          '</span></p>'
-
-          wrapper.insertAdjacentHTML('beforeend', resultHTML)
+        if (!wrapper) {
+          return
         }
+
+        // Section to announce the overall problem.
+        var headerNodeLink = document.createElement('a')
+        headerNodeLink.href = result.url
+        headerNodeLink.textContent = "(see guidance)"
+
+        var headerNode = document.createElement('h3')
+        headerNode.textContent = result.summary + ' (' + result.id + ') '
+        headerNode.appendChild(headerNodeLink)
+
+        // Section to explain the reasons
+        var reasonsListNode = document.createElement('ul')
+        selectorObj.reasons.forEach(function (reason) {
+          var listItemNode = document.createElement('li')
+          listItemNode.textContent = reason
+          reasonsListNode.appendChild(listItemNode)
+        })
+
+        var reasonsHeaderNode = document.createElement('h4')
+        reasonsHeaderNode.textContent = 'Possible reasons why:'
+
+        var reasonsNode = document.createElement('div')
+        reasonsNode.appendChild(reasonsHeaderNode)
+        reasonsNode.appendChild(reasonsListNode)
+
+        // Section to help find the element
+        var findHeader = document.createElement('h4')
+        findHeader.textContent = 'Element can be found using the selector:'
+
+        var findSelectorNode = document.createElement('span')
+        findSelectorNode.className = 'selector' 
+        findSelectorNode.textContent = selectorObj.selector
+        
+        var findNode = document.createElement('p')
+        findNode.appendChild(findHeader)
+        findNode.appendChild(findSelectorNode)
+
+        // Put all the sections together
+        var resultHTML = document.createElement('div')
+        resultHTML.appendChild(headerNode)
+        resultHTML.appendChild(reasonsNode)
+        resultHTML.appendChild(findNode)
+
+        wrapper.appendChild(resultHTML)
       })
     })
   }

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -172,12 +172,9 @@
     display: none;
   }
 
-  h3 {
-    @include govuk-font($size: 19, $weight: bold);
-  }
-
   p,
-  h3 {
+  h3,
+  h4 {
     margin-top: 0;
     margin-bottom: $govuk-gutter / 2;
   }
@@ -188,6 +185,13 @@
 
   h3:not(:first-child) {
     margin-top: $govuk-gutter;
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+    padding-left: 1em;
+    margin-bottom: 1em;
   }
 
   .selector {


### PR DESCRIPTION
Some axe summaries include HTML, so by constructing the DOM manually we can avoid any issues.

This also adds some typography improvements and headings

## Before

<img width="992" alt="screen shot 2019-02-12 at 13 05 27" src="https://user-images.githubusercontent.com/2445413/52637341-e7456d80-2ec6-11e9-8f4a-8d541ee80ac7.png">
<img width="986" alt="screen shot 2019-02-12 at 13 05 22" src="https://user-images.githubusercontent.com/2445413/52637342-e7de0400-2ec6-11e9-9192-6bb3a82f9f35.png">

## After

<img width="989" alt="screen shot 2019-02-12 at 13 04 31" src="https://user-images.githubusercontent.com/2445413/52637311-d0068000-2ec6-11e9-8ff2-5a2acf02e8ab.png">
<img width="1003" alt="screen shot 2019-02-12 at 13 04 26" src="https://user-images.githubusercontent.com/2445413/52637312-d0068000-2ec6-11e9-836a-4dbdae36fdec.png">

Fixes https://github.com/alphagov/govuk_publishing_components/issues/736


---

Component guide for this PR:
https://govuk-publishing-compon-pr-737.herokuapp.com/component-guide/
