### PR TITLE
Update feature tests to use examples from govuk-content-schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 - Replace gems version of warning button with GOV.UK Frontend version (PR #848)
 - Prevent double click by default for submit buttons (PR #849)
+- Update contextual navigation feature tests to use examples from govuk-content-schemas (PR #847)
 
 ## 16.16.0
 - Add attachment (experimental) component (PR #842)

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -91,7 +91,7 @@ describe "Contextual navigation" do
     content_store_has_random_item(
       links: {
         "parent" => [random_item("mainstream_browse_page", "title" => "A parent")],
-        "ordered_related_items" => [random_item("guide", "title" => "A related link curated in Publisher")]
+        "ordered_related_items" => [example_item("guide", "guide")]
       }
     )
   end
@@ -103,8 +103,8 @@ describe "Contextual navigation" do
       "document_type" => "travel_advice",
       "links" => {
         "parent" => [random_item("mainstream_browse_page", "title" => "A parent")],
-        "ordered_related_items" => [random_item("guide", "title" => "A related link curated in Publisher")]
         "taxons" => [example_item("taxon", "taxon")],
+        "ordered_related_items" => [example_item("guide", "guide")]
       }
     )
 
@@ -172,7 +172,7 @@ describe "Contextual navigation" do
   def then_i_see_the_related_links_sidebar
     within '.gem-c-contextual-sidebar' do
       expect(page).to have_selector(".gem-c-related-navigation")
-      expect(page).to have_content("A related link curated in Publisher")
+      expect(page).to have_content("The national curriculum")
     end
   end
 

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -213,6 +213,10 @@ describe "Contextual navigation" do
     GovukSchemas::Example.find(schema_name, example_name: "step_by_step_nav")
   end
 
+  def example_item(schema_name, example_name)
+    GovukSchemas::Example.find(schema_name, example_name: example_name)
+  end
+
   def random_item(schema_name, merge_with = {})
     GovukSchemas::RandomExample.for_schema(frontend_schema: schema_name) do |random_item|
       random_item.merge(merge_with)

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -103,8 +103,8 @@ describe "Contextual navigation" do
       "document_type" => "travel_advice",
       "links" => {
         "parent" => [random_item("mainstream_browse_page", "title" => "A parent")],
-        "taxons" => [random_item("taxon", "phase" => "live")],
         "ordered_related_items" => [random_item("guide", "title" => "A related link curated in Publisher")]
+        "taxons" => [example_item("taxon", "taxon")],
       }
     )
 
@@ -112,8 +112,8 @@ describe "Contextual navigation" do
   end
 
   def given_theres_a_guide_with_a_live_taxon_tagged_to_it
-    alpha_taxon = random_item("taxon", "title" => "An alpha taxon", "phase" => "alpha")
-    live_taxon = random_item("taxon", "title" => "A live taxon", "phase" => "live")
+    alpha_taxon = example_item("taxon", "taxon_in_alpha_phase")
+    live_taxon = example_item("taxon", "taxon")
 
     content_store_has_random_item(
       schema: "guide",
@@ -186,13 +186,13 @@ describe "Contextual navigation" do
   def and_the_taxonomy_breadcrumbs
     within '.gem-c-breadcrumbs' do
       expect(page).to have_link("Home")
-      expect(page).to have_link("A live taxon")
+      expect(page).to have_link("A level")
     end
   end
 
   def then_i_see_the_taxon_in_the_related_navigation_footer
     within '.gem-c-contextual-footer' do
-      expect(page).to have_css(".gem-c-related-navigation__link", text: "A live taxon")
+      expect(page).to have_css(".gem-c-related-navigation__link", text: "A level")
     end
   end
 

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -124,9 +124,8 @@ describe "Contextual navigation" do
   end
 
   def given_theres_a_page_with_just_legacy_taxonomy
-    topic = random_item("topic", "title" => "A legacy topic")
     content_store_has_random_item(links: {
-      "topics" => [topic],
+      "topics" => [example_item("topic", "topic")],
       "parent" => [example_item("mainstream_browse_page", "top_level_page")]
     })
   end
@@ -198,7 +197,7 @@ describe "Contextual navigation" do
 
   def then_i_see_the_legacy_topic_in_the_related_navigation_footer
     within '.gem-c-contextual-footer' do
-      expect(page).to have_css(".gem-c-related-navigation__link", text: "A legacy topic")
+      expect(page).to have_css(".gem-c-related-navigation__link", text: "Oil and gas")
     end
   end
 

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -82,7 +82,7 @@ describe "Contextual navigation" do
     content_store_has_random_item(
       links: {
         "parent" => [random_item("mainstream_browse_page", "title" => "A parent")],
-        "mainstream_browse_pages" => [random_item("mainstream_browse_page", "title" => "A browse page")],
+        "mainstream_browse_pages" => [example_item("mainstream_browse_page", "root_page")],
       }
     )
   end
@@ -165,7 +165,7 @@ describe "Contextual navigation" do
   def then_i_see_the_browse_page_in_the_footer
     within '.gem-c-contextual-footer' do
       expect(page).to have_selector(".gem-c-related-navigation")
-      expect(page).to have_content("A browse page")
+      expect(page).to have_content("Browse")
     end
   end
 

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -81,7 +81,7 @@ describe "Contextual navigation" do
   def given_theres_a_page_with_browse_page
     content_store_has_random_item(
       links: {
-        "parent" => [random_item("mainstream_browse_page", "title" => "A parent")],
+        "parent" => [example_item("mainstream_browse_page", "top_level_page")],
         "mainstream_browse_pages" => [example_item("mainstream_browse_page", "root_page")],
       }
     )
@@ -90,7 +90,7 @@ describe "Contextual navigation" do
   def given_theres_a_page_with_related_items
     content_store_has_random_item(
       links: {
-        "parent" => [random_item("mainstream_browse_page", "title" => "A parent")],
+        "parent" => [example_item("mainstream_browse_page", "top_level_page")],
         "ordered_related_items" => [example_item("guide", "guide")]
       }
     )
@@ -102,7 +102,7 @@ describe "Contextual navigation" do
       "base_path" => "/page-with-contextual-navigation",
       "document_type" => "travel_advice",
       "links" => {
-        "parent" => [random_item("mainstream_browse_page", "title" => "A parent")],
+        "parent" => [example_item("mainstream_browse_page", "top_level_page")],
         "taxons" => [example_item("taxon", "taxon")],
         "ordered_related_items" => [example_item("guide", "guide")]
       }
@@ -127,7 +127,7 @@ describe "Contextual navigation" do
     topic = random_item("topic", "title" => "A legacy topic")
     content_store_has_random_item(links: {
       "topics" => [topic],
-      "parent" => [random_item("mainstream_browse_page", "title" => "A parent")]
+      "parent" => [example_item("mainstream_browse_page", "top_level_page")]
     })
   end
 
@@ -179,7 +179,7 @@ describe "Contextual navigation" do
   def and_the_parent_based_breadcrumbs
     within '.gem-c-breadcrumbs' do
       expect(page).to have_link("Home")
-      expect(page).to have_link("A parent")
+      expect(page).to have_link("Benefits")
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/uR7v1Rri

Related to:
https://github.com/alphagov/govuk-content-schemas/pull/892
https://github.com/alphagov/govuk-content-schemas/pull/891

Content item types, `facet_groups`, `facets` and `facet_values` were changed to be "base_path-less" in https://github.com/alphagov/govuk-content-schemas/pull/891. 

We did this because, that's how they were already being treated in publishing-api and content-store, but we couldn't add re-usable test examples until this was explicitly stated in `govuk-content-schemas`.

However, this started causing the [feature tests in this app](https://ci.integration.publishing.service.gov.uk/job/govuk_publishing_components/job/master/731/consoleFull) to fail with errors like:

```
 Failure/Error:
       GovukSchemas::RandomExample.for_schema(frontend_schema: schema_name) do |random_item|
         random_item.merge(merge_with)
       end

     GovukSchemas::InvalidContentGenerated:
       The content item you are trying to generate is invalid against the schema.
       The item was valid before being customised.
```
and
```
         {
           "schema": "046a2c23-3e82-578d-86d3-8d23a5e24eb2#",
           "fragment": "#/links/taxons/1/links/facet_groups/2",
           "message": "The property '#/links/taxons/1/links/facet_groups/2' did not contain a required property of 'base_path' in schema 046a2c23-3e82-578d-86d3-8d23a5e24eb2#",
           "failed_attribute": "Required"
         },
```

The feature tests rely on `govuk_schemas` to create a random content item based on a schema, and then modify a part of it, e.g. the content item title. `govuk_schemas` validates the content item it creates twice. Once when the base content item is created, and again when the modifications are added, i.e. when the content item is "customised".

It's not entirely clear why the validation was failing. The content item was being created "correctly", but the links for `facet_groups` and `facet_values` were being validated against the wrong schema definition. 

Also, the links being created were unnecessary. `taxons` and `parent` links etc, don't need to be tagged to a `facet_group` and it's extremely unlikely that they ever will be.

Rather than spending a lot of time trying to fix random content item generation here, the feature tests have been updated to read in already validated examples to generate the links hash.

## Note about tests
The tests won't pass until https://github.com/alphagov/govuk-content-schemas/pull/892 is deployed to production and the new [taxon_in_alpha_phase](https://github.com/alphagov/govuk-content-schemas/blob/master/examples/taxon/frontend/taxon_in_alpha_phase.json) example is available.
