### PR TITLE
Add date input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## 16.7.0
 
+* Add date input component based on GOV.UK Frontend (PR #792)
 * Update fieldset component to use GOV.UK Frontend styles (PR #791)
 * Add width option to input component (PR #790)
 * Add tracking to toggle.js (PR #796)

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -31,6 +31,7 @@
 @import "components/checkboxes";
 @import "components/contents-list";
 @import "components/copy-to-clipboard";
+@import "components/date-input";
 @import "components/details";
 @import "components/document-list";
 @import "components/error-alert";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_date-input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_date-input.scss
@@ -1,1 +1,15 @@
 @import "govuk-frontend/components/date-input/date-input";
+
+// Add spacing between input items on narrow containers when they collapse under each other
+.govuk-date-input {
+  margin-top: - govuk-spacing(2);
+}
+
+.govuk-date-input__item {
+  margin-top: govuk-spacing(2);
+}
+
+// Remove spacing for the last input item to make the most of space when in narrow containers
+.govuk-date-input__item:last-child {
+  margin-right: 0;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_date-input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_date-input.scss
@@ -1,0 +1,1 @@
+@import "govuk-frontend/components/date-input/date-input";

--- a/app/views/govuk_publishing_components/components/_date_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_date_input.html.erb
@@ -54,7 +54,8 @@
             label: {
               text: item[:label] || item[:name].capitalize
             },
-            error_style: error_message,
+            grouped: true,
+            has_error: error_message,
             name: name ? (name + "[" + item[:name] + "]") : item[:name],
             value: item[:value],
             width: item[:width],

--- a/app/views/govuk_publishing_components/components/_date_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_date_input.html.erb
@@ -44,7 +44,7 @@
           label: {
             text: item[:name].capitalize
           },
-          has_error: has_error,
+          error_style: has_error,
           name: item[:name],
           value: item[:value],
           width: item[:width],

--- a/app/views/govuk_publishing_components/components/_date_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_date_input.html.erb
@@ -12,20 +12,18 @@
   error_message ||= nil
   describedby ||= nil
 
-  has_error = error_message
-
   css_classes = %w(gem-c-date-input govuk-date-input)
   form_group_css_classes = %w(govuk-form-group)
-  form_group_css_classes << "govuk-form-group--error" if has_error
+  form_group_css_classes << "govuk-form-group--error" if error_message
 
   hint_id = "hint-#{SecureRandom.hex(4)}"
   error_id = "error-#{SecureRandom.hex(4)}"
 
   aria_described_by ||= nil
-  if hint || has_error || describedby
+  if hint || error_message || describedby
     aria_described_by = []
     aria_described_by << hint_id if hint
-    aria_described_by << error_id if has_error
+    aria_described_by << error_id if error_message
     aria_described_by << describedby if describedby
     aria_described_by = aria_described_by.join(" ")
   end
@@ -56,7 +54,7 @@
             label: {
               text: item[:label] || item[:name].capitalize
             },
-            error_style: has_error,
+            error_style: error_message,
             name: name ? (name + "[" + item[:name] + "]") : item[:name],
             value: item[:value],
             width: item[:width],

--- a/app/views/govuk_publishing_components/components/_date_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_date_input.html.erb
@@ -4,13 +4,26 @@
   legend_text ||= nil
   hint ||= nil
   error_message ||= nil
+  describedby ||= nil
 
   has_error = error_message
 
   css_classes = %w(gem-c-date-input govuk-date-input)
-  css_classes << "govuk-input--error" if has_error
   form_group_css_classes = %w(govuk-form-group)
   form_group_css_classes << "govuk-form-group--error" if has_error
+
+  hint_id = "hint-#{SecureRandom.hex(4)}"
+  error_id = "error-#{SecureRandom.hex(4)}"
+
+  aria_described_by ||= nil
+  if hint || has_error || describedby
+    aria_described_by = []
+    aria_described_by << hint_id if hint
+    aria_described_by << error_id if has_error
+    aria_described_by << describedby if describedby
+    aria_described_by = aria_described_by.join(" ")
+  end
+
 %>
 
 <% date_input_items = [
@@ -20,12 +33,10 @@
 ] %>
 
 <%= content_tag :div, class: form_group_css_classes do %>
-
   <% fieldset_content = capture do %>
-
     <% if hint %>
       <%= render "govuk_publishing_components/components/hint", {
-        id: id + '-hint',
+        id: hint_id,
         text: hint,
         margin_bottom: 2
       } %>
@@ -33,32 +44,40 @@
 
     <% if error_message %>
       <%= render "govuk_publishing_components/components/error_message", {
-        id:  id + '-error',
+        id:  error_id,
         text: error_message
       } %>
     <% end %>
 
-    <% date_input_items.each do |item| %>
-      <%= tag.div class: "govuk-date-input__item" do %>
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: item[:name].capitalize
-          },
-          error_style: has_error,
-          name: item[:name],
-          value: item[:value],
-          width: item[:width],
-          id: item[:id],
-          type: "number",
-          data: item[:data],
-          autocomplete: item[:autocomplete]
-        } %>
+    <%= tag.div class: css_classes, id: id do %>
+      <% date_input_items.each do |item| %>
+        <%= tag.div class: "govuk-date-input__item" do %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: item[:name].capitalize
+            },
+            error_style: has_error,
+            name: item[:name],
+            value: item[:value],
+            width: item[:width],
+            id: item[:id],
+            type: "number",
+            data: item[:data],
+            autocomplete: item[:autocomplete]
+          } %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>
 
-  <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: legend_text,
-    text: fieldset_content
-  } %>
+  <% if legend_text %>
+    <%= render "govuk_publishing_components/components/fieldset", {
+      describedby: aria_described_by,
+      legend_text: legend_text,
+      text: fieldset_content,
+      role: "group"
+    } %>
+  <% else %>
+    <%= fieldset_content %>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_date_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_date_input.html.erb
@@ -1,5 +1,11 @@
 <%
   id ||= "input-#{SecureRandom.hex(4)}"
+  name ||= nil
+  items ||= [
+    { :name => "day", :width => 2 },
+    { :name => "month", :width => 2 },
+    { :name => "year", :width => 4 }
+  ]
 
   legend_text ||= nil
   hint ||= nil
@@ -26,12 +32,6 @@
 
 %>
 
-<% date_input_items = [
-  { :name => "day", :width => 2 },
-  { :name => "month", :width => 2 },
-  { :name => "year", :width => 4 }
-] %>
-
 <%= content_tag :div, class: form_group_css_classes do %>
   <% fieldset_content = capture do %>
     <% if hint %>
@@ -50,14 +50,14 @@
     <% end %>
 
     <%= tag.div class: css_classes, id: id do %>
-      <% date_input_items.each do |item| %>
+      <% items.each do |item| %>
         <%= tag.div class: "govuk-date-input__item" do %>
           <%= render "govuk_publishing_components/components/input", {
             label: {
-              text: item[:name].capitalize
+              text: item[:label] || item[:name].capitalize
             },
             error_style: has_error,
-            name: item[:name],
+            name: name ? (name + "[" + item[:name] + "]") : item[:name],
             value: item[:value],
             width: item[:width],
             id: item[:id],

--- a/app/views/govuk_publishing_components/components/_date_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_date_input.html.erb
@@ -1,0 +1,64 @@
+<%
+  id ||= "input-#{SecureRandom.hex(4)}"
+
+  legend_text ||= nil
+  hint ||= nil
+  error_message ||= nil
+
+  has_error = error_message
+
+  css_classes = %w(gem-c-date-input govuk-date-input)
+  css_classes << "govuk-input--error" if has_error
+  form_group_css_classes = %w(govuk-form-group)
+  form_group_css_classes << "govuk-form-group--error" if has_error
+%>
+
+<% date_input_items = [
+  { :name => "day", :width => 2 },
+  { :name => "month", :width => 2 },
+  { :name => "year", :width => 4 }
+] %>
+
+<%= content_tag :div, class: form_group_css_classes do %>
+
+  <% fieldset_content = capture do %>
+
+    <% if hint %>
+      <%= render "govuk_publishing_components/components/hint", {
+        id: id + '-hint',
+        text: hint,
+        margin_bottom: 2
+      } %>
+    <% end %>
+
+    <% if error_message %>
+      <%= render "govuk_publishing_components/components/error_message", {
+        id:  id + '-error',
+        text: error_message
+      } %>
+    <% end %>
+
+    <% date_input_items.each do |item| %>
+      <%= tag.div class: "govuk-date-input__item" do %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: item[:name].capitalize
+          },
+          has_error: has_error,
+          name: item[:name],
+          value: item[:value],
+          width: item[:width],
+          id: item[:id],
+          type: "number",
+          data: item[:data],
+          autocomplete: item[:autocomplete]
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/fieldset", {
+    legend_text: legend_text,
+    text: fieldset_content
+  } %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_fieldset.html.erb
+++ b/app/views/govuk_publishing_components/components/_fieldset.html.erb
@@ -1,7 +1,9 @@
 <% text = text || yield %>
-<fieldset class="gem-c-fieldset govuk-fieldset">
-  <legend class="govuk-fieldset__legend">
+<% describedby ||= nil %>
+<% role ||= nil %>
+<%= tag.fieldset class: "gem-c-fieldset govuk-fieldset", aria: { describedby: describedby }, role: role do %>
+  <%= tag.legend class: "govuk-fieldset__legend" do %>
     <%= legend_text %>
-  </legend>
+  <% end %>
   <%= text %>
-</fieldset>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -11,27 +11,27 @@
   hint ||= nil
   error_message ||= nil
   error_items ||= nil
-  error_style ||= nil
+  grouped ||= nil
   autofocus ||= nil
   tabindex ||= nil
   readonly ||= nil
   maxlength ||= nil
   width ||= nil
-  has_error = error_message || error_items&.any?
+  has_error ||= error_message || error_items&.any?
   hint_id = "hint-#{SecureRandom.hex(4)}"
   error_id = "error-#{SecureRandom.hex(4)}"
 
   css_classes = %w(gem-c-input govuk-input)
-  css_classes << "govuk-input--error" if has_error || error_style
+  css_classes << "govuk-input--error" if has_error
   css_classes << "govuk-input--width-#{width}" if [2, 3, 4, 5, 10, 20, 30].include?(width)
   form_group_css_classes = %w(govuk-form-group)
-  form_group_css_classes << "govuk-form-group--error" if has_error
+  form_group_css_classes << "govuk-form-group--error" if has_error && !grouped
 
   aria_described_by ||= nil
   if hint || has_error || describedby
     aria_described_by = []
     aria_described_by << hint_id if hint
-    aria_described_by << error_id if has_error
+    aria_described_by << error_id if has_error && !grouped
     aria_described_by << describedby if describedby
     aria_described_by = aria_described_by.join(" ")
   end

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -11,6 +11,7 @@
   hint ||= nil
   error_message ||= nil
   error_items ||= nil
+  error_style ||= nil
   autofocus ||= nil
   tabindex ||= nil
   readonly ||= nil
@@ -21,7 +22,7 @@
   error_id = "error-#{SecureRandom.hex(4)}"
 
   css_classes = %w(gem-c-input govuk-input)
-  css_classes << "govuk-input--error" if has_error
+  css_classes << "govuk-input--error" if has_error || error_style
   css_classes << "govuk-input--width-#{width}" if [2, 3, 4, 5, 10, 20, 30].include?(width)
   form_group_css_classes = %w(govuk-form-group)
   form_group_css_classes << "govuk-form-group--error" if has_error

--- a/app/views/govuk_publishing_components/components/docs/date_input.yml
+++ b/app/views/govuk_publishing_components/components/docs/date_input.yml
@@ -10,7 +10,7 @@ accessibility_criteria: |
   * indicate when they have focus
   * be recognisable as form input elements
   * have correctly associated labels
-  * be of the appropriate type for their use, e.g. password inputs should be of type 'password'
+  * be of the appropriate type for their use, in this case 'number'
 
   Labels use the [label component](/component-guide/label).
 
@@ -21,6 +21,9 @@ examples:
   default:
     data: {}
   with_name:
+    description: |
+      Settting a name at the component level helps generating the name for each individual input within the
+      component as follows: `custom-name[day]`, `custom-name[month]`, `custom-name[year]`
     data:
       name: "dob"
   with_legend:

--- a/app/views/govuk_publishing_components/components/docs/date_input.yml
+++ b/app/views/govuk_publishing_components/components/docs/date_input.yml
@@ -1,0 +1,34 @@
+name: Form date input
+description: Use the date input component to help users enter a memorable date or one they can easily look up.
+accessibility_criteria: |
+  Inputs in the component must:
+
+  * accept focus
+  * be focusable with a keyboard
+  * be usable with a keyboard
+  * be usable with touch
+  * indicate when they have focus
+  * be recognisable as form input elements
+  * have correctly associated labels
+  * be of the appropriate type for their use, e.g. password inputs should be of type 'password'
+
+  Labels use the [label component](/component-guide/label).
+
+  Avoid using autofocus and tabindex unless you have user research to support this behaviour.
+govuk_frontend_components:
+  - date-input
+examples:
+  default:
+    data: {}
+  with_legend:
+    data:
+      legend_text: "What is your name?"
+  with_hint:
+    data:
+      legend_text: "What is your name?"
+      hint: "For example, 31 3 1980"
+  with_error:
+    data:
+      legend_text: "What is your name?"
+      hint: "For example, 31 3 1980"
+      error_message: "Error message goes here"

--- a/app/views/govuk_publishing_components/components/docs/date_input.yml
+++ b/app/views/govuk_publishing_components/components/docs/date_input.yml
@@ -20,15 +20,35 @@ govuk_frontend_components:
 examples:
   default:
     data: {}
+  with_name:
+    data:
+      name: "dob"
   with_legend:
     data:
-      legend_text: "What is your name?"
+      legend_text: "What is your date of birth?"
   with_hint:
     data:
-      legend_text: "What is your name?"
+      legend_text: "What is your date of birth?"
       hint: "For example, 31 3 1980"
   with_error:
     data:
-      legend_text: "What is your name?"
+      legend_text: "What is your date of birth?"
       hint: "For example, 31 3 1980"
       error_message: "Error message goes here"
+  with_custom_items:
+    data:
+      legend_text: "Beth yw eich dyddiad geni?"
+      hint: "Er enghraifft, 31 3 1980"
+      items:
+        - label: Dydd
+          name: dob-dydd
+          width: 2
+          value: 31
+        - label: Mis
+          name: dob-mis
+          width: 2
+          value: 3
+        - label: Blwyddyn
+          name: dob-blwyddyn
+          width: 4
+          value: 1980

--- a/spec/components/date_input_spec.rb
+++ b/spec/components/date_input_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+describe "Date input", type: :view do
+  def component_name
+    "date_input"
+  end
+
+  it "renders with default fields when no data is given" do
+    render_component({})
+
+    assert_select ".govuk-date-input", 1
+    assert_select ".govuk-date-input__item", 3
+    assert_select ".govuk-input[type='number'].govuk-input--width-2", 2
+    assert_select ".govuk-input[type='number'].govuk-input--width-4", 1
+
+    assert_select ".govuk-date-input__item:first-child", text: "Day"
+  end
+
+  it "renders with custom name on input fields" do
+    render_component(
+      name: "dob"
+    )
+
+    assert_select ".govuk-input[name='dob[day]'].govuk-input--width-2", 1
+    assert_select ".govuk-input[name='dob[month]'].govuk-input--width-2", 1
+    assert_select ".govuk-input[name='dob[year]'].govuk-input--width-4", 1
+  end
+
+  it "renders with legend and fieldset" do
+    render_component(
+      legend_text: "What is your date of birth?"
+    )
+
+    assert_select ".govuk-fieldset[role=group] .govuk-fieldset__legend", text: "What is your date of birth?"
+    assert_select ".govuk-fieldset[role=group] .govuk-date-input", 1
+    assert_select ".govuk-fieldset[role=group] .govuk-date-input__item", 3
+  end
+
+  it "renders with hint" do
+    render_component(
+      legend_text: "What is your date of birth?",
+      hint: "For example, 31 3 1980"
+    )
+
+    assert_select ".govuk-fieldset[role=group] .govuk-hint", text: "For example, 31 3 1980"
+  end
+
+  it "renders with error message" do
+    render_component(
+      legend_text: "What is your date of birth?",
+      error_message: "Error message goes here"
+    )
+
+    assert_select ".govuk-form-group--error .govuk-fieldset[role=group] .govuk-error-message", text: "Error message goes here"
+    assert_select ".govuk-form-group--error .govuk-fieldset[role=group] .govuk-date-input__item .govuk-input--error", 3
+  end
+
+  it "renders with custom items" do
+    render_component(
+      legend_text: "What is your date of birth?",
+      items: [
+        { label: "Dydd", name: "dob-dydd", width: 2, value: 31 },
+        { label: "Mis", name: "dob-mis", width: 2, value: 3 },
+        { label: "Blwyddyn", name: "dob-blwyddyn", width: 4, value: 1980 }
+      ]
+    )
+
+    assert_select ".govuk-date-input__item:nth-child(1)", text: "Dydd"
+    assert_select ".govuk-date-input__item:nth-child(2)", text: "Mis"
+    assert_select ".govuk-date-input__item:nth-child(3)", text: "Blwyddyn"
+
+    assert_select ".govuk-input[name='dob-dydd'][value='31'].govuk-input--width-2"
+    assert_select ".govuk-input[name='dob-mis'][value='3'].govuk-input--width-2"
+    assert_select ".govuk-input[name='dob-blwyddyn'][value='1980'].govuk-input--width-4"
+  end
+end


### PR DESCRIPTION
This PR
- adds the [date input component](https://govuk-publishing-compon-pr-792.herokuapp.com/component-guide/date_input) from `govuk-frontend` and
  - updates the input component to allow `error_style` without an `error_message` (so that inputs can be styles with a thick red box without requiring an error message attached to them)
  - updates the fieldset component to support `describedby` and `role` attributes required for accessibility enhancements of the date-input component.

[Trello card](https://trello.com/c/0ZphzvRd)