### PR TITLE
Design tweaks and fixes for the cookie banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 * Add aria-live flag to notice component (PR #911)
 * Check the consent cookie before setting cookies (PR #916)
+* Override vertical align: top for inline buttons (PR #912)
+* Change cookie banner text to green (PR #912)
+* Accessibility and design fixes for cookie banner (#912)
 
 ## 16.29.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -24,16 +24,14 @@ $gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
 
 .gem-c-button--inline {
   display: block;
+  width: 100%;
   margin-bottom: govuk-spacing(1);
-
-  @include govuk-media-query($from: mobile) {
-    @include box-sizing(border-box);
-    display: inline-block;
-    width: 48%;
-  }
+  vertical-align: top;
 
   @include govuk-media-query($from: desktop) {
+    display: inline-block;
     width: auto;
+    vertical-align: baseline;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -38,13 +38,42 @@ $govuk-cookie-banner-background-new: govuk-colour("white");
   margin-bottom: govuk-spacing(1);
   padding-right: govuk-spacing(4);
   padding-bottom: govuk-spacing(2);
+
+  @include govuk-media-query($from: desktop) {
+    padding-bottom: 0;
+  }
 }
 
 .gem-c-cookie-banner__buttons {
-  vertical-align: middle;
+  @include govuk-clearfix;
 
   @include govuk-media-query($from: desktop) {
     display: inline-block;
+  }
+}
+
+.gem-c-cookie-banner__button {
+  display: inline-block;
+  width: 100%;
+
+  @include govuk-media-query($from: mobile, $until: desktop) {
+    width: 49%;
+
+    &.gem-c-cookie-banner__button-accept {
+      float: left;
+    }
+
+    &.gem-c-cookie-banner__button-settings {
+      float: right;
+    }
+  }
+
+  @include govuk-media-query($from: desktop) {
+    width: auto;
+  }
+
+  @include govuk-media-query($until: 455px) {
+    width: 100%;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -1,5 +1,6 @@
 $govuk-cookie-banner-background: #d5e8f3;
 $govuk-cookie-banner-background-new: govuk-colour("white");
+$govuk-cookie-banner-text-green: #00823b;
 
 .js-enabled {
   .gem-c-cookie-banner,
@@ -38,6 +39,7 @@ $govuk-cookie-banner-background-new: govuk-colour("white");
   margin-bottom: govuk-spacing(1);
   padding-right: govuk-spacing(4);
   padding-bottom: govuk-spacing(2);
+  color: $govuk-cookie-banner-text-green;
 
   @include govuk-media-query($from: desktop) {
     padding-bottom: 0;
@@ -80,7 +82,7 @@ $govuk-cookie-banner-background-new: govuk-colour("white");
 .gem-c-cookie-banner__confirmation {
   display: none;
   position: relative;
-  padding: 0 govuk-spacing(2);
+  padding: govuk-spacing(1);
 }
 
 .gem-c-cookie-banner__confirmation-message,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -40,10 +40,6 @@ $govuk-cookie-banner-text-green: #00823b;
   padding-right: govuk-spacing(4);
   padding-bottom: govuk-spacing(2);
   color: $govuk-cookie-banner-text-green;
-
-  @include govuk-media-query($from: desktop) {
-    padding-bottom: 0;
-  }
 }
 
 .gem-c-cookie-banner__buttons {
@@ -89,13 +85,17 @@ $govuk-cookie-banner-text-green: #00823b;
 .gem-c-cookie-banner__hide-button {
   display: block;
 
-  @include govuk-media-query($from: tablet) {
+  @include govuk-media-query($from: desktop) {
     display: inline-block;
   }
 }
 
 .gem-c-cookie-banner__confirmation-message {
   margin-right: govuk-spacing(4);
+
+  @include govuk-media-query($from: desktop) {
+    max-width: 90%;
+  }
 }
 
 .gem-c-cookie-banner__hide-button {
@@ -114,10 +114,10 @@ $govuk-cookie-banner-text-green: #00823b;
     cursor: pointer;
   }
 
-  @include govuk-media-query($from: tablet) {
+  @include govuk-media-query($from: desktop) {
     margin-top: govuk-spacing(0);
     position: absolute;
-    right: 0;
+    right: govuk-spacing(1);
   }
 }
 

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -15,28 +15,32 @@
     <p class="gem-c-cookie-banner__message"><%= message %></p>
     <% if new_cookie_banner %>
       <div class="gem-c-cookie-banner__buttons">
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Accept cookies",
-          secondary: true,
-          inline_layout: true,
-          data_attributes: {
-            module: "track-click",
-            "accept-cookies": "true",
-            "track-category": "cookieBanner",
-            "track-action": "Cookie banner accepted"
-          }
-        } %>
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Cookie settings",
-          href: "/help/cookies",
-          secondary: true,
-          inline_layout: true,
-          data_attributes: {
-            module: "track-click",
-            "track-category": "cookieBanner",
-            "track-action": "Cookie banner settings clicked"
-          }
-        } %>
+        <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Accept cookies",
+            secondary: true,
+            inline_layout: true,
+            data_attributes: {
+              module: "track-click",
+              "accept-cookies": "true",
+              "track-category": "cookieBanner",
+              "track-action": "Cookie banner accepted"
+            }
+          } %>
+        </div>
+        <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Cookie settings",
+            href: "/help/cookies",
+            secondary: true,
+            inline_layout: true,
+            data_attributes: {
+              module: "track-click",
+              "track-category": "cookieBanner",
+              "track-action": "Cookie banner settings clicked"
+            }
+          } %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -7,7 +7,6 @@
   cookie_banner_helper = GovukPublishingComponents::Presenters::CookieBannerHelper.new(local_assigns)
 
   message = cookie_banner_helper.message
-  confirmation_message = cookie_banner_helper.confirmation_message
 %>
 
 <div id="<%= id %>" class="<%= cookie_banner_class %>" data-module="cookie-banner">
@@ -47,7 +46,12 @@
 
   <% if new_cookie_banner %>
     <div class="gem-c-cookie-banner__confirmation govuk-width-container">
-      <p class="gem-c-cookie-banner__confirmation-message"><%= confirmation_message %></p>
+      <p class="gem-c-cookie-banner__confirmation-message">
+        You&#8217;ve accepted all cookies. You can
+        <a class="govuk-link" href="/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">
+          change your cookie settings
+        </a> at any time.
+      </p>
       <button class="gem-c-cookie-banner__hide-button" data-hide-cookie-banner="true">Hide</button>
     </div>
   <% end %>

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -9,7 +9,7 @@
   message = cookie_banner_helper.message
 %>
 
-<div id="<%= id %>" class="<%= cookie_banner_class %>" data-module="cookie-banner">
+<div id="<%= id %>" class="<%= cookie_banner_class %>" data-module="cookie-banner" aria-live="polite">
   <div class="gem-c-cookie-banner__wrapper govuk-width-container">
     <p class="gem-c-cookie-banner__message"><%= message %></p>
     <% if new_cookie_banner %>

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -2,6 +2,8 @@ name: Cookie banner
 description: Help users manage their personal data by telling them when you store cookies on their device.
 body: |
   Setting `data-hide-cookie-banner="true"` on any link inside the banner will overwrite the default action and when clicked will dismiss the cookie banner for a period of 365 days (approx. 1 year).
+
+  If the examples below are not showing the banner, make sure the `seen_cookie_message` cookie is not present or is set to false.
 accessibility_criteria: |
   Text in the cookie banner must be clear and unambiguous and should provide a way to dismiss the message.
 

--- a/lib/govuk_publishing_components/presenters/cookie_banner_helper.rb
+++ b/lib/govuk_publishing_components/presenters/cookie_banner_helper.rb
@@ -9,10 +9,6 @@ module GovukPublishingComponents
         @local_assigns = local_assigns
       end
 
-      def confirmation_message
-        'You\'ve accepted all cookies. You can <a class="govuk-link" href="/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.'.html_safe
-      end
-
       def message
         return @message if @message.present?
 


### PR DESCRIPTION
## Before
<img width="1440" alt="Screen Shot 2019-06-07 at 14 25 59" src="https://user-images.githubusercontent.com/29889908/59107313-432d7980-8930-11e9-89a0-7881c3706721.png">
<img width="1440" alt="Screen Shot 2019-06-07 at 14 26 06" src="https://user-images.githubusercontent.com/29889908/59107320-46c10080-8930-11e9-821f-d2f78e96042b.png">


## After
<img width="1438" alt="Screen Shot 2019-06-07 at 14 23 41" src="https://user-images.githubusercontent.com/29889908/59107299-3a3ca800-8930-11e9-8fe5-e9b462d3ed2d.png">
<img width="1440" alt="Screen Shot 2019-06-07 at 14 25 41" src="https://user-images.githubusercontent.com/29889908/59107305-3c9f0200-8930-11e9-9dcd-c0d65210e1c3.png">