### PR TITLE
Remove radios divider CSS overwrite

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
@@ -1,7 +1,1 @@
 @import "govuk-frontend/components/radios/radios";
-
-// This is here as it seems to have been missed from govuk-frontend
-// @FIXME if a colour has been added to govuk-radios__divider remove this
-.gem-c-radios__divider {
-  @include govuk-text-colour;
-}

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -65,9 +65,7 @@
       } do %>
       <% items.each_with_index do |item, index| %>
         <% if item === :or %>
-          <div class="gem-c-radios__divider govuk-radios__divider">
-            <%= t('components.radio.or') %>
-          </div>
+          <%= tag.div t('components.radio.or'), class: "govuk-radios__divider" %>
         <% else %>
           <%
             item_next = items[index + 1] unless index === items.size - 1
@@ -107,9 +105,7 @@
           <% end %>
 
           <% if item[:conditional] %>
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="<%= conditional_id %>">
-              <%= item[:conditional] %>
-            </div>
+            <%= tag.div item[:conditional], class:"govuk-radios__conditional govuk-radios__conditional--hidden", id: conditional_id %>
           <% end %>
 
         <% end %>


### PR DESCRIPTION
A fix for this was added in [govuk-frontend 2.2.0](https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md#220-feature-release)