### PR TITLE
[DO NOT MERGE] Add expander component

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/expander.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/expander.js
@@ -1,0 +1,53 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none of this JS runs :(
+
+(function (Modules) {
+  function Expander () {}
+
+  Expander.prototype.start = function ($module) {
+    this.$module = $module[0] // this is the expander element
+    this.$toggle = this.$module.querySelector('.js-toggle')
+    this.$content = this.$module.querySelector('.js-content')
+
+    var openOnLoad = this.$module.getAttribute('data-open-on-load') === 'true' ? true : false
+
+    if (!openOnLoad) {
+      this.collapseContent()
+    }
+    this.replaceTitleWithButton(openOnLoad)
+
+    this.$module.toggleContent = this.toggleContent.bind(this)
+    this.$toggleButton = this.$module.querySelector('.js-button')
+    this.$toggleButton.addEventListener('click', this.$module.toggleContent)
+  }
+
+  Expander.prototype.collapseContent = function () {
+    this.$content.style.display = 'none'
+  }
+
+  Expander.prototype.replaceTitleWithButton = function (expanded) {
+    var toggleHtml = this.$toggle.innerHTML
+    var $button = document.createElement('button')
+
+    $button.classList.add('gem-c-expander__button')
+    $button.classList.add('js-button')
+    $button.setAttribute('type', 'button')
+    $button.setAttribute('aria-expanded', expanded)
+    $button.setAttribute('aria-controls', this.$content.getAttribute('id'))
+    $button.innerHTML = toggleHtml
+
+    this.$toggle.parentNode.replaceChild($button, this.$toggle)
+  }
+
+  Expander.prototype.toggleContent = function (e) {
+    if (this.$content.style.display === 'none') {
+      this.$toggleButton.setAttribute('aria-expanded', true)
+      this.$content.style.display = 'block'
+    } else {
+      this.$toggleButton.setAttribute('aria-expanded', false)
+      this.$content.style.display = 'none'
+    }
+  }
+
+  Modules.Expander = Expander
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -38,6 +38,7 @@
 @import "components/error-alert";
 @import "components/error-message";
 @import "components/error-summary";
+@import "components/expander";
 @import "components/feedback";
 @import "components/fieldset";
 @import "components/file-upload";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_expander.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_expander.scss
@@ -1,0 +1,46 @@
+.gem-c-expander {
+  border-bottom: solid 1px govuk-colour("black");
+}
+
+.gem-c-expander__title {
+  @include govuk-font(19, $weight: bold);
+  position: relative;
+  padding: govuk-spacing(2) 0 0 0;
+  cursor: pointer;
+}
+
+.gem-c-expander__content {
+  padding: govuk-spacing(2) 0;
+}
+
+.gem-c-expander__icon {
+  display: none;
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 30px;
+  height: 100%;
+  fill: currentColor;
+}
+
+.gem-c-expander__button {
+  @include govuk-font(19, $weight: bold);
+  @include govuk-focusable;
+  position: relative;
+  width: 100%;
+  border: 0;
+  padding: govuk-spacing(2) govuk-spacing(6) govuk-spacing(2) 0;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.js-enabled {
+  [aria-expanded="true"] .gem-c-expander__icon--up {
+    display: block;
+  }
+
+  [aria-expanded="false"] .gem-c-expander__icon--down {
+    display: block;
+  }
+}

--- a/app/views/govuk_publishing_components/components/_expander.html.erb
+++ b/app/views/govuk_publishing_components/components/_expander.html.erb
@@ -1,0 +1,24 @@
+<%
+  title ||= false
+  open_on_load ||= false
+  margin_bottom ||= 0
+
+  content_id = "expander-content-#{SecureRandom.hex(4)}"
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+
+  css_classes = %w( gem-c-expander )
+  css_classes << (shared_helper.get_margin_bottom) unless margin_bottom == 0
+%>
+<% if title %>
+  <%= tag.div class: css_classes, data: { module: "expander", 'open-on-load': open_on_load } do %>
+    <div class="gem-c-expander__title js-toggle">
+      <%= title %>
+      <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="gem-c-expander__icon gem-c-expander__icon--up"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
+      <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="gem-c-expander__icon gem-c-expander__icon--down"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
+    </div>
+
+    <div class="gem-c-expander__content js-content" id="<%= content_id %>">
+      <%= yield %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/expander.yml
+++ b/app/views/govuk_publishing_components/components/docs/expander.yml
@@ -1,0 +1,30 @@
+name: Expander (experimental)
+description: A block of content that can be expanded and collapsed.
+accessibility_criteria: |
+  The component must:
+
+  - indicate that it is expandable/collapsible
+  - indicate the initial state of expandable content
+  - indicate where the state of expandable content has changed
+  - be operable with a keyboard
+  - be expanded by default without Javascript enabled
+examples:
+  default:
+    data:
+      title: Organisation
+      block: |
+        This is some content that is passed to the component. It should be distinct from the component, in that the component should not style or interact with it, other than to show and hide it.
+  expand_by_default:
+    description: Shows the content by default. It can still be hidden.
+    data:
+      title: Location
+      open_on_load: true
+      block: |
+        This is some content that is passed to the component. It should be distinct from the component, in that the component should not style or interact with it, other than to show and hide it.
+  with_margin_bottom:
+    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](http://govuk-frontend-review.herokuapp.com/docs/#settings/spacing-variable-govuk-spacing-points). It defaults to a margin bottom of 0.
+    data:
+      title: Person
+      margin_bottom: 9
+      block: |
+        This is some content that is passed to the component. It should be distinct from the component, in that the component should not style or interact with it, other than to show and hide it.

--- a/spec/components/expander_spec.rb
+++ b/spec/components/expander_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe "expander", type: :view do
+  def component_name
+    "expander"
+  end
+
+  it "renders nothing without passed content" do
+    assert_empty render_component({})
+  end
+
+  it "shows the given title and content" do
+    render_component(title: "Some title") do
+      "This is more info"
+    end
+
+    assert_select ".gem-c-expander"
+    assert_select ".gem-c-expander__title", text: "Some title"
+    assert_select ".gem-c-expander__content", text: "This is more info"
+  end
+
+  it "sets open on load correctly" do
+    render_component(title: "Some title", open_on_load: true) do
+      "This is more info"
+    end
+
+    assert_select ".gem-c-expander[data-open-on-load='true']"
+  end
+
+  it "sets a margin bottom" do
+    render_component(title: "Some title", margin_bottom: 9) do
+      "This is more info"
+    end
+
+    assert_select '.gem-c-expander.govuk-\!-margin-bottom-9'
+  end
+end

--- a/spec/javascripts/components/expander-spec.js
+++ b/spec/javascripts/components/expander-spec.js
@@ -1,0 +1,75 @@
+describe('An expander module', function () {
+  "use strict";
+
+  var $element;
+  var expander;
+  var html = '\
+    <div class="gem-c-expander" data-module="expander">\
+      <div class="gem-c-expander__title js-toggle">\
+        Organisation\
+        <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="gem-c-expander__icon gem-c-expander__icon--up"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>\
+        <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="gem-c-expander__icon gem-c-expander__icon--down"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>\
+      </div>\
+      <div class="gem-c-expander__content js-content" id="expander-content-2386afad">\
+        This is some content that could appear inside this component. Its not very interesting or complicated but its still here, and thats fine.\
+      </div>\
+    </div>';
+
+  describe("a normal expander", function () {
+    beforeEach(function () {
+      expander = new GOVUK.Modules.Expander();
+      $element = $(html);
+      expander.start($element);
+    });
+
+    afterEach(function () {
+      $(document).off();
+    });
+
+    it("collapses the content on page load", function () {
+      expect($element.find('.gem-c-expander__content').css('display')).toBe('none');
+    });
+
+    it("replaces the title with a button and sets correct aria attributes", function () {
+      expect($element.find('.gem-c-expander__button').text().trim()).toBe('Organisation');
+      expect($element.find('.gem-c-expander__icon').length).toBe(2);
+      expect($element.find('.gem-c-expander__button .gem-c-expander__icon').length).toBe(2);
+      expect($element.find('.gem-c-expander__button').attr('type')).toBe('button');
+      expect($element.find('.gem-c-expander__button').attr('aria-expanded')).toBe('false');
+      expect($element.find('.gem-c-expander__button').attr('aria-controls')).toBe('expander-content-2386afad');
+    });
+
+    it("toggles the content when the button is clicked and updates aria attributes accordingly", function () {
+      var $button = $element.find('.gem-c-expander__button');
+
+      $button.click();
+      expect($element.find('.gem-c-expander__content').css('display')).toBe('block');
+      expect($element.find('.gem-c-expander__button').attr('aria-expanded')).toBe('true');
+
+      $button.click();
+      expect($element.find('.gem-c-expander__content').css('display')).toBe('none');
+      expect($element.find('.gem-c-expander__button').attr('aria-expanded')).toBe('false');
+    });
+  });
+
+  describe("an expander set to open on load", function () {
+    beforeEach(function () {
+      expander = new GOVUK.Modules.Expander();
+      $element = $(html);
+      $element.attr('data-open-on-load', true)
+      expander.start($element);
+    });
+
+    afterEach(function () {
+      $(document).off();
+    });
+
+    it("does not collapse the content on page load", function () {
+      expect($element.find('.gem-c-expander__content').css('display')).not.toBe('none');
+    });
+
+    it("sets correct aria attributes on the button", function () {
+      expect($element.find('.gem-c-expander__button').attr('aria-expanded')).toBe('true');
+    });
+  });
+});


### PR DESCRIPTION
Adds an expander component. This is a simple component that accepts a block of any content, then hides it behind a toggle button. This is intended for use in finder-frontend, to wrap search facets with.

<img width="501" alt="Screen Shot 2019-04-16 at 15 19 29" src="https://user-images.githubusercontent.com/861310/56217394-114c1500-605b-11e9-951b-392b46f6e5eb.png">

The accessibility of this component has been modelled after finder-frontend's option select component, and does the following:

- content is expanded by default if JS disabled
- toggle control is turned into a button if JS enabled
- aria-expanded and aria-controls are set accordingly

See it: https://govuk-publishing-compon-pr-820.herokuapp.com/component-guide/expander

Trello card: https://trello.com/c/bDJmf7Sq/609-prototype-the-new-facet-accordion
