### PR TITLE
Add a margin_bottom option to textarea component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove classes option from components (PR #727)
+* Add margin option to textarea component (PR #757)
 
 ## 15.3.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
@@ -1,5 +1,1 @@
 @import "govuk-frontend/components/textarea/textarea";
-
-.gem-c-textarea {
-  margin-bottom: govuk-spacing(1);
-}

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -7,6 +7,7 @@
 
   label ||= nil
   hint ||= nil
+  margin_bottom ||= 3
   error_message ||= nil
   error_items ||= nil
   character_count ||= nil
@@ -18,6 +19,7 @@
   css_classes = %w(gem-c-textarea govuk-textarea)
   css_classes << "js-character-count" if character_count
   css_classes << "govuk-textarea--error" if has_error
+  css_classes << ([*0..9].include?(margin_bottom) ? "govuk-!-margin-bottom-#{margin_bottom}" : "govuk-!-margin-bottom-3")
   form_group_css_classes = %w(govuk-form-group)
   form_group_css_classes << "govuk-form-group--error" if has_error
 

--- a/spec/components/textarea_spec.rb
+++ b/spec/components/textarea_spec.rb
@@ -72,6 +72,26 @@ describe "Textarea", type: :view do
     assert_select ".govuk-textarea", text: "More detail provided"
   end
 
+  it "applies a specified bottom margin" do
+    render_component(
+      label: { text: "Can you provide more detail?" },
+      name: "with-custom-margin-bottom",
+      margin_bottom: 6
+    )
+
+    assert_select '.govuk-textarea.govuk-\!-margin-bottom-6'
+  end
+
+  it "defaults to the initial bottom margin if an incorrect value is passed" do
+    render_component(
+      label: { text: "Can you provide more detail?" },
+      name: "with-fallback-margin-bottom",
+      margin_bottom: 12
+    )
+
+    assert_select '.govuk-textarea.govuk-\!-margin-bottom-3'
+  end
+
   context "when a hint is provided" do
     before do
       render_component(


### PR DESCRIPTION
This PR replaces a custom overwrite for the `magin-bottom` with a custom attribute to set a value from the spacing scale which seems to became a common approach in dealing with spacing for components (see #724, #727).

The reason behind this update is that textarea components should, by default, as the rest of the input form fields, have a `govuk-spacing(3)` set to `margin-bottom`.

~~Tests and changelog to be added.~~