### PR TITLE
Add Attachment component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 - Update cookie-banner behaviour without Javascript (PR #843)
+- Add attachment (experimental) component (PR #842)
 
 ## 16.14.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -24,6 +24,7 @@
 // components
 @import "components/accessible-autocomplete";
 @import "components/accordion";
+@import "components/attachment";
 @import "components/attachment-link";
 @import "components/back-link";
 @import "components/breadcrumbs";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -1,0 +1,44 @@
+$thumbnail-width: 99px;
+$thumbnail-height: 140px;
+$thumbnail-border: 5px;
+$thumbnail-border-colour: rgba(11, 12, 12, .1);
+$thumbnail-shadow-colour: rgba(11, 12, 12, .4);
+$thumbnail-shadow-width: 0 2px 2px;
+
+.gem-c-attachment {
+  @include govuk-font(19);
+  @include govuk-clearfix;
+}
+
+.gem-c-attachment__thumbnail {
+  float: left;
+  margin-bottom: govuk-spacing(3);
+  margin-right: govuk-spacing(5);
+  padding: $thumbnail-border;
+  position: relative;
+}
+
+.gem-c-attachment__thumbnail-image {
+  display: block;
+  width: $thumbnail-width;
+  max-width: 100%;
+  height: $thumbnail-height;
+  outline: $thumbnail-border solid $thumbnail-border-colour;
+  background: govuk-colour("white");
+  box-shadow: $thumbnail-shadow-width $thumbnail-shadow-colour;
+}
+
+.gem-c-attachment__title {
+  @include govuk-font($size: 27);
+  margin: 0 0 govuk-spacing(3);
+}
+
+.gem-c-attachment__metadata {
+  @include govuk-font($size: 14);
+  margin: 0 0 govuk-spacing(3);
+}
+
+.gem-c-attachment__abbr {
+  cursor: help;
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -24,6 +24,7 @@ $thumbnail-shadow-width: 0 2px 2px;
   max-width: $thumbnail-width;
   height: $thumbnail-height;
   outline: $thumbnail-border solid $thumbnail-border-colour;
+  border: $thumbnail-border-colour; // for IE9 & IE10
   background: govuk-colour("white");
   box-shadow: $thumbnail-shadow-width $thumbnail-shadow-colour;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -20,8 +20,8 @@ $thumbnail-shadow-width: 0 2px 2px;
 
 .gem-c-attachment__thumbnail-image {
   display: block;
-  width: $thumbnail-width;
-  max-width: 100%;
+  width: auto; // for IE8
+  max-width: $thumbnail-width;
   height: $thumbnail-height;
   outline: $thumbnail-border solid $thumbnail-border-colour;
   background: govuk-colour("white");

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -8,15 +8,15 @@
     content = tag.abbr(attachment.content_type_abbr,
                        class: "gem-c-attachment__abbr",
                        title: attachment.readable_content_type)
-    attributes << tag.span(content)
+    attributes << tag.span(content, class: "gem-c-attachment__attribute")
   end
 
   if attachment.readable_file_size
-    attributes << tag.span(attachment.readable_file_size)
+    attributes << tag.span(attachment.readable_file_size, class: "gem-c-attachment__attribute")
   end
 
   if attachment.readable_number_of_pages
-    attributes << tag.span(attachment.readable_number_of_pages)
+    attributes << tag.span(attachment.readable_number_of_pages, class: "gem-c-attachment__attribute")
   end
 %>
 <%= tag.section class: "gem-c-attachment" do %>

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -1,0 +1,47 @@
+<%
+  attachment = GovukPublishingComponents::Presenters::Attachment.new(attachment)
+  target ||= "_self"
+  hide_help_text ||= false
+  attributes = []
+
+  if attachment.content_type_abbr
+    content = tag.abbr(attachment.content_type_abbr,
+                       class: "gem-c-attachment__abbr",
+                       title: attachment.readable_content_type)
+    attributes << tag.span(content)
+  end
+
+  if attachment.readable_file_size
+    attributes << tag.span(attachment.readable_file_size)
+  end
+
+  if attachment.readable_number_of_pages
+    attributes << tag.span(attachment.readable_number_of_pages)
+  end
+%>
+<%= tag.section class: "gem-c-attachment" do %>
+  <%= tag.div class: "gem-c-attachment__thumbnail" do %>
+    <%= link_to attachment.url, target: target, tabindex: "-1", "aria-hidden": true do %>
+      <%= tag.img class: "gem-c-attachment__thumbnail-image",
+                  src: attachment.thumbnail
+      %>
+    <% end %>
+  <% end %>
+
+  <%= tag.h2 class: "gem-c-attachment__title" do %>
+    <%= link_to attachment.title, attachment.url,
+          class: "govuk-link",
+          target: target %>
+  <% end %>
+  <%= tag.p class: "gem-c-attachment__metadata" do %>
+    <%= raw(attributes.join(', ')) if attributes.any? %>
+  <% end %>
+
+  <% unless hide_help_text %>
+    <% if attachment.opendocument? %>
+      <%= tag.p class: "gem-c-attachment__metadata" do %>
+        <%= t("components.attachment.opendocument_html", target: target) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -1,0 +1,57 @@
+name: Attachment (experimental)
+description: Displays a link to download an attachment and metadata about the file
+body: |
+  This component is marked as experimental as it is part of a drive to provide
+  a consistent place for attachment presentation logic (currently this logic is
+  within [Govspeak][] and [Whitehall][]). The API for this
+  component may change during this process.
+
+  It shows a link to a document that is attached to GOV.UK content along with a
+  thumbnail and relevant file data.
+
+  It is intended to be rendered in Govspeak and as an attachment 'preview' in
+  Content Publisher.
+
+  [Govspeak]: https://github.com/alphagov/govspeak/blob/c3a0742c87537a371108d097cea23688efa90a14/lib/govspeak/presenters/attachment_presenter.rb
+  [Whitehall]: https://github.com/alphagov/whitehall/blob/5c760eea912320c5a80ef59791df47161d889f2f/app/helpers/document_helper.rb
+shared_accessibility_criteria:
+- link
+accessibility_criteria: |
+  The thumbnail image has no `alt` attribute, which causes the link which wraps
+  the thumbnail to contain no content. Since screen readers will have nothing to
+  read in this case, we set `aria-hidden=true` on the thumbail so that it's hidden.
+examples:
+  default:
+    data:
+      attachment:
+        title: "Department for Transport information asset register"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/747661/department-for-transport-information-asset-register.csv
+        filename: department-for-transport-information-asset-register.csv
+        content_type: text/csv
+        file_size: 20000
+  with_number_of_pages:
+    data:
+      attachment:
+        title: "Temporary snow ploughs: guidance note"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/259634/temporary-snow-ploughs.pdf
+        filename: temporary-snow-ploughs.pdf
+        content_type: application/pdf
+        file_size: 20000
+        number_of_pages: 7
+  opendocument:
+    data:
+      attachment:
+        title: "BEIS Information Asset Register"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/744083/BEIS_Information_Asset_Register_.ods
+        filename: BEIS_Information_Asset_Register_.ods
+        content_type: application/vnd.oasis.opendocument.spreadsheet
+        file_size: 20000
+  help_text_disabled:
+    data:
+      attachment:
+        title: "BEIS Information Asset Register"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/744083/BEIS_Information_Asset_Register_.ods
+        filename: BEIS_Information_Asset_Register_.ods
+        content_type: application/vnd.oasis.opendocument.spreadsheet
+        file_size: 20000
+      hide_help_text: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,8 @@ en:
   common:
     translations: "Translations"
   components:
+    attachment:
+      opendocument_html: "This file is in an <a href='https://www.gov.uk/guidance/open-document-format-odf-guidance-for-uk-government/overview-of-productivity-software' target=%{target} class='govuk-link'>OpenDocument</a> format"
     autocomplete:
       multiselect: "To select multiple items in a list, hold down Ctrl (PC) or Cmd (Mac) key."
     back_link:

--- a/lib/govuk_publishing_components/presenters/attachment.rb
+++ b/lib/govuk_publishing_components/presenters/attachment.rb
@@ -48,6 +48,14 @@ module GovukPublishingComponents
         pluralize(attachment_data[:number_of_pages], "page")
       end
 
+      def thumbnail
+        "https://www.gov.uk/government/assets/pub-cover-doc-afe3b0a8a9511beeca890340170aee8b5649413f948e512c9b8ce432d8513d32.png"
+      end
+
+      def opendocument?
+        content_type.opendocument?
+      end
+
       class SupportedContentType
         attr_reader :content_type, :name, :abbr
 
@@ -77,6 +85,10 @@ module GovukPublishingComponents
           { content_type: "text/xml", extension: ".xsd", abbr: "XSD", name: "XML Schema" }.freeze,
         ].freeze
 
+        OPENDOCUMENT_CONTENT_TYPES = %w(application/vnd.oasis.opendocument.presentation
+                                        application/vnd.oasis.opendocument.spreadsheet
+                                        application/vnd.oasis.opendocument.text).freeze
+
         def self.find(content_type, extension = nil)
           matching_types = TYPES.select { |type| type[:content_type] == content_type }
 
@@ -96,6 +108,10 @@ module GovukPublishingComponents
           @name = content_type[:name]
           @abbr = content_type[:abbr]
         end
+
+        def opendocument?
+          OPENDOCUMENT_CONTENT_TYPES.include?(content_type)
+        end
       end
 
       class UnsupportedContentType
@@ -108,6 +124,10 @@ module GovukPublishingComponents
         def name; end
 
         def abbr; end
+
+        def opendocument?
+          false
+        end
       end
     end
   end

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+describe "Attachment", type: :view do
+  def component_name
+    "attachment"
+  end
+
+  it "fails to render when no attachment is given" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  it "renders an attachment" do
+    render_component(attachment: { title: "Attachment", url: "https://gov.uk/attachment" })
+    assert_select ".gem-c-attachment"
+    assert_select "a[href='https://gov.uk/attachment']", text: "Attachment"
+    assert_select "img[src='https://www.gov.uk/government/assets/pub-cover-doc-afe3b0a8a9511beeca890340170aee8b5649413f948e512c9b8ce432d8513d32.png'][class='gem-c-attachment__thumbnail-image']"
+  end
+
+  it "can have a target specified" do
+    render_component(
+      attachment: { title: "Attachment", url: "https://gov.uk/attachment" },
+      target: "_blank",
+    )
+    assert_select "a[href='https://gov.uk/attachment'][target=_blank]"
+  end
+
+  it "can include attribute metadata" do
+    render_component(
+      attachment: {
+        title: "Attachment",
+        url: "attachment",
+        content_type: "application/pdf",
+        file_size: 2048,
+        number_of_pages: 2,
+      },
+    )
+    assert_select "abbr.gem-c-attachment__abbr[title='Portable Document Format']", text: "PDF"
+    expect(rendered).to match(/2 KB/)
+    expect(rendered).to match(/2 pages/)
+  end
+
+  it "shows OpenDocument help text if OpenDocument format" do
+    render_component(
+      attachment: {
+        title: "Attachment",
+        url: "attachment",
+        content_type: "application/vnd.oasis.opendocument.spreadsheet",
+      },
+    )
+    assert_select "a[href='https://www.gov.uk/guidance/open-document-format-odf-guidance-for-uk-government/overview-of-productivity-software']"
+  end
+
+  it "does not show help text if disabled" do
+    render_component(
+      attachment: {
+        title: "Attachment",
+        url: "attachment",
+        content_type: "application/vnd.oasis.opendocument.spreadsheet",
+      },
+      hide_help_text: true,
+    )
+    assert_select "a[href='https://www.gov.uk/guidance/open-document-format-odf-guidance-for-uk-government/overview-of-productivity-software']", false
+  end
+end

--- a/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
@@ -85,4 +85,20 @@ RSpec.describe GovukPublishingComponents::Presenters::Attachment do
       expect(attachment.readable_number_of_pages).to eq("3 pages")
     end
   end
+
+  describe "#opendocument?" do
+    it "returns true if content type is an OpenDocument" do
+      attachment = described_class.new(title: "test",
+                                       url: "test",
+                                       content_type: "application/vnd.oasis.opendocument.text")
+      expect(attachment.opendocument?).to be true
+    end
+
+    it "returns false if content type is an OpenDocument" do
+      attachment = described_class.new(title: "test",
+                                       url: "test",
+                                       content_type: "application/msword")
+      expect(attachment.opendocument?).to be false
+    end
+  end
 end


### PR DESCRIPTION
For: https://trello.com/c/zMYmFTPx/801-show-metadata-for-attachments

🎉 View in the [component guide](http://govuk-publishing-compon-pr-842.herokuapp.com/component-guide/attachment) 🎉 

This adds a component for an attachment, which is intended to be used by Govspeak and Content Publisher.