### PR TITLE
Add inverse option to contextual breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add inverse option to contextual breadcrumbs (PR #943)
 * Adds support for secondary content items for step by step (PR #900)
 * Adds missing tests for related to step navs (PR #900)
 * Adds missing tests for also part of step navs component (PR #900)

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -1,5 +1,6 @@
 <% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request) %>
 <% prioritise_taxon_breadcrumbs ||= false %>
+<% inverse ||= false %>
 
 <div class='gem-c-contextual-breadcrumbs'>
   <% if navigation.content_tagged_to_current_step_by_step? %>
@@ -8,27 +9,29 @@
       navigation.step_nav_helper.header %>
   <% elsif navigation.content_tagged_to_a_finder? %>
     <%# Rendering finder breadcrumbs because the page is tagged to a finder %>
-    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
+    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs, inverse: inverse %>
   <% elsif navigation.content_is_tagged_to_a_live_taxon? && prioritise_taxon_breadcrumbs %>
     <%# Rendering taxonomy breadcrumbs because the page is tagged to live taxons
           and we want to prioritise them over all other breadcrumbs %>
     <%= render 'govuk_publishing_components/components/breadcrumbs',
                breadcrumbs: navigation.taxon_breadcrumbs[:breadcrumbs],
-               collapse_on_mobile: true %>
+               collapse_on_mobile: true,
+               inverse: inverse %>
   <% elsif navigation.content_tagged_to_mainstream_browse_pages? %>
     <%# Rendering parent-based breadcrumbs because the page is tagged to mainstream browse %>
-    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
+    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs, inverse: inverse %>
   <% elsif navigation.content_has_curated_related_items? %>
     <%# Rendering parent-based breadcrumbs because the page has curated related links %>
-    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
+    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs, inverse: inverse %>
   <% elsif navigation.content_is_tagged_to_a_live_taxon? && !navigation.content_is_a_specialist_document? %>
     <%# Rendering taxonomy breadcrumbs because the page is tagged to live taxons %>
     <%= render 'govuk_publishing_components/components/breadcrumbs',
       breadcrumbs: navigation.taxon_breadcrumbs[:breadcrumbs],
-      collapse_on_mobile: true %>
+      collapse_on_mobile: true,
+      inverse: inverse %>
   <% elsif navigation.breadcrumbs.any? %>
     <%# Rendering parent-based breadcrumbs because no browse, no related links, no live taxons %>
-    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs %>
+    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs, inverse: inverse %>
   <% else %>
     <%# Not rendering any breadcrumbs because there aren't any %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/docs/contextual_breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_breadcrumbs.yml
@@ -24,3 +24,11 @@ examples:
     data:
       content_item:
         title: "A content item"
+  inverse:
+    description: Passes the 'inverse' option to the breadcrumbs, if shown.
+    data:
+      content_item:
+        title: "Another content item"
+      inverse: true
+    context:
+      dark_background: true

--- a/spec/components/contextual_breadcrumbs_spec.rb
+++ b/spec/components/contextual_breadcrumbs_spec.rb
@@ -45,6 +45,11 @@ describe "ContextualBreadcrumbs", type: :view do
     assert_select "a", text: "Passports"
   end
 
+  it "renders inverse parent-based breadcrumbs if the content_item is tagged to mainstream browse" do
+    render_component(content_item: example_document_for("place", "find-regional-passport-office"), inverse: true)
+    assert_select ".gem-c-breadcrumbs.gem-c-breadcrumbs--inverse"
+  end
+
   it "renders curated related items breadcrumbs if the content_item has curated related items" do
     content_item = example_document_for("licence", "licence_without_continuation_link")
     content_item = remove_mainstream_browse(content_item)
@@ -65,6 +70,15 @@ describe "ContextualBreadcrumbs", type: :view do
     assert_select "a", text: "Home"
     assert_select "a", text: "School curriculum"
     assert_select "a", text: "Education, training and skills"
+  end
+
+  it "renders inverse taxon breadcrumbs if there are some and no mainstream or curated_content" do
+    content_item = example_document_for("guide", "guide")
+    content_item = remove_mainstream_browse(content_item)
+    content_item = remove_curated_related_item(content_item)
+    content_item = set_live_taxons(content_item)
+    render_component(content_item: content_item, inverse: true)
+    assert_select ".gem-c-breadcrumbs.gem-c-breadcrumbs--inverse"
   end
 
   it "renders no taxon breadcrumbs if they are not live" do
@@ -118,6 +132,12 @@ describe "ContextualBreadcrumbs", type: :view do
 
     assert_select "a", text: "Home"
     assert_select "a", text: "EU Withdrawal Act 2018 statutory instruments"
+  end
+
+  it "renders inverse parent finder breadcrumb" do
+    content_item = example_document_for("guide", "guide-with-facet-groups")
+    render_component(content_item: content_item, prioritise_taxon_breadcrumbs: true, inverse: true)
+    assert_select ".gem-c-breadcrumbs.gem-c-breadcrumbs--inverse"
   end
 
   it "renders no breadcrumbs if there aren't any" do


### PR DESCRIPTION
The breadcrumb already has an inverse option, which turns the links white for rendering on a blue background. This PR adds an inverse option to the contextual breadcrumb component, which calls the breadcrumb component.

This is needed in finders where we are adding a blue banner to some finder headers.

Trello card: https://trello.com/c/A6eidvxn/799-implement-blue-topic-page-finder-headers-on-supergroup-finders-when-user-has-come-from-topic-page-l