### PR TITLE
Update cookies banner behaviour without Javascript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Update cookie-banner behaviour without Javascript (PR #843)
+
 ## 16.14.1
 
 - Revert the cookie banner tracking which was added in v16.12.0 (PR #839)

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -271,10 +271,9 @@ html {
   }
 }
 
-// Hide survey and cookie banners
+// Hide survey banner
 // scss-lint:disable IdSelector
-#user-satisfaction-survey-container,
-#global-cookie-message {
+#user-satisfaction-survey-container {
   display: none;
 }
 // scss-lint:enable IdSelector

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -16,3 +16,11 @@ $govuk-cookie-banner-background: #d5e8f3;
   margin-top: 0;
   margin-bottom: 0;
 }
+
+.gem-c-cookie-banner__hide-link {
+  display: none;
+
+  .js-enabled & {
+    display: inline-block;
+  }
+}

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -1,7 +1,7 @@
 <%
   id ||= 'global-cookie-message'
   message ||= capture do %>
-  GOV.UK uses cookies to make the site simpler. <a class="govuk-link" href="/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner clicked">Find out more about cookies</a> or <a class="govuk-link" href="#" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner hidden">hide this message</a>
+  GOV.UK uses cookies to make the site simpler. <a class="govuk-link" href="/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner clicked">Find out more about cookies</a> <span class="gem-c-cookie-banner__hide-link">or <a class="govuk-link" href="#" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner hidden">hide this message</a></span>
 <% end %>
 
 <div id="<%= id %>" class="gem-c-cookie-banner" data-module="cookie-banner">


### PR DESCRIPTION
# Changes

The banner was supposed to not show without Javascript. It did not
display in the component guide, but showed up on the frontend. However
we want the banner to still display, as there are other cookies that
may still be set by servers, and not Javascript.

We also don't show the "Hide this message" link without Javascript.

## Screenshots
All are running without Javascript:

### Before
![Screenshot at May 07 3-53-57 pm](https://user-images.githubusercontent.com/424772/57309661-60c4b480-70e0-11e9-988e-91adf3887a1f.png)


### After
![Screenshot at May 07 3-54-10 pm](https://user-images.githubusercontent.com/424772/57309685-6a4e1c80-70e0-11e9-9a25-39f21e124b50.png)
