### PR TITLE
Use delegated event handlers for checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Enable ability to add data attributes to a single radio button (PR #766)
+* Use delegated event handlers for checkbox events (PR #770)
 
 ## 16.0.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -11,7 +11,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var _this = this;
       this.applyAriaControlsAttributes(scope);
 
-      $(scope).find('[data-nested=true] input[type=checkbox]').on('change', function(e) {
+      $(scope).on('change', '[data-nested=true] input[type=checkbox]', function(e) {
         var checkbox = e.target;
         var isNested = $(checkbox).closest('.govuk-checkboxes--nested');
         var hasNested = $('.govuk-checkboxes--nested[data-parent=' + checkbox.id + ']');
@@ -23,7 +23,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
       });
 
-      $(scope).find('input[type=checkbox]').on('change', function(e) {
+      $(scope).on('change', 'input[type=checkbox]', function(e) {
         if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
           var $checkbox = $(e.target);
           var category = $checkbox.data("track-category");


### PR DESCRIPTION
Rather than setting up an event handler on every individual checkbox, set up delegated event handlers on the wrapper.

This will significantly reduce the number of event handlers being bound on pages with large numbers of checkboxes (like finder-frontend).

<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->
