### PR TITLE
Update inline button style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update inline button styling on mobile (PR #872)
+
 ## 16.21.0
 
 * Add request different format section to attachment component (PR #858)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -23,12 +23,11 @@ $gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
 }
 
 .gem-c-button--inline {
-  width: 100%;
+  width: auto;
   margin-bottom: govuk-spacing(1);
   margin-right: govuk-spacing(2);
 
   @include govuk-media-query($from: tablet) {
-    width: auto;
     margin-bottom: 0;
   }
 }

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -93,7 +93,7 @@ examples:
   inline_layout:
     description: Buttons will display adjacent to each other until mobile view, when they will appear on top of each other.
     embed: |
-      <button class="govuk-button">First button</button>
+      <button class="gem-c-button govuk-button gem-c-button--inline">First button</button>
       <%= component %>
     data:
       text: "Second button"


### PR DESCRIPTION
Update the inline button style so they appear adjacent to each other for as long as possible before stacking one on top of the other, so it takes up less vertical space.

## Before
<img width="225" alt="Screen Shot 2019-05-20 at 14 42 29" src="https://user-images.githubusercontent.com/29889908/58026141-b8661580-7b0d-11e9-8111-eed7a221173b.png">

## After
<img width="204" alt="Screen Shot 2019-05-20 at 14 42 33" src="https://user-images.githubusercontent.com/29889908/58026150-bc923300-7b0d-11e9-9844-42dbb88b8f84.png">
