### PR TITLE
Version 16.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 16.11.0
 
 - Fix script in header component not being compatible with the govuk_template script (PR #818)
 - Upgrade to govuk-frontend 2.10.0 (PR #817)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (16.10.1)
+    govuk_publishing_components (16.11.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '16.10.1'.freeze
+  VERSION = '16.11.0'.freeze
 end


### PR DESCRIPTION
- Fix script in header component not being compatible with the govuk_template script (PR #818)
- Upgrade to govuk-frontend 2.10.0 (PR #817)
