### PR TITLE
Add an option to display search icon in input element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+ - Add search icon option to the input component.
+
 ## 16.12.0
 
 - Fire GA event when cookie banner isn't shown, instead of when it is (PR #821)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -1,1 +1,6 @@
 @import "govuk-frontend/components/input/input";
+
+.gem-c-input--search-icon {
+  background: govuk-colour("white") url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='currentColor'%3E%3C/path%3E%3C/svg%3E") no-repeat -5px -3px;
+  padding-left: govuk-spacing(6);
+}

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -20,10 +20,12 @@
   has_error ||= error_message || error_items&.any?
   hint_id = "hint-#{SecureRandom.hex(4)}"
   error_id = "error-#{SecureRandom.hex(4)}"
+  search_icon ||= nil
 
   css_classes = %w(gem-c-input govuk-input)
   css_classes << "govuk-input--error" if has_error
   css_classes << "govuk-input--width-#{width}" if [2, 3, 4, 5, 10, 20, 30].include?(width)
+  css_classes << "gem-c-input--search-icon" if search_icon
   form_group_css_classes = %w(govuk-form-group)
   form_group_css_classes << "govuk-form-group--error" if has_error && !grouped
 

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -117,3 +117,10 @@ examples:
       hint: It’s on your National insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
       name: "name"
       width: 10
+  with_search_icon:
+    data:
+      label:
+        text: "Search the internet"
+      name: "search-box"
+      type: "search"
+      search_icon: true


### PR DESCRIPTION
We'd like to able to add a icon to an input to show that this is a search input, similar to other inputs in the finder facet. 

At the moment it's all lonely and blank:
<img width="320" alt="" src="https://user-images.githubusercontent.com/1732331/56815974-7dd4ca00-683a-11e9-8b68-7ca94887b175.png">

And it'd be nice to have a search icon in it:
<img width="320" alt="" src="https://user-images.githubusercontent.com/1732331/56817382-62b78980-683d-11e9-9fc0-35457714346e.png">


I've added this in a specific search icon flag `search_icon` - set to true and an extra gem class is added, which sets the icon in the background and adds padding.

Tested in Internet Explorer 9 to 11, plus the rest of the [GDS supported browsers](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices). IE 8 doesn't display the icon since it's an SVG, but the input still functions correctly.