### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use delegated event handlers for checkbox events (PR #770)
+
 ## 16.1.0
 
 * Enable ability to add data attributes to a single radio button (PR #766)
-* Use delegated event handlers for checkbox events (PR #770)
 
 ## 16.0.0
 


### PR DESCRIPTION
Bad Git! Not sure why this didn't conflict…

This was merged after 16.1 went out so needs to be unreleased (as it was in the PR!)

<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->
