### PR TITLE
Update skip-link to allow custom link text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update skip-link to allow custom link text (PR #755)
 * Support an embed option on examples to allow embedding a component in a particular HTML context (PR #747)
 
 ## 15.2.0

--- a/app/views/govuk_publishing_components/components/_skip_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_skip_link.html.erb
@@ -1,4 +1,5 @@
 <%
   href ||= '#main-content'
+  text ||= t('components.skip_link.text')
 %>
-<%= link_to("Skip to main content", href, class: "gem-c-skip-link govuk-skip-link") %>
+<%= link_to(text, href, class: "gem-c-skip-link govuk-skip-link") %>

--- a/app/views/govuk_publishing_components/components/docs/skip_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/skip_link.yml
@@ -12,4 +12,13 @@ accessibility_criteria: |
 examples:
   default:
     data:
-      href: '#content'
+  with_different_text:
+    data:
+      text: 'Skip to results'
+  with_different_href:
+    data:
+      href: '#somewhere-on-the-page'
+  custom_title_and_href:
+    data:
+      text: 'Skip to my content'
+      href: '#my-content'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,8 @@ en:
       policies: "Policies"
       statistical_data_sets: "Statistical data sets"
       topical_events: "Topical events"
+    skip_link:
+      text: "Skip to main content"
     step_by_step_nav:
       show: "Show"
       hide: "Hide"

--- a/spec/components/skip_link_spec.rb
+++ b/spec/components/skip_link_spec.rb
@@ -5,8 +5,18 @@ describe "Skip Link", type: :view do
     "skip_link"
   end
 
-  it "renders a skip link correctly" do
-    render_component(href: '#main-content')
+  it "renders a skip link correctly by default" do
+    render_component({})
     assert_select ".govuk-skip-link[href=\"#main-content\"]", text: "Skip to main content"
+  end
+
+  it "renders a skip link correctly when href is specified" do
+    render_component(href: '#skip-to')
+    assert_select ".govuk-skip-link[href=\"#skip-to\"]", text: "Skip to main content"
+  end
+
+  it "renders a skip link correctly when text is specified" do
+    render_component(text: 'Go to somewhere on the page')
+    assert_select ".govuk-skip-link[href=\"#main-content\"]", text: "Go to somewhere on the page"
   end
 end


### PR DESCRIPTION
This commit ensures that the default behaviour for this component creates
a skip link to the main page content. It also allows the developer to
specify the link text should they need to have multiple skip links.

By doing this it also brings this component more inline with
GOV.UK Design System https://design-system.service.gov.uk/components/skip-link/

<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->
