### PR TITLE
Update govuk-frontend to 2.9.0

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -6,6 +6,8 @@
 @import "govuk-frontend/helpers/all";
 @import "govuk-frontend/core/all";
 
+@include _govuk-font-face-nta;
+
 .component-guide-wrapper {
   padding-bottom: $govuk-gutter * 1.5;
 }

--- a/app/views/govuk_publishing_components/components/_error_message.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_message.html.erb
@@ -6,5 +6,5 @@
 %>
 
 <%= tag.span id: id, class: css_classes do %>
-  <%= text %>
+  <span class="govuk-visually-hidden">Error:</span> <%= text %>
 <% end %>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       "integrity": "sha512-gAy4kMSPpuRJV3mwictJqlg5LhE84Vw2CydKdC4tvrLhR6+G3KW51zbL/vYujcLA2jvWOq3HMHrVeNuw+mrLVA=="
     },
     "govuk-frontend": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.5.1.tgz",
-      "integrity": "sha512-DDi1HGRTNRH/UmqOYACOR01V+aae36pnHHf5/g08spscJO5AazA/BQTenlNm8WFJ4UAeikb1TrCbgGWJE4Vypw=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.9.0.tgz",
+      "integrity": "sha512-aE8Jg82H76qpMPKtnnvZbkmDQAzAtuc5uMEffkWo0fv6sWEwTISrqUF5jXWZ8tmtdWF8JGeAp71oSCL2x+RkFg=="
     },
     "jquery": {
       "version": "1.12.4",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "accessible-autocomplete": "git://github.com/alphagov/accessible-autocomplete.git#add-multiselect-support",
-    "govuk-frontend": "^2.5.1",
+    "govuk-frontend": "2.9.0",
     "jquery": "1.12.4",
-    "axe-core": "^3.2.2"
+    "axe-core": "3.2.2"
   }
 }

--- a/spec/components/date_input_spec.rb
+++ b/spec/components/date_input_spec.rb
@@ -51,7 +51,7 @@ describe "Date input", type: :view do
       error_message: "Error message goes here"
     )
 
-    assert_select ".govuk-form-group--error .govuk-fieldset[role=group] .govuk-error-message", text: "Error message goes here"
+    assert_select ".govuk-form-group--error .govuk-fieldset[role=group] .govuk-error-message", text: "Error: Error message goes here"
     assert_select ".govuk-form-group--error .govuk-fieldset[role=group] .govuk-date-input__item .govuk-input--error", 3
   end
 

--- a/spec/components/error_message_spec.rb
+++ b/spec/components/error_message_spec.rb
@@ -8,6 +8,6 @@ describe "Error message", type: :view do
   it "renders error message" do
     render_component(text: "Please enter your National Insurance number")
 
-    assert_select(".govuk-error-message", text: "Please enter your National Insurance number")
+    assert_select(".govuk-error-message", text: "Error: Please enter your National Insurance number")
   end
 end

--- a/spec/components/file_upload_spec.rb
+++ b/spec/components/file_upload_spec.rb
@@ -90,7 +90,7 @@ describe "File upload", type: :view do
     end
 
     it "renders the error message" do
-      assert_select ".govuk-error-message", text: "Please upload a file"
+      assert_select ".govuk-error-message", text: "Error: Please upload a file"
     end
 
     it "has 'aria-describedby' the error message id" do
@@ -116,7 +116,7 @@ describe "File upload", type: :view do
     end
 
     it "renders the error message" do
-      assert_select ".govuk-error-message", text: "Error item 1Error item 2"
+      assert_select ".govuk-error-message", text: "Error: Error item 1Error item 2"
     end
 
     it "has 'aria-describedby' the error message id" do

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -168,7 +168,7 @@ describe "Input", type: :view do
     end
 
     it "renders the error message" do
-      assert_select ".govuk-error-message", text: "Please enter a valid email address"
+      assert_select ".govuk-error-message", text: "Error: Please enter a valid email address"
     end
 
     it "has 'aria-describedby' the error message id" do
@@ -194,7 +194,7 @@ describe "Input", type: :view do
     end
 
     it "renders the error message" do
-      assert_select ".govuk-error-message", text: "Error item 1Error item 2"
+      assert_select ".govuk-error-message", text: "Error: Error item 1Error item 2"
     end
 
     it "has 'aria-describedby' the error message id" do

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -271,7 +271,7 @@ describe "Radio", type: :view do
       ]
     )
 
-    assert_select ".govuk-error-message", text: "Please select one option"
+    assert_select ".govuk-error-message", text: "Error: Please select one option"
 
     dom = Nokogiri::HTML(rendered)
     error_id = dom.xpath('//span')[0].attr('id')
@@ -295,7 +295,7 @@ describe "Radio", type: :view do
       ]
     )
 
-    assert_select ".govuk-error-message", text: "Please select one option"
+    assert_select ".govuk-error-message", text: "Error: Please select one option"
 
     dom = Nokogiri::HTML(rendered)
     hint_id = dom.xpath('//span')[0].attr('id')
@@ -327,7 +327,7 @@ describe "Radio", type: :view do
       ]
     )
 
-    assert_select ".govuk-error-message", text: "Error item 1Error item 2"
+    assert_select ".govuk-error-message", text: "Error: Error item 1Error item 2"
   end
 
   it "renders radio-group with welsh translated 'or'" do

--- a/spec/components/textarea_spec.rb
+++ b/spec/components/textarea_spec.rb
@@ -129,7 +129,7 @@ describe "Textarea", type: :view do
     end
 
     it "renders the error message" do
-      assert_select ".govuk-error-message", text: "Please enter more detail"
+      assert_select ".govuk-error-message", text: "Error: Please enter more detail"
     end
 
     it "has 'aria-describedby' the error message id" do
@@ -155,7 +155,7 @@ describe "Textarea", type: :view do
     end
 
     it "renders the error message" do
-      assert_select ".govuk-error-message", text: "Error item 1Error item 2"
+      assert_select ".govuk-error-message", text: "Error: Error item 1Error item 2"
     end
 
     it "has 'aria-describedby' the error message id" do


### PR DESCRIPTION
This PR:
- updates this repo to use govuk-frontend v2.9.0 (and pins this version)
- updates the error_message component to add a visually hidden  "Error:" prefix to the message
- adds nta typeface to the component guide (the font is not disabled by default for projects that have compatibility with govuk_template enabled [in an effort to remove a duplicate requests](https://github.com/alphagov/govuk_publishing_components/issues/597) so we'll have to re-enable it for the component guide).

### New notable features since last update
- Prevent accidental multiple submissions of forms - this can be enabled by setting `data-prevent-double-click="true"` on a button component.
- Prefix error messages with a visually hidden "Error:" to make it clearer to users of assistive technologies - updated the error_message component to reflect this update.
- Prevent horizontal jump as scrollbars appear - this is a great feature but make sure your application doesn't rely on the `overflow` state of the document.
- Allow `initAll` to be scoped to a specific part of a page.

[See detailed changelog](https://github.com/alphagov/govuk-frontend/releases)