### PR TITLE
Suppress subscription components heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Control when checkboxes change event sends Google Analytics tracking info (PR #801)
 * Updates govuk-frontend from 2.5.1 to 2.9.0 (PR #794)
 * Adds small form option to subscription component (PR #803)
+* Suppress subscription components heading (PR #804)
 
 ## 16.8.0
 

--- a/app/views/govuk_publishing_components/components/_subscription-links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription-links.html.erb
@@ -11,10 +11,13 @@
   css_classes << (shared_helper.get_margin_bottom) unless local_assigns[:margin_bottom] == 0
   css_classes << brand_helper.brand_class
   data = {"module": "gem-toggle"} if sl_helper.feed_link_box_value
+  hide_heading ||= false
 %>
 <% if sl_helper.component_data_is_valid? %>
   <%= tag.section class: css_classes, data: data do %>
-    <h2 class="gem-c-subscription-links__hidden-header visuallyhidden"><%= t("govuk_component.subscription_links.subscriptions", default: "Subscriptions") %></h2>
+    <% unless hide_heading %>
+      <h2 class="gem-c-subscription-links__hidden-header visuallyhidden"><%= t("govuk_component.subscription_links.subscriptions", default: "Subscriptions") %></h2>
+    <% end %>
     <ul
       class="gem-c-subscription-links__list<%= ' gem-c-subscription-links__list--small' if local_assigns[:small_form] == true %>"
       <%= "data-module=track-click" if sl_helper.tracking_is_present? %>

--- a/app/views/govuk_publishing_components/components/docs/subscription-links.yml
+++ b/app/views/govuk_publishing_components/components/docs/subscription-links.yml
@@ -1,5 +1,7 @@
 name: Subscription links
 description: Links to ‘Get email alerts’ and ‘Subscribe to feed’
+body: |
+  <strong>NOTE: This component includes a h2 heading by default but can be suppressed by using `hide_heading` option (see below)<strong>
 accessibility_criteria: |
   Icons in subscription links must be presentational and ignored by screen readers.
 
@@ -77,4 +79,11 @@ examples:
       email_signup_link: '/foreign-travel-advice/singapore/email-signup'
       feed_link: '/foreign-travel-advice/singapore.atom'
       small_form: true
-
+  without_heading:
+    description: |
+      By default the component includes an h2 heading. The component could be used anywhere on the page and could mean
+      that it produces invalid markup or make the site unaccessible.
+    data:
+      email_signup_link: '/foreign-travel-advice/singapore/email-signup'
+      feed_link: '/foreign-travel-advice/singapore.atom'
+      hide_heading: true

--- a/spec/components/subscription_links_spec.rb
+++ b/spec/components/subscription_links_spec.rb
@@ -83,4 +83,21 @@ describe "subscription links", type: :view do
     render_component(email_signup_link: 'email-signup', feed_link: 'singapore.atom', small_form: true)
     assert_select ".gem-c-subscription-links__list--small"
   end
+
+  describe 'component heading' do
+    it 'renders a heading by default' do
+      render_component(email_signup_link: 'email-signup', feed_link: 'singapore.atom')
+      assert_select "h2.gem-c-subscription-links__hidden-header"
+    end
+
+    it 'renders a heading by default' do
+      render_component(email_signup_link: 'email-signup', feed_link: 'singapore.atom', hide_heading: false)
+      assert_select "h2.gem-c-subscription-links__hidden-header"
+    end
+
+    it 'renders without a heading' do
+      render_component(email_signup_link: 'email-signup', feed_link: 'singapore.atom', hide_heading: true)
+      assert_select "h2.gem-c-subscription-links__hidden-header", false
+    end
+  end
 end


### PR DESCRIPTION
For some unknown reason this component includes a h2 heading by default.
This means that if a service uses it unexpectedly it will include the heading.
It also stops a team from using this component anywhere else on a page.

By using the 'hide_heading' option, it will suppress the heading when
the component is being rendered.

Component: https://govuk-publishing-compon-pr-804.herokuapp.com/component-guide/subscription-links

Demo: https://govuk-publishing-compon-pr-804.herokuapp.com/component-guide/subscription-links/without_heading

Ticket: https://trello.com/c/nMB9EUx0/581-update-top-section-of-results-layout