### PR TITLE
Revert "Bump jquery from 1.12.4 to 3.4.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1070,9 +1070,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
-      "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ=="
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.4.tgz",
+      "integrity": "sha1-AeHfuikP5z3rp3zurLD5ui/sngw="
     },
     "js-tokens": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "accessible-autocomplete": "git://github.com/alphagov/accessible-autocomplete.git#add-multiselect-support",
     "axe-core": "3.2.2",
     "govuk-frontend": "2.11.0",
-    "jquery": "3.4.0"
+    "jquery": "1.12.4"
   },
   "devDependencies": {
     "sass-lint": "^1.13.1",


### PR DESCRIPTION
Reverts alphagov/govuk_publishing_components#904

We (unfortunately) still need the older version of jQuery, since the newer version hasn't had all of the components tested in it thoroughly.