### PR TITLE
Control when checkboxes change event sends tracking info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Control when checkboxes change event sends Google Analytics tracking info (PR #801)
+
 ## 16.8.0
 
 * Add date input component based on GOV.UK Frontend (PR #792)

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -25,26 +25,29 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       $(scope).on('change', 'input[type=checkbox]', function(e) {
         if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
-          var $checkbox = $(e.target);
-          var category = $checkbox.data("track-category");
-          if (typeof category !== "undefined") {
-            var isChecked = $checkbox.is(":checked");
-            var uncheckTrackCategory = $checkbox.data("uncheck-track-category");
-            if (!isChecked && typeof uncheckTrackCategory !== "undefined") {
-              category = uncheckTrackCategory;
+          // where checkboxes are manipulated externally in finders, suppressAnalytics
+          // is passed to prevent duplicate GA events
+          if(typeof e.suppressAnalytics === 'undefined' || e.suppressAnalytics !== true ) {
+            var $checkbox = $(e.target);
+            var category = $checkbox.data("track-category");
+            if (typeof category !== "undefined") {
+              var isChecked = $checkbox.is(":checked");
+              var uncheckTrackCategory = $checkbox.data("uncheck-track-category");
+              if (!isChecked && typeof uncheckTrackCategory !== "undefined") {
+                category = uncheckTrackCategory;
+              }
+              var action = $checkbox.data("track-action");
+              var options = $checkbox.data("track-options");
+              if (typeof options !== 'object' || options === null) {
+                options = {};
+              }
+              options['value'] = $checkbox.data("track-value");
+              options['label'] = $checkbox.data("track-label");
+              GOVUK.analytics.trackEvent(category, action, options);
             }
-            var action = $checkbox.data("track-action");
-            var options = $checkbox.data("track-options");
-            if (typeof options !== 'object' || options === null) {
-              options = {};
-            }
-            options['value'] = $checkbox.data("track-value");
-            options['label'] = $checkbox.data("track-label");
-            GOVUK.analytics.trackEvent(category, action, options);
           }
         }
       });
-
     };
 
     this.toggleNestedCheckboxes = function(scope, checkbox) {

--- a/spec/javascripts/components/checkboxes-spec.js
+++ b/spec/javascripts/components/checkboxes-spec.js
@@ -133,4 +133,26 @@ describe("Checkboxes component", function () {
     expect($checkbox.is(":checked")).toBe(false);
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith("unselectedFavouriteColour", "favourite-color", expectedBlueOptions);
   });
+
+  describe('controlling Google analytics track event when a checkbox is changed', function () {
+    it('fires a Google analytics event if suppressAnalytics not passed to the change event', function () {
+      $checkbox = $checkboxesWrapper.find(":input[value='blue']");
+      $checkbox.trigger("change");
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalled();
+    })
+
+    it('fires a Google analytics event if suppressAnalytics is set to false and passed to the change event', function () {
+      $checkbox = $checkboxesWrapper.find(":input[value='blue']");
+      fakeOnChangeEvent = { type: "change", suppressAnalytics: false};
+      $checkbox.trigger(fakeOnChangeEvent);
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalled();
+    })
+
+    it('does not fire a Google analytics event if suppressAnalytics is passed to the change event', function () {
+      $checkbox = $checkboxesWrapper.find(":input[value='blue']");
+      fakeOnChangeEvent = { type: "change", suppressAnalytics: true};
+      $checkbox.trigger(fakeOnChangeEvent);
+      expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled();
+    })
+  });
 });


### PR DESCRIPTION
There are some cases where you might not want to track the change to the
checkboxes. For example, an event being triggered from another component
which unticks/ticks a checkbox like finder-frontend has. Facet tags
when clicked untickes the relevant checkbox and tracks the change.

https://trello.com/c/7vQb8Yww/434-bug-fix-issue-where-use-of-brexit-checkbox-fires-multiple-ga-events

Will be needed for https://github.com/alphagov/finder-frontend/pull/984
