### PR TITLE
Add margin option to subscription links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add margin option to subscription links (PR #748)
+* Add multiple selection option to autocomplete (PR #723)
+
 ## 15.1.0
 
 * Add description option to notice component (PR #740, PR #742)
@@ -19,7 +24,6 @@
 
 * BREAKING: Add govuk-frontend spacing scale to hint (PR #724)
 * Increase focus contrast of feedback links (PR #731)
-* Add multiple selection option to autocomplete (PR #723)
 
 ## 13.8.1
 

--- a/app/views/govuk_publishing_components/components/_subscription-links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription-links.html.erb
@@ -1,13 +1,16 @@
 <%
   brand ||= false
+  margin_bottom ||= 0
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
   sl_helper = GovukPublishingComponents::Presenters::SubscriptionLinksHelper.new(local_assigns)
+
+  css_classes = %w( gem-c-subscription-links )
+  css_classes << ([*0..9].include?(margin_bottom) ? "govuk-!-margin-bottom-#{margin_bottom}" : "govuk-!-margin-bottom-0")
+  css_classes << brand_helper.brand_class
+  data = {"module": "gem-toggle"} if sl_helper.feed_link_box_value
 %>
 <% if sl_helper.component_data_is_valid? %>
-  <section
-    class="gem-c-subscription-links <%= brand_helper.brand_class %>"
-    <%= "data-module=gem-toggle" if sl_helper.feed_link_box_value %>
-  >
+  <%= tag.section class: css_classes, data: data do %>
     <h2 class="gem-c-subscription-links__hidden-header visuallyhidden"><%= t("govuk_component.subscription_links.subscriptions", default: "Subscriptions") %></h2>
     <ul
       class="gem-c-subscription-links__list"
@@ -44,5 +47,5 @@
         } %>
       </div>
     <% end %>
-  </section>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/subscription-links.yml
+++ b/app/views/govuk_publishing_components/components/docs/subscription-links.yml
@@ -17,6 +17,12 @@ examples:
     data:
       email_signup_link: '/foreign-travel-advice/singapore/email-signup'
       feed_link: '/foreign-travel-advice/singapore.atom'
+  with_margin:
+    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](http://govuk-frontend-review.herokuapp.com/docs/#settings/spacing-variable-govuk-spacing-points). It defaults to having no margin bottom, although some margin is supplied by the links themselves (so that when they stack on mobile there is space between them).
+    data:
+      email_signup_link: '/foreign-travel-advice/singapore/email-signup'
+      feed_link: '/foreign-travel-advice/singapore.atom'
+      margin_bottom: 9
   with_only_email_signup_link:
     data:
       email_signup_link: '/foreign-travel-advice/singapore/email-signup'

--- a/spec/components/subscription_links_spec.rb
+++ b/spec/components/subscription_links_spec.rb
@@ -28,6 +28,11 @@ describe "subscription links", type: :view do
     assert_select ".gem-c-subscription-links__link--feed[href=\"singapore.atom\"]", text: "Subscribe to feed"
   end
 
+  it "adds margin" do
+    render_component(email_signup_link: 'email-signup', feed_link: 'singapore.atom', margin_bottom: 7)
+    assert_select '.gem-c-subscription-links.govuk-\!-margin-bottom-7'
+  end
+
   it "renders custom texts" do
     render_component(email_signup_link: 'email-signup', feed_link: 'singapore.atom', email_signup_link_text: 'Get email!', feed_link_text: 'View feed!')
     assert_select ".gem-c-subscription-links__link--email-alerts[href=\"email-signup\"]", text: "Get email!"


### PR DESCRIPTION
Adds a margin option to the subscription links component, using the GOV.UK Frontend spacing scale (as previously applied to the hint component).

![screen shot 2019-02-14 at 10 32 12](https://user-images.githubusercontent.com/861310/52781186-d1a98280-3043-11e9-80e8-e38deb27cbb8.png)

Needed for https://github.com/alphagov/finder-frontend/pull/881

Trello card: https://trello.com/c/l40K2yBl/353-use-subscription-component-for-email-alerts-and-rss-feed-signup