### PR TITLE
 Update the modal component to prevent the page from scrolling behind it when open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Updates govuk-frontend from 2.5.1 to 2.9.0 (PR #794)
 * Adds small form option to subscription component (PR #803)
 * Suppress subscription components heading (PR #804)
+* Update the modal component to prevent the page from scrolling behind it when open (PR #805)
 
 ## 16.8.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/modal-dialogue.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/modal-dialogue.js
@@ -8,6 +8,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module = $module[0]
     this.$dialogBox = this.$module.querySelector('.gem-c-modal-dialogue__box')
     this.$closeButton = this.$module.querySelector('.gem-c-modal-dialogue__close-button')
+    this.$html = document.querySelector('html')
     this.$body = document.querySelector('body')
 
     this.$module.open = this.handleOpen.bind(this)
@@ -33,8 +34,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       event.preventDefault()
     }
 
-    this.$body.classList.add('app-o-template__body--modal')
-    this.$body.classList.add('app-o-template__body--blur')
+    this.$html.classList.add('gem-o-template--modal')
+    this.$body.classList.add('gem-o-template__body--modal')
+    this.$body.classList.add('gem-o-template__body--blur')
     this.$focusedElementBeforeOpen = document.activeElement
     this.$module.style.display = 'block'
     this.$dialogBox.focus()
@@ -47,8 +49,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       event.preventDefault()
     }
 
-    this.$body.classList.remove('app-o-template__body--modal')
-    this.$body.classList.remove('app-o-template__body--blur')
+    this.$html.classList.remove('gem-o-template--modal')
+    this.$body.classList.remove('gem-o-template__body--modal')
+    this.$body.classList.remove('gem-o-template__body--blur')
     this.$module.style.display = 'none'
     this.$focusedElementBeforeOpen.focus()
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_modal-dialogue.scss
@@ -72,11 +72,17 @@ $govuk-modal-wide-breakpoint: $govuk-page-width + $govuk-modal-margin * 2 + $gov
   touch-action: none;
 }
 
-.app-o-template__body--modal {
+.gem-o-template--modal {
+  @include govuk-media-query($media-type: screen) {
+    overflow-y: inherit;
+  }
+}
+
+.gem-o-template__body--modal {
   overflow: hidden;
 }
 
-.app-o-template__body--blur {
+.gem-o-template__body--blur {
   .govuk-skip-link,
   .govuk-header,
   .govuk-phase-banner,


### PR DESCRIPTION
govuk-frontend v2.8.0 introduces an `overflow-y: scroll` for `.govuk-template` that needs to be overwritten when the modal opens otherwise the content will scroll behind the modal. https://github.com/alphagov/govuk-frontend/pull/1230