### PR TITLE
Bump Webmock 3.0.1 => 3.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
       sass (>= 3.2.0)
     govuk_schemas (3.2.0)
       json-schema (~> 2.8.0)
-    hashdiff (0.3.7)
+    hashdiff (0.3.8)
     highline (2.0.1)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
@@ -303,7 +303,7 @@ GEM
     unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
-    webmock (3.0.1)
+    webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -329,11 +329,11 @@ DEPENDENCIES
   pry-byebug
   rspec-rails (~> 3.6)
   uglifier (>= 1.3.0)
-  webmock (~> 3.0.1)
+  webmock (~> 3.5.0)
   yard
 
 RUBY VERSION
    ruby 2.6.1p33
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |s|
   # Needed to load slimmer test helpers
   # https://github.com/alphagov/slimmer/issues/201
   s.add_development_dependency "pry-byebug"
-  s.add_development_dependency "webmock", "~> 3.0.1"
+  s.add_development_dependency "webmock", "~> 3.5.0"
   s.add_development_dependency "yard"
 end


### PR DESCRIPTION
This will allow Webmock to work correctly with Ruby 2.6