### PR TITLE
Add options to document list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Support data attributes for error summary items (PR #924)
 * Disable youtube embeds if campaign cookies turned off (PR #919)
+* Add options to document list component (PR #917)
 * Add aria-live flag to notice component (PR #911)
 * Check the consent cookie before setting cookies (PR #916)
 * Override vertical align: top for inline buttons (PR #912)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -80,3 +80,19 @@
   width: 100%;
   margin-right: 25px;
 }
+
+.gem-c-document-list__item--highlight {
+  border: 1px solid govuk-colour("grey-2");
+  padding: govuk-spacing(6);
+  margin-bottom: govuk-spacing(6);
+
+  .gem-c-document-list__item-title {
+    @include govuk-font(24, bold);
+  }
+}
+
+.gem-c-document-list__highlight-text {
+  @include govuk-font(16, bold);
+  margin: 0 0 govuk-spacing(3) 0;
+
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -39,8 +39,16 @@
 
 .gem-c-document-list__item-description {
   @include govuk-text-colour;
-  @include govuk-font($size: 16, $line-height: 1.5);
   margin: 0 0 5px 0;
+}
+
+.gem-c-document-list__subtext {
+  margin: govuk-spacing(1) 0 0 0;
+}
+
+.gem-c-document-list__item-description,
+.gem-c-document-list__subtext {
+  @include govuk-font($size: 16, $line-height: 1.5);
 }
 
 .gem-c-document-list__item-metadata {

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -14,7 +14,12 @@
     <ol class="gem-c-document-list<%= margin_bottom_class %><%= margin_top_class %>">
   <% end %>
     <% items.each do |item| %>
-      <li class="gem-c-document-list__item<%= within_multitype_list_class %> <%= brand_helper.brand_class %>">
+      <% highlight_class = " gem-c-document-list__item--highlight" if item[:highlight] %>
+
+      <li class="gem-c-document-list__item<%= within_multitype_list_class %> <%= brand_helper.brand_class %> <%= highlight_class %>">
+        <% if item[:highlight] && item[:highlight_text] %>
+          <p class='gem-c-document-list__highlight-text'><%= item[:highlight_text] %></p>
+        <% end %>
         <%=
           link_to(
             item[:link][:text],

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -47,6 +47,10 @@
             <% end %>
           </ul>
         <% end %>
+
+        <% if item[:subtext] %>
+          <p class="gem-c-document-list__subtext"><%= item[:subtext] %></p>
+        <% end %>
       </li>
     <% end %>
   <% unless within_multitype_list %>

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -76,6 +76,27 @@ examples:
           text: 'Become an apprentice'
           path: '/become-an-apprentice'
           description: 'Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship.'
+      - link:
+          text: 'Become a journeyman'
+          path: '/become-a-journeyman'
+          description: 'Becoming a journeyman - what to expect, what to take, pay and training, making an application, complaining about being a journeyman.'
+  with_description_and_metadata:
+    data:
+      items:
+      - link:
+          text: 'School behaviour and attendance: parental responsibility measures'
+          path: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+          description: 'The responsibilities parents have relating to school behaviour and attendance.'
+        metadata:
+          public_updated_at: 2017-01-05 14:50:33
+          document_type: 'Statutory guidance'
+      - link:
+          text: 'School exclusion'
+          path: '/government/publications/school-exclusion'
+          description: 'Rules governing school exclusion.'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Statutory guidance'
   with_branding:
     description: Where this component could be used on an organisation page (such as the [Attorney General's Office](https://www.gov.uk/government/organisations/attorney-generals-office)) branding can be applied for link colours and border colours. See the [branding documentation](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) for more details.
     data:
@@ -115,6 +136,26 @@ examples:
           path: '/government/organisations/advisory-committee-on-the-microbiological-safety-of-food'
           context: 'moving to GOV.UK'
           description: "Works with 4 agencies and public bodies"
+  with_subtext:
+    description: This is used on finders to highlight search results from past governments.
+    data:
+      items:
+      - link:
+          text: 'Department for Education – Statistics at DfE'
+          path: '/government/organisations/department-for-education/about/statistics'
+          description: 'The Department for Education publishes official statistics on education and children.'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Corporate information'
+        subtext: 'First published during the 2007 Labour Government'
+      - link:
+          text: 'State-funded school inspections and outcomes: management information'
+          path: '/government/organisations/department-for-education/about/statistics'
+          description: 'Management information published monthly and a one-off publication of inspections and outcomes from 2005 to 2015.'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Statistical data set'
+        subtext: 'First published during the 1996 Conservative Government'
   right_to_left:
     data:
       items:

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -156,6 +156,28 @@ examples:
           public_updated_at: 2017-07-19 15:01:48
           document_type: 'Statistical data set'
         subtext: 'First published during the 1996 Conservative Government'
+  highlighted_result:
+    description: Highlight one or more of the items in the list. This is used on finders to provide a 'top result' for a search. The `highlight_text` parameter is optional.
+    data:
+      items:
+      - link:
+          text: 'Department for Education – Statistics at DfE'
+          path: '/government/organisations/department-for-education/about/statistics'
+          description: 'The Department for Education publishes official statistics on education and children.'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Corporate information'
+        subtext: 'First published during the 2007 Labour Government'
+        highlight: true
+        highlight_text: 'Most relevant result'
+      - link:
+          text: 'State-funded school inspections and outcomes: management information'
+          path: '/government/organisations/department-for-education/about/statistics'
+          description: 'Management information published monthly and a one-off publication of inspections and outcomes from 2005 to 2015.'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Statistical data set'
+        subtext: 'First published during the 1996 Conservative Government'
   right_to_left:
     data:
       items:

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -214,7 +214,6 @@ describe "Document list", type: :view do
           link: {
             text: "Link Title",
             path: "/link/path",
-            context: "some context"
           },
           subtext: "This is some subtext"
         }
@@ -222,5 +221,31 @@ describe "Document list", type: :view do
     )
 
     assert_select '.gem-c-document-list__subtext', text: 'This is some subtext'
+  end
+
+  it "highlights items" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+          },
+          highlight: true,
+          highlight_text: 'Most relevant result'
+        },
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+          },
+          highlight: true
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list__item.gem-c-document-list__item--highlight', count: 2
+    assert_select '.gem-c-document-list__item:nth-child(1) .gem-c-document-list__highlight-text', text: 'Most relevant result'
+    assert_select '.gem-c-document-list__item:nth-child(2) .gem-c-document-list__highlight-text', false
   end
 end

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -206,4 +206,21 @@ describe "Document list", type: :view do
     assert_select '.gem-c-document-list__item-title--context[href="/link/path"]', text: 'Link Title'
     assert_select '.gem-c-document-list__item-context', text: 'some context'
   end
+
+  it "adds subtext" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+            context: "some context"
+          },
+          subtext: "This is some subtext"
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list__subtext', text: 'This is some subtext'
+  end
 end


### PR DESCRIPTION
Adds the following...

Add 'subtext' option, small grey text to appear beneath metadata. This is needed for search results in finders, (where we want to use the document list component). This is not styled other than to match the font size of the description, specific styles will be added in finder-frontend for any elements that will be passed into the subtext area.

![Screen Shot 2019-06-11 at 10 29 39](https://user-images.githubusercontent.com/861310/59260607-da961380-8c33-11e9-9ef6-9b7f9258eae7.png)

Add 'highlight' option, including optional highlight text. This is needed to highlight the 'top result' in finders.

![Screen Shot 2019-06-11 at 16 20 16](https://user-images.githubusercontent.com/861310/59284824-d33b2e00-8c64-11e9-9a39-e1c40d911d86.png)

Trello card: https://trello.com/c/DAblviIN/793-investigate-using-more-components-in-finder-frontend

Some examples of what this looks like currently:

- [subtext](https://www.gov.uk/search/all?parent=&keywords=%22every+child+matters%22&level_one_taxon=&manual=&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=relevance) (was broken but fixed in [this PR](https://github.com/alphagov/finder-frontend/pull/1198))
- [highlight option](https://www.gov.uk/find-eu-exit-guidance-business?parent=&keywords=eori&order=relevance) can be seen here, but you need to set a request header of `GOVUK-ABTest-FinderAnswerABTest` to `B` (I'd suggest using [this chrome extension](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj)). In the real world it wouldn't have the metadata beneath the description text, I just left this in for the component guide to make sure the layout still worked okay.
