### PR TITLE
Change step by step navigation active step link state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Change step by step navigation active step link state (PR #937)
 * Fix dialog element role in modal dialogue component (PR #920)
 
 ## 17.1.1

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -392,7 +392,6 @@ $top-border: solid 2px $grey-3;
 
   .gem-c-step-nav__link {
     @include govuk-link-style-text;
-    text-decoration: none;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -2,7 +2,6 @@ $stroke-width: 2px;
 $stroke-width-large: 3px;
 $number-circle-size: 26px;
 $number-circle-size-large: 35px;
-$dot-size: 16px;
 $top-border: solid 2px $grey-3;
 
 @mixin step-nav-vertical-line ($line-style: solid) {
@@ -372,20 +371,19 @@ $top-border: solid 2px $grey-3;
     z-index: 5;
     top: .6em; // position the dot to align with the first row of text in the link
     left: -($gutter + $gutter-half);
-    margin-left: ($number-circle-size / 2) - ($dot-size / 2);
-    width: $dot-size;
-    height: $dot-size;
-    margin-top: -($dot-size / 2);
+    margin-top: -($stroke-width / 2);
+    margin-left: ($number-circle-size / 2);
+    width: $number-circle-size / 2;
+    height: $stroke-width;
     background: $black;
-    border: solid 2px $white;
-    border-radius: 100px;
   }
 
   .gem-c-step-nav--large & {
     @include media(tablet) {
       &:before {
         left: -($gutter * 2);
-        margin-left: ($number-circle-size-large / 2) - ($dot-size / 2);
+        margin-left: ($number-circle-size-large / 2);
+        height: $stroke-width-large;
       }
     }
   }


### PR DESCRIPTION
Adds underline to the currently active step link, following user research.

Before:

<img width="866" alt="Screen Shot 2019-06-18 at 11 09 32" src="https://user-images.githubusercontent.com/861310/59673774-c913b500-91b9-11e9-95c0-3405e93b2fa0.png">

After:

<img width="861" alt="Screen Shot 2019-06-18 at 11 09 41" src="https://user-images.githubusercontent.com/861310/59673789-d16bf000-91b9-11e9-9544-383124dbb55c.png">

Also changes the active link 'dot' to a line, to look like this:

<img width="861" alt="Screen Shot 2019-06-18 at 14 50 20" src="https://user-images.githubusercontent.com/861310/59689952-7ac1de80-91d8-11e9-8d73-415b7718bb4d.png">

