### PR TITLE
MVP add new cookie banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Add new version of (experimental) cookie banner (PR #845)
+- Add inline variation for button component (PR #845)
+
 ## 16.17.0
 
 - Replace gems version of warning button with GOV.UK Frontend version (PR #848)

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -8,6 +8,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module = $module[0]
     this.$module.hideCookieMessage = this.hideCookieMessage.bind(this)
     this.$module.showConfirmationMessage = this.showConfirmationMessage.bind(this)
+    this.$module.setCookieConsent = this.setCookieConsent.bind(this)
 
     this.$hideLink = this.$module.querySelector('a[data-hide-cookie-banner], button[data-hide-cookie-banner]')
     if (this.$hideLink) {
@@ -16,16 +17,29 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     this.$acceptCookiesLink = this.$module.querySelector('button[data-accept-cookies]')
     if (this.$acceptCookiesLink) {
-      this.$acceptCookiesLink.addEventListener('click', this.$module.showConfirmationMessage)
+      this.$acceptCookiesLink.addEventListener('click', this.$module.setCookieConsent)
     }
 
     this.showCookieMessage()
   }
 
   CookieBanner.prototype.showCookieMessage = function () {
+    var newCookieBanner = document.querySelector('.gem-c-cookie-banner--new')
     var hasCookieMessage = (this.$module && window.GOVUK.cookie('seen_cookie_message') !== 'true')
     if (hasCookieMessage) {
       this.$module.style.display = 'block'
+    }
+
+    if (newCookieBanner && hasCookieMessage) {
+      if (!window.GOVUK.cookie('cookie_policy')) {
+        window.GOVUK.setDefaultConsentCookie()
+      }
+    } else if (!newCookieBanner) {
+      // Remove the consent cookie if we're using the old cookie banner
+      // TODO: this can be removed later when we switch to the new banner
+      if (window.GOVUK.cookie('cookie_policy')) {
+        window.GOVUK.cookie('cookie_policy', null)
+      }
     }
   }
 
@@ -40,7 +54,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
   }
 
-  CookieBanner.prototype.showConfirmationMessage = function (event) {
+  CookieBanner.prototype.setCookieConsent = function () {
+    window.GOVUK.approveAllCookieTypes()
+    this.$module.showConfirmationMessage()
+    window.GOVUK.setCookie('seen_cookie_message', 'true')
+  }
+
+  CookieBanner.prototype.showConfirmationMessage = function () {
     this.$cookieBannerMainContent = document.querySelector('.gem-c-cookie-banner__wrapper')
     this.$cookieBannerConfirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
 

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -6,11 +6,17 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   CookieBanner.prototype.start = function ($module) {
     this.$module = $module[0]
-
     this.$module.hideCookieMessage = this.hideCookieMessage.bind(this)
-    this.$hideLink = this.$module.querySelector('a[data-hide-cookie-banner]')
+    this.$module.showConfirmationMessage = this.showConfirmationMessage.bind(this)
+
+    this.$hideLink = this.$module.querySelector('a[data-hide-cookie-banner], button[data-hide-cookie-banner]')
     if (this.$hideLink) {
       this.$hideLink.addEventListener('click', this.$module.hideCookieMessage)
+    }
+
+    this.$acceptCookiesLink = this.$module.querySelector('button[data-accept-cookies]')
+    if (this.$acceptCookiesLink) {
+      this.$acceptCookiesLink.addEventListener('click', this.$module.showConfirmationMessage)
     }
 
     this.showCookieMessage()
@@ -32,6 +38,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (event.target) {
       event.preventDefault()
     }
+  }
+
+  CookieBanner.prototype.showConfirmationMessage = function (event) {
+    this.$cookieBannerMainContent = document.querySelector('.gem-c-cookie-banner__wrapper')
+    this.$cookieBannerConfirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
+
+    this.$cookieBannerMainContent.style.display = 'none'
+    this.$cookieBannerConfirmationMessage.style.display = 'block'
   }
 
   Modules.CookieBanner = CookieBanner

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -3,6 +3,13 @@
 (function () {
   'use strict'
   var root = this
+  var defaultCookieConsent = {
+    'essential': true,
+    'settings': false,
+    'usage': false,
+    'campaigns': false
+  }
+
   if (typeof root.GOVUK === 'undefined') { root.GOVUK = {} }
 
   /*
@@ -30,6 +37,49 @@
     } else {
       return window.GOVUK.getCookie(name)
     }
+  }
+
+  window.GOVUK.setDefaultConsentCookie = function () {
+    window.GOVUK.setCookie('cookie_policy', JSON.stringify(defaultCookieConsent))
+  }
+
+  window.GOVUK.approveAllCookieTypes = function () {
+    var approvedConsent = {
+      'essential': true,
+      'settings': true,
+      'usage': true,
+      'campaigns': true
+    }
+
+    window.GOVUK.setCookie('cookie_policy', JSON.stringify(approvedConsent))
+  }
+
+  window.GOVUK.denyAllCookieTypes = function () {
+    var deniedConsent = {
+      'essential': false,
+      'settings': false,
+      'usage': false,
+      'campaigns': false
+    }
+
+    window.GOVUK.setCookie('cookie_policy', JSON.stringify(deniedConsent))
+  }
+
+  window.GOVUK.setConsentCookie = function (options) {
+    var currentConsentCookie = window.GOVUK.getCookie('cookie_policy')
+    var cookieConsentJSON
+
+    if (currentConsentCookie) {
+      cookieConsentJSON = JSON.parse(currentConsentCookie)
+    } else {
+      cookieConsentJSON = defaultCookieConsent
+    }
+
+    for (var cookieType in options) {
+      cookieConsentJSON[cookieType] = options[cookieType]
+    }
+
+    window.GOVUK.setCookie('cookie_policy', JSON.stringify(cookieConsentJSON))
   }
 
   window.GOVUK.setCookie = function (name, value, options) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -22,6 +22,17 @@ $gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
   @include responsive-bottom-margin;
 }
 
+.gem-c-button--inline {
+  width: 100%;
+  margin-bottom: govuk-spacing(1);
+  margin-right: govuk-spacing(2);
+
+  @include govuk-media-query($from: tablet) {
+    width: auto;
+    margin-bottom: 0;
+  }
+}
+
 .gem-c-button__info-text {
   @include govuk-text-colour;
   @include govuk-font($size: 16);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -2,7 +2,8 @@ $govuk-cookie-banner-background: #d5e8f3;
 $govuk-cookie-banner-background-new: govuk-colour("white");
 
 .js-enabled {
-  .gem-c-cookie-banner {
+  .gem-c-cookie-banner,
+  .gem-c-cookie-banner--new {
     display: none; // shown with JS, always on for non-JS
   }
 }
@@ -26,6 +27,7 @@ $govuk-cookie-banner-background-new: govuk-colour("white");
   }
 }
 
+// Styles for the new version of the cookie banner
 .gem-c-cookie-banner--new {
   @include govuk-font($size: 16);
   border: 2px solid govuk-colour("black");
@@ -38,9 +40,51 @@ $govuk-cookie-banner-background-new: govuk-colour("white");
   padding-bottom: govuk-spacing(2);
 }
 
-.gem-c-cookie-banner--new .gem-c-cookie-banner__buttons {
+.gem-c-cookie-banner__buttons {
   display: inline-block;
   vertical-align: middle;
+}
+
+.gem-c-cookie-banner__confirmation {
+  display: none;
+  position: relative;
+  padding: 0 govuk-spacing(2);
+}
+
+.gem-c-cookie-banner__confirmation-message,
+.gem-c-cookie-banner__hide-button {
+  display: block;
+
+  @include govuk-media-query($from: tablet) {
+    display: inline-block;
+  }
+}
+
+.gem-c-cookie-banner__confirmation-message {
+  margin-right: govuk-spacing(4);
+}
+
+.gem-c-cookie-banner__hide-button {
+  @include govuk-font($size: 16);
+  outline: 0;
+  border: 0;
+  background: none;
+  text-decoration: underline;
+  color: $govuk-link-colour;
+  padding: govuk-spacing(0);
+  margin-top: govuk-spacing(2);
+
+
+  &:hover {
+    color: $govuk-link-hover-colour;
+    cursor: pointer;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(0);
+    position: absolute;
+    right: 0;
+  }
 }
 
 // Override the styles from govuk_template
@@ -52,9 +96,14 @@ $govuk-cookie-banner-background-new: govuk-colour("white");
   box-sizing: border-box;
 
   .gem-c-cookie-banner__message,
-  .gem-c-cookie-banner__buttons {
-    @include govuk-width-container;
+  .gem-c-cookie-banner__buttons,
+  .gem-c-cookie-banner__confirmation,
+  .gem-c-cookie-banner__confirmation-message {
     @include core-19;
+  }
+
+  p {
+    margin: 0;
   }
 }
 // sass-lint:enable no-ids

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -1,4 +1,5 @@
 $govuk-cookie-banner-background: #d5e8f3;
+$govuk-cookie-banner-background-new: govuk-colour("white");
 
 .js-enabled {
   .gem-c-cookie-banner {
@@ -8,7 +9,7 @@ $govuk-cookie-banner-background: #d5e8f3;
 
 .gem-c-cookie-banner {
   @include govuk-font($size: 16);
-  padding: 10px 0;
+  padding: govuk-spacing(2) 0;
   background-color: $govuk-cookie-banner-background;
 }
 
@@ -24,3 +25,37 @@ $govuk-cookie-banner-background: #d5e8f3;
     display: inline-block;
   }
 }
+
+.gem-c-cookie-banner--new {
+  @include govuk-font($size: 16);
+  border: 2px solid govuk-colour("black");
+}
+
+.gem-c-cookie-banner--new .gem-c-cookie-banner__message {
+  display: inline-block;
+  margin-bottom: govuk-spacing(1);
+  padding-right: govuk-spacing(4);
+  padding-bottom: govuk-spacing(2);
+}
+
+.gem-c-cookie-banner--new .gem-c-cookie-banner__buttons {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+// Override the styles from govuk_template
+// scss-lint:disable IdSelector
+// sass-lint:disable no-ids
+.gem-c-cookie-banner--new#global-cookie-message {
+  background-color: $govuk-cookie-banner-background-new;
+  padding: govuk-spacing(4) 0;
+  box-sizing: border-box;
+
+  .gem-c-cookie-banner__message,
+  .gem-c-cookie-banner__buttons {
+    @include govuk-width-container;
+    @include core-19;
+  }
+}
+// sass-lint:enable no-ids
+// scss-lint:enable IdSelector

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -1,9 +1,41 @@
 <%
+  new_cookie_banner ||= false
   id ||= 'global-cookie-message'
-  message ||= capture do %>
-  GOV.UK uses cookies to make the site simpler. <a class="govuk-link" href="/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner clicked">Find out more about cookies</a> <span class="gem-c-cookie-banner__hide-link">or <a class="govuk-link" href="#" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner hidden">hide this message</a></span>
-<% end %>
 
-<div id="<%= id %>" class="gem-c-cookie-banner" data-module="cookie-banner">
-  <p class="gem-c-cookie-banner__message govuk-width-container"><%= message %></p>
+  cookie_banner_class = new_cookie_banner ? "gem-c-cookie-banner--new" : "gem-c-cookie-banner"
+
+  cookie_banner_helper = GovukPublishingComponents::Presenters::CookieBannerHelper.new(local_assigns)
+
+  message = cookie_banner_helper.message
+%>
+
+<div id="<%= id %>" class="<%= cookie_banner_class %>" data-module="cookie-banner">
+  <div class="gem-c-cookie-banner__wrapper govuk-width-container">
+    <p class="gem-c-cookie-banner__message"><%= message %></p>
+    <% if new_cookie_banner %>
+      <div class="gem-c-cookie-banner__buttons">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Accept cookies",
+          secondary: true,
+          inline_layout: true,
+          data_attributes: {
+            module: "track-click",
+            "track-category": "cookieBanner",
+            "track-action": "Cookie banner accepted"
+          }
+        } %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Cookie settings",
+          href: "/help/cookies",
+          secondary: true,
+          inline_layout: true,
+          data_attributes: {
+            module: "track-click",
+            "track-category": "cookieBanner",
+            "track-action": "Cookie banner settings clicked"
+          }
+        } %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -7,6 +7,7 @@
   cookie_banner_helper = GovukPublishingComponents::Presenters::CookieBannerHelper.new(local_assigns)
 
   message = cookie_banner_helper.message
+  confirmation_message = cookie_banner_helper.confirmation_message
 %>
 
 <div id="<%= id %>" class="<%= cookie_banner_class %>" data-module="cookie-banner">
@@ -20,6 +21,7 @@
           inline_layout: true,
           data_attributes: {
             module: "track-click",
+            "accept-cookies": "true",
             "track-category": "cookieBanner",
             "track-action": "Cookie banner accepted"
           }
@@ -38,4 +40,11 @@
       </div>
     <% end %>
   </div>
+
+  <% if new_cookie_banner %>
+    <div class="gem-c-cookie-banner__confirmation govuk-width-container">
+      <p class="gem-c-cookie-banner__confirmation-message"><%= confirmation_message %></p>
+      <button class="gem-c-cookie-banner__hide-button" data-hide-cookie-banner="true">Hide</button>
+    </div>
+  <% end %>
 </div>

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -92,3 +92,12 @@ examples:
       text: "Click me"
       margin_bottom: true
       title: "A button to click"
+  inline_layout:
+    description: Buttons will display adjacent to each other until mobile view, when they will appear on top of each other.
+    embed: |
+      <button class="govuk-button">First button</button>
+      <%= component %>
+    data:
+      text: "Second button"
+      inline_layout: true
+

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -10,6 +10,8 @@ accessibility_criteria: |
   - accept focus
   - be focusable with a keyboard
   - indicate when they have focus
+accessibility_excluded_rules:
+  - 'duplicate-id' # a banner should have a unique id for a given page. However, this page contains multiple examples of the banner with the same id.
 examples:
   default:
     data: {}
@@ -17,3 +19,7 @@ examples:
     data:
       id: custom-message
       message: GOV.UK uses cookies to make the site simpler. <a class="govuk-link" href="/help/cookies">Find out more about cookies</a>
+  new_cookie_banner:
+    description: FOR TESTING PURPOSES ONLY. This is a new proposed iteration of the cookie banner. The current banner will remain the same across the live site for now.
+    data:
+        new_cookie_banner: true

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -26,6 +26,7 @@ require "govuk_publishing_components/presenters/image_card_helper"
 require "govuk_publishing_components/presenters/organisation_logo_helper"
 require "govuk_publishing_components/presenters/highlight_boxes_helper"
 require "govuk_publishing_components/presenters/taxonomy_list_helper"
+require "govuk_publishing_components/presenters/cookie_banner_helper"
 
 require "govuk_publishing_components/app_helpers/taxon_breadcrumbs"
 require "govuk_publishing_components/app_helpers/table_helper"

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
   module Presenters
     class ButtonHelper
       attr_reader :href, :text, :title, :info_text, :rel, :data_attributes,
-        :margin_bottom, :target, :type, :start, :secondary, :secondary_quiet, :destructive
+        :margin_bottom, :inline_layout, :target, :type, :start, :secondary, :secondary_quiet, :destructive
 
       def initialize(local_assigns)
         @href = local_assigns[:href]
@@ -15,6 +15,7 @@ module GovukPublishingComponents
         @default_data_attributes = { "prevent-double-click" => true }
         @data_attributes = local_assigns[:data_attributes]
         @margin_bottom = local_assigns[:margin_bottom]
+        @inline_layout = local_assigns[:inline_layout]
         @target = local_assigns[:target]
         @type = local_assigns[:type]
         @start = local_assigns[:start]
@@ -51,6 +52,7 @@ module GovukPublishingComponents
         classes << "gem-c-button--secondary-quiet" if secondary_quiet
         classes << "govuk-button--warning" if destructive
         classes << "gem-c-button--bottom-margin" if margin_bottom
+        classes << "gem-c-button--inline" if inline_layout
         classes.join(" ")
       end
     end

--- a/lib/govuk_publishing_components/presenters/cookie_banner_helper.rb
+++ b/lib/govuk_publishing_components/presenters/cookie_banner_helper.rb
@@ -1,0 +1,23 @@
+module GovukPublishingComponents
+  module Presenters
+    class CookieBannerHelper
+      attr_reader :local_assigns
+
+      def initialize(local_assigns)
+        @message = local_assigns[:message]
+        @new_cookie_banner = local_assigns[:new_cookie_banner]
+        @local_assigns = local_assigns
+      end
+
+      def message
+        return @message if @message.present?
+
+        if @new_cookie_banner
+          "GOV.UK uses cookies to make the site simpler."
+        else
+          'GOV.UK uses cookies to make the site simpler. <a class="govuk-link" href="/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner clicked">Find out more about cookies</a> <span class="gem-c-cookie-banner__hide-link">or <a class="govuk-link" href="#" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner hidden">hide this message</a></span>'.html_safe
+        end
+      end
+    end
+  end
+end

--- a/lib/govuk_publishing_components/presenters/cookie_banner_helper.rb
+++ b/lib/govuk_publishing_components/presenters/cookie_banner_helper.rb
@@ -9,6 +9,10 @@ module GovukPublishingComponents
         @local_assigns = local_assigns
       end
 
+      def confirmation_message
+        'You\'ve accepted all cookies. You can <a class="govuk-link" href="/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.'.html_safe
+      end
+
       def message
         return @message if @message.present?
 

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -161,4 +161,10 @@ describe "Button", type: :view do
 
     assert_select ".govuk-button[title='Do it!']"
   end
+
+  it "renders an inline button" do
+    render_component(text: "Button one", inline_layout: true)
+
+    assert_select ".gem-c-button--inline", text: "Button one"
+  end
 end

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -8,13 +8,39 @@ describe "Cookie banner", type: :view do
   it "renders with default values" do
     render_component({})
     assert_select '.gem-c-cookie-banner[id="global-cookie-message"][data-module="cookie-banner"]'
-    assert_select '.gem-c-cookie-banner__message.govuk-width-container', text: "GOV.UK uses cookies to make the site simpler. Find out more about cookies or hide this message"
+    assert_select '.govuk-width-container .gem-c-cookie-banner__message', text: "GOV.UK uses cookies to make the site simpler. Find out more about cookies or hide this message"
     assert_select 'a[data-hide-cookie-banner="true"]'
   end
 
   it "renders with custom values" do
     render_component(id: 'custom-cookie-message', message: "Custom message")
     assert_select '.gem-c-cookie-banner[id="custom-cookie-message"][data-module="cookie-banner"]'
-    assert_select '.gem-c-cookie-banner__message.govuk-width-container', text: "Custom message"
+    assert_select '.govuk-width-container .gem-c-cookie-banner__message', text: "Custom message"
+  end
+end
+
+describe "New cookie banner", type: :view do
+  def component_name
+    "cookie_banner"
+  end
+
+  it "renders the new cookie banner message" do
+    render_component(new_cookie_banner: true)
+    assert_select '.govuk-width-container .gem-c-cookie-banner__message', text: "GOV.UK uses cookies to make the site simpler."
+  end
+
+  it "allows you to pass a custom banner message" do
+    render_component(new_cookie_banner: true, message: "another custom message")
+    assert_select '.govuk-width-container .gem-c-cookie-banner__message', text: "another custom message"
+  end
+
+  it "renders a button for accepting cookies" do
+    render_component(new_cookie_banner: true)
+    assert_select '.gem-c-cookie-banner__buttons .gem-c-button', text: "Accept cookies"
+  end
+
+  it "renders a button for viewing cookie settings" do
+    render_component(new_cookie_banner: true)
+    assert_select '.gem-c-cookie-banner__buttons .gem-c-button', text: "Cookie settings"
   end
 end

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -30,6 +30,7 @@ describe('Cookie banner is shown', function () {
   it('should show the cookie banner', function () {
     var banner = document.querySelector('[data-module="cookie-banner"]')
     expect(window.GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
+    expect(window.GOVUK.getCookie('cookie_policy')).toBeFalsy()
     expect(banner).toBeVisible()
   })
 
@@ -40,5 +41,66 @@ describe('Cookie banner is shown', function () {
 
     expect(banner).toBeHidden()
     expect(window.GOVUK.getCookie('seen_cookie_message')).toBeTruthy()
+  })
+})
+
+describe('New cookie banner', function () {
+  'use strict'
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML =
+    '<div id="global-cookie-message" class="gem-c-cookie-banner--new" data-module="cookie-banner">' +
+      '<div class="gem-c-cookie-banner__wrapper govuk-width-container" data-cookie-banner-main="true">' +
+        '<p class="gem-c-cookie-banner__message">GOV.UK uses cookies to make the site simpler.</p>' +
+        '<div class="gem-c-cookie-banner__buttons">' +
+            '<button class="gem-c-button govuk-button gem-c-button--secondary-quiet gem-c-button--inline" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">Accept cookies</button>' +
+            '<a class="gem-c-button govuk-button gem-c-button--secondary-quiet gem-c-button--inline" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="/help/cookies">Cookie settings</a>' +
+          '</div>' +
+        '</div>' +
+        '<div class="gem-c-cookie-banner__confirmation govuk-width-container" data-cookie-banner-confirmation="true" style="display: none;">' +
+          '<p class="gem-c-cookie-banner__confirmation-message">' +
+            'You have accepted all cookies' +
+          '</p>' +
+          '<button class="gem-c-cookie-banner__hide-button" data-hide-cookie-banner="true">Hide</button>' +
+        '</div>' +
+    '</div>'
+
+    document.body.appendChild(container)
+    var element = document.querySelector('.gem-c-cookie-banner--new[data-module="cookie-banner"]')
+    window.GOVUK.cookie('seen_cookie_message', null)
+    window.GOVUK.cookie('cookie_policy', null)
+    new GOVUK.Modules.CookieBanner().start($(element))
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
+  it('sets a default consent cookie', function () {
+    var banner = document.querySelector('.gem-c-cookie-banner--new[data-module="cookie-banner"]')
+    expect(window.GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
+    expect(window.GOVUK.getCookie('cookie_policy')).toEqual('"{\\"essential\\":true,\\"settings\\":false,\\"usage\\":false,\\"campaigns\\":false}"')
+    expect(banner).toBeVisible()
+  })
+
+  it('sets consent cookie when accepting cookies', function() {
+    var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
+    acceptCookiesButton.click()
+    expect(window.GOVUK.getCookie('cookie_policy')).toEqual('"{\\"essential\\":true,\\"settings\\":true,\\"usage\\":true,\\"campaigns\\":true}"')
+  })
+
+  it('shows a confirmation message when accepting cookies', function() {
+    var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
+    var mainCookieBanner = document.querySelector('div[data-cookie-banner-main]')
+    var confirmationMessage = document.querySelector('div[data-cookie-banner-confirmation]')
+
+    expect(mainCookieBanner).toBeVisible()
+    expect(confirmationMessage).not.toBeVisible()
+
+    acceptCookiesButton.click()
+
+    expect(mainCookieBanner).not.toBeVisible()
+    expect(confirmationMessage).toBeVisible()
   })
 })


### PR DESCRIPTION
This PR introduces a WIP cookie banner which allows users to accept cookies or view the cookie settings page (a new page which will allow users to individually opt-in/opt-out of specified cookie settings. The aim is for this new banner to eventually replace the current banner we have, which doesn't have this functionality.

**To do before merging:**

- ~Add to Changelog~
- ~Write up follow-up cards for the work still to be completed~
- ~Make changes / write follow-up cards for comments on this PR~
- ~Update copy / create card to update copy~
- ~Confirm cookie category names~
- ~Remove "IGNORE test commit"~

This PR introduces the new cookie banner under a flag `new_cookie_banner: true` so that we don't interfere with the current banner while testing. The new banner shouldn't interfere/effect the current banner or cookie behaviour in any way.

## Example of how it looks in a frontend app
<img width="1424" alt="Screen Shot 2019-05-08 at 15 11 39" src="https://user-images.githubusercontent.com/29889908/57381822-9d0d1900-71a3-11e9-81b7-e49d7d7d53bb.png">

You can [preview the new banner in the component guide](https://govuk-publishing-compon-pr-845.herokuapp.com//component-guide/cookie_banner)

**Note: this is an MVP. There are follow-up tasks involved in implementing the cookie consent mechanism itself, captured by [this Trello card](https://trello.com/c/iKCN59XS/51-placeholder-building-cookie-consent-mechanism)**