### PR TITLE
Make inline buttons 50% width from mobile - tablet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add descriptions for search actions on machine readable components (PR #897)
+* Make inline buttons 50% width from mobile - tablet (PR #898)
 
 ## 16.27.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -23,12 +23,17 @@ $gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
 }
 
 .gem-c-button--inline {
-  width: auto;
+  display: block;
   margin-bottom: govuk-spacing(1);
-  margin-right: govuk-spacing(2);
 
-  @include govuk-media-query($from: tablet) {
-    margin-bottom: 0;
+  @include govuk-media-query($from: mobile) {
+    @include box-sizing(border-box);
+    display: inline-block;
+    width: 48%;
+  }
+
+  @include govuk-media-query($from: desktop) {
+    width: auto;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -41,8 +41,11 @@ $govuk-cookie-banner-background-new: govuk-colour("white");
 }
 
 .gem-c-cookie-banner__buttons {
-  display: inline-block;
   vertical-align: middle;
+
+  @include govuk-media-query($from: desktop) {
+    display: inline-block;
+  }
 }
 
 .gem-c-cookie-banner__confirmation {


### PR DESCRIPTION
A design tweak to make inline buttons fill the space from mobile - tablet.

## Buttons (old)
![buttons-old](https://user-images.githubusercontent.com/29889908/58630019-029d8280-82d6-11e9-819f-38de509f6210.gif)

## Buttons (new)
![buttons-new](https://user-images.githubusercontent.com/29889908/58630023-05987300-82d6-11e9-964d-c5b8e005331a.gif)

## Within cookie banner (old)
![banner-old](https://user-images.githubusercontent.com/29889908/58630027-09c49080-82d6-11e9-84ed-9e8237869600.gif)

## Within cookie banner (new)
![govuk-banner-buttons](https://user-images.githubusercontent.com/29889908/58630029-0cbf8100-82d6-11e9-8772-512ae587a383.gif)
