### PR TITLE
Remove link to Whitehall publications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Don't include changes that are purely internal. The CHANGELOG should be a
   useful summary for people upgrading their application, not a replication
   of the commit log.
+  
+## Unreleased
+
+- Remove links to Whitehall publications (PR #823)
 
 ## 16.11.0
 

--- a/app/views/govuk_publishing_components/components/_government_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_government_navigation.html.erb
@@ -25,11 +25,6 @@
       </a>
     </li>
     <li class="clear-child">
-      <a class="<%= 'active' if active == 'publications' %>" href="/government/publications">
-        <%= t("govuk_component.government_navigation.publications", default: "Publications") %>
-      </a>
-    </li>
-    <li>
       <a class="<%= 'active' if active == 'consultations' %>" href="<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>">
         <%= t("govuk_component.government_navigation.consultations", default: "Consultations") %>
       </a>

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -105,8 +105,6 @@ examples:
               text: Worldwide
             - href: '/government/policies'
               text: Policies
-            - href: '/government/publications'
-              text: Publications
             - href: '/news-and-communications'
               text: News and communications
       meta:


### PR DESCRIPTION
This PR removes the link to the Whitehall publications finder from the _Government navigation_ component, as it does not map directly to any of the new finders.

Trello: https://trello.com/c/3BuGZK2A