### PR TITLE
Add #sanitize to code examples containing HTML

### DIFF
--- a/app/models/govuk_publishing_components/component_example.rb
+++ b/app/models/govuk_publishing_components/component_example.rb
@@ -29,7 +29,18 @@ module GovukPublishingComponents
     end
 
     def pretty_data
-      JSON.pretty_generate(data).gsub('\\n', "\n    ").gsub(/"(\w*)":/, '\1:').strip
+      json_key_regex = /"(\w*)":/ # matches quoted keys ending with a colon, i.e. "key":
+      output = JSON.pretty_generate(data).gsub('\\n', "\n    ").gsub(json_key_regex, '\1:')
+
+      quoted_string_regex = /"((?:[^"\\]|\\.)*)"/ # matches "some text" - ignores escaped quotes, i.e. \"
+      output.gsub(quoted_string_regex) do |group|
+        match = Regexp.last_match[1]
+        contains_html?(match) ? "sanitize(#{group})" : group
+      end
+    end
+
+    def contains_html?(input)
+      ActionController::Base.helpers.strip_tags(input) != input
     end
 
     def data?

--- a/spec/component_guide/component_example_spec.rb
+++ b/spec/component_guide/component_example_spec.rb
@@ -71,7 +71,16 @@ describe 'Component example' do
     expect(page).to have_content(example)
   end
 
-  it 'marks strings in examples as html_safe' do
+  it 'sanitizes strings in code example' do
+    visit '/component-guide/test-component-with-html-params'
+    within ".component-call" do
+      1.upto(7) do |i|
+        expect(page).to have_text("sanitize(\"<span class=\\\"param-#{i}\\\">#{i}</span>\")")
+      end
+    end
+  end
+
+  it 'marks strings in preview as html_safe' do
     visit '/component-guide/test-component-with-html-params'
     within ".test-component-with-html-params" do
       7.times do |i|


### PR DESCRIPTION
Copy-pasting examples with attributes containing HTML caused
those attributes to be rendered incorrectly because Rails automatically
escapes all strings.

This commit finds all attributes containing HTML and adds
the 'sanitize' helper to the code examples allowing them to be copy-pasted as-is.

Screenshot:

![image](https://user-images.githubusercontent.com/6050162/58700171-486e4f80-8397-11e9-8c64-2a18914ef7a3.png)
