### PR TITLE
Add gds-api-adapters and Plek as dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Add gds-adpi-adapters and plek as dependencies (PR #830)
+
 ## 16.13.0
 
  - Add an option to display search icon in input element (PR #824)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,11 @@ PATH
   remote: .
   specs:
     govuk_publishing_components (16.13.0)
+      gds-api-adapters
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
+      plek
       rails (>= 5.0.0.1)
       rake
       rouge
@@ -85,7 +87,7 @@ GEM
     ffi (1.10.0)
     foreman (0.85.0)
       thor (~> 0.19.1)
-    gds-api-adapters (57.4.1)
+    gds-api-adapters (59.1.0)
       addressable
       link_header
       null_logger
@@ -187,7 +189,7 @@ GEM
     psych (3.1.0)
     public_suffix (3.0.3)
     rack (2.0.6)
-    rack-cache (1.8.0)
+    rack-cache (1.9.0)
       rack (>= 0.4)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -296,7 +298,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.6)
     unicode-display_width (1.4.1)
     unicorn (5.4.1)
       kgio (~> 2.6)
@@ -318,7 +320,6 @@ PLATFORMS
 DEPENDENCIES
   capybara (~> 2.14.4)
   foreman (~> 0.64)
-  gds-api-adapters
   govuk-lint (~> 3.11)
   govuk_publishing_components!
   govuk_schemas (~> 3.2)
@@ -329,9 +330,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   webmock (~> 3.5.0)
   yard
-
-RUBY VERSION
-   ruby 2.6.3p62
 
 BUNDLED WITH
    1.17.3

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -16,17 +16,18 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{node_modules,app,config,db,lib}/**/*", "DEVELOPMENT.md", "LICENCE.md", "Rakefile", "README.md"]
 
+  s.add_dependency "gds-api-adapters"
   s.add_dependency "govspeak", ">= 5.0.3"
   s.add_dependency "govuk_app_config"
   s.add_dependency "govuk_frontend_toolkit"
   s.add_dependency "rails", ">= 5.0.0.1"
   s.add_dependency "rake"
   s.add_dependency "rouge"
+  s.add_dependency "plek"
   s.add_dependency "sass-rails", ">= 5.0.4"
 
   s.add_development_dependency "capybara", "~> 2.14.4"
   s.add_development_dependency "foreman", "~> 0.64"
-  s.add_development_dependency "gds-api-adapters"
   s.add_development_dependency "govuk-lint", "~> 3.11"
   s.add_development_dependency "govuk_schemas", "~> 3.2"
   s.add_development_dependency "jasmine", "~> 2.4.0"


### PR DESCRIPTION
Trello: https://trello.com/c/zMYmFTPx/801-show-metadata-for-attachments

GDS Api Adapters was a listed as a development dependency for this gem,
however it's required outside dev environment to pull in data from
Rummager [1]. Plek is also used here, so this is flagged as a
dependency.

Arguably both of these stretch beyond what this gem should actually be
doing, so shouldn't be encouraged patterns.

[1]: https://github.com/alphagov/govuk_publishing_components/blob/c1c602af10a3ee1dea24c77357c34b5afc843561/lib/govuk_publishing_components/presenters/services.rb

<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->
