### PR TITLE
Update pull request template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,6 +1,3 @@
+<!--
 Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-
----
-
-Component guide for this PR:
-https://govuk-publishing-compon-pr-[THIS PR NUMBER].herokuapp.com/component-guide/
+-->


### PR DESCRIPTION
Something isn't working with the PR templates.

There are [32 PRs](https://github.com/alphagov/govuk_publishing_components/pulls?q=is%3Apr+%22THIS+PR+NUMBER%22+is%3Aclosed) with "THIS PR NUMBER" in the description, and [38 more](https://github.com/alphagov/govuk_publishing_components/pulls?utf8=%E2%9C%93&q=is%3Apr+%22Remember+to+update+the+CHANGELOG+if+your+change+needs+to+be+listed+in+the+next+version+of+the+gem.%22+is%3Aclosed+) with "Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem". 

This removes the link to Heroku, because that'll be added automatically. Also hides "Remember to update the CHANGELOG" in a comment tag so only the PR author sees it.
