### PR TITLE
Use "Component Guide" as title and breadcrumbs root instead of `component_guide_title`

### DIFF
--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -48,7 +48,7 @@ module GovukPublishingComponents
 
     def index_breadcrumb
       {
-        title: GovukPublishingComponents::Config.component_guide_title,
+        title: "Component Guide",
         url: component_guide_path
       }
     end

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'govuk_publishing_components/components/title', title: GovukPublishingComponents::Config.component_guide_title %>
+<%= render 'govuk_publishing_components/components/title', title: "Component Guide" %>
 
 <div class="component-markdown">
   <p>Components are packages of template, style, behaviour and documentation that live in your application.</p>


### PR DESCRIPTION
We're currently using the `component_guide_title` defined in config of the consumer application for the header, heading one and breadcrumb root. While the link in the header points to the root of the application, the breadcrumb root is pointing to the component guide route. This PR updates the template to keep the custom defined title only for the header and use a "Component Guide" for the rest.

Example using Content Publisher app.

### Before
<img width="1440" alt="Screen Shot 2019-05-30 at 17 32 43" src="https://user-images.githubusercontent.com/788096/58648553-db5caa80-8301-11e9-874d-3bb783207cc5.png">

<img width="1440" alt="Screen Shot 2019-05-30 at 17 33 50" src="https://user-images.githubusercontent.com/788096/58648588-eb748a00-8301-11e9-91cc-f7155a03a38c.png">

### After
<img width="1440" alt="Screen Shot 2019-05-30 at 17 32 26" src="https://user-images.githubusercontent.com/788096/58648660-16f77480-8302-11e9-9579-2b31eefd6710.png">

<img width="1440" alt="Screen Shot 2019-05-30 at 17 33 37" src="https://user-images.githubusercontent.com/788096/58648672-1e1e8280-8302-11e9-8d1d-d071148a1fd2.png">
