### PR TITLE
Fix allowing/denying cookies

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -12,6 +12,7 @@
   }
 
   var COOKIE_CATEGORIES = {
+    'TLSversion': 'usage',
     'cookie_policy': 'essential',
     'govuk_not_first_visit': 'essential',
     'govuk_browser_upgrade_dismisssed': 'essential',

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -84,25 +84,39 @@
     window.GOVUK.setCookie('cookie_policy', JSON.stringify(deniedConsent))
   }
 
-  window.GOVUK.setConsentCookie = function (options) {
-    var currentConsentCookie = window.GOVUK.getCookie('cookie_policy')
-    var cookieConsentJSON
+  window.GOVUK.getConsentCookie = function () {
+    var consentCookie = window.GOVUK.cookie('cookie_policy')
+    var consentCookieObj
 
-    if (currentConsentCookie) {
-      cookieConsentJSON = JSON.parse(currentConsentCookie)
+    if (consentCookie) {
+      consentCookieObj = JSON.parse(consentCookie)
+
+      if (typeof consentCookieObj !== 'object' && consentCookieObj !== null) {
+        consentCookieObj = JSON.parse(consentCookieObj)
+      }
     } else {
-      cookieConsentJSON = DEFAULT_COOKIE_CONSENT
+      return null
+    }
+
+    return consentCookieObj
+  }
+
+  window.GOVUK.setConsentCookie = function (options) {
+    var cookieConsent = window.GOVUK.getConsentCookie()
+
+    if (!cookieConsent) {
+      cookieConsent = DEFAULT_COOKIE_CONSENT
     }
 
     for (var cookieType in options) {
-      cookieConsentJSON[cookieType] = options[cookieType]
+      cookieConsent[cookieType] = options[cookieType]
     }
 
-    window.GOVUK.setCookie('cookie_policy', JSON.stringify(cookieConsentJSON))
+    window.GOVUK.setCookie('cookie_policy', JSON.stringify(cookieConsent))
   }
 
   window.GOVUK.checkConsentCookie = function (cookieName, cookieValue) {
-    var currentConsentCookie = window.GOVUK.getCookie('cookie_policy')
+    var currentConsentCookie = window.GOVUK.getConsentCookie()
 
     // If we're setting the consent cookie OR deleting a cookie, allow by default
     if (cookieName === 'cookie_policy' || (cookieValue === null || cookieValue === false)) {
@@ -114,17 +128,17 @@
       window.GOVUK.setDefaultConsentCookie()
     }
 
-    var consent = JSON.parse(window.GOVUK.getCookie('cookie_policy'))
+    currentConsentCookie = window.GOVUK.getConsentCookie()
 
     // Survey cookies are dynamically generated, so we need to check for these separately
     if (cookieName.match('^govuk_surveySeen') || cookieName.match('^govuk_taken')) {
-      return consent['essential']
+      return currentConsentCookie['essential']
     }
 
     if (COOKIE_CATEGORIES[cookieName]) {
       var cookieCategory = COOKIE_CATEGORIES[cookieName]
 
-      return consent[cookieCategory]
+      return currentConsentCookie[cookieCategory]
     } else {
       // Deny the cookie if it is not known to us
       return false

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -114,9 +114,14 @@
       window.GOVUK.setDefaultConsentCookie()
     }
 
-    if (COOKIE_CATEGORIES[cookieName]) {
-      var consent = JSON.parse(window.GOVUK.getCookie('cookie_policy'))
+    var consent = JSON.parse(window.GOVUK.getCookie('cookie_policy'))
 
+    // Survey cookies are dynamically generated, so we need to check for these separately
+    if (cookieName.match('^govuk_surveySeen') || cookieName.match('^govuk_taken')) {
+      return consent['essential']
+    }
+
+    if (COOKIE_CATEGORIES[cookieName]) {
       var cookieCategory = COOKIE_CATEGORIES[cookieName]
 
       return consent[cookieCategory]

--- a/spec/javascripts/components/cookie-banner-new-spec.js
+++ b/spec/javascripts/components/cookie-banner-new-spec.js
@@ -30,11 +30,6 @@ describe('New cookie banner', function () {
     document.body.appendChild(container)
     element = document.querySelector('.gem-c-cookie-banner--new')
 
-    // For some reason, JSON.parse on the cookie works in the browser, but fails in Jasmine tests.
-    // It seems to be due to extra escaping of quotes when the code is run in the tests, which means JSON.parse doesn't
-    // work as expected. So we'll stub this value instead.
-    spyOn(JSON, "parse").and.returnValue({"essential":true,"settings":true,"usage":true,"campaigns":true});
-
     window.GOVUK.cookie('cookie_policy', null)
     window.GOVUK.cookie('seen_cookie_message', null)
   })

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -20,11 +20,6 @@ describe('Cookie banner', function () {
     document.body.appendChild(container)
     var element = document.querySelector('[data-module="cookie-banner"]')
 
-    // For some reason, JSON.parse on the cookie works in the browser, but fails in Jasmine tests.
-    // It seems to be due to extra escaping of quotes when the code is run in the tests, which means JSON.parse doesn't
-    // work as expected. So we'll stub this value instead.
-    spyOn(JSON, "parse").and.returnValue({"essential":true,"settings":true,"usage":true,"campaigns":true});
-
     window.GOVUK.cookie('seen_cookie_message', null)
     window.GOVUK.cookie('cookie_policy', null)
     new GOVUK.Modules.CookieBanner().start($(element))

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
@@ -99,12 +99,6 @@ describe('Youtube link enhancement', function () {
 
   describe('cookie consent for campaign set to false', function () {
     beforeEach(function () {
-      // For some reason, JSON.parse on the cookie works in the browser, but fails in Jasmine tests.
-      // It seems to be due to extra escaping of quotes when the code is run in the tests, which means JSON.parse doesn't
-      // work as expected. So we'll stub this value instead.
-      spyOn(JSON, 'parse').and.returnValue({
-        'campaigns': false
-      })
       window.GOVUK.cookie('cookie_policy', "{\"campaigns\":false}")
     })
 


### PR DESCRIPTION
We discovered that changes from recent cookie related changes (like in #916) caused errors in other frontends including static. 

This PR fixes those problems, and we also double check against other frontends.