### PR TITLE
Add disabled attribute to checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+* Add disabled attribute to checkbox items
+
 ## 16.7.0
 
 * Update fieldset component to use GOV.UK Frontend styles (PR #791)

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -219,6 +219,19 @@ examples:
           value: "irish"
         - label: "Other"
           value: "other"
+  checkbox_items_with_disabled_items:
+    data:
+      name: "planet"
+      heading: "What is favourite planet?"
+      hint_text: "You can't choose a dwarf planet"
+      items:
+        - label: "Earth"
+          value: "earth"
+        - label: "Mars"
+          value: "mars"
+        - label: "Pluto"
+          value: "pluto"
+          disabled: true
   checkbox_items_with_nested_checkboxes:
     data:
       name: "favourite_colour"

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -63,11 +63,12 @@ module GovukPublishingComponents
         controls = checkbox[:conditional].present? ? "#{checkbox_id}-conditional-#{index || rand(1..100)}" : checkbox[:controls]
         checkbox_name = checkbox[:name].present? ? checkbox[:name] : @name
         checked = true if checkbox[:checked].present?
+        disabled = true if checkbox[:disabled].present?
         data = checkbox[:data_attributes] || {}
         data[:controls] = controls
 
         capture do
-          concat check_box_tag checkbox_name, checkbox[:value], checked, class: "govuk-checkboxes__input", id: checkbox_id, data: data
+          concat check_box_tag checkbox_name, checkbox[:value], checked, disabled: disabled, class: "govuk-checkboxes__input", id: checkbox_id, data: data
           concat content_tag(:label, checkbox[:label], for: checkbox_id, class: "govuk-label govuk-checkboxes__label")
           concat content_tag(:span, checkbox[:hint], id: "#{checkbox_id}-item-hint", class: "govuk-hint govuk-checkboxes__hint") if checkbox[:hint]
         end

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -324,4 +324,18 @@ describe "Checkboxes", type: :view do
     assert_select ".govuk-checkboxes.govuk-checkboxes--nested"
     assert_select ".govuk-checkboxes.govuk-checkboxes--nested input[value=light_red]"
   end
+
+  it "renders checkboxes with disabled attribute applied" do
+    render_component(
+      name: "planet",
+      heading: "What is your favourite planet?",
+      hint_text: "Choose carefully",
+      items: [
+        { label: "Earth", value: "Earth" },
+        { label: "Pluto", value: "pluto", disabled: true },
+      ]
+    )
+    assert_select ".govuk-checkboxes__input[disabled]", value: 'pluto'
+  end
+
 end


### PR DESCRIPTION
This adds a disabled attribute option to checkbox items.

<img width="987" alt="Screen Shot 2019-03-22 at 16 34 09" src="https://user-images.githubusercontent.com/8124374/54838878-909b3280-4cc1-11e9-8ff1-24044aeadc64.png">

Trello: https://trello.com/c/qBt4q04L/548.