### PR TITLE
Use a content security policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Add unsafe-eval to Content Security Policy for component-guide routes (PR #913)
+* Add nonce attribute to inline scripts if Content Security Policy use a nonce generator PR (PR #913)
 * Add aria-live flag to notice component (PR #911)
 
 ## 16.29.0

--- a/app/controllers/govuk_publishing_components/application_controller.rb
+++ b/app/controllers/govuk_publishing_components/application_controller.rb
@@ -5,6 +5,17 @@ module GovukPublishingComponents
     before_action :set_x_frame_options_header
     before_action :set_disable_slimmer_header
 
+    content_security_policy do |p|
+      # don't do anything if the app doesn't have a content security policy
+      next unless p.directives.any?
+
+      # Unfortunately the axe core script uses a dependency that uses eval
+      # see: https://github.com/dequelabs/axe-core/issues/1175
+      # Thus all components shown by govuk_publishing_components need this
+      # enabled
+      p.script_src(*p.script_src, :unsafe_eval)
+    end
+
   private
 
     def set_x_frame_options_header

--- a/app/views/govuk_publishing_components/components/_google_tag_manager_script.html.erb
+++ b/app/views/govuk_publishing_components/components/_google_tag_manager_script.html.erb
@@ -7,7 +7,7 @@
     gtm_attributes << "gtm_preview=" + gtm_preview if gtm_preview
   gtm_attributes = gtm_attributes.join('&')
 %>
-<script>
+<%= javascript_tag nonce: true do %>
 var doNotTrack = ( navigator.doNotTrack === '1' || navigator.doNotTrack === 'yes' || navigator.msDoNotTrack === '1' || window.doNotTrack === '1' )
 if (!doNotTrack) {
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -16,4 +16,4 @@ if (!doNotTrack) {
   'https://www.googletagmanager.com/gtm.js?id='+i+dl+'&<%= raw gtm_attributes %>';f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','<%= gtm_id %>');
 }
-</script>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -14,9 +14,9 @@
     <%= yield :head %>
   </head>
   <body class="gem-c-layout-for-admin govuk-template__body">
-    <script>
+    <%= javascript_tag nonce: true do %>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+    <% end %>
     <%= yield %>
     <%= javascript_include_tag "application" %>
   </body>

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -26,9 +26,9 @@
     <%= javascript_include_tag "govuk_publishing_components/vendor/modernizr" %>
   </head>
   <body class="gem-c-layout-for-admin govuk-template__body <%= 'hide-header-and-footer' if @preview %>">
-    <script>
+    <%= javascript_tag nonce: true do %>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+    <% end %>
     <% if @preview %>
       <main id="wrapper" class="govuk-width-container">
     <% else %>

--- a/spec/dummy/config/initializers/content_security_policy.rb
+++ b/spec/dummy/config/initializers/content_security_policy.rb
@@ -1,0 +1,5 @@
+require "govuk_app_config"
+
+GovukContentSecurityPolicy.configure
+
+Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }


### PR DESCRIPTION
This adds the GOV.UK content security policy to the demo version of this app and adds a nonce to all inline javascript. This will then allow other apps to add a [nonce generator](https://edgeguides.rubyonrails.org/security.html#content-security-policy) which disables unsafe inline scripts and the components won't have violations.

This also adds unsafe_eval to the Content Security Policy on component-guide routes as the [axe-core](https://github.com/dequelabs/axe-core/issues/1175) script uses a dependency that makes use of eval.  This will resolve reports like:

![Screen Shot 2019-06-10 at 10 11 47](https://user-images.githubusercontent.com/282717/59185368-32674880-8b68-11e9-9937-fb6a912ebd7c.png)