### PR TITLE
Add aria-live flag to notice component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add aria-live flag to notice component (PR #911)
+
 ## 16.29.0
 
 * Accept error_items on date input component (PR #907)

--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -3,6 +3,7 @@
   description_text ||= false
   description_govspeak ||= false
   description ||= yield || false
+  aria_live ||= false
   local_assigns[:margin_bottom] ||= 8
   local_assigns[:margin_bottom] = 8 if local_assigns[:margin_bottom] > 9
 
@@ -11,10 +12,12 @@
   css_classes = %w(gem-c-notice)
   css_classes << (shared_helper.get_margin_bottom)
 
+  aria_attributes = aria_live ? {label: 'Notice', live: 'polite'} : {label: 'Notice'}
+
   description_present = description.present? || description_text.present? || description_govspeak.present?
 %>
 <% if title || description_present %>
-  <%= tag.section class: css_classes, aria: { label: "Notice" }, role: "region" do %>
+  <%= tag.section class: css_classes, aria: aria_attributes, role: "region" do %>
     <% if title %>
       <% if description_present %>
         <%= tag.h2 title, class: "gem-c-notice__title" %>

--- a/app/views/govuk_publishing_components/components/docs/notice.yml
+++ b/app/views/govuk_publishing_components/components/docs/notice.yml
@@ -36,3 +36,9 @@ examples:
   without_title:
     data:
       description_govspeak: '<p>Scheduled to publish at 8am on 25 April 2019<br/><a href="change-date">Change date</a><br/><a href="stop-scheduled-publishing">Stop scheduled publishing</a></p>'
+  with_aria_live:
+    description: Passing the aria live flag to the notice component will read the notice out to users if the notice changes, e.g on form submission the notice may go from hidden to visible.
+    data:
+      title: 'Your settings have been saved'
+      description_govspeak: <p>This is a confirmation message to tell you your settings have been saved</p>
+      aria_live: true

--- a/spec/components/notice_spec.rb
+++ b/spec/components/notice_spec.rb
@@ -71,4 +71,9 @@ describe "Notice", type: :view do
     render_component(title: 'Advisory Committee on Novel Foods and Processes has a <a href="http://www.food.gov.uk/acnfp">separate website</a>')
     assert_select ".gem-c-notice__title", text: 'Advisory Committee on Novel Foods and Processes has a <a href="http://www.food.gov.uk/acnfp">separate website</a>'
   end
+
+  it "adds an aria-live attribute when the aria-live flag is provided" do
+    render_component(title: 'Your settings have been saved', aria_live: true)
+    assert_select ".gem-c-notice[aria-live=polite]"
+  end
 end


### PR DESCRIPTION
I came across this when trying to use the notice component as a notice telling the user their settings were saved. We scroll to the top of the page so users who can visually see confirmation of their settings. However, in order to get the notice content to be read out correctly for screen reader users, the aria-live needs to be on the section tag of the notice component itself (not a wrapper), hence adding this flag to the component

This will be used on the new cookie settings page, when the user presses "save changes": https://new-cookie-banner.herokuapp.com/help/cookies

<img width="984" alt="Screen Shot 2019-06-06 at 13 45 08" src="https://user-images.githubusercontent.com/29889908/59033750-53c2ee80-8861-11e9-914c-f3ae94516bb4.png">
