### PR TITLE
Adds small form option to subscription component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## Unreleased
 
 * Control when checkboxes change event sends Google Analytics tracking info (PR #801)
+* Updates govuk-frontend from 2.5.1 to 2.9.0 (PR #794)
+* Adds small form option to subscription component (PR #803)
 
 ## 16.8.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -1,6 +1,6 @@
 .gem-c-subscription-links {
   @include govuk-text-colour;
-  @include bold-19;
+  @include govuk-font(19, $weight: bold);
 
   .gem-c-subscription-links__hidden-header {
     @include govuk-visually-hidden;
@@ -8,15 +8,15 @@
 
   .gem-c-subscription-links__list {
     list-style: none;
-    margin: 0 (-$gutter-half / 2);
+    margin: 0 (-govuk-spacing(3) / 2);
     padding: 0;
   }
 
   .gem-c-subscription-links__list-item {
     display: inline-block;
-    margin-left: $gutter-half / 2;
-    margin-right: $gutter-half / 2;
-    margin-bottom: $gutter-half;
+    margin-left: govuk-spacing(2);
+    margin-right: govuk-spacing(2);
+    margin-bottom: govuk-spacing(3);
   }
 
   .gem-c-subscription-links__link {
@@ -49,13 +49,13 @@
 
     @include device-pixel-ratio() {
       background-image: image-url("govuk_publishing_components/mail-icon-x2.png");
-      background-size: 20px 14px;
+      background-size: govuk-spacing(4) govuk-spacing(3);
     }
   }
 
   .gem-c-subscription-links__feed-box {
-    padding: $gutter-half;
-    margin-bottom: $gutter-half;
+    padding: govuk-spacing(3);
+    margin-bottom: govuk-spacing(3);
     background: $grey-3;
 
     .js-enabled &.js-hidden {
@@ -65,6 +65,10 @@
 
   .gem-c-subscription-links__feed-hidden-description {
     @include govuk-visually-hidden;
+  }
+
+  .gem-c-subscription-links--small {
+    @include govuk-font(16);
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -22,7 +22,6 @@
   .gem-c-subscription-links__link {
     @extend %govuk-link;
     text-decoration: none;
-    padding-left: 28px;
     background-repeat: no-repeat;
     background-position: 0 20%;
 
@@ -33,6 +32,7 @@
 
   .gem-c-subscription-links__link--feed {
     background-image: image-url("govuk_publishing_components/feed-icon-black.png");
+    padding-left: govuk-spacing(4);
 
     // if this is a toggle, only show if js is enabled
     &[data-controls] {
@@ -46,6 +46,7 @@
 
   .gem-c-subscription-links__link--email-alerts {
     background-image: image-url("govuk_publishing_components/mail-icon.png");
+    padding-left: govuk-spacing(5);
 
     @include device-pixel-ratio() {
       background-image: image-url("govuk_publishing_components/mail-icon-x2.png");

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -12,6 +12,10 @@
     padding: 0;
   }
 
+  .gem-c-subscription-links__list--small {
+    @include govuk-font(16);
+  }
+
   .gem-c-subscription-links__list-item {
     display: inline-block;
     margin-left: govuk-spacing(2);
@@ -66,10 +70,6 @@
 
   .gem-c-subscription-links__feed-hidden-description {
     @include govuk-visually-hidden;
-  }
-
-  .gem-c-subscription-links--small {
-    @include govuk-font(16);
   }
 }
 

--- a/app/views/govuk_publishing_components/components/_subscription-links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription-links.html.erb
@@ -16,7 +16,7 @@
   <%= tag.section class: css_classes, data: data do %>
     <h2 class="gem-c-subscription-links__hidden-header visuallyhidden"><%= t("govuk_component.subscription_links.subscriptions", default: "Subscriptions") %></h2>
     <ul
-      class="gem-c-subscription-links__list"
+      class="gem-c-subscription-links__list<%= ' gem-c-subscription-links--small' if local_assigns[:small_form] == true %>"
       <%= "data-module=track-click" if sl_helper.tracking_is_present? %>
     >
       <% if sl_helper.email_signup_link.present? %>

--- a/app/views/govuk_publishing_components/components/_subscription-links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription-links.html.erb
@@ -16,7 +16,7 @@
   <%= tag.section class: css_classes, data: data do %>
     <h2 class="gem-c-subscription-links__hidden-header visuallyhidden"><%= t("govuk_component.subscription_links.subscriptions", default: "Subscriptions") %></h2>
     <ul
-      class="gem-c-subscription-links__list<%= ' gem-c-subscription-links--small' if local_assigns[:small_form] == true %>"
+      class="gem-c-subscription-links__list<%= ' gem-c-subscription-links__list--small' if local_assigns[:small_form] == true %>"
       <%= "data-module=track-click" if sl_helper.tracking_is_present? %>
     >
       <% if sl_helper.email_signup_link.present? %>

--- a/app/views/govuk_publishing_components/components/docs/subscription-links.yml
+++ b/app/views/govuk_publishing_components/components/docs/subscription-links.yml
@@ -72,3 +72,9 @@ examples:
           dimension29: 'dimension29feedLink'
         }
       }
+  as_small_form:
+    data:
+      email_signup_link: '/foreign-travel-advice/singapore/email-signup'
+      feed_link: '/foreign-travel-advice/singapore.atom'
+      small_form: true
+

--- a/spec/components/subscription_links_spec.rb
+++ b/spec/components/subscription_links_spec.rb
@@ -78,4 +78,9 @@ describe "subscription links", type: :view do
     assert_select ".gem-c-subscription-links[data-module=\"gem-toggle\"]"
     assert_select ".gem-c-subscription-links__list[data-module=\"track-click\"] .gem-c-subscription-links__link--feed[data-track-category=\"test\"]"
   end
+
+  it "adds small form modifier to the list of links" do
+    render_component(email_signup_link: 'email-signup', feed_link: 'singapore.atom', small_form: true)
+    assert_select ".gem-c-subscription-links__list--small"
+  end
 end


### PR DESCRIPTION
In finder-frontend, we needed the subscriptions component to be less "shouty" and be less prominent on the page. The component is used in three other repositories. This PR creates a 'small form' version by making the font smaller and not bold.

- updates css to use govuk-frontend mixins
- add small form option and styling
- position icons closer to the text

Component: https://govuk-publishing-compon-pr-803.herokuapp.com/component-guide/subscription-links

Demo: https://govuk-publishing-compon-pr-803.herokuapp.com/component-guide/subscription-links/as_small_form

Ticket: https://trello.com/c/nMB9EUx0/581-update-top-section-of-results-layout