### PR TITLE
Version 17.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 17.3.0
 
 * Set the expiry of consent cookie to 1 year (PR #940)
 * Sets the default expiry of cookies to 30 days if not specified (PR #940)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (17.2.0)
+    govuk_publishing_components (17.3.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '17.2.0'.freeze
+  VERSION = '17.3.0'.freeze
 end


### PR DESCRIPTION
Includes:

* Set the expiry of consent cookie to 1 year (PR #940)
* Sets the default expiry of cookies to 30 days if not specified (PR #940)