### PR TITLE
Fix attachment rendering within Govspeak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Add new version of (experimental) cookie banner (PR #845)
 - Add inline variation for button component (PR #845)
+- Fix govspeak overriding attachment styling (PR #856)
 
 ## 16.17.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -6,6 +6,11 @@
 // - alphagov/govspeak: ✔︎
 
 .gem-c-govspeak {
+
+  // Scope attachment and attachment-link component styles to gem-c-govspeak
+  @import "../attachment-link";
+  @import "../attachment";
+
   // This block is duplicated from Whitehall as a transitional step, see the
   // commit message for 2d893c10ee3f2cab27162b9aba38b12379a71d07 before making
   // changes, original version:

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_component_output.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_component_output.html.erb
@@ -1,7 +1,7 @@
 <% component = capture do %>
   <% if example.has_block? %>
     <%= render component_doc.partial_path, example.html_safe_data do %>
-      <%= example.block.html_safe %>
+      <%= ERB.new(example.block).result(binding).html_safe %>
     <% end %>
   <% else %>
     <%= render component_doc.partial_path, example.html_safe_data %>

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_component_output.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_component_output.html.erb
@@ -1,7 +1,7 @@
 <% component = capture do %>
   <% if example.has_block? %>
     <%= render component_doc.partial_path, example.html_safe_data do %>
-      <%= ERB.new(example.block).result(binding).html_safe %>
+      <%= render inline: example.block %>
     <% end %>
   <% else %>
     <%= render component_doc.partial_path, example.html_safe_data %>
@@ -9,7 +9,7 @@
 <% end %>
 
 <% if example.has_embed? %>
-  <%= ERB.new(example.embed).result(binding).html_safe %>
+  <%= render inline: example.embed, locals: { component: component } %>
 <% else %>
   <%= component %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -54,3 +54,18 @@ examples:
         content_type: text/plain
         file_size: 108515
       hide_help_text: true
+  embedded_in_govspeak:
+    description: |
+      This component can be embedded in Govspeak with the `[Attachment:]` code.
+    embed: |
+      <%= render "govuk_publishing_components/components/govspeak" do %>
+        <p>Some text.</p>
+        <%= component %>
+      <% end %>
+    data:
+      attachment:
+        title: "BEIS Information Asset Register"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/744083/BEIS_Information_Asset_Register_.ods
+        filename: BEIS_Information_Asset_Register_.ods
+        content_type: application/vnd.oasis.opendocument.spreadsheet
+        file_size: 20000

--- a/app/views/govuk_publishing_components/components/docs/attachment_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment_link.yml
@@ -39,6 +39,21 @@ examples:
         content_type: application/pdf
         file_size: 20000
         number_of_pages: 1
+  embedded_in_govspeak:
+    description: |
+      This component can be embedded in Govspeak with the `[AttachmentLink:]` code.
+    embed: |
+      <%= render "govuk_publishing_components/components/govspeak" do %>
+        <p>Some introductory information about <%= component %>.</p>
+      <% end %>
+    data:
+      attachment:
+        title: "Temporary snow ploughs: guidance note"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/259634/temporary-snow-ploughs.pdf
+        filename: temporary-snow-ploughs.pdf
+        content_type: application/pdf
+        file_size: 20000
+        number_of_pages: 1
   with_target_blank:
     data:
       attachment:

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -375,13 +375,15 @@ examples:
           </ol>
         </div>
   inline_attachment:
+    description: Legacy inline attachment embed used by Whitehall and Specialist Publisher
     data:
       block: |
         <p>testing my attachment <span class="inline-attachment" id="attachment_1399340">
           <a href="/government/uploads/system/uploads/attachment_data/file/498071/PHE_Payments_over__25k_Jun_15.csv">testing</a>
           (<span class="type"><abbr title="Comma-separated Values">CSV</abbr></span>, <span class="file-size">65.4KB</span>)</span> works in the middle of copy.
         </p>
-  block_attachments:
+  whitehall_block_attachments:
+    description: Attachments rendered by govspeak extensions within Whitehall
     data:
       block: |
         <section class="attachment embedded" id="attachment_1399345">
@@ -521,7 +523,8 @@ examples:
             </p>
           </div>
         </section>
-  block_attachment_rtl:
+  whitehall_block_attachment_rtl:
+    description: Attachments rendered by govspeak extensions within Whitehall
     data:
       direction: rtl
       block: |

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -374,6 +374,33 @@ examples:
             </li>
           </ol>
         </div>
+  attachment_link:
+    description: Attachment link component rendered within Govspeak
+    data:
+      block: |
+        <p>
+          A reference to my
+          <%= render "govuk_publishing_components/components/attachment_link",
+              attachment: { url: "https://example.com/file.pdf",
+                            title: "Attachment",
+                            file_size: 1024,
+                            content_type: "application/pdf",
+                            number_of_pages: 2 }
+          %>
+          that is in my paragraph.
+        </p>
+  attachment:
+    description: Attachment component rendered within Govspeak
+    data:
+      block: |
+        <p>An attachment as a block</p>
+
+        <%= render "govuk_publishing_components/components/attachment",
+            attachment: { url: "https://example.com/file.odt",
+                          title: "Attachment",
+                          file_size: 1024,
+                          content_type: "application/vnd.oasis.opendocument.text" }
+        %>
   inline_attachment:
     description: Legacy inline attachment embed used by Whitehall and Specialist Publisher
     data:


### PR DESCRIPTION
Trello: https://trello.com/c/zMYmFTPx/801-show-metadata-for-attachments

This PR does a few things to demonstrate attachment components in a govspeak context (info in commits) and then looks at fixing a styling issue caused by specificity problems between govspeak and attachment component.

Before:

![Screen Shot 2019-05-15 at 09 48 28](https://user-images.githubusercontent.com/282717/57762113-c45d6c00-76f6-11e9-8927-ce7c9063b743.png)

After:

![Screen Shot 2019-05-15 at 09 49 29](https://user-images.githubusercontent.com/282717/57762117-c6272f80-76f6-11e9-8ec4-bc2a9dca3563.png)

