### PR TITLE
Track when the cookie banner isn't shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Fire GA event when cookie banner isn't shown, instead of when it is (PR #821)
+
 ## 16.11.0
 
 - Fix script in header component not being compatible with the govuk_template script (PR #818)

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -18,17 +18,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   CookieBanner.prototype.showCookieMessage = function () {
     var hasCookieMessage = (this.$module && window.GOVUK.cookie('seen_cookie_message') !== 'true')
-
     if (hasCookieMessage) {
       this.$module.style.display = 'block'
-      document.addEventListener('DOMContentLoaded', function (event) {
-        if (window.GOVUK.analytics && typeof window.GOVUK.analytics.trackEvent === 'function') {
-          window.GOVUK.analytics.trackEvent('cookieBanner', 'Cookie banner shown', {
-            value: 1,
-            nonInteraction: true
-          })
-        }
-      })
+    } else {
+      if (window.GOVUK.analytics && typeof window.GOVUK.analytics.trackEvent === 'function') {
+        window.GOVUK.analytics.trackEvent('cookieBanner', 'Cookie banner not shown', {
+          nonInteraction: true
+        })
+      }
     }
   }
 

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -1,12 +1,19 @@
 /* eslint-env jasmine, jquery */
 /* global GOVUK */
 
-describe('Cookie banner component', function () {
+var container
+
+var GOVUK = window.GOVUK || {};
+
+GOVUK.analytics = {
+  trackEvent: function () {}
+};
+
+describe('Cookie banner is shown', function () {
   'use strict'
 
-  var container
-
   beforeEach(function () {
+    spyOn(GOVUK.analytics, 'trackEvent');
     container = document.createElement('div')
     container.innerHTML =
     '<div id="global-cookie-message" class="gem-c-cookie-banner" data-module="cookie-banner">' +
@@ -22,6 +29,7 @@ describe('Cookie banner component', function () {
   })
 
   afterEach(function () {
+    GOVUK.analytics.trackEvent.calls.reset();
     document.body.removeChild(container)
   })
 
@@ -31,6 +39,14 @@ describe('Cookie banner component', function () {
     expect(banner).toBeVisible()
   })
 
+  it('should not fire a Google Analytics event when the cookie banner is shown', function() {
+    var banner = document.querySelector('[data-module="cookie-banner"]')
+    expect(window.GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
+    expect(banner).toBeVisible()
+
+    expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled();
+  })
+
   it('should hide when pressing the "hide" link', function () {
     var banner = document.querySelector('[data-module="cookie-banner"]')
     var link = document.querySelector('a[data-hide-cookie-banner="true"]')
@@ -38,5 +54,42 @@ describe('Cookie banner component', function () {
 
     expect(banner).toBeHidden()
     expect(window.GOVUK.getCookie('seen_cookie_message')).toBeTruthy()
+  })
+})
+
+describe('Cookie banner is hidden', function() {
+  'use strict'
+
+  beforeEach(function () {
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    container = document.createElement('div')
+    container.innerHTML =
+    '<div id="global-cookie-message" class="gem-c-cookie-banner" data-module="cookie-banner">' +
+      '<p class="gem-c-cookie-banner__message govuk-width-container">' +
+        '<a class="govuk-link" href="/help/cookies">Find out more about cookies</a> or <a class="govuk-link" href="#" data-hide-cookie-banner="true">hide this message</a>' +
+      '</p>' +
+    '</div>'
+
+    document.body.appendChild(container)
+    var element = document.querySelector('[data-module="cookie-banner"]')
+    window.GOVUK.cookie('seen_cookie_message', null)
+    window.GOVUK.setCookie('seen_cookie_message', true)
+    new GOVUK.Modules.CookieBanner().start($(element))
+  })
+
+  afterEach(function () {
+    GOVUK.analytics.trackEvent.calls.reset();
+    document.body.removeChild(container)
+  })
+
+  it('should fire a Google Analytics event when the cookie banner is hidden', function() {
+    var banner = document.querySelector('[data-module="cookie-banner"]')
+    window.GOVUK.setCookie('seen_cookie_message', true)
+
+    expect(window.GOVUK.getCookie('seen_cookie_message')).toBeTruthy()
+    expect(banner).toBeHidden()
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cookieBanner', 'Cookie banner not shown', { nonInteraction: true });
   })
 })


### PR DESCRIPTION
Trello: https://trello.com/c/tOKIPmZ3/99-improve-cookie-banner-tracking

Because the cookie banner is now persistent, we'd rather track when it's not shown rather than when it is.
