### PR TITLE
Add cookie banner component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## 16.7.0
-
+## Unreleased
 * Add date input component based on GOV.UK Frontend (PR #792)
+* Add cookie banner component and migrate the remaining [govuk-template.js](https://github.com/alphagov/govuk_template/blob/master/source/assets/javascripts/govuk-template.js) scripts from [govuk_template](https://github.com/alphagov/govuk_template/) (PR #795)
+
+## 16.7.0
 * Update fieldset component to use GOV.UK Frontend styles (PR #791)
 * Add width option to input component (PR #790)
 * Add tracking to toggle.js (PR #796)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,5 +334,8 @@ DEPENDENCIES
   webmock (~> 3.5.0)
   yard
 
+RUBY VERSION
+   ruby 2.6.1p33
+
 BUNDLED WITH
    1.17.3

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -1,0 +1,47 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function CookieBanner () { }
+
+  CookieBanner.prototype.start = function ($module) {
+    this.$module = $module[0]
+
+    this.$module.hideCookieMessage = this.hideCookieMessage.bind(this)
+    this.$hideLink = this.$module.querySelector('a[data-hide-cookie-banner]')
+    if (this.$hideLink) {
+      this.$hideLink.addEventListener('click', this.$module.hideCookieMessage)
+    }
+
+    this.showCookieMessage()
+  }
+
+  CookieBanner.prototype.showCookieMessage = function () {
+    var hasCookieMessage = (this.$module && window.GOVUK.cookie('seen_cookie_message') !== 'true')
+
+    if (hasCookieMessage) {
+      this.$module.style.display = 'block'
+      document.addEventListener('DOMContentLoaded', function (event) {
+        if (window.GOVUK.analytics && typeof window.GOVUK.analytics.trackEvent === 'function') {
+          window.GOVUK.analytics.trackEvent('cookieBanner', 'Cookie banner shown', {
+            value: 1,
+            nonInteraction: true
+          })
+        }
+      })
+    }
+  }
+
+  CookieBanner.prototype.hideCookieMessage = function (event) {
+    if (this.$module) {
+      this.$module.style.display = 'none'
+      window.GOVUK.cookie('seen_cookie_message', 'true', { days: 365 })
+    }
+
+    if (event.target) {
+      event.preventDefault()
+    }
+  }
+
+  Modules.CookieBanner = CookieBanner
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -1,0 +1,65 @@
+// used by the cookie banner component
+
+(function () {
+  'use strict'
+  var root = this
+  if (typeof root.GOVUK === 'undefined') { root.GOVUK = {} }
+
+  /*
+    Cookie methods
+    ==============
+
+    Usage:
+
+      Setting a cookie:
+      GOVUK.cookie('hobnob', 'tasty', { days: 30 });
+
+      Reading a cookie:
+      GOVUK.cookie('hobnob');
+
+      Deleting a cookie:
+      GOVUK.cookie('hobnob', null);
+  */
+  window.GOVUK.cookie = function (name, value, options) {
+    if (typeof value !== 'undefined') {
+      if (value === false || value === null) {
+        return window.GOVUK.setCookie(name, '', { days: -1 })
+      } else {
+        return window.GOVUK.setCookie(name, value, options)
+      }
+    } else {
+      return window.GOVUK.getCookie(name)
+    }
+  }
+
+  window.GOVUK.setCookie = function (name, value, options) {
+    if (typeof options === 'undefined') {
+      options = {}
+    }
+    var cookieString = name + '=' + value + '; path=/'
+    if (options.days) {
+      var date = new Date()
+      date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000))
+      cookieString = cookieString + '; expires=' + date.toGMTString()
+    }
+    if (document.location.protocol === 'https:') {
+      cookieString = cookieString + '; Secure'
+    }
+    document.cookie = cookieString
+  }
+
+  window.GOVUK.getCookie = function (name) {
+    var nameEQ = name + '='
+    var cookies = document.cookie.split(';')
+    for (var i = 0, len = cookies.length; i < len; i++) {
+      var cookie = cookies[i]
+      while (cookie.charAt(0) === ' ') {
+        cookie = cookie.substring(1, cookie.length)
+      }
+      if (cookie.indexOf(nameEQ) === 0) {
+        return decodeURIComponent(cookie.substring(nameEQ.length))
+      }
+    }
+    return null
+  }
+}).call(this)

--- a/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
@@ -1,0 +1,32 @@
+// used by the header navigation from govuk_template
+
+(function () {
+  'use strict'
+
+  if (document.querySelectorAll && document.addEventListener) {
+    var els = document.querySelectorAll('.js-header-toggle')
+    var i
+    var _i
+    for (i = 0, _i = els.length; i < _i; i++) {
+      els[i].addEventListener('click', function (e) {
+        e.preventDefault()
+        var target = document.getElementById(this.getAttribute('href').substr(1))
+        var targetClass = target.getAttribute('class') || ''
+        var sourceClass = this.getAttribute('class') || ''
+
+        if (targetClass.indexOf('js-visible') !== -1) {
+          target.setAttribute('class', targetClass.replace(/(^|\s)js-visible(\s|$)/, ''))
+        } else {
+          target.setAttribute('class', targetClass + ' js-visible')
+        }
+        if (sourceClass.indexOf('js-visible') !== -1) {
+          this.setAttribute('class', sourceClass.replace(/(^|\s)js-visible(\s|$)/, ''))
+        } else {
+          this.setAttribute('class', sourceClass + ' js-visible')
+        }
+        this.setAttribute('aria-expanded', this.getAttribute('aria-expanded') !== 'true')
+        target.setAttribute('aria-hidden', target.getAttribute('aria-hidden') === 'false')
+      })
+    }
+  }
+}).call(this)

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -268,7 +268,7 @@ html {
 // scss-lint:disable IdSelector
 #user-satisfaction-survey-container,
 #global-cookie-message {
-  display: none !important;
+  display: none;
 }
 // scss-lint:enable IdSelector
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -30,6 +30,7 @@
 @import "components/character-count";
 @import "components/checkboxes";
 @import "components/contents-list";
+@import "components/cookie-banner";
 @import "components/copy-to-clipboard";
 @import "components/date-input";
 @import "components/details";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -1,0 +1,18 @@
+$govuk-cookie-banner-background: #d5e8f3;
+
+.js-enabled {
+  .gem-c-cookie-banner {
+    display: none; // shown with JS, always on for non-JS
+  }
+}
+
+.gem-c-cookie-banner {
+  @include govuk-font($size: 16);
+  padding: 10px 0;
+  background-color: $govuk-cookie-banner-background;
+}
+
+.gem-c-cookie-banner__message {
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -1,0 +1,9 @@
+<%
+  id ||= 'global-cookie-message'
+  message ||= capture do %>
+  GOV.UK uses cookies to make the site simpler. <a class="govuk-link" href="https://www.gov.uk/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner clicked">Find out more about cookies</a> or <a class="govuk-link" href="#" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner hidden">hide this message</a>
+<% end %>
+
+<div id="<%= id %>" class="gem-c-cookie-banner" data-module="cookie-banner">
+  <p class="gem-c-cookie-banner__message govuk-width-container"><%= message %></p>
+</div>

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -12,8 +12,7 @@ accessibility_criteria: |
   - indicate when they have focus
 examples:
   default:
-    data:
-      id: default
+    data: {}
   custom_message:
     data:
       id: custom-message

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -1,0 +1,20 @@
+name: Cookie banner
+description: Help users manage their personal data by telling them when you store cookies on their device.
+body: |
+  Setting `data-hide-cookie-banner="true"` on any link inside the banner will overwrite the default action and when clicked will dismiss the cookie banner for a period of 365 days (approx. 1 year).
+accessibility_criteria: |
+  Text in the cookie banner must be clear and unambiguous and should provide a way to dismiss the message.
+
+  Links in the component must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - indicate when they have focus
+examples:
+  default:
+    data:
+      id: default
+  custom_message:
+    data:
+      id: custom-message
+      message: GOV.UK uses cookies to make the site simpler. <a class="govuk-link" href="https://www.gov.uk/help/cookies">Find out more about cookies</a>

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe "Cookie banner", type: :view do
+  def component_name
+    "cookie_banner"
+  end
+
+  it "renders with default values" do
+    render_component({})
+    assert_select '.gem-c-cookie-banner[id="global-cookie-message"][data-module="cookie-banner"]'
+    assert_select '.gem-c-cookie-banner__message.govuk-width-container', text: "GOV.UK uses cookies to make the site simpler. Find out more about cookies or hide this message"
+    assert_select 'a[data-hide-cookie-banner="true"]'
+  end
+
+  it "renders with custom values" do
+    render_component(id: 'custom-cookie-message', message: "Custom message")
+    assert_select '.gem-c-cookie-banner[id="custom-cookie-message"][data-module="cookie-banner"]'
+    assert_select '.gem-c-cookie-banner__message.govuk-width-container', text: "Custom message"
+  end
+end

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -1,0 +1,42 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+describe('Cookie banner component', function () {
+  'use strict'
+
+  var container
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML =
+    '<div id="global-cookie-message" class="gem-c-cookie-banner" data-module="cookie-banner">' +
+      '<p class="gem-c-cookie-banner__message govuk-width-container">' +
+        '<a class="govuk-link" href="https://www.gov.uk/help/cookies">Find out more about cookies</a> or <a class="govuk-link" href="#" data-hide-cookie-banner="true">hide this message</a>' +
+      '</p>' +
+    '</div>'
+
+    document.body.appendChild(container)
+    var element = document.querySelector('[data-module="cookie-banner"]')
+    window.GOVUK.cookie('seen_cookie_message', null)
+    new GOVUK.Modules.CookieBanner().start($(element))
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
+  it('should show the cookie banner', function () {
+    var banner = document.querySelector('[data-module="cookie-banner"]')
+    expect(window.GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
+    expect(banner).toBeVisible()
+  })
+
+  it('should hide when pressing the "hide" link', function () {
+    var banner = document.querySelector('[data-module="cookie-banner"]')
+    var link = document.querySelector('a[data-hide-cookie-banner="true"]')
+    link.dispatchEvent(new window.Event('click'))
+
+    expect(banner).toBeHidden()
+    expect(window.GOVUK.getCookie('seen_cookie_message')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Need
We need to update the cookie banner which is currently part of govuk_template. There was [an attempt to do this update in govuk_template](https://github.com/alphagov/govuk_template/pull/368), but since that's a deprecated repository we shouldn't do any new work or releases on it.

Instead, this PR moves [the remaining `govuk-template.js` scripts](https://github.com/alphagov/govuk_template/blob/master/source/assets/javascripts/govuk-template.js) into `app/assets/javascripts/govuk_publishing_components/lib/` and extracts the cookie banner into its own component.

## Complementary work
A follow up PR will come after this, updating static to remove `govuk-template.js` and the associated markup for the cookie banner and replace it with this component.

Update: PR in static https://github.com/alphagov/static/pull/1662

[Trello card](https://trello.com/c/y8JyxGL9)