### PR TITLE
Add SVG thumbnail icons to attachment component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Add inline SVG icons to attachment component (PR #850)
+
 ## 16.17.0
+
 - Replace gems version of warning button with GOV.UK Frontend version (PR #848)
 - Prevent double click by default for submit buttons (PR #849)
 - Update contextual navigation feature tests to use examples from govuk-content-schemas (PR #847)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -1,9 +1,11 @@
 $thumbnail-width: 99px;
 $thumbnail-height: 140px;
-$thumbnail-border: 5px;
+$thumbnail-border-width: 5px;
+$thumbnail-background: govuk-colour("white");
 $thumbnail-border-colour: rgba(11, 12, 12, .1);
 $thumbnail-shadow-colour: rgba(11, 12, 12, .4);
 $thumbnail-shadow-width: 0 2px 2px;
+$thumbnail-icon-border-colour: govuk-colour("grey-3");
 
 .gem-c-attachment {
   @include govuk-font(19);
@@ -11,11 +13,12 @@ $thumbnail-shadow-width: 0 2px 2px;
 }
 
 .gem-c-attachment__thumbnail {
-  float: left;
-  margin-bottom: govuk-spacing(3);
-  margin-right: govuk-spacing(5);
-  padding: $thumbnail-border;
   position: relative;
+  width: auto;
+  margin-right: govuk-spacing(5);
+  margin-bottom: govuk-spacing(3);
+  padding: $thumbnail-border-width;
+  float: left;
 }
 
 .gem-c-attachment__thumbnail-image {
@@ -23,10 +26,12 @@ $thumbnail-shadow-width: 0 2px 2px;
   width: auto; // for IE8
   max-width: $thumbnail-width;
   height: $thumbnail-height;
-  outline: $thumbnail-border solid $thumbnail-border-colour;
   border: $thumbnail-border-colour; // for IE9 & IE10
-  background: govuk-colour("white");
+  outline: $thumbnail-border-width solid $thumbnail-border-colour;
+  background: $thumbnail-background;
   box-shadow: $thumbnail-shadow-width $thumbnail-shadow-colour;
+  fill: $thumbnail-icon-border-colour;
+  stroke: $thumbnail-icon-border-colour;
 }
 
 .gem-c-attachment__title {
@@ -40,6 +45,6 @@ $thumbnail-shadow-width: 0 2px 2px;
 }
 
 .gem-c-attachment__abbr {
-  cursor: help;
   text-decoration: none;
+  cursor: help;
 }

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -25,7 +25,11 @@
 %>
 <%= tag.section class: "gem-c-attachment" do %>
   <%= tag.div class: "gem-c-attachment__thumbnail" do %>
-    <%= link_to attachment.url, target: target, tabindex: "-1", "aria-hidden": true do %>
+    <%= link_to attachment.url,
+                class: "govuk-link",
+                target: target,
+                tabindex: "-1",
+                "aria-hidden": true do %>
       <% if attachment.document? %>
         <%= render "govuk_publishing_components/components/attachment/thumbnail_document.svg" %>
       <% elsif attachment.spreadsheet? %>

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -4,10 +4,14 @@
   hide_help_text ||= false
   attributes = []
 
-  if attachment.content_type_abbr
-    content = tag.abbr(attachment.content_type_abbr,
-                       class: "gem-c-attachment__abbr",
-                       title: attachment.readable_content_type)
+  if attachment.readable_content_type
+    content = if attachment.content_type_abbr
+                raw tag.abbr(attachment.content_type.abbr,
+                             title: attachment.readable_content_type,
+                             class: "gem-c-attachment__abbr")
+              else
+                attachment.readable_content_type
+              end
     attributes << tag.span(content, class: "gem-c-attachment__attribute")
   end
 

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -22,9 +22,13 @@
 <%= tag.section class: "gem-c-attachment" do %>
   <%= tag.div class: "gem-c-attachment__thumbnail" do %>
     <%= link_to attachment.url, target: target, tabindex: "-1", "aria-hidden": true do %>
-      <%= tag.img class: "gem-c-attachment__thumbnail-image",
-                  src: attachment.thumbnail
-      %>
+      <% if attachment.document? %>
+        <%= render "govuk_publishing_components/components/attachment/thumbnail_document.svg" %>
+      <% elsif attachment.spreadsheet? %>
+        <%= render "govuk_publishing_components/components/attachment/thumbnail_spreadsheet.svg" %>
+      <% else %>
+        <%= render "govuk_publishing_components/components/attachment/thumbnail_generic.svg" %>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -45,8 +45,9 @@
           class: "govuk-link",
           target: target %>
   <% end %>
-  <%= tag.p class: "gem-c-attachment__metadata" do %>
-    <%= raw(attributes.join(', ')) if attributes.any? %>
+
+  <% if attributes.any? %>
+    <%= tag.p raw(attributes.join(', ')), class: "gem-c-attachment__metadata" %>
   <% end %>
 
   <% unless hide_help_text %>

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -4,23 +4,29 @@
   hide_help_text ||= false
   attributes = []
 
-  if attachment.readable_content_type
+  if attachment.content_type_name
     content = if attachment.content_type_abbr
                 raw tag.abbr(attachment.content_type.abbr,
-                             title: attachment.readable_content_type,
+                             title: attachment.content_type_name,
                              class: "gem-c-attachment__abbr")
               else
-                attachment.readable_content_type
+                attachment.content_type_name
               end
     attributes << tag.span(content, class: "gem-c-attachment__attribute")
   end
 
-  if attachment.readable_file_size
-    attributes << tag.span(attachment.readable_file_size, class: "gem-c-attachment__attribute")
+  if attachment.file_size
+    attributes << tag.span(
+      number_to_human_size(attachment.file_size),
+      class: "gem-c-attachment__attribute",
+    )
   end
 
-  if attachment.readable_number_of_pages
-    attributes << tag.span(attachment.readable_number_of_pages, class: "gem-c-attachment__attribute")
+  if attachment.number_of_pages
+    attributes << tag.span(
+      pluralize(attachment.number_of_pages, "page"),
+      class: "gem-c-attachment__attribute",
+    )
   end
 %>
 <%= tag.section class: "gem-c-attachment" do %>

--- a/app/views/govuk_publishing_components/components/_attachment_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment_link.html.erb
@@ -2,10 +2,10 @@
   attachment = GovukPublishingComponents::Presenters::Attachment.new(attachment)
   target ||= nil
   attributes = []
-  if attachment.readable_content_type
+  if attachment.content_type_name
     content = if attachment.content_type_abbr
                 raw tag.abbr(attachment.content_type.abbr,
-                             title: attachment.readable_content_type,
+                             title: attachment.content_type_name,
                              class: "gem-c-attachment-link__abbr")
               else
                 attachment.readable_content_type
@@ -14,12 +14,18 @@
     attributes << tag.span(content, class: "gem-c-attachment-link__attribute")
   end
 
-  if attachment.readable_file_size
-    attributes << tag.span(attachment.readable_file_size, class: "gem-c-attachment-link__attribute")
+  if attachment.file_size
+    attributes << tag.span(
+      number_to_human_size(attachment.file_size),
+      class: "gem-c-attachment-link__attribute",
+    )
   end
 
-  if attachment.readable_number_of_pages
-    attributes << tag.span(attachment.readable_number_of_pages, class: "gem-c-attachment-link__attribute")
+  if attachment.number_of_pages
+    attributes << tag.span(
+      pluralize(attachment.number_of_pages, "page"),
+      class: "gem-c-attachment-link__attribute",
+    )
   end
 %>
 <%= tag.span(class: "gem-c-attachment-link") do %>

--- a/app/views/govuk_publishing_components/components/attachment/_thumbnail_document.svg
+++ b/app/views/govuk_publishing_components/components/attachment/_thumbnail_document.svg
@@ -1,4 +1,3 @@
-<svg class="gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--svg" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 99 140">
-  <defs><style>.cls-1{fill:#dee0e2}</style></defs>
-  <path class="cls-1" d="M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z"/>
+<svg class="gem-c-attachment__thumbnail-image" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+  <path d="M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z" stroke-width="0"/>
 </svg>

--- a/app/views/govuk_publishing_components/components/attachment/_thumbnail_document.svg
+++ b/app/views/govuk_publishing_components/components/attachment/_thumbnail_document.svg
@@ -1,0 +1,4 @@
+<svg class="gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--svg" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 99 140">
+  <defs><style>.cls-1{fill:#dee0e2}</style></defs>
+  <path class="cls-1" d="M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z"/>
+</svg>

--- a/app/views/govuk_publishing_components/components/attachment/_thumbnail_generic.svg
+++ b/app/views/govuk_publishing_components/components/attachment/_thumbnail_generic.svg
@@ -1,4 +1,4 @@
-<svg class="gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--svg" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 120">
-  <defs><style>.cls-1{fill:none;stroke:#dee0e2;stroke-miterlimit:10;stroke-width:2px}</style></defs>
-  <path class="cls-1" d="M74.85 5v106H5"/><path class="cls-1" d="M79.85 10v106H10"/>
+<svg class="gem-c-attachment__thumbnail-image" version="1.1" viewBox="0 0 84 120" width="84" height="120" aria-hidden="true">
+  <path d="M74.85 5v106H5" fill="none" stroke-miterlimit="10" stroke-width="2"/>
+  <path d="M79.85 10v106H10" fill="none" stroke-miterlimit="10" stroke-width="2"/>
 </svg>

--- a/app/views/govuk_publishing_components/components/attachment/_thumbnail_generic.svg
+++ b/app/views/govuk_publishing_components/components/attachment/_thumbnail_generic.svg
@@ -1,0 +1,4 @@
+<svg class="gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--svg" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84 120">
+  <defs><style>.cls-1{fill:none;stroke:#dee0e2;stroke-miterlimit:10;stroke-width:2px}</style></defs>
+  <path class="cls-1" d="M74.85 5v106H5"/><path class="cls-1" d="M79.85 10v106H10"/>
+</svg>

--- a/app/views/govuk_publishing_components/components/attachment/_thumbnail_spreadsheet.svg
+++ b/app/views/govuk_publishing_components/components/attachment/_thumbnail_spreadsheet.svg
@@ -1,6 +1,5 @@
-<svg class="gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--svg" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 99 140">
-  <defs><style>.cls-1{fill:#dee0e2}.cls-2{fill:none;stroke:#dee0e2;stroke-miterlimit:10;stroke-width:2px}</style></defs>
-  <path class="cls-1" d="M12 12h75v27H12zM12 59h18.75v63H12zM67 61v59H51V61h16m2-2H49v63h20V59z"/>
-  <path class="cls-1" d="M49 61.05V120H32.8V61.05H49m2-2H30.75v63H51V59zM85 61.05V120H69.05V61.05H85m2-2H67v63h20V59z"/>
-  <path class="cls-2" d="M30 68.5h56.5M30 77.34h56.5M30 112.7h56.5M30 95.02h56.5M30 86.18h56.5M30 103.86h56.5"/>
+<svg class="gem-c-attachment__thumbnail-image" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+  <path d="M12 12h75v27H12zm0 47h18.75v63H12zm55 2v59H51V61h16m2-2H49v63h20V59z" stroke-width="0"/>
+  <path d="M49 61.05V120H32.8V61.05H49m2-2H30.75v63H51V59zm34 2V120H69.05V61.05H85m2-2H67v63h20V59z" stroke-width="0"/>
+  <path d="M30 68.5h56.5M30 77.34h56.5M30 112.7h56.5M30 95.02h56.5M30 86.18h56.5M30 103.86h56.5" fill="none" stroke-miterlimit="10" stroke-width="2"/>
 </svg>

--- a/app/views/govuk_publishing_components/components/attachment/_thumbnail_spreadsheet.svg
+++ b/app/views/govuk_publishing_components/components/attachment/_thumbnail_spreadsheet.svg
@@ -1,0 +1,6 @@
+<svg class="gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--svg" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 99 140">
+  <defs><style>.cls-1{fill:#dee0e2}.cls-2{fill:none;stroke:#dee0e2;stroke-miterlimit:10;stroke-width:2px}</style></defs>
+  <path class="cls-1" d="M12 12h75v27H12zM12 59h18.75v63H12zM67 61v59H51V61h16m2-2H49v63h20V59z"/>
+  <path class="cls-1" d="M49 61.05V120H32.8V61.05H49m2-2H30.75v63H51V59zM85 61.05V120H69.05V61.05H85m2-2H67v63h20V59z"/>
+  <path class="cls-2" d="M30 68.5h56.5M30 77.34h56.5M30 112.7h56.5M30 95.02h56.5M30 86.18h56.5M30 103.86h56.5"/>
+</svg>

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -17,9 +17,8 @@ body: |
 shared_accessibility_criteria:
 - link
 accessibility_criteria: |
-  The thumbnail image has no `alt` attribute, which causes the link which wraps
-  the thumbnail to contain no content. Since screen readers will have nothing to
-  read in this case, we set `aria-hidden=true` on the thumbail so that it's hidden.
+  The thumbnail image, and the link wrapping it, must not focusable or shown to
+  screenreaders.
 examples:
   default:
     data:
@@ -49,9 +48,9 @@ examples:
   help_text_disabled:
     data:
       attachment:
-        title: "BEIS Information Asset Register"
-        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/744083/BEIS_Information_Asset_Register_.ods
-        filename: BEIS_Information_Asset_Register_.ods
-        content_type: application/vnd.oasis.opendocument.spreadsheet
-        file_size: 20000
+        title: "Attitudes in Iraq: June 2005 wave 1"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/137879/20130110_Iraq_wave01.txt
+        filename: 20130110_Iraq_wave01.txt
+        content_type: text/plain
+        file_size: 108515
       hide_help_text: true

--- a/lib/govuk_publishing_components/presenters/attachment.rb
+++ b/lib/govuk_publishing_components/presenters/attachment.rb
@@ -1,9 +1,6 @@
 module GovukPublishingComponents
   module Presenters
     class Attachment
-      include ActionView::Helpers::NumberHelper
-      include ActionView::Helpers::TextHelper
-
       delegate :opendocument?, :document?, :spreadsheet?, to: :content_type
 
       attr_reader :attachment_data
@@ -34,20 +31,16 @@ module GovukPublishingComponents
         content_type.abbr
       end
 
-      def readable_content_type
+      def content_type_name
         content_type.name
       end
 
-      def readable_file_size
-        return unless attachment_data[:file_size]
-
-        number_to_human_size(attachment_data[:file_size])
+      def file_size
+        attachment_data[:file_size]
       end
 
-      def readable_number_of_pages
-        return unless attachment_data[:number_of_pages]
-
-        pluralize(attachment_data[:number_of_pages], "page")
+      def number_of_pages
+        attachment_data[:number_of_pages]
       end
 
       class SupportedContentType

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -15,7 +15,6 @@ describe "Attachment", type: :view do
     render_component(attachment: { title: "Attachment", url: "https://gov.uk/attachment" })
     assert_select ".gem-c-attachment"
     assert_select "a[href='https://gov.uk/attachment']", text: "Attachment"
-    assert_select "img[src='https://www.gov.uk/government/assets/pub-cover-doc-afe3b0a8a9511beeca890340170aee8b5649413f948e512c9b8ce432d8513d32.png'][class='gem-c-attachment__thumbnail-image']"
   end
 
   it "can have a target specified" do

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -40,6 +40,16 @@ describe "Attachment", type: :view do
     expect(rendered).to match(/2 pages/)
   end
 
+  it "can show file type that doesn't have an abbreviation" do
+    render_component(
+      attachment: {
+        title: "Attachment",
+        url: "attachment",
+        content_type: "text/plain",
+      },
+    )
+    expect(rendered).to match(/Plain Text/)
+  end
   it "shows OpenDocument help text if OpenDocument format" do
     render_component(
       attachment: {

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -50,6 +50,19 @@ describe "Attachment", type: :view do
     )
     expect(rendered).to match(/Plain Text/)
   end
+
+  it "doesn't show metadata information when there isn't any to show" do
+    render_component(
+      attachment: {
+        title: "Attachment",
+        url: "attachment",
+        content_type: "unknown/type",
+      },
+    )
+
+    assert_select ".gem-c-attachment__metadata", false
+  end
+
   it "shows OpenDocument help text if OpenDocument format" do
     render_component(
       attachment: {

--- a/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
@@ -62,30 +62,6 @@ RSpec.describe GovukPublishingComponents::Presenters::Attachment do
     end
   end
 
-  describe "#readable_file_size" do
-    it "returns nil if there isn't a file_size provided" do
-      attachment = described_class.new(title: "test", url: "test")
-      expect(attachment.readable_file_size).to be_nil
-    end
-
-    it "returns a human readable file size if file_size is provided" do
-      attachment = described_class.new(title: "test", url: "test", file_size: 1024)
-      expect(attachment.readable_file_size).to eq("1 KB")
-    end
-  end
-
-  describe "#readable_number_of_pages" do
-    it "returns nil if there isn't a number_of_pages provided" do
-      attachment = described_class.new(title: "test", url: "test")
-      expect(attachment.readable_number_of_pages).to be_nil
-    end
-
-    it "returns a pluralised number of pages if number_of_pages is provided" do
-      attachment = described_class.new(title: "test", url: "test", number_of_pages: 3)
-      expect(attachment.readable_number_of_pages).to eq("3 pages")
-    end
-  end
-
   describe "#opendocument?" do
     it "returns true if content type is an OpenDocument" do
       attachment = described_class.new(title: "test",

--- a/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
@@ -101,4 +101,36 @@ RSpec.describe GovukPublishingComponents::Presenters::Attachment do
       expect(attachment.opendocument?).to be false
     end
   end
+
+  describe "#document?" do
+    it "returns true for content types specified as a document" do
+      attachment = described_class.new(title: "test",
+                                       url: "test",
+                                       content_type: "application/msword")
+      expect(attachment.document?).to be true
+    end
+
+    it "returns false for a content type not specified as a document" do
+      attachment = described_class.new(title: "test",
+                                       url: "test",
+                                       content_type: "text/plain")
+      expect(attachment.document?).to be false
+    end
+  end
+
+  describe "#spreadsheet?" do
+    it "returns true for content types specified as a document" do
+      attachment = described_class.new(title: "test",
+                                       url: "test",
+                                       content_type: "text/csv")
+      expect(attachment.spreadsheet?).to be true
+    end
+
+    it "returns false for a content type not specified as a spreadsheet" do
+      attachment = described_class.new(title: "test",
+                                       url: "test",
+                                       content_type: "text/plain")
+      expect(attachment.spreadsheet?).to be false
+    end
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/HO5MZZEG/822-show-thumbnails-for-attachment-file-formats

This adds in inline SVGs for the different file types that can be shown as an attachment: document, spreadsheet and generic. It does not include HTML attachments as this component does not support these yet. It also does not allow the concept of passing an image in for a PDF attachment as a [product decision](https://gov-uk.atlassian.net/wiki/spaces/GOVUK/pages/1399422981/Design+documentation+Content+Publisher+Q1+19+20#Designdocumentation%E2%80%93ContentPublisherQ119/20-RemovepreviewfromPDFattachments) has been made to remove that functionality.

This also fixes two small issues: content type wasn't showing when it lacked an abbreviation, and we were still getting the browser default outline on the thumbnail link.

Examples of the different icons (which some are rendering incorrectly currently)
![Screen Shot 2019-05-09 at 12 17 07](https://user-images.githubusercontent.com/282717/57449735-9a1e3100-7254-11e9-8643-49cae1e61f94.png)
![Screen Shot 2019-05-09 at 12 17 26](https://user-images.githubusercontent.com/282717/57449740-9be7f480-7254-11e9-89c3-a2469355cab0.png)
![Screen Shot 2019-05-09 at 12 17 31](https://user-images.githubusercontent.com/282717/57449745-9db1b800-7254-11e9-948e-5ccf61859cc9.png)

This PR is marked as a draft as I'm hoping @alex-ju can do some more styling with the svgs and fix the missing grey fills
