### PR TITLE
Add custom width to inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add width option to input component (PR #790)
+
 ## 16.6.0
 
 * Allow custom name attribute on search input (PR #787)

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -15,12 +15,14 @@
   tabindex ||= nil
   readonly ||= nil
   maxlength ||= nil
+  width ||= nil
   has_error = error_message || error_items&.any?
   hint_id = "hint-#{SecureRandom.hex(4)}"
   error_id = "error-#{SecureRandom.hex(4)}"
 
   css_classes = %w(gem-c-input govuk-input)
   css_classes << "govuk-input--error" if has_error
+  css_classes << "govuk-input--width-#{width}" if [2, 3, 4, 5, 10, 20, 30].include?(width)
   form_group_css_classes = %w(govuk-form-group)
   form_group_css_classes << "govuk-form-group--error" if has_error
 

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -110,3 +110,10 @@ examples:
       name: "name"
       type: "email"
       autocomplete: "email"
+  with_custom_width:
+    data:
+      label:
+        text: "National insurance number"
+      hint: It’s on your National insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      name: "name"
+      width: 10

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -123,6 +123,23 @@ describe "Input", type: :view do
     assert_select ".govuk-input[maxlength='10']"
   end
 
+  it "renders input with custom width" do
+    render_component(
+      name: "email-address",
+      width: 10
+    )
+
+    assert_select ".govuk-input.govuk-input--width-10"
+  end
+
+  it "renders default input width if the custom width is not supported" do
+    render_component(
+      name: "email-address",
+      width: 11
+    )
+    expect(page).to have_no_css('.govuk-input--width-10')
+  end
+
   context "when a hint is provided" do
     before do
       render_component(


### PR DESCRIPTION
This PR adds a `width` option to the input component, which allows to set a specific width for an text input based on the number characters that are expected to be inserted. This feature is added primarily as a preparation for the date-input component which will use the input component within.

Currently, the supported values (defined in govuk-frontend) are 2, 3, 4, 5, 10, 20, 30 which implies that the bigger value should be used in case the expected length is between these values.

[Trello card](https://trello.com/c/0ZphzvRd)