### PR TITLE
Add machine readable breadcrumbs for step by steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Add machine readable breadcrumbs to the step by step header (PR #892)
+
 ## 16.25.0
 
 * Support data attributes in modal dialogue (PR #890)

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
@@ -2,8 +2,17 @@
   title ||= false
   path ||= false
   tracking_id ||= false
+  breadcrumbs = [
+    { title: "Home", url: "/" },
+    { title: title, url: path }
+  ]
+  breadcrumb_presenter = GovukPublishingComponents::Presenters::Breadcrumbs.new(breadcrumbs, request.path)
 %>
 <% if title %>
+  <script type="application/ld+json">
+    <%= raw breadcrumb_presenter.structured_data.to_json %>
+  </script>
+
   <div class="gem-c-step-nav-header" data-module="track-click">
     <span class="gem-c-step-nav-header__part-of">Part of</span>
     <% if path %>

--- a/spec/components/step_by_step_nav_header_spec.rb
+++ b/spec/components/step_by_step_nav_header_spec.rb
@@ -33,4 +33,27 @@ describe "Step by step navigation header", type: :view do
 
     assert_select ".gem-c-step-nav-header .gem-c-step-nav-header__title[data-track-options='{\"dimension96\" : \"brian\" }']"
   end
+
+  it "renders machine readable breadcrumbs" do
+    render_component(title: "This is my title", path: "/notalink")
+
+    expected_breadcrumb_values = [
+      ["Home", "http://www.dev.gov.uk/"],
+      ["This is my title", "http://www.dev.gov.uk/notalink"]
+    ]
+
+    schema_sections = css_select("script[type='application/ld+json']")
+
+    breadcrumb_schema = schema_sections
+      .map { |section| JSON.parse(section.text) }
+      .detect { |schema| schema["@type"] == "BreadcrumbList" }
+
+    breadcrumbs = breadcrumb_schema["itemListElement"]
+
+    # breadcrumbs looks something like this:
+    # [{"@type":"ListItem","position":1,"item":{"name":"Home","@id":"http://www.dev.gov.uk/"}},{"@type":"ListItem","position":2,"item":{"name":"This is my title","@id":"http://www.dev.gov.uk/notalink"}}]}
+    rendered_values = breadcrumbs.map { |b| b["item"].values }
+
+    assert_equal expected_breadcrumb_values, rendered_values
+  end
 end


### PR DESCRIPTION
We've removed the `partOf` metadata for step by steps which linked back to the "parent" because we were using a partial HowTo schema which is not supported by Google's search indexing process.

This PR adds in machine readable breadcrumbs for pages that show the step by step header which should reinstate some of that experience for search engines.

I didn't want to assert too much on the exact format of the breadcrumbs schema output as they're defined in https://github.com/alphagov/govuk_publishing_components/blob/e3fd7fa321f4a38218a400fa795bb120c4681a4b/lib/govuk_publishing_components/presenters/breadcrumbs.rb (not the step by step header itself) and are used in the contextual breadcrumbs component too.

It's implementing https://schema.org/BreadcrumbList which looks like this in the examples:

![Screenshot 2019-05-28 14 17 31](https://user-images.githubusercontent.com/773037/58481008-6cd9ea00-8153-11e9-9a44-88e8d7c2a71e.png)