### PR TITLE
Rename notice description_html to description

### DIFF
--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -1,10 +1,10 @@
 <% if defined?(title) %>
   <%
     description_text ||= false
-    description_govspeak ||= yield || ""
-    description_html ||= false
+    description_govspeak ||= false
+    description ||= yield || false
     margin_bottom_class = " gem-c-notice--bottom-margin" unless local_assigns[:margin_bottom]
-    description_present = description_text.present? || description_govspeak.present? || description_html.present?
+    description_present = description.present? || description_text.present? || description_govspeak.present?
   %>
   <section class="gem-c-notice<%= margin_bottom_class %>" aria-label="Notice" role="region">
     <% if description_present %>
@@ -17,11 +17,11 @@
       <p class="gem-c-notice__description"><%= description_text %></p>
     <% end %>
 
-    <% if description_html %>
-      <%= description_html %>
+    <% if description %>
+      <%= description %>
     <% end %>
 
-    <% unless description_govspeak.empty? %>
+    <% if description_govspeak.present? %>
       <%= render 'govuk_publishing_components/components/govspeak', content: description_govspeak %>
     <% end %>
   </section>

--- a/app/views/govuk_publishing_components/components/docs/notice.yml
+++ b/app/views/govuk_publishing_components/components/docs/notice.yml
@@ -13,14 +13,14 @@ examples:
   default:
     data:
       title: 'Statistics release cancelled'
+  with_description:
+    data:
+      title: 'Statistics release cancelled'
+      description: '<p>The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p>This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a rel="external" href="https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/">www.ogauthority.co.uk</a></p>'
   with_description_text:
     data:
       title: 'Statistics release cancelled'
       description_text: 'Duplicate, added in error'
-  with_description_html:
-    data:
-      title: 'Statistics release cancelled'
-      description_html: '<p>The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p>This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a rel="external" href="https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/">www.ogauthority.co.uk</a></p>'
   with_description_govspeak:
     data:
       title: 'Statistics release update'

--- a/spec/components/notice_spec.rb
+++ b/spec/components/notice_spec.rb
@@ -20,25 +20,25 @@ describe "Notice", type: :view do
     assert_select ".gem-c-notice[aria-label=Notice][role=region]"
   end
 
+  it "renders a notice with a title and description" do
+    render_component(title: "Statistics release cancelled", description: "<pre>Some HTML</pre>".html_safe)
+    assert_select ".gem-c-notice__title", text: "Statistics release cancelled"
+    assert_select ".gem-c-notice pre", text: "Some HTML"
+  end
+
   it "renders a notice with a title and description text" do
     render_component(title: "Statistics release cancelled", description_text: "Duplicate, added in error")
     assert_select ".gem-c-notice__title", text: "Statistics release cancelled"
     assert_select ".gem-c-notice__description", text: "Duplicate, added in error"
   end
 
-  it "renders a notice with a title and description HTML" do
-    render_component(title: "Statistics release cancelled", description_html: "<pre>Some HTML</pre>".html_safe)
-    assert_select ".gem-c-notice__title", text: "Statistics release cancelled"
-    assert_select ".gem-c-notice pre", text: "Some HTML"
-  end
-
-  it "renders a notice with a title and description govspeak from a block" do
+  it "renders a notice with a title and description from a block" do
     render_component(title: "Statistics release cancelled") do
-      "Duplicate, added in error"
+      "<pre>Some HTML</pre>".html_safe
     end
 
     assert_select ".gem-c-notice__title", text: "Statistics release cancelled"
-    assert_select ".govuk-govspeak", text: "Duplicate, added in error"
+    assert_select ".gem-c-notice pre", text: "Some HTML"
   end
 
   it "renders a notice with a title and description govspeak" do
@@ -51,10 +51,10 @@ describe "Notice", type: :view do
   end
 
   it "renders title as heading only if description present" do
-    render_component(title: "Statistics release cancelled", description_text: "Duplicate, added in error")
+    render_component(title: "Statistics release cancelled", description: "<p>Some HTML</p>".html_safe)
     assert_select "h2.gem-c-notice__title", text: "Statistics release cancelled"
 
-    render_component(title: "Statistics release cancelled", description_html: "<p>Some HTML</p>".html_safe)
+    render_component(title: "Statistics release cancelled", description_text: "Duplicate, added in error")
     assert_select "h2.gem-c-notice__title", text: "Statistics release cancelled"
 
     render_component(title: "Statistics release cancelled", description_govspeak: "[some](govspeak)".html_safe)


### PR DESCRIPTION
https://trello.com/c/HcfYSpjX/634-allow-notice-component-to-accept-html

Previously the notice component would accept a block in order to set the
description_govspeak variable. Turns out this isn't currently used, and
rendering Govspeak within a component is not consistent with the others.

This changes the notice component to accept a block that will now set
the description_html parameter. As this change increases the importance
of this parameter, it makes sense to rename it to just 'description'.

Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.

---

Component guide for this PR:
https://govuk-publishing-compon-pr-[THIS PR NUMBER].herokuapp.com/component-guide/
