### PR TITLE
Add request different format to attachment component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 - Don't include changes that are purely internal. The CHANGELOG should be a
   useful summary for people upgrading their application, not a replication
   of the commit log.
-  
+
 ## Unreleased
 
 - Remove links to Whitehall publications (PR #823)
+- Add request different format section to attachment component (PR #858)
 
 ## 16.20.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -10,6 +10,11 @@ $thumbnail-icon-border-colour: govuk-colour("grey-3");
 .gem-c-attachment {
   @include govuk-font(19);
   @include govuk-clearfix;
+  position: relative;
+
+  .govuk-details__summary {
+    @include govuk-font($size: 14);
+  }
 }
 
 .gem-c-attachment__thumbnail {
@@ -34,6 +39,10 @@ $thumbnail-icon-border-colour: govuk-colour("grey-3");
   stroke: $thumbnail-icon-border-colour;
 }
 
+.gem-c-attachment__details {
+  padding-left: $thumbnail-width + $thumbnail-border-width * 2 + govuk-spacing(5);
+}
+
 .gem-c-attachment__title {
   @include govuk-font($size: 27);
   margin: 0 0 govuk-spacing(3);
@@ -42,6 +51,10 @@ $thumbnail-icon-border-colour: govuk-colour("grey-3");
 .gem-c-attachment__metadata {
   @include govuk-font($size: 14);
   margin: 0 0 govuk-spacing(3);
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
 }
 
 .gem-c-attachment__abbr {

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -1,7 +1,7 @@
 <%
   attachment = GovukPublishingComponents::Presenters::Attachment.new(attachment)
   target ||= "_self"
-  hide_help_text ||= false
+  hide_opendocument_metadata ||= false
   attributes = []
 
   if attachment.content_type_name
@@ -57,7 +57,7 @@
       <%= tag.p raw(attributes.join(', ')), class: "gem-c-attachment__metadata" %>
     <% end %>
 
-    <% unless hide_help_text %>
+    <% unless hide_opendocument_metadata %>
       <% if attachment.opendocument? %>
         <%= tag.p class: "gem-c-attachment__metadata" do %>
           <%= t("components.attachment.opendocument_html", target: target) %>

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -46,20 +46,31 @@
     <% end %>
   <% end %>
 
-  <%= tag.h2 class: "gem-c-attachment__title" do %>
-    <%= link_to attachment.title, attachment.url,
-          class: "govuk-link",
-          target: target %>
-  <% end %>
+  <%= tag.div class: "gem-c-attachment__details" do %>
+    <%= tag.h2 class: "gem-c-attachment__title" do %>
+      <%= link_to attachment.title, attachment.url,
+            class: "govuk-link",
+            target: target %>
+    <% end %>
 
-  <% if attributes.any? %>
-    <%= tag.p raw(attributes.join(', ')), class: "gem-c-attachment__metadata" %>
-  <% end %>
+    <% if attributes.any? %>
+      <%= tag.p raw(attributes.join(', ')), class: "gem-c-attachment__metadata" %>
+    <% end %>
 
-  <% unless hide_help_text %>
-    <% if attachment.opendocument? %>
-      <%= tag.p class: "gem-c-attachment__metadata" do %>
-        <%= t("components.attachment.opendocument_html", target: target) %>
+    <% unless hide_help_text %>
+      <% if attachment.opendocument? %>
+        <%= tag.p class: "gem-c-attachment__metadata" do %>
+          <%= t("components.attachment.opendocument_html", target: target) %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% if attachment.alternative_format_contact_email %>
+      <%= tag.p t("components.attachment.request_format_text"), class: "gem-c-attachment__metadata" %>
+      <%= render "govuk_publishing_components/components/details", {
+        title: t("components.attachment.request_format_cta")
+      } do %>
+        <%= t("components.attachment.request_format_details_html", alternative_format_contact_email: attachment.alternative_format_contact_email) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -69,3 +69,12 @@ examples:
         filename: BEIS_Information_Asset_Register_.ods
         content_type: application/vnd.oasis.opendocument.spreadsheet
         file_size: 20000
+  with_contact_email:
+    data:
+      attachment:
+        title: "Department for Transport information asset register"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/747661/department-for-transport-information-asset-register.csv
+        filename: department-for-transport-information-asset-register.csv
+        content_type: application/pdf
+        file_size: 20000
+        alternative_format_contact_email: defra.helpline@defra.gsi.gov.uk

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -53,7 +53,7 @@ examples:
         filename: 20130110_Iraq_wave01.txt
         content_type: text/plain
         file_size: 108515
-      hide_help_text: true
+      hide_opendocument_metadata: true
   embedded_in_govspeak:
     description: |
       This component can be embedded in Govspeak with the `[Attachment:]` code.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,9 @@ en:
   components:
     attachment:
       opendocument_html: "This file is in an <a href='https://www.gov.uk/guidance/open-document-format-odf-guidance-for-uk-government/overview-of-productivity-software' target=%{target} class='govuk-link'>OpenDocument</a> format"
+      request_format_text: "This file may not be suitable for users of assistive technology."
+      request_format_cta: "Request a different format"
+      request_format_details_html: "If you use assistive technology and need a version of this document in a more accessible format, please email <a href='mailto:%{alternative_format_contact_email}' target='_blank' class='govuk-link'>%{alternative_format_contact_email}</a>. Please tell us what format you need. It will help us if you say what assistive technology you use."
     autocomplete:
       multiselect: "To select multiple items in a list, hold down Ctrl (PC) or Cmd (Mac) key."
     back_link:

--- a/lib/govuk_publishing_components/presenters/attachment.rb
+++ b/lib/govuk_publishing_components/presenters/attachment.rb
@@ -7,7 +7,7 @@ module GovukPublishingComponents
 
       # Expects a hash of attachment data
       # * title and url are required
-      # * content_type, filename, file_size, number of pages can be provided
+      # * content_type, filename, file_size, number of pages, alternative_format_contact_email can be provided
       def initialize(attachment_data)
         @attachment_data = attachment_data.with_indifferent_access
       end
@@ -41,6 +41,10 @@ module GovukPublishingComponents
 
       def number_of_pages
         attachment_data[:number_of_pages]
+      end
+
+      def alternative_format_contact_email
+        attachment_data[:alternative_format_contact_email]
       end
 
       class SupportedContentType

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -74,7 +74,7 @@ describe "Attachment", type: :view do
     assert_select "a[href='https://www.gov.uk/guidance/open-document-format-odf-guidance-for-uk-government/overview-of-productivity-software']"
   end
 
-  it "shows section to request a different form if a contact email is provided" do
+  it "shows section to request a different format if a contact email is provided" do
     render_component(
       attachment: {
         title: "Attachment",
@@ -86,14 +86,14 @@ describe "Attachment", type: :view do
     assert_select "a[href='mailto:defra.helpline@defra.gsi.gov.uk']"
   end
 
-  it "does not show help text if disabled" do
+  it "does not show opendocument metadata if disabled" do
     render_component(
       attachment: {
         title: "Attachment",
         url: "attachment",
         content_type: "application/vnd.oasis.opendocument.spreadsheet",
       },
-      hide_help_text: true,
+      hide_opendocument_metadata: true,
     )
     assert_select "a[href='https://www.gov.uk/guidance/open-document-format-odf-guidance-for-uk-government/overview-of-productivity-software']", false
   end

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -74,6 +74,18 @@ describe "Attachment", type: :view do
     assert_select "a[href='https://www.gov.uk/guidance/open-document-format-odf-guidance-for-uk-government/overview-of-productivity-software']"
   end
 
+  it "shows section to request a different form if a contact email is provided" do
+    render_component(
+      attachment: {
+        title: "Attachment",
+        url: "attachment",
+        content_type: "application/vnd.oasis.opendocument.spreadsheet",
+        alternative_format_contact_email: "defra.helpline@defra.gsi.gov.uk"
+      },
+    )
+    assert_select "a[href='mailto:defra.helpline@defra.gsi.gov.uk']"
+  end
+
   it "does not show help text if disabled" do
     render_component(
       attachment: {


### PR DESCRIPTION
Add request different format section using the Details component instead of requiring JavaScript for revealing the additional content.

[Trello card](https://trello.com/c/OcuVomSb)