### PR TITLE
Version 16.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 16.14.0
 
 - Add attachment link (experimental) component (PR #833)
 - Add plek as a dependency (PR #834)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (16.13.0)
+    govuk_publishing_components (16.14.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '16.13.0'.freeze
+  VERSION = '16.14.0'.freeze
 end


### PR DESCRIPTION
- Add attachment link (experimental) component (PR #833)
- Add plek as a dependency (PR #834)
- Provide `GovukPublishingComponents.render` method for rendering components outside of views (PR #832)
- Remove govspeak dependency with kramdown for markdown rendering (PR #827)