### PR TITLE
Add welsh translation for contents list heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add Welsh translation of the contents list heading (PR #862)
 * Enable passing data attributes to attachment components (PR #874)
 * Add potentialSearchAction to the GovernmentOrganization schema (PR #870)
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -6,3 +6,5 @@ cy:
       or: 'neu'
     back_link:
       back: "Yn ôl"
+    contents_list: 
+      contents: Cynnwys

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -128,6 +128,11 @@ describe "Contents list", type: :view do
     assert_select ".gem-c-contents-list__link.brand__color", count: 6
   end
 
+  it "renders the heading in welsh" do
+    I18n.with_locale(:cy) { render_component(contents: contents_list) }
+    assert_select ".gem-c-contents-list__title", text: "Cynnwys"
+  end
+
   it "hides the title" do
     render_component(contents: nested_contents_list, hide_title: true)
     assert_select ".gem-c-contents-list__title", false


### PR DESCRIPTION
For an organisation about page - when language translation exists not all the page furniture is translated. In this example the 'contents' heading is still showing in English. However, other furniture e.g footer back to top link has the word contents translated properly.

Example page: https://www.gov.uk/government/organisations/animal-and-plant-health-agency/about.cy

Raised in zendesk by AHPA org here: https://govuk.zendesk.com/agent/tickets/2915580

Temp fix in the app itself done here: https://github.com/alphagov/government-frontend/pull/1339
