### PR TITLE
Remove autocomplete hide facets option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove autocomplete hide facets option (PR #761)
 * Remove classes option from components (PR #727)
 * Add margin option to textarea component (PR #757)
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
@@ -39,9 +39,3 @@
     display: none;
   }
 }
-
-.gem-c-accessible-autocomplete--hide-facets {
-  .autocomplete__list {
-    display: none;
-  }
-}

--- a/app/views/govuk_publishing_components/components/_accessible_autocomplete.html.erb
+++ b/app/views/govuk_publishing_components/components/_accessible_autocomplete.html.erb
@@ -5,10 +5,6 @@
   options ||= []
   selected_option ||= nil
   multiple ||= false
-  hide_facets ||= false
-
-  classes = %w(gem-c-accessible-autocomplete)
-  classes << "gem-c-accessible-autocomplete--hide-facets" if hide_facets
 %>
 <% if label && options.any? %>
   <div class="govuk-form-group">
@@ -18,7 +14,7 @@
       }.merge(label.symbolize_keys)
     %>
 
-    <%= tag.div class: classes, data: { module: "accessible-autocomplete" } do %>
+    <%= tag.div class: "gem-c-accessible-autocomplete", data: { module: "accessible-autocomplete" } do %>
       <% if multiple %>
         <span class="govuk-hint app-c-autocomplete__multiselect-instructions"><%= t('components.autocomplete.multiselect') %></span>
       <% end %>

--- a/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
+++ b/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
@@ -47,11 +47,3 @@ examples:
       label:
         text: 'Countries'
       options: [['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us'], ['The Separate Customs Territory of Taiwan, Penghu, Kinmen, and Matsu (Chinese Taipei)', 'tw']]
-  with_multiple_selections_hide_facets:
-    description: This parameter hides the facet tags shown by the component in multiple mode when options have been chosen. This seems counter to likely requirements but is needed for finders where the app generates its own facet tags.
-    data:
-      multiple: true
-      hide_facets: true
-      label:
-        text: 'Countries'
-      options: [['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us'], ['The Separate Customs Territory of Taiwan, Penghu, Kinmen, and Matsu (Chinese Taipei)', 'tw']]

--- a/spec/components/accessible_autocomplete_spec.rb
+++ b/spec/components/accessible_autocomplete_spec.rb
@@ -63,15 +63,4 @@ describe "AccessibleAutocomplete", type: :view do
     assert_select "select[multiple]"
     assert_select ".gem-c-accessible-autocomplete.gem-c-accessible-autocomplete--hide-facets", false
   end
-
-  it 'does not show facet tags for multiple when given the option' do
-    render_component(
-      multiple: true,
-      hide_facets: true,
-      label: { text: "Countries" },
-      options: [['United Kingdom', 'gb'], ['United States', 'us']]
-    )
-
-    assert_select ".gem-c-accessible-autocomplete.gem-c-accessible-autocomplete--hide-facets"
-  end
 end


### PR DESCRIPTION
There was an option in the autocomplete component where when it was in multiple mode you could hide the facet tags that it automatically created. This was done because in finders we already had facet tags of our own, so we didn't need duplicates.

Having investigated this in more detail, we've decided that we don't want this option anymore, as it created an accessibility issue, so we're removing it.

