### PR TITLE
Expose API to change modal size to narrow/wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+- Support dynamic resizing of the modal component (PR #812)
+
 ## 16.9.2
 
 * Correct breadcrumb structured data for missing URL (PR #810)

--- a/app/assets/javascripts/govuk_publishing_components/components/modal-dialogue.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/modal-dialogue.js
@@ -11,6 +11,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$html = document.querySelector('html')
     this.$body = document.querySelector('body')
 
+    this.$module.resize = this.handleResize.bind(this)
     this.$module.open = this.handleOpen.bind(this)
     this.$module.close = this.handleClose.bind(this)
     this.$module.focusDialog = this.handleFocusDialog.bind(this)
@@ -26,6 +27,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     if (this.$closeButton) {
       this.$closeButton.addEventListener('click', this.$module.close)
+    }
+  }
+
+  ModalDialogue.prototype.handleResize = function (size) {
+    if (size == "narrow") {
+      this.$dialogBox.classList.remove('gem-c-modal-dialogue__box--wide')
+    }
+
+    if (size == "wide") {
+      this.$dialogBox.classList.add('gem-c-modal-dialogue__box--wide')
     }
   }
 

--- a/spec/javascripts/components/modal-dialogue-spec.js
+++ b/spec/javascripts/components/modal-dialogue-spec.js
@@ -76,6 +76,25 @@ describe('Modal dialogue component', function () {
     })
   })
 
+  describe('resize', function () {
+    it('should resize the modal to full width', function () {
+      var modal = document.querySelector('.gem-c-modal-dialogue')
+      modal.resize('wide')
+
+      var dialogBox = modal.querySelector('.gem-c-modal-dialogue__box')
+      expect(dialogBox).toHaveClass('gem-c-modal-dialogue__box--wide')
+    })
+
+    it('should resize the modal to narrow width', function () {
+      var modal = document.querySelector('.gem-c-modal-dialogue')
+      modal.resize('wide')
+      modal.resize('narrow')
+
+      var dialogBox = modal.querySelector('.gem-c-modal-dialogue__box')
+      expect(dialogBox).not.toHaveClass('gem-c-modal-dialogue__box--wide')
+    })
+  })
+
   describe('open', function () {
     beforeEach(function () {
       var modal = document.querySelector('.gem-c-modal-dialogue')


### PR DESCRIPTION
https://trello.com/c/4kQa7EZO/762-allow-users-embed-videos

This adds an API to the modal object to support dynamically changing its
size, in order to accommodate different workflows that are presented in
a single modal instance using the multi-section-viewer component.

<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->
