### PR TITLE
Fix rogue failing test

### DIFF
--- a/spec/components/contextual_footer_spec.rb
+++ b/spec/components/contextual_footer_spec.rb
@@ -6,9 +6,13 @@ RSpec.describe 'Contextual footer', type: :view do
   end
 
   it 'renders the footer' do
-    render_component(
-      content_item: GovukSchemas::RandomExample.for_schema(frontend_schema: 'speech')
-    )
+    content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: 'speech') do |payload|
+      # If this item is a part of a step nav this component might not render
+      payload["links"].delete("part_of_step_navs")
+      payload
+    end
+
+    render_component(content_item: content_item)
 
     assert_select '.gem-c-contextual-footer'
   end


### PR DESCRIPTION
Ah tests that rely on random data, what joy you bring...

This fixes a test that has failed quite a few times with:

```
Failures:

  1) Contextual footer renders the footer
     Failure/Error: assert_select '.gem-c-contextual-footer'

     NoMethodError:
       undefined method `document' for nil:NilClass
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/rails-dom-testing-2.0.3/lib/rails/dom/testing/assertions/selector_assertions.rb:295:in `nodeset'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/rails-dom-testing-2.0.3/lib/rails/dom/testing/assertions/selector_assertions.rb:164:in `block in assert_select'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/rails-dom-testing-2.0.3/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb:72:in `extract_root'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/rails-dom-testing-2.0.3/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb:9:in `initialize'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/rails-dom-testing-2.0.3/lib/rails/dom/testing/assertions/selector_assertions.rb:164:in `new'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/rails-dom-testing-2.0.3/lib/rails/dom/testing/assertions/selector_assertions.rb:164:in `assert_select'
     # ./spec/components/contextual_footer_spec.rb:13:in `block (2 levels) in <top (required)>'
```

The reason this fails is that the component won't render if there is a
particular link case (one part_of_steps_nav link) and if the component
isn't rendered the assert_select doesn't think there is a DOM document
to check.

To verify this resolves the problem I've ran the test 1000 times and it
passed each time.

