### PR TITLE
Suppress search components submit button 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## UNRELEASED
 
 * Allow custom name attribute on search input (PR #787)
+* Suppress search components submit button (PR #786)
 
 ## 16.5.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -152,6 +152,10 @@ $large-input-size: 50px;
       border-right: 0;
     }
 
+    .gem-c-search__input[type="search"].gem-c-search__suppressed-button {
+      border-right: solid 1px $grey-2;
+    }
+
     .js-enabled & {
       .gem-c-search__label {
         color: $secondary-text-colour;

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -9,6 +9,7 @@
   id ||= "search-main-" + SecureRandom.hex(4)
   label_text ||= "Search GOV.UK"
   name ||= 'q'
+  hide_search_button ||= false
 %>
 
 <div class="gem-c-search <%= class_name %>" data-module="gem-toggle-input-class-on-focus">
@@ -16,9 +17,13 @@
     <%= label_text %>
   </label>
   <div class="gem-c-search__item-wrapper">
-    <input type="search" value="<%= value %>" id="<%= id %>" name="<%= name %>" title="Search" class="gem-c-search__item gem-c-search__input js-class-toggle">
-    <div class="gem-c-search__item gem-c-search__submit-wrapper">
-      <button type="submit" class="gem-c-search__submit">Search</button>
-    </div>
+    <input type="search" value="<%= value %>"
+      id="<%= id %>" name="<%= name %>" title="Search"
+      class="gem-c-search__item gem-c-search__input js-class-toggle<%= ' gem-c-search__suppressed-button' if hide_search_button %>">
+    <% unless hide_search_button %>
+      <div class="gem-c-search__item gem-c-search__submit-wrapper">
+        <button type="submit" class="gem-c-search__submit">Search</button>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/govuk_publishing_components/components/docs/search.yml
+++ b/app/views/govuk_publishing_components/components/docs/search.yml
@@ -42,3 +42,7 @@ examples:
     description: To be used if you need to change the default name 'q'
     data:
       name: "my_own_fieldname"
+  remove_search_submit_button:
+      description: Sometimes this component may be used inside an existing form which has another submit button. A form should only have one submit button. The search button will be displayed by default.
+      data:
+        show_search_button: false

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -52,4 +52,9 @@ describe "Search", type: :view do
     render_component(name: "my_custom_field")
     assert_select 'input[name="my_custom_field"]'
   end
+
+  it "renders a search box without a submit button" do
+    render_component(hide_search_button: true)
+    assert_select '.gem-c-search__submit-wrapper button[type="submit"]', false, "This component should not have a submit button"
+  end
 end


### PR DESCRIPTION
We are using this component in finders-frontend and need to be able to suppress the submit button otherwise there will be two submit buttons in the form.

ticket: https://trello.com/c/LznDjL1r/505-all-content-update-page-heading-to-search?menu=filter&filter=label:Finders