### PR TITLE
[DO NOT MERGE] Add an option count to the autocomplete when no facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Support an embed option on examples to allow embedding a component in a particular HTML context (PR #747)
+* Add an option count to the autocomplete when no facets (PR #753)
 
 ## 15.2.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
@@ -8,9 +8,19 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Modules.AccessibleAutocomplete = function () {
     var $selectElem;
+    var updateCount;
+    var updateCountSelected;
+    var $updateCountElement;
 
     this.start = function ($element) {
       $selectElem = $element.find('select');
+      updateCount = $element.data('hint');
+
+      if (updateCount) {
+        $updateCountElement = $('#' + $element.data('hint'));
+        updateCountSelected = $element.data('selected-text');
+        updateCountText($selectElem);
+      }
 
       var configOptions = {
         selectElement: document.getElementById($selectElem.attr('id')),
@@ -25,6 +35,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       new accessibleAutocomplete.enhanceSelectElement(configOptions);
       //attach the onConfirm function to data attr, to call it in finder-frontend when clearing facet tags
       $selectElem.data('onconfirm', this.onConfirm);
+
+      // add aria-describedby to link the input to the 'x selected' information for screen readers
+      if (updateCount) {
+        $element.find('.autocomplete__input').attr('aria-describedby', $element.data('hint'));
+      }
     };
 
     this.onConfirm = function(label, value, removeDropDown) {
@@ -51,6 +66,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           $selectElem.change();
         }
 
+        if (updateCount) {
+          updateCountText($selectElem);
+        }
+
         // used to clear the autocomplete when clicking on a facet tag in finder-frontend
         // very brittle but menu visibility is determined by autocomplete after this function is called
         // setting autocomplete val to '' causes menu to appear, we don't want that, this solves it
@@ -64,6 +83,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
       }
     };
+
+    function updateCountText($selectElem) {
+      var countText = $selectElem.val() ? $selectElem.val().length : 0;
+      $updateCountElement.html(countText + " " + updateCountSelected);
+    }
 
     function track (category, action, label, options) {
       if (GOVUK.analytics && GOVUK.analytics.trackEvent) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
@@ -19,10 +19,6 @@
     height: auto;
   }
 
-  .js-enabled & .app-c-autocomplete__multiselect-instructions {
-    display: none;
-  }
-
   .autocomplete__list .autocomplete__option {
     padding: 5px 6px;
 
@@ -43,5 +39,23 @@
 .gem-c-accessible-autocomplete--hide-facets {
   .autocomplete__list {
     display: none;
+  }
+}
+
+.gem-c-autocomplete__multiselect-instructions {
+  display: block;
+}
+
+.gem-c-autocomplete__multiselect-count {
+  display: none;
+}
+
+.js-enabled {
+  .gem-c-autocomplete__multiselect-instructions {
+    display: none;
+  }
+
+  .gem-c-autocomplete__multiselect-count {
+    display: block;
   }
 }

--- a/app/views/govuk_publishing_components/components/_accessible_autocomplete.html.erb
+++ b/app/views/govuk_publishing_components/components/_accessible_autocomplete.html.erb
@@ -7,31 +7,36 @@
   multiple ||= false
   hide_facets ||= false
 
-  classes = %w(gem-c-accessible-autocomplete)
+  classes = %w(gem-c-accessible-autocomplete govuk-form-group)
   classes << "gem-c-accessible-autocomplete--hide-facets" if hide_facets
+  hint_text = "0 #{t('components.autocomplete.selected')}" if hide_facets && multiple
+  hint_id = "describes-select-#{SecureRandom.hex(4)}" if hide_facets && multiple
 %>
 <% if label && options.any? %>
-  <div class="govuk-form-group">
+  <%= tag.div class: classes, data: { module: "accessible-autocomplete", hint: hint_id, selected_text: t('components.autocomplete.selected') } do %>
     <%=
       render "govuk_publishing_components/components/label", {
         html_for: id
       }.merge(label.symbolize_keys)
     %>
 
-    <%= tag.div class: classes, data: { module: "accessible-autocomplete" } do %>
-      <% if multiple %>
-        <span class="govuk-hint app-c-autocomplete__multiselect-instructions"><%= t('components.autocomplete.multiselect') %></span>
-      <% end %>
-
-      <%=
-        select_tag(
-          id,
-          options_for_select(options, selected_option),
-          multiple: multiple,
-          class: "govuk-select",
-          data: data_attributes
-        )
-      %>
+    <% if hint_text %>
+      <span class="govuk-hint gem-c-autocomplete__multiselect-count" id="<%= hint_id %>" aria-live="polite"><%= t('components.autocomplete.selected') %></span>
     <% end %>
-  </div>
+
+    <% if multiple %>
+      <span class="govuk-hint gem-c-autocomplete__multiselect-instructions"><%= t('components.autocomplete.multiselect') %></span>
+    <% end %>
+
+    <%=
+      select_tag(
+        id,
+        options_for_select(options, selected_option),
+        multiple: multiple,
+        class: "govuk-select",
+        data: data_attributes,
+        described_by: hint_id
+      )
+    %>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
+++ b/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
@@ -6,6 +6,8 @@ body: |
   [label component](https://github.com/component-guide/label).
 
   If Javascript is disabled, the component appears as a select box, so the user can still select an option.
+
+  Note that in single selection mode the autocomplete requires an empty item at the start of the options, or it is impossible to deselect a value.
 accessibility_criteria: |
   [Accessibility acceptance criteria](https://github.com/alphagov/accessible-autocomplete/blob/master/accessibility-criteria.md)
 examples:
@@ -41,7 +43,10 @@ examples:
         track_option:
           custom_dimension: 'your_custom_dimension'
   with_multiple_selections:
-    description: This parameter allows the user to choose more than one option from the autocomplete. The component generates a select multiple in place of a regular select, and the autocomplete Javascript detects this and provides the multiple selection functionality.
+    description: |
+      This parameter allows the user to choose more than one option from the autocomplete. The component generates a select multiple in place of a regular select, and the autocomplete Javascript detects this and provides the multiple selection functionality.
+
+      Note that the select multiple does not require an empty value, in contrast to when in single selection mode.
     data:
       multiple: true
       label:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
   components:
     autocomplete:
       multiselect: "To select multiple items in a list, hold down Ctrl (PC) or Cmd (Mac) key."
+      selected: "selected"
     back_link:
       back: 'Back'
     contents_list:

--- a/spec/components/accessible_autocomplete_spec.rb
+++ b/spec/components/accessible_autocomplete_spec.rb
@@ -62,6 +62,7 @@ describe "AccessibleAutocomplete", type: :view do
 
     assert_select "select[multiple]"
     assert_select ".gem-c-accessible-autocomplete.gem-c-accessible-autocomplete--hide-facets", false
+    assert_select ".gem-c-accessible-autocomplete .gem-c-autocomplete__multiselect-instructions"
   end
 
   it 'does not show facet tags for multiple when given the option' do

--- a/spec/javascripts/components/accessible-autocomplete-spec.js
+++ b/spec/javascripts/components/accessible-autocomplete-spec.js
@@ -1,17 +1,9 @@
 describe("An accessible autocomplete component", function () {
   "use strict";
 
-  function loadAutocompleteComponent() {
-    setFixtures(html);
+  function loadAutocompleteComponent(markup) {
+    setFixtures(markup);
     var autocomplete = new GOVUK.Modules.AccessibleAutocomplete();
-    autocomplete.start($('.gem-c-accessible-autocomplete'));
-  }
-
-  function loadAutocompleteMultiple() {
-    //var multipleHtml = html.replace('<select', '<select multiple ');
-    setFixtures(html);
-    var autocomplete = new GOVUK.Modules.AccessibleAutocomplete();
-    $('.gem-c-accessible-autocomplete').find('select').attr('multiple','multiple').find('option:first-child').remove();
     autocomplete.start($('.gem-c-accessible-autocomplete'));
   }
 
@@ -22,8 +14,33 @@ describe("An accessible autocomplete component", function () {
         <option value="mo">Moose</option>\
         <option value="de">Deer</option>\
       </select>\
-    </div>\
-  ';
+    </div>';
+
+  var multiselecthtml = '\
+    <div class="gem-c-accessible-autocomplete" data-module="accessible-autocomplete">\
+      <select id="test" class="govuk-select" multiple data-track-category="category" data-track-action="action">\
+        <option value="mo">Moose</option>\
+        <option value="de">Deer</option>\
+      </select>\
+    </div>';
+
+  var multiselecthtmlwithoutfacets = '\
+    <div class="gem-c-accessible-autocomplete gem-c-accessible-autocomplete--hide-facets" data-module="accessible-autocomplete" data-hint="ce1" data-selected-text="selected">\
+      <label for="autocomplete-8b93b936" class="gem-c-label govuk-label ">\
+        Countries\
+      </label>\
+      <span id="ce1" class="govuk-hint">0 selected</span>\
+      <span class="govuk-hint gem-c-autocomplete__multiselect-instructions">To select multiple items in a list, hold down Ctrl (PC) or Cmd (Mac) key.</span>\
+      <select name="autocomplete-8b93b936[]" id="autocomplete-8b93b936-select" multiple="multiple" class="govuk-select" described_by="describes_select">\
+        <option value="fr" selected>France</option>\
+        <option value="de" selected>Germany</option>\
+        <option value="se">Sweden</option>\
+        <option value="ch">Switzerland</option>\
+        <option value="gb">United Kingdom</option>\
+        <option value="us">United States</option>\
+        <option value="tw">The Separate Customs Territory of Taiwan, Penghu, Kinmen, and Matsu (Chinese Taipei)</option>\
+      </select>\
+    </div>';
 
   // the autocomplete onConfirm function fires after the tests run unless we put
   // in a timeout like this - makes the tests a bit verbose unfortunately
@@ -39,7 +56,7 @@ describe("An accessible autocomplete component", function () {
 
   describe('updates the hidden select when', function () {
     beforeEach(function (done) {
-      loadAutocompleteComponent();
+      loadAutocompleteComponent(html);
 
       // the autocomplete is complex enough that all of these
       // events are necessary to simulate user input
@@ -59,7 +76,7 @@ describe("An accessible autocomplete component", function () {
 
   describe('updates the hidden select when', function () {
     beforeEach(function (done) {
-      loadAutocompleteComponent();
+      loadAutocompleteComponent(html);
 
       $('select').val('de').change();
       $('.autocomplete__input').val('Deer');
@@ -86,7 +103,7 @@ describe("An accessible autocomplete component", function () {
       };
       spyOn(GOVUK.analytics, 'trackEvent');
 
-      loadAutocompleteComponent();
+      loadAutocompleteComponent(html);
 
       $('.autocomplete__input').val('Moose').click().focus().trigger(
         $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
@@ -111,7 +128,7 @@ describe("An accessible autocomplete component", function () {
       };
       spyOn(GOVUK.analytics, 'trackEvent');
 
-      loadAutocompleteComponent();
+      loadAutocompleteComponent(html);
 
       $('.autocomplete__input').val('Deer').click().focus().trigger(
         $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
@@ -134,7 +151,7 @@ describe("An accessible autocomplete component", function () {
 
   describe('in multiple mode', function() {
     beforeEach(function (done) {
-      loadAutocompleteMultiple();
+      loadAutocompleteComponent(multiselecthtml);
       // use the component api for this test
       // as methods in previous tests don't seem to
       // work in multiple mode
@@ -155,7 +172,7 @@ describe("An accessible autocomplete component", function () {
 
   describe('in multiple mode', function() {
     beforeEach(function (done) {
-      loadAutocompleteMultiple();
+      loadAutocompleteComponent(multiselecthtml);
       var onConfirm = $('select').data('onconfirm');
 
       $('.autocomplete__input').val('Moose');
@@ -171,6 +188,39 @@ describe("An accessible autocomplete component", function () {
 
     it('selects multiple options in the select', function () {
       expect($('select').val()).toEqual(['mo', 'de']);
+    });
+  });
+
+  describe('in multiple mode with facets hidden', function() {
+    it('shows the number of selected options text', function () {
+      loadAutocompleteComponent(multiselecthtmlwithoutfacets);
+      expect($('#ce1')).toHaveText("2 selected");
+    });
+
+    it('associates the input with the count element', function() {
+      loadAutocompleteComponent(multiselecthtmlwithoutfacets);
+      expect($('.autocomplete__input').attr('aria-describedby')).toBe('ce1');
+    });
+  });
+
+  describe('in multiple mode with facets hidden', function() {
+    beforeEach(function (done) {
+      loadAutocompleteComponent(multiselecthtmlwithoutfacets);
+      var onConfirm = $('select').data('onconfirm');
+
+      $('.autocomplete__input').val('Germany');
+      onConfirm('Germany', 'de');
+
+      $('.autocomplete__input').val('Sweden');
+      onConfirm('Sweden', 'se');
+
+      testAsyncWithDeferredReturnValue().done(function () {
+        done();
+      });
+    });
+
+    it('updates the number of selected options text', function () {
+      expect($('#ce1')).toHaveText("3 selected");
     });
   });
 });


### PR DESCRIPTION
When the autocomplete is in multiple mode it appends facet tags beneath itself to show what's been selected (in single selection mode the chosen option remains in the input). 

We have a requirement to use this in finders but facet tags are already present on the page so we're using an option in the component to hide the component-generated facet tags. The result of this is a potential accessibility problem - users with assistive text may become confused when selecting an option only for their option to disappear, and this can also be a problem on mobile where the facet tags collapse beneath the facets and may not be visible on screen.

Based on the previous option select component, this PR adds a 'x selected' hint to the component when it is in this mode, as shown.

![screen shot 2019-02-15 at 15 50 50](https://user-images.githubusercontent.com/861310/52867892-e10af780-3139-11e9-9fe9-0025b21fbea6.png)

This text updates when the user makes a selection and also is set to the correct value on page load if options are pre-selected.

https://govuk-publishing-compon-pr-753.herokuapp.com/component-guide/accessible_autocomplete

Trello card: https://trello.com/c/iZxdvyMI/380-make-autocomplete-more-accessible

