### PR TITLE
Update alert components to use consistent bottom margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Remove autocomplete hide facets option (PR #761)
 * Remove classes option from components (PR #727)
 * Add margin option to textarea component (PR #757)
+* Update alert components to use consistent bottom margin (PR #765)
 
 ## 15.3.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
@@ -2,7 +2,7 @@
   color: $gem-text-colour;
   padding: $gem-spacing-scale-3;
   border: $gem-border-width-mobile solid $gem-error-colour;
-  margin-bottom: $gem-spacing-scale-4;
+  @include govuk-responsive-margin(8, "bottom");
 
   @include media(tablet) {
     padding: $gem-spacing-scale-4;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
@@ -2,7 +2,7 @@
   color: $gem-text-colour;
   padding: $gem-spacing-scale-3;
   border: $gem-border-width-mobile solid $gem-success-colour;
-  margin-bottom: $gem-spacing-scale-4;
+  @include govuk-responsive-margin(8, "bottom");
 
   @include media(tablet) {
     padding: $gem-spacing-scale-4;


### PR DESCRIPTION
This PR updates `error-alert` and `success-alert` components to use the same `margin-bottom` with `error-summary` component.

### Context
Error summary uses responsive-margin bottom of 8, which evens the space between the component and the next elements on the page (e.g. title) with the component and the previous element on the page (e.g. back button).

These two components are only being used by [Signon](https://github.com/alphagov/signon/blob/master/app/assets/stylesheets/application.scss#L3) and Content Publisher and this fixes the spacing in both applications.

### Before
<img width="1440" alt="screen shot 2019-02-25 at 11 49 48" src="https://user-images.githubusercontent.com/788096/53335716-22e32d00-38f4-11e9-901f-123f3cc5429d.png">

### After
<img width="1440" alt="screen shot 2019-02-25 at 11 50 13" src="https://user-images.githubusercontent.com/788096/53335723-25de1d80-38f4-11e9-8db4-f6d52c7e5ed9.png">
