### PR TITLE
Update GOV.UK Frontend to 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
  - Add search icon option to the input component.
  - Permit Document List metadata fields to have nil values.
+ - Upgrade to GOV.UK Frontend version 2.11.0.
 
 ## 16.12.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
       "integrity": "sha512-gAy4kMSPpuRJV3mwictJqlg5LhE84Vw2CydKdC4tvrLhR6+G3KW51zbL/vYujcLA2jvWOq3HMHrVeNuw+mrLVA=="
     },
     "govuk-frontend": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.10.0.tgz",
-      "integrity": "sha512-Tfo76yz5ybFMX1heojeiWAyxUx0gABM2/hfMk1zu+9hWvApmfxeTaQOJkje4jeo1ybRo+FhgKFqqAzkBOOUnqg=="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.11.0.tgz",
+      "integrity": "sha512-kZR0ZrSju+Jqh8o5niKklj8/m5XmsNNUSQLL4M4urnMcrLypwW2dU3RkR8UCnzS2DDy4BTHb7CZw0VjQPoi3jg=="
     },
     "jquery": {
       "version": "1.12.4",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "accessible-autocomplete": "git://github.com/alphagov/accessible-autocomplete.git#add-multiselect-support",
-    "govuk-frontend": "2.10.0",
-    "jquery": "1.12.4",
-    "axe-core": "3.2.2"
+    "axe-core": "3.2.2",
+    "govuk-frontend": "2.11.0",
+    "jquery": "1.12.4"
   }
 }


### PR DESCRIPTION
* GOV.UK Frontend updated from version 2.10.0 to 2.11.0

[Release notes for GOV.UK Frontend v2.11.0](https://github.com/alphagov/govuk-frontend/releases/tag/v2.11.0)