### PR TITLE
Update notice component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ## Unreleased
 
+* Update notice component to render without title (PR #884)
+* Add margin option to notice component (PR #884)
+
 # 16.23.0
 
 * Add contents list heading Welsh translation (PR #881)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
@@ -1,11 +1,11 @@
 .gem-c-notice {
   @include govuk-text-colour;
   clear: both;
-  padding: $gutter-two-thirds;
-  border: 2px solid $govuk-blue;
+  padding: govuk-spacing(4);
+  border: 2px solid govuk-colour("blue");
 
-  @include media(mobile) {
-    padding: $gutter-half;
+  @include govuk-media-query($from: mobile) {
+    padding: govuk-spacing(3);
   }
 
   .govuk-govspeak, {
@@ -24,8 +24,8 @@
 }
 
 .gem-c-notice__title {
-  @include bold-27;
-  margin: 0 0 $gutter-one-third 0;
+  @include govuk-font(27, $weight: bold);
+  margin: 0 0 govuk-spacing(2) 0;
 
   &:last-child {
     margin-bottom: 0;
@@ -37,6 +37,6 @@
 }
 
 .gem-c-notice__description {
-  @include core-19;
+  @include govuk-font(19);
   margin: 0;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
@@ -1,12 +1,10 @@
 .gem-c-notice {
   @include govuk-text-colour;
-  clear: both;
-  padding: govuk-spacing(4);
-  border: 2px solid govuk-colour("blue");
+  @include govuk-responsive-padding(4);
+  @include govuk-responsive-margin(8, "bottom");
 
-  @include govuk-media-query($from: mobile) {
-    padding: govuk-spacing(3);
-  }
+  clear: both;
+  border: 2px solid govuk-colour("blue");
 
   .govuk-govspeak, {
     p:last-child {
@@ -19,13 +17,10 @@
   }
 }
 
-.gem-c-notice--bottom-margin {
-  @include responsive-bottom-margin;
-}
-
 .gem-c-notice__title {
-  @include govuk-font(27, $weight: bold);
-  margin: 0 0 govuk-spacing(2) 0;
+  @include govuk-font(24, $weight: bold);
+  margin-top: 0;
+  @include govuk-responsive-margin(4, "bottom");
 
   &:last-child {
     margin-bottom: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
@@ -8,10 +8,14 @@
     padding: $gutter-half;
   }
 
-  .govuk-govspeak {
+  .govuk-govspeak, {
     p:last-child {
       margin-bottom: 0;
     }
+  }
+
+  .govuk-body:last-child {
+    margin-bottom: 0;
   }
 }
 

--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -1,16 +1,19 @@
-<% if defined?(title) %>
-  <%
-    description_text ||= false
-    description_govspeak ||= false
-    description ||= yield || false
-    margin_bottom_class = " gem-c-notice--bottom-margin" unless local_assigns[:margin_bottom]
-    description_present = description.present? || description_text.present? || description_govspeak.present?
-  %>
+<%
+  title ||= false
+  description_text ||= false
+  description_govspeak ||= false
+  description ||= yield || false
+  margin_bottom_class = " gem-c-notice--bottom-margin" unless local_assigns[:margin_bottom]
+  description_present = description.present? || description_text.present? || description_govspeak.present?
+%>
+<% if title || description_present %>
   <section class="gem-c-notice<%= margin_bottom_class %>" aria-label="Notice" role="region">
-    <% if description_present %>
-      <h2 class="gem-c-notice__title"><%= title %></h2>
-    <% else %>
-      <span class="gem-c-notice__title"><%= title %></span>
+    <% if title %>
+      <% if description_present %>
+        <h2 class="gem-c-notice__title"><%= title %></h2>
+      <% else %>
+        <span class="gem-c-notice__title"><%= title %></span>
+      <% end %>
     <% end %>
 
     <% if description_text %>

--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -3,29 +3,30 @@
   description_text ||= false
   description_govspeak ||= false
   description ||= yield || false
-  margin_bottom_class = " gem-c-notice--bottom-margin" unless local_assigns[:margin_bottom]
+  local_assigns[:margin_bottom] ||= 8
+  local_assigns[:margin_bottom] = 8 if local_assigns[:margin_bottom] > 9
+
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+
+  css_classes = %w(gem-c-notice)
+  css_classes << (shared_helper.get_margin_bottom)
+
   description_present = description.present? || description_text.present? || description_govspeak.present?
 %>
 <% if title || description_present %>
-  <section class="gem-c-notice<%= margin_bottom_class %>" aria-label="Notice" role="region">
+  <%= tag.section class: css_classes, aria: { label: "Notice" }, role: "region" do %>
     <% if title %>
       <% if description_present %>
-        <h2 class="gem-c-notice__title"><%= title %></h2>
+        <%= tag.h2 title, class: "gem-c-notice__title" %>
       <% else %>
-        <span class="gem-c-notice__title"><%= title %></span>
+        <%= tag.span title, class: "gem-c-notice__title" %>
       <% end %>
     <% end %>
 
-    <% if description_text %>
-      <p class="gem-c-notice__description"><%= description_text %></p>
-    <% end %>
+    <%= tag.p description_text, class: "gem-c-notice__description" if description_text %>
 
-    <% if description %>
-      <%= description %>
-    <% end %>
+    <%= description if description %>
 
-    <% if description_govspeak.present? %>
-      <%= render 'govuk_publishing_components/components/govspeak', content: description_govspeak %>
-    <% end %>
-  </section>
+    <%= render 'govuk_publishing_components/components/govspeak', content: description_govspeak if description_govspeak %>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/notice.yml
+++ b/app/views/govuk_publishing_components/components/docs/notice.yml
@@ -16,11 +16,11 @@ examples:
   with_description:
     data:
       title: 'Statistics release cancelled'
-      description: '<p>The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p>This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a rel="external" href="https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/">www.ogauthority.co.uk</a></p>'
+      description: '<p class="govuk-body">The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p class="govuk-body">This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a class="govuk-link" rel="external" href="https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/">www.ogauthority.co.uk</a></p>'
   with_description_from_a_block:
     data:
       title: 'Statistics release update'
-      block: '<p>The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p>This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a rel="external" href="https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/">www.ogauthority.co.uk</a></p>'
+      block: '<p class="govuk-body">The Oil &amp; Gas Authority launched a new website on 3 October 2016 to reflect its new status as a government company.</p><p class="govuk-body">This formalises the transfer of the Secretary of State’s regulatory powers in respect of oil and gas to the OGA, and grants it new powers. This website will no longer be updated. Visitors should refer to <a class="govuk-link" rel="external" href="https://www.ogauthority.co.uk/news-publications/announcements/2015/establishment-of-the-oil-and-gas-authority-1/">www.ogauthority.co.uk</a></p>'
   with_description_text:
     data:
       title: 'Statistics release cancelled'
@@ -33,3 +33,6 @@ examples:
     description: In some circumstances it may be necessary to include simple markup in the title, such as a link. Note that this will be wrapped in a H2 tag if there is no description included, so be sure that any markup inserted is valid inside that tag (e.g. another heading tag inside a H2 would be invalid).
     data:
       title: 'Advisory Committee on Novel Foods and Processes has a <a href="http://www.food.gov.uk/acnfp">separate website</a>'
+  without_title:
+    data:
+      description_govspeak: '<p>Scheduled to publish at 8am on 25 April 2019<br/><a href="change-date">Change date</a><br/><a href="stop-scheduled-publishing">Stop scheduled publishing</a></p>'


### PR DESCRIPTION
This PR updates the [Notice component](https://govuk-publishing-compon-pr-884.herokuapp.com/component-guide/notice) to:
- allow rendering without a `title` (used in admin interfaces to play back neutral messages after a user action [Trello card](https://trello.com/c/R1zp5SAu))
- update scss to use govuk-frontend ([Trello card](https://trello.com/c/ajPzDAOX))
- align notice component styles with the standard error-summary component styles (consists in font-size change for the title and usage of mixins to generate responsive paddings and margins for the main container)
- uses helpers (Rails tag helpers and internal SharedHelper - to set custom margins consistently) to generate markup
- updates examples with custom content (using `description` attributes) to use govuk-frontend classes
- ensures paragraphs (part of the `description` attributes) are styled correctly (last item doesn't have a margin-bottom) regardless of how they were generated (text, govspeak, html or yeld)

### Before

Desktop
![notice-desktop-before](https://user-images.githubusercontent.com/788096/58186027-057fee00-7cac-11e9-9eb7-dd5b5f404b3e.png)

Mobile
<img width="470" alt="notice-mobile-before" src="https://user-images.githubusercontent.com/788096/58186339-9787f680-7cac-11e9-8a88-6ce54d16ed44.png">

### After

Desktop
![notice-desktop-after](https://user-images.githubusercontent.com/788096/58185910-d23d5f00-7cab-11e9-918c-42e4ac79a163.png)

Mobile
<img width="470" alt="notice-mobile-after" src="https://user-images.githubusercontent.com/788096/58186275-78896480-7cac-11e9-9080-74913f3f2c98.png">
