### PR TITLE
Update feedback component error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update feedback component error handling (PR #918)
 * Support data attributes for error summary items (PR #924)
 * Disable youtube embeds if campaign cookies turned off (PR #919)
 * Add aria-live flag to notice component (PR #911)

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -123,7 +123,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function showError (error) {
-        error = [
+        var genericError = [
           '<h2 class="gem-c-feedback__heading">',
           '  Sorry, we’re unable to receive your message right now. ',
           '</h2>',
@@ -131,8 +131,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           ' feedback on the <a href="/contact/govuk">contact page</a>.</p>'
         ].join('')
 
+        // if the response is not a 404 or 500, show the error message if it exists
+        // otherwise show the generic message
+        // this covers the 422 status the feedback application return for empty fields
+        // for all other, show generic error
         if (typeof (error.responseJSON) !== 'undefined') {
-          error = typeof (error.responseJSON.message) === 'undefined' ? error : error.responseJSON.message
+          error = typeof (error.responseJSON.message) === 'undefined' ? genericError : error.responseJSON.message
+        } else {
+          error = genericError
         }
         var $errors = that.$activeForm.find('.js-errors')
         $errors.html(error).removeClass(jshiddenClass).focus()


### PR DESCRIPTION
At the moment, the `alphagov/feedback` application responds with a 422 HTTP status if all fields are left empty in the form.

**Current behaviour**
<img width="1320" alt="Screen Shot 2019-06-11 at 10 34 54" src="https://user-images.githubusercontent.com/3758555/59261037-a3743200-8c34-11e9-8f27-b52b8eed33e7.png">


The feedback components javascript was setup to always apply the constructed error message first and then check for the `responseJSON.message` property, which would always return undefined.

This resulted in 422 status error message to never being applied.

This PR updates the logic to account for that.
Resolves: #915 
Trello ticket: https://trello.com/c/r5jiQ7Wk/130-feedback-component-insufficient-error-message-11

**New behaviour** (mock api response)
<img width="1242" alt="Screen Shot 2019-06-11 at 11 02 30" src="https://user-images.githubusercontent.com/3758555/59263223-893c5300-8c38-11e9-8fc3-330a8e7af71d.png">
