### PR TITLE
Update ODT guidance link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update ODT guidance link ([PR #906](https://github.com/alphagov/govuk_publishing_components/pull/906))
 * Fix focus states on cookie-banner confirmation message ([PR #1109](https://github.com/alphagov/govuk_publishing_components/pull/1109))
 * Allow custom heading size on checkboxes and radios ([PR #1107](https://github.com/alphagov/govuk_publishing_components/pull/1107))
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,7 +24,7 @@ en:
     translations: "Translations"
   components:
     attachment:
-      opendocument_html: "This file is in an <a href='https://www.gov.uk/guidance/open-document-format-odf-guidance-for-uk-government/overview-of-productivity-software' target=%{target} class='govuk-link'>OpenDocument</a> format"
+      opendocument_html: "This file is in an <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation' target=%{target} class='govuk-link'>OpenDocument</a> format"
       request_format_text: "This file may not be suitable for users of assistive technology."
       request_format_cta: "Request a different format"
       request_format_details_html: "If you use assistive technology and need a version of this document in a more accessible format, please email <a href='mailto:%{alternative_format_contact_email}' target='_blank' class='govuk-link'>%{alternative_format_contact_email}</a>. Please tell us what format you need. It will help us if you say what assistive technology you use."

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -71,7 +71,7 @@ describe "Attachment", type: :view do
         content_type: "application/vnd.oasis.opendocument.spreadsheet",
       },
     )
-    assert_select "a[href='https://www.gov.uk/guidance/open-document-format-odf-guidance-for-uk-government/overview-of-productivity-software']"
+    assert_select "a[href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation']"
   end
 
   it "shows section to request a different format if a contact email is provided" do


### PR DESCRIPTION
The ODT guidance has been published under a new path. This updates link with attachments to the guidance.
