### PR TITLE
Revert "Merge pull request #849 from alphagov/prevent-double-click-on…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Revert 'Prevent double click by default for submit buttons' (PR #865)
 * Add SearchResultsPage schema.org schema (PR #861)
 
 ## 16.19.0

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -8,8 +8,6 @@ body: |
   These instances of buttons are added by Content Designers, ideally this duplication would not exist but we currently don't have shared markup
   via our components within the generated [govspeak](https://github.com/alphagov/govspeak).
   (This is a challenge to the reader)
-
-  Buttons with type submit (implicitly defined of unset) are enhanced to [prevent them from being double clicked](https://github.com/alphagov/govuk-frontend/commit/884e7dd73ad943d71fb701da15626e6a7ad0b933).
 accessibility_criteria: |
   The button must:
 

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -12,7 +12,6 @@ module GovukPublishingComponents
         @title = local_assigns[:title]
         @info_text = local_assigns[:info_text]
         @rel = local_assigns[:rel]
-        @default_data_attributes = { "prevent-double-click" => true }
         @data_attributes = local_assigns[:data_attributes]
         @margin_bottom = local_assigns[:margin_bottom]
         @inline_layout = local_assigns[:inline_layout]
@@ -33,7 +32,7 @@ module GovukPublishingComponents
         options[:role] = "button" if link?
         options[:type] = button_type
         options[:rel] = rel if rel
-        options[:data] = button_type == "submit" ? data_attributes.to_h.merge(@default_data_attributes) : data_attributes
+        options[:data] = data_attributes if data_attributes
         options[:title] = title if title
         options[:target] = target if target
         options

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -99,33 +99,7 @@ describe "Button", type: :view do
     assert_select ".govuk-button.gem-c-button--bottom-margin", text: "Submit"
   end
 
-  it "renders the default data attribute for buttons" do
-    render_component(
-      text: "Submit",
-    )
-
-    assert_select "button.govuk-button[data-prevent-double-click='true']"
-  end
-
-  it "renders the default data attribute for submit buttons" do
-    render_component(
-      text: "Submit",
-      type: "submit"
-    )
-
-    assert_select "button.govuk-button[data-prevent-double-click='true']"
-  end
-
-  it "doesn't render the default data attribute for buttons with type button" do
-    render_component(
-      text: "Submit",
-      type: "button"
-    )
-
-    assert_select "button.govuk-button[data-prevent-double-click='true']", false
-  end
-
-  it "renders custom data attributes correctly for buttons" do
+  it "renders data attributes correctly for buttons" do
     render_component(
       text: "Submit",
       data_attributes: {


### PR DESCRIPTION
…-buttons"

https://trello.com/c/JLkfkNxQ/815-fix-the-double-click-so-actions-are-only-carried-out-once

This reverts commit 19cc9d09a152e4e38153c6d792e582a5f6c08b38, reversing
changes made to 9f259ca57bf08f141e30f035b4403d3331115c3a.

Previously we changed the button component to automatically prevent
double click for submit-type buttons. This caused an unexpected testing
issue in a consuming app (Content Publisher) in the context of a modal,
where multiple buttons are clicked in succession without a page reload.

This reverts the change to automatically prevent double click, pending
an iteration to the logic in govuk-frontend to scope the prevention to
the same button.

<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->
