### PR TITLE
Enable rendering an open details element

### DIFF
--- a/app/views/govuk_publishing_components/components/_details.html.erb
+++ b/app/views/govuk_publishing_components/components/_details.html.erb
@@ -1,5 +1,6 @@
 <% data_attributes ||= nil %>
-<%= tag.details class: "gem-c-details govuk-details", data: data_attributes do %>
+<% open ||= nil %>
+<%= tag.details class: "gem-c-details govuk-details", data: data_attributes, open: open do %>
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
       <%= title %>

--- a/app/views/govuk_publishing_components/components/docs/details.yml
+++ b/app/views/govuk_publishing_components/components/docs/details.yml
@@ -28,3 +28,9 @@ examples:
         tracking: GTM-123AB
       block: |
         We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
+  open:
+    data:
+      title: Help with nationality
+      open: true
+      block: |
+        We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.

--- a/spec/components/details_spec.rb
+++ b/spec/components/details_spec.rb
@@ -14,4 +14,12 @@ describe "Details", type: :view do
     assert_select ".govuk-details__summary-text", text: "Some title"
     assert_select ".govuk-details__text", text: "This is more info"
   end
+
+  it "renders an open details element" do
+    render_component(title: "Some title", open: true) do
+      "This is more info"
+    end
+
+    assert_select "details.gem-c-details[open]"
+  end
 end


### PR DESCRIPTION
There are situations when we would want a details element to be open when the page is loaded.