### PR TITLE
Remove old reference to bold_unstyled

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -279,10 +279,6 @@ examples:
           <li>تابعنا باللغة العربية عبر</li>
           <li>تابعنا باللغة العربية عبر تويتر </li>
         </ul>
-  with_bold_unstyled:
-    data:
-      block: |
-        <p>This content has <strong>text in strong tags</strong>, but they are not styled as bold</p>
   with_youtube_embed:
     data:
       block: |


### PR DESCRIPTION
Enabling bold styling for strong tags was done in https://github.com/alphagov/govuk_publishing_components/pull/463 . However, an old component guide example was left behind which is now confusing.

## The out of date example:
<img width="979" alt="screen shot 2019-02-12 at 13 47 05" src="https://user-images.githubusercontent.com/29889908/52639686-b5cfa080-2ecc-11e9-9f0f-2a3ebdce8323.png">

---

Component guide for this PR:
https://govuk-publishing-compon-pr-738.herokuapp.com/component-guide/govspeak
