### PR TITLE
Cookie banner tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@
 
 ## Unreleased
 
-- Fix broken call to content_type fallback method (PR #869)
-- Remove links to Whitehall publications (PR #823)
-- Add request different format section to attachment component (PR #858)
+* Fix broken call to content_type fallback method (PR #869)
+* Remove links to Whitehall publications (PR #823)
+* Add request different format section to attachment component (PR #858)
+* Change default new cookie banner consent to on (PR #864)
+* Hide new cookie banner on cookie settings page (PR #864)
 
 ## 16.20.1
 

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -10,17 +10,24 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.showConfirmationMessage = this.showConfirmationMessage.bind(this)
     this.$module.setCookieConsent = this.setCookieConsent.bind(this)
 
-    this.$hideLink = this.$module.querySelector('a[data-hide-cookie-banner], button[data-hide-cookie-banner]')
-    if (this.$hideLink) {
-      this.$hideLink.addEventListener('click', this.$module.hideCookieMessage)
-    }
+    var newCookieBanner = document.querySelector('.gem-c-cookie-banner--new')
 
-    this.$acceptCookiesLink = this.$module.querySelector('button[data-accept-cookies]')
-    if (this.$acceptCookiesLink) {
-      this.$acceptCookiesLink.addEventListener('click', this.$module.setCookieConsent)
-    }
+    // Hide the cookie banner on the cookie settings page, to avoid circular journeys
+    if (newCookieBanner && window.location.pathname === '/help/cookies') {
+      this.$module.style.display = 'none'
+    } else {
+      this.$hideLink = this.$module.querySelector('a[data-hide-cookie-banner], button[data-hide-cookie-banner]')
+      if (this.$hideLink) {
+        this.$hideLink.addEventListener('click', this.$module.hideCookieMessage)
+      }
 
-    this.showCookieMessage()
+      this.$acceptCookiesLink = this.$module.querySelector('button[data-accept-cookies]')
+      if (this.$acceptCookiesLink) {
+        this.$acceptCookiesLink.addEventListener('click', this.$module.setCookieConsent)
+      }
+
+      this.showCookieMessage()
+    }
   }
 
   CookieBanner.prototype.showCookieMessage = function () {

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -5,9 +5,9 @@
   var root = this
   var defaultCookieConsent = {
     'essential': true,
-    'settings': false,
-    'usage': false,
-    'campaigns': false
+    'settings': true,
+    'usage': true,
+    'campaigns': true
   }
 
   if (typeof root.GOVUK === 'undefined') { root.GOVUK = {} }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -65,7 +65,7 @@ $govuk-cookie-banner-background-new: govuk-colour("white");
 }
 
 .gem-c-cookie-banner__hide-button {
-  @include govuk-font($size: 16);
+  @include govuk-font($size: 19);
   outline: 0;
   border: 0;
   background: none;
@@ -99,7 +99,7 @@ $govuk-cookie-banner-background-new: govuk-colour("white");
   .gem-c-cookie-banner__buttons,
   .gem-c-cookie-banner__confirmation,
   .gem-c-cookie-banner__confirmation-message {
-    @include core-19;
+    @include govuk-font($size: 19);
   }
 
   p {

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -80,7 +80,7 @@ describe('New cookie banner', function () {
   it('sets a default consent cookie', function () {
     var banner = document.querySelector('.gem-c-cookie-banner--new[data-module="cookie-banner"]')
     expect(window.GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
-    expect(window.GOVUK.getCookie('cookie_policy')).toEqual('"{\\"essential\\":true,\\"settings\\":false,\\"usage\\":false,\\"campaigns\\":false}"')
+    expect(window.GOVUK.getCookie('cookie_policy')).toEqual('"{\\"essential\\":true,\\"settings\\":true,\\"usage\\":true,\\"campaigns\\":true}"')
     expect(banner).toBeVisible()
   })
 


### PR DESCRIPTION
This PR contains 3 changes:

1. Make 'hide button' font consistent with the rest of the cookie banner
2. Set the default consent to 'on'. This is for user testing and still up for debate - the consent cookie doesn't have any effect on what cookies are set yet. We want to test out if/how users understand implicit consent.
3. Hide the new cookie banner on the cookie settings page (/help/cookies) to avoid circular journeys. The cookie banner contains a link to the cookie settings page. GA analysis has found that a high proportion of users click the link to cookie settings when they're already on that page. The page already lets users accept cookies, so we can just hide the banner to avoid confusion.

## Hide button - before
<img width="886" alt="Screen Shot 2019-05-16 at 16 46 07" src="https://user-images.githubusercontent.com/29889908/57868046-22bf4300-77fa-11e9-93ef-0045f95f3228.png">

## Hide button - after
<img width="885" alt="Screen Shot 2019-05-16 at 16 45 16" src="https://user-images.githubusercontent.com/29889908/57867972-04f1de00-77fa-11e9-9a7b-a97f6bb4eac7.png">