### PR TITLE
Version 16.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 16.13.0
 
- - Add search icon option to the input component.
- - Permit Document List metadata fields to have nil values.
- - Upgrade to GOV.UK Frontend version 2.11.0.
+ - Add an option to display search icon in input element (PR #824)
+ - Permit Document List metadata fields to have nil values. (PR #828)
+ - Upgrade to GOV.UK Frontend version 2.11.0. (PR #826)
 
 ## 16.12.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (16.12.0)
+    govuk_publishing_components (16.13.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '16.12.0'.freeze
+  VERSION = '16.13.0'.freeze
 end


### PR DESCRIPTION
 - Add an option to display search icon in input element (PR #824)
 - Permit Document List metadata fields to have nil values. (PR #828)
 - Upgrade to GOV.UK Frontend version 2.11.0. (PR #826)