### PR TITLE
Update to SassC Rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       rails (>= 5.0.0.1)
       rake
       rouge
-      sass-rails (>= 5.0.4)
+      sassc-rails (>= 2.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -100,13 +100,13 @@ GEM
       rubocop (~> 0.64)
       rubocop-rspec (~> 1.28)
       scss_lint
-    govuk_app_config (1.16.0)
+    govuk_app_config (1.16.1)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
       unicorn (~> 5.4.0)
-    govuk_frontend_toolkit (8.1.0)
+    govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_schemas (3.2.0)
@@ -148,7 +148,7 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    multipart-post (2.1.0)
+    multipart-post (2.1.1)
     netrc (0.11.0)
     nio4r (2.3.1)
     nokogiri (1.10.1)
@@ -250,12 +250,15 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
+    sassc-rails (2.1.1)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     scss_lint (0.57.1)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 5.0.0.1"
   s.add_dependency "rake"
   s.add_dependency "rouge"
-  s.add_dependency "sass-rails", ">= 5.0.4"
+  s.add_dependency "sassc-rails", ">= 2.0.1"
 
   s.add_development_dependency "capybara", "~> 2.14.4"
   s.add_development_dependency "foreman", "~> 0.64"


### PR DESCRIPTION
Ruby Sass is deprecated so needs to be replaced with something that is supported. [SassC Rails](https://github.com/sass/sassc-rails) is faster and a drop in replacement, according to its readme, and it seems to be both of these.

Fixes #601.

[Trello ticket](https://trello.com/c/V5y9atIh/80-draft-investigate-swapping-out-sass-rails-for-sassc-rails).