### PR TITLE
Permit Document List metadata fields to be blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
  - Add search icon option to the input component.
+ - Permit Document List metadata fields to have nil values.
 
 ## 16.12.0
 

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -34,7 +34,7 @@
 
         <% if item[:metadata] %>
           <ul class="gem-c-document-list__item-metadata">
-            <% item[:metadata].each do |item_metadata_key, item_metadata_value| %>
+            <% item[:metadata].compact.each do |item_metadata_key, item_metadata_value| %>
               <li class="gem-c-document-list__attribute">
                 <% if item_metadata_key.to_s.eql?("public_updated_at") %>
                   <time datetime="<%= item_metadata_value.iso8601 %>">

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -74,6 +74,27 @@ describe "Document list", type: :view do
     assert_select "#{attribute} time[datetime='2017-07-19T15:01:48Z']"
   end
 
+  it "renders a document list item even when public_updated_at is nil" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Some news stories are timeless",
+            path: "/timeless-news",
+          },
+          metadata: {
+            document_type: "News Story",
+            public_updated_at: nil
+          }
+        }
+      ]
+    )
+
+    assert_select ".gem-c-document-list__item-title[href='/timeless-news']", text: "Some news stories are timeless"
+    assert_select ".gem-c-document-list__attribute", text: "News Story"
+  end
+
+
   it "renders a document list with link tracking" do
     render_component(
       items: [


### PR DESCRIPTION
This will enable us to provide nil as a value in document list
metadata. E.g. public_updated_at: nil. This is useful, as
sometimes we can have nil fields and dont check for them,
which causes errors. We could fix this when using the component
but it is nicer to fix it once here.