### PR TITLE
Replaces gem-c-button--destructive with govuk-button--warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+- Replace gems version of warning button with GOV.UK Frontend version (PR #848)
+
 ## 16.16.0
 - Add attachment (experimental) component (PR #842)
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -8,10 +8,6 @@ $gem-secondary-button-hover-background-colour: govuk-colour("grey-4");
 $gem-quiet-button-colour: govuk-colour("grey-1");
 $gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
 
-$gem-destructive-button-background-colour: govuk-colour("red");
-$gem-destructive-button-hover-background-colour: darken($gem-destructive-button-background-colour, 5%);
-$gem-destructive-button-border-colour: govuk-colour("black");
-
 // Because govuk-frontend adds a responsive bottom margin by default for each component
 // we reset it to zero so we can set it separately using `gem-c-button--bottom-margin`
 // If we decide to use responsive margins consistently across components we can remove this
@@ -95,22 +91,6 @@ $gem-destructive-button-border-colour: govuk-colour("black");
 
   &:before {
     content: none;
-  }
-}
-
-.gem-c-button--destructive {
-  background-color: $gem-destructive-button-background-colour;
-  box-shadow: 0 2px 0 $gem-destructive-button-border-colour;
-
-  &:link,
-  &:visited,
-  &:active,
-  &:focus {
-    background-color: $gem-destructive-button-background-colour;
-  }
-
-  &:hover {
-    background-color: $gem-destructive-button-hover-background-colour;
   }
 }
 

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -48,7 +48,7 @@ module GovukPublishingComponents
         classes << "govuk-button--start" if start
         classes << "gem-c-button--secondary" if secondary
         classes << "gem-c-button--secondary-quiet" if secondary_quiet
-        classes << "gem-c-button--destructive" if destructive
+        classes << "govuk-button--warning" if destructive
         classes << "gem-c-button--bottom-margin" if margin_bottom
         classes.join(" ")
       end

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -54,8 +54,8 @@ describe "Button", type: :view do
 
   it "renders destructive button" do
     render_component(text: "Warning", href: "#", destructive: true)
-    assert_select ".gem-c-button--destructive[href='#']", text: "Warning"
-    assert_select ".gem-c-button--destructive"
+    assert_select ".govuk-button--warning[href='#']", text: "Warning"
+    assert_select ".govuk-button--warning"
   end
 
   it "renders an anchor if href set" do


### PR DESCRIPTION
As these two styles are identical, this PR removes the CSS from the gem and configures the button component to use GOV.UK Frontend warning button (https://design-system.service.gov.uk/components/button/#warning-buttons). 

## Before 
![image](https://user-images.githubusercontent.com/3441519/57438228-5b2fb180-723b-11e9-94bf-425d4ec3b22d.png)


## After
![image](https://user-images.githubusercontent.com/3441519/57438242-6551b000-723b-11e9-8674-0651d4457601.png)


👉 https://design-system.service.gov.uk/components/button/#warning-buttons
👉 https://govuk-publishing-compon-pr-848.herokuapp.com/component-guide/button/destructive_button