### PR TITLE
Support error items on date component and refactor error items logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
   of the commit log.
 
 ## 16.28.0
-* Make inline buttons 50% width from mobile - tablet (PR #898)
 
+* Make inline buttons 50% width from mobile - tablet (PR #898)
 * Remove dependence on Poltergeist and PhantomJS by moving to govuk_test gem (PR #905)
 
 ## 16.27.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Accept error_items on date input component (PR #907)
+* Accept items on error message component (PR #907)
+
 ## 16.28.0
 
 * Make inline buttons 50% width from mobile - tablet (PR #898)

--- a/app/views/govuk_publishing_components/components/_date_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_date_input.html.erb
@@ -10,20 +10,22 @@
   legend_text ||= nil
   hint ||= nil
   error_message ||= nil
+  error_items ||= []
   describedby ||= nil
+  has_error ||= error_message || error_items.any?
 
   css_classes = %w(gem-c-date-input govuk-date-input)
   form_group_css_classes = %w(govuk-form-group)
-  form_group_css_classes << "govuk-form-group--error" if error_message
+  form_group_css_classes << "govuk-form-group--error" if has_error
 
   hint_id = "hint-#{SecureRandom.hex(4)}"
   error_id = "error-#{SecureRandom.hex(4)}"
 
   aria_described_by ||= nil
-  if hint || error_message || describedby
+  if hint || has_error || describedby
     aria_described_by = []
     aria_described_by << hint_id if hint
-    aria_described_by << error_id if error_message
+    aria_described_by << error_id if has_error
     aria_described_by << describedby if describedby
     aria_described_by = aria_described_by.join(" ")
   end
@@ -45,6 +47,11 @@
         id:  error_id,
         text: error_message
       } %>
+    <% elsif error_items %>
+      <%= render "govuk_publishing_components/components/error_message", {
+        id: error_id,
+        text: raw(error_items.map { |item| item[:text] }.join("<br/>"))
+      } %>
     <% end %>
 
     <%= tag.div class: css_classes, id: id do %>
@@ -55,7 +62,7 @@
               text: item[:label] || item[:name].capitalize
             },
             grouped: true,
-            has_error: error_message,
+            has_error: has_error,
             name: name ? (name + "[" + item[:name] + "]") : item[:name],
             value: item[:value],
             width: item[:width],

--- a/app/views/govuk_publishing_components/components/_date_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_date_input.html.erb
@@ -42,15 +42,11 @@
       } %>
     <% end %>
 
-    <% if error_message %>
+    <% if has_error %>
       <%= render "govuk_publishing_components/components/error_message", {
         id:  error_id,
-        text: error_message
-      } %>
-    <% elsif error_items %>
-      <%= render "govuk_publishing_components/components/error_message", {
-        id: error_id,
-        text: raw(error_items.map { |item| item[:text] }.join("<br/>"))
+        text: error_message,
+        items: error_items,
       } %>
     <% end %>
 

--- a/app/views/govuk_publishing_components/components/_error_message.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_message.html.erb
@@ -3,8 +3,13 @@
   classes ||= ''
   css_classes = %w( gem-c-error-message govuk-error-message )
   css_classes << classes if classes
-%>
+  items ||= []
 
+  if items.any?
+    errors = items.map { |item| capture { item[:text] } }
+    text = raw(errors.join("<br />"))
+  end
+%>
 <%= tag.span id: id, class: css_classes do %>
   <span class="govuk-visually-hidden">Error:</span> <%= text %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_file_upload.html.erb
+++ b/app/views/govuk_publishing_components/components/_file_upload.html.erb
@@ -7,8 +7,8 @@
   label ||= nil
   hint ||= nil
   error_message ||= nil
-  error_items ||= nil
-  has_error = error_message || error_items&.any?
+  error_items ||= []
+  has_error = error_message || error_items.any?
   hint_id = "hint-#{SecureRandom.hex(4)}"
   error_id = "error-#{SecureRandom.hex(4)}"
 
@@ -38,15 +38,11 @@
     } %>
   <% end %>
 
-  <% if error_message %>
+  <% if has_error %>
     <%= render "govuk_publishing_components/components/error_message", {
       id: error_id,
-      text: error_message
-    } %>
-  <% elsif error_items %>
-    <%= render "govuk_publishing_components/components/error_message", {
-      id: error_id,
-      text: raw(error_items.map { |item| item[:text] }.join("<br/>"))
+      text: error_message,
+      items: error_items,
     } %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -10,14 +10,14 @@
   label ||= nil
   hint ||= nil
   error_message ||= nil
-  error_items ||= nil
+  error_items ||= []
   grouped ||= nil
   autofocus ||= nil
   tabindex ||= nil
   readonly ||= nil
   maxlength ||= nil
   width ||= nil
-  has_error ||= error_message || error_items&.any?
+  has_error ||= error_message || error_items.any?
   hint_id = "hint-#{SecureRandom.hex(4)}"
   error_id = "error-#{SecureRandom.hex(4)}"
   search_icon ||= nil
@@ -53,15 +53,11 @@
     } %>
   <% end %>
 
-  <% if error_message %>
+  <% if has_error %>
     <%= render "govuk_publishing_components/components/error_message", {
       id: error_id,
-      text: error_message
-    } %>
-  <% elsif error_items %>
-    <%= render "govuk_publishing_components/components/error_message", {
-      id: error_id,
-      text: raw(error_items.map { |item| item[:text] }.join("<br/>"))
+      text: error_message,
+      items: error_items,
     } %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -9,9 +9,9 @@
   is_page_heading ||= false
   hint ||= nil
   error_message ||= nil
-  error_items ||= nil
+  error_items ||= []
 
-  has_error = error_message || error_items&.any?
+  has_error = error_message || error_items.any?
   hint_id = "hint-#{SecureRandom.hex(4)}" if hint
   error_id = "error-#{SecureRandom.hex(4)}"
 
@@ -47,15 +47,11 @@
       } %>
     <% end %>
 
-    <% if error_message %>
+    <% if has_error %>
       <%= render "govuk_publishing_components/components/error_message", {
         id: error_id,
-        text: error_message
-      } %>
-    <% elsif error_items %>
-      <%= render "govuk_publishing_components/components/error_message", {
-        id: error_id,
-        text: raw(error_items.map { |item| item[:text] }.join("<br/>"))
+        text: error_message,
+        items: error_items,
       } %>
     <% end %>
 

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -10,11 +10,11 @@
   local_assigns[:margin_bottom] ||= 6
   local_assigns[:margin_bottom] = 6 if local_assigns[:margin_bottom] > 9
   error_message ||= nil
-  error_items ||= nil
+  error_items ||= []
   character_count ||= nil
   maxlength ||= nil
   hint_id = "hint-#{SecureRandom.hex(4)}"
-  has_error ||= error_message || error_items&.any?
+  has_error ||= error_message || error_items.any?
   error_id = "error-#{SecureRandom.hex(4)}"
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
@@ -47,15 +47,11 @@
     } %>
   <% end %>
 
-  <% if error_message %>
+  <% if has_error %>
     <%= render "govuk_publishing_components/components/error_message", {
       id: error_id,
-      text: error_message
-    } %>
-  <% elsif error_items %>
-    <%= render "govuk_publishing_components/components/error_message", {
-      id: error_id,
-      text: raw(error_items.map { |item| item[:text] }.join("<br/>"))
+      text: error_message,
+      items: error_items,
     } %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/docs/date_input.yml
+++ b/app/views/govuk_publishing_components/components/docs/date_input.yml
@@ -38,6 +38,13 @@ examples:
       legend_text: "What is your date of birth?"
       hint: "For example, 31 3 1980"
       error_message: "Error message goes here"
+  with_error_items:
+    data:
+      legend_text: "What is your date of birth?"
+      hint: "For example, 31 3 1980"
+      error_items:
+        - text: "Error 1"
+        - text: "Error 2"
   with_custom_items:
     data:
       legend_text: "Beth yw eich dyddiad geni?"

--- a/app/views/govuk_publishing_components/components/docs/error_message.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_message.yml
@@ -14,3 +14,9 @@ examples:
   default:
     data:
       text: "Please enter your National Insurance Number"
+  with_items:
+    description: Error items are a common pattern where a collection of error is passed with each item having a text attribute of the error
+    data:
+      items:
+        - text: Error 1
+        - text: Error 2

--- a/spec/components/error_message_spec.rb
+++ b/spec/components/error_message_spec.rb
@@ -10,4 +10,14 @@ describe "Error message", type: :view do
 
     assert_select(".govuk-error-message", text: "Error: Please enter your National Insurance number")
   end
+
+  it "escapes HTML in items and allows HTML safe strings" do
+    render_component(items: [
+      { text: "Error where HTML is <strong>escaped</strong>" },
+      { text: "Error where HTML is <strong>maintained</strong>".html_safe },
+    ])
+
+    assert_select(".govuk-error-message", html: %r{Error where HTML is &lt;strong&gt;escaped&lt;/strong&gt;})
+    assert_select(".govuk-error-message", html: %r{Error where HTML is <strong>maintained</strong>})
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/rGjDviSL/848-adapt-scheduling-implementation-for-iterated-workflow

This enables the date input field to accept error_items as per the form input components.

It also moves the logic to flatten error_items into a singular string out of individual components and into the error_message components. Refactoring this has allowed fixing a potential XSS issue in the previous common implementation
