### PR TITLE
Fix formatting for 16.14.1 heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 - Update cookie-banner behaviour without Javascript (PR #843)
 
-## 16.14.1
+## 16.14.1
 
 - Revert the cookie banner tracking which was added in v16.12.0 (PR #839)
 


### PR DESCRIPTION
There was the "wrong type" of space here which stopped the heading being formatted correctly by GitHub