### PR TITLE
Allow target on error summary links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Allow target attribute on links for the error summary component (PR #894)
+
 ## 16.26.0
 
 * Add machine readable breadcrumbs to the step by step header (PR #892)

--- a/app/views/govuk_publishing_components/components/_error_summary.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_summary.html.erb
@@ -31,7 +31,7 @@
         <% items.each_with_index do |item, index| %>
           <li class="gem-c-error-summary__list-item">
             <% if item[:href] %>
-              <%= link_to item[:text], item[:href] %>
+              <%= link_to item[:text], item[:href], target: item[:target] %>
             <% else %>
               <%= item[:text] %>
             <% end %>

--- a/app/views/govuk_publishing_components/components/docs/error_summary.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_summary.yml
@@ -32,3 +32,14 @@ examples:
         tracking: GTM-123AB
       items:
       - text: Descriptive link to the question with an error 1
+  with_custom_target_on_links:
+    data:
+      title: Message to alert the user to a problem goes here
+      description: Optional description of the errors and how to correct them
+      items:
+      - text: Descriptive link to the question with an error oppening in a new window
+        href: '#example-error-1'
+        target: '_blank'
+      - text: Descriptive link to the question with an error oppening in the same window
+        href: '#example-error-2'
+        target: '_self'

--- a/spec/components/error_summary_spec.rb
+++ b/spec/components/error_summary_spec.rb
@@ -81,7 +81,8 @@ describe "Error summary", type: :view do
         },
         {
           text: 'Descriptive link to the question with an error 3',
-          href: '#example-error-3'
+          href: '#example-error-3',
+          target: '_blank'
         },
         {
           text: 'Description for error 4 with no link'
@@ -101,8 +102,8 @@ describe "Error summary", type: :view do
       text: 'Descriptive link to the question with an error 2'
     )
     assert_select(
-      "ul li a:last-of-type[href='#example-error-3']",
-      text: 'Descriptive link to the question with an error 3'
+      "ul li a:last-of-type[href='#example-error-3'][target='_blank']",
+      text: 'Descriptive link to the question with an error 3',
     )
     assert_select(
       "ul li:last-of-type",


### PR DESCRIPTION
This PR allows passing a target attribute for links on error summary component

This feature is used in Content Publisher when the change a users needs to do in order to fix the error is on another page than the current one and we don't want them to loose context.

[Trello](https://trello.com/c/TI9uPeMu)