### PR TITLE
Use relative url for cookies page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unrelease
 
 * Fix margin spacing for small form subscription links (PR #808)
+* Use relative path for linking to the cookies help page from the Cookie banner (PR #807)
 
 ## 16.9.0
 

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -1,7 +1,7 @@
 <%
   id ||= 'global-cookie-message'
   message ||= capture do %>
-  GOV.UK uses cookies to make the site simpler. <a class="govuk-link" href="https://www.gov.uk/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner clicked">Find out more about cookies</a> or <a class="govuk-link" href="#" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner hidden">hide this message</a>
+  GOV.UK uses cookies to make the site simpler. <a class="govuk-link" href="/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner clicked">Find out more about cookies</a> or <a class="govuk-link" href="#" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner hidden">hide this message</a>
 <% end %>
 
 <div id="<%= id %>" class="gem-c-cookie-banner" data-module="cookie-banner">

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -16,4 +16,4 @@ examples:
   custom_message:
     data:
       id: custom-message
-      message: GOV.UK uses cookies to make the site simpler. <a class="govuk-link" href="https://www.gov.uk/help/cookies">Find out more about cookies</a>
+      message: GOV.UK uses cookies to make the site simpler. <a class="govuk-link" href="/help/cookies">Find out more about cookies</a>

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -11,7 +11,7 @@ describe('Cookie banner component', function () {
     container.innerHTML =
     '<div id="global-cookie-message" class="gem-c-cookie-banner" data-module="cookie-banner">' +
       '<p class="gem-c-cookie-banner__message govuk-width-container">' +
-        '<a class="govuk-link" href="https://www.gov.uk/help/cookies">Find out more about cookies</a> or <a class="govuk-link" href="#" data-hide-cookie-banner="true">hide this message</a>' +
+        '<a class="govuk-link" href="/help/cookies">Find out more about cookies</a> or <a class="govuk-link" href="#" data-hide-cookie-banner="true">hide this message</a>' +
       '</p>' +
     '</div>'
 


### PR DESCRIPTION
Using the full URL triggers the external link tracking on GOV.UK


<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->