### PR TITLE
Add description to SearchAction in schema metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add descriptions for search actions on machine readable components (PR #897)
+
 ## 16.27.0
 
 * Allow target attribute on links for the error summary component (PR #894)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,12 +28,16 @@ en:
       request_format_text: "This file may not be suitable for users of assistive technology."
       request_format_cta: "Request a different format"
       request_format_details_html: "If you use assistive technology and need a version of this document in a more accessible format, please email <a href='mailto:%{alternative_format_contact_email}' target='_blank' class='govuk-link'>%{alternative_format_contact_email}</a>. Please tell us what format you need. It will help us if you say what assistive technology you use."
+    article_schema:
+      scoped_search_description: "Search within %{title}"
     autocomplete:
       multiselect: "To select multiple items in a list, hold down Ctrl (PC) or Cmd (Mac) key."
     back_link:
       back: 'Back'
     contents_list:
       contents: Contents
+    organisation_schema:
+      all_content_search_description: "Find all content from %{organisation}"
     radio:
       or: 'or'
     related_navigation:

--- a/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/article_schema.rb
@@ -32,7 +32,11 @@ module GovukPublishingComponents
         return {} unless page.document_type == "manual"
 
         manuals_facet_params = { manual: page.base_path }
-        PotentialSearchActionSchema.new(manuals_facet_params).structured_data
+        PotentialSearchActionSchema.new(manuals_facet_params, search_description).structured_data
+      end
+
+      def search_description
+        I18n.t(:scoped_search_description, scope: %i(components article_schema), title: page.title)
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/machine_readable/organisation_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/organisation_schema.rb
@@ -55,12 +55,16 @@ module GovukPublishingComponents
       end
 
       def search_action
-        PotentialSearchActionSchema.new(organisation_facet_params).structured_data
+        PotentialSearchActionSchema.new(organisation_facet_params, search_description).structured_data
       end
 
       def slug
         uri = URI.parse(page.canonical_url)
         File.basename(uri.path)
+      end
+
+      def search_description
+        I18n.t(:all_content_search_description, scope: %i(components organisation_schema), organisation: page.title)
       end
 
       def organisation_facet_params

--- a/lib/govuk_publishing_components/presenters/machine_readable/potential_search_action_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/potential_search_action_schema.rb
@@ -3,12 +3,13 @@ require 'plek'
 module GovukPublishingComponents
   module Presenters
     class PotentialSearchActionSchema
-      attr_reader :facet_params
+      attr_reader :facet_params, :description
 
       BASE_SEARCH_URL = "#{Plek.current.website_root}/search/all?keywords={query}&order=relevance".freeze
 
-      def initialize(facet_params)
+      def initialize(facet_params, description)
         @facet_params = facet_params
+        @description = description
       end
 
       def structured_data
@@ -16,6 +17,7 @@ module GovukPublishingComponents
         {
           "potentialAction" => {
             "@type": "SearchAction",
+            "description": description,
             "target": search_template,
             "query": "required"
           }

--- a/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
           "base_path" => "/guidance/plane-manual",
           "details" => {
             "body" => "Ensure you have a left phalange before take off."
-          }
+          },
+          "title" => "Phoebe's flying guide"
         )
       end
 
@@ -43,6 +44,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
 
       search_action = {
         "@type": "SearchAction",
+        "description": "Search within Phoebe's flying guide",
         "target": "http://www.dev.gov.uk/search/all?keywords={query}&order=relevance&manual=%2Fguidance%2Fplane-manual",
         "query": "required"
       }
@@ -80,6 +82,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
 
       search_action = {
         "@type": "SearchAction",
+        "description": "Find all content from Ministry of Magic",
         "target": "http://www.dev.gov.uk/search/all?keywords={query}&order=relevance&organisations%5B%5D=ministry-of-magic",
         "query": "required"
       }


### PR DESCRIPTION
This adds some basic context around what the search action's target.

This is important as we may want to add other search actions on things
like org pages which have a number of links to finders.