### PR TITLE
Upgrade to Capybara 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,13 +64,14 @@ GEM
       oj (~> 3.0)
     builder (3.2.3)
     byebug (11.0.1)
-    capybara (2.18.0)
+    capybara (3.22.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     childprocess (1.0.1)
       rake (< 13.0)
     coderay (1.1.2)
@@ -88,7 +89,7 @@ GEM
     ffi (1.11.1)
     foreman (0.85.0)
       thor (~> 0.19.1)
-    gds-api-adapters (59.3.0)
+    gds-api-adapters (59.4.0)
       addressable
       link_header
       null_logger
@@ -101,7 +102,7 @@ GEM
       rubocop (~> 0.64)
       rubocop-rspec (~> 1.28)
       scss_lint
-    govuk_app_config (1.17.0)
+    govuk_app_config (1.18.1)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
@@ -117,7 +118,7 @@ GEM
       puma
       selenium-webdriver
       webdrivers
-    hashdiff (0.3.9)
+    hashdiff (0.4.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (1.6.0)
@@ -165,14 +166,14 @@ GEM
     parser (2.6.3.0)
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
-    plek (2.1.1)
+    plek (3.0.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    public_suffix (3.0.3)
+    public_suffix (3.1.0)
     puma (3.12.1)
     rack (2.0.7)
     rack-cache (1.9.0)
@@ -209,6 +210,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    regexp_parser (1.5.1)
     request_store (1.4.1)
       rack (>= 1.4)
     rest-client (2.0.2)
@@ -233,7 +235,7 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.70.0)
+    rubocop (0.71.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
@@ -242,7 +244,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-rspec (1.33.0)
       rubocop (>= 0.60.0)
-    ruby-progressbar (1.10.0)
+    ruby-progressbar (1.10.1)
     rubyzip (1.2.3)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -308,7 +310,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  capybara (~> 2.18.0)
+  capybara (~> 3.22.0)
   foreman (~> 0.64)
   gds-api-adapters (~> 59.1)
   govuk-lint (~> 3.11)

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -26,16 +26,16 @@ Gem::Specification.new do |s|
   s.add_dependency "rouge"
   s.add_dependency "sassc-rails", ">= 2.0.1"
 
-  s.add_development_dependency "capybara", "~> 2.18.0"
+  s.add_development_dependency "capybara", "~> 3.22.0"
   s.add_development_dependency "foreman", "~> 0.64"
   s.add_development_dependency "gds-api-adapters", "~> 59.1"
   s.add_development_dependency "govuk-lint", "~> 3.11"
   s.add_development_dependency "govuk_schemas", "~> 3.2"
   s.add_development_dependency "govuk_test", "~> 0.4.3"
   s.add_development_dependency "jasmine", "~> 2.4.0"
+  s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rspec-rails", "~> 3.6"
   s.add_development_dependency "uglifier", ">= 1.3.0"
-  s.add_development_dependency "pry-byebug"
   # Webmock is needed to load slimmer test helpers
   # https://github.com/alphagov/slimmer/issues/201
   s.add_development_dependency "webmock", "~> 3.5.0"

--- a/spec/component_guide/component_example_spec.rb
+++ b/spec/component_guide/component_example_spec.rb
@@ -38,9 +38,12 @@ describe 'Component example' do
   it 'yields a block in component examples' do
     visit '/component-guide/test-component-with-block'
 
-    expect(page).to have_selector('.component-guide-preview .test-component-with-block', text: 'Here\'s a block')
+    expect(page).to have_selector('.component-guide-preview .test-component-with-block', text: "Here's a block")
 
-    expect(page).to have_content(%(<%= render "components/test-component-with-block", {\n} do %>\n<div class="test-block">Here's a block</div>\n<% end %>))
+    expect(page).to have_content(%(<%= render "components/test-component-with-block", {))
+    expect(page).to have_content(%(} do %>))
+    expect(page).to have_content(%(<div class="test-block">Here's a block</div>))
+    expect(page).to have_content(%(<% end %>))
   end
 
   it 'allows examples to embedded in HTML' do
@@ -49,12 +52,9 @@ describe 'Component example' do
     expect(page).to have_selector('.component-guide-preview .input-control-for-embedded-component')
     expect(page).to have_selector('.component-guide-preview .test-component-with-embed')
 
-    example = <<~EXAMPLE
-      <input class="input-control-for-embedded-component">
-      <%= render "components/test-component-with-embed", {
-      } %>
-    EXAMPLE
-    expect(page).to have_content(example)
+    expect(page).to have_content(%(<input class="input-control-for-embedded-component">))
+    expect(page).to have_content(%(<%= render "components/test-component-with-embed", {))
+    expect(page).to have_content(%(} %>))
   end
 
   it 'allows specific examples to embed different HTML' do
@@ -63,12 +63,9 @@ describe 'Component example' do
     expect(page).to have_selector('.component-guide-preview .button-control-for-embedded-component')
     expect(page).to have_selector('.component-guide-preview .test-component-with-embed')
 
-    example = <<~EXAMPLE
-      <button class="button-control-for-embedded-component">Action</button>
-      <%= render "components/test-component-with-embed", {
-      } %>
-    EXAMPLE
-    expect(page).to have_content(example)
+    expect(page).to have_content(%(<button class="button-control-for-embedded-component">Action</button>))
+    expect(page).to have_content(%(<%= render "components/test-component-with-embed", {))
+    expect(page).to have_content(%(} %>))
   end
 
   it 'sanitizes strings in code example' do

--- a/spec/components/contextual_footer_spec.rb
+++ b/spec/components/contextual_footer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Contextual footer', type: :view do
 
     render_component(content_item: content_item)
 
-    assert_select '.gem-c-contextual-footer'
+    has_selector? '.gem-c-contextual-footer'
   end
 
   context 'part of a step by step' do
@@ -23,7 +23,7 @@ RSpec.describe 'Contextual footer', type: :view do
         content_item: GovukSchemas::RandomExample.for_schema(frontend_schema: 'step_by_step_nav')
       )
 
-      refute_selector '.gem-c-contextual-footer'
+      assert_no_selector '.gem-c-contextual-footer'
     end
   end
 end


### PR DESCRIPTION
Capybara 3 brings in some breaking changes - but the only one that seems to have affected Publishing Components is that `has_content` doesn't play nicely with `\n` and newlines. Some tests had to be tweaked to account for this change.