### PR TITLE
Disable youtube embeds if campaign cookies are turned off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Disable youtube embeds if campaign cookies turned off (PR #919)
 * Add aria-live flag to notice component (PR #911)
 * Check the consent cookie before setting cookies (PR #916)
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -13,10 +13,12 @@ window.GOVUK = window.GOVUK || {};
   YoutubeLinkEnhancement.prototype.init = function () {
     var $youtubeLinks = this.$element.find('a[href*="youtube.com"], a[href*="youtu.be"]')
     var _this = this
+
     $youtubeLinks.each(function () {
       var $link = $(this)
-
-      if (_this.hasDisabledEmbed($link)) {
+      // if users have disabled 'campaigns' cookie in the new cookie page settings
+      // we also need to disable the youtube video embed
+      if (_this.hasDisabledEmbed($link) || !YoutubeLinkEnhancement.campaignCookies()) {
         return true
       }
 
@@ -59,6 +61,11 @@ window.GOVUK = window.GOVUK || {};
     if ($captions.length) {
       return $captions.first().attr('href')
     }
+  }
+
+  YoutubeLinkEnhancement.campaignCookies = function () {
+    var cookiePolicy = window.GOVUK.getCookie('cookie_policy') ? JSON.parse(window.GOVUK.getCookie('cookie_policy')) : 'undefined'
+    return cookiePolicy !== 'undefined' ? cookiePolicy.campaigns : true
   }
 
   YoutubeLinkEnhancement.nextId = function () {

--- a/spec/javascripts/components/govspeak-spec.js
+++ b/spec/javascripts/components/govspeak-spec.js
@@ -1,4 +1,15 @@
 describe('Govspeak component', function () {
+  beforeEach(function () {
+    // For some reason, JSON.parse on the cookie works in the browser, but fails in Jasmine tests.
+    // It seems to be due to extra escaping of quotes when the code is run in the tests, which means JSON.parse doesn't
+    // work as expected. So we'll stub this value instead.  
+    spyOn(JSON, 'parse').and.returnValue({
+      'essential': true,
+      'settings': true,
+      'usage': true
+    })
+    window.GOVUK.cookie('cookie_policy', null)
+  })
   var govspeakModule = new GOVUK.Modules.Govspeak()
 
   it('embeds youtube videos', function () {

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
@@ -1,64 +1,121 @@
 describe('Youtube link enhancement', function () {
-  it('replaces a link and it\'s container with a media-player embed', function () {
-    var $element = $('<div><p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">Agile at GDS</a></p></div>')
-    var $toReplace = $element.find('p, a')
-
-    var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement($element)
-    enhancement.init()
-
-    expect($element.find('.media-player .video').length).toBe(1)
-    expect($element.find($toReplace).length).toBe(0)
-  })
-
-  it('doesn\'t replace non Youtube links', function () {
-    var $element = $('<div><p><a href="https://www.gov.uk/">GOV.UK</a></p></div>')
-    var $toReplace = $element.find('p, a')
-
-    var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement($element)
-    enhancement.init()
-
-    expect($element.find('.media-player .video').length).toBe(0)
-    expect($element.find($toReplace).length).toBe(2)
-  })
-
-  it('doesn\'t replace links marked not to embed', function () {
-    var $element = $('<div><p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ" data-youtube-player="off">Agile at GDS</a></p></div>')
-    var $toReplace = $element.find('p, a')
-
-    var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement($element)
-    enhancement.init()
-
-    expect($element.find('.media-player .video').length).toBe(0)
-    expect($element.find($toReplace).length).toBe(2)
-  })
-
-  describe('parseVideoId', function () {
-    it('returns an id for a youtube.com video URL', function () {
-      var url = 'https://www.youtube.com/watch?v=0XpAtr24uUQ'
-      var id = GOVUK.GovspeakYoutubeLinkEnhancement.parseVideoId(url)
-
-      expect(id).toEqual('0XpAtr24uUQ')
+  describe('default behaviour and no consent', function () {
+    beforeEach(function () {
+      // For some reason, JSON.parse on the cookie works in the browser, but fails in Jasmine tests.
+      // It seems to be due to extra escaping of quotes when the code is run in the tests, which means JSON.parse doesn't
+      // work as expected. So we'll stub this value instead.
+      spyOn(JSON, 'parse').and.returnValue({
+        'essential': true,
+        'settings': true,
+        'usage': true
+      })
+      window.GOVUK.cookie('cookie_policy', null)
     })
 
-    it('returns an id for a youtu.be video URL', function () {
-      var url = 'https://youtu.be/0XpAtr24uUQ'
-      var id = GOVUK.GovspeakYoutubeLinkEnhancement.parseVideoId(url)
+    it('replaces a link and it\'s container with a media-player embed', function () {
+      var $element = $('<div><p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">Agile at GDS</a></p></div>')
+      var $toReplace = $element.find('p, a')
 
-      expect(id).toEqual('0XpAtr24uUQ')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement($element)
+      enhancement.init()
+      expect($element.find('.media-player .video').length).toBe(1)
+      expect($element.find($toReplace).length).toBe(0)
     })
 
-    it('doesn\'t return an id for a Youtube non video', function () {
-      var url = 'https://www.youtube.com/channel/UCSNK6abAoM6Kj0SkHOStNLg'
-      var id = GOVUK.GovspeakYoutubeLinkEnhancement.parseVideoId(url)
+    it('doesn\'t replace non Youtube links', function () {
+      var $element = $('<div><p><a href="https://www.gov.uk/">GOV.UK</a></p></div>')
+      var $toReplace = $element.find('p, a')
 
-      expect(id).not.toBeDefined()
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement($element)
+      enhancement.init()
+
+      expect($element.find('.media-player .video').length).toBe(0)
+      expect($element.find($toReplace).length).toBe(2)
     })
 
-    it('doesn\'t return an id for a non youtube link', function () {
-      var url = 'https://www.gov.uk'
-      var id = GOVUK.GovspeakYoutubeLinkEnhancement.parseVideoId(url)
+    it('doesn\'t replace links marked not to embed', function () {
+      var $element = $('<div><p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ" data-youtube-player="off">Agile at GDS</a></p></div>')
+      var $toReplace = $element.find('p, a')
 
-      expect(id).not.toBeDefined()
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement($element)
+      enhancement.init()
+
+      expect($element.find('.media-player .video').length).toBe(0)
+      expect($element.find($toReplace).length).toBe(2)
+    })
+
+    describe('parseVideoId', function () {
+      it('returns an id for a youtube.com video URL', function () {
+        var url = 'https://www.youtube.com/watch?v=0XpAtr24uUQ'
+        var id = GOVUK.GovspeakYoutubeLinkEnhancement.parseVideoId(url)
+
+        expect(id).toEqual('0XpAtr24uUQ')
+      })
+
+      it('returns an id for a youtu.be video URL', function () {
+        var url = 'https://youtu.be/0XpAtr24uUQ'
+        var id = GOVUK.GovspeakYoutubeLinkEnhancement.parseVideoId(url)
+
+        expect(id).toEqual('0XpAtr24uUQ')
+      })
+
+      it('doesn\'t return an id for a Youtube non video', function () {
+        var url = 'https://www.youtube.com/channel/UCSNK6abAoM6Kj0SkHOStNLg'
+        var id = GOVUK.GovspeakYoutubeLinkEnhancement.parseVideoId(url)
+
+        expect(id).not.toBeDefined()
+      })
+
+      it('doesn\'t return an id for a non youtube link', function () {
+        var url = 'https://www.gov.uk'
+        var id = GOVUK.GovspeakYoutubeLinkEnhancement.parseVideoId(url)
+
+        expect(id).not.toBeDefined()
+      })
+    })
+  })
+
+  describe('cookie consent for campaign true', function () {
+    beforeEach(function () {
+      // For some reason, JSON.parse on the cookie works in the browser, but fails in Jasmine tests.
+      // It seems to be due to extra escaping of quotes when the code is run in the tests, which means JSON.parse doesn't
+      // work as expected. So we'll stub this value instead.
+      spyOn(JSON, 'parse').and.returnValue({
+        'campaigns': true
+      })
+      window.GOVUK.cookie('cookie_policy', "{\"campaigns\":true}")
+    })
+
+    it('replaces a link and its container with a media-player embed when campaign cookies are turned on', function () {
+      var $element = $('<div><p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">Agile at GDS</a></p></div>')
+      var $toReplace = $element.find('p, a')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement($element)
+      enhancement.init()
+
+      expect($element.find('.media-player .video').length).toBe(1)
+      expect($element.find($toReplace).length).toBe(0)
+    })
+  })
+
+  describe('cookie consent for campaign set to false', function () {
+    beforeEach(function () {
+      // For some reason, JSON.parse on the cookie works in the browser, but fails in Jasmine tests.
+      // It seems to be due to extra escaping of quotes when the code is run in the tests, which means JSON.parse doesn't
+      // work as expected. So we'll stub this value instead.
+      spyOn(JSON, 'parse').and.returnValue({
+        'campaigns': false
+      })
+      window.GOVUK.cookie('cookie_policy', "{\"campaigns\":false}")
+    })
+
+    it('doesn\'t replace links when campaign cookies are turned off', function () {
+      var $element = $('<div><p><a href="https://www.youtube.com/watch?v=0XpAtr24uUQ">Agile at GDS</a></p></div>')
+      var $toReplace = $element.find('p, a')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement($element)
+      enhancement.init()
+
+      expect($element.find('.media-player .video').length).toBe(0)
+      expect($element.find($toReplace).length).toBe(2)
     })
   })
 })


### PR DESCRIPTION
New cookie settings page (https://github.com/alphagov/frontend/pull/1856) will allow users to set certain cookie groups on or off.

When they set `campaigns` cookie to off we need to disable youtube embeds as they store cookies.

If the new cookie settings is not available, we continue to embed the youtube videos

_Note: tests currently include a workaround by stubbing the return value of JSON.parse. Without this stubbing, it looks as though the value returned includes escaped quotes, which means an additional JSON.parse is required (but this works fine in the browser)._

**Campaign cookie turned OFF**
<img width="1190" alt="Screen Shot 2019-06-11 at 14 24 25" src="https://user-images.githubusercontent.com/3758555/59275836-fbbb2c00-8c54-11e9-8f2e-83f04522dc3b.png">

**Campaign cookie turned ON**
<img width="1193" alt="Screen Shot 2019-06-11 at 14 24 54" src="https://user-images.githubusercontent.com/3758555/59275837-fbbb2c00-8c54-11e9-8307-53c57d843659.png">

**No campaign cookie (current behaviour)**
<img width="1144" alt="Screen Shot 2019-06-11 at 14 25 34" src="https://user-images.githubusercontent.com/3758555/59275838-fc53c280-8c54-11e9-81b6-f78aaf673c86.png">
