### PR TITLE
Bump version to 16.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## 16.20.0
+## 16.20.1
 
 * Revert 'Prevent double click by default for submit buttons' (PR #865)
+
+## 16.20.0
+
 * Add SearchResultsPage schema.org schema (PR #861)
 
 ## 16.19.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (16.20.0)
+    govuk_publishing_components (16.20.1)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -314,6 +314,9 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   webmock (~> 3.5.0)
   yard
+
+RUBY VERSION
+   ruby 2.6.3p62
 
 BUNDLED WITH
    1.17.3

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '16.20.0'.freeze
+  VERSION = '16.20.1'.freeze
 end


### PR DESCRIPTION
https://trello.com/c/JLkfkNxQ/815-fix-the-double-click-so-actions-are-only-carried-out-once

<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->
