### PR TITLE
Upgrade to govuk-frontend 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Upgrade to govuk-frontend 2.10.0 (PR #817)
+
 ## 16.10.1
 
 - Enforce compatibility with deprecated packages for media print stylesheet (PR #815)

--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -1,4 +1,5 @@
 <%
+  # cb_helper.css_classes generates "gem-c-checkboxes"
   cb_helper = GovukPublishingComponents::Presenters::CheckboxesHelper.new(local_assigns)
   id = cb_helper.id
 %>
@@ -17,7 +18,7 @@
           <%= tag.span error, id: "#{id}-error", class: "govuk-error-message" %>
         <% end %>
 
-        <%= tag.ul class: "govuk-checkboxes gem-c-checkboxes__list", data: {
+        <%= tag.ul class: cb_helper.list_classes, data: {
           module: ('checkboxes' if cb_helper.has_conditional),
           nested: ('true' if cb_helper.has_nested),
         } do %>

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -4,6 +4,7 @@
 
   label ||= nil
   heading ||= nil
+  small ||= false
   is_page_heading ||= false
   hint ||= nil
   error_message ||= nil
@@ -15,6 +16,9 @@
 
   form_group_css_classes = %w(govuk-form-group)
   form_group_css_classes << "govuk-form-group--error" if has_error
+
+  radio_classes = %w(govuk-radios)
+  radio_classes << "govuk-radios--small" if small
 
   aria = "#{hint_id} #{"#{error_id}" if has_error}".strip if hint or has_error
 
@@ -53,7 +57,7 @@
       } %>
     <% end %>
 
-    <%= content_tag :div, class: "govuk-radios",
+    <%= content_tag :div, class: radio_classes,
       data: {
         module: ('radios' if has_conditional)
       } do %>

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -32,6 +32,16 @@ examples:
           value: "green"
         - label: "Blue"
           value: "blue"
+  with_small_checkboxes:
+    data:
+      name: "favourite_small_synonym"
+      heading: "What is your favourite synonym for small?"
+      small: true
+      items:
+        - label: "Tiny"
+          value: "tiny"
+        - label: "Little"
+          value: "little"
   with_a_heading_on_one_checkbox:
     description: One checkbox does not require a fieldset and therefore does not require a legend. However, if a heading is supplied, a fieldset will be included in the component and the heading used as the legend, as shown.
     data:

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -44,6 +44,15 @@ examples:
         text: "Use Government Gateway"
       - value: "govuk-verify"
         text: "Use GOV.UK Verify"
+  with_small_radios:
+    data:
+      name: "radio-group"
+      small: true
+      items:
+      - value: "government-gateway"
+        text: "Use Government Gateway"
+      - value: "govuk-verify"
+        text: "Use GOV.UK Verify"
   with_bold:
     description: 'Used to provide better contrast between long labels and hint text, Note that the `:or` option [is documented as a string due to a bug](https://github.com/alphagov/govuk_publishing_components/issues/102)'
     data:

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
       include ActionView::Helpers
       include ActionView::Context
 
-      attr_reader :items, :name, :css_classes, :error, :has_conditional, :has_nested, :id, :hint_text
+      attr_reader :items, :name, :css_classes, :list_classes, :error, :has_conditional, :has_nested, :id, :hint_text
 
       def initialize(options)
         @items = options[:items] || []
@@ -12,6 +12,9 @@ module GovukPublishingComponents
         @css_classes = %w(gem-c-checkboxes govuk-form-group)
         @css_classes << "govuk-form-group--error" if options[:error]
         @error = true if options[:error]
+
+        @list_classes = %w(govuk-checkboxes gem-c-checkboxes__list)
+        @list_classes << "govuk-checkboxes--small" if options[:small]
 
         # check if any item is set as being conditional
         @has_conditional = options[:items].any? { |item| item.is_a?(Hash) && item[:conditional] }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,8 +4,9 @@
   "dependencies": {
     "accessible-autocomplete": {
       "version": "git://github.com/alphagov/accessible-autocomplete.git#0c518b4fa79b9a95b544410858486ed9e6403c84",
+      "from": "git://github.com/alphagov/accessible-autocomplete.git#add-multiselect-support",
       "requires": {
-        "preact": "8.4.2"
+        "preact": "^8.3.1"
       }
     },
     "axe-core": {
@@ -14,9 +15,9 @@
       "integrity": "sha512-gAy4kMSPpuRJV3mwictJqlg5LhE84Vw2CydKdC4tvrLhR6+G3KW51zbL/vYujcLA2jvWOq3HMHrVeNuw+mrLVA=="
     },
     "govuk-frontend": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.9.0.tgz",
-      "integrity": "sha512-aE8Jg82H76qpMPKtnnvZbkmDQAzAtuc5uMEffkWo0fv6sWEwTISrqUF5jXWZ8tmtdWF8JGeAp71oSCL2x+RkFg=="
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.10.0.tgz",
+      "integrity": "sha512-Tfo76yz5ybFMX1heojeiWAyxUx0gABM2/hfMk1zu+9hWvApmfxeTaQOJkje4jeo1ybRo+FhgKFqqAzkBOOUnqg=="
     },
     "jquery": {
       "version": "1.12.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "accessible-autocomplete": "git://github.com/alphagov/accessible-autocomplete.git#add-multiselect-support",
-    "govuk-frontend": "2.9.0",
+    "govuk-frontend": "2.10.0",
     "jquery": "1.12.4",
     "axe-core": "3.2.2"
   }

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -36,6 +36,19 @@ describe "Checkboxes", type: :view do
     assert_select ".govuk-label", text: "Green"
   end
 
+  it "renders small checkboxes" do
+    render_component(
+      name: "favourite_colour",
+      heading: "What is your favourite colour?",
+      small: true,
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+      ]
+    )
+    assert_select ".govuk-checkboxes.govuk-checkboxes--small"
+  end
+
   it "renders nothing if no heading is supplied" do
     render_component(
       name: "favourite_colour",

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -53,6 +53,25 @@ describe "Radio", type: :view do
     assert_select ".govuk-radios__item:last-child .govuk-radios__label", text: "Use GOV.UK Verify"
   end
 
+  it "renders small radios" do
+    render_component(
+      name: "radio-group-multiple-items",
+      small: true,
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        },
+        {
+          value: "govuk-verify",
+          text: "Use GOV.UK Verify"
+        }
+      ]
+    )
+
+    assert_select ".govuk-radios.govuk-radios--small"
+  end
+
   it "renders radio-group with a legend" do
     render_component(
       name: "favourite-smartie",


### PR DESCRIPTION
This PR:

- updates this repo to govuk-frontend version 2.10.0
- updates the checkboxes component to have a 'small' option
- updates the radio component to have a 'small' option

[See detailed changelog](https://github.com/alphagov/govuk-frontend/releases/tag/v2.10.0)

Links:

- [small checkboxes](https://govuk-publishing-compon-pr-817.herokuapp.com/component-guide/checkboxes/with_small_checkboxes)
- [small radios](https://govuk-publishing-compon-pr-817.herokuapp.com/component-guide/radio/with_small_radios)

Trello card: https://trello.com/c/wp21yw0C/635-use-small-radios-and-checkboxes-in-finder-frontend