### PR TITLE
Render data attributes with error summary items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Support data attributes for error summary items (PR #924)
 * Disable youtube embeds if campaign cookies turned off (PR #919)
 * Add aria-live flag to notice component (PR #911)
 * Check the consent cookie before setting cookies (PR #916)

--- a/app/views/govuk_publishing_components/components/_error_summary.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_summary.html.erb
@@ -31,9 +31,11 @@
         <% items.each_with_index do |item, index| %>
           <li class="gem-c-error-summary__list-item">
             <% if item[:href] %>
-              <%= link_to item[:text], item[:href], target: item[:target] %>
+              <%= link_to item[:text], item[:href], target: item[:target], data: item[:data_attributes] %>
             <% else %>
-              <%= item[:text] %>
+              <%= tag.span data: item[:data_attributes] do %>
+                <%= item[:text] %>
+              <% end %>
             <% end %>
           </li>
         <% end %>

--- a/app/views/govuk_publishing_components/components/docs/error_summary.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_summary.yml
@@ -21,9 +21,15 @@ examples:
       items:
       - text: Descriptive link to the question with an error 1
         href: '#example-error-1'
+        data_attributes:
+          tracking: GTM-123AA
       - text: Descriptive link to the question with an error 2
         href: '#example-error-2'
+        data_attributes:
+          tracking: GTM-123AB
       - text: Description of error without link
+        data_attributes:
+          tracking: GTM-123AC
   with_data_attributes:
     data:
       title: Message to alert the user to a problem goes here

--- a/spec/components/error_summary_spec.rb
+++ b/spec/components/error_summary_spec.rb
@@ -46,46 +46,25 @@ describe "Error summary", type: :view do
     assert_select ".govuk-error-summary__list", count: 0
   end
 
-  it "renders an error summary with items" do
-    render_component(
-      title: 'Message to alert the user to a problem goes here',
-      description: 'Optional description of the errors and how to correct them',
-      items: [
-        {
-          text: 'Descriptive link to the question with an error',
-          href: '#example-error-1'
-        }
-      ]
-    )
-
-    assert_select ".govuk-error-summary__title", text: 'Message to alert the user to a problem goes here'
-    assert_select ".govuk-error-summary__body p", text: 'Optional description of the errors and how to correct them'
-    assert_select(
-      "ul li a:first-of-type[href='#example-error-1']",
-      text: 'Descriptive link to the question with an error'
-    )
-  end
-
-  it "renders an error summary with multiple links" do
+  it "renders an error summary with items links" do
     render_component(
       title: 'Message to alert the user to a problem goes here',
       description: 'Optional description of the errors and how to correct them',
       items: [
         {
           text: 'Descriptive link to the question with an error 1',
-          href: '#example-error-1'
+          href: '#example-error-1',
+          data_attributes: { gtm: "tracking-1" }
         },
         {
           text: 'Descriptive link to the question with an error 2',
-          href: '#example-error-2'
+          href: '#example-error-2',
+          target: '_blank',
+          data_attributes: { gtm: "tracking-2" }
         },
         {
-          text: 'Descriptive link to the question with an error 3',
-          href: '#example-error-3',
-          target: '_blank'
-        },
-        {
-          text: 'Description for error 4 with no link'
+          text: 'Description for error 3 with no link',
+          data_attributes: { gtm: "tracking-3" }
         }
       ]
     )
@@ -94,20 +73,16 @@ describe "Error summary", type: :view do
     assert_select ".govuk-error-summary__body p", text: 'Optional description of the errors and how to correct them'
 
     assert_select(
-      "ul li a:first-of-type[href='#example-error-1']",
+      "ul li a:first-of-type[href='#example-error-1'][data-gtm='tracking-1']",
       text: 'Descriptive link to the question with an error 1'
     )
     assert_select(
-      "ul li a:nth-of-type(1)[href='#example-error-2']",
+      "ul li a:nth-of-type(1)[href='#example-error-2'][data-gtm='tracking-2']",
       text: 'Descriptive link to the question with an error 2'
     )
     assert_select(
-      "ul li a:last-of-type[href='#example-error-3'][target='_blank']",
-      text: 'Descriptive link to the question with an error 3',
-    )
-    assert_select(
-      "ul li:last-of-type",
-      text: 'Description for error 4 with no link'
+      "ul li:last-of-type span[data-gtm='tracking-3']",
+      text: 'Description for error 3 with no link'
     )
   end
 end


### PR DESCRIPTION
    This enables data attributes for individual items of the error summary
    component to better support tracking of the multiple items displayed.

<!--
Remember to update the CHANGELOG if your change needs to be listed in the next version of the gem.
-->
