### PR TITLE
Cookie consent mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add aria-live flag to notice component (PR #911)
+* Check the consent cookie before setting cookies (PR #916)
 
 ## 16.29.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -10,42 +10,65 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.showConfirmationMessage = this.showConfirmationMessage.bind(this)
     this.$module.setCookieConsent = this.setCookieConsent.bind(this)
 
+    this.$module.newCookieBanner = document.querySelector('.gem-c-cookie-banner--new')
+
+    // Temporary check while we have 2 banners co-existing.
+    // Once the new banner has been deployed, we will be able to remove code relating to the old banner
+    // Separating the code out like this does mean some repetition, but will make it easier to remove later
+    if (this.$module.newCookieBanner) {
+      this.setupNewCookieMessage()
+    } else {
+      this.setupCookieMessage()
+    }
+  }
+
+  CookieBanner.prototype.setupCookieMessage = function () {
+    this.$hideLink = this.$module.querySelector('a[data-hide-cookie-banner]')
+    if (this.$hideLink) {
+      this.$hideLink.addEventListener('click', this.$module.hideCookieMessage)
+    }
+
+    this.showCookieMessage()
+  }
+
+  CookieBanner.prototype.setupNewCookieMessage = function () {
+    this.$hideLink = this.$module.querySelector('button[data-hide-cookie-banner]')
+    if (this.$hideLink) {
+      this.$hideLink.addEventListener('click', this.$module.hideCookieMessage)
+    }
+
+    this.$acceptCookiesLink = this.$module.querySelector('button[data-accept-cookies]')
+    if (this.$acceptCookiesLink) {
+      this.$acceptCookiesLink.addEventListener('click', this.$module.setCookieConsent)
+    }
+
+    this.showNewCookieMessage()
+  }
+
+  CookieBanner.prototype.showCookieMessage = function () {
+    var shouldHaveCookieMessage = (this.$module && window.GOVUK.cookie('seen_cookie_message') !== 'true')
+
+    if (shouldHaveCookieMessage) {
+      this.$module.style.display = 'block'
+    }
+  }
+
+  CookieBanner.prototype.showNewCookieMessage = function () {
     var newCookieBanner = document.querySelector('.gem-c-cookie-banner--new')
 
     // Hide the cookie banner on the cookie settings page, to avoid circular journeys
     if (newCookieBanner && window.location.pathname === '/help/cookies') {
       this.$module.style.display = 'none'
-    } else {
-      this.$hideLink = this.$module.querySelector('a[data-hide-cookie-banner], button[data-hide-cookie-banner]')
-      if (this.$hideLink) {
-        this.$hideLink.addEventListener('click', this.$module.hideCookieMessage)
-      }
-
-      this.$acceptCookiesLink = this.$module.querySelector('button[data-accept-cookies]')
-      if (this.$acceptCookiesLink) {
-        this.$acceptCookiesLink.addEventListener('click', this.$module.setCookieConsent)
-      }
-
-      this.showCookieMessage()
     }
-  }
 
-  CookieBanner.prototype.showCookieMessage = function () {
-    var newCookieBanner = document.querySelector('.gem-c-cookie-banner--new')
-    var hasCookieMessage = (this.$module && window.GOVUK.cookie('seen_cookie_message') !== 'true')
-    if (hasCookieMessage) {
+    var shouldHaveCookieMessage = (this.$module && window.GOVUK.cookie('seen_cookie_message') !== 'true')
+
+    if (shouldHaveCookieMessage) {
       this.$module.style.display = 'block'
-    }
 
-    if (newCookieBanner && hasCookieMessage) {
+      // Set the default consent cookie if it isn't already present
       if (!window.GOVUK.cookie('cookie_policy')) {
         window.GOVUK.setDefaultConsentCookie()
-      }
-    } else if (!newCookieBanner) {
-      // Remove the consent cookie if we're using the old cookie banner
-      // TODO: this can be removed later when we switch to the new banner
-      if (window.GOVUK.cookie('cookie_policy')) {
-        window.GOVUK.cookie('cookie_policy', null)
       }
     }
   }

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -3,11 +3,30 @@
 (function () {
   'use strict'
   var root = this
-  var defaultCookieConsent = {
+
+  var DEFAULT_COOKIE_CONSENT = {
     'essential': true,
     'settings': true,
     'usage': true,
     'campaigns': true
+  }
+
+  var COOKIE_CATEGORIES = {
+    'cookie_policy': 'essential',
+    'govuk_not_first_visit': 'essential',
+    'govuk_browser_upgrade_dismisssed': 'essential',
+    'seen_cookie_message': 'essential',
+    'govuk_surveySeenUserSatisfactionSurvey': 'essential',
+    'govuk_takenUserSatisfactionSurvey': 'essential',
+    '_email-alert-frontend_session': 'essential',
+    'global_bar_seen': 'essential',
+    'licensing_session': 'essential',
+    'govuk_contact_referrer': 'essential',
+    'JS-Detection': 'usage',
+    '_ga': 'usage',
+    '_gid': 'usage',
+    '_gat': 'usage',
+    'analytics_next_page_call': 'usage'
   }
 
   if (typeof root.GOVUK === 'undefined') { root.GOVUK = {} }
@@ -40,7 +59,7 @@
   }
 
   window.GOVUK.setDefaultConsentCookie = function () {
-    window.GOVUK.setCookie('cookie_policy', JSON.stringify(defaultCookieConsent))
+    window.GOVUK.setCookie('cookie_policy', JSON.stringify(DEFAULT_COOKIE_CONSENT))
   }
 
   window.GOVUK.approveAllCookieTypes = function () {
@@ -72,7 +91,7 @@
     if (currentConsentCookie) {
       cookieConsentJSON = JSON.parse(currentConsentCookie)
     } else {
-      cookieConsentJSON = defaultCookieConsent
+      cookieConsentJSON = DEFAULT_COOKIE_CONSENT
     }
 
     for (var cookieType in options) {
@@ -82,20 +101,47 @@
     window.GOVUK.setCookie('cookie_policy', JSON.stringify(cookieConsentJSON))
   }
 
+  window.GOVUK.checkConsentCookie = function (cookieName, cookieValue) {
+    var currentConsentCookie = window.GOVUK.getCookie('cookie_policy')
+
+    // If we're setting the consent cookie OR deleting a cookie, allow by default
+    if (cookieName === 'cookie_policy' || (cookieValue === null || false)) {
+      return true
+    }
+
+    // If the consent cookie doesn't exist, set the default consent cookie
+    if (!currentConsentCookie) {
+      window.GOVUK.setDefaultConsentCookie()
+    }
+
+    if (COOKIE_CATEGORIES[cookieName]) {
+      var consent = JSON.parse(window.GOVUK.getCookie('cookie_policy'))
+
+      var cookieCategory = COOKIE_CATEGORIES[cookieName]
+
+      return consent[cookieCategory]
+    } else {
+      // Deny the cookie if it is not known to us
+      return false
+    }
+  }
+
   window.GOVUK.setCookie = function (name, value, options) {
-    if (typeof options === 'undefined') {
-      options = {}
+    if (window.GOVUK.checkConsentCookie(name, value)) {
+      if (typeof options === 'undefined') {
+        options = {}
+      }
+      var cookieString = name + '=' + value + '; path=/'
+      if (options.days) {
+        var date = new Date()
+        date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000))
+        cookieString = cookieString + '; expires=' + date.toGMTString()
+      }
+      if (document.location.protocol === 'https:') {
+        cookieString = cookieString + '; Secure'
+      }
+      document.cookie = cookieString
     }
-    var cookieString = name + '=' + value + '; path=/'
-    if (options.days) {
-      var date = new Date()
-      date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000))
-      cookieString = cookieString + '; expires=' + date.toGMTString()
-    }
-    if (document.location.protocol === 'https:') {
-      cookieString = cookieString + '; Secure'
-    }
-    document.cookie = cookieString
   }
 
   window.GOVUK.getCookie = function (name) {

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -105,7 +105,7 @@
     var currentConsentCookie = window.GOVUK.getCookie('cookie_policy')
 
     // If we're setting the consent cookie OR deleting a cookie, allow by default
-    if (cookieName === 'cookie_policy' || (cookieValue === null || false)) {
+    if (cookieName === 'cookie_policy' || (cookieValue === null || cookieValue === false)) {
       return true
     }
 

--- a/spec/javascripts/components/cookie-banner-new-spec.js
+++ b/spec/javascripts/components/cookie-banner-new-spec.js
@@ -1,0 +1,113 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+var container, element;
+
+var GOVUK = window.GOVUK || {};
+
+describe('New cookie banner', function () {
+  'use strict'
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML =
+      '<div id="global-cookie-message" class="gem-c-cookie-banner--new" data-module="cookie-banner">' +
+        '<div class="gem-c-cookie-banner__wrapper govuk-width-container" data-cookie-banner-main="true">' +
+          '<p class="gem-c-cookie-banner__message">GOV.UK uses cookies to make the site simpler.</p>' +
+          '<div class="gem-c-cookie-banner__buttons">' +
+            '<button class="gem-c-button govuk-button gem-c-button--secondary-quiet gem-c-button--inline" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">Accept cookies</button>' +
+            '<a class="gem-c-button govuk-button gem-c-button--secondary-quiet gem-c-button--inline" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="/help/cookies">Cookie settings</a>' +
+          '</div>' +
+        '</div>' +
+        '<div class="gem-c-cookie-banner__confirmation govuk-width-container" data-cookie-banner-confirmation="true" style="display: none;">' +
+          '<p class="gem-c-cookie-banner__confirmation-message">' +
+            'You have accepted all cookies' +
+          '</p>' +
+          '<button class="gem-c-cookie-banner__hide-button" data-hide-cookie-banner="true">Hide</button>' +
+        '</div>' +
+      '</div>'
+
+    document.body.appendChild(container)
+    element = document.querySelector('.gem-c-cookie-banner--new')
+
+    // For some reason, JSON.parse on the cookie works in the browser, but fails in Jasmine tests.
+    // It seems to be due to extra escaping of quotes when the code is run in the tests, which means JSON.parse doesn't
+    // work as expected. So we'll stub this value instead.
+    spyOn(JSON, "parse").and.returnValue({"essential":true,"settings":true,"usage":true,"campaigns":true});
+
+    window.GOVUK.cookie('cookie_policy', null)
+    window.GOVUK.cookie('seen_cookie_message', null)
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
+  it('should show the new cookie banner', function() {
+    new GOVUK.Modules.CookieBanner().start($(element))
+
+    var newCookieBanner = document.querySelector('.gem-c-cookie-banner--new')
+    var cookieBannerMain = document.querySelector('.gem-c-cookie-banner__wrapper')
+    var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
+
+    expect(newCookieBanner).toBeVisible()
+    expect(cookieBannerMain).toBeVisible()
+    expect(cookieBannerConfirmation).not.toBeVisible()
+  })
+
+  it('sets a default consent cookie', function () {
+    new GOVUK.Modules.CookieBanner().start($(element))
+
+    expect(window.GOVUK.getCookie('seen_cookie_message')).toEqual(null)
+    expect(window.GOVUK.getCookie('cookie_policy')).toEqual('"{\\"essential\\":true,\\"settings\\":true,\\"usage\\":true,\\"campaigns\\":true}"')
+  })
+
+  it('sets consent cookie when accepting cookies', function () {
+    new GOVUK.Modules.CookieBanner().start($(element))
+
+    // Manually reset the consent cookie so we can check the accept button works as intended
+    expect(window.GOVUK.getCookie('cookie_policy')).toEqual('"{\\"essential\\":true,\\"settings\\":true,\\"usage\\":true,\\"campaigns\\":true}"')
+    window.GOVUK.cookie('cookie_policy', null)
+
+    var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
+    acceptCookiesButton.click()
+
+    expect(window.GOVUK.getCookie('cookie_policy')).toEqual('"{\\"essential\\":true,\\"settings\\":true,\\"usage\\":true,\\"campaigns\\":true}"')
+  })
+
+  it('shows a confirmation message when cookies have been accepted', function () {
+    new GOVUK.Modules.CookieBanner().start($(element))
+
+    var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
+    var mainCookieBanner = document.querySelector('div[data-cookie-banner-main]')
+    var confirmationMessage = document.querySelector('div[data-cookie-banner-confirmation]')
+
+    expect(mainCookieBanner).toBeVisible()
+    expect(confirmationMessage).not.toBeVisible()
+
+    acceptCookiesButton.click()
+
+    expect(mainCookieBanner).not.toBeVisible()
+    expect(confirmationMessage).toBeVisible()
+  })
+
+  it('should hide when pressing the "hide" link', function () {
+    new GOVUK.Modules.CookieBanner().start($(element))
+
+    var banner = document.querySelector('[data-module="cookie-banner"]')
+    var link = document.querySelector('button[data-hide-cookie-banner="true"]')
+    link.dispatchEvent(new window.Event('click'))
+
+    expect(banner).toBeHidden()
+    expect(window.GOVUK.getCookie('seen_cookie_message')).toBeTruthy()
+  })
+
+  it('does not show the banner if user has acknowledged the banner previously', function() {
+    window.GOVUK.setCookie('seen_cookie_message', "true")
+    new GOVUK.Modules.CookieBanner().start($(element))
+
+    var newCookieBanner = document.querySelector('.gem-c-cookie-banner--new')
+
+    expect(newCookieBanner).not.toBeVisible()
+  })
+})

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -5,7 +5,7 @@ var container
 
 var GOVUK = window.GOVUK || {};
 
-describe('Cookie banner is shown', function () {
+describe('Cookie banner', function () {
   'use strict'
 
   beforeEach(function () {
@@ -19,7 +19,14 @@ describe('Cookie banner is shown', function () {
 
     document.body.appendChild(container)
     var element = document.querySelector('[data-module="cookie-banner"]')
+
+    // For some reason, JSON.parse on the cookie works in the browser, but fails in Jasmine tests.
+    // It seems to be due to extra escaping of quotes when the code is run in the tests, which means JSON.parse doesn't
+    // work as expected. So we'll stub this value instead.
+    spyOn(JSON, "parse").and.returnValue({"essential":true,"settings":true,"usage":true,"campaigns":true});
+
     window.GOVUK.cookie('seen_cookie_message', null)
+    window.GOVUK.cookie('cookie_policy', null)
     new GOVUK.Modules.CookieBanner().start($(element))
   })
 
@@ -30,7 +37,6 @@ describe('Cookie banner is shown', function () {
   it('should show the cookie banner', function () {
     var banner = document.querySelector('[data-module="cookie-banner"]')
     expect(window.GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
-    expect(window.GOVUK.getCookie('cookie_policy')).toBeFalsy()
     expect(banner).toBeVisible()
   })
 
@@ -41,66 +47,5 @@ describe('Cookie banner is shown', function () {
 
     expect(banner).toBeHidden()
     expect(window.GOVUK.getCookie('seen_cookie_message')).toBeTruthy()
-  })
-})
-
-describe('New cookie banner', function () {
-  'use strict'
-
-  beforeEach(function () {
-    container = document.createElement('div')
-    container.innerHTML =
-    '<div id="global-cookie-message" class="gem-c-cookie-banner--new" data-module="cookie-banner">' +
-      '<div class="gem-c-cookie-banner__wrapper govuk-width-container" data-cookie-banner-main="true">' +
-        '<p class="gem-c-cookie-banner__message">GOV.UK uses cookies to make the site simpler.</p>' +
-        '<div class="gem-c-cookie-banner__buttons">' +
-            '<button class="gem-c-button govuk-button gem-c-button--secondary-quiet gem-c-button--inline" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">Accept cookies</button>' +
-            '<a class="gem-c-button govuk-button gem-c-button--secondary-quiet gem-c-button--inline" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="/help/cookies">Cookie settings</a>' +
-          '</div>' +
-        '</div>' +
-        '<div class="gem-c-cookie-banner__confirmation govuk-width-container" data-cookie-banner-confirmation="true" style="display: none;">' +
-          '<p class="gem-c-cookie-banner__confirmation-message">' +
-            'You have accepted all cookies' +
-          '</p>' +
-          '<button class="gem-c-cookie-banner__hide-button" data-hide-cookie-banner="true">Hide</button>' +
-        '</div>' +
-    '</div>'
-
-    document.body.appendChild(container)
-    var element = document.querySelector('.gem-c-cookie-banner--new[data-module="cookie-banner"]')
-    window.GOVUK.cookie('seen_cookie_message', null)
-    window.GOVUK.cookie('cookie_policy', null)
-    new GOVUK.Modules.CookieBanner().start($(element))
-  })
-
-  afterEach(function () {
-    document.body.removeChild(container)
-  })
-
-  it('sets a default consent cookie', function () {
-    var banner = document.querySelector('.gem-c-cookie-banner--new[data-module="cookie-banner"]')
-    expect(window.GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
-    expect(window.GOVUK.getCookie('cookie_policy')).toEqual('"{\\"essential\\":true,\\"settings\\":true,\\"usage\\":true,\\"campaigns\\":true}"')
-    expect(banner).toBeVisible()
-  })
-
-  it('sets consent cookie when accepting cookies', function() {
-    var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
-    acceptCookiesButton.click()
-    expect(window.GOVUK.getCookie('cookie_policy')).toEqual('"{\\"essential\\":true,\\"settings\\":true,\\"usage\\":true,\\"campaigns\\":true}"')
-  })
-
-  it('shows a confirmation message when accepting cookies', function() {
-    var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
-    var mainCookieBanner = document.querySelector('div[data-cookie-banner-main]')
-    var confirmationMessage = document.querySelector('div[data-cookie-banner-confirmation]')
-
-    expect(mainCookieBanner).toBeVisible()
-    expect(confirmationMessage).not.toBeVisible()
-
-    acceptCookiesButton.click()
-
-    expect(mainCookieBanner).not.toBeVisible()
-    expect(confirmationMessage).toBeVisible()
   })
 })


### PR DESCRIPTION
We need to check what cookies a user has consented to before we set each cookie.

This also tidies up the cookie banner code so the old banner and new banner are more separate. This will make it easier for us to remove the old banner code once the new banner has been deployed.

**Note: the new cookie banner tests currently include a workaround by stubbing the return value of JSON.parse. Without this stubbing, it looks as though the value returned includes escaped quotes, which means an additional JSON.parse is required (but this works fine in the browser).**

Edited to add: it looks like the problem mentioned above could be related to phantomJS. I tried to update our version of jasmine and use chromeheadless instead, but this results in some test failures around step-by-step nav which I'm not familiar with. Leaving a [WIP branch here for now](https://github.com/alphagov/govuk_publishing_components/compare/update-jasmine?expand=1), for when I have more time to take a look 