### PR TITLE
Add the closed step by step for secondary content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Adds support for secondary content items for step by step (PR #900)
+* Adds missing tests for related to step navs (PR #900)
+* Adds missing tests for also part of step navs component (PR #900)
+
 ## 17.3.0
 
 * Set the expiry of consent cookie to 1 year (PR #940)

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
@@ -462,6 +462,41 @@ examples:
           Expand the step by step in the querystring
 
           Show a list of the other step by steps (including other step by steps that have been marked as "hidden") under an "Also part of" heading, if the content item is part of less than 5 step by step journeys
+
+      Changes to the rules when there is a secondary step by step linked:
+
+      1. Content item is part of one step by step
+
+          No change. Expand the step by step in the sidebar.
+
+      2. Content item is part of multiple step by steps and no secondary step by step
+
+          No change. Will show a list of primary step by steps under the "Part of" heading. Secondary step by steps will not be shown.
+
+      3. User is on a step by step journey (the query string is in the url)
+
+          No change. Active step by step will be expanded.
+
+      4. Content item is part of multiple primary step by steps and a single secondary step by step 
+
+          No change. Show "Part of" step by steps list. Secondary step by step won't be shown.
+
+      5. Content item is part of multiple step by steps and multiple secondary step by steps
+
+          No change. Show "Part of" step by step list. Secondary step by step won't be shown.
+
+      6. Step by step is marked as "hidden" for the content page
+
+          No change. "Also part of" component will only show when an active step by step is shown.
+
+      7. Content item is part of one secondary step by step and no other step by steps are linked.
+
+          Show secondary step by step expanded.
+
+      8. Content item is part of multiple secondary step by steps and no other step by steps are linked.
+
+          Show secondary step by step list in "Part of" component.
+
     data:
       tracking_id: "this-is-the-content-id"
       steps: [

--- a/spec/components/contextual_footer_spec.rb
+++ b/spec/components/contextual_footer_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe 'Contextual footer', type: :view do
 
   it 'renders the footer' do
     content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: 'speech') do |payload|
-      # If this item is a part of a step nav this component might not render
+      # If this item is a part of a step nav or secondary step nav this component might not render
       payload["links"].delete("part_of_step_navs")
+      payload["links"].delete("secondary_to_step_navs")
       payload
     end
 

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -120,6 +120,14 @@ describe "Contextual navigation" do
     and_no_step_by_step_header
   end
 
+  scenario "There's 2 primary step by step, 1 secondary step by step and I am interacting with one of the primary" do
+    given_there_are_two_primary_step_by_steps_and_one_secondary_to_step_navs
+    and_i_visit_that_page_by_clicking_on_a_step_by_step_link
+    then_i_see_the_step_by_step_that_i_am_interacting_with
+    and_i_see_the_other_step_by_step_as_an_also_part_of_list
+    and_i_dont_see_the_secondary_step_by_step_in_the_also_part_of_list
+  end
+
   include GdsApi::TestHelpers::ContentStore
 
   def given_theres_a_page_with_a_step_by_step
@@ -168,6 +176,21 @@ describe "Contextual navigation" do
     content_store_has_random_item(links: {
       secondary_to_step_navs: 1.times.map { random_step_nav_item("step_by_step_nav") },
       part_of_step_navs: part_of_step_navs
+    })
+  end
+
+  def given_there_are_two_primary_step_by_steps_and_one_secondary_to_step_navs
+    part_of_step_navs = 2.times.map { random_step_nav_item("step_by_step_nav") }
+    part_of_step_navs[0]["title"] = "PRIMARY STEP BY STEP - NOT INTERACTING WITH"
+    part_of_step_navs[1]["content_id"] = "8ad999bd-8603-40eb-97c0-999cb22047cd"
+    part_of_step_navs[1]["title"] = "PRIMARY STEP BY STEP - INTERACTING WITH"
+
+    secondary_to_step_navs = 1.times.map { random_step_nav_item("step_by_step_nav") }
+    secondary_to_step_navs[0]["title"] = "SECONDARY STEP BY STEP"
+
+    content_store_has_random_item(links: {
+      part_of_step_navs: part_of_step_navs,
+      secondary_to_step_navs: secondary_to_step_navs
     })
   end
 
@@ -301,6 +324,12 @@ describe "Contextual navigation" do
       expect(page).to have_content('Also part of')
       expect(page).to have_content("PRIMARY STEP BY STEP - NOT INTERACTING WITH")
       expect(page).not_to have_content("PRIMARY STEP BY STEP - INTERACTING WITH")
+    end
+  end
+
+  def and_i_dont_see_the_secondary_step_by_step_in_the_also_part_of_list
+    within '.gem-c-step-nav-related:last-child' do
+      expect(page).not_to have_content("SECONDARY STEP BY STEP")
     end
   end
 

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -64,6 +64,41 @@ describe "Contextual navigation" do
     and_the_parent_based_breadcrumbs
   end
 
+  scenario "There's a secondary step by step list and no primary step by step list" do
+    given_theres_a_page_with_a_secondary_step_by_step
+    and_i_visit_that_page
+    then_i_see_the_step_by_step
+    and_the_step_by_step_header
+  end
+
+  scenario "There's between 2-5 secondary step by step lists and no primary step by step list" do
+    given_there_are_two_secondary_step_by_step_lists
+    and_i_visit_that_page
+    then_i_just_see_the_step_by_step_related_links
+  end
+
+  scenario "There's 6 or more secondary step by step lists and no primary step by step list" do
+    given_there_are_six_secondary_step_by_step_lists
+    and_i_visit_that_page
+    then_theres_no_step_by_step_at_all
+    and_no_step_by_step_header
+  end
+
+  scenario "There's 3 secondary step by steps and 2 primary step by step lists" do
+    given_there_are_three_secondary_step_by_steps_and_two_primary_to_step_navs
+    and_i_visit_that_page
+    then_i_just_see_the_step_by_step_related_links_with_just_two_links
+    and_i_dont_see_the_secondary_step_by_step_related_links
+  end
+
+  scenario "There's 1 primary step by step and 1 secondary step by step" do
+    given_there_are_one_primary_step_by_steps_and_one_secondary_to_step_navs
+    and_i_visit_that_page
+    then_i_see_the_step_by_step
+    and_the_step_by_step_header
+    then_i_see_the_primary_step_by_step
+  end
+
   include GdsApi::TestHelpers::ContentStore
 
   def given_theres_a_page_with_a_step_by_step
@@ -76,6 +111,38 @@ describe "Contextual navigation" do
 
   def given_theres_are_six_step_by_step_lists
     content_store_has_random_item(links: { part_of_step_navs: 6.times.map { random_step_nav_item("step_by_step_nav") } })
+  end
+
+  def given_theres_a_page_with_a_secondary_step_by_step
+    content_store_has_random_item(links: { secondary_to_step_navs: [random_step_nav_item("step_by_step_nav")] })
+  end
+
+  def given_there_are_two_secondary_step_by_step_lists
+    content_store_has_random_item(links: { secondary_to_step_navs: 2.times.map { random_step_nav_item("step_by_step_nav") } })
+  end
+
+  def given_there_are_six_secondary_step_by_step_lists
+    content_store_has_random_item(links: { secondary_to_step_navs: 6.times.map { random_step_nav_item("step_by_step_nav") } })
+  end
+
+  def given_there_are_three_secondary_step_by_steps_and_two_primary_to_step_navs
+    secondary_to_step_navs = 3.times.map { random_step_nav_item("step_by_step_nav") }
+    secondary_to_step_navs[0]["title"] = "SECONDARY STEP BY STEP"
+
+    content_store_has_random_item(links: {
+      secondary_to_step_navs: secondary_to_step_navs,
+      part_of_step_navs: 2.times.map { random_step_nav_item("step_by_step_nav") }
+    })
+  end
+
+  def given_there_are_one_primary_step_by_steps_and_one_secondary_to_step_navs
+    part_of_step_navs = 1.times.map { random_step_nav_item("step_by_step_nav") }
+    part_of_step_navs[0]["title"] = "PRIMARY STEP BY STEP"
+
+    content_store_has_random_item(links: {
+      secondary_to_step_navs: 1.times.map { random_step_nav_item("step_by_step_nav") },
+      part_of_step_navs: part_of_step_navs
+    })
   end
 
   def given_theres_a_page_with_browse_page
@@ -152,6 +219,14 @@ describe "Contextual navigation" do
     expect(page).not_to have_selector(".gem-c-step-nav__header")
   end
 
+  def then_i_just_see_the_step_by_step_related_links_with_just_two_links
+    expect(page).to have_selector(".gem-c-step-nav-related")
+    expect(page).not_to have_selector(".gem-c-step-nav__header")
+    within('.gem-c-step-nav-related') do
+      expect(page).to have_xpath(".//li", count: 2)
+    end
+  end
+
   def and_no_step_by_step_header
     expect(page).not_to have_selector(".gem-c-step-nav-header")
   end
@@ -159,6 +234,12 @@ describe "Contextual navigation" do
   def then_theres_no_step_by_step_at_all
     expect(page).not_to have_selector(".gem-c-step-nav-related")
     expect(page).not_to have_selector(".gem-c-step-nav__header")
+  end
+
+  def and_i_dont_see_the_secondary_step_by_step_related_links
+    within '.gem-c-step-nav-related' do
+      expect(page).not_to have_content("SECONDARY STEP BY STEP")
+    end
   end
 
   def then_i_see_the_browse_page_in_the_footer
@@ -172,6 +253,12 @@ describe "Contextual navigation" do
     within '.gem-c-contextual-sidebar' do
       expect(page).to have_selector(".gem-c-related-navigation")
       expect(page).to have_content("The national curriculum")
+    end
+  end
+
+  def then_i_see_the_primary_step_by_step
+    within '.gem-c-step-nav-header' do
+      expect(page).to have_content("PRIMARY STEP BY STEP")
     end
   end
 

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -99,6 +99,27 @@ describe "Contextual navigation" do
     then_i_see_the_primary_step_by_step
   end
 
+  scenario "There's a related to step by step lists and no primary step by step list" do
+    given_there_is_a_related_to_step_nav
+    and_i_visit_that_page
+    then_theres_no_step_by_step_at_all
+    and_no_step_by_step_header
+  end
+
+  scenario "There are three related to step by step lists and no primary step by step list" do
+    given_there_are_three_related_to_step_nav
+    and_i_visit_that_page
+    then_theres_no_step_by_step_at_all
+    and_no_step_by_step_header
+  end
+
+  scenario "There are three related to step by step lists, no primary step by step list and one secondary to step nav" do
+    given_there_are_three_related_to_step_nav_and_one_secondary_to_step_nav
+    and_i_visit_that_page
+    then_theres_no_step_by_step_at_all
+    and_no_step_by_step_header
+  end
+
   include GdsApi::TestHelpers::ContentStore
 
   def given_theres_a_page_with_a_step_by_step
@@ -142,6 +163,25 @@ describe "Contextual navigation" do
     content_store_has_random_item(links: {
       secondary_to_step_navs: 1.times.map { random_step_nav_item("step_by_step_nav") },
       part_of_step_navs: part_of_step_navs
+    })
+  end
+
+  def given_there_is_a_related_to_step_nav
+    content_store_has_random_item(links: {
+      related_to_step_navs: 1.times.map { random_step_nav_item("step_by_step_nav") }
+    })
+  end
+
+  def given_there_are_three_related_to_step_nav
+    content_store_has_random_item(links: {
+      related_to_step_navs: 3.times.map { random_step_nav_item("step_by_step_nav") }
+    })
+  end
+
+  def given_there_are_three_related_to_step_nav_and_one_secondary_to_step_nav
+    content_store_has_random_item(links: {
+      related_to_step_navs: 3.times.map { random_step_nav_item("step_by_step_nav") },
+      secondary_to_step_navs: 1.times.map { random_step_nav_item("step_by_step_nav") }
     })
   end
 

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -25,8 +25,8 @@ describe "Contextual navigation" do
   scenario "I see the step by step I am currently interacting with" do
     given_theres_are_two_step_by_step_lists
     and_i_visit_that_page_by_clicking_on_a_step_by_step_link
-    then_i_see_the_step_by_step
-    and_the_step_by_step_header
+    then_i_see_the_step_by_step_that_i_am_interacting_with
+    and_i_see_the_other_step_by_step_as_an_also_part_of_list
   end
 
   scenario "There's a mainstream browse page tagged" do
@@ -127,7 +127,12 @@ describe "Contextual navigation" do
   end
 
   def given_theres_are_two_step_by_step_lists
-    content_store_has_random_item(links: { part_of_step_navs: 2.times.map { random_step_nav_item("step_by_step_nav") } })
+    part_of_step_navs = 2.times.map { random_step_nav_item("step_by_step_nav") }
+    part_of_step_navs[0]["title"] = "PRIMARY STEP BY STEP - NOT INTERACTING WITH"
+    part_of_step_navs[1]["content_id"] = "8ad999bd-8603-40eb-97c0-999cb22047cd"
+    part_of_step_navs[1]["title"] = "PRIMARY STEP BY STEP - INTERACTING WITH"
+
+    content_store_has_random_item(links: { part_of_step_navs: part_of_step_navs })
   end
 
   def given_theres_are_six_step_by_step_lists
@@ -242,12 +247,21 @@ describe "Contextual navigation" do
   end
 
   def and_i_visit_that_page_by_clicking_on_a_step_by_step_link
-    visit "/contextual-navigation/page-with-contextual-navigation?step-by-step-nav=8ad782bd-8603-40eb-97c0-434cb22047cd"
+    visit "/contextual-navigation/page-with-contextual-navigation?step-by-step-nav=8ad999bd-8603-40eb-97c0-999cb22047cd"
   end
 
   def then_i_see_the_step_by_step
     expect(page).to have_selector(".gem-c-step-nav-related")
     expect(page).to have_selector(".gem-c-step-nav__header")
+  end
+
+  def then_i_see_the_step_by_step_that_i_am_interacting_with
+    expect(page).to have_selector(".gem-c-step-nav-related")
+    expect(page).to have_selector(".gem-c-step-nav__header")
+    within '.gem-c-step-nav-header' do
+      expect(page).to have_content("PRIMARY STEP BY STEP - INTERACTING WITH")
+      expect(page).not_to have_content("PRIMARY STEP BY STEP - NOT INTERACTING WITH")
+    end
   end
 
   def and_the_step_by_step_header
@@ -279,6 +293,14 @@ describe "Contextual navigation" do
   def and_i_dont_see_the_secondary_step_by_step_related_links
     within '.gem-c-step-nav-related' do
       expect(page).not_to have_content("SECONDARY STEP BY STEP")
+    end
+  end
+
+  def and_i_see_the_other_step_by_step_as_an_also_part_of_list
+    within '.gem-c-step-nav-related:last-child' do
+      expect(page).to have_content('Also part of')
+      expect(page).to have_content("PRIMARY STEP BY STEP - NOT INTERACTING WITH")
+      expect(page).not_to have_content("PRIMARY STEP BY STEP - INTERACTING WITH")
     end
   end
 

--- a/spec/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation_spec.rb
@@ -474,6 +474,584 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
     end
   end
 
+  context("secondary step by steps") do
+    let(:step_nav) do
+      {
+        "content_id" => "aaaa-bbbb",
+        "title" => "Lose your lunch: lurch by lurch",
+        "base_path" => "/lose-your-lunch",
+        "details" => {
+          "step_by_step_nav" => {
+            "steps" => [
+              "title": "Step one"
+            ]
+          }
+        }
+      }
+    end
+
+    context "secondary steps without other step by step links" do
+      context "for a content item with a single `secondary_to_step_navs` links" do
+        let(:content_store_response) do
+          {
+            "title" => "Book a session in the vomit comet",
+            "document_type" => "transaction",
+            "links" => {
+              "secondary_to_step_navs" => [step_nav],
+            }
+          }
+        end
+
+        it "parses the content item" do
+          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+          expect(step_nav_links.step_navs.count).to eq(0)
+          expect(step_nav_links.secondary_step_by_steps.count).to eq(1)
+
+          expect(step_nav_links.show_secondary_step_by_step?).to be true
+          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be true
+          expect(step_nav_links.show_header?).to be true
+          expect(step_nav_links.header).to eq(
+            path: "/lose-your-lunch",
+            title: "Lose your lunch: lurch by lurch",
+            tracking_id: "aaaa-bbbb"
+          )
+
+          expect(step_nav_links.show_related_links?).to be true
+          expect(step_nav_links.related_links).to eq([
+            {
+              href: "/lose-your-lunch",
+              text: "Lose your lunch: lurch by lurch",
+              tracking_id: "aaaa-bbbb"
+            }
+          ])
+
+          expect(step_nav_links.show_sidebar?).to be true
+        end
+      end
+
+      context "for a content item with a couple `secondary_to_step_navs` links" do
+        let(:step_nav2) do
+          {
+            "content_id" => "aaaa-bbbb-2",
+            "title" => "Lose your lunch: lurch by lurch 2",
+            "base_path" => "/lose-your-lunch-2",
+          }
+        end
+
+        let(:content_store_response) do
+          {
+            "title" => "Book a session in the vomit comet",
+            "document_type" => "transaction",
+            "links" => {
+              "secondary_to_step_navs" => [step_nav, step_nav2],
+            }
+          }
+        end
+
+        it "parses the content item" do
+          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+          expect(step_nav_links.step_navs.count).to eq(0)
+          expect(step_nav_links.secondary_step_by_steps.count).to eq(2)
+
+          expect(step_nav_links.show_secondary_step_by_step?).to be false
+          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be true
+          expect(step_nav_links.show_related_links?).to be true
+          expect(step_nav_links.related_links).to eq([
+            {
+              href: "/lose-your-lunch",
+              text: "Lose your lunch: lurch by lurch",
+              tracking_id: "aaaa-bbbb"
+            },
+            {
+              href: "/lose-your-lunch-2",
+              text: "Lose your lunch: lurch by lurch 2",
+              tracking_id: "aaaa-bbbb-2"
+            }
+          ])
+
+          expect(step_nav_links.show_header?).to be false
+          expect(step_nav_links.show_sidebar?).to be false
+        end
+      end
+
+      context "for a content item with many `secondary_to_step_navs` links" do
+        let(:content_store_response) do
+          {
+            "title" => "Book a session in the vomit comet",
+            "document_type" => "transaction",
+            "links" => {
+              "secondary_to_step_navs" => Array.new(6, step_nav),
+            }
+          }
+        end
+
+        it "parses the content item" do
+          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+          expect(step_nav_links.step_navs.count).to eq(0)
+          expect(step_nav_links.secondary_step_by_steps.count).to eq(6)
+
+          expect(step_nav_links.show_secondary_step_by_step?).to be false
+          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
+          expect(step_nav_links.show_header?).to be false
+          expect(step_nav_links.show_related_links?).to be false
+          expect(step_nav_links.show_sidebar?).to be false
+        end
+      end
+    end
+
+    context "secondary step by steps with primary step by steps" do
+      let(:primary_step_nav) do
+        {
+          "content_id" => "PRIMARY-aaaa-bbbb",
+          "title" => "PRIMARY Lose your lunch: lurch by lurch",
+          "base_path" => "/PRIMARY-lose-your-lunch",
+          "details" => {
+            "step_by_step_nav" => {
+              "steps" => [
+                "title": "Step one"
+              ]
+            }
+          }
+        }
+      end
+
+      context "for a content item with a single `secondary_to_step_navs` links and a single `part_of_step_navs` link" do
+        let(:content_store_response) do
+          {
+            "title" => "Book a session in the vomit comet",
+            "document_type" => "transaction",
+            "links" => {
+              "part_of_step_navs" => [primary_step_nav],
+              "secondary_to_step_navs" => [step_nav],
+            }
+          }
+        end
+
+        it "parses the content item" do
+          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+          expect(step_nav_links.step_navs.count).to eq(1)
+          expect(step_nav_links.secondary_step_by_steps.count).to eq(1)
+
+          expect(step_nav_links.show_secondary_step_by_step?).to be false
+          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
+          expect(step_nav_links.show_header?).to be true
+          expect(step_nav_links.header).to eq(
+            path: "/PRIMARY-lose-your-lunch",
+            title: "PRIMARY Lose your lunch: lurch by lurch",
+            tracking_id: "PRIMARY-aaaa-bbbb"
+          )
+
+          expect(step_nav_links.show_related_links?).to be true
+          expect(step_nav_links.related_links).to eq([
+            {
+              href: "/PRIMARY-lose-your-lunch",
+              text: "PRIMARY Lose your lunch: lurch by lurch",
+              tracking_id: "PRIMARY-aaaa-bbbb"
+            }
+          ])
+
+          expect(step_nav_links.show_sidebar?).to be true
+        end
+      end
+
+      context "for a content item with a couple `secondary_to_step_navs` links and a single `part_of_step_navs` link" do
+        let(:step_nav2) do
+          {
+            "content_id" => "aaaa-bbbb-2",
+            "title" => "Lose your lunch: lurch by lurch 2",
+            "base_path" => "/lose-your-lunch-2",
+          }
+        end
+
+        let(:content_store_response) do
+          {
+            "title" => "Book a session in the vomit comet",
+            "document_type" => "transaction",
+            "links" => {
+              "part_of_step_navs" => [primary_step_nav],
+              "secondary_to_step_navs" => [step_nav, step_nav2],
+            }
+          }
+        end
+
+        it "parses the content item" do
+          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+          expect(step_nav_links.step_navs.count).to eq(1)
+          expect(step_nav_links.secondary_step_by_steps.count).to eq(2)
+
+          expect(step_nav_links.show_secondary_step_by_step?).to be false
+          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
+          expect(step_nav_links.show_header?).to be true
+          expect(step_nav_links.header).to eq(
+            path: "/PRIMARY-lose-your-lunch",
+            title: "PRIMARY Lose your lunch: lurch by lurch",
+            tracking_id: "PRIMARY-aaaa-bbbb"
+          )
+
+          expect(step_nav_links.show_related_links?).to be true
+          expect(step_nav_links.related_links).to eq([
+            {
+              href: "/PRIMARY-lose-your-lunch",
+              text: "PRIMARY Lose your lunch: lurch by lurch",
+              tracking_id: "PRIMARY-aaaa-bbbb"
+            }
+          ])
+
+          expect(step_nav_links.show_sidebar?).to be true
+        end
+      end
+
+      context "for a content item with a single `secondary_to_step_navs` links and a couple `part_of_step_navs` link" do
+        let(:primary_step_nav2) do
+          {
+            "content_id" => "PRIMARY-aaaa-bbbb-2",
+            "title" => "PRIMARY Lose your lunch: lurch by lurch 2",
+            "base_path" => "/PRIMARY-lose-your-lunch-2",
+          }
+        end
+
+        let(:content_store_response) do
+          {
+            "title" => "Book a session in the vomit comet",
+            "document_type" => "transaction",
+            "links" => {
+              "part_of_step_navs" => [primary_step_nav, primary_step_nav2],
+              "secondary_to_step_navs" => [step_nav],
+            }
+          }
+        end
+
+        it "parses the content item" do
+          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+          expect(step_nav_links.step_navs.count).to eq(2)
+          expect(step_nav_links.secondary_step_by_steps.count).to eq(1)
+
+          expect(step_nav_links.show_secondary_step_by_step?).to be false
+          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
+          expect(step_nav_links.show_related_links?).to be true
+          expect(step_nav_links.related_links).to eq([
+            {
+              href: "/PRIMARY-lose-your-lunch",
+              text: "PRIMARY Lose your lunch: lurch by lurch",
+              tracking_id: "PRIMARY-aaaa-bbbb"
+            },
+            {
+              href: "/PRIMARY-lose-your-lunch-2",
+              text: "PRIMARY Lose your lunch: lurch by lurch 2",
+              tracking_id: "PRIMARY-aaaa-bbbb-2"
+            }
+          ])
+
+          expect(step_nav_links.show_header?).to be false
+          expect(step_nav_links.show_sidebar?).to be false
+        end
+      end
+
+      context "for a content item with a couple `secondary_to_step_navs` links and a couple `part_of_step_navs` link" do
+        let(:primary_step_nav2) do
+          {
+            "content_id" => "PRIMARY-aaaa-bbbb-2",
+            "title" => "PRIMARY Lose your lunch: lurch by lurch 2",
+            "base_path" => "/PRIMARY-lose-your-lunch-2",
+          }
+        end
+
+        let(:step_nav2) do
+          {
+            "content_id" => "aaaa-bbbb-2",
+            "title" => "Lose your lunch: lurch by lurch 2",
+            "base_path" => "/lose-your-lunch-2",
+          }
+        end
+
+        let(:content_store_response) do
+          {
+            "title" => "Book a session in the vomit comet",
+            "document_type" => "transaction",
+            "links" => {
+              "part_of_step_navs" => [primary_step_nav, primary_step_nav2],
+              "secondary_to_step_navs" => [step_nav, step_nav2],
+            }
+          }
+        end
+
+        it "parses the content item" do
+          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+          expect(step_nav_links.step_navs.count).to eq(2)
+          expect(step_nav_links.secondary_step_by_steps.count).to eq(2)
+
+          expect(step_nav_links.show_secondary_step_by_step?).to be false
+          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
+          expect(step_nav_links.show_related_links?).to be true
+          expect(step_nav_links.related_links).to eq([
+            {
+              href: "/PRIMARY-lose-your-lunch",
+              text: "PRIMARY Lose your lunch: lurch by lurch",
+              tracking_id: "PRIMARY-aaaa-bbbb"
+            },
+            {
+              href: "/PRIMARY-lose-your-lunch-2",
+              text: "PRIMARY Lose your lunch: lurch by lurch 2",
+              tracking_id: "PRIMARY-aaaa-bbbb-2"
+            }
+          ])
+
+          expect(step_nav_links.show_header?).to be false
+          expect(step_nav_links.show_sidebar?).to be false
+        end
+      end
+
+      context "for a content item with many `secondary_to_step_navs` links and many `part_of_step_navs` link" do
+        let(:content_store_response) do
+          {
+            "title" => "Book a session in the vomit comet",
+            "document_type" => "transaction",
+            "links" => {
+              "part_of_step_navs" => Array.new(6, primary_step_nav),
+              "secondary_to_step_navs" => Array.new(6, step_nav),
+            }
+          }
+        end
+
+        it "parses the content item" do
+          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+          expect(step_nav_links.step_navs.count).to eq(6)
+          expect(step_nav_links.secondary_step_by_steps.count).to eq(6)
+
+          expect(step_nav_links.show_secondary_step_by_step?).to be false
+          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
+          expect(step_nav_links.show_header?).to be false
+          expect(step_nav_links.show_related_links?).to be false
+          expect(step_nav_links.show_sidebar?).to be false
+        end
+      end
+    end
+
+    context "secondary step by steps with related to step by steps" do
+      let(:related_to_step_nav) do
+        {
+          "content_id" => "RELATED-aaaa-bbbb",
+          "title" => "RELATED Lose your lunch: lurch by lurch",
+          "base_path" => "/RELATED-lose-your-lunch",
+          "details" => {
+            "step_by_step_nav" => {
+              "steps" => [
+                "title": "Step one"
+              ]
+            }
+          }
+        }
+      end
+
+      context "for a content item with a single `secondary_to_step_navs` links and a single `related_to_step_navs` link" do
+        let(:content_store_response) do
+          {
+            "title" => "Book a session in the vomit comet",
+            "document_type" => "transaction",
+            "links" => {
+              "related_to_step_navs" => Array.new(1, related_to_step_nav),
+              "secondary_to_step_navs" => Array.new(1, step_nav),
+            }
+          }
+        end
+
+        it "parses the content item" do
+          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+          expect(step_nav_links.step_navs.count).to eq(0)
+          expect(step_nav_links.secondary_step_by_steps.count).to eq(1)
+          expect(step_nav_links.related_to_step_navs.count).to eq(1)
+
+          expect(step_nav_links.show_secondary_step_by_step?).to be false
+          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
+          expect(step_nav_links.show_header?).to be false
+          expect(step_nav_links.show_related_links?).to be false
+          expect(step_nav_links.show_sidebar?).to be false
+        end
+      end
+
+      context "for a content item with a couple `secondary_to_step_navs` links and a single `related_to_step_navs` link" do
+        let(:content_store_response) do
+          {
+            "title" => "Book a session in the vomit comet",
+            "document_type" => "transaction",
+            "links" => {
+              "related_to_step_navs" => Array.new(1, related_to_step_nav),
+              "secondary_to_step_navs" => Array.new(2, step_nav),
+            }
+          }
+        end
+
+        it "parses the content item" do
+          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+          expect(step_nav_links.step_navs.count).to eq(0)
+          expect(step_nav_links.secondary_step_by_steps.count).to eq(2)
+          expect(step_nav_links.related_to_step_navs.count).to eq(1)
+
+          expect(step_nav_links.show_secondary_step_by_step?).to be false
+          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
+          expect(step_nav_links.show_header?).to be false
+          expect(step_nav_links.show_related_links?).to be false
+          expect(step_nav_links.show_sidebar?).to be false
+        end
+      end
+
+      context "for a content item with a single `secondary_to_step_navs` links and a couple `related_to_step_navs` link" do
+        let(:content_store_response) do
+          {
+            "title" => "Book a session in the vomit comet",
+            "document_type" => "transaction",
+            "links" => {
+              "related_to_step_navs" => Array.new(2, related_to_step_nav),
+              "secondary_to_step_navs" => Array.new(1, step_nav),
+            }
+          }
+        end
+
+        it "parses the content item" do
+          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+          expect(step_nav_links.step_navs.count).to eq(0)
+          expect(step_nav_links.secondary_step_by_steps.count).to eq(1)
+          expect(step_nav_links.related_to_step_navs.count).to eq(2)
+
+          expect(step_nav_links.show_secondary_step_by_step?).to be false
+          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
+          expect(step_nav_links.show_header?).to be false
+          expect(step_nav_links.show_related_links?).to be false
+          expect(step_nav_links.show_sidebar?).to be false
+        end
+      end
+
+      context "for a content item with a couple `secondary_to_step_navs` links and a couple `related_to_step_navs` link" do
+        let(:content_store_response) do
+          {
+            "title" => "Book a session in the vomit comet",
+            "document_type" => "transaction",
+            "links" => {
+              "related_to_step_navs" => Array.new(2, related_to_step_nav),
+              "secondary_to_step_navs" => Array.new(2, step_nav),
+            }
+          }
+        end
+
+        it "parses the content item" do
+          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+          expect(step_nav_links.step_navs.count).to eq(0)
+          expect(step_nav_links.secondary_step_by_steps.count).to eq(2)
+          expect(step_nav_links.related_to_step_navs.count).to eq(2)
+
+          expect(step_nav_links.show_secondary_step_by_step?).to be false
+          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
+          expect(step_nav_links.show_header?).to be false
+          expect(step_nav_links.show_related_links?).to be false
+          expect(step_nav_links.show_sidebar?).to be false
+        end
+      end
+
+      context "for a content item with many `secondary_to_step_navs` links and many `related_to_step_navs` link" do
+        let(:content_store_response) do
+          {
+            "title" => "Book a session in the vomit comet",
+            "document_type" => "transaction",
+            "links" => {
+              "related_to_step_navs" => Array.new(6, related_to_step_nav),
+              "secondary_to_step_navs" => Array.new(6, step_nav),
+            }
+          }
+        end
+
+        it "parses the content item" do
+          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
+
+          expect(step_nav_links.step_navs.count).to eq(0)
+          expect(step_nav_links.secondary_step_by_steps.count).to eq(6)
+          expect(step_nav_links.related_to_step_navs.count).to eq(6)
+
+          expect(step_nav_links.show_secondary_step_by_step?).to be false
+          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
+          expect(step_nav_links.show_header?).to be false
+          expect(step_nav_links.show_related_links?).to be false
+          expect(step_nav_links.show_sidebar?).to be false
+        end
+      end
+    end
+
+    context "secondary step by step with active step by step" do
+      it "shows header for related to step nav when a step by step is active and there is also a secondary step by step" do
+        related_to_step_navs = {
+          "content_id" => "cccc-dddd",
+          "title" => "Learn to spacewalk: small step by giant leap",
+          "base_path" => "/learn-to-spacewalk"
+        }
+        content_item = {
+          "title" => "Book a session in the vomit comet",
+          "document_type" => "transaction",
+          "links" => {
+            "secondary_to_step_navs" => [step_nav],
+            "related_to_step_navs" => [related_to_step_navs],
+          }
+        }
+        step_nav_links = described_class.new(content_item, "/driving-lessons-learning-to-drive", "step-by-step-nav" => "cccc-dddd")
+        expect(step_nav_links.step_navs.count).to eq(0)
+        expect(step_nav_links.secondary_step_by_steps.count).to eq(1)
+
+        expect(step_nav_links.show_secondary_step_by_step?).to be false
+        expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
+        expect(step_nav_links.active_step_by_step?).to eq(true)
+        expect(step_nav_links.show_header?).to eq(true)
+        expect(step_nav_links.related_links).to eq([
+          {
+            href: "/learn-to-spacewalk",
+            text: "Learn to spacewalk: small step by giant leap",
+            tracking_id: "cccc-dddd"
+          }
+        ])
+      end
+
+      it "shows header for part of step nav when a step by step is active and there is also a secondary step by step" do
+        part_of_step_navs = {
+          "content_id" => "cccc-dddd",
+          "title" => "Learn to spacewalk: small step by giant leap",
+          "base_path" => "/learn-to-spacewalk"
+        }
+        content_item = {
+          "title" => "Book a session in the vomit comet",
+          "document_type" => "transaction",
+          "links" => {
+            "secondary_to_step_navs" => [step_nav],
+            "part_of_step_navs" => [part_of_step_navs],
+          }
+        }
+        step_nav_links = described_class.new(content_item, "/driving-lessons-learning-to-drive", "step-by-step-nav" => "cccc-dddd")
+        expect(step_nav_links.step_navs.count).to eq(1)
+        expect(step_nav_links.secondary_step_by_steps.count).to eq(1)
+
+        expect(step_nav_links.show_secondary_step_by_step?).to be false
+        expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
+        expect(step_nav_links.active_step_by_step?).to eq(true)
+        expect(step_nav_links.show_header?).to eq(true)
+        expect(step_nav_links.related_links).to eq([
+          {
+            href: "/learn-to-spacewalk",
+            text: "Learn to spacewalk: small step by giant leap",
+            tracking_id: "cccc-dddd"
+          }
+        ])
+      end
+    end
+  end
+
   def payload_for(schema, content_item)
     GovukSchemas::RandomExample.for_schema(frontend_schema: schema) do |payload|
       payload.merge(content_item)


### PR DESCRIPTION
## What
    
Make it possible for the step by step side bar to appear in the side navigation for all content that uses the contextual navigation.
    
(Note: we will keep all content the same for the breadcrumbs and side nav as for step by steps elsewhere, we are not changing 'part of' for example.)
    
Update developer documentation with these changes.
    
**Logic:**

- If only one secondary step by step and no other step by steps linked - show secondary step by step and expand it
- If multiple secondary step by steps linked and no other step by steps linked - show "Part of" step by step with secondary step by steps
- If multiple secondary step by steps exceed 5 - do not show anything
- If one primary step by step and one/multiple secondary - Show primary and hide secondary
- If multiple primary and one/multiple secondary - Show "Part of" step by step (with only primary)
- If you are on an active step by step - no secondary step by steps should show

If the content is tagged to the business finder and is secondary content on a step by step then the secondary content takes precedence.
    
## Why
We want to add a new feature to 'step by step publisher' that makes it possible to add step by step navigation to secondary content. (Secondary content = content that is about the service but is not useful enough to include in the step by step).
    
**MVP = add the closed step by step to the side nav for these pages**
    
**Nice to have =  make is possible to assign a step in the step by step to open for that piece of secondary content, where relevant.**

## Before
![Screen Shot 2019-06-11 at 10 31 39](https://user-images.githubusercontent.com/4599889/59260823-3b255080-8c34-11e9-8931-682be13a5ec9.png)

## After
<img width="1119" alt="Screen Shot 2019-06-11 at 12 53 00" src="https://user-images.githubusercontent.com/4599889/59269872-ebe91b00-8c47-11e9-81d4-747ab61a6ab6.png">

## Multiple secondary step by steps
<img width="546" alt="Screen Shot 2019-06-11 at 09 57 50" src="https://user-images.githubusercontent.com/4599889/59258247-7cffc800-8c2f-11e9-8232-73f350a9cb7f.png">

## Combined step by steps < 5 (Secondary, related)
![Screen Shot 2019-06-11 at 11 02 03](https://user-images.githubusercontent.com/4599889/59263158-7164cf00-8c38-11e9-963b-a6e38a1f3611.png)

## Combined step by steps > 5 (Secondary, related)
![Screen Shot 2019-06-11 at 10 31 39](https://user-images.githubusercontent.com/4599889/59260823-3b255080-8c34-11e9-8931-682be13a5ec9.png)

Ref: https://trello.com/c/eC8EXI21/120-step-by-step-add-the-closed-step-by-step-to-the-side-nav-for-secondary-content

Related PR: https://github.com/alphagov/collections-publisher/pull/618