### PR TITLE
Fix script in header component not being compatible with the govuk_template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+- Fix script in header component not being compatible with the govuk_template script (PR #818)
 - Upgrade to govuk-frontend 2.10.0 (PR #817)
 
 ## 16.10.1

--- a/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
@@ -4,7 +4,7 @@
   'use strict'
 
   if (document.querySelectorAll && document.addEventListener) {
-    var els = document.querySelectorAll('.js-header-toggle')
+    var els = document.querySelectorAll('a.js-header-toggle')
     var i
     var _i
     for (i = 0, _i = els.length; i < _i; i++) {


### PR DESCRIPTION
Attach click event listener only to anchors.

This mitigates [an issue](https://github.com/alphagov/govuk-frontend/issues/1270) when we use `js-header-toggle` as a selector for both menu buttons coming from govuk_template (which are marked-up with `<a>`) and for menu buttons coming from govuk-frontend (marked-up with `<button>`). It doesn't affect the overall functionality but when the header component is used, the script coming from govuk_template throws and error since both scripts are attached to the same button.

The incompatibility between the two repos could be resolved in govuk-frontend, but we can prevent it in this gem by being more specific about the elements we attach the event listener to.

Before: https://govuk-publishing-components.herokuapp.com/component-guide/layout_header/with_navigation/preview

After: https://govuk-publishing-compon-pr-818.herokuapp.com/component-guide/layout_header/with_navigation/preview

**Note**
This is currently an issue only for projects using the header component or admin-layout.

[Trello card](https://trello.com/c/tw3UcDCh)