### PR TITLE
Update error alert component to use govuk-frontend

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
@@ -1,11 +1,11 @@
 .gem-c-error-alert {
   color: $gem-text-colour;
-  padding: $gem-spacing-scale-3;
+  padding: govuk-spacing(3);
   border: $gem-border-width-mobile solid $gem-error-colour;
   @include govuk-responsive-margin(8, "bottom");
 
   @include govuk-media-query($from: tablet) {
-    padding: $gem-spacing-scale-4;
+    padding: govuk-spacing(4);
     border-width: $gem-border-width-tablet;
   }
 }
@@ -17,10 +17,10 @@
 
 .gem-c-error-summary__title {
   margin-top: 0;
-  margin-bottom: $gem-spacing-scale-3;
+  margin-bottom: govuk-spacing(3);
 
   @include govuk-media-query($from: tablet) {
-    margin-bottom: $gem-spacing-scale-4;
+    margin-bottom: govuk-spacing(4);
   }
 
   @include govuk-font(24, $weight: bold);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
@@ -4,14 +4,14 @@
   border: $gem-border-width-mobile solid $gem-error-colour;
   @include govuk-responsive-margin(8, "bottom");
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     padding: $gem-spacing-scale-4;
     border-width: $gem-border-width-tablet;
   }
 }
 
 .gem-c-error-alert__message {
-  @include bold-19;
+  @include govuk-font(19, $weight: bold);
   margin: 0;
 }
 
@@ -19,15 +19,15 @@
   margin-top: 0;
   margin-bottom: $gem-spacing-scale-3;
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     margin-bottom: $gem-spacing-scale-4;
   }
 
-  @include bold-24;
+  @include govuk-font(24, $weight: bold);
 }
 
 .gem-c-error-summary__body {
-  @include core-19;
+  @include govuk-font(19);
   margin: 0;
 }
 

--- a/app/views/govuk_publishing_components/components/docs/error_alert.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_alert.yml
@@ -1,4 +1,4 @@
-name: Error Alert
+name: Error alert
 description: Used at the top of the page, to summarise a unsuccessful user action.
 accessibility_criteria: |
   - should be focused on page load, to ensure the message is noticed by


### PR DESCRIPTION
This PR:
- updates the error-alert component to use govuk-frontend instead of govuk_frontend_toolkit
- uses `govuk-spacing` mixin instead of locally defined `gem-spacing-scale-`
- updates component name for consistency

[Trello card](https://trello.com/c/ajPzDAOX)