### PR TITLE
Change Header link from announcements to news and communications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Support an embed option on examples to allow embedding a component in a particular HTML context (PR #747)
+* Change header link from Announcements to News and communications (PR #752)
 
 ## 15.2.0
 

--- a/app/views/govuk_publishing_components/components/_government_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_government_navigation.html.erb
@@ -40,8 +40,8 @@
       </a>
     </li>
     <li>
-      <a class="<%= 'active' if active == 'announcements' %>" href="/government/announcements">
-        <%= t("govuk_component.government_navigation.announcements", default: "Announcements") %>
+      <a class="<%= 'active' if active == 'announcements' %>" href="/news-and-communications">
+        <%= t("govuk_component.government_navigation.news_and_communications", default: "News and communications") %>
       </a>
     </li>
   </ul>

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -107,8 +107,8 @@ examples:
               text: Policies
             - href: '/government/publications'
               text: Publications
-            - href: '/government/announcements'
-              text: Announcements
+            - href: '/news-and-communications'
+              text: News and communications
       meta:
         items:
           - href: '/help'

--- a/spec/components/government_navigation_spec.rb
+++ b/spec/components/government_navigation_spec.rb
@@ -10,7 +10,7 @@ describe "Government navigation", type: :view do
 
     assert_select "\#proposition-links li a", text: "Departments"
     assert_link_with_text("/government/organisations", "Departments")
-    assert_link_with_text("/government/announcements", "Announcements")
+    assert_link_with_text("/news-and-communications", "News and communications")
   end
 
   it "has no active links by default" do


### PR DESCRIPTION
This will change Announcements to News and communications
throughout govuk. This has already been done in whitehall
with https://github.com/alphagov/whitehall/pull/4636,
so this will make things consistent.

Example page that will change once the version has been
bumped and government-frontend deployed:
https://www.gov.uk/government/news/assets-liquidated-an-unhappy-valentine-for-teesside-crook

https://trello.com/c/7NS3f7I8/378-investigate-why-announcements-link-is-persisting-in-whitehall-header-in-some-places

<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->
