### PR TITLE
Correct breadcrumb structured data for missing URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Correct breadcrumb structured data for missing URL (PR #810)
+
 ## 16.9.1
 
 * Fix margin spacing for small form subscription links (PR #808)

--- a/lib/govuk_publishing_components/presenters/breadcrumbs.rb
+++ b/lib/govuk_publishing_components/presenters/breadcrumbs.rb
@@ -19,9 +19,9 @@ module GovukPublishingComponents
       attr_reader :breadcrumbs, :request_path
 
       def item_list_element
-        breadcrumbs.each_with_index.map do |crumb, index|
-          Breadcrumb.new(crumb, index).item_list_element(@request_path)
-        end
+        breadcrumbs.each_with_index.map { |crumb, index| Breadcrumb.new(crumb, index) }.
+          select(&:is_link?).
+          map { |breadcrumb| breadcrumb.item_list_element(@request_path) }
       end
     end
 

--- a/spec/components/breadcrumbs_spec.rb
+++ b/spec/components/breadcrumbs_spec.rb
@@ -38,6 +38,20 @@ describe "Breadcrumbs", type: :view do
     expect(structured_data["itemListElement"][2]["item"]["name"]).to eq("Section 3")
   end
 
+  it "omits breadcrumb structured data when no url is present" do
+    breadcrumbs = [
+      { title: 'Section 1', url: '/section-1' },
+      { title: 'Section 2' },
+    ]
+    structured_data = GovukPublishingComponents::Presenters::Breadcrumbs.new(breadcrumbs, "/section-3").structured_data
+    expect(structured_data["@type"]).to eq("BreadcrumbList")
+    expect(structured_data["itemListElement"].count).to eq(1)
+    expect(structured_data["itemListElement"].first["@type"]).to eq("ListItem")
+    expect(structured_data["itemListElement"].first["position"]).to eq(1)
+    expect(structured_data["itemListElement"].first["item"]["@id"]).to eq("http://www.dev.gov.uk/section-1")
+    expect(structured_data["itemListElement"].first["item"]["name"]).to eq("Section 1")
+  end
+
   it "renders all data attributes for tracking" do
     render_component(breadcrumbs: [{ title: 'Section', url: '/section' }])
 


### PR DESCRIPTION
This makes no change to the markup versions of breadcrumbs.

When using the pattern of [last breadcrumb is current page](https://govuk-publishing-components.herokuapp.com/component-guide/breadcrumbs/last_breadcrumb_is_current_page) structured data is generated that fails the [Google structured data testing tool's validation](https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Fwww.gov.uk%2Fprepare-eu-exit/).  

To fix this, we omit breadcrumb items with no url from the structured data.
