### PR TITLE
Add ministers with roles to org schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Change step by step navigation active step link state (PR #937)
 * Fix dialog element role in modal dialogue component (PR #920)
+* Add ministers to organisation page schema. (PR #921)
 
 ## 17.1.1
 

--- a/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
@@ -69,6 +69,28 @@ examples:
             - title: "Dodgy Wands Commission"
               base_path: "/dodgy-wands-commission"
       schema: :organisation
+  organisation_schema_with_people:
+    data:
+      content_item:
+        title: "Ministry of Organisation"
+        base_path: "/foo"
+        details:
+          ordered_ministers:
+            - name_prefix: "Minister"
+              name: "Rufus Scrimgeour MP"
+              role: "Minister for Magic"
+              href: "/rufus-scrimgeour"
+              role_href: "/minister-for-magic"
+              image:
+                url: "https://images.gov.uk/rufus.jpg"
+            - name_prefix: "Minister"
+              name: "Rufus Scrimgeour MP"
+              role: "Head of Auror Office"
+              href: "/rufus-scrimgeour"
+              role_href: "/head-of-auror-office"
+              image:
+                url: "https://images.gov.uk/rufus.jpg"
+      schema: :organisation
   search_results_page_schema:
     data:
       content_item:


### PR DESCRIPTION
This adds the ministers of an organisation to the [GovernmentOrganization](https://schema.org/GovernmentOrganization) schema which is present on [organisation pages](https://www.gov.uk/government/organisations).  It includes their name, prefix ("Rt Hon" etc.), url of people page and image.

For each role they inhabit we also include the role name, and the url of the role page.

This will enable consumers of organisation pages to more clearly identify the people and roles within an organisation.

[component guide example](https://govuk-publishing-compon-pr-921.herokuapp.com/component-guide/machine_readable_metadata/organisation_schema_with_people)

I've spun up a collections review app so you can see structured data tests for some orgs:

- [Attorney General's Office](https://search.google.com/structured-data/testing-tool/u/0/#url=http%3A%2F%2Fgovuk-collections-pr-1143.herokuapp.com%2Fgovernment%2Forganisations%2Fattorney-generals-office) (should have a person in the schema)
- [Cabinet Office](https://search.google.com/structured-data/testing-tool/u/0/#url=http%3A%2F%2Fgovuk-collections-pr-1143.herokuapp.com%2Fgovernment%2Forganisations%2Fcabinet-office) (should have many people in the schema
- [CMA](https://search.google.com/structured-data/testing-tool/u/0/#url=http%3A%2F%2Fgovuk-collections-pr-1143.herokuapp.com%2Fgovernment%2Forganisations%2Fcompetition-and-markets-authority) (shouldn't have any people in the schema.

Feel free to look at [random org pages](http://govuk-collections-pr-1143.herokuapp.com/government/organisations) in the [structured data testing tool](https://search.google.com/structured-data/testing-tool/u/0/)

## Background

I'm reimplementing the Person schema instead of reusing the existing implementation.  The other one is closely coupled to describing people page content items, whereas the ministers described on org pages are described in a different json format to people pages and also have role information embedded like this (abridged for clarity): 

### An abridged organisation content item
```
{
  "title": "The Attorney General's Office",
  "details": {
    "ordered_ministers": [
      {
        "name_prefix": "The Rt Hon",
        "name": "Geoffrey Cox QC MP",
        "role": "Attorney General",
        "href": "/government/people/geoffrey-cox",
        "role_href": "/government/ministers/attorney-general",
        "image": {
          "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3579/Geoffrey_Cox.jpg",
       },
       {
        "name_prefix": "The Rt Hon",
        "name": "Geoffrey Cox QC MP",
        "role": "Hockey Captain",
        "href": "/government/people/geoffrey-cox",
        "role_href": "/government/ministers/hockey-captain",
        "image": {
          "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3579/Geoffrey_Cox.jpg",
         }
      }
    }
  }
}
```

There may be an opportunity to do some refactoring when we get to implementing a similar approach for speeches and other things also tagged to people, but I think it's likely that org pages will remain "different" because of the structure of their content items.

There is one entry in a content item per role, not per person, so we need to be able to collapse the roles to avoid having more than one Theresa May in the Cabinet Office schema for example.  (She's currently [the Prime Minister, the First Lord of the Treasury and Minister for the Civil Service](https://www.gov.uk/government/organisations/cabinet-office))

This looks something like this in practice (abridged for clarity):

### An abridged organisation schema item
```
{
  "@context":"http://schema.org",
  "@type":"GovernmentOrganization",
  "name":"Attorney General's Office",
  "member":[
    {
      "@type":"Person",
      "honorificPrefix":"The Rt Hon",
      "image":"https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3579/Geoffrey_Cox.jpg",
      "name":"Geoffrey Cox QC MP",
      "url":"https://www.gov.uk/government/people/geoffrey-cox",
      "hasOccupation":[
         {
            "@type":"Role",
            "name":"Attorney General",
            "url":"https://www.gov.uk/government/ministers/attorney-general"
         },
         {
            "@type":"Role",
            "name":"Hockey Captain",
            "url":"https://www.gov.uk/government/ministers/hockey-captain"
         }
       ]
    }
  ]
}
```

We could do this aggregation of roles to people in one `reduce`, but I think that might be more difficult to understand than generating the people and roles in step one, and then joining the schemas in a second step.  There are only a few ministers at most per organisation, so this doesn't add any particular overhead.

This passes the [structured data testing tool](https://search.google.com/structured-data/testing-tool/u/0/) when tested.

https://trello.com/c/iNXeAeJc/146-to-add-the-person-schema-to-org-pages-on-govuk