### PR TITLE
Reduce checkboxes markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* BREAKING: Reduce checkboxes markup (PR #767)
 * Support data attributes for the back-link component (PR #773)
 * Create shared helper for components (PR #759)
 * Use delegated event handlers for checkbox events (PR #770)

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -56,7 +56,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     };
 
     this.toggleParentCheckbox = function(scope, checkbox) {
-      var siblings = $(checkbox).closest('.gem-c-checkboxes__list-item').siblings();
+      var siblings = $(checkbox).closest('.govuk-checkboxes__item').siblings();
       var parent_id = scope.data('parent');
 
       if (checkbox.checked && siblings.length == siblings.find(':checked').length) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
@@ -1,16 +1,7 @@
 @import "govuk-frontend/components/checkboxes/checkboxes";
 
-.gem-c-checkbox.gem-c-checkbox--margin-bottom:last-child,
-.gem-c-checkbox.gem-c-checkbox--margin-bottom:last-of-type {
-  margin-bottom: $gutter-two-thirds;
-
-  @include media(tablet) {
-    margin-bottom: $gutter;
-  }
-}
-
 .govuk-checkboxes--nested {
-  margin-left: (govuk-spacing(3) + 3px);
+  margin-left: -(govuk-spacing(4) + 2px); //22px
   box-sizing: border-box;
   border-left-style: solid;
   border-left-width: 4px;
@@ -24,22 +15,14 @@
   }
 }
 
+.govuk-checkboxes__conditional {
+  margin-top: govuk-spacing(2);
+  margin-left: -(govuk-spacing(4) + 2px); //22px
+}
+
 .gem-c-checkboxes__list {
   padding-left: govuk-spacing(0);
   margin: 0;
-}
-
-.gem-c-checkboxes__list-item {
-  list-style: none;
-  margin-bottom: govuk-spacing(2);
-}
-
-.gem-c-checkboxes__list-item:last-child {
-  margin-bottom: 0;
-
-  .govuk-checkboxes--nested {
-    margin-bottom: 0;
-  }
 }
 
 .gem-c-checkboxes {

--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -22,7 +22,7 @@
           nested: ('true' if cb_helper.has_nested),
         } do %>
           <% cb_helper.items.each_with_index do |item, index| %>
-            <%= tag.li class: "gem-c-checkboxes__list-item" do %>
+            <%= tag.li class: "govuk-checkboxes__item" do %>
               <%= cb_helper.checkbox_markup(item, index) %>
 
               <% if item[:conditional] %>
@@ -32,7 +32,7 @@
               <% if item[:items].present? %>
                 <%= tag.ul id: "#{id}-nested-#{index}", class: "govuk-checkboxes govuk-checkboxes--nested", data: { parent: "#{id}-#{index}" } do %>
                   <% item[:items].each_with_index do |nested_item, nested_index| %>
-                    <%= tag.li class: "gem-c-checkboxes__list-item" do %>
+                    <%= tag.li class: "govuk-checkboxes__item" do %>
                       <%= cb_helper.checkbox_markup(nested_item, "#{index}-#{nested_index}") %>
                     <% end %>
                   <% end %>
@@ -45,6 +45,8 @@
     <% end %>
 
   <% else %>
-    <%= cb_helper.checkbox_markup(cb_helper.items[0], 0) %>
+    <div class="govuk-checkboxes__item">
+      <%= cb_helper.checkbox_markup(cb_helper.items[0], 0) %>
+    </div>
   <% end %>
 <% end %>

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -66,17 +66,10 @@ module GovukPublishingComponents
         data = checkbox[:data_attributes] || {}
         data[:controls] = controls
 
-        markup = capture do
+        capture do
           concat check_box_tag checkbox_name, checkbox[:value], checked, class: "govuk-checkboxes__input", id: checkbox_id, data: data
           concat content_tag(:label, checkbox[:label], for: checkbox_id, class: "govuk-label govuk-checkboxes__label")
           concat content_tag(:span, checkbox[:hint], id: "#{checkbox_id}-item-hint", class: "govuk-hint govuk-checkboxes__hint") if checkbox[:hint]
-        end
-
-        content_tag(
-          :div,
-          class: "gem-c-checkbox govuk-checkboxes__item",
-        ) do
-          markup
         end
       end
     end

--- a/spec/javascripts/components/checkboxes-spec.js
+++ b/spec/javascripts/components/checkboxes-spec.js
@@ -11,40 +11,40 @@ describe("Checkboxes component", function () {
            <h1 class="govuk-fieldset__heading">What is your favourite colour?</h1>\
         </legend>\
         <span id="checkboxes-1ac8e5cf-hint" class="govuk-hint">Select all that apply.</span>\
-        <div class="govuk-checkboxes" data-nested="true">\
-           <div class="gem-c-checkbox govuk-checkboxes__item">\
+        <ul class="govuk-checkboxes gem-c-checkboxes__list" data-nested="true">\
+           <li class="govuk-checkboxes__item">\
               <input id="checkboxes-1ac8e5cf-0" name="favourite_colour" type="checkbox" value="red" class="govuk-checkboxes__input" data-track-category="choseFavouriteColour" data-track-action="favourite-color" data-track-label="red" data-track-value="1" data-track-options=\'{"dimension28": "wubbalubbadubdub","dimension29": "Pickle Rick"}\'>\
               <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-0">Red</label>\
-           </div>\
-           <div id="checkboxes-1ac8e5cf-nested-0" class="govuk-checkboxes govuk-checkboxes--nested" data-parent="checkboxes-1ac8e5cf-0">\
-              <div class="gem-c-checkbox govuk-checkboxes__item">\
-                 <input id="checkboxes-1ac8e5cf-0-0" name="favourite_colour" type="checkbox" value="light_red" class="govuk-checkboxes__input" data-controls="thing">\
-                 <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-0-0">Light Red</label>\
-              </div>\
-              <div class="gem-c-checkbox govuk-checkboxes__item">\
-                 <input id="checkboxes-1ac8e5cf-0-1" name="favourite_colour" type="checkbox" value="dark_red" class="govuk-checkboxes__input">\
-                 <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-0-1">Dark Red</label>\
-              </div>\
-           </div>\
-           <div class="gem-c-checkbox govuk-checkboxes__item">\
+              <ul id="checkboxes-1ac8e5cf-nested-0" class="govuk-checkboxes govuk-checkboxes--nested" data-parent="checkboxes-1ac8e5cf-0">\
+                <li class="govuk-checkboxes__item">\
+                   <input id="checkboxes-1ac8e5cf-0-0" name="favourite_colour" type="checkbox" value="light_red" class="govuk-checkboxes__input" data-controls="thing">\
+                   <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-0-0">Light Red</label>\
+                </li>\
+                <li class="govuk-checkboxes__item">\
+                   <input id="checkboxes-1ac8e5cf-0-1" name="favourite_colour" type="checkbox" value="dark_red" class="govuk-checkboxes__input">\
+                   <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-0-1">Dark Red</label>\
+                </li>\
+              </ul>\
+           </li>\
+           <li class="govuk-checkboxes__item">\
               <input id="checkboxes-1ac8e5cf-1" name="favourite_colour" type="checkbox" value="blue" class="govuk-checkboxes__input" data-track-category="choseFavouriteColour" data-uncheck-track-category="unselectedFavouriteColour" data-track-action="favourite-color" data-track-label="blue" data-track-value="2" data-track-options=\'{"dimension28":"Get schwifty","dimension29":"Squanch"}\'>\
               <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-1">Blue</label>\
-           </div>\
-           <div id="checkboxes-1ac8e5cf-nested-1" class="govuk-checkboxes govuk-checkboxes--nested" data-parent="checkboxes-1ac8e5cf-1">\
-              <div class="gem-c-checkbox govuk-checkboxes__item">\
-                 <input id="checkboxes-1ac8e5cf-1-0" name="favourite_colour" type="checkbox" value="light_blue" class="govuk-checkboxes__input" data-controls="thing2">\
-                 <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-1-0">Light blue</label>\
-              </div>\
-              <div class="gem-c-checkbox govuk-checkboxes__item">\
-                 <input id="checkboxes-1ac8e5cf-1-1" name="favourite_colour" type="checkbox" value="dark_blue" class="govuk-checkboxes__input">\
-                 <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-1-1">Dark blue</label>\
-              </div>\
-           </div>\
-           <div class="gem-c-checkbox govuk-checkboxes__item">\
+              <ul id="checkboxes-1ac8e5cf-nested-1" class="govuk-checkboxes govuk-checkboxes--nested" data-parent="checkboxes-1ac8e5cf-1">\
+                <li class="govuk-checkboxes__item">\
+                   <input id="checkboxes-1ac8e5cf-1-0" name="favourite_colour" type="checkbox" value="light_blue" class="govuk-checkboxes__input" data-controls="thing2">\
+                   <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-1-0">Light blue</label>\
+                </li>\
+                <li class="govuk-checkboxes__item">\
+                   <input id="checkboxes-1ac8e5cf-1-1" name="favourite_colour" type="checkbox" value="dark_blue" class="govuk-checkboxes__input">\
+                   <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-1-1">Dark blue</label>\
+                </li>\
+              </ul>\
+           </li>\
+           <li class="govuk-checkboxes__item">\
               <input id="checkboxes-1ac8e5cf-2" name="favourite_colour" type="checkbox" value="other" class="govuk-checkboxes__input">\
               <label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-2">Other</label>\
-           </div>\
-        </div>\
+           </li>\
+        </ul>\
      </fieldset>\
   </div>';
 
@@ -59,16 +59,16 @@ describe("Checkboxes component", function () {
     setFixtures(FIXTURE);
     loadCheckboxesComponent();
 
-    $parentCheckboxWrapper = $('.govuk-checkboxes--nested:eq(0)').prev('.govuk-checkboxes__item');
-    $parentCheckbox = $parentCheckboxWrapper.find('.govuk-checkboxes__input');
-    $nestedChildren = $parentCheckboxWrapper.next('.govuk-checkboxes--nested').find('.govuk-checkboxes__input');
+    $parentCheckboxWrapper = $('.govuk-checkboxes--nested:eq(0)').closest('.govuk-checkboxes__item');
+    $parentCheckbox = $parentCheckboxWrapper.find('> .govuk-checkboxes__input');
+    $nestedChildren = $parentCheckboxWrapper.find('.govuk-checkboxes--nested .govuk-checkboxes__input');
     $checkboxesWrapper = $(".gem-c-checkboxes");
     expectedRedOptions =  {label: "red", value: 1, dimension28: "wubbalubbadubdub", dimension29: "Pickle Rick"};
     expectedBlueOptions = {label: "blue", value: 2, dimension28: "Get schwifty", dimension29: "Squanch"};
 
     GOVUK.analytics = {
       trackEvent: function(){}
-    }
+    };
 
     spyOn(GOVUK.analytics, 'trackEvent');
   });


### PR DESCRIPTION
Checkboxes are being rendered in large numbers in finders, which is slower than we'd like. This PR removes an unneeded `div` from the checkbox markup, which fractionally improves the rendering speed.

![screen shot 2019-02-25 at 15 17 41](https://user-images.githubusercontent.com/861310/53347289-ac085d00-3910-11e9-9a10-1833fb7dea0c.png)

Appearance and functionality of the checkboxes should remain exactly the same as it was before. I've checked it in a few browsers, old and new, but would appreciate more pairs of eyes.

This change also removes some redundant CSS and classes, and fixes the simulated markup for checkboxes in the JS spec file.

Trello card: https://trello.com/c/ZvgrsGJv/440-reduce-checkbox-component-markup