### PR TITLE
Support rendering raw HTML in notice component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+* Add description_html option to notice component (PR #740)
+
 ## 15.0.0
 
 * BREAKING: Adds custom event category for checkbox change events. Any app with it's own tracking logic for checkboxes will need to remove it (PR #729)

--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -2,10 +2,12 @@
   <%
     description_text ||= false
     description_govspeak ||= yield || ""
+    description_html ||= false
     margin_bottom_class = " gem-c-notice--bottom-margin" unless local_assigns[:margin_bottom]
+    description_present = description_text.present? || description_govspeak.present? || description_html.present?
   %>
   <section class="gem-c-notice<%= margin_bottom_class %>" aria-label="Notice" role="region">
-    <% if description_text.present? || description_govspeak.present? %>
+    <% if description_present %>
       <h2 class="gem-c-notice__title"><%= title %></h2>
     <% else %>
       <span class="gem-c-notice__title"><%= title %></span>
@@ -13,6 +15,10 @@
 
     <% if description_text %>
       <p class="gem-c-notice__description"><%= description_text %></p>
+    <% end %>
+
+    <% if description_html %>
+      <%= description_html %>
     <% end %>
 
     <% unless description_govspeak.empty? %>

--- a/app/views/govuk_publishing_components/components/docs/notice.yml
+++ b/app/views/govuk_publishing_components/components/docs/notice.yml
@@ -17,6 +17,10 @@ examples:
     data:
       title: 'Statistics release cancelled'
       description_text: 'Duplicate, added in error'
+  with_description_html:
+    data:
+      title: 'Statistics release cancelled'
+      description_html: '<p>The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p>This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a rel="external" href="https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/">www.ogauthority.co.uk</a></p>'
   with_description_govspeak:
     data:
       title: 'Statistics release update'

--- a/spec/components/notice_spec.rb
+++ b/spec/components/notice_spec.rb
@@ -26,7 +26,13 @@ describe "Notice", type: :view do
     assert_select ".gem-c-notice__description", text: "Duplicate, added in error"
   end
 
-  it "renders a notice with a title and description text from a block" do
+  it "renders a notice with a title and description HTML" do
+    render_component(title: "Statistics release cancelled", description_html: "<pre>Some HTML</pre>".html_safe)
+    assert_select ".gem-c-notice__title", text: "Statistics release cancelled"
+    assert_select ".gem-c-notice pre", text: "Some HTML"
+  end
+
+  it "renders a notice with a title and description govspeak from a block" do
     render_component(title: "Statistics release cancelled") do
       "Duplicate, added in error"
     end
@@ -47,7 +53,12 @@ describe "Notice", type: :view do
   it "renders title as heading only if description present" do
     render_component(title: "Statistics release cancelled", description_text: "Duplicate, added in error")
     assert_select "h2.gem-c-notice__title", text: "Statistics release cancelled"
-    assert_select "p.gem-c-notice__description", text: "Duplicate, added in error"
+
+    render_component(title: "Statistics release cancelled", description_html: "<p>Some HTML</p>".html_safe)
+    assert_select "h2.gem-c-notice__title", text: "Statistics release cancelled"
+
+    render_component(title: "Statistics release cancelled", description_govspeak: "[some](govspeak)".html_safe)
+    assert_select "h2.gem-c-notice__title", text: "Statistics release cancelled"
   end
 
   it "render title as paragraph if no description present" do


### PR DESCRIPTION
https://trello.com/c/HcfYSpjX/634-allow-notice-component-to-accept-html

Previously only paragraph text or Govspeak could be passed to this
component. This adds a 'description_text' option as an alternative,
which is not nested in any other tag.

As with the Govspeak component, it seems better to require the consumer
of this component to specify that the HTML they're passing-in is safe,
so it was necessary to specify this in the tests.

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-[THIS PR NUMBER].herokuapp.com/component-guide/
