### PR TITLE
Allow custom name attribute on search input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## UNRELEASED
+
+* Allow custom name attribute on search input (PR #787)
+
 ## 16.5.0
 
 * Change consultations header link to link to new finders (PR #783)

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -8,6 +8,7 @@
   value ||= ""
   id ||= "search-main-" + SecureRandom.hex(4)
   label_text ||= "Search GOV.UK"
+  name ||= 'q'
 %>
 
 <div class="gem-c-search <%= class_name %>" data-module="gem-toggle-input-class-on-focus">
@@ -15,7 +16,7 @@
     <%= label_text %>
   </label>
   <div class="gem-c-search__item-wrapper">
-    <input type="search" value="<%= value %>" id="<%= id %>" name="q" title="Search" class="gem-c-search__item gem-c-search__input js-class-toggle">
+    <input type="search" value="<%= value %>" id="<%= id %>" name="<%= name %>" title="Search" class="gem-c-search__item gem-c-search__input js-class-toggle">
     <div class="gem-c-search__item gem-c-search__submit-wrapper">
       <button type="submit" class="gem-c-search__submit">Search</button>
     </div>

--- a/app/views/govuk_publishing_components/components/docs/search.yml
+++ b/app/views/govuk_publishing_components/components/docs/search.yml
@@ -2,7 +2,7 @@ name: "Search"
 description: "Search box"
 body: |
   A search box with label and attached submit button. The component must be used within an HTML form.
-  The search input has a name="q" attribute and a customisable ID.
+  The search input has a name="q" attribute and a customisable ID and NAME.
 
   It can be used on white or on govuk-blue using the on_govuk_blue option.
 
@@ -38,3 +38,7 @@ examples:
   large_version:
     data:
       size: "large"
+  change_field_name:
+    description: To be used if you need to change the default name 'q'
+    data:
+      name: "my_own_fieldname"

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -42,4 +42,14 @@ describe "Search", type: :view do
     render_component(size: "large")
     assert_select ".gem-c-search.gem-c-search--large"
   end
+
+  it "renders a search box with a default name" do
+    render_component({})
+    assert_select 'input[name="q"]'
+  end
+
+  it "renders a search box with a custom name" do
+    render_component(name: "my_custom_field")
+    assert_select 'input[name="my_custom_field"]'
+  end
 end


### PR DESCRIPTION
Not all use cases will need to use 'q' but to ensure backwards compatiblity
I have made it the default.

In finder-frontend we use 'keyword' as the field name.

Ticket: https://trello.com/c/LznDjL1r/505-all-content-update-page-heading-to-search

<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->
