### PR TITLE
Remove experimental status of Attachment components

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -1,18 +1,16 @@
-name: Attachment (experimental)
+name: Attachment
 description: Displays a link to download an attachment and metadata about the file
 body: |
-  This component is marked as experimental as it is part of a drive to provide
-  a consistent place for attachment presentation logic (currently this logic is
-  within [Govspeak][] and [Whitehall][]). The API for this
-  component may change during this process.
-
-  It shows a link to a document that is attached to GOV.UK content along with a
-  thumbnail and relevant file data.
+  This component shows a link to a document that is attached to GOV.UK content
+  along with a thumbnail and relevant file data.
 
   It is intended to be rendered in Govspeak and as an attachment 'preview' in
   Content Publisher.
 
-  [Govspeak]: https://github.com/alphagov/govspeak/blob/c3a0742c87537a371108d097cea23688efa90a14/lib/govspeak/presenters/attachment_presenter.rb
+  It is not as rich in features as the [attachment rendering][Whitehall]
+  provided by Whitehall, it lacks support for multiple languages, CSV previews
+  and publication fields
+
   [Whitehall]: https://github.com/alphagov/whitehall/blob/5c760eea912320c5a80ef59791df47161d889f2f/app/helpers/document_helper.rb
 shared_accessibility_criteria:
 - link

--- a/app/views/govuk_publishing_components/components/docs/attachment_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment_link.yml
@@ -1,19 +1,11 @@
-name: Attachment link (experimental)
+name: Attachment link
 description: A link to a file with metadata of the file contents
 body: |
-  This component is marked as experimental as it is part of a drive to provide
-  a consistent place for attachment presentation logic (currently this logic is
-  within [Govspeak][] and [Whitehall][]). The API for this
-  component may change during this process.
-
-  It provides a means to show a link to an attachment with some
+  This component provides a means to show a link to an attachment with some
   relevant file data.
 
   It is expected to be embedded inside an element that provides text styles
   (such as `.govuk-body`) so does not provide its own text styling.
-
-  [Govspeak]: https://github.com/alphagov/govspeak/blob/c3a0742c87537a371108d097cea23688efa90a14/lib/govspeak/presenters/attachment_presenter.rb
-  [Whitehall]: https://github.com/alphagov/whitehall/blob/5c760eea912320c5a80ef59791df47161d889f2f/app/helpers/document_helper.rb
 shared_accessibility_criteria:
 - link
 examples:


### PR DESCRIPTION
Trello: https://trello.com/c/BQ5bBkMw/881-wrap-up-technical-loose-ends-on-attachments

As these are now used in production by Content Publisher and Govspeak
these are no longer considered experimental. Hopefully there won't be
need for any drastic API changes to them in the near future.

As these are purely internal changes I don't believe they need a changelog entry.