### PR TITLE
Fix resetting cookie mechanism for new banner

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -122,12 +122,12 @@
     window.GOVUK.setCookie('cookie_policy', JSON.stringify(cookieConsent))
   }
 
-  window.GOVUK.checkConsentCookieCategory = function (cookieCategory) {
+  window.GOVUK.checkConsentCookieCategory = function (cookieName, cookieCategory) {
     var currentConsentCookie = window.GOVUK.getConsentCookie()
 
-    // If the consent cookie doesn't exist, set the default consent cookie
-    if (!currentConsentCookie) {
-      window.GOVUK.setDefaultConsentCookie()
+    // If the consent cookie doesn't exist, but the cookie is in our known list, return true
+    if (!currentConsentCookie && COOKIE_CATEGORIES[cookieName]) {
+      return true
     }
 
     currentConsentCookie = window.GOVUK.getConsentCookie()
@@ -142,8 +142,6 @@
   }
 
   window.GOVUK.checkConsentCookie = function (cookieName, cookieValue) {
-    var currentConsentCookie = window.GOVUK.getConsentCookie()
-
     // If we're setting the consent cookie OR deleting a cookie, allow by default
     if (cookieName === 'cookie_policy' || (cookieValue === null || cookieValue === false)) {
       return true
@@ -151,18 +149,13 @@
 
     // Survey cookies are dynamically generated, so we need to check for these separately
     if (cookieName.match('^govuk_surveySeen') || cookieName.match('^govuk_taken')) {
-      return window.GOVUK.checkConsentCookieCategory('essential')
-    }
-
-    // If the consent cookie doesn't exist, set the default consent cookie
-    if (!currentConsentCookie && COOKIE_CATEGORIES[cookieName]) {
-      return true
+      return window.GOVUK.checkConsentCookieCategory(cookieName, 'essential')
     }
 
     if (COOKIE_CATEGORIES[cookieName]) {
       var cookieCategory = COOKIE_CATEGORIES[cookieName]
 
-      return window.GOVUK.checkConsentCookieCategory(cookieCategory)
+      return window.GOVUK.checkConsentCookieCategory(cookieName, cookieCategory)
     } else {
       // Deny the cookie if it is not known to us
       return false

--- a/spec/javascripts/components/cookie-functions-spec.js
+++ b/spec/javascripts/components/cookie-functions-spec.js
@@ -107,6 +107,14 @@ describe('Cookie helper functions', function () {
       expect(window.GOVUK.checkConsentCookie('test_cookie', false)).toBe(true)
     })
 
+    it('does not set a default consent cookie if one is not present', function() {
+      window.GOVUK.cookie('cookie_policy', null)
+
+      window.GOVUK.checkConsentCookieCategory('seen_cookie_message', true)
+
+      expect(window.GOVUK.getConsentCookie()).toBeFalsy()
+    })
+
     it('returns true if the consent cookie does not exist and the cookie name is recognised', function() {
       expect(window.GOVUK.getConsentCookie()).toBeFalsy()
 


### PR DESCRIPTION
As a result of a rebase to some previous PRs, a bug got through where the new consent cookie was being set before the new banner was deployed. As we rely on this cookie not being set to reset `seen_cookie_message` and show the new banner to everyone, this needed to be fixed before going live.