### PR TITLE
fix margin spacing for small form subscription links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unrelease
+
+* Fix margin spacing for small form subscription links (PR #808)
+
 ## 16.9.0
 
 * Control when checkboxes change event sends Google Analytics tracking info (PR #801)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -23,6 +23,21 @@
     margin-bottom: govuk-spacing(3);
   }
 
+  .gem-c-subscription-links__list-item--small {
+    display: inline-block;
+    margin-left: 0;
+    margin-right: 0;
+    margin-bottom: govuk-spacing(2);
+
+    &:first-child {
+      margin-right: govuk-spacing(2);
+    }
+
+    &:only-child {
+      margin-right: 0;
+    }
+  }
+
   .gem-c-subscription-links__link {
     @extend %govuk-link;
     text-decoration: none;

--- a/app/views/govuk_publishing_components/components/_subscription-links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription-links.html.erb
@@ -23,7 +23,7 @@
       <%= "data-module=track-click" if sl_helper.tracking_is_present? %>
     >
       <% if sl_helper.email_signup_link.present? %>
-        <li class="gem-c-subscription-links__list-item">
+        <li class="gem-c-subscription-links__list-item<%= ' gem-c-subscription-links__list-item--small' if local_assigns[:small_form] == true %>" >
           <%= link_to sl_helper.email_signup_link_text, sl_helper.email_signup_link,
             class: "gem-c-subscription-links__link gem-c-subscription-links__link--email-alerts #{brand_helper.color_class}",
             data: sl_helper.email_signup_link_data_attributes
@@ -32,7 +32,7 @@
       <% end %>
 
       <% if sl_helper.feed_link_box_value || sl_helper.feed_link %>
-        <li class="gem-c-subscription-links__list-item">
+        <li class="gem-c-subscription-links__list-item<%= ' gem-c-subscription-links__list-item--small' if local_assigns[:small_form] == true %>">
           <%= link_to sl_helper.feed_link_text, sl_helper.feed_link,
             class: "gem-c-subscription-links__link gem-c-subscription-links__link--feed #{brand_helper.color_class}",
             data: sl_helper.feed_link_data_attributes

--- a/spec/components/subscription_links_spec.rb
+++ b/spec/components/subscription_links_spec.rb
@@ -82,6 +82,7 @@ describe "subscription links", type: :view do
   it "adds small form modifier to the list of links" do
     render_component(email_signup_link: 'email-signup', feed_link: 'singapore.atom', small_form: true)
     assert_select ".gem-c-subscription-links__list--small"
+    assert_select ".gem-c-subscription-links__list-item--small"
   end
 
   describe 'component heading' do


### PR DESCRIPTION
there no need for the far left/right margin to be applied to small form subscription links. If space is needed it can be done by wrapping an element around this component and applying a maring left/right to it
