### PR TITLE
Reset seen_cookie_message for new banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add tracking to the hide button on new cookie banner (PR #928)
 * Delete cookies when a user removes consent (PR #923)
+* Reset seen_cookie_message if new cookie banner present (PR #925)
 
 ## 17.0.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -42,6 +42,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.$acceptCookiesLink.addEventListener('click', this.$module.setCookieConsent)
     }
 
+    // Force the new cookie banner to show if we don't think the user has seen it before
+    // This involves resetting the seen_cookie_message cookie, which may be set to true if they've seen the old cookie banner
+    if (!window.GOVUK.cookie('cookie_policy')) {
+      if (window.GOVUK.cookie('seen_cookie_message') === 'true') {
+        window.GOVUK.cookie('seen_cookie_message', false)
+      }
+    }
+
     this.showNewCookieMessage()
   }
 
@@ -59,16 +67,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     // Hide the cookie banner on the cookie settings page, to avoid circular journeys
     if (newCookieBanner && window.location.pathname === '/help/cookies') {
       this.$module.style.display = 'none'
-    }
+    } else {
+      var shouldHaveCookieMessage = (this.$module && window.GOVUK.cookie('seen_cookie_message') !== 'true')
 
-    var shouldHaveCookieMessage = (this.$module && window.GOVUK.cookie('seen_cookie_message') !== 'true')
+      if (shouldHaveCookieMessage) {
+        this.$module.style.display = 'block'
 
-    if (shouldHaveCookieMessage) {
-      this.$module.style.display = 'block'
-
-      // Set the default consent cookie if it isn't already present
-      if (!window.GOVUK.cookie('cookie_policy')) {
-        window.GOVUK.setDefaultConsentCookie()
+        // Set the default consent cookie if it isn't already present
+        if (!window.GOVUK.cookie('cookie_policy')) {
+          window.GOVUK.setDefaultConsentCookie()
+        }
       }
     }
   }

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -142,6 +142,8 @@
   }
 
   window.GOVUK.checkConsentCookie = function (cookieName, cookieValue) {
+    var currentConsentCookie = window.GOVUK.getConsentCookie()
+
     // If we're setting the consent cookie OR deleting a cookie, allow by default
     if (cookieName === 'cookie_policy' || (cookieValue === null || cookieValue === false)) {
       return true
@@ -150,6 +152,11 @@
     // Survey cookies are dynamically generated, so we need to check for these separately
     if (cookieName.match('^govuk_surveySeen') || cookieName.match('^govuk_taken')) {
       return window.GOVUK.checkConsentCookieCategory('essential')
+    }
+
+    // If the consent cookie doesn't exist, set the default consent cookie
+    if (!currentConsentCookie && COOKIE_CATEGORIES[cookieName]) {
+      return true
     }
 
     if (COOKIE_CATEGORIES[cookieName]) {

--- a/spec/javascripts/components/cookie-banner-new-spec.js
+++ b/spec/javascripts/components/cookie-banner-new-spec.js
@@ -97,8 +97,9 @@ describe('New cookie banner', function () {
     expect(window.GOVUK.getCookie('seen_cookie_message')).toBeTruthy()
   })
 
-  it('does not show the banner if user has acknowledged the banner previously', function() {
+  it('does not show the banner if user has acknowledged the banner previously and consent cookie is present', function() {
     window.GOVUK.setCookie('seen_cookie_message', "true")
+    window.GOVUK.setDefaultConsentCookie()
     new GOVUK.Modules.CookieBanner().start($(element))
 
     var newCookieBanner = document.querySelector('.gem-c-cookie-banner--new')

--- a/spec/javascripts/components/cookie-functions-spec.js
+++ b/spec/javascripts/components/cookie-functions-spec.js
@@ -107,13 +107,16 @@ describe('Cookie helper functions', function () {
       expect(window.GOVUK.checkConsentCookie('test_cookie', false)).toBe(true)
     })
 
-    it('sets a default cookie if one does not already exist', function() {
+    it('returns true if the consent cookie does not exist and the cookie name is recognised', function() {
       expect(window.GOVUK.getConsentCookie()).toBeFalsy()
 
-      window.GOVUK.cookie('seen_cookie_message', true)
+      expect(window.GOVUK.checkConsentCookie('seen_cookie_message', true)).toBe(true)
+    })
 
-      expect(window.GOVUK.cookie('seen_cookie_message')).toBeTruthy()
-      expect(window.GOVUK.getConsentCookie()).toEqual({ essential: true, settings: true, usage: false, campaigns: true })
+    it('returns false if the consent cookie does not exist and the cookie name is not recognised', function() {
+      expect(window.GOVUK.getConsentCookie()).toBeFalsy()
+
+      expect(window.GOVUK.checkConsentCookie('fake_cookie')).toBe(false)
     })
 
     it('returns the consent for a given cookie', function() {


### PR DESCRIPTION
Some users will already have acknowledged the old cookie banner, meaning they will have the seen_cookie_message set to true. If we deploy the new cookie banner, these users won't see it.

We therefore need to reset that cookie for users who have not yet seen the new cookie banner.

**Note: this can safely be merged and deployed as it won't have any effect until the new banner is switched on via a flag in Static**