### PR TITLE
Add SearchResultsPage schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add SearchResultsPage schema.org schema (PR #861)
+
 ## 16.19.0
 
 * Adds support to allow parent finder to show as breadcrumbs (PR #831)
@@ -17,7 +21,6 @@
 * Add new version of (experimental) cookie banner (PR #845)
 * Add inline variation for button component (PR #845)
 * Fix govspeak overriding attachment styling (PR #856)
-
 
 ## 16.17.0
 

--- a/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
@@ -69,3 +69,10 @@ examples:
             - title: "Dodgy Wands Commission"
               base_path: "/dodgy-wands-commission"
       schema: :organisation
+  search_results_page_schema:
+    data:
+      content_item:
+        title: "The finding of all things"
+        base_path: "/finder/all"
+        details: {}
+      schema: :search_results_page

--- a/lib/govuk_publishing_components/presenters/machine_readable/search_results_page_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/search_results_page_schema.rb
@@ -1,0 +1,16 @@
+module GovukPublishingComponents
+  module Presenters
+    class SearchResultsPageSchema
+      def initialize(page)
+        @page = page
+      end
+
+      def structured_data
+        # http://schema.org/SearchResultsPage
+        data = ArticleSchema.new(@page).structured_data
+        data["@type"] = "SearchResultsPage"
+        data
+      end
+    end
+  end
+end

--- a/lib/govuk_publishing_components/presenters/schema_org.rb
+++ b/lib/govuk_publishing_components/presenters/schema_org.rb
@@ -6,6 +6,7 @@ require 'govuk_publishing_components/presenters/machine_readable/is_part_of_sche
 require 'govuk_publishing_components/presenters/machine_readable/news_article_schema'
 require 'govuk_publishing_components/presenters/machine_readable/organisation_schema'
 require 'govuk_publishing_components/presenters/machine_readable/person_schema'
+require 'govuk_publishing_components/presenters/machine_readable/search_results_page_schema'
 
 module GovukPublishingComponents
   module Presenters
@@ -25,6 +26,8 @@ module GovukPublishingComponents
           PersonSchema.new(page).structured_data
         elsif page.schema == :organisation
           OrganisationSchema.new(page).structured_data
+        elsif page.schema == :search_results_page
+          SearchResultsPageSchema.new(page).structured_data
         else
           raise "#{page.schema} is not supported"
         end

--- a/spec/components/machine_readable_metadata_spec.rb
+++ b/spec/components/machine_readable_metadata_spec.rb
@@ -50,6 +50,15 @@ describe "Machine readable metadata", type: :view do
     assert_meta_tag "twitter:image", "https://example.org/high-res.jpg"
   end
 
+  it "generates machine readable JSON-LD for finders" do
+    example = GovukSchemas::RandomExample.for_schema(frontend_schema: "finder")
+    render_component(content_item: example, schema: :search_results_page)
+
+    json_linked_data = Nokogiri::HTML(rendered).css('script').text
+
+    assert JSON.parse(json_linked_data)
+  end
+
   def assert_meta_tag(name, content)
     assert_select "meta[name='#{name}'][content='#{content}']"
   end


### PR DESCRIPTION
This adds a naive implementation of https://schema.org/SearchResultsPage which
permits us to add basic schema information to finder pages.  Using this approach
also adds other page metadata (contained in the machine_readable_metadata partial).

We're paying more attention to how these are indexed for search because finders
have different requirements for search visibility.  Specialist finders need
to be findable via Google because these search pages are a critical for a subset
of users.

More general search pages have a more nuanced need.  We generally want people
to avoid navigating from Google search to an internal search page unless it
is for a specific reason.

We have already excluded search results page with keywords from being indexed,
and we similarly exclude everything past the first page.  We'll probably iterate
this approach.

https://trello.com/c/OVkRpKDk/735-add-metadata-for-finders
https://trello.com/c/4EAytHVV/747-plan-noindexing-of-finder-pages
<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->
