### PR TITLE
Allow embed option in component docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Support an embed option on examples to allow embedding a component in a particular HTML context (PR #747)
+
 ## 15.2.0
 
 * Add margin option to subscription links (PR #748)

--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -6,7 +6,8 @@ module GovukPublishingComponents
                 :body,
                 :component,
                 :accessibility_excluded_rules,
-                :source
+                :source,
+                :embed
 
     def initialize(component)
       @component = component
@@ -16,6 +17,7 @@ module GovukPublishingComponents
       @body = component[:body]
       @accessibility_excluded_rules = component[:accessibility_excluded_rules]
       @source = component[:source]
+      @embed = component[:embed]
     end
 
     def accessibility_criteria
@@ -74,6 +76,7 @@ module GovukPublishingComponents
     def examples
       @examples ||= component[:examples].map do |id, example_data|
         example_data = example_data || {}
+        example_data["embed"] ||= embed
         ComponentExample.new(id.to_s, example_data)
       end
     end

--- a/app/models/govuk_publishing_components/component_example.rb
+++ b/app/models/govuk_publishing_components/component_example.rb
@@ -6,7 +6,8 @@ module GovukPublishingComponents
                 :data,
                 :context,
                 :description,
-                :block
+                :block,
+                :embed
 
     def initialize(id, example)
       @id = id
@@ -14,6 +15,7 @@ module GovukPublishingComponents
       @context = example["context"] || {}
       @description = example["description"] || false
       @block = @data.delete(:block) || false
+      @embed = example["embed"]
     end
 
     def name
@@ -71,6 +73,10 @@ module GovukPublishingComponents
 
     def has_block?
       !!block
+    end
+
+    def has_embed?
+      !!embed
     end
 
   private

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_call.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_call.html.erb
@@ -1,12 +1,20 @@
+<%
+component_code =
+  if example.has_block?
+    "<%= render \"#{@component_doc.partial_path}\", #{example.pretty_data} do %\>\n" +
+    "  #{example.block.html_safe}" +
+    "<% end %\>"
+  else
+    "<%= render \"#{@component_doc.partial_path}\", #{example.pretty_data} %\>"
+  end
+
+code =
+  if example.has_embed?
+    example.embed.sub("<%= component %\>", component_code)
+  else
+    component_code
+  end
+%>
 <div class="component-call component-highlight" contenteditable>
-  <% if example.has_block? %>
-    <%
-      code = "<%= render \"#{@component_doc.partial_path}\", #{example.pretty_data} do %\>\n"
-      code += "  #{example.block.html_safe}"
-      code += "<% end %\>"
-    -%>
-    <pre><code><%= example.highlight_code(code) %></code></pre>
-  <% else %>
-    <pre><code><%= example.highlight_code("\<%= render \"#{@component_doc.partial_path}\", #{example.pretty_data} %\>") %></code></pre>
-  <% end %>
+  <pre><code><%= example.highlight_code(code) %></code></pre>
 </div>

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_component_output.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_component_output.html.erb
@@ -1,7 +1,15 @@
-<% if example.has_block? %>
-  <%= render component_doc.partial_path, example.html_safe_data do %>
-    <%= example.block.html_safe %>
+<% component = capture do %>
+  <% if example.has_block? %>
+    <%= render component_doc.partial_path, example.html_safe_data do %>
+      <%= example.block.html_safe %>
+    <% end %>
+  <% else %>
+    <%= render component_doc.partial_path, example.html_safe_data %>
   <% end %>
+<% end %>
+
+<% if example.has_embed? %>
+  <%= ERB.new(example.embed).result(binding).html_safe %>
 <% else %>
-  <%= render component_doc.partial_path, example.html_safe_data %>
+  <%= component %>
 <% end %>

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -127,6 +127,32 @@ examples:
         <span>Some text</span>
 ```
 
+#### Yaml configuration for components that need contextual HTML
+
+If a component is only visible, or behaves differently, in a certain context
+the examples for it can be embedded within HTML using the embed option.
+eg.
+
+```ruby
+<button class="trigger-for-component">Click me</button>
+<%= render "my-hidden-by-default-component", { param: value } %>
+```
+
+To configure a HTML embed in the component yaml file you can specify `embed` at
+the root or individual examples:
+
+```yaml
+embed: |
+  <button class="trigger-for-component">Click me<button>
+  <%= component %>
+examples:
+  default:
+  different_embed_example:
+    embed: |
+      <button class="different-trigger-for-component">Click me<button>
+      <%= component %>
+```
+
 #### [Accessibility Acceptance Criteria](accessibility_acceptance_criteria.md)
 
 Markdown listing what this component must do to be accessible.

--- a/spec/component_guide/component_example_spec.rb
+++ b/spec/component_guide/component_example_spec.rb
@@ -43,6 +43,34 @@ describe 'Component example' do
     expect(page).to have_content(%(<%= render "components/test-component-with-block", {\n} do %>\n<div class="test-block">Here's a block</div>\n<% end %>))
   end
 
+  it 'allows examples to embedded in HTML' do
+    visit '/component-guide/test-component-with-embed'
+
+    expect(page).to have_selector('.component-guide-preview .input-control-for-embedded-component')
+    expect(page).to have_selector('.component-guide-preview .test-component-with-embed')
+
+    example = <<~EXAMPLE
+      <input class="input-control-for-embedded-component">
+      <%= render "components/test-component-with-embed", {
+      } %>
+    EXAMPLE
+    expect(page).to have_content(example)
+  end
+
+  it 'allows specific examples to embed different HTML' do
+    visit '/component-guide/test-component-with-embed/button_example'
+
+    expect(page).to have_selector('.component-guide-preview .button-control-for-embedded-component')
+    expect(page).to have_selector('.component-guide-preview .test-component-with-embed')
+
+    example = <<~EXAMPLE
+      <button class="button-control-for-embedded-component">Action</button>
+      <%= render "components/test-component-with-embed", {
+      } %>
+    EXAMPLE
+    expect(page).to have_content(example)
+  end
+
   it 'marks strings in examples as html_safe' do
     visit '/component-guide/test-component-with-html-params'
     within ".test-component-with-html-params" do

--- a/spec/dummy/app/views/components/_test-component-with-embed.html.erb
+++ b/spec/dummy/app/views/components/_test-component-with-embed.html.erb
@@ -1,0 +1,1 @@
+<div class="test-component-with-embed">Test component with embed</div>

--- a/spec/dummy/app/views/components/docs/test-component-with-embed.yml
+++ b/spec/dummy/app/views/components/docs/test-component-with-embed.yml
@@ -1,0 +1,14 @@
+name: Test component with embed
+description: |
+  A test component that shows the component code embedded next to a control it interacts with.
+embed: |
+  <input class="input-control-for-embedded-component">
+  <%= component %>
+examples:
+  default:
+  button_example:
+    description: This component also can be contolled by a button
+    embed: |
+      <button class="button-control-for-embedded-component">Action</button>
+      <%= component %>
+


### PR DESCRIPTION
Trello: https://trello.com/c/mHrLEKSK/635-allow-govukpublishingcomponents-to-show-contextual-code-around-an-example

The embed option allows for component examples to be illustrated within
contextual HTML. It is intended for components that do not have a visual
presence without some other HTML. The Content Publisher application has
a number of these, such as Contextual Guidance and Input Length
Suggestor, and is likely to have another for modals. These cannot be
viewed inside the component-guide and just appear as empty boxes.

This resolves this by allowing the ability to include an option of
`embed` in a component document file which contains the HTML that is
needed in the vicinity of the component eg:

```
name: Component
embed: |
  <button data-trigger-component=true>Click me</button>
  <%= component %>
examples:
  default:
```

This can also be applied on individual examples eg:

```
name: Component
examples:
  default:
  inside_div:
    description: This component behaves differently inside a div
    embed: |
      <div><%= component %></div>
```

## Examples

There's an [example component in the dummy app](https://govuk-publishing-compon-pr-747.herokuapp.com/component-guide/test-component-with-embed)

More useful though is looking at a couple of cases in Content Publisher:

Before:
![screen shot 2019-02-14 at 11 43 03](https://user-images.githubusercontent.com/282717/52784731-fd316a80-304d-11e9-8b7b-e4933655c132.png)

After:
![screen shot 2019-02-14 at 11 46 03](https://user-images.githubusercontent.com/282717/52784792-29e58200-304e-11e9-92eb-008382c1c2af.png)


Before:
![screen shot 2019-02-14 at 11 43 14](https://user-images.githubusercontent.com/282717/52784719-f4d92f80-304d-11e9-8c2c-be648700a476.png)


After:
![screen shot 2019-02-14 at 11 45 48](https://user-images.githubusercontent.com/282717/52784781-22be7400-304e-11e9-9ce0-ebf39488c2e7.png)

There's currently a workaround for this in this PR: https://github.com/alphagov/content-publisher/pull/735