### PR TITLE
Adds support to allow parent finder to show as breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,60 +7,66 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased changes
+
+* Adds support to allow parent finder to show as breadcrumbs (PR #831)
+
 ## 16.18.0
 
-- Add inline radio button option (PR #860)
-- Add new version of (experimental) cookie banner (PR #845)
-- Add inline variation for button component (PR #845)
-- Fix govspeak overriding attachment styling (PR #856)
+* Add inline radio button option (PR #860)
+* Add new version of (experimental) cookie banner (PR #845)
+* Add inline variation for button component (PR #845)
+* Fix govspeak overriding attachment styling (PR #856)
+
 
 ## 16.17.0
 
-- Replace gems version of warning button with GOV.UK Frontend version (PR #848)
-- Prevent double click by default for submit buttons (PR #849)
-- Add inline SVG icons to attachment component (PR #850)
-- Update contextual navigation feature tests to use examples from govuk-content-schemas (PR #847)
+* Replace gems version of warning button with GOV.UK Frontend version (PR #848)
+* Prevent double click by default for submit buttons (PR #849)
+* Add inline SVG icons to attachment component (PR #850)
+* Update contextual navigation feature tests to use examples from govuk-content-schemas (PR #847)
 
 ## 16.16.0
-- Add attachment (experimental) component (PR #842)
+
+* Add attachment (experimental) component (PR #842)
 
 ## 16.15.0
 
-- Update cookie-banner behaviour without Javascript (PR #843)
+* Update cookie-banner behaviour without Javascript (PR #843)
 
 ## 16.14.1
 
-- Revert the cookie banner tracking which was added in v16.12.0 (PR #839)
+* Revert the cookie banner tracking which was added in v16.12.0 (PR #839)
 
 ## 16.14.0
 
-- Add attachment link (experimental) component (PR #833)
-- Add plek as a dependency (PR #834)
-- Provide `GovukPublishingComponents.render` method for rendering components outside of views (PR #832)
-- Remove govspeak dependency with kramdown for markdown rendering (PR #827)
+* Add attachment link (experimental) component (PR #833)
+* Add plek as a dependency (PR #834)
+* Provide `GovukPublishingComponents.render` method for rendering components outside of views (PR #832)
+* Remove govspeak dependency with kramdown for markdown rendering (PR #827)
 
 ## 16.13.0
 
- - Add an option to display search icon in input element (PR #824)
- - Permit Document List metadata fields to have nil values. (PR #828)
- - Upgrade to GOV.UK Frontend version 2.11.0. (PR #826)
+* Add an option to display search icon in input element (PR #824)
+* Permit Document List metadata fields to have nil values. (PR #828)
+* Upgrade to GOV.UK Frontend version 2.11.0. (PR #826)
 
 ## 16.12.0
 
-- Fire GA event when cookie banner isn't shown, instead of when it is (PR #821)
+* Fire GA event when cookie banner isn't shown, instead of when it is (PR #821)
 
 ## 16.11.0
 
-- Fix script in header component not being compatible with the govuk_template script (PR #818)
-- Upgrade to govuk-frontend 2.10.0 (PR #817)
+* Fix script in header component not being compatible with the govuk_template script (PR #818)
+* Upgrade to govuk-frontend 2.10.0 (PR #817)
 
 ## 16.10.1
 
-- Enforce compatibility with deprecated packages for media print stylesheet (PR #815)
+* Enforce compatibility with deprecated packages for media print stylesheet (PR #815)
 
 ## 16.10.0
 
-- Support dynamic resizing of the modal component (PR #812)
+* Support dynamic resizing of the modal component (PR #812)
 
 ## 16.9.2
 

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -6,6 +6,9 @@
     <%# Rendering step by step nav breadcrumbs because there's 1 step by step %>
     <%= render 'govuk_publishing_components/components/step_by_step_nav_header',
       navigation.step_nav_helper.header %>
+  <% elsif navigation.content_tagged_to_a_finder? %>
+    <%# Rendering finder breadcrumbs because the page is tagged to a finder %>
+    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
   <% elsif navigation.content_is_tagged_to_a_live_taxon? && prioritise_taxon_breadcrumbs %>
     <%# Rendering taxonomy breadcrumbs because the page is tagged to live taxons
           and we want to prioritise them over all other breadcrumbs %>

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -21,7 +21,7 @@ module GovukPublishingComponents
       end
 
       def breadcrumbs
-        if content_is_a_specialist_document?
+        if content_tagged_to_a_finder?
           parent_finder = content_item.dig("links", "finder", 0)
           return [] unless parent_finder
 
@@ -38,6 +38,10 @@ module GovukPublishingComponents
         else
           ContentBreadcrumbsBasedOnParent.new(content_item).breadcrumbs[:breadcrumbs]
         end
+      end
+
+      def content_tagged_to_a_finder?
+        content_item.dig("links", "finder").present?
       end
 
       def content_tagged_to_mainstream_browse_pages?

--- a/spec/components/contextual_breadcrumbs_spec.rb
+++ b/spec/components/contextual_breadcrumbs_spec.rb
@@ -104,6 +104,14 @@ describe "ContextualBreadcrumbs", type: :view do
     assert_select "a", text: "Competition and Markets Authority cases"
   end
 
+  it "renders parent finder breadcrumb if content has a finder linked" do
+    content_item = example_document_for("guide", "guide-with-facet-groups")
+    render_component(content_item: content_item)
+
+    assert_select "a", text: "Home"
+    assert_select "a", text: "EU Withdrawal Act 2018 statutory instruments"
+  end
+
   it "renders no breadcrumbs if there aren't any" do
     content_item = example_document_for("guide", "guide")
     content_item = remove_mainstream_browse(content_item)

--- a/spec/components/contextual_breadcrumbs_spec.rb
+++ b/spec/components/contextual_breadcrumbs_spec.rb
@@ -112,6 +112,14 @@ describe "ContextualBreadcrumbs", type: :view do
     assert_select "a", text: "EU Withdrawal Act 2018 statutory instruments"
   end
 
+  it "renders parent finder breadcrumb if content has a finder linked and taxon is prioritised" do
+    content_item = example_document_for("guide", "guide-with-facet-groups")
+    render_component(content_item: content_item, prioritise_taxon_breadcrumbs: true)
+
+    assert_select "a", text: "Home"
+    assert_select "a", text: "EU Withdrawal Act 2018 statutory instruments"
+  end
+
   it "renders no breadcrumbs if there aren't any" do
     content_item = example_document_for("guide", "guide")
     content_item = remove_mainstream_browse(content_item)


### PR DESCRIPTION
Previously only content items that were a specialist document showed it's parent finder as breadcrumb links. This functionality has now been changed to support all documents which have a finder linked.

This work was done as part of the following ticket:
https://trello.com/c/uR7v1Rri/71-update-the-breadcrumbs-of-business-finder-content-to-link-to-the-business-finder