### PR TITLE
Removes option to not have a submit button on search component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -152,10 +152,6 @@ $large-input-size: 50px;
       border-right: 0;
     }
 
-    .gem-c-search__input[type="search"].gem-c-search__suppressed-button {
-      border-right: solid 1px $grey-2;
-    }
-
     .js-enabled & {
       .gem-c-search__label {
         color: $secondary-text-colour;

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -9,7 +9,6 @@
   id ||= "search-main-" + SecureRandom.hex(4)
   label_text ||= "Search GOV.UK"
   name ||= 'q'
-  hide_search_button ||= false
 %>
 
 <div class="gem-c-search <%= class_name %>" data-module="gem-toggle-input-class-on-focus">
@@ -19,11 +18,9 @@
   <div class="gem-c-search__item-wrapper">
     <input type="search" value="<%= value %>"
       id="<%= id %>" name="<%= name %>" title="Search"
-      class="gem-c-search__item gem-c-search__input js-class-toggle<%= ' gem-c-search__suppressed-button' if hide_search_button %>">
-    <% unless hide_search_button %>
-      <div class="gem-c-search__item gem-c-search__submit-wrapper">
-        <button type="submit" class="gem-c-search__submit">Search</button>
-      </div>
-    <% end %>
+      class="gem-c-search__item gem-c-search__input js-class-toggle">
+    <div class="gem-c-search__item gem-c-search__submit-wrapper">
+      <button type="submit" class="gem-c-search__submit">Search</button>
+    </div>
   </div>
 </div>

--- a/app/views/govuk_publishing_components/components/docs/search.yml
+++ b/app/views/govuk_publishing_components/components/docs/search.yml
@@ -42,7 +42,3 @@ examples:
     description: To be used if you need to change the default name 'q'
     data:
       name: "my_own_fieldname"
-  remove_search_submit_button:
-      description: Sometimes this component may be used inside an existing form which has another submit button. A form should only have one submit button. The search button will be displayed by default.
-      data:
-        show_search_button: false

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -52,9 +52,4 @@ describe "Search", type: :view do
     render_component(name: "my_custom_field")
     assert_select 'input[name="my_custom_field"]'
   end
-
-  it "renders a search box without a submit button" do
-    render_component(hide_search_button: true)
-    assert_select '.gem-c-search__submit-wrapper button[type="submit"]', false, "This component should not have a submit button"
-  end
 end


### PR DESCRIPTION
This pull request removes the `hide_search_button` parameter from the search component - this was originally used on the [search all finder](https://gov.uk/search/all), but has since been replaced with an input component to better match the rest of the finder sidebar. See [`finder-frontend` PR 1088](https://github.com/alphagov/finder-frontend/pull/1088) for more info on that.

To avoid bloat creep, this option has been removed as (I think) the search all finder was the only place using this option. If it's being used elsewhere, please comment and I'll close this pull request.