### PR TITLE
Update contents-list component to use govuk-frontend

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -4,10 +4,10 @@
   // Always render the contents list above a
   // back to contents link
   position: relative;
-  margin: 0 0 $gutter-two-thirds 0;
+  margin: 0 0 govuk-spacing(4) 0;
   z-index: 1;
-  background: $white;
-  box-shadow: 0 20px 15px -10px $white;
+  background: govuk-colour("white");
+  box-shadow: 0 20px 15px -10px govuk-colour("white");
 }
 
 .gem-c-contents-list__title {
@@ -49,17 +49,17 @@
 }
 
 .gem-c-contents-list__list-item {
-  padding-top: $gutter-one-third;
+  padding-top: govuk-spacing(2);
   line-height: 1.3;
   list-style-type: none;
 
-  @include media(tablet) {
-    padding-top: $gutter-one-quarter;
+  @include govuk-media-query($from: tablet) {
+    padding-top: govuk-spacing(6) / 4;
   }
 }
 
 .gem-c-contents-list__list-item--dashed {
-  $contents-spacing: $gutter-half + 10;
+  $contents-spacing: govuk-spacing(5);
   margin-left: $contents-spacing;
   padding-right: $contents-spacing;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_contents-list.scss
@@ -9,7 +9,7 @@
 
 // Put indentation back where we use list style types
 .gem-c-contents-list__list-item--dashed {
-  margin-left: $gutter / 2;
+  margin-left: govuk-spacing(3);
   list-style-type: disc;
 }
 


### PR DESCRIPTION
This PR updates the contents list component to use govuk-frontend instead of govuk_frontend_toolkit.

**Notes:**
`$gutter` = `govuk-spacing(6)` = `30px`

[Trello card](https://trello.com/c/ajPzDAOX)