### PR TITLE
Delete cookies when a user remove consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add tracking to the hide button on new cookie banner (PR #928)
+* Delete cookies when a user removes consent (PR #923)
 
 ## 17.0.0
 
@@ -21,7 +22,7 @@
 * BREAKING: Check the consent cookie before setting cookies (PR #916)
 * Override vertical align: top for inline buttons (PR #912)
 * Change cookie banner text to green (PR #912)
-* Accessibility and design fixes for cookie banner (#912)
+* Accessibility and design fixes for cookie banner (PR #912)
 
 ## 16.29.0
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -115,6 +115,19 @@
 
     for (var cookieType in options) {
       cookieConsent[cookieType] = options[cookieType]
+
+      // Delete cookies of that type if consent being set to false
+      if (!options[cookieType]) {
+        for (var cookie in COOKIE_CATEGORIES) {
+          if (COOKIE_CATEGORIES[cookie] === cookieType) {
+            window.GOVUK.cookie(cookie, null)
+
+            if (window.GOVUK.cookie(cookie)) {
+              document.cookie = cookie + '=;expires=' + new Date() + ';domain=.' + window.location.hostname + ';path=/'
+            }
+          }
+        }
+      }
     }
 
     window.GOVUK.setCookie('cookie_policy', JSON.stringify(cookieConsent))

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -74,17 +74,6 @@
     window.GOVUK.setCookie('cookie_policy', JSON.stringify(approvedConsent))
   }
 
-  window.GOVUK.denyAllCookieTypes = function () {
-    var deniedConsent = {
-      'essential': false,
-      'settings': false,
-      'usage': false,
-      'campaigns': false
-    }
-
-    window.GOVUK.setCookie('cookie_policy', JSON.stringify(deniedConsent))
-  }
-
   window.GOVUK.getConsentCookie = function () {
     var consentCookie = window.GOVUK.cookie('cookie_policy')
     var consentCookieObj

--- a/spec/javascripts/components/cookie-functions-spec.js
+++ b/spec/javascripts/components/cookie-functions-spec.js
@@ -1,0 +1,133 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+var container
+
+var GOVUK = window.GOVUK || {};
+
+describe('Cookie helper functions', function () {
+  'use strict'
+
+  beforeEach(function () {
+    window.GOVUK.cookie('seen_cookie_message', null)
+    window.GOVUK.cookie('cookie_policy', null)
+  })
+
+  describe('window.GOVUK.cookie', function() {
+    it('returns the cookie value if not provided with a value to set', function() {
+      window.GOVUK.cookie('seen_cookie_message', 'testing fetching cookie value')
+
+      window.GOVUK.cookie('seen_cookie_message')
+
+      expect(window.GOVUK.cookie('seen_cookie_message')).toBe('testing fetching cookie value')
+    })
+
+    it('can create a new cookie', function () {
+      expect(window.GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
+
+      window.GOVUK.cookie('seen_cookie_message', 'test')
+
+      expect(window.GOVUK.getCookie('seen_cookie_message')).toBe('test')
+    })
+
+    it('can change the value of an existing cookie', function() {
+      window.GOVUK.cookie('seen_cookie_message', 'test1')
+
+      expect(window.GOVUK.getCookie('seen_cookie_message')).toBe('test1')
+
+      window.GOVUK.cookie('seen_cookie_message', 'test2')
+
+      expect(window.GOVUK.getCookie('seen_cookie_message')).toBe('test2')
+    })
+
+    it('deletes the cookie if value is set to false', function() {
+      window.GOVUK.cookie('seen_cookie_message', false)
+
+      expect(window.GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
+    })
+
+    it('deletes the cookie if value is set to null', function() {
+      window.GOVUK.cookie('seen_cookie_message', null)
+
+      expect(window.GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
+    })
+  })
+
+  describe('consent cookie methods', function() {
+    it('can set the consent cookie to default values', function() {
+      expect(window.GOVUK.getCookie('cookie_policy')).toBeFalsy()
+
+      window.GOVUK.setDefaultConsentCookie()
+
+      expect(window.GOVUK.getConsentCookie()).toEqual({'essential': true, 'settings': true, 'usage': true, 'campaigns': true})
+    })
+
+    it('can set the consent cookie to approve all cookie categories', function() {
+      window.GOVUK.setConsentCookie({'usage': false, 'essential': false})
+
+      expect(window.GOVUK.getConsentCookie().essential).toBe(false)
+      expect(window.GOVUK.getConsentCookie().usage).toBe(false)
+
+      window.GOVUK.approveAllCookieTypes()
+
+      expect(window.GOVUK.getConsentCookie()).toEqual({'essential': true, 'settings': true, 'usage': true, 'campaigns': true})
+    })
+
+    it('returns null if the consent cookie does not exist', function() {
+      expect(window.GOVUK.getConsentCookie()).toEqual(null)
+    })
+
+    it('returns null if the consent cookie is malformed', function () {
+      window.GOVUK.cookie('cookie_policy', "malformed consent cookie")
+
+      expect(window.GOVUK.getConsentCookie()).toBe(null)
+    })
+
+    it('deletes relevant cookies in that category if consent is set to false', function() {
+      window.GOVUK.setConsentCookie({'essential': true})
+
+      window.GOVUK.setCookie('seen_cookie_message', 'this is an essential cookie')
+
+      expect(window.GOVUK.cookie('seen_cookie_message')).toBe('this is an essential cookie')
+
+      window.GOVUK.setConsentCookie({'essential': false})
+
+      expect(window.GOVUK.getConsentCookie().essential).toBe(false)
+      expect(window.GOVUK.cookie('seen_cookie_message')).toBeFalsy()
+    })
+  })
+
+  describe('check cookie consent', function() {
+    it('returns true if trying to set the consent cookie', function() {
+      expect(window.GOVUK.checkConsentCookie('cookie_policy', {'essential': true})).toBe(true)
+    })
+
+    it('returns true if deleting a cookie', function() {
+      expect(window.GOVUK.checkConsentCookie('test_cookie', null)).toBe(true)
+      expect(window.GOVUK.checkConsentCookie('test_cookie', false)).toBe(true)
+    })
+
+    it('sets a default cookie if one does not already exist', function() {
+      expect(window.GOVUK.getConsentCookie()).toBeFalsy()
+
+      window.GOVUK.cookie('seen_cookie_message', true)
+
+      expect(window.GOVUK.cookie('seen_cookie_message')).toBeTruthy()
+      expect(window.GOVUK.getConsentCookie()).toEqual({ essential: true, settings: true, usage: false, campaigns: true })
+    })
+
+    it('returns the consent for a given cookie', function() {
+      window.GOVUK.setConsentCookie({'usage': false})
+
+      expect(window.GOVUK.checkConsentCookie('analytics_next_page_call', 'set a usage cookie')).toBeFalsy()
+
+      window.GOVUK.setConsentCookie({'usage': true})
+
+      expect(window.GOVUK.checkConsentCookie('analytics_next_page_call', 'set a usage cookie')).toBeTruthy()
+    })
+
+    it('denies consent for cookies not in our list of cookies', function() {
+      expect(window.GOVUK.checkConsentCookie('fake_cookie', 'just for testing')).toBeFalsy()
+    })
+  })
+})


### PR DESCRIPTION
When a user removes consent for a particular cookie category we need to delete all cookies of that type. For example: if a user removes consent for usage cookies, we want to delete usage cookies for that user.