### PR TITLE
Prevent double click for buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 - Replace gems version of warning button with GOV.UK Frontend version (PR #848)
+- Prevent double click by default for submit buttons (PR #849)
 
 ## 16.16.0
 - Add attachment (experimental) component (PR #842)

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -8,6 +8,8 @@ body: |
   These instances of buttons are added by Content Designers, ideally this duplication would not exist but we currently don't have shared markup
   via our components within the generated [govspeak](https://github.com/alphagov/govspeak).
   (This is a challenge to the reader)
+
+  Buttons with type submit (implicitly defined of unset) are enhanced to [prevent them from being double clicked](https://github.com/alphagov/govuk-frontend/commit/884e7dd73ad943d71fb701da15626e6a7ad0b933).
 accessibility_criteria: |
   The button must:
 

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -12,7 +12,8 @@ module GovukPublishingComponents
         @title = local_assigns[:title]
         @info_text = local_assigns[:info_text]
         @rel = local_assigns[:rel]
-        @data_attributes = local_assigns[:data_attributes]
+        @default_data_attributes = { "prevent-double-click" => true }
+        @data_attributes = local_assigns[:data_attributes] ? local_assigns[:data_attributes].merge(@default_data_attributes) : @default_data_attributes
         @margin_bottom = local_assigns[:margin_bottom]
         @target = local_assigns[:target]
         @type = local_assigns[:type]

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -32,8 +32,7 @@ module GovukPublishingComponents
         options[:role] = "button" if link?
         options[:type] = button_type
         options[:rel] = rel if rel
-        options[:data] = data_attributes ? data_attributes.merge(@default_data_attributes) : @default_data_attributes
-        options[:data] = data_attributes if button_type != "submit"
+        options[:data] = button_type == "submit" ? data_attributes.to_h.merge(@default_data_attributes) : data_attributes
         options[:title] = title if title
         options[:target] = target if target
         options

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -13,7 +13,7 @@ module GovukPublishingComponents
         @info_text = local_assigns[:info_text]
         @rel = local_assigns[:rel]
         @default_data_attributes = { "prevent-double-click" => true }
-        @data_attributes = local_assigns[:data_attributes] ? local_assigns[:data_attributes].merge(@default_data_attributes) : @default_data_attributes
+        @data_attributes = local_assigns[:data_attributes]
         @margin_bottom = local_assigns[:margin_bottom]
         @target = local_assigns[:target]
         @type = local_assigns[:type]
@@ -32,7 +32,8 @@ module GovukPublishingComponents
         options[:role] = "button" if link?
         options[:type] = button_type
         options[:rel] = rel if rel
-        options[:data] = data_attributes if data_attributes
+        options[:data] = data_attributes ? data_attributes.merge(@default_data_attributes) : @default_data_attributes
+        options[:data] = data_attributes if button_type != "submit"
         options[:title] = title if title
         options[:target] = target if target
         options

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -107,6 +107,24 @@ describe "Button", type: :view do
     assert_select "button.govuk-button[data-prevent-double-click='true']"
   end
 
+  it "renders the default data attribute for submit buttons" do
+    render_component(
+      text: "Submit",
+      type: "submit"
+    )
+
+    assert_select "button.govuk-button[data-prevent-double-click='true']"
+  end
+
+  it "doesn't render the default data attribute for buttons with type button" do
+    render_component(
+      text: "Submit",
+      type: "button"
+    )
+
+    assert_select "button.govuk-button[data-prevent-double-click='true']", false
+  end
+
   it "renders custom data attributes correctly for buttons" do
     render_component(
       text: "Submit",
@@ -120,7 +138,6 @@ describe "Button", type: :view do
     assert_select "button.govuk-button[data-module='cross-domain-tracking']"
     assert_select "button.govuk-button[data-tracking-code='GA-123ABC']"
     assert_select "button.govuk-button[data-tracking-name='transactionTracker']"
-    assert_select "button.govuk-button[data-prevent-double-click='true']"
   end
 
   it "renders data attributes correctly for links" do

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -99,7 +99,15 @@ describe "Button", type: :view do
     assert_select ".govuk-button.gem-c-button--bottom-margin", text: "Submit"
   end
 
-  it "renders data attributes correctly for buttons" do
+  it "renders the default data attribute for buttons" do
+    render_component(
+      text: "Submit",
+    )
+
+    assert_select "button.govuk-button[data-prevent-double-click='true']"
+  end
+
+  it "renders custom data attributes correctly for buttons" do
     render_component(
       text: "Submit",
       data_attributes: {
@@ -112,6 +120,7 @@ describe "Button", type: :view do
     assert_select "button.govuk-button[data-module='cross-domain-tracking']"
     assert_select "button.govuk-button[data-tracking-code='GA-123ABC']"
     assert_select "button.govuk-button[data-tracking-name='transactionTracker']"
+    assert_select "button.govuk-button[data-prevent-double-click='true']"
   end
 
   it "renders data attributes correctly for links" do


### PR DESCRIPTION
### What
Set `prevent-double-click` data attribute to `true` by default for the button component.

See [original commit](https://github.com/alphagov/govuk-frontend/commit/884e7dd73ad943d71fb701da15626e6a7ad0b933) for more details about how this works.

### Why
We discovered in research that users with low digital skills sometimes use double click to trigger an action which may result in unexpected system failures (for example when trying to remove an entity the second attempt fails) or double additions. For this reason we think the best measure is to introduce this preventive measure for all instances of buttons instead of trying to figure out when a system may fail because of it.

[Trello card](https://trello.com/c/JLkfkNxQ)