### PR TITLE
Change Plek(rummager) to Plek(search)

### DIFF
--- a/lib/govuk_publishing_components/presenters/services.rb
+++ b/lib/govuk_publishing_components/presenters/services.rb
@@ -5,7 +5,7 @@ module GovukPublishingComponents
     # @private
     module Services
       def self.rummager
-        @rummager ||= GdsApi::Rummager.new(Plek.find('rummager'))
+        @rummager ||= GdsApi::Rummager.new(Plek.find('search'))
       end
     end
   end


### PR DESCRIPTION
For the migration to search-api we're going to re-target the 'search'
alias to search-api.

---

[Trello card](https://trello.com/c/yrq9hZmU/77-point-the-search-alias-to-search-api-if-rummager-is-disabled)