### PR TITLE
Fix broken call to fallback content_type method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+- Fix broken call to content_type fallback method (PR #869)
 - Remove links to Whitehall publications (PR #823)
 - Add request different format section to attachment component (PR #858)
 

--- a/app/views/govuk_publishing_components/components/_attachment_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment_link.html.erb
@@ -8,7 +8,7 @@
                              title: attachment.content_type_name,
                              class: "gem-c-attachment-link__abbr")
               else
-                attachment.readable_content_type
+                attachment.content_type_name
               end
 
     attributes << tag.span(content, class: "gem-c-attachment-link__attribute")

--- a/spec/components/attachment_link_spec.rb
+++ b/spec/components/attachment_link_spec.rb
@@ -40,4 +40,15 @@ describe "Attachment Link", type: :view do
     expect(rendered).to match(/2 KB/)
     expect(rendered).to match(/2 pages/)
   end
+
+  it "can show file type that doesn't have an abbreviation" do
+    render_component(
+      attachment: {
+        title: "Attachment",
+        url: "attachment",
+        content_type: "text/plain",
+      },
+    )
+    expect(rendered).to match(/Plain Text/)
+  end
 end


### PR DESCRIPTION
<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->
