### PR TITLE
Feed data attributes to back link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Support data attributes for the back-link component (PR #773)
 * Create shared helper for components (PR #759)
 * Use delegated event handlers for checkbox events (PR #770)
 

--- a/app/views/govuk_publishing_components/components/_back_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_back_link.html.erb
@@ -1,10 +1,10 @@
 <%
   text ||= t('components.back_link.back')
+  data_attributes ||= nil
 %>
-<%= link_to text,
+<%= link_to(
+  text,
   href,
-  class: %w(
-    gem-c-back-link
-    govuk-back-link
-  )
- %>
+  class: %w(gem-c-back-link govuk-back-link),
+  data: data_attributes
+) %>

--- a/app/views/govuk_publishing_components/components/docs/back_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/back_link.yml
@@ -14,3 +14,8 @@ examples:
     data:
       text: 'Back to document list'
       href: '#'
+  with_data_attributes:
+    data:
+      href: '#'
+      data_attributes:
+        tracking: GT-1234

--- a/spec/components/back_link_spec.rb
+++ b/spec/components/back_link_spec.rb
@@ -13,11 +13,16 @@ describe "Back Link", type: :view do
 
   it "renders a back link correctly" do
     render_component(href: '/back-me')
-    assert_select ".govuk-back-link[href=\"/back-me\"]", text: "Back"
+    assert_select '.govuk-back-link[href="/back-me"]', text: "Back"
   end
 
   it "can render in welsh" do
     I18n.with_locale(:cy) { render_component(href: '/back-me') }
-    assert_select ".govuk-back-link[href=\"/back-me\"]", text: "Yn ôl"
+    assert_select '.govuk-back-link[href="/back-me"]', text: "Yn ôl"
+  end
+
+  it "renders a back link with data attributes" do
+    render_component(href: '/back-me', data_attributes: { tracking: "GT-123" })
+    assert_select '.govuk-back-link[data-tracking="GT-123"]'
   end
 end


### PR DESCRIPTION
 https://trello.com/c/jsJLqcSa/667-allow-users-to-edit-image-metadata-in-the-context-of-a-modal