### PR TITLE
Revert cookie banner tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Revert the cookie banner tracking which was added in v16.12.0 (PR #839)
+
 ## 16.14.0
 
 - Add attachment link (experimental) component (PR #833)

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -20,12 +20,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var hasCookieMessage = (this.$module && window.GOVUK.cookie('seen_cookie_message') !== 'true')
     if (hasCookieMessage) {
       this.$module.style.display = 'block'
-    } else {
-      if (window.GOVUK.analytics && typeof window.GOVUK.analytics.trackEvent === 'function') {
-        window.GOVUK.analytics.trackEvent('cookieBanner', 'Cookie banner not shown', {
-          nonInteraction: true
-        })
-      }
     }
   }
 

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -5,15 +5,10 @@ var container
 
 var GOVUK = window.GOVUK || {};
 
-GOVUK.analytics = {
-  trackEvent: function () {}
-};
-
 describe('Cookie banner is shown', function () {
   'use strict'
 
   beforeEach(function () {
-    spyOn(GOVUK.analytics, 'trackEvent');
     container = document.createElement('div')
     container.innerHTML =
     '<div id="global-cookie-message" class="gem-c-cookie-banner" data-module="cookie-banner">' +
@@ -29,7 +24,6 @@ describe('Cookie banner is shown', function () {
   })
 
   afterEach(function () {
-    GOVUK.analytics.trackEvent.calls.reset();
     document.body.removeChild(container)
   })
 
@@ -39,14 +33,6 @@ describe('Cookie banner is shown', function () {
     expect(banner).toBeVisible()
   })
 
-  it('should not fire a Google Analytics event when the cookie banner is shown', function() {
-    var banner = document.querySelector('[data-module="cookie-banner"]')
-    expect(window.GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
-    expect(banner).toBeVisible()
-
-    expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled();
-  })
-
   it('should hide when pressing the "hide" link', function () {
     var banner = document.querySelector('[data-module="cookie-banner"]')
     var link = document.querySelector('a[data-hide-cookie-banner="true"]')
@@ -54,42 +40,5 @@ describe('Cookie banner is shown', function () {
 
     expect(banner).toBeHidden()
     expect(window.GOVUK.getCookie('seen_cookie_message')).toBeTruthy()
-  })
-})
-
-describe('Cookie banner is hidden', function() {
-  'use strict'
-
-  beforeEach(function () {
-    spyOn(GOVUK.analytics, 'trackEvent');
-
-    container = document.createElement('div')
-    container.innerHTML =
-    '<div id="global-cookie-message" class="gem-c-cookie-banner" data-module="cookie-banner">' +
-      '<p class="gem-c-cookie-banner__message govuk-width-container">' +
-        '<a class="govuk-link" href="/help/cookies">Find out more about cookies</a> or <a class="govuk-link" href="#" data-hide-cookie-banner="true">hide this message</a>' +
-      '</p>' +
-    '</div>'
-
-    document.body.appendChild(container)
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    window.GOVUK.cookie('seen_cookie_message', null)
-    window.GOVUK.setCookie('seen_cookie_message', true)
-    new GOVUK.Modules.CookieBanner().start($(element))
-  })
-
-  afterEach(function () {
-    GOVUK.analytics.trackEvent.calls.reset();
-    document.body.removeChild(container)
-  })
-
-  it('should fire a Google Analytics event when the cookie banner is hidden', function() {
-    var banner = document.querySelector('[data-module="cookie-banner"]')
-    window.GOVUK.setCookie('seen_cookie_message', true)
-
-    expect(window.GOVUK.getCookie('seen_cookie_message')).toBeTruthy()
-    expect(banner).toBeHidden()
-
-    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cookieBanner', 'Cookie banner not shown', { nonInteraction: true });
   })
 })


### PR DESCRIPTION
Removes the cookie banner tracking which fires when the cookie banner is hidden. This would fire an additional event on every user page view, which will build up our analytics events to hit our limit. Instead, we will be adding a custom dimension to the existing pageview event.

This essentially reverts #821.
