### PR TITLE
Add docs for publishing to RubyGems

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Components should be added to this gem if they are required in more than one app
 - [Develop a component](/docs/develop-component.md)
 - [Run the component guide](/docs/run-component-guide.md)
 - [Move a component from an application to the gem](/docs/moving-components-upstream-into-this-gem.md)
+- [Publish this gem](/docs/publishing-to-rubygems.md)
 
 ## Architecture / structure
 

--- a/docs/publishing-to-rubygems.md
+++ b/docs/publishing-to-rubygems.md
@@ -29,3 +29,5 @@ Before publishing a new version [check the open and approved pull requests](http
 7. Create a pull request and copy the changelog text for the current version in the pull request description.
 
 8. Once the pull request is approved, merge to master. This action will trigger the CI to publish the new version to RubyGems. A [dependabot](https://github.com/dependabot) pull request will automatically be raised in frontend applications.
+
+See an [example pull request](https://github.com/alphagov/govuk_publishing_components/pull/873/files) for publishing a new version to RubyGems.

--- a/docs/publishing-to-rubygems.md
+++ b/docs/publishing-to-rubygems.md
@@ -1,0 +1,31 @@
+# Publishing to RubyGems
+
+Before publishing a new version [check the open and approved pull requests](https://github.com/alphagov/govuk_publishing_components/pulls?q=is%3Apr+is%3Aopen+review%3Aapproved) and reach out to the authors to see if you can get their work published in the same release.
+
+1. Checkout **master** and pull latest changes.
+
+2. Create and checkout a new branch (`release-[version-number]`).
+  The version number is determined by looking at the [current "Unreleased" changes in CHANGELOG](../CHANGELOG.md) and updating the previous release number depending on the kind of entries:
+
+  - `Breaking changes` corresponds to a `major` (1.X.X) change.
+  - `New features` corresponds to a `minor` (X.1.X) change.
+  - `Fixes` corresponds to a `patch` (X.X.1) change.
+
+  For example if the previous version is `2.3.0` and there are entries for `Breaking changes` then the new release should be `3.0.0`.
+
+  See [Semantic Versioning](https://semver.org/) for more information.
+
+3. Update [`CHANGELOG.md`](../CHANGELOG.md) "Unreleased" heading with the new version number and [review the latest commits](https://github.com/alphagov/govuk_publishing_components/commits/master) to make sure the latest changes are correctly reflected in the [CHANGELOG]((../CHANGELOG.md)).
+
+4. Update [`lib/govuk_publishing_components/version.rb`](../lib/govuk_publishing_components/version.rb) version with the new version number.
+
+5. Run `bundle install && npm install` to ensure you have the latest dependencies installed.
+
+6. Commit changes. These should include updates in the following files:
+  - [`CHANGELOG.md`](../CHANGELOG.md)
+  - [`lib/govuk_publishing_components/version.rb`](../lib/govuk_publishing_components/version.rb)
+  - [`Gemfile.lock`](../Gemfile.lock)
+
+7. Create a pull request and copy the changelog text for the current version in the pull request description.
+
+8. Once the pull request is approved, merge to master. This action will trigger the CI to publish the new version to RubyGems. A [dependabot](https://github.com/dependabot) pull request will automatically be raised in frontend applications.


### PR DESCRIPTION
Add documentation for publishing to RubyGems.

[See rendered version](https://github.com/alphagov/govuk_publishing_components/blob/add-publishing-docs/docs/publishing-to-rubygems.md)