### PR TITLE
Fix new cookie mechanism not being session based

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ## Unreleased
 
+* Set the expiry of consent cookie to 1 year (PR #940)
+* Sets the default expiry of cookies to 30 days if not specified (PR #940)
+
 ## 17.2.0
 
 * Change step by step navigation active step link state (PR #937)

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -46,7 +46,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     // This involves resetting the seen_cookie_message cookie, which may be set to true if they've seen the old cookie banner
     if (!window.GOVUK.cookie('cookie_policy')) {
       if (window.GOVUK.cookie('seen_cookie_message') === 'true') {
-        window.GOVUK.cookie('seen_cookie_message', false)
+        window.GOVUK.cookie('seen_cookie_message', false, { days: 365 })
       }
     }
 
@@ -95,7 +95,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   CookieBanner.prototype.setCookieConsent = function () {
     window.GOVUK.approveAllCookieTypes()
     this.$module.showConfirmationMessage()
-    window.GOVUK.setCookie('seen_cookie_message', 'true')
+    window.GOVUK.cookie('seen_cookie_message', 'true', { days: 365 })
   }
 
   CookieBanner.prototype.showConfirmationMessage = function () {

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -52,6 +52,10 @@
       if (value === false || value === null) {
         return window.GOVUK.setCookie(name, '', { days: -1 })
       } else {
+        // Default expiry date of 30 days
+        if (typeof options === 'undefined') {
+          options = { days: 30 }
+        }
         return window.GOVUK.setCookie(name, value, options)
       }
     } else {
@@ -60,7 +64,7 @@
   }
 
   window.GOVUK.setDefaultConsentCookie = function () {
-    window.GOVUK.setCookie('cookie_policy', JSON.stringify(DEFAULT_COOKIE_CONSENT))
+    window.GOVUK.setCookie('cookie_policy', JSON.stringify(DEFAULT_COOKIE_CONSENT), { days: 365 })
   }
 
   window.GOVUK.approveAllCookieTypes = function () {
@@ -71,7 +75,7 @@
       'campaigns': true
     }
 
-    window.GOVUK.setCookie('cookie_policy', JSON.stringify(approvedConsent))
+    window.GOVUK.setCookie('cookie_policy', JSON.stringify(approvedConsent), { days: 365 })
   }
 
   window.GOVUK.getConsentCookie = function () {
@@ -119,7 +123,7 @@
       }
     }
 
-    window.GOVUK.setCookie('cookie_policy', JSON.stringify(cookieConsent))
+    window.GOVUK.setCookie('cookie_policy', JSON.stringify(cookieConsent), { days: 365 })
   }
 
   window.GOVUK.checkConsentCookieCategory = function (cookieName, cookieCategory) {


### PR DESCRIPTION
We had assumed that not passing `days` to `window.GOVUK.cookie()` set a default expiry, but it doesn't set any expiry date (therefore creating a session cookie).

This PR:

- Sets the expiry date of the consent cookie and the `seen_cookie_message` cookie to 1 year
- Adds a default expiry of 30 days to `window.GOVUK.cookie()`