### PR TITLE
Bump to version 15.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 15.0.0
 
-* `BREAKING:` Adds custom event category for checkbox change events. Any app with it's own tracking logic for checkboxes will need to remove it (PR #729)
+* BREAKING: Adds custom event category for checkbox change events. Any app with it's own tracking logic for checkboxes will need to remove it (PR #729)
 
 ## 14.0.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (14.0.0)
+    govuk_publishing_components (15.0.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -94,7 +94,7 @@ GEM
       plek (>= 1.9.0)
       rack-cache
       rest-client (~> 2.0)
-    globalid (0.4.1)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
     govspeak (5.9.0)
       actionview (~> 5.0)
@@ -111,7 +111,7 @@ GEM
       rubocop (~> 0.58)
       rubocop-rspec (~> 1.28)
       scss_lint
-    govuk_app_config (1.11.2)
+    govuk_app_config (1.11.3)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
@@ -123,7 +123,7 @@ GEM
     govuk_schemas (3.2.0)
       json-schema (~> 2.8.0)
     hashdiff (0.3.7)
-    highline (2.0.0)
+    highline (2.0.1)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -171,7 +171,7 @@ GEM
     nokogumbo (1.5.0)
       nokogiri
     null_logger (0.0.1)
-    oj (3.7.6)
+    oj (3.7.8)
     parallel (1.12.1)
     parser (2.5.3.0)
       ast (~> 2.4.0)
@@ -230,7 +230,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rinku (2.0.4)
+    rinku (2.0.5)
     rouge (3.3.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
@@ -331,6 +331,9 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   webmock (~> 3.0.1)
   yard
+
+RUBY VERSION
+   ruby 2.5.3p105
 
 BUNDLED WITH
    1.17.1

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '14.0.0'.freeze
+  VERSION = '15.0.0'.freeze
 end


### PR DESCRIPTION
## 15.0.0

* BREAKING: Adds custom event category for checkbox change events. Any app with it's own tracking logic for checkboxes will need to remove it (PR #729)

---

Component guide for this PR:
https://govuk-publishing-compon-pr-735.herokuapp.com/component-guide/
