### PR TITLE
Version 6.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 16.12.0
 
 - Fire GA event when cookie banner isn't shown, instead of when it is (PR #821)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (16.11.0)
+    govuk_publishing_components (16.12.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -108,7 +108,7 @@ GEM
       rubocop (~> 0.64)
       rubocop-rspec (~> 1.28)
       scss_lint
-    govuk_app_config (1.14.0)
+    govuk_app_config (1.16.0)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
@@ -157,7 +157,7 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    money (6.13.2)
+    money (6.13.3)
       i18n (>= 0.6.4, <= 2)
     multipart-post (2.0.0)
     netrc (0.11.0)
@@ -167,7 +167,7 @@ GEM
     nokogumbo (2.0.1)
       nokogiri (~> 1.8, >= 1.8.4)
     null_logger (0.0.1)
-    oj (3.7.11)
+    oj (3.7.12)
     parallel (1.13.0)
     parser (2.6.0.0)
       ast (~> 2.4.0)
@@ -227,7 +227,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rinku (2.0.5)
+    rinku (2.0.6)
     rouge (3.3.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '16.11.0'.freeze
+  VERSION = '16.12.0'.freeze
 end


### PR DESCRIPTION
Bump gem to include the following change:

- Fire GA event when cookie banner isn't shown, instead of when it is (PR #821) ([Trello](https://trello.com/c/tOKIPmZ3/99-improve-cookie-banner-tracking))
