### PR TITLE
Add JS and SCSS lint

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,0 +1,361 @@
+# Not yet supported by sass-lint:
+# ChainedClasses, DisableLinterReason, ElsePlacement, PropertyCount
+# PseudoElement, SelectorDepth, SpaceAroundOperator, TrailingWhitespace
+# UnnecessaryParentReference, Compass::*
+#
+# The following settings/values are unsupported by sass-lint:
+# Linter Comment, option "style"
+# Linter Indentation, option "allow_non_nested_indentation"
+# Linter Indentation, option "character"
+# Linter NestingDepth, option "ignore_parent_selectors"
+# Linter SpaceBeforeBrace, option "allow_single_line_padding"
+
+files:
+  include: '**/*.s+(a|c)ss'
+options:
+  formatter: stylish
+  merge-default-rules: true
+rules:
+
+  # Rule bem-depth will enforce how many elements a BEM selector can contain.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/bem-depth.md
+  bem-depth: 0
+
+  # Rule border-zero will enforce whether one should use 0 or none when specifying a zero border value
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/border-zero.md
+  border-zero: 2
+
+  # Rule brace-style will enforce the use of the chosen brace style.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/brace-style.md
+  brace-style:
+    - 2
+    - allow-single-line: false
+
+  # Rule class-name-format will enforce a convention for class names.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/class-name-format.md#example-7
+  # will allow .block {}, .block__element{}, .block--modifier {}
+  class-name-format:
+    - 2
+    - convention: hyphenatedbem
+
+  # Rule clean-import-paths will enforce whether or not @import paths should have leading underscores and/or filename extensions.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/clean-import-paths.md
+  clean-import-paths:
+    - 2
+    - filename-extension: false
+      leading-underscore: false
+
+  # TODO: empty-args
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/empty-args.md
+
+  # Rule empty-line-between-blocks will enforce whether or not nested blocks should include a space between the last non-comment declaration or not.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/empty-line-between-blocks.md
+  empty-line-between-blocks:
+    - 2
+    - ignore-single-line-rulesets: true
+
+  # Rule extends-before-declarations will enforce that extends should be written before declarations in a ruleset.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/extends-before-declarations.md
+  extends-before-declarations: 0
+
+  # Rule extends-before-mixins will enforce that extends should be written before mixins in a ruleset.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/extends-before-mixins.md
+  extends-before-mixins: 0
+
+  # Rule final-newline will enforce whether or not files should end with a newline.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/final-newline.md
+  final-newline:
+    - 2
+    - include: true
+
+  # Rule force-attribute-nesting will enforce the nesting of attributes
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/force-attribute-nesting.md
+  force-attribute-nesting:
+    - 0
+
+  # Rule force-element-nesting will enforce the nesting of elements
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/force-element-nesting.md
+  force-element-nesting:
+    - 0
+
+  # Rule force-pseudo-nesting will enforce the nesting of pseudo elements/classes.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/force-pseudo-nesting.md
+  force-pseudo-nesting:
+    - 0
+
+  # Rule function-name-format will enforce a convention for function names.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/function-name-format.md
+  function-name-format:
+    - 2
+    - allow-leading-underscore: true
+      convention: hyphenatedlowercase
+
+  # Rule hex-length will enforce the length of hexadecimal values
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/hex-length.md
+  hex-length:
+    - 2
+    - style: long
+
+  # Rule hex-notation will enforce the case of hexadecimal values
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/hex-notation.md
+  hex-notation:
+    - 2
+    - style: lowercase
+
+  # Rule id-name-format will enforce a convention for ids.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/id-name-format.md
+  id-name-format:
+    - 2
+    - convention: hyphenatedlowercase
+
+  # Rule indentation will enforce an indentation size (tabs and spaces) and it will also ensure that tabs and spaces are not mixed.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/indentation.md
+  indentation:
+    - 2
+    - size: 2
+
+  # Rule leading-zero will enforce whether or not decimal numbers should include a leading zero.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/leading-zero.md
+  leading-zero:
+    - 2
+    - include: false
+
+  # Rule mixin-name-format will enforce a convention for mixin names.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/mixin-name-format.md
+  mixin-name-format:
+    - 2
+    - allow-leading-underscore: true
+      convention: hyphenatedlowercase
+
+  # Rule mixins-before-declarations will enforce that mixins should be written before declarations in a ruleset.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/mixins-before-declarations.md
+  mixins-before-declarations: 0
+
+  # Rule nesting-depth will enforce how deeply a selector can be nested.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/nesting-depth.md
+  nesting-depth:
+    - 2
+    - max-depth: 3
+
+  # TODO: no-attribute-selectors
+  # Rule no-attribute-selectors will warn against the use of attribute selectors.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-attribute-selectors.md
+
+  # TODO: no-colour-hex
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-color-hex.md
+
+  # Rule no-color-keywords will enforce the use of hexadecimal color values rather than literals.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-color-keywords.md
+  no-color-keywords: 2
+
+  # Rule no-color-literals will disallow the use of color literals and basic color functions in any declarations other than variables or maps/lists.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-color-literals.md
+  no-color-literals:
+    - 2
+    - allow-rgba: true
+
+  # TODO: no-combniators
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-combinators.md
+
+  # Rule no-css-comments will enforce the use of Sass single-line comments and disallow CSS comments. Bang comments (/*! */, will be printed even in minified mode) are still allowed.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-css-comments.md
+  no-css-comments: 2
+
+  # Rule no-debug will enforce that @debug statements are not allowed to be used.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-debug.md
+  no-debug: 2
+
+  # TODO: no-disallowed-properties
+  # Rule no-disallowed-properties will warn against the use of certain properties.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-disallowed-properties.md
+
+  # Rule no-duplicate-properties will enforce that duplicate properties are not allowed within the same block.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-duplicate-properties.md
+  no-duplicate-properties: 2
+
+  # Rule no-empty-rulesets will enforce that rulesets are not empty.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-empty-rulesets.md
+  no-empty-rulesets: 2
+
+  # Rule no-extends will enforce that @extend is not allowed to be used.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-extends.md
+  no-extends: 0
+
+  # Rule no-ids will enforce that ID selectors are not allowed to be used.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-ids.md
+  no-ids: 2
+
+  # Rule no-important will enforce that important declarations are not allowed to be used.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-important.md
+  no-important: 0
+
+  # Rule no-invalid-hex will enforce that only valid of hexadecimal values are written.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-invalid-hex.md
+  no-invalid-hex: 2
+
+  # Rule no-mergeable-selectors will enforce that selectors aren't repeated and that their properties are merged.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-mergeable-selectors.md
+  no-mergeable-selectors: 0
+
+  # Rule no-misspelled-properties will enforce the correct spelling of CSS properties and prevent the use of unknown CSS properties.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-misspelled-properties.md
+  no-misspelled-properties: 2
+
+  # Rule no-qualifying-elements will enforce that selectors are not allowed to have qualifying elements.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-qualifying-elements.md
+  no-qualifying-elements:
+    - 2
+    - allow-element-with-attribute: true
+      allow-element-with-class: false
+      allow-element-with-id: false
+
+  # TODO: no-trailing-whitespace
+  # Rule no-trailing-whitespace will enforce that trailing whitespace is not allowed.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-trailing-whitespace.md
+
+  # Rule no-trailing-zero will enforce that trailing zeros are not allowed.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-trailing-zero.md
+  no-trailing-zero: 2
+
+  # Rule no-transition-all will enforce whether the keyword all can be used with the transition or transition-property property.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-transition-all.md
+  no-transition-all: 2
+
+  # TODO: no-universal-selectors
+  # Rule no-universal-selectors will warn against the use of * (universal) selectors.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-universal-selectors.md
+
+  # Rule no-url-protocols will enforce that protocols and domains are not used within urls.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-url-protocols.md
+  no-url-protocols: 2
+
+  # Rule no-vendor-prefixes will enforce that vendor prefixes are not allowed to be used.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-vendor-prefixes.md
+  no-vendor-prefixes: 0
+
+  # Rule no-warn will enforce that @warn statements are not allowed to be used.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-warn.md
+  no-warn: 0
+
+  # Rule placeholder-in-extend will enforce whether extends should only include placeholder selectors.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/placeholder-in-extend.md
+  placeholder-in-extend: 2
+
+  # Rule placeholder-name-format will enforce a convention for placeholder names.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/placeholder-name-format.md
+  placeholder-name-format:
+    - 2
+    - convention: hyphenatedlowercase
+
+  # Rule property-sort-order will enforce the order in which declarations are written.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/property-sort-order.md
+  property-sort-order: 0
+
+  # Rule property-units will disallow the use of units not specified in global or per-property.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/property-units.md
+  property-units:
+    - 2
+    - global: [
+        'cm',
+        'em',
+        'pt',
+        'px',
+        'rem',
+        'vh',
+        'ex'
+      ]
+
+  # Rule pseudo-element will enforce that:
+  # - pseudo-elements must start with double colons
+  # - pseudo-classes must start with single colon
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/pseudo-element.md
+  pseudo-element:
+    - 0
+
+  # Rule quotes will enforce whether single quotes ('') or double quotes ("") should be used for all strings.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/quotes.md
+  quotes:
+    - 2
+    - style: double
+
+  # Rule shorthand-values will enforce that values in their shorthand form are as concise as specified.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/shorthand-values.md
+  shorthand-values:
+    - 0
+    - allowed-shorthands:
+        - 1
+        - 2
+        - 3
+
+  # Rule single-line-per-selector will enforce whether selectors should be placed on a new line.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/single-line-per-selector.md
+  single-line-per-selector: 2
+
+  # Rule space-after-bang will enforce whether or not a space should be included after a bang (!).
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-after-bang.md
+  space-after-bang:
+    - 2
+    - include: false
+
+  # Rule space-after-colon will enforce whether or not a space should be included after a colon (:).
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-after-colon.md
+  space-after-colon:
+    - 2
+    - include: true
+
+  # Rule space-after-comma will enforce whether or not a space should be included after a comma (,).
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-after-comma.md
+  space-after-comma:
+    - 2
+    - include: true
+
+  # Rule space-around-operator will enforce whether or not a single space should be included before and after the following operators: +, -, /, *, %, <, > ==, !=, <= and >=.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-around-operator.md
+  space-around-operator:
+    - 2
+    - include: true
+
+  # Rule space-before-bang will enforce whether or not a space should be included before a bang (!).
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-before-bang.md
+  space-before-bang:
+    - 2
+    - include: true
+
+  # Rule space-before-brace will enforce whether or not a space should be included before a brace ({).
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-before-brace.md
+  space-before-brace:
+    - 2
+    - include: true
+
+  # Rule space-before-colon will enforce whether or not a space should be included before a colon (:).
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-before-colon.md
+  space-before-colon: 2
+
+  # Rule space-between-parens will enforce whether or not a space should be included before the first item and after the last item inside parenthesis (()).
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-between-parens.md
+  space-between-parens: 2
+
+  # Rule trailing-semicolon will enforce whether the last declaration in a block should include a semicolon (;) or not.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/trailing-semicolon.md
+  trailing-semicolon: 2
+
+  # Rule url-quotes will enforce that URLs are wrapped in quotes.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/url-quotes.md
+  url-quotes: 2
+
+  # Rule variable-for-property will enforce the use of variables for the values of specified properties.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/variable-for-property.md
+  variable-for-property:
+    - 0
+    - properties: []
+
+  # Rule variable-name-format will enforce a convention for variable names.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/variable-name-format.md
+  variable-name-format:
+    - 2
+    - allow-leading-underscore: true
+      convention: hyphenatedlowercase
+
+  # Rule zero-unit will enforce whether or not values of 0 used for length should be unitless.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/zero-unit.md
+  zero-unit: 2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,5 +315,8 @@ DEPENDENCIES
   webmock (~> 3.5.0)
   yard
 
+RUBY VERSION
+   ruby 2.6.3p62
+
 BUNDLED WITH
    1.17.3

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,12 @@ node {
   govuk.buildProject(
     rubyLintDiff: false,
     beforeTest: {
-      sh("npm install")
+      stage("Install npm dependencies") {
+        sh("npm install")
+      }
+      stage("Lint Javascript and SCSS") {
+        sh("npm run lint")
+      }
     }
   )
 }

--- a/app/assets/javascripts/govuk_publishing_components/all_components.js
+++ b/app/assets/javascripts/govuk_publishing_components/all_components.js
@@ -1,6 +1,6 @@
-//= require_tree ./lib
-//= require_tree ./components
-//= require govuk-frontend/all.js
+// = require_tree ./lib
+// = require_tree ./components
+// = require govuk-frontend/all.js
 
 // Initialise all GOVUKFrontend components
 window.GOVUKFrontend.initAll()

--- a/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
@@ -1,54 +1,56 @@
-//= require accessible-autocomplete/dist/accessible-autocomplete.min.js
+/* eslint-env jquery */
+/* global accessibleAutocomplete */
+// = require accessible-autocomplete/dist/accessible-autocomplete.min.js
 
-window.GOVUK = window.GOVUK || {};
+window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  "use strict";
+  'use strict'
 
   Modules.AccessibleAutocomplete = function () {
-    var $selectElem;
+    var $selectElem
 
     this.start = function ($element) {
-      $selectElem = $element.find('select');
+      $selectElem = $element.find('select')
 
       var configOptions = {
         selectElement: document.getElementById($selectElem.attr('id')),
         showAllValues: true,
         confirmOnBlur: true,
         preserveNullOptions: true, // https://github.com/alphagov/accessible-autocomplete#null-options
-        defaultValue: ""
-      };
+        defaultValue: ''
+      }
 
-      configOptions.onConfirm = this.onConfirm;
+      configOptions.onConfirm = this.onConfirm
 
-      new accessibleAutocomplete.enhanceSelectElement(configOptions);
-      //attach the onConfirm function to data attr, to call it in finder-frontend when clearing facet tags
-      $selectElem.data('onconfirm', this.onConfirm);
-    };
+      new accessibleAutocomplete.enhanceSelectElement(configOptions) // eslint-disable-line no-new, new-cap
+      // attach the onConfirm function to data attr, to call it in finder-frontend when clearing facet tags
+      $selectElem.data('onconfirm', this.onConfirm)
+    }
 
-    this.onConfirm = function(label, value, removeDropDown) {
-      function escapeHTML(str){
-        return new Option(str).innerHTML;
+    this.onConfirm = function (label, value, removeDropDown) {
+      function escapeHTML (str) {
+        return new window.Option(str).innerHTML
       }
 
       if ($selectElem.data('track-category') !== undefined && $selectElem.data('track-action') !== undefined) {
-        track($selectElem.data('track-category'), $selectElem.data('track-action'), label, $selectElem.data('track-options'));
+        track($selectElem.data('track-category'), $selectElem.data('track-action'), label, $selectElem.data('track-options'))
       }
       // This is to compensate for the fact that the accessible-autocomplete library will not
       // update the hidden select if the onConfirm function is supplied
       // https://github.com/alphagov/accessible-autocomplete/issues/322
       if (typeof label !== 'undefined') {
         if (typeof value === 'undefined') {
-          value = $selectElem.children("option").filter(function () { return $(this).html() == escapeHTML(label); }).val();
+          value = $selectElem.children('option').filter(function () { return $(this).html() === escapeHTML(label) }).val()
         }
 
         if (typeof value !== 'undefined') {
-          var $option = $selectElem.find('option[value=\'' + value + '\']');
+          var $option = $selectElem.find('option[value=\'' + value + '\']')
           // if removeDropDown we are clearing the selection from outside the component
-          var selectState = typeof removeDropDown === 'undefined' ? true : false;
-          $option.prop('selected', selectState);
-          $selectElem.change();
+          var selectState = typeof removeDropDown === 'undefined'
+          $option.prop('selected', selectState)
+          $selectElem.change()
         }
 
         // used to clear the autocomplete when clicking on a facet tag in finder-frontend
@@ -56,22 +58,22 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         // setting autocomplete val to '' causes menu to appear, we don't want that, this solves it
         // ideally will rewrite autocomplete to have better hooks in future
         if (removeDropDown) {
-          $selectElem.closest('.gem-c-accessible-autocomplete').addClass('gem-c-accessible-autocomplete--hide-menu');
-          setTimeout(function() {
-            $('.autocomplete__menu').remove(); // this element is recreated every time the user starts typing
-            $selectElem.closest('.gem-c-accessible-autocomplete').removeClass('gem-c-accessible-autocomplete--hide-menu');
-          }, 100);
+          $selectElem.closest('.gem-c-accessible-autocomplete').addClass('gem-c-accessible-autocomplete--hide-menu')
+          setTimeout(function () {
+            $('.autocomplete__menu').remove() // this element is recreated every time the user starts typing
+            $selectElem.closest('.gem-c-accessible-autocomplete').removeClass('gem-c-accessible-autocomplete--hide-menu')
+          }, 100)
         }
       }
-    };
+    }
 
     function track (category, action, label, options) {
-      if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
-        options = options || {};
-        options.label = label;
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        options = options || {}
+        options.label = label
 
-        GOVUK.analytics.trackEvent(category, action, options);
+        window.GOVUK.analytics.trackEvent(category, action, options)
       }
     }
-  };
-})(window.GOVUK.Modules);
+  }
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -1,2 +1,2 @@
 // This component relies on JavaScript from GOV.UK Frontend
-//= require govuk-frontend/components/accordion/accordion.js
+// = require govuk-frontend/components/accordion/accordion.js

--- a/app/assets/javascripts/govuk_publishing_components/components/character-count.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/character-count.js
@@ -1,2 +1,2 @@
 // This component relies on JavaScript from GOV.UK Frontend
-//= require govuk-frontend/components/character-count/character-count.js
+// = require govuk-frontend/components/character-count/character-count.js

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -1,78 +1,78 @@
-// This component relies on JavaScript from GOV.UK Frontend
-//= require govuk-frontend/components/checkboxes/checkboxes.js
-window.GOVUK = window.GOVUK || {};
+/* eslint-env jquery */
+// = require govuk-frontend/components/checkboxes/checkboxes.js
+window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  'use strict';
+  'use strict'
 
-   Modules.Checkboxes = function () {
+  Modules.Checkboxes = function () {
     this.start = function (scope) {
-      var _this = this;
-      this.applyAriaControlsAttributes(scope);
+      var _this = this
+      this.applyAriaControlsAttributes(scope)
 
-      $(scope).on('change', '[data-nested=true] input[type=checkbox]', function(e) {
-        var checkbox = e.target;
-        var isNested = $(checkbox).closest('.govuk-checkboxes--nested');
-        var hasNested = $('.govuk-checkboxes--nested[data-parent=' + checkbox.id + ']');
+      $(scope).on('change', '[data-nested=true] input[type=checkbox]', function (e) {
+        var checkbox = e.target
+        var isNested = $(checkbox).closest('.govuk-checkboxes--nested')
+        var hasNested = $('.govuk-checkboxes--nested[data-parent=' + checkbox.id + ']')
 
         if (hasNested.length) {
-          _this.toggleNestedCheckboxes(hasNested, checkbox);
+          _this.toggleNestedCheckboxes(hasNested, checkbox)
         } else if (isNested.length) {
-          _this.toggleParentCheckbox(isNested, checkbox);
+          _this.toggleParentCheckbox(isNested, checkbox)
         }
-      });
+      })
 
-      $(scope).on('change', 'input[type=checkbox]', function(e) {
-        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+      $(scope).on('change', 'input[type=checkbox]', function (e) {
+        if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
           // where checkboxes are manipulated externally in finders, suppressAnalytics
           // is passed to prevent duplicate GA events
-          if(typeof e.suppressAnalytics === 'undefined' || e.suppressAnalytics !== true ) {
-            var $checkbox = $(e.target);
-            var category = $checkbox.data("track-category");
-            if (typeof category !== "undefined") {
-              var isChecked = $checkbox.is(":checked");
-              var uncheckTrackCategory = $checkbox.data("uncheck-track-category");
-              if (!isChecked && typeof uncheckTrackCategory !== "undefined") {
-                category = uncheckTrackCategory;
+          if (typeof e.suppressAnalytics === 'undefined' || e.suppressAnalytics !== true) {
+            var $checkbox = $(e.target)
+            var category = $checkbox.data('track-category')
+            if (typeof category !== 'undefined') {
+              var isChecked = $checkbox.is(':checked')
+              var uncheckTrackCategory = $checkbox.data('uncheck-track-category')
+              if (!isChecked && typeof uncheckTrackCategory !== 'undefined') {
+                category = uncheckTrackCategory
               }
-              var action = $checkbox.data("track-action");
-              var options = $checkbox.data("track-options");
+              var action = $checkbox.data('track-action')
+              var options = $checkbox.data('track-options')
               if (typeof options !== 'object' || options === null) {
-                options = {};
+                options = {}
               }
-              options['value'] = $checkbox.data("track-value");
-              options['label'] = $checkbox.data("track-label");
-              GOVUK.analytics.trackEvent(category, action, options);
+              options['value'] = $checkbox.data('track-value')
+              options['label'] = $checkbox.data('track-label')
+              window.GOVUK.analytics.trackEvent(category, action, options)
             }
           }
         }
-      });
-    };
+      })
+    }
 
-    this.toggleNestedCheckboxes = function(scope, checkbox) {
+    this.toggleNestedCheckboxes = function (scope, checkbox) {
       if (checkbox.checked) {
-        scope.find('input[type=checkbox]').prop("checked", true);
+        scope.find('input[type=checkbox]').prop('checked', true)
       } else {
-        scope.find('input[type=checkbox]').prop("checked", false);
+        scope.find('input[type=checkbox]').prop('checked', false)
       }
-    };
+    }
 
-    this.toggleParentCheckbox = function(scope, checkbox) {
-      var siblings = $(checkbox).closest('.govuk-checkboxes__item').siblings();
-      var parent_id = scope.data('parent');
+    this.toggleParentCheckbox = function (scope, checkbox) {
+      var siblings = $(checkbox).closest('.govuk-checkboxes__item').siblings()
+      var parentId = scope.data('parent')
 
-      if (checkbox.checked && siblings.length == siblings.find(':checked').length) {
-        $('#' + parent_id).prop("checked", true);
+      if (checkbox.checked && siblings.length === siblings.find(':checked').length) {
+        $('#' + parentId).prop('checked', true)
       } else {
-        $('#' + parent_id).prop("checked", false);
+        $('#' + parentId).prop('checked', false)
       }
-    };
+    }
 
     this.applyAriaControlsAttributes = function (scope) {
       $(scope).find('[data-controls]').each(function () {
-        $(this).attr('aria-controls', $(this).attr('data-controls'));
-      });
-    };
-  };
-})(window.GOVUK.Modules);
+        $(this).attr('aria-controls', $(this).attr('data-controls'))
+      })
+    }
+  }
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/components/copy-to-clipboard.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/copy-to-clipboard.js
@@ -1,23 +1,23 @@
-window.GOVUK = window.GOVUK || {};
+window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  'use strict';
+  'use strict'
 
   Modules.CopyToClipboard = function () {
     this.start = function (element) {
-      var input = element[0].querySelector('.gem-c-input');
-      var copyButton = element[0].querySelector('.gem-c-button');
+      var input = element[0].querySelector('.gem-c-input')
+      var copyButton = element[0].querySelector('.gem-c-button')
 
-      input.addEventListener('click', function() {
-        input.select();
-      });
+      input.addEventListener('click', function () {
+        input.select()
+      })
 
       copyButton.addEventListener('click', function (event) {
-        event.preventDefault();
-        input.select();
-        document.execCommand('copy');
-      });
-    };
-  };
-})(window.GOVUK.Modules);
+        event.preventDefault()
+        input.select()
+        document.execCommand('copy')
+      })
+    }
+  }
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/components/error-summary.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/error-summary.js
@@ -1,2 +1,2 @@
 // This component relies on JavaScript from GOV.UK Frontend
-//= require govuk-frontend/components/error-summary/error-summary.js
+// = require govuk-frontend/components/error-summary/error-summary.js

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -1,110 +1,111 @@
-window.GOVUK = window.GOVUK || {};
+/* eslint-env jquery */
+
+window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  "use strict";
+  'use strict'
 
   Modules.Feedback = function () {
-
     this.start = function ($element) {
-      this.$prompt = $element.find('.js-prompt');
-      this.$fields = $element.find('.gem-c-feedback__form-field');
-      this.$forms = $element.find('.js-feedback-form');
-      this.$toggleForms = $element.find('.js-toggle-form');
-      this.$closeForms = $element.find('.js-close-form');
-      this.$activeForm = false;
-      this.$pageIsUsefulButton = $element.find('.js-page-is-useful');
-      this.$pageIsNotUsefulButton = $element.find('.js-page-is-not-useful');
-      this.$somethingIsWrongButton = $element.find('.js-something-is-wrong');
-      this.$promptQuestions = $element.find('.js-prompt-questions');
-      this.$promptSuccessMessage = $element.find('.js-prompt-success');
-      this.$somethingIsWrongForm = $element.find('#something-is-wrong');
+      this.$prompt = $element.find('.js-prompt')
+      this.$fields = $element.find('.gem-c-feedback__form-field')
+      this.$forms = $element.find('.js-feedback-form')
+      this.$toggleForms = $element.find('.js-toggle-form')
+      this.$closeForms = $element.find('.js-close-form')
+      this.$activeForm = false
+      this.$pageIsUsefulButton = $element.find('.js-page-is-useful')
+      this.$pageIsNotUsefulButton = $element.find('.js-page-is-not-useful')
+      this.$somethingIsWrongButton = $element.find('.js-something-is-wrong')
+      this.$promptQuestions = $element.find('.js-prompt-questions')
+      this.$promptSuccessMessage = $element.find('.js-prompt-success')
+      this.$somethingIsWrongForm = $element.find('#something-is-wrong')
 
-      var that = this;
-      var jshiddenClass = 'js-hidden';
+      var that = this
+      var jshiddenClass = 'js-hidden'
 
-      setInitialAriaAttributes();
-      setHiddenValues();
+      setInitialAriaAttributes()
+      setHiddenValues()
 
-      this.$toggleForms.on('click', function(e) {
-        e.preventDefault();
-        toggleForm($(e.target).attr('aria-controls'));
-        trackEvent(getTrackEventParams($(this)));
-        updateAriaAttributes($(this));
-      });
+      this.$toggleForms.on('click', function (e) {
+        e.preventDefault()
+        toggleForm($(e.target).attr('aria-controls'))
+        trackEvent(getTrackEventParams($(this)))
+        updateAriaAttributes($(this))
+      })
 
-      this.$closeForms.on('click', function(e) {
-        e.preventDefault();
-        toggleForm($(e.target).attr('aria-controls'));
-        trackEvent(getTrackEventParams($(this)));
-        setInitialAriaAttributes();
-        revealInitialPrompt();
-      });
+      this.$closeForms.on('click', function (e) {
+        e.preventDefault()
+        toggleForm($(e.target).attr('aria-controls'))
+        trackEvent(getTrackEventParams($(this)))
+        setInitialAriaAttributes()
+        revealInitialPrompt()
+      })
 
-      this.$pageIsUsefulButton.on('click', function(e) {
-        e.preventDefault();
-        trackEvent(getTrackEventParams(that.$pageIsUsefulButton));
-        showFormSuccess();
-        revealInitialPrompt();
-      });
+      this.$pageIsUsefulButton.on('click', function (e) {
+        e.preventDefault()
+        trackEvent(getTrackEventParams(that.$pageIsUsefulButton))
+        showFormSuccess()
+        revealInitialPrompt()
+      })
 
-      $element.find('form').on('submit', function(e) {
-        e.preventDefault();
-        var $form = $(this);
+      $element.find('form').on('submit', function (e) {
+        e.preventDefault()
+        var $form = $(this)
         $.ajax({
-          type: "POST",
+          type: 'POST',
           url: $form.attr('action'),
-          dataType: "json",
+          dataType: 'json',
           data: $form.serialize(),
           beforeSend: disableSubmitFormButton($form),
           timeout: 6000
         }).done(function (xhr) {
-          trackEvent(getTrackEventParams($form));
-          showFormSuccess(xhr.message);
-          revealInitialPrompt();
-          setInitialAriaAttributes();
-          that.$activeForm.toggleClass(jshiddenClass);
+          trackEvent(getTrackEventParams($form))
+          showFormSuccess(xhr.message)
+          revealInitialPrompt()
+          setInitialAriaAttributes()
+          that.$activeForm.toggleClass(jshiddenClass)
         }).fail(function (xhr) {
-          showError(xhr);
-          enableSubmitFormButton($form);
-        });
-      });
+          showError(xhr)
+          enableSubmitFormButton($form)
+        })
+      })
 
       function disableSubmitFormButton ($form) {
-        $form.find('input[type="submit"]').prop('disabled', true);
+        $form.find('input[type="submit"]').prop('disabled', true)
       }
 
       function enableSubmitFormButton ($form) {
-        $form.find('input[type="submit"]').removeAttr('disabled');
+        $form.find('input[type="submit"]').removeAttr('disabled')
       }
 
       function setInitialAriaAttributes () {
-        that.$forms.attr('aria-hidden', true);
-        that.$pageIsNotUsefulButton.attr('aria-expanded', false);
-        that.$somethingIsWrongButton.attr('aria-expanded', false);
+        that.$forms.attr('aria-hidden', true)
+        that.$pageIsNotUsefulButton.attr('aria-expanded', false)
+        that.$somethingIsWrongButton.attr('aria-expanded', false)
       }
 
       function setHiddenValues () {
-        that.$somethingIsWrongForm.append('<input type="hidden" name="javascript_enabled" value="true"/>');
-        that.$somethingIsWrongForm.append($('<input type="hidden" name="referrer">').val(document.referrer || "unknown"));
+        that.$somethingIsWrongForm.append('<input type="hidden" name="javascript_enabled" value="true"/>')
+        that.$somethingIsWrongForm.append($('<input type="hidden" name="referrer">').val(document.referrer || 'unknown'))
       }
 
       function updateAriaAttributes (linkClicked) {
-        linkClicked.attr('aria-expanded', true);
-        $('#' + linkClicked.attr('aria-controls')).attr('aria-hidden', false);
+        linkClicked.attr('aria-expanded', true)
+        $('#' + linkClicked.attr('aria-controls')).attr('aria-hidden', false)
       }
 
       function toggleForm (formId) {
-        that.$activeForm = $element.find('#' + formId);
-        that.$activeForm.toggleClass(jshiddenClass);
-        that.$prompt.toggleClass(jshiddenClass);
+        that.$activeForm = $element.find('#' + formId)
+        that.$activeForm.toggleClass(jshiddenClass)
+        that.$prompt.toggleClass(jshiddenClass)
 
-        var formIsVisible = !that.$activeForm.hasClass(jshiddenClass);
+        var formIsVisible = !that.$activeForm.hasClass(jshiddenClass)
 
         if (formIsVisible) {
-          that.$activeForm.find('.gem-c-input').first().focus();
+          that.$activeForm.find('.gem-c-input').first().focus()
         } else {
-          that.$activeForm = false;
+          that.$activeForm = false
         }
       }
 
@@ -112,40 +113,40 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         return {
           category: $node.data('track-category'),
           action: $node.data('track-action')
-        };
+        }
       }
 
       function trackEvent (trackEventParams) {
-        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
-          GOVUK.analytics.trackEvent(trackEventParams.category, trackEventParams.action);
+        if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+          window.GOVUK.analytics.trackEvent(trackEventParams.category, trackEventParams.action)
         }
       }
 
       function showError (error) {
-        var error = [
+        error = [
           '<h2 class="gem-c-feedback__heading">',
           '  Sorry, we’re unable to receive your message right now. ',
           '</h2>',
           '<p>If the problem persists, we have other ways for you to provide',
           ' feedback on the <a href="/contact/govuk">contact page</a>.</p>'
-        ].join('');
+        ].join('')
 
-        if (typeof(error.responseJSON) !== 'undefined') {
-          error = typeof(error.responseJSON.message) == 'undefined' ? error : error.responseJSON.message;
+        if (typeof (error.responseJSON) !== 'undefined') {
+          error = typeof (error.responseJSON.message) === 'undefined' ? error : error.responseJSON.message
         }
-        var $errors = that.$activeForm.find('.js-errors');
-        $errors.html(error).removeClass(jshiddenClass).focus();
+        var $errors = that.$activeForm.find('.js-errors')
+        $errors.html(error).removeClass(jshiddenClass).focus()
       }
 
       function showFormSuccess () {
-        that.$promptQuestions.addClass(jshiddenClass);
-        that.$promptSuccessMessage.removeClass(jshiddenClass).focus();
+        that.$promptQuestions.addClass(jshiddenClass)
+        that.$promptSuccessMessage.removeClass(jshiddenClass).focus()
       }
 
       function revealInitialPrompt () {
-        that.$prompt.removeClass(jshiddenClass);
-        that.$prompt.focus();
+        that.$prompt.removeClass(jshiddenClass)
+        that.$prompt.focus()
       }
-    };
-  };
-})(window.GOVUK.Modules);
+    }
+  }
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/components/initial-focus.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/initial-focus.js
@@ -1,12 +1,12 @@
-window.GOVUK = window.GOVUK || {};
+window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  'use strict';
+  'use strict'
 
   Modules.InitialFocus = function () {
     this.start = function (element) {
-      element.focus();
-    };
-  };
-})(window.GOVUK.Modules);
+      element.focus()
+    }
+  }
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/components/modal-dialogue.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/modal-dialogue.js
@@ -31,11 +31,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   ModalDialogue.prototype.handleResize = function (size) {
-    if (size == "narrow") {
+    if (size === 'narrow') {
       this.$dialogBox.classList.remove('gem-c-modal-dialogue__box--wide')
     }
 
-    if (size == "wide") {
+    if (size === 'wide') {
       this.$dialogBox.classList.add('gem-c-modal-dialogue__box--wide')
     }
   }

--- a/app/assets/javascripts/govuk_publishing_components/components/radio.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/radio.js
@@ -1,2 +1,2 @@
 // This component relies on JavaScript from GOV.UK Frontend
-//= require govuk-frontend/components/radios/radios.js
+// = require govuk-frontend/components/radios/radios.js

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -1,223 +1,225 @@
-window.GOVUK = window.GOVUK || {};
+/* eslint-env jquery */
+
+window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  "use strict";
+  'use strict'
 
   Modules.Gemstepnav = function () {
-    var actions = {}; // stores text for JS appended elements 'show' and 'hide' on steps, and 'show/hide all' button
-    var rememberShownStep = false;
-    var stepNavSize;
-    var sessionStoreLink = 'govuk-step-nav-active-link';
-    var activeLinkClass = 'gem-c-step-nav__list-item--active';
-    var activeStepClass = 'gem-c-step-nav__step--active';
-    var activeLinkHref = '#content';
-    var uniqueId;
+    var actions = {} // stores text for JS appended elements 'show' and 'hide' on steps, and 'show/hide all' button
+    var rememberShownStep = false
+    var stepNavSize
+    var sessionStoreLink = 'govuk-step-nav-active-link'
+    var activeLinkClass = 'gem-c-step-nav__list-item--active'
+    var activeStepClass = 'gem-c-step-nav__step--active'
+    var activeLinkHref = '#content'
+    var uniqueId
 
     this.start = function ($element) {
       // Indicate that js has worked
-      $element.addClass('gem-c-step-nav--active');
+      $element.addClass('gem-c-step-nav--active')
 
       // Prevent FOUC, remove class hiding content
-      $element.removeClass('js-hidden');
+      $element.removeClass('js-hidden')
 
-      stepNavSize = $element.hasClass('gem-c-step-nav--large') ? 'Big' : 'Small';
-      rememberShownStep = !!$element.filter('[data-remember]').length && stepNavSize == 'Big';
-      var $steps = $element.find('.js-step');
-      var $stepHeaders = $element.find('.js-toggle-panel');
-      var totalSteps = $element.find('.js-panel').length;
-      var totalLinks = $element.find('.gem-c-step-nav__link').length;
-      var $showOrHideAllButton;
+      stepNavSize = $element.hasClass('gem-c-step-nav--large') ? 'Big' : 'Small'
+      rememberShownStep = !!$element.filter('[data-remember]').length && stepNavSize === 'Big'
+      var $steps = $element.find('.js-step')
+      var $stepHeaders = $element.find('.js-toggle-panel')
+      var totalSteps = $element.find('.js-panel').length
+      var totalLinks = $element.find('.gem-c-step-nav__link').length
+      var $showOrHideAllButton
 
-      uniqueId = $element.data('id') || false;
+      uniqueId = $element.data('id') || false
 
       if (uniqueId) {
-        sessionStoreLink = sessionStoreLink + "_" + uniqueId;
+        sessionStoreLink = sessionStoreLink + '_' + uniqueId
       }
 
-      var stepNavTracker = new StepNavTracker(totalSteps, totalLinks, uniqueId);
+      var stepNavTracker = new StepNavTracker(totalSteps, totalLinks, uniqueId)
 
-      getTextForInsertedElements();
-      addButtonstoSteps();
-      addShowHideAllButton();
-      addShowHideToggle();
-      addAriaControlsAttrForShowHideAllButton();
+      getTextForInsertedElements()
+      addButtonstoSteps()
+      addShowHideAllButton()
+      addShowHideToggle()
+      addAriaControlsAttrForShowHideAllButton()
 
-      ensureOnlyOneActiveLink();
-      showPreviouslyOpenedSteps();
+      ensureOnlyOneActiveLink()
+      showPreviouslyOpenedSteps()
 
-      bindToggleForSteps(stepNavTracker);
-      bindToggleShowHideAllButton(stepNavTracker);
-      bindComponentLinkClicks(stepNavTracker);
+      bindToggleForSteps(stepNavTracker)
+      bindToggleShowHideAllButton(stepNavTracker)
+      bindComponentLinkClicks(stepNavTracker)
 
-      function getTextForInsertedElements() {
-        actions.showText = $element.attr('data-show-text');
-        actions.hideText = $element.attr('data-hide-text');
-        actions.showAllText = $element.attr('data-show-all-text');
-        actions.hideAllText = $element.attr('data-hide-all-text');
+      function getTextForInsertedElements () {
+        actions.showText = $element.attr('data-show-text')
+        actions.hideText = $element.attr('data-hide-text')
+        actions.showAllText = $element.attr('data-show-all-text')
+        actions.hideAllText = $element.attr('data-hide-all-text')
       }
 
-      function addShowHideAllButton() {
-        $element.prepend('<div class="gem-c-step-nav__controls"><button aria-expanded="false" class="gem-c-step-nav__button gem-c-step-nav__button--controls js-step-controls-button">' + actions.showAllText + '</button></div>');
+      function addShowHideAllButton () {
+        $element.prepend('<div class="gem-c-step-nav__controls"><button aria-expanded="false" class="gem-c-step-nav__button gem-c-step-nav__button--controls js-step-controls-button">' + actions.showAllText + '</button></div>')
       }
 
-      function addShowHideToggle() {
-        $stepHeaders.each(function() {
-          var linkText = actions.showText;
+      function addShowHideToggle () {
+        $stepHeaders.each(function () {
+          var linkText = actions.showText // eslint-disable-line no-unused-vars
 
           if (headerIsOpen($(this))) {
-            linkText = actions.hideText;
+            linkText = actions.hideText
           }
 
           if (!$(this).find('.js-toggle-link').length) {
             $(this).find('.js-step-title-button').append(
               '<span class="gem-c-step-nav__toggle-link js-toggle-link" aria-hidden="true" hidden></span>'
-            );
+            )
           }
-        });
+        })
       }
 
-      function headerIsOpen($stepHeader) {
-        return (typeof $stepHeader.closest('.js-step').data('show') !== 'undefined');
+      function headerIsOpen ($stepHeader) {
+        return (typeof $stepHeader.closest('.js-step').data('show') !== 'undefined')
       }
 
-      function addAriaControlsAttrForShowHideAllButton() {
-        var ariaControlsValue = $element.find('.js-panel').first().attr('id');
+      function addAriaControlsAttrForShowHideAllButton () {
+        var ariaControlsValue = $element.find('.js-panel').first().attr('id')
 
-        $showOrHideAllButton = $element.find('.js-step-controls-button');
-        $showOrHideAllButton.attr('aria-controls', ariaControlsValue);
+        $showOrHideAllButton = $element.find('.js-step-controls-button')
+        $showOrHideAllButton.attr('aria-controls', ariaControlsValue)
       }
 
       // called by show all/hide all, sets all steps accordingly
-      function setAllStepsShownState(isShown) {
-        var data = [];
+      function setAllStepsShownState (isShown) {
+        var data = []
 
         $.each($steps, function () {
-          var stepView = new StepView($(this));
-          stepView.setIsShown(isShown);
+          var stepView = new StepView($(this))
+          stepView.setIsShown(isShown)
 
           if (isShown) {
-            data.push($(this).attr('id'));
+            data.push($(this).attr('id'))
           }
-        });
+        })
 
         if (isShown) {
-          saveToSessionStorage(uniqueId, JSON.stringify(data));
+          saveToSessionStorage(uniqueId, JSON.stringify(data))
         } else {
-          removeFromSessionStorage(uniqueId);
+          removeFromSessionStorage(uniqueId)
         }
       }
 
       // called on load, determines whether each step should be open or closed
-      function showPreviouslyOpenedSteps() {
-        var data = loadFromSessionStorage(uniqueId) || [];
+      function showPreviouslyOpenedSteps () {
+        var data = loadFromSessionStorage(uniqueId) || []
 
-        $.each($steps, function() {
-          var id = $(this).attr('id');
-          var stepView = new StepView($(this));
+        $.each($steps, function () {
+          var id = $(this).attr('id')
+          var stepView = new StepView($(this))
 
           // show the step if it has been remembered or if it has the 'data-show' attribute
-          if ((rememberShownStep && data.indexOf(id) > -1) || typeof $(this).attr('data-show') !== "undefined") {
-            stepView.setIsShown(true);
+          if ((rememberShownStep && data.indexOf(id) > -1) || typeof $(this).attr('data-show') !== 'undefined') {
+            stepView.setIsShown(true)
           } else {
-            stepView.setIsShown(false);
+            stepView.setIsShown(false)
           }
-        });
+        })
 
         if (data.length > 0) {
-          $showOrHideAllButton.attr('aria-expanded', true);
-          setShowHideAllText();
+          $showOrHideAllButton.attr('aria-expanded', true)
+          setShowHideAllText()
         }
       }
 
-      function addButtonstoSteps() {
+      function addButtonstoSteps () {
         $.each($steps, function () {
-          var $step = $(this);
-          var $title = $step.find('.js-step-title');
-          var contentId = $step.find('.js-panel').first().attr('id');
+          var $step = $(this)
+          var $title = $step.find('.js-step-title')
+          var contentId = $step.find('.js-panel').first().attr('id')
 
           $title.wrapInner(
             '<span class="js-step-title-text"></span>'
-          );
+          )
 
           $title.wrapInner(
             '<button ' +
             'class="gem-c-step-nav__button gem-c-step-nav__button--title js-step-title-button" ' +
             'aria-expanded="false" aria-controls="' + contentId + '">' +
             '</button>'
-          );
-        });
+          )
+        })
       }
 
-      function bindToggleForSteps(stepNavTracker) {
+      function bindToggleForSteps (stepNavTracker) {
         $element.find('.js-toggle-panel').click(function (event) {
-          var $step = $(this).closest('.js-step');
+          var $step = $(this).closest('.js-step')
 
-          var stepView = new StepView($step);
-          stepView.toggle();
+          var stepView = new StepView($step)
+          stepView.toggle()
 
-          var stepIsOptional = typeof $step.data('optional') !== 'undefined' ? true : false;
-          var toggleClick = new StepToggleClick(event, stepView, $steps, stepNavTracker, stepIsOptional);
-          toggleClick.track();
+          var stepIsOptional = typeof $step.data('optional') !== 'undefined'
+          var toggleClick = new StepToggleClick(event, stepView, $steps, stepNavTracker, stepIsOptional)
+          toggleClick.track()
 
-          setShowHideAllText();
-          rememberStepState($step);
-        });
+          setShowHideAllText()
+          rememberStepState($step)
+        })
       }
 
       // if the step is open, store its id in session store
       // if the step is closed, remove its id from session store
-      function rememberStepState($step) {
+      function rememberStepState ($step) {
         if (rememberShownStep) {
-          var data = JSON.parse(loadFromSessionStorage(uniqueId)) || [];
-          var thisstep = $step.attr('id');
-          var shown = $step.hasClass('step-is-shown');
+          var data = JSON.parse(loadFromSessionStorage(uniqueId)) || []
+          var thisstep = $step.attr('id')
+          var shown = $step.hasClass('step-is-shown')
 
           if (shown) {
-            data.push(thisstep);
+            data.push(thisstep)
           } else {
-            var i = data.indexOf(thisstep);
+            var i = data.indexOf(thisstep)
             if (i > -1) {
-              data.splice(i, 1);
+              data.splice(i, 1)
             }
           }
-          saveToSessionStorage(uniqueId, JSON.stringify(data));
+          saveToSessionStorage(uniqueId, JSON.stringify(data))
         }
       }
 
       // tracking click events on links in step content
-      function bindComponentLinkClicks(stepNavTracker) {
+      function bindComponentLinkClicks (stepNavTracker) {
         $element.find('.js-link').click(function (event) {
-          var linkClick = new componentLinkClick(event, stepNavTracker, $(this).attr('data-position'));
-          linkClick.track();
-          var thisLinkHref = $(this).attr('href');
+          var linkClick = new componentLinkClick(event, stepNavTracker, $(this).attr('data-position')) // eslint-disable-line no-new, new-cap
+          linkClick.track()
+          var thisLinkHref = $(this).attr('href')
 
           if ($(this).attr('rel') !== 'external') {
-            saveToSessionStorage(sessionStoreLink, $(this).attr('data-position'));
+            saveToSessionStorage(sessionStoreLink, $(this).attr('data-position'))
           }
 
-          if (thisLinkHref == activeLinkHref) {
-            setOnlyThisLinkActive($(this));
-            setActiveStepClass();
+          if (thisLinkHref === activeLinkHref) {
+            setOnlyThisLinkActive($(this))
+            setActiveStepClass()
           }
-        });
+        })
       }
 
-      function saveToSessionStorage(key, value) {
-        sessionStorage.setItem(key, value);
+      function saveToSessionStorage (key, value) {
+        window.sessionStorage.setItem(key, value)
       }
 
-      function loadFromSessionStorage(key) {
-        return sessionStorage.getItem(key);
+      function loadFromSessionStorage (key) {
+        return window.sessionStorage.getItem(key)
       }
 
-      function removeFromSessionStorage(key) {
-        sessionStorage.removeItem(key);
+      function removeFromSessionStorage (key) {
+        window.sessionStorage.removeItem(key)
       }
 
-      function setOnlyThisLinkActive(clicked) {
-        $element.find('.' + activeLinkClass).removeClass(activeLinkClass);
-        clicked.parent().addClass(activeLinkClass);
+      function setOnlyThisLinkActive (clicked) {
+        $element.find('.' + activeLinkClass).removeClass(activeLinkClass)
+        clicked.parent().addClass(activeLinkClass)
       }
 
       // if a link occurs more than once in a step nav, the backend doesn't know which one to highlight
@@ -225,206 +227,206 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       // if the user clicked on one of those links previously, it will be in the session store
       // this code ensures only that link and its corresponding step have the highlighting
       // otherwise it accepts what the backend has already passed to the component
-      function ensureOnlyOneActiveLink() {
-        var $activeLinks = $element.find('.js-list-item.' + activeLinkClass);
+      function ensureOnlyOneActiveLink () {
+        var $activeLinks = $element.find('.js-list-item.' + activeLinkClass)
 
         if ($activeLinks.length <= 1) {
-          return;
+          return
         }
 
-        var lastClicked = loadFromSessionStorage(sessionStoreLink) || $element.find('.' + activeLinkClass).first().attr('data-position');
+        var lastClicked = loadFromSessionStorage(sessionStoreLink) || $element.find('.' + activeLinkClass).first().attr('data-position')
 
         // it's possible for the saved link position value to not match any of the currently duplicate highlighted links
         // so check this otherwise it'll take the highlighting off all of them
         if (!$element.find('.js-link[data-position="' + lastClicked + '"]').parent().hasClass(activeLinkClass)) {
-          lastClicked = $element.find('.' + activeLinkClass).first().find('.js-link').attr('data-position');
+          lastClicked = $element.find('.' + activeLinkClass).first().find('.js-link').attr('data-position')
         }
-        removeActiveStateFromAllButCurrent($activeLinks, lastClicked);
-        setActiveStepClass();
+        removeActiveStateFromAllButCurrent($activeLinks, lastClicked)
+        setActiveStepClass()
       }
 
-      function removeActiveStateFromAllButCurrent($activeLinks, current) {
-        $activeLinks.each(function() {
+      function removeActiveStateFromAllButCurrent ($activeLinks, current) {
+        $activeLinks.each(function () {
           if ($(this).find('.js-link').attr('data-position').toString() !== current.toString()) {
-            $(this).removeClass(activeLinkClass);
-            $(this).find('.visuallyhidden').remove();
+            $(this).removeClass(activeLinkClass)
+            $(this).find('.visuallyhidden').remove()
           }
-        });
+        })
       }
 
-      function setActiveStepClass() {
-        $element.find('.' + activeStepClass).removeClass(activeStepClass).removeAttr('data-show');
-        $element.find('.' + activeLinkClass).closest('.gem-c-step-nav__step').addClass(activeStepClass).attr('data-show', "");
+      function setActiveStepClass () {
+        $element.find('.' + activeStepClass).removeClass(activeStepClass).removeAttr('data-show')
+        $element.find('.' + activeLinkClass).closest('.gem-c-step-nav__step').addClass(activeStepClass).attr('data-show', '')
       }
 
-      function bindToggleShowHideAllButton(stepNavTracker) {
-        $showOrHideAllButton = $element.find('.js-step-controls-button');
+      function bindToggleShowHideAllButton (stepNavTracker) {
+        $showOrHideAllButton = $element.find('.js-step-controls-button')
         $showOrHideAllButton.on('click', function () {
-          var shouldshowAll;
+          var shouldshowAll
 
-          if ($showOrHideAllButton.text() == actions.showAllText) {
-            $showOrHideAllButton.text(actions.hideAllText);
-            $element.find('.js-toggle-link').html(actions.hideText);
-            shouldshowAll = true;
+          if ($showOrHideAllButton.text() === actions.showAllText) {
+            $showOrHideAllButton.text(actions.hideAllText)
+            $element.find('.js-toggle-link').html(actions.hideText)
+            shouldshowAll = true
 
             stepNavTracker.track('pageElementInteraction', 'stepNavAllShown', {
-              label: actions.showAllText + ": " + stepNavSize
-            });
+              label: actions.showAllText + ': ' + stepNavSize
+            })
           } else {
-            $showOrHideAllButton.text(actions.showAllText);
-            $element.find('.js-toggle-link').html(actions.showText);
-            shouldshowAll = false;
+            $showOrHideAllButton.text(actions.showAllText)
+            $element.find('.js-toggle-link').html(actions.showText)
+            shouldshowAll = false
 
             stepNavTracker.track('pageElementInteraction', 'stepNavAllHidden', {
-              label: actions.hideAllText + ": " + stepNavSize
-            });
+              label: actions.hideAllText + ': ' + stepNavSize
+            })
           }
 
-          setAllStepsShownState(shouldshowAll);
-          $showOrHideAllButton.attr('aria-expanded', shouldshowAll);
-          setShowHideAllText();
+          setAllStepsShownState(shouldshowAll)
+          $showOrHideAllButton.attr('aria-expanded', shouldshowAll)
+          setShowHideAllText()
 
-          return false;
-        });
+          return false
+        })
       }
 
-      function setShowHideAllText() {
-        var shownSteps = $element.find('.step-is-shown').length;
+      function setShowHideAllText () {
+        var shownSteps = $element.find('.step-is-shown').length
         // Find out if the number of is-opens == total number of steps
         if (shownSteps === totalSteps) {
-          $showOrHideAllButton.text(actions.hideAllText);
+          $showOrHideAllButton.text(actions.hideAllText)
         } else {
-          $showOrHideAllButton.text(actions.showAllText);
+          $showOrHideAllButton.text(actions.showAllText)
         }
-      }
-    };
-
-    function StepView($stepElement) {
-      var $titleLink = $stepElement.find('.js-step-title-button');
-      var $stepContent = $stepElement.find('.js-panel');
-
-      this.title = $stepElement.find('.js-step-title-text').text().trim();
-      this.element = $stepElement;
-
-      this.show = show;
-      this.hide = hide;
-      this.toggle = toggle;
-      this.setIsShown = setIsShown;
-      this.isShown = isShown;
-      this.isHidden = isHidden;
-      this.numberOfContentItems = numberOfContentItems;
-
-      function show() {
-        setIsShown(true);
-      }
-
-      function hide() {
-        setIsShown(false);
-      }
-
-      function toggle() {
-        setIsShown(isHidden());
-      }
-
-      function setIsShown(isShown) {
-        $stepElement.toggleClass('step-is-shown', isShown);
-        $stepContent.toggleClass('js-hidden', !isShown);
-        $titleLink.attr("aria-expanded", isShown);
-        $stepElement.find('.js-toggle-link').html(isShown ? actions.hideText : actions.showText);
-      }
-
-      function isShown() {
-        return $stepElement.hasClass('step-is-shown');
-      }
-
-      function isHidden() {
-        return !isShown();
-      }
-
-      function numberOfContentItems() {
-        return $stepContent.find('.js-link').length;
       }
     }
 
-    function StepToggleClick(event, stepView, $steps, stepNavTracker, stepIsOptional) {
-      this.track = trackClick;
-      var $target = $(event.target);
+    function StepView ($stepElement) {
+      var $titleLink = $stepElement.find('.js-step-title-button')
+      var $stepContent = $stepElement.find('.js-panel')
 
-      function trackClick() {
-        var tracking_options = {label: trackingLabel(), dimension28: stepView.numberOfContentItems().toString()};
-        stepNavTracker.track('pageElementInteraction', trackingAction(), tracking_options);
+      this.title = $stepElement.find('.js-step-title-text').text().trim()
+      this.element = $stepElement
+
+      this.show = show
+      this.hide = hide
+      this.toggle = toggle
+      this.setIsShown = setIsShown
+      this.isShown = isShown
+      this.isHidden = isHidden
+      this.numberOfContentItems = numberOfContentItems
+
+      function show () {
+        setIsShown(true)
       }
 
-      function trackingLabel() {
-        return $target.closest('.js-toggle-panel').attr('data-position') + ' - ' + stepView.title + ' - ' + locateClickElement() + ": " + stepNavSize + isOptional();
+      function hide () {
+        setIsShown(false)
+      }
+
+      function toggle () {
+        setIsShown(isHidden())
+      }
+
+      function setIsShown (isShown) {
+        $stepElement.toggleClass('step-is-shown', isShown)
+        $stepContent.toggleClass('js-hidden', !isShown)
+        $titleLink.attr('aria-expanded', isShown)
+        $stepElement.find('.js-toggle-link').html(isShown ? actions.hideText : actions.showText)
+      }
+
+      function isShown () {
+        return $stepElement.hasClass('step-is-shown')
+      }
+
+      function isHidden () {
+        return !isShown()
+      }
+
+      function numberOfContentItems () {
+        return $stepContent.find('.js-link').length
+      }
+    }
+
+    function StepToggleClick (event, stepView, $steps, stepNavTracker, stepIsOptional) {
+      this.track = trackClick
+      var $target = $(event.target)
+
+      function trackClick () {
+        var trackingOptions = { label: trackingLabel(), dimension28: stepView.numberOfContentItems().toString() }
+        stepNavTracker.track('pageElementInteraction', trackingAction(), trackingOptions)
+      }
+
+      function trackingLabel () {
+        return $target.closest('.js-toggle-panel').attr('data-position') + ' - ' + stepView.title + ' - ' + locateClickElement() + ': ' + stepNavSize + isOptional()
       }
 
       // returns index of the clicked step in the overall number of steps
-      function stepIndex() {
-        return $steps.index(stepView.element) + 1;
+      function stepIndex () { // eslint-disable-line no-unused-vars
+        return $steps.index(stepView.element) + 1
       }
 
-      function trackingAction() {
-        return (stepView.isHidden() ? 'stepNavHidden' : 'stepNavShown');
+      function trackingAction () {
+        return (stepView.isHidden() ? 'stepNavHidden' : 'stepNavShown')
       }
 
-      function locateClickElement() {
+      function locateClickElement () {
         if (clickedOnIcon()) {
-          return iconType() + ' click';
+          return iconType() + ' click'
         } else if (clickedOnHeading()) {
-          return 'Heading click';
+          return 'Heading click'
         } else {
-          return 'Elsewhere click';
+          return 'Elsewhere click'
         }
       }
 
-      function clickedOnIcon() {
-        return $target.hasClass('js-toggle-link');
+      function clickedOnIcon () {
+        return $target.hasClass('js-toggle-link')
       }
 
-      function clickedOnHeading() {
-        return $target.hasClass('js-step-title-text');
+      function clickedOnHeading () {
+        return $target.hasClass('js-step-title-text')
       }
 
-      function iconType() {
-        return (stepView.isHidden() ? 'Minus' : 'Plus');
+      function iconType () {
+        return (stepView.isHidden() ? 'Minus' : 'Plus')
       }
 
-      function isOptional() {
-        return (stepIsOptional ? ' ; optional' : '');
+      function isOptional () {
+        return (stepIsOptional ? ' ; optional' : '')
       }
     }
 
-    function componentLinkClick(event, stepNavTracker, linkPosition) {
-      this.track = trackClick;
+    function componentLinkClick (event, stepNavTracker, linkPosition) {
+      this.track = trackClick
 
-      function trackClick() {
-        var tracking_options = {label: $(event.target).attr('href') + " : " + stepNavSize};
-        var dimension28 = $(event.target).closest('.gem-c-step-nav__list').attr('data-length');
+      function trackClick () {
+        var trackingOptions = { label: $(event.target).attr('href') + ' : ' + stepNavSize }
+        var dimension28 = $(event.target).closest('.gem-c-step-nav__list').attr('data-length')
 
         if (dimension28) {
-          tracking_options['dimension28'] = dimension28;
+          trackingOptions['dimension28'] = dimension28
         }
 
-        stepNavTracker.track('stepNavLinkClicked', linkPosition, tracking_options);
+        stepNavTracker.track('stepNavLinkClicked', linkPosition, trackingOptions)
       }
     }
 
     // A helper that sends a custom event request to Google Analytics if
     // the GOVUK module is setup
-    function StepNavTracker(totalSteps, totalLinks, uniqueId) {
-      this.track = function(category, action, options) {
+    function StepNavTracker (totalSteps, totalLinks, uniqueId) {
+      this.track = function (category, action, options) {
         // dimension26 records the total number of expand/collapse steps in this step nav
         // dimension27 records the total number of links in this step nav
         // dimension28 records the number of links in the step that was shown/hidden (handled in click event)
-        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
-          options = options || {};
-          options["dimension26"] = options["dimension26"] || totalSteps.toString();
-          options["dimension27"] = options["dimension27"] || totalLinks.toString();
-          options["dimension96"] = options["dimension96"] || uniqueId;
-          GOVUK.analytics.trackEvent(category, action, options);
+        if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+          options = options || {}
+          options['dimension26'] = options['dimension26'] || totalSteps.toString()
+          options['dimension27'] = options['dimension27'] || totalLinks.toString()
+          options['dimension96'] = options['dimension96'] || uniqueId
+          window.GOVUK.analytics.trackEvent(category, action, options)
         }
-      };
+      }
     }
-  };
-})(window.GOVUK.Modules);
+  }
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/dependencies.js
+++ b/app/assets/javascripts/govuk_publishing_components/dependencies.js
@@ -1,15 +1,17 @@
+/* eslint-env jquery */
+
 // This adds in javascript that initialises components and dependencies
 // that are provided by Slimmer in public frontend applications.
-//= require jquery/dist/jquery
-//= require govuk/modules
+// = require jquery/dist/jquery
+// = require govuk/modules
 
 $(document).ready(function () {
-  'use strict';
+  'use strict'
 
-  GOVUK.modules.start();
+  window.GOVUK.modules.start()
 
   // Static has a Toggle module in here we have a GemToggle module, we can't
   // easily change govspeak to use GemToggle but we can use the GemToggle module
-  var gemToggle = new GOVUK.Modules.GemToggle();
-  gemToggle.start($("[data-module=toggle]"));
-});
+  var gemToggle = new window.GOVUK.Modules.GemToggle()
+  gemToggle.start($('[data-module=toggle]'))
+})

--- a/app/assets/javascripts/govuk_publishing_components/lib/current-location.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/current-location.js
@@ -1,10 +1,10 @@
 // used by the step by step navigation component
 
-(function(root) {
-  "use strict";
-  window.GOVUK = window.GOVUK || {};
+(function (root) {
+  'use strict'
+  window.GOVUK = window.GOVUK || {}
 
-  GOVUK.getCurrentLocation = function(){
-    return root.location;
-  };
-}(window));
+  window.GOVUK.getCurrentLocation = function () {
+    return root.location
+  }
+}(window))

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/barchart-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/barchart-enhancement.js
@@ -1,4 +1,4 @@
-//= require govuk_publishing_components/vendor/magna-charta.min
+// = require govuk_publishing_components/vendor/magna-charta.min
 
 window.GOVUK = window.GOVUK || {};
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -1,5 +1,5 @@
-//= require govuk_publishing_components/vendor/jquery-ui-1.10.2.custom
-//= require govuk_publishing_components/vendor/jquery.player.min
+// = require govuk_publishing_components/vendor/jquery-ui-1.10.2.custom
+// = require govuk_publishing_components/vendor/jquery.player.min
 
 window.GOVUK = window.GOVUK || {};
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/select.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/select.js
@@ -1,50 +1,52 @@
-window.GOVUK = window.GOVUK || {};
+/* eslint-env jquery */
+
+window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  'use strict';
+  'use strict'
 
   Modules.TrackSelectChange = function () {
     this.start = function (element) {
-      element.change(function(e) {
-        var selectedOption = $(this).find(":selected");
-        var trackable = '[data-track-category][data-track-action]';
+      element.change(function (e) {
+        var selectedOption = $(this).find(':selected')
+        var trackable = '[data-track-category][data-track-action]'
 
         if (selectedOption.is(trackable)) {
-          fireTrackingChange(selectedOption);
+          fireTrackingChange(selectedOption)
         }
-      });
+      })
 
-      function fireTrackingChange(element) {
-        var options = {transport: 'beacon'},
-            category = element.attr('data-track-category'),
-            action = element.attr('data-track-action'),
-            label = element.attr('data-track-label'),
-            value = element.attr('data-track-value'),
-            dimension = element.attr('data-track-dimension'),
-            dimensionIndex = element.attr('data-track-dimension-index'),
-            extraOptions = element.attr('data-track-options');
+      function fireTrackingChange (element) {
+        var options = { transport: 'beacon' }
+        var category = element.attr('data-track-category')
+        var action = element.attr('data-track-action')
+        var label = element.attr('data-track-label')
+        var value = element.attr('data-track-value')
+        var dimension = element.attr('data-track-dimension')
+        var dimensionIndex = element.attr('data-track-dimension-index')
+        var extraOptions = element.attr('data-track-options')
 
         if (label) {
-          options.label = label;
+          options.label = label
         }
 
         if (value) {
-          options.value = value;
+          options.value = value
         }
 
         if (dimension && dimensionIndex) {
-          options['dimension' + dimensionIndex] = dimension;
+          options['dimension' + dimensionIndex] = dimension
         }
 
         if (extraOptions) {
-          $.extend(options, JSON.parse(extraOptions));
+          $.extend(options, JSON.parse(extraOptions))
         }
 
-        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
-          GOVUK.analytics.trackEvent(category, action, options);
+        if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+          window.GOVUK.analytics.trackEvent(category, action, options)
         }
       };
-    };
-  };
-})(window.GOVUK.Modules);
+    }
+  }
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/lib/toggle-input-class-on-focus.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/toggle-input-class-on-focus.js
@@ -9,26 +9,26 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Modules.GemToggleInputClassOnFocus = function () {
     this.start = function ($el) {
-      var $toggleTarget = $el.find('.js-class-toggle');
+      var $toggleTarget = $el.find('.js-class-toggle')
 
-      if(!inputIsEmpty()) {
-        addFocusClass();
+      if (!inputIsEmpty()) {
+        addFocusClass()
       }
 
-      $toggleTarget.on('focus', addFocusClass);
-      $toggleTarget.on('blur', removeFocusClassFromEmptyInput);
+      $toggleTarget.on('focus', addFocusClass)
+      $toggleTarget.on('blur', removeFocusClassFromEmptyInput)
 
-      function inputIsEmpty() {
-        return $toggleTarget.val() === '';
+      function inputIsEmpty () {
+        return $toggleTarget.val() === ''
       }
 
-      function addFocusClass() {
-        $toggleTarget.addClass('focus');
+      function addFocusClass () {
+        $toggleTarget.addClass('focus')
       }
 
-      function removeFocusClassFromEmptyInput() {
-        if(inputIsEmpty()) {
-          $toggleTarget.removeClass('focus');
+      function removeFocusClassFromEmptyInput () {
+        if (inputIsEmpty()) {
+          $toggleTarget.removeClass('focus')
         }
       }
     }

--- a/app/assets/javascripts/govuk_publishing_components/lib/toggle.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/toggle.js
@@ -1,3 +1,4 @@
+/* eslint-env jquery */
 /*
   Toggle the display of elements
 
@@ -40,70 +41,70 @@
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  'use strict';
+  'use strict'
 
   Modules.GemToggle = function () {
     this.start = function ($el) {
-      var toggleSelector = '[data-controls][data-expanded]';
-      var toggleClass = $el.attr('data-toggle-class') || 'js-hidden';
-      var trackable = '[data-track-category][data-track-action]';
+      var toggleSelector = '[data-controls][data-expanded]'
+      var toggleClass = $el.attr('data-toggle-class') || 'js-hidden'
+      var trackable = '[data-track-category][data-track-action]'
 
-      $el.on('click', toggleSelector, toggle);
-      $el.find(toggleSelector).each(addAriaAttrs);
+      $el.on('click', toggleSelector, toggle)
+      $el.find(toggleSelector).each(addAriaAttrs)
 
       // Add the ARIA attributes with JavaScript
       // If the JS fails and there's no interactive elements, having
       // no aria attributes is an accurate representation.
       function addAriaAttrs () {
-        var $toggle = $(this);
-        $toggle.attr('role', 'button');
-        $toggle.attr('aria-controls', $toggle.data('controls'));
-        $toggle.attr('aria-expanded', $toggle.data('expanded'));
+        var $toggle = $(this)
+        $toggle.attr('role', 'button')
+        $toggle.attr('aria-controls', $toggle.data('controls'))
+        $toggle.attr('aria-expanded', $toggle.data('expanded'))
 
-        var $targets = getTargetElements($toggle);
-        $targets.attr('aria-live', 'polite');
-        $targets.attr('role', 'region');
-        $toggle.data('$targets', $targets);
+        var $targets = getTargetElements($toggle)
+        $targets.attr('aria-live', 'polite')
+        $targets.attr('role', 'region')
+        $toggle.data('$targets', $targets)
       }
 
       function toggle (event) {
-        var $toggle = $(event.target),
-          expanded = $toggle.attr('aria-expanded') === 'true',
-          $targets = $toggle.data('$targets');
+        var $toggle = $(event.target)
+        var expanded = $toggle.attr('aria-expanded') === 'true'
+        var $targets = $toggle.data('$targets')
 
         if (expanded) {
-          $toggle.attr('aria-expanded', false);
-          $targets.addClass(toggleClass);
+          $toggle.attr('aria-expanded', false)
+          $targets.addClass(toggleClass)
         } else {
-          $toggle.attr('aria-expanded', true);
-          $targets.removeClass(toggleClass);
+          $toggle.attr('aria-expanded', true)
+          $targets.removeClass(toggleClass)
         }
 
-        var toggledText = $toggle.data('toggled-text');
+        var toggledText = $toggle.data('toggled-text')
         if (typeof toggledText === 'string') {
-          $toggle.data('toggled-text', $toggle.text());
-          $toggle.text(toggledText);
+          $toggle.data('toggled-text', $toggle.text())
+          $toggle.text(toggledText)
         }
 
-        if (GOVUK.analytics && GOVUK.analytics.trackEvent && $toggle.is(trackable)) {
-          track($toggle);
+        if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent && $toggle.is(trackable)) {
+          track($toggle)
         }
 
-        event.preventDefault();
+        event.preventDefault()
       }
 
       function getTargetElements ($toggle) {
-        var ids = $toggle.attr('aria-controls').split(' '),
-          selector = '#' + ids.join(', #');
+        var ids = $toggle.attr('aria-controls').split(' ')
+        var selector = '#' + ids.join(', #')
 
-        return $el.find(selector);
+        return $el.find(selector)
       }
 
       function track ($toggle) {
-        var options = { label: $toggle.data('toggled-text') || $toggle.text() };
+        var options = { label: $toggle.data('toggled-text') || $toggle.text() }
 
-        GOVUK.analytics.trackEvent($toggle.data('track-category'), $toggle.data('track-action'), options);
+        window.GOVUK.analytics.trackEvent($toggle.data('track-category'), $toggle.data('track-action'), options)
       }
-    };
-  };
-})(window.GOVUK.Modules);
+    }
+  }
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -91,7 +91,7 @@
   margin-top: $govuk-gutter-half;
   margin-bottom: $govuk-gutter-half;
 
-  font-family: Consolas, Monaco, 'Andale Mono', monospace;
+  font-family: Consolas, Monaco, "Andale Mono", monospace;
   font-size: 16px;
   line-height: 1.5;
   border: 1px solid $govuk-border-colour;
@@ -125,6 +125,10 @@
 }
 
 .component-guide-preview {
+  padding: ($govuk-gutter * 1.5) $govuk-gutter $govuk-gutter;
+  border: 1px solid $govuk-border-colour;
+  position: relative;
+
   &.direction-rtl {
     direction: rtl;
     text-align: start;
@@ -138,17 +142,13 @@
     padding: 0;
   }
 
-  padding: ($govuk-gutter * 1.5) $govuk-gutter $govuk-gutter;
-  border: 1px solid $govuk-border-colour;
-  position: relative;
-
   &:before {
     @include govuk-font($size: 14);
     content: attr(data-content);
     position: absolute;
     top: 0;
     left: 0;
-    padding: 0.21053em 0.78947em;
+    padding: .21053em .78947em;
     background: $govuk-border-colour;
     color: govuk-colour("black");
     font-weight: bold;
@@ -246,12 +246,14 @@ html {
 
 .hide-header-and-footer {
   // scss-lint:disable IdSelector
+  // sass-lint:disable no-ids
   #global-header,
   #global-header-bar,
   #global-breadcrumb,
   #footer {
     display: none;
   }
+  // sass-lint:enable no-ids
   // scss-lint:enable IdSelector
 }
 
@@ -273,15 +275,18 @@ html {
 
 // Hide survey banner
 // scss-lint:disable IdSelector
-#user-satisfaction-survey-container {
+// sass-lint:disable no-ids
+#user-satisfaction-survey-container,
+#global-cookie-message {
   display: none;
 }
+// sass-lint:enable no-ids
 // scss-lint:enable IdSelector
 
 // Rouge syntax highlighting
 // Based on https://github.com/alphagov/tech-docs-template/blob/master/template/source/stylesheets/palette/_syntax-highlighting.scss
 
-$code-00: scale-color(govuk-colour("grey-4"), $lightness:50%); // Default Background
+$code-00: scale-color(govuk-colour("grey-4"), $lightness: 50%); // Default Background
 $code-01: #f5f5f5; // Lighter Background (Unused)
 $code-02: #bfc1c3; // Selection Background
 $code-03: darken($govuk-secondary-text-colour, 2%); // Comments, Invisibles, Line Highlighting
@@ -291,17 +296,18 @@ $code-06: #ffffff; // Light Foreground (Unused)
 $code-07: #ffffff; // Light Background (Unused)
 
 $code-08: #ae5f3d; // Variables, XML Tags, Markup Link Text, Markup Lists
-$code-09: #0E7754; // Integers, Boolean, Constants, XML Attributes, Markup Link Url
-$code-0a: #4C4077; // Classes, Markup Bold, Search Text Background
+$code-09: #0e7754; // Integers, Boolean, Constants, XML Attributes, Markup Link Url
+$code-0a: #4c4077; // Classes, Markup Bold, Search Text Background
 $code-0b: govuk-colour("blue"); // Strings, Inherited Class, Markup Code
 $code-0c: govuk-colour("blue"); // Support, Regular Expressions, Escape Characters, Markup Quotes
-$code-0d: #4C4077; // Functions, Methods, Attribute IDs, Headings
+$code-0d: #4c4077; // Functions, Methods, Attribute IDs, Headings
 $code-0e: #a71d5d; // Keywords, Storage, Selector, Markup Italic
-$code-0f: #C92424; // Deprecated, Opening/Closing Embedded Language Tags e.g. <?php ?> (Unused)
+$code-0f: #c92424; // Deprecated, Opening/Closing Embedded Language Tags e.g. <?php ?> (Unused)
 
-$code-insert-bg: #DEF8CA;
-$code-delete-bg: #FADDDD;
+$code-insert-bg: #def8ca;
+$code-delete-bg: #fadddd;
 
+// sass-lint:disable no-empty-rulesets
 .component-highlight {
 
   // Map Rouge / Pygments Tokens to work with 'Base 16' themes
@@ -498,6 +504,7 @@ $code-delete-bg: #FADDDD;
     font-weight: bold;
   }
 }
+// sass-lint:enable no-empty-rulesets
 
 // Specific for this Gem, optimized for erb render statements
 .component-highlight {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -5,14 +5,14 @@
   &:visited,
   &:hover,
   &:active {
-    color: govuk-colour('white');
+    color: govuk-colour("white");
   }
 }
 
 .gem-c-breadcrumbs--inverse .govuk-breadcrumbs__list-item {
-  color: govuk-colour('white');
+  color: govuk-colour("white");
 }
 
 .gem-c-breadcrumbs--inverse .govuk-breadcrumbs__list-item:before {
-  border-color: govuk-colour('white');
+  border-color: govuk-colour("white");
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
@@ -5,7 +5,7 @@
   box-sizing: border-box;
   border-left-style: solid;
   border-left-width: 4px;
-  border-color: govuk-colour('grey-2');
+  border-color: govuk-colour("grey-2");
   margin-top: govuk-spacing(2);
   margin-bottom: govuk-spacing(2);
   padding: govuk-spacing(2) govuk-spacing(4);
@@ -34,6 +34,6 @@
   }
 
   .gem-c-checkboxes__legend--hidden {
-    @include govuk-visually-hidden();
+    @include govuk-visually-hidden;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -13,7 +13,7 @@
   list-style: none;
 
   &:last-child {
-    border-bottom: none;
+    border-bottom: 0;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -38,7 +38,7 @@
 }
 
 .gem-c-feedback__column-two-thirds {
-  @include grid-column( 2 / 3 );
+  @include grid-column(2 / 3);
 }
 
 .gem-c-feedback__prompt {
@@ -197,7 +197,9 @@
 // so we need to apply  govuk-input styles using a stronger selector
 .gem-c-feedback input[type="text"] {
   // scss-lint:disable PlaceholderInExtend
+  // sass-lint:disable placeholder-in-extend
   @extend .govuk-input;
+  // sass-lint:enable placeholder-in-extend
   // scss-lint:enable PlaceholderInExtend
   margin: 0;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak-html-publication.scss
@@ -51,15 +51,16 @@
     h4 .number,
     h5 .number,
     h6 .number {
-      margin-right: 0.1em;
+      margin-right: .1em;
 
       .direction-rtl & {
         margin-right: 0;
-        margin-left: 0.1em;
+        margin-left: .1em;
       }
     }
 
     // scss-lint:disable QualifyingElement
+    // sass-lint:disable no-qualifying-elements
     // this class will only be for tables and is to distinguish from a bare `table`
     // the row classes below should not be applied to anything else but `tr`s
     table.financial-data {
@@ -129,6 +130,7 @@
         background-color: $grey-3;
       }
     }
+    // sass-lint:enable no-qualifying-elements
     // scss-lint:enable QualifyingElement
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -8,7 +8,7 @@
 }
 
 .gem-c-image-card__image-wrapper {
-  @include grid-column( 1 / 3, mobile );
+  @include grid-column(1 / 3, mobile);
   margin: 0;
 
   @include media(tablet) {
@@ -28,7 +28,7 @@
 }
 
 .gem-c-image-card__text-wrapper {
-  @include grid-column( 2 / 3, mobile );
+  @include grid-column(2 / 3, mobile);
 }
 
 .gem-c-image-card__title {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -16,21 +16,21 @@
 }
 
 .gem-c-metadata--inverse {
-  color: govuk-colour('white');
+  color: govuk-colour("white");
 
   a:link,
   a:active,
   a:visited {
-    color: govuk-colour('white');
+    color: govuk-colour("white");
   }
 
   a:focus {
-    color: govuk-colour('black');
+    color: govuk-colour("black");
   }
 }
 
 .gem-c-metadata__term {
-  margin-top: 0.5em;
+  margin-top: .5em;
   line-height: normal;
 
   @include media(tablet) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
@@ -19,7 +19,7 @@ $govuk-modal-wide-breakpoint: $govuk-page-width + $govuk-modal-margin * 2 + $gov
 .gem-c-modal-dialogue__box {
   display: block;
   position: fixed;
-  background: govuk-colour('white');
+  background: govuk-colour("white");
   top: 0;
   right: 0;
   bottom: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -64,19 +64,19 @@
 
 // all crest images are currently in whitehall
 @mixin crest($crest) {
-  background: image-url('crests/#{$crest}_13px.png') no-repeat 5px 0;
+  background: image-url("crests/#{$crest}_13px.png") no-repeat 5px 0;
   background-size: auto 20px;
 
-  @include device-pixel-ratio() {
-    background-image: image-url('crests/#{$crest}_13px_x2.png');
+  @include device-pixel-ratio {
+    background-image: image-url("crests/#{$crest}_13px_x2.png");
   }
 
   @include media(tablet) {
-    background: image-url('crests/#{$crest}_18px.png') no-repeat 6px 0;
+    background: image-url("crests/#{$crest}_18px.png") no-repeat 6px 0;
     background-size: auto 26px;
 
-    @include device-pixel-ratio() {
-      background-image: image-url('crests/#{$crest}_18px_x2.png');
+    @include device-pixel-ratio {
+      background-image: image-url("crests/#{$crest}_18px_x2.png");
     }
   }
 }
@@ -92,51 +92,51 @@
 }
 
 .gem-c-organisation-logo__crest--dit {
-  @include crest('dit_crest');
+  @include crest("dit_crest");
 }
 
 .gem-c-organisation-logo__crest--bis {
-  @include crest('bis_crest');
+  @include crest("bis_crest");
 }
 
 .gem-c-organisation-logo__crest--hmrc {
-  @include crest('hmrc_crest');
+  @include crest("hmrc_crest");
 }
 
 .gem-c-organisation-logo__crest--ho {
-  @include crest('ho_crest');
+  @include crest("ho_crest");
   @include tall-crest;
 }
 
 .gem-c-organisation-logo__crest--mod {
-  @include crest('mod_crest');
+  @include crest("mod_crest");
   @include tall-crest;
 }
 
 .gem-c-organisation-logo__crest--single-identity,
 .gem-c-organisation-logo__crest--eo,
 .gem-c-organisation-logo__crest--org {
-  @include crest('org_crest');
+  @include crest("org_crest");
 }
 
 .gem-c-organisation-logo__crest--portcullis {
-  @include crest('portcullis');
+  @include crest("portcullis");
 }
 
 .gem-c-organisation-logo__crest--so {
-  @include crest('so_crest');
+  @include crest("so_crest");
 }
 
 .gem-c-organisation-logo__crest--ukaea {
-  @include crest('ukaea_crest');
+  @include crest("ukaea_crest");
 }
 
 .gem-c-organisation-logo__crest--ukho {
-  @include crest('ukho');
+  @include crest("ukho");
   @include tall-crest;
 }
 
 .gem-c-organisation-logo__crest--wales {
-  @include crest('wales_crest');
+  @include crest("wales_crest");
   @include tall-crest;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
@@ -58,7 +58,7 @@
 
 .gem-c-pagination__link-label {
   display: inline-block;
-  margin-top: 0.1em;
+  margin-top: .1em;
   text-decoration: underline;
   margin-left: $gutter;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
@@ -18,14 +18,14 @@
 
 .gem-c-related-navigation__sub-heading--footer {
   @include bold-19;
-  border-top: none;
+  border-top: 0;
   padding-top: 0;
   margin-top: $gutter-half;
   margin-bottom: $gutter-one-third;
 }
 
 .gem-c-related-navigation__main-heading  + .gem-c-related-navigation__sub-heading {
-  border-top: none;
+  border-top: 0;
   padding-top: 0;
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -22,7 +22,7 @@ $large-input-size: 50px;
   @include govuk-focusable;
 
   padding: 6px;
-  margin: 0.5em 0;
+  margin: .5em 0;
   width: 100%;
   height: $input-size;
   border: 0;
@@ -98,7 +98,7 @@ $large-input-size: 50px;
       border: 0;
     }
 
-    @include device-pixel-ratio() {
+    @include device-pixel-ratio {
       background-size: 52.5px auto;
       background-position: 115% 50%;
     }
@@ -174,7 +174,7 @@ $large-input-size: 50px;
     height: $large-input-size;
     background-position: 8px 50%;
 
-    @include device-pixel-ratio() {
+    @include device-pixel-ratio {
       background-size: 60px auto;
       background-position: 160% 50%;
     }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
@@ -17,7 +17,7 @@
   @include bold-16;
 
   display: block;
-  padding-bottom: 0.2em;
+  padding-bottom: .2em;
 }
 
 .gem-c-step-nav-header__title {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -75,7 +75,7 @@ $top-border: solid 2px $grey-3;
   @include _core-font-generator(14px, 14px, 14px, 1, 1, false);
   position: relative;
   z-index: 1; // this and relative position stops focus outline underlap with border of accordion
-  padding: 0.5em 0;
+  padding: .5em 0;
   text-decoration: underline;
 
   &:hover {
@@ -132,8 +132,10 @@ $top-border: solid 2px $grey-3;
 
   &:after {
     // scss-lint:disable DuplicateProperty
+    // sass-lint:disable no-duplicate-properties
     height: -webkit-calc(100% - #{$gutter-half}); // fallback for iphone 4
     height: calc(100% - #{$gutter-half});
+    // sass-lint:enable no-duplicate-properties
     // scss-lint:enable DuplicateProperty
   }
 
@@ -215,14 +217,11 @@ $top-border: solid 2px $grey-3;
 }
 
 .gem-c-step-nav__circle-background {
-  $shadow-offset: 0.1em;
+  $shadow-offset: .1em;
   $shadow-colour: $white;
 
   // to make numbers readable for users zooming text only in browsers such as Firefox
-  text-shadow: 0 -#{$shadow-offset} 0 $shadow-colour,
-              $shadow-offset 0 0 $shadow-colour,
-              0 $shadow-offset 0 $shadow-colour,
-              -#{$shadow-offset} 0 0 $shadow-colour;
+  text-shadow: 0 -#{$shadow-offset} 0 $shadow-colour, $shadow-offset 0 0 $shadow-colour, 0 $shadow-offset 0 $shadow-colour, -#{$shadow-offset} 0 0 $shadow-colour;
 }
 
 .gem-c-step-nav__circle-step-label,
@@ -371,7 +370,7 @@ $top-border: solid 2px $grey-3;
     content: "";
     position: absolute;
     z-index: 5;
-    top: 0.6em; // position the dot to align with the first row of text in the link
+    top: .6em; // position the dot to align with the first row of text in the link
     left: -($gutter + $gutter-half);
     margin-left: ($number-circle-size / 2) - ($dot-size / 2);
     width: $dot-size;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -67,7 +67,7 @@
     background-image: image-url("govuk_publishing_components/mail-icon.png");
     padding-left: govuk-spacing(5);
 
-    @include device-pixel-ratio() {
+    @include device-pixel-ratio {
       background-image: image-url("govuk_publishing_components/mail-icon-x2.png");
       background-size: govuk-spacing(4) govuk-spacing(3);
     }
@@ -87,4 +87,3 @@
     @include govuk-visually-hidden;
   }
 }
-

--- a/app/assets/stylesheets/govuk_publishing_components/components/_taxonomy-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_taxonomy-navigation.scss
@@ -8,11 +8,11 @@
   // taxonomy template code is populated across all
   // application caches.
   h2 {
-    margin-bottom: 0.5em;
+    margin-bottom: .5em;
   }
 
   .taxon-description {
-    margin-bottom: 0.75em;
+    margin-bottom: .75em;
   }
 
   ul {
@@ -25,7 +25,7 @@
     li {
       // reset the default browser styles
       padding: 0;
-      margin-bottom: 0.75em;
+      margin-bottom: .75em;
     }
   }
   // END FIXME

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_advisory.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_advisory.scss
@@ -1,5 +1,5 @@
-$info-background: #D5E8F3;
-$high-alert-border:#C00;
+$info-background: #d5e8f3;
+$high-alert-border: #cc0000;
 
 .gem-c-govspeak .advisory {
   background: image-url("icon-information.png") no-repeat scroll 98% 1em $info-background;
@@ -8,13 +8,13 @@ $high-alert-border:#C00;
   padding: 1em;
   text-align: left;
 
-  @include device-pixel-ratio() {
+  @include device-pixel-ratio {
     background-image: image-url("icon-information-2x.png");
     background-size: 27px 27px;
   }
 
   p {
-    margin: 0 0.75em 0 0;
+    margin: 0 .75em 0 0;
     min-height: 1.75em;
     padding-right: 3em;
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -37,7 +37,7 @@
         width: $thumbnail-width;
         height: 140px;
         background: $white;
-        outline: $thumb-border-width solid transparentize($black, 0.9);
+        outline: $thumb-border-width solid transparentize($black, .9);
 
         @include ie-lte(8) {
           // IE8 incorrectly asserts the "max-width: 100%" rule to be 0

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
@@ -1,6 +1,7 @@
 @import "govuk-frontend/components/button/button";
 
 // scss-lint:disable PlaceholderInExtend
+// sass-lint:disable placeholder-in-extend
 .gem-c-govspeak {
   .button,
   .govuk-button {
@@ -12,4 +13,5 @@
     @extend .govuk-button--start;
   }
 }
+// sass-lint:enable placeholder-in-extend
 // scss-lint:enable PlaceholderInExtend

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -8,6 +8,7 @@
 
 // Disable linting for vendor asset
 // scss-lint:disable all
+// sass-lint:disable-all
 /*
  * magna-charta example stylesheet
  * https://github.com/alphagov/magna-charta
@@ -72,7 +73,7 @@
 
     // KEY STYLES
     .mc-thead {
-      background-color: #fff;
+      background-color: #ffffff;
       display: table-header-group;
       padding: $bar-spacing;
       border: 1px solid $key-border;
@@ -247,7 +248,7 @@
 
     .mc-bar-outdented {
       span {
-        color: #111;
+        color: #111111;
       }
     }
 
@@ -268,7 +269,7 @@
       .mc-tbody {
         .mc-tr {
           .mc-bar-cell {
-            color: #111;
+            color: #111111;
           }
 
           .mc-bar-negative {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_form-download.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_form-download.scss
@@ -1,5 +1,5 @@
 .gem-c-govspeak .form-download {
-  padding: 0.25em 0;
+  padding: .25em 0;
 
   @include govuk-media-query($until: tablet) {
     margin: 1em 0 1.5em;
@@ -16,7 +16,7 @@
     min-height: 2.5em;
     padding: 0 0 0 2.5em;
 
-    @include device-pixel-ratio() {
+    @include device-pixel-ratio {
       background-image: image-url("icon-file-download-2x.png");
       background-size: 25px 25px;
     }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_highlight-answer.scss
@@ -1,11 +1,11 @@
 $highlight-answer-bg-color: #28a197;
-$highlight-answer-color: #fff;
+$highlight-answer-color: #ffffff;
 
 .gem-c-govspeak .highlight-answer {
   background-color: $highlight-answer-bg-color;
   color: $highlight-answer-color;
   text-align: center;
-  padding: 1.75em 0.75em 1.25em;
+  padding: 1.75em .75em 1.25em;
   margin: 0 -1em 1em;
 
   p {
@@ -15,7 +15,7 @@ $highlight-answer-color: #fff;
     em {
       @include govuk-font($size: 80, $weight: bold);
       display: block;
-      padding-top: 0.1em;
+      padding-top: .1em;
       color: $highlight-answer-color;
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_place.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_place.scss
@@ -19,11 +19,11 @@
     @include govuk-font($size: 16);
 
     p {
-      margin: 0.25em 0;
+      margin: .25em 0;
     }
   }
 
   @include govuk-media-query($until: tablet) {
-    margin: 0.75em 0;
+    margin: .75em 0;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_steps.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_steps.scss
@@ -4,17 +4,17 @@
   overflow: hidden;
 
   > li {
-    background-position: 0 0.87em;
+    background-position: 0 .87em;
     background-repeat: no-repeat;
     list-style-type: decimal;
     margin-left: 0;
-    padding: 0.75em 0 0.75em 2.2em;
+    padding: .75em 0 .75em 2.2em;
 
     @for $i from 1 through 14 {
       &:nth-child(#{$i}) {
         background-image: image-url("icon-steps/icon-step-#{$i}.png");
 
-        @include device-pixel-ratio() {
+        @include device-pixel-ratio {
           background-image: image-url("icon-steps/icon-step-#{$i}-2x.png");
           background-size: 24px 24px;
         }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_summary.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_summary.scss
@@ -14,8 +14,8 @@
 
   p,
   h2 {
-    border: none;
-    margin: 0 0.75em 0 0;
+    border: 0;
+    margin: 0 .75em 0 0;
   }
 
   h2 {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -15,7 +15,7 @@
 
     caption {
       text-align: left;
-      margin-bottom: 0.5em;
+      margin-bottom: .5em;
     }
 
     th,

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
@@ -19,7 +19,7 @@
     background-size: $icon-size $icon-size;
     background-repeat: no-repeat;
 
-    @include device-pixel-ratio() {
+    @include device-pixel-ratio {
       background-image: image-url("icon-important-2x.png");
     }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -1,7 +1,7 @@
 @import "govuk-frontend/settings/colours-organisations";
 @import "govuk-frontend/helpers/colour";
 
-@mixin organisation-brand-colour() {
+@mixin organisation-brand-colour {
   @each $organisation in map-keys($govuk-colours-organisations) {
     .brand--#{$organisation} {
       .brand__color {
@@ -15,7 +15,7 @@
 
         &:hover,
         &:focus {
-          color: darken( govuk-organisation-colour($organisation), 10% );
+          color: darken(govuk-organisation-colour($organisation), 10%);
         }
       }
 
@@ -46,7 +46,7 @@
 
     &:hover,
     &:focus {
-      color: darken( govuk-organisation-colour("office-of-the-leader-of-the-house-of-commons"), 10% );
+      color: darken(govuk-organisation-colour("office-of-the-leader-of-the-house-of-commons"), 10%);
     }
   }
 
@@ -70,7 +70,7 @@
 
     &:hover,
     &:focus {
-      color: darken( govuk-colour("bright-purple"), 10% );
+      color: darken(govuk-colour("bright-purple"), 10%);
     }
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_contents-list-helper.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_contents-list-helper.scss
@@ -15,7 +15,7 @@
 }
 
 .gem-c-contents-list__numbered-text {
-  $contents-text-padding: 0.3em;
+  $contents-text-padding: .3em;
   padding-left: $contents-text-padding;
 
   .direction-rtl & {

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -124,8 +124,8 @@
   // Text styles
 
   sup {
-    font-size: 0.8em;
-    line-height: 0.7em;
+    font-size: .8em;
+    line-height: .7em;
     vertical-align: super;
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_back-arrow.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_back-arrow.scss
@@ -4,7 +4,7 @@
   border-bottom: 5px solid transparent;
   border-right: 6px solid;
   border-top: 5px solid transparent;
-  content: '';
+  content: "";
   display: block;
   left: 0;
   margin-top: -6px;

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_media-down.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_media-down.scss
@@ -10,11 +10,11 @@ $is-ie: false !default;
 @mixin media-down($size: false, $max-width: false, $min-width: false) {
   @if $is-ie == false {
     @if $size == mobile {
-      @media (max-width: 640px){
+      @media (max-width: 640px) {
         @content;
       }
     } @else if $size == tablet {
-      @media (max-width: 800px){
+      @media (max-width: 800px) {
         @content;
       }
     }

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_accordion.scss
@@ -11,12 +11,12 @@
 
 // Change the colour from the blue link colour to black.
 .govuk-accordion__section-button {
-  color: govuk-colour('black') !important;
+  color: govuk-colour("black") !important;
 }
 
 // Change the summary subheading size.
 .govuk-accordion__section-summary {
-  @include govuk-typography-common();
+  @include govuk-typography-common;
   @include govuk-typography-responsive($size: 16, $important: true);
 
   .govuk-accordion--condensed & {
@@ -24,7 +24,7 @@
   }
 }
 
-// Hide the unusable 'Open all' button and the '+' icons.
+// Hide the unusable "Open all" button and the "+" icons.
 .govuk-accordion__open-all,
 .govuk-accordion__icon {
   display: none !important;

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_step-by-step-nav.scss
@@ -79,7 +79,7 @@ $stroke-width: 3px;
 
 .gem-c-step-nav__title {
   @include bold-19;
-  margin: 0 0 0.5em 0;
+  margin: 0 0 .5em 0;
   padding: 0;
 }
 
@@ -111,7 +111,7 @@ $stroke-width: 3px;
 }
 
 .gem-c-step-nav__link {
-  margin-bottom: 0.3em;
+  margin-bottom: .3em;
 }
 
 // scss-lint:enable SelectorFormat

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,5 @@
 {
+  "name": "govuk_publishing_components",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
@@ -9,25 +10,2351 @@
         "preact": "^8.3.1"
       }
     },
+    "acorn": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      }
+    },
     "axe-core": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.2.2.tgz",
       "integrity": "sha512-gAy4kMSPpuRJV3mwictJqlg5LhE84Vw2CydKdC4tvrLhR6+G3KW51zbL/vYujcLA2jvWOq3HMHrVeNuw+mrLVA=="
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^1.0.1"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.9"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "debug-log": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "deglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
+      "integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
+      "dev": true,
+      "requires": {
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^3.0.9",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
+      }
+    },
+    "doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "requires": {
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.4.6",
+        "debug": "^2.1.1",
+        "doctrine": "^1.2.2",
+        "es6-map": "^0.1.3",
+        "escope": "^3.6.0",
+        "espree": "^3.1.6",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^1.1.1",
+        "glob": "^7.0.3",
+        "globals": "^9.2.0",
+        "ignore": "^3.1.2",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "optionator": "^0.8.1",
+        "path-is-absolute": "^1.0.0",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "shelljs": "^0.6.0",
+        "strip-json-comments": "~1.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
+      }
+    },
+    "eslint-config-standard": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
+      "integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
+      "dev": true
+    },
+    "eslint-config-standard-jsx": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz",
+      "integrity": "sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==",
+      "dev": true
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
+      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "pkg-dir": "^2.0.0"
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
+      "integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^1.3.0",
+        "regexpp": "^2.0.1"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
+      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+      "dev": true,
+      "requires": {
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.8",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.1",
+        "eslint-module-utils": "^2.2.0",
+        "has": "^1.0.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.3",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.6.0"
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
+      "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^1.3.1",
+        "eslint-utils": "^1.3.1",
+        "ignore": "^4.0.2",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
+      "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
+      "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
+      "integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.0.1",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        }
+      }
+    },
+    "eslint-plugin-standard": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",
+      "integrity": "sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "file-entry-cache": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "requires": {
+        "locate-path": "^2.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
+      }
+    },
+    "front-matter": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.1.2.tgz",
+      "integrity": "sha1-91mDufL0E75ljJPf172M5AePXNs=",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.4.6"
+      }
+    },
+    "fs-extra": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^3.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globule": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
+      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "dev": true,
+      "requires": {
+        "glob": "~7.1.1",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2"
+      }
+    },
+    "gonzales-pe-sl": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/gonzales-pe-sl/-/gonzales-pe-sl-4.2.3.tgz",
+      "integrity": "sha1-aoaLw4BkXxQf7rBCxvl/zHG1n+Y=",
+      "dev": true,
+      "requires": {
+        "minimist": "1.1.x"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
+          "dev": true
+        }
+      }
     },
     "govuk-frontend": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.11.0.tgz",
       "integrity": "sha512-kZR0ZrSju+Jqh8o5niKklj8/m5XmsNNUSQLL4M4urnMcrLypwW2dU3RkR8UCnzS2DDy4BTHb7CZw0VjQPoi3jg=="
     },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
+      "integrity": "sha512-XTHBZSIIxNsIsZXg7XB5l8z/OBFosl1Wao4tXLpeC7eKU4Vm/kdop2azkPqULwnfGQjmeDIyey9g7afMMtdWAA==",
+      "dev": true,
+      "requires": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
     "jquery": {
       "version": "1.12.4",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.4.tgz",
       "integrity": "sha1-AeHfuikP5z3rp3zurLD5ui/sngw="
     },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsx-ast-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3"
+      }
+    },
+    "known-css-properties": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.3.0.tgz",
+      "integrity": "sha512-QMQcnKAiQccfQTqtBh/qwquGZ2XK/DXND1jrcN9M8gMMy99Gwla7GQjndVUsEqIaRyP6bsFRuhwRj5poafBGJQ==",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
+      "dev": true
+    },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "requires": {
+        "pify": "^2.0.0"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pkg-conf": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "load-json-file": "^4.0.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "pkg-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+      "dev": true,
+      "requires": {
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      }
+    },
+    "pluralize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "dev": true
+    },
     "preact": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/preact/-/preact-8.4.2.tgz",
       "integrity": "sha512-TsINETWiisfB6RTk0wh3/mvxbGRvx+ljeBccZ4Z6MPFKgu/KFGyf2Bmw3Z/jlXhL5JlNKY6QAbA9PVyzIy9//A=="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "react-is": {
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.2.tgz",
+      "integrity": "sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "mute-stream": "0.0.5"
+      }
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      }
+    },
+    "resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0"
+      }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "rxjs": {
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sass-lint": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sass-lint/-/sass-lint-1.13.1.tgz",
+      "integrity": "sha512-DSyah8/MyjzW2BWYmQWekYEKir44BpLqrCFsgs9iaWiVTcwZfwXHF586hh3D1n+/9ihUNMfd8iHAyb9KkGgs7Q==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.8.1",
+        "eslint": "^2.7.0",
+        "front-matter": "2.1.2",
+        "fs-extra": "^3.0.1",
+        "glob": "^7.0.0",
+        "globule": "^1.0.0",
+        "gonzales-pe-sl": "^4.2.3",
+        "js-yaml": "^3.5.4",
+        "known-css-properties": "^0.3.0",
+        "lodash.capitalize": "^4.1.0",
+        "lodash.kebabcase": "^4.0.0",
+        "merge": "^1.2.0",
+        "path-is-absolute": "^1.0.0",
+        "util": "^0.10.3"
+      }
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "standard": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-12.0.1.tgz",
+      "integrity": "sha512-UqdHjh87OG2gUrNCSM4QRLF5n9h3TFPwrCNyVlkqu31Hej0L/rc8hzKqVvkb2W3x0WMq7PzZdkLfEcBhVOR6lg==",
+      "dev": true,
+      "requires": {
+        "eslint": "~5.4.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-config-standard-jsx": "6.0.2",
+        "eslint-plugin-import": "~2.14.0",
+        "eslint-plugin-node": "~7.0.1",
+        "eslint-plugin-promise": "~4.0.0",
+        "eslint-plugin-react": "~7.11.1",
+        "eslint-plugin-standard": "~4.0.0",
+        "standard-engine": "~9.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
+          "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+          "dev": true
+        },
+        "acorn-jsx": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+          "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.9.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
+          "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+          "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+          "dev": true
+        },
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "eslint": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.4.0.tgz",
+          "integrity": "sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.5.0",
+            "babel-code-frame": "^6.26.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^4.0.0",
+            "eslint-utils": "^1.3.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^4.0.0",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.7.0",
+            "ignore": "^4.0.2",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^5.2.0",
+            "is-resolvable": "^1.1.0",
+            "js-yaml": "^3.11.0",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.5",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^2.0.0",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.5.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "^2.0.1",
+            "table": "^4.0.3",
+            "text-table": "^0.2.0"
+          }
+        },
+        "espree": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+          "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+          "dev": true,
+          "requires": {
+            "acorn": "^6.0.2",
+            "acorn-jsx": "^5.0.0",
+            "eslint-visitor-keys": "^1.0.0"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+          "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+          "dev": true,
+          "requires": {
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "globals": {
+          "version": "11.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+          "dev": true
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+          "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+          "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+          "dev": true
+        },
+        "progress": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+          "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "dev": true,
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "table": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+          "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.0.1",
+            "ajv-keywords": "^3.0.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          }
+        }
+      }
+    },
+    "standard-engine": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-9.0.0.tgz",
+      "integrity": "sha512-ZfNfCWZ2Xq67VNvKMPiVMKHnMdvxYzvZkf1AH8/cw2NLDBm5LRsxMqvEJpsjLI/dUosZ3Z1d6JlHDp5rAvvk2w==",
+      "dev": true,
+      "requires": {
+        "deglob": "^2.1.0",
+        "get-stdin": "^6.0.0",
+        "minimist": "^1.1.0",
+        "pkg-conf": "^2.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "dev": true
+    },
+    "table": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "dev": true,
+      "requires": {
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
+        "slice-ansi": "0.0.4",
+        "string-width": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,25 @@
 {
+  "private": true,
+  "name": "govuk_publishing_components",
+  "license": "MIT",
+  "scripts": {
+    "lint:js": "standard 'app/assets/javascripts/govuk_publishing_components/**/*.js'",
+    "lint:scss": "sass-lint 'app/assets/stylesheets/**/*.scss' -v -q",
+    "lint": "npm run lint:js && npm run lint:scss"
+  },
+  "standard": {
+    "ignore": [
+      "app/assets/javascripts/govuk_publishing_components/vendor/**/*.js"
+    ]
+  },
   "dependencies": {
     "accessible-autocomplete": "git://github.com/alphagov/accessible-autocomplete.git#add-multiselect-support",
     "axe-core": "3.2.2",
     "govuk-frontend": "2.11.0",
     "jquery": "1.12.4"
+  },
+  "devDependencies": {
+    "sass-lint": "^1.13.1",
+    "standard": "^12.0.1"
   }
 }


### PR DESCRIPTION
### Changes
- set up npm-based linting using standardjs and sass-lint conform reflecting the [component conventions](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_conventions.md#javascript)
- update JavaScript files to conform with standardjs linting rules
- update SCSS files to conform with `sass-lint` linting rules
- update Jenkins tasks to run linting

This will align linting tools with the [govuk-frontend repo](https://github.com/alphagov/govuk-frontend).

**Note**
`scss-` rules are still preserved until `govuk-lint` is retired otherwise CI will fail

### IDE Integration
For `standardjs` there is a list on the project's website: https://standardjs.com/#are-there-text-editor-plugins

For `sass-lint` there are a couple of extensions, I'll list a couple below:
 - Atom: https://atom.io/packages/linter-sass-lint
 - Sublime: https://sublimelinter.readthedocs.io/en/stable/
 - Visual Studio Code: https://marketplace.visualstudio.com/items?itemName=glen-84.sass-lint
 - Other IDEs: https://github.com/sasstools/sass-lint#ide-integration

### Related
https://github.com/alphagov/govuk_publishing_components/issues/124