### PR TITLE
Add potentialSearchAction to orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add potentialSearchAction to the GovernmentOrganization schema (PR #870)
+
 ## 16.22.0
 
 * Update inline button styling on mobile (PR #872)

--- a/lib/govuk_publishing_components/presenters/machine_readable/organisation_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/organisation_schema.rb
@@ -17,7 +17,12 @@ module GovukPublishingComponents
             "@id" => page.canonical_url,
           },
           "name" => page.title,
-          "description" => page.description || page.body
+          "description" => page.description || page.body,
+          "potentialAction" => {
+            "@type": "SearchAction",
+            "target": scoped_search_url,
+            "query": "required"
+          }
         }.merge(parent_organisations).merge(sub_organisations)
       end
 
@@ -52,6 +57,15 @@ module GovukPublishingComponents
           "@type" => "GovernmentOrganization",
           "sameAs" => url
         }
+      end
+
+      def slug
+        uri = URI.parse(page.canonical_url)
+        File.basename(uri.path)
+      end
+
+      def scoped_search_url
+        "#{Plek.current.website_root}/search/all?keywords={query}&organisations[]=#{slug}"
       end
     end
   end

--- a/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
@@ -51,6 +51,12 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
         "description" => "The magical ministry."
       )
 
+      search_action = {
+        "@type": "SearchAction",
+        "target": "http://www.dev.gov.uk/search/all?keywords={query}&organisations[]=ministry-of-magic",
+        "query": "required"
+      }
+
       structured_data = generate_structured_data(
         content_item: content_item,
         schema: :organisation
@@ -60,6 +66,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
       expect(structured_data["name"]).to eq("Ministry of Magic")
       expect(structured_data["description"]).to eq("The magical ministry.")
       expect(structured_data["mainEntityOfPage"]["@id"]).to eq("http://www.dev.gov.uk/ministry-of-magic")
+      expect(structured_data["potentialAction"]).to eq(search_action)
     end
 
     it "generates organisation structure" do


### PR DESCRIPTION
This indicates to external consumers of the site how to perform a search scoped to a GovernmentOrganization.  This _might_ result in a [sitelinks](https://developers.google.com/search/docs/data-types/sitelinks-searchbox) box pointing at GOV.UK search appearing for organisation searches in Google.

This information will appear in organisation pages like https://www.gov.uk/government/organisations/ministry-of-housing-communities-and-local-government, so should be relevant to external search results that feature those pages.

This follows "Example 3" in https://schema.org/SearchAction and passes the validation checks on https://search.google.com/structured-data/testing-tool/u/0/

https://trello.com/c/4EAytHVV/747-plan-noindexing-of-finder-pages
