### PR TITLE
Bumps gem version to 16.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## UNRELEASED
+## 16.6.0
 
 * Allow custom name attribute on search input (PR #787)
 * Suppress search components submit button (PR #786)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (16.5.0)
+    govuk_publishing_components (16.6.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '16.5.0'.freeze
+  VERSION = '16.6.0'.freeze
 end


### PR DESCRIPTION
Bumps the gem version to 16.6.0

## Changelog
* Allow custom name attribute on search input (PR #787)
* Suppress search components submit button (PR #786)
* Fixes issue in test for consultations header link (PR #788)
