### PR TITLE
Release v16.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
-
-- Add inline SVG icons to attachment component (PR #850)
-
 ## 16.17.0
 
 - Replace gems version of warning button with GOV.UK Frontend version (PR #848)
 - Prevent double click by default for submit buttons (PR #849)
+- Add inline SVG icons to attachment component (PR #850)
 - Update contextual navigation feature tests to use examples from govuk-content-schemas (PR #847)
 
 ## 16.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (16.16.0)
+    govuk_publishing_components (16.17.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -314,6 +314,9 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   webmock (~> 3.5.0)
   yard
+
+RUBY VERSION
+   ruby 2.6.3p62
 
 BUNDLED WITH
    1.17.3

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '16.16.0'.freeze
+  VERSION = '16.17.0'.freeze
 end


### PR DESCRIPTION
## 16.17.0

- Replace gems version of warning button with GOV.UK Frontend version (PR #848)
- Prevent double click by default for submit buttons (PR #849)
- Add inline SVG icons to attachment component (PR #850)
- Update contextual navigation feature tests to use examples from govuk-content-schemas (PR #847)

### Note
https://github.com/alphagov/govuk_publishing_components/pull/851 was wrongly labeled as a release since it only updated the README.md file.