### PR TITLE
Update govspeak to use govuk-frontend mixins

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak-html-publication.scss
@@ -1,6 +1,6 @@
 // Override govspeak styles with HTML publication specific ones
 .gem-c-govspeak-html-publication {
-  margin-bottom: $gutter * 1.5;
+  margin-bottom: govuk-spacing(6) * 1.5;
   z-index: 2;
 
   // This fixes the positioning of the sticky element. The reason it's done on the parent element
@@ -22,25 +22,25 @@
     }
 
     .stat-headline:first-child {
-      margin-top: $gutter;
+      margin-top: govuk-spacing(6);
 
       @include govuk-media-query($from: tablet) {
-        margin-top: ($gutter * 2) + $gutter-two-thirds;
+        margin-top: govuk-spacing(9) + govuk-spacing(4);
       }
     }
 
     h2,
     h3 {
-      margin-top: $gutter;
+      margin-top: govuk-spacing(6);
 
       @include govuk-media-query($from: tablet) {
-        margin-top: ($gutter * 2) + $gutter-two-thirds;
+        margin-top: govuk-spacing(9) + govuk-spacing(4);
       }
     }
 
     h2:first-child,
     h3:first-child {
-      margin-top: $gutter-two-thirds;
+      margin-top: govuk-spacing(4);
 
       @include govuk-media-query($from: tablet) {
         margin-top: 0;
@@ -67,7 +67,7 @@
 
       .numeric {
         text-align: right;
-        font-family: $nta-light-tabular;
+        @include govuk-font(14, $weight: regular, $tabular: true);
       }
 
       // make all elements inside thead look the same
@@ -75,12 +75,16 @@
       // and make all of thead and tfoot stand out
       thead,
       tfoot {
-        background-color: $grey-3;
+        background-color: govuk-colour("grey-3");
       }
 
       thead th,
       thead td {
-        font-weight: bold;
+        @include govuk-font(14, $weight: bold, $tabular: true);
+
+        &.numeric {
+          @include govuk-font(14, $weight: bold, $tabular: true);
+        }
       }
 
       // don't make `th`s bold unless they are a section heading or a (sub)total row
@@ -93,30 +97,30 @@
       // is intentionally small and not balanced with other padding
       // as tables can be quite wide
       tr > :first-child {
-        padding-left: $gutter-one-third / 2;
+        padding-left: govuk-spacing(1);
       }
 
       // add spacing so that groupings are clearer
       tr.section-heading > * {
         font-weight: bold;
-        padding-top: $gutter;
+        padding-top: govuk-spacing(6);
       }
 
       // ideally this should be just a top margin on the tfoot
       // but as that is very tricky, this is more complex
       tbody:last-of-type tr:last-child > *,
       tfoot ~ tbody:last-of-type tr:last-child > * {
-        padding-bottom: $gutter;
+        padding-bottom: govuk-spacing(6);
       }
 
       tbody:last-child tr:last-child > * {
-        padding-bottom: $gutter-one-third;
+        padding-bottom: govuk-spacing(2);
       }
 
       // total and subtotal rows
       tr.subtotal > *,
       tr.total > * {
-        border-top: 3px solid $grey-2;
+        border-top: 3px solid govuk-colour("grey-2");
       }
 
       tr.total > *,
@@ -127,7 +131,7 @@
       // the total is usually in the tfoot, so already has that background colour
       // but when it's used inside the tbody, it should also be highlighted
       tr.total {
-        background-color: $grey-3;
+        background-color: govuk-colour("grey-3");
       }
     }
     // sass-lint:enable no-qualifying-elements

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_advisory.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_advisory.scss
@@ -8,7 +8,7 @@ $high-alert-border: #cc0000;
   padding: 1em;
   text-align: left;
 
-  @include device-pixel-ratio {
+  @include govuk-device-pixel-ratio {
     background-image: image-url("icon-information-2x.png");
     background-size: 27px 27px;
   }
@@ -24,7 +24,7 @@ $high-alert-border: #cc0000;
   }
 
   &.high-alert {
-    background-color: $panel-colour;
+    background-color: govuk-colour("grey-3");
     border-color: $high-alert-border;
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -29,12 +29,10 @@
     }
 
     .attachment-thumb {
-      $thumb-border-width: govuk-spacing(2) / 2;
-
       position: relative;
       float: left;
-      margin-top: $thumb-border-width;
-      margin-left: -($thumbnail-width + govuk-spacing(6) - $thumb-border-width);
+      margin-top: $govuk-border-width;
+      margin-left: -($thumbnail-width + govuk-spacing(6) - $govuk-border-width);
       padding-bottom: govuk-spacing(3);
 
       img {
@@ -42,7 +40,7 @@
         width: $thumbnail-width;
         height: 140px;
         background: govuk-colour("white");
-        outline: $thumb-border-width solid transparentize(govuk-colour("black"), .9);
+        outline: $govuk-border-width solid transparentize(govuk-colour("black"), .9);
 
         @include govuk-if-ie8 {
           // IE8 incorrectly asserts the "max-width: 100%" rule to be 0
@@ -51,7 +49,7 @@
           // width above.
           // http://www.456bereastreet.com/archive/201202/using_max-width_on_images_can_make_them_disappear_in_ie8/
           max-width: none;
-          border: $thumb-border-width solid govuk-colour("grey-3");
+          border: $govuk-border-width solid govuk-colour("grey-3");
         }
 
         box-shadow: 0 2px 2px rgba(govuk-colour("black"), .4);

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -19,9 +19,9 @@
 
   .attachment {
     position: relative;
-    margin: $gutter 0;
-    padding: $gutter-half 0 0 ($thumbnail-width + $gutter);
-    @extend %contain-floats;
+    margin: govuk-spacing(6) 0;
+    padding: govuk-spacing(3) 0 0 ($thumbnail-width + govuk-spacing(6));
+    @include govuk-clearfix;
 
     &:first-child {
       margin-top: 0;
@@ -29,32 +29,32 @@
     }
 
     .attachment-thumb {
-      $thumb-border-width: $gutter-one-third / 2;
+      $thumb-border-width: govuk-spacing(2) / 2;
 
       position: relative;
       float: left;
       margin-top: $thumb-border-width;
-      margin-left: -($thumbnail-width + $gutter - $thumb-border-width);
-      padding-bottom: $gutter-half;
+      margin-left: -($thumbnail-width + govuk-spacing(6) - $thumb-border-width);
+      padding-bottom: govuk-spacing(3);
 
       img {
         display: block;
         width: $thumbnail-width;
         height: 140px;
-        background: $white;
-        outline: $thumb-border-width solid transparentize($black, .9);
+        background: govuk-colour("white");
+        outline: $thumb-border-width solid transparentize(govuk-colour("black"), .9);
 
-        @include ie-lte(8) {
+        @include govuk-if-ie8 {
           // IE8 incorrectly asserts the "max-width: 100%" rule to be 0
           // because of the collapsed width on its floating container
           // Reset the max-width so that thumbnails render at the specified
           // width above.
           // http://www.456bereastreet.com/archive/201202/using_max-width_on_images_can_make_them_disappear_in_ie8/
           max-width: none;
-          border: $thumb-border-width solid $grey-3;
+          border: $thumb-border-width solid govuk-colour("grey-3");
         }
 
-        @include box-shadow(0 2px 2px rgba($black, .4));
+        box-shadow: 0 2px 2px rgba(govuk-colour("black"), .4);
       }
     }
 
@@ -65,7 +65,7 @@
       }
 
       p {
-        margin: $gutter-one-third 0;
+        margin: govuk-spacing(2) 0;
       }
 
       .metadata {
@@ -88,7 +88,7 @@
       }
 
       .preview {
-        padding-right: $gutter-half;
+        padding-right: govuk-spacing(3);
       }
 
       .opendocument-help {
@@ -109,12 +109,12 @@
   }
 
   &.direction-rtl .attachment {
-    padding: $gutter-half ($thumbnail-width + $gutter) 0 0;
+    padding: govuk-spacing(3) ($thumbnail-width + govuk-spacing(6)) 0 0;
 
     .attachment-thumb {
       float: right;
       margin-left: 0;
-      margin-right: (($thumbnail-width * -1) - $gutter-half);
+      margin-right: (($thumbnail-width * -1) - govuk-spacing(3));
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss
@@ -9,7 +9,7 @@
 .gem-c-govspeak {
   .call-to-action {
     margin: 2em 0;
-    background-color: $panel-colour;
+    background-color: govuk-colour("grey-3");
     padding: 2em;
 
     &:first-child {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -32,10 +32,9 @@
 
   // CHART COLOUR SCHEME
 
-  @import "colours"; // Cabinet Office colour palette (feel free to choose your own)
   $chart-border: govuk-colour("white"); // Chart border colour
   $key-border: govuk-colour("white"); // Key border colour
-  $bar-colours: govuk-colour("blue"), $turquoise, $green, $grass-green, $yellow, $orange, $govuk-error-colour, $mellow-red;
+  $bar-colours: govuk-colour("blue"), govuk-colour("turquoise"), govuk-colour("green"), govuk-colour("light-green"), govuk-colour("yellow"), govuk-colour("orange"), govuk-colour("red"), govuk-colour("bright-red");
 
   // HELPER MIXINS
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -36,20 +36,6 @@
   $key-border: govuk-colour("white"); // Key border colour
   $bar-colours: govuk-colour("blue"), govuk-colour("turquoise"), govuk-colour("green"), govuk-colour("light-green"), govuk-colour("yellow"), govuk-colour("orange"), govuk-colour("red"), govuk-colour("bright-red");
 
-  // HELPER MIXINS
-
-  @mixin visually-hidden {
-    // Hides content visually, but not from screen readers
-    position: absolute !important;
-    clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
-    clip: rect(1px, 1px, 1px, 1px);
-    padding: 0 !important;
-    border: 0 !important;
-    height: 1px !important;
-    width: 1px !important;
-    overflow: hidden;
-  }
-
   // CHART STYLES
   .mc-chart {
     font-size: $base-unit;
@@ -299,7 +285,7 @@
   // Hides the original table
   .visually-hidden,
   .visually-hidden caption {
-    @include visually-hidden;
+    @include govuk-visually-hidden;
 
     // It's reapplied to captions because Firefox can't hide
     // table captions unless it's applied directly to it. Go figure.

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -6,16 +6,8 @@
 // - alphagov/whitehall: ✔︎
 // - alphagov/govspeak: ✔︎
 
-// Disable linting for vendor asset
-// scss-lint:disable all
-// sass-lint:disable-all
-/*
- * magna-charta example stylesheet
- * https://github.com/alphagov/magna-charta
- *
- * Author: Tim Paul
- * Licensed under the MIT license.
- */
+// adapted from magna-charta example stylesheet
+// https://github.com/alphagov/magna-charta/blob/master/demo/stylesheets/magna-charta.css
 
 .gem-c-govspeak {
   // DEFAULT CHART STYLES
@@ -35,6 +27,8 @@
   $chart-border: govuk-colour("white"); // Chart border colour
   $key-border: govuk-colour("white"); // Key border colour
   $bar-colours: govuk-colour("blue"), govuk-colour("turquoise"), govuk-colour("green"), govuk-colour("light-green"), govuk-colour("yellow"), govuk-colour("orange"), govuk-colour("red"), govuk-colour("bright-red");
+  $bar-cell-colour: #ebebeb;
+  $bar-outdented-colour: #111111;
 
   // CHART STYLES
   .mc-chart {
@@ -58,7 +52,7 @@
 
     // KEY STYLES
     .mc-thead {
-      background-color: #ffffff;
+      background-color: govuk-colour("white");
       display: table-header-group;
       padding: $bar-spacing;
       border: 1px solid $key-border;
@@ -213,7 +207,8 @@
       }
     }
 
-    .mc-td, .mc-th {
+    .mc-td,
+    .mc-th {
       padding: 0;
       padding-right: $bar-spacing;
       margin-right: $stack-spacing;
@@ -221,7 +216,7 @@
 
       &.mc-bar-cell {
         display: block;
-        background-color: #ebebeb; // Just for testing
+        background-color: $bar-cell-colour; // Just for testing
         text-align: left;
         padding: $bar-padding 0;
         margin-bottom: 1px;
@@ -233,7 +228,7 @@
 
     .mc-bar-outdented {
       span {
-        color: #111111;
+        color: $bar-outdented-colour;
       }
     }
 
@@ -251,15 +246,13 @@
 
     // OUTDENTED BAR VALUES
     &.mc-outdented {
-      .mc-tbody {
-        .mc-tr {
-          .mc-bar-cell {
-            color: #111111;
-          }
+      .mc-tr {
+        .mc-bar-cell {
+          color: $bar-cell-colour;
+        }
 
-          .mc-bar-negative {
-            text-align: left;
-          }
+        .mc-bar-negative {
+          text-align: left;
         }
       }
     }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -33,9 +33,9 @@
   // CHART COLOUR SCHEME
 
   @import "colours"; // Cabinet Office colour palette (feel free to choose your own)
-  $chart-border: $white; // Chart border colour
-  $key-border: $white; // Key border colour
-  $bar-colours: $govuk-blue, $turquoise, $green, $grass-green, $yellow, $orange, $red, $mellow-red;
+  $chart-border: govuk-colour("white"); // Chart border colour
+  $key-border: govuk-colour("white"); // Key border colour
+  $bar-colours: govuk-colour("blue"), $turquoise, $green, $grass-green, $yellow, $orange, $govuk-error-colour, $mellow-red;
 
   // HELPER MIXINS
 
@@ -151,7 +151,7 @@
           text-align: left;
           padding: $bar-padding 0;
           margin-bottom: 1px;
-          color: $white;
+          color: govuk-colour("white");
           text-indent: $bar-padding;
         }
 
@@ -196,7 +196,7 @@
       .mc-stacked-total {
         padding: $bar-padding 0;
         background-color: transparent !important;
-        color: $black;
+        color: govuk-colour("black");
         display: inline-block;
         text-indent: 5px;
       }
@@ -240,7 +240,7 @@
         text-align: left;
         padding: $bar-padding 0;
         margin-bottom: 1px;
-        color: $white;
+        color: govuk-colour("white");
         text-indent: 4px;
         line-height: 1.5;
       }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
@@ -9,19 +9,19 @@
   // .address is used by the `$A` markdown pattern
   .address,
   .contact {
-    border-left: 1px solid $border-colour;
-    padding-left: $gutter-half;
-    margin-bottom: $gutter;
-    margin-top: $gutter;
+    border-left: 1px solid govuk-colour("grey-2");
+    padding-left: govuk-spacing(3);
+    margin-bottom: govuk-spacing(6);
+    margin-top: govuk-spacing(6);
   }
 
   .contact {
-    @extend %contain-floats;
+    @include govuk-clearfix;
     position: relative;
 
     .content {
       float: none;
-      width: $full-width;
+      width: 100%;
 
       h3 {
         @include govuk-font($size: 19, $weight: bold);

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_example.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_example.scss
@@ -7,7 +7,7 @@
 
 .gem-c-govspeak {
   .example {
-    border-left: 1em solid $panel-colour;
+    border-left: 1em solid govuk-colour("grey-3");
     padding: 1em 0 1em 1em;
     margin: 2em 0;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
@@ -11,9 +11,9 @@
 
 .gem-c-govspeak {
   .footnotes {
-    border-top: 1px solid $border-colour;
-    margin-top: $gutter;
-    padding-top: $gutter-one-third;
+    border-top: 1px solid govuk-colour("grey-2");
+    margin-top: govuk-spacing(6);
+    padding-top: govuk-spacing(2);
 
     ol {
       margin-top: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_form-download.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_form-download.scss
@@ -16,7 +16,7 @@
     min-height: 2.5em;
     padding: 0 0 0 2.5em;
 
-    @include device-pixel-ratio {
+    @include govuk-device-pixel-ratio {
       background-image: image-url("icon-file-download-2x.png");
       background-size: 25px 25px;
     }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_images.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_images.scss
@@ -8,21 +8,21 @@
   img {
     width: auto;
     height: auto;
-    max-width: $full-width;
+    max-width: 100%;
   }
 
   figure {
-    width: $full-width;
+    width: 100%;
     clear: both;
     overflow: hidden;
-    padding: $gutter-one-third 0 0;
+    padding: govuk-spacing(2) 0 0;
 
     img {
       display: inline;
       text-align: center;
       width: auto;
       height: auto;
-      max-width: $full-width;
+      max-width: 100%;
     }
 
     figcaption {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_information-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_information-callout.scss
@@ -8,7 +8,7 @@
 
 .gem-c-govspeak {
   .info-notice {
-    border-left: 1em solid $panel-colour;
+    border-left: 1em solid govuk-colour("grey-3");
     padding: 1em 0 1em 1em;
     margin: 2em 0;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_legislative-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_legislative-list.scss
@@ -19,7 +19,7 @@
     }
 
     ol {
-      margin: 10px 0 10px govuk-spacing(6);
+      margin: govuk-spacing(2) 0 govuk-spacing(2) govuk-spacing(6);
       list-style: none;
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_legislative-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_legislative-list.scss
@@ -19,7 +19,7 @@
     }
 
     ol {
-      margin: 10px 0 10px $gutter;
+      margin: 10px 0 10px govuk-spacing(6);
       list-style: none;
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_place.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_place.scss
@@ -1,6 +1,6 @@
 .gem-c-govspeak  .place {
   margin: 1.5em 0;
-  border-bottom: solid 1px $border-colour;
+  border-bottom: solid 1px govuk-colour("grey-2");
   padding-bottom: 1.5em;
 
   .address {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_stat-headline.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_stat-headline.scss
@@ -7,12 +7,12 @@
 
 .gem-c-govspeak {
   .stat-headline {
-    margin-bottom: $gutter-half;
-    margin-top: $gutter-half;
+    margin-bottom: govuk-spacing(3);
+    margin-top: govuk-spacing(3);
 
     @include govuk-media-query($from: tablet) {
-      margin-bottom: $gutter-two-thirds;
-      margin-top: $gutter-two-thirds;
+      margin-bottom: govuk-spacing(4);
+      margin-top: govuk-spacing(4);
     }
 
     p {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_steps.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_steps.scss
@@ -14,7 +14,7 @@
       &:nth-child(#{$i}) {
         background-image: image-url("icon-steps/icon-step-#{$i}.png");
 
-        @include device-pixel-ratio {
+        @include govuk-device-pixel-ratio {
           background-image: image-url("icon-steps/icon-step-#{$i}-2x.png");
           background-size: 24px 24px;
         }

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_summary.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_summary.scss
@@ -1,7 +1,7 @@
 .gem-c-govspeak .summary {
   margin: 0 0 2em;
   padding: 0;
-  color: $text-colour;
+  color: $govuk-text-colour;
 
   p {
     @include govuk-font($size: 19);

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -9,8 +9,8 @@
   table {
     border-collapse: collapse;
     border-spacing: 0;
-    margin: $gutter 0;
-    width: $full-width;
+    margin: govuk-spacing(6) 0;
+    width: 100%;
     @include govuk-font($size: 14);
 
     caption {
@@ -21,14 +21,14 @@
     th,
     td {
       vertical-align: top;
-      padding: $gutter-one-third $gutter-one-third $gutter-one-third 0;
-      border-bottom: solid 1px $border-colour;
+      padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
+      border-bottom: solid 1px govuk-colour("grey-2");
     }
 
     th {
       @include govuk-font($size: 14, $weight: bold);
       text-align: left;
-      color: $black;
+      color: $govuk-text-colour;
     }
 
     td small {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -15,7 +15,7 @@
   &.direction-rtl ol,
   &.direction-rtl ul {
     margin-left: 0;
-    margin-right: $gutter-two-thirds;
+    margin-right: govuk-spacing(4);
 
     ul,
     ol {
@@ -27,26 +27,26 @@
   // Block quotes
 
   blockquote {
-    padding: 0 0 0 $gutter-two-thirds;
+    padding: 0 0 0 govuk-spacing(4);
     margin: 0;
     border: 0;
 
-    @include media(desktop) {
-      margin: 0 0 0 (-$gutter);
+    @include govuk-media-query($from: desktop) {
+      margin: 0 0 0 (- govuk-spacing(6));
     }
 
     p {
-      padding-left: $gutter-half;
+      padding-left: govuk-spacing(3);
 
-      @include media(tablet) {
-        padding-left: $gutter;
+      @include govuk-media-query($from: tablet) {
+        padding-left: govuk-spacing(6);
       }
 
       &:before {
         content: "\201C";
         float: left;
         clear: both;
-        margin-left: -$gutter-half;
+        margin-left: -(govuk-spacing(3));
       }
 
       &:last-child:after {
@@ -56,25 +56,25 @@
   }
 
   &.direction-rtl blockquote {
-    padding: 0 $gutter-two-thirds 0 0;
+    padding: 0 govuk-spacing(4) 0 0;
 
     @include govuk-media-query($from: desktop) {
-      margin: 0 (-$gutter) 0 0;
+      margin: 0 (- govuk-spacing(6)) 0 0;
     }
 
     p {
-      padding-right: $gutter-half;
+      padding-right: govuk-spacing(3);
       padding-left: 0;
 
       @include govuk-media-query($from: tablet) {
-        padding-right: $gutter;
+        padding-right: govuk-spacing(6);
         padding-left: 0;
       }
 
       &:before {
         content: "\201D";
         float: right;
-        margin-right: -$gutter-half;
+        margin-right: -(govuk-spacing(3));
         margin-left: 0;
       }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -46,7 +46,7 @@
         content: "\201C";
         float: left;
         clear: both;
-        margin-left: -(govuk-spacing(3));
+        margin-left: (- govuk-spacing(3));
       }
 
       &:last-child:after {
@@ -74,7 +74,7 @@
       &:before {
         content: "\201D";
         float: right;
-        margin-right: -(govuk-spacing(3));
+        margin-right: (- govuk-spacing(3));
         margin-left: 0;
       }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
@@ -19,7 +19,7 @@
     background-size: $icon-size $icon-size;
     background-repeat: no-repeat;
 
-    @include device-pixel-ratio {
+    @include govuk-device-pixel-ratio {
       background-image: image-url("icon-important-2x.png");
     }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_govspeak.scss
@@ -6,9 +6,9 @@
   .info-notice,
   .help-notice,
   .call-to-action {
-    margin: $gutter-half 0;
-    padding: 0 $gutter-half;
-    border: 1pt solid $border-colour;
+    margin: govuk-spacing(3) 0;
+    padding: 0 govuk-spacing(3);
+    border: 1pt solid govuk-colour("grey-2");
   }
 
   .help-notice p {
@@ -23,7 +23,7 @@
   }
 
   .attachment {
-    margin: $gutter 0;
+    margin: govuk-spacing(6) 0;
 
     &:first-child {
       margin-top: 0;
@@ -41,7 +41,7 @@
 
     .accessibility-warning {
       h2 {
-        @include core-14;
+        @include govuk-font(14);
       }
 
       .toggler {
@@ -51,7 +51,7 @@
   }
 
   .footnotes {
-    border-top: 1px solid $text-colour;
+    border-top: 1px solid $govuk-text-colour;
   }
 
   .legislative-list {


### PR DESCRIPTION
This PR updates the **Govspeak content** and **Govspeak content (HTML Publications)** components to use govuk-frontend instead of govuk_frontend_toolkit

To ease the review a bit I attach below comparison screen captures for both components

![govspeak_compare](https://user-images.githubusercontent.com/788096/59609289-0cfdb000-910f-11e9-9fd7-e8586c752fb2.png)

![govspeak_html_compare](https://user-images.githubusercontent.com/788096/59609322-1850db80-910f-11e9-9af9-1ff7c12bf422.png)

[Trello card](https://trello.com/c/ajPzDAOX)