### PR TITLE
Release version 16.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 16.1.0
 
 * Enable ability to add data attributes to a single radio button (PR #766)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (16.0.0)
+    govuk_publishing_components (16.1.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '16.0.0'.freeze
+  VERSION = '16.1.0'.freeze
 end


### PR DESCRIPTION
Enable ability to add data attributes to a single radio button:
https://github.com/alphagov/govuk_publishing_components/pull/766

Trello:
https://trello.com/c/pcbHvl7B/636-change-note-guidance

<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->
