### PR TITLE
Add SearchAction for manuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add contents list heading Welsh translation (PR #881)
 * Enable passing data attributes to attachment components (PR #874)
 * Add potentialSearchAction to the GovernmentOrganization schema (PR #870)
+* Add potentialSearchAction to manuals (PR #879)
 
 ## 16.22.0
 

--- a/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
@@ -9,7 +9,9 @@ module GovukPublishingComponents
 
       def structured_data
         # http://schema.org/Article
-        data = CreativeWorkSchema.new(@page).structured_data.merge(body)
+        data = CreativeWorkSchema.new(@page).structured_data
+          .merge(body)
+          .merge(search_action)
         data["@type"] = "Article"
         data
       end
@@ -24,6 +26,13 @@ module GovukPublishingComponents
         {
           "articleBody" => page.body
         }
+      end
+
+      def search_action
+        return {} unless page.document_type == "manual"
+
+        manuals_facet_params = { manual: page.base_path }
+        PotentialSearchActionSchema.new(manuals_facet_params).structured_data
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/machine_readable/organisation_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/organisation_schema.rb
@@ -18,12 +18,7 @@ module GovukPublishingComponents
           },
           "name" => page.title,
           "description" => page.description || page.body,
-          "potentialAction" => {
-            "@type": "SearchAction",
-            "target": scoped_search_url,
-            "query": "required"
-          }
-        }.merge(parent_organisations).merge(sub_organisations)
+        }.merge(parent_organisations).merge(sub_organisations).merge(search_action)
       end
 
     private
@@ -59,13 +54,17 @@ module GovukPublishingComponents
         }
       end
 
+      def search_action
+        PotentialSearchActionSchema.new(organisation_facet_params).structured_data
+      end
+
       def slug
         uri = URI.parse(page.canonical_url)
         File.basename(uri.path)
       end
 
-      def scoped_search_url
-        "#{Plek.current.website_root}/search/all?keywords={query}&organisations[]=#{slug}"
+      def organisation_facet_params
+        { organisations: [slug] }
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/machine_readable/page.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/page.rb
@@ -43,6 +43,14 @@ module GovukPublishingComponents
         local_assigns[:image_placeholders]
       end
 
+      def document_type
+        content_item["document_type"]
+      end
+
+      def base_path
+        content_item["base_path"]
+      end
+
       def content_item
         local_assigns[:content_item]
       end

--- a/lib/govuk_publishing_components/presenters/machine_readable/potential_search_action_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/potential_search_action_schema.rb
@@ -1,0 +1,32 @@
+require 'plek'
+
+module GovukPublishingComponents
+  module Presenters
+    class PotentialSearchActionSchema
+      attr_reader :facet_params
+
+      BASE_SEARCH_URL = "#{Plek.current.website_root}/search/all?keywords={query}".freeze
+
+      def initialize(facet_params)
+        @facet_params = facet_params
+      end
+
+      def structured_data
+        # http://schema.org/SearchAction - minimal
+        {
+          "potentialAction" => {
+            "@type": "SearchAction",
+            "target": search_template,
+            "query": "required"
+          }
+        }
+      end
+
+    private
+
+      def search_template
+        "#{BASE_SEARCH_URL}&#{facet_params.to_query}"
+      end
+    end
+  end
+end

--- a/lib/govuk_publishing_components/presenters/machine_readable/potential_search_action_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/potential_search_action_schema.rb
@@ -5,7 +5,7 @@ module GovukPublishingComponents
     class PotentialSearchActionSchema
       attr_reader :facet_params
 
-      BASE_SEARCH_URL = "#{Plek.current.website_root}/search/all?keywords={query}".freeze
+      BASE_SEARCH_URL = "#{Plek.current.website_root}/search/all?keywords={query}&order=relevance".freeze
 
       def initialize(facet_params)
         @facet_params = facet_params

--- a/lib/govuk_publishing_components/presenters/schema_org.rb
+++ b/lib/govuk_publishing_components/presenters/schema_org.rb
@@ -7,6 +7,7 @@ require 'govuk_publishing_components/presenters/machine_readable/is_part_of_sche
 require 'govuk_publishing_components/presenters/machine_readable/news_article_schema'
 require 'govuk_publishing_components/presenters/machine_readable/organisation_schema'
 require 'govuk_publishing_components/presenters/machine_readable/person_schema'
+require 'govuk_publishing_components/presenters/machine_readable/potential_search_action_schema'
 require 'govuk_publishing_components/presenters/machine_readable/search_results_page_schema'
 
 module GovukPublishingComponents

--- a/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
 
       search_action = {
         "@type": "SearchAction",
-        "target": "http://www.dev.gov.uk/search/all?keywords={query}&manual=%2Fguidance%2Fplane-manual",
+        "target": "http://www.dev.gov.uk/search/all?keywords={query}&order=relevance&manual=%2Fguidance%2Fplane-manual",
         "query": "required"
       }
       expect(structured_data['potentialAction']).to eql(search_action)
@@ -80,7 +80,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
 
       search_action = {
         "@type": "SearchAction",
-        "target": "http://www.dev.gov.uk/search/all?keywords={query}&organisations%5B%5D=ministry-of-magic",
+        "target": "http://www.dev.gov.uk/search/all?keywords={query}&order=relevance&organisations%5B%5D=ministry-of-magic",
         "query": "required"
       }
 

--- a/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
 
       search_action = {
         "@type": "SearchAction",
-        "target": "http://www.dev.gov.uk/search/all?keywords={query}&organisations[]=ministry-of-magic",
+        "target": "http://www.dev.gov.uk/search/all?keywords={query}&organisations%5B%5D=ministry-of-magic",
         "query": "required"
       }
 

--- a/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
@@ -22,6 +22,33 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
       expect(structured_data['articleBody']).to eql("Foo")
     end
 
+    it "generates search info in Articles for manuals" do
+      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "manual") do |random_item|
+        random_item.merge(
+          "base_path" => "/guidance/plane-manual",
+          "details" => {
+            "body" => "Ensure you have a left phalange before take off."
+          }
+        )
+      end
+
+      structured_data = generate_structured_data(
+        content_item: content_item,
+        schema: :article,
+      ).structured_data
+
+      expect(structured_data['@type']).to eql("Article")
+      expect(structured_data['mainEntityOfPage']['@id']).to eql("http://www.dev.gov.uk/guidance/plane-manual")
+      expect(structured_data['articleBody']).to eql("Ensure you have a left phalange before take off.")
+
+      search_action = {
+        "@type": "SearchAction",
+        "target": "http://www.dev.gov.uk/search/all?keywords={query}&manual=%2Fguidance%2Fplane-manual",
+        "query": "required"
+      }
+      expect(structured_data['potentialAction']).to eql(search_action)
+    end
+
     it "generates schema.org NewsArticles" do
       content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "answer")
 


### PR DESCRIPTION
Manuals like [The Highway Code](https://www.gov.uk/guidance/the-highway-code) have an embedded search box which allows searches scoped to that manual.

By advertising this in our machine readable metadata it's more obvious to external consumers of the site that these things are available.

This is part of the work to make our search more visible to external consumers of the site.

Possibly useful to review by commit because the majority of the change is extracting the `potentialSearchAction` schema from organisations to make it available for use in manuals.

https://trello.com/c/4EAytHVV/747-plan-indexing-of-finder-pages
