### PR TITLE
Change link in header to new policy papers and consultations finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change consultations header link to link to new finders (PR #783)
+
 ## 16.4.0
 
 * Add `autocomplete` attribute option to input component and use it on feedback component's survey signup form (PR #733)

--- a/app/views/govuk_publishing_components/components/_government_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_government_navigation.html.erb
@@ -30,7 +30,7 @@
       </a>
     </li>
     <li>
-      <a class="<%= 'active' if active == 'consultations' %>" href="/government/publications?publication_filter_option=consultations">
+      <a class="<%= 'active' if active == 'consultations' %>" href="/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations">
         <%= t("govuk_component.government_navigation.consultations", default: "Consultations") %>
       </a>
     </li>

--- a/spec/components/government_navigation_spec.rb
+++ b/spec/components/government_navigation_spec.rb
@@ -11,6 +11,7 @@ describe "Government navigation", type: :view do
     assert_select "\#proposition-links li a", text: "Departments"
     assert_link_with_text("/government/organisations", "Departments")
     assert_link_with_text("/news-and-communications", "News and communications")
+    assert_link_with_text("/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations", "Consultations")
   end
 
   it "has no active links by default" do


### PR DESCRIPTION
Changes link in header to consultations to new policy papers and consultations finder
Uses appropriate parameters to only show closed and open
consultations

Trello: https://trello.com/c/dkz8ZIol/511-change-whitehall-header-link-to-consultations-finder-s

<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->
