### PR TITLE
Add tests for new cookie expiry date logic

### DIFF
--- a/spec/javascripts/components/cookie-banner-new-spec.js
+++ b/spec/javascripts/components/cookie-banner-new-spec.js
@@ -58,6 +58,7 @@ describe('New cookie banner', function () {
   })
 
   it('sets consent cookie when accepting cookies', function () {
+    spyOn(window.GOVUK, 'setCookie').and.callThrough()
     new GOVUK.Modules.CookieBanner().start($(element))
 
     // Manually reset the consent cookie so we can check the accept button works as intended
@@ -67,6 +68,7 @@ describe('New cookie banner', function () {
     var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
     acceptCookiesButton.click()
 
+    expect(window.GOVUK.setCookie).toHaveBeenCalledWith('seen_cookie_message', 'true', { days: 365 })
     expect(window.GOVUK.getCookie('cookie_policy')).toEqual('"{\\"essential\\":true,\\"settings\\":true,\\"usage\\":true,\\"campaigns\\":true}"')
   })
 
@@ -87,6 +89,8 @@ describe('New cookie banner', function () {
   })
 
   it('should hide when pressing the "hide" link', function () {
+    spyOn(window.GOVUK, 'setCookie').and.callThrough()
+
     new GOVUK.Modules.CookieBanner().start($(element))
 
     var banner = document.querySelector('[data-module="cookie-banner"]')
@@ -94,6 +98,7 @@ describe('New cookie banner', function () {
     link.dispatchEvent(new window.Event('click'))
 
     expect(banner).toBeHidden()
+    expect(window.GOVUK.setCookie).toHaveBeenCalledWith('seen_cookie_message', 'true', { days: 365 })
     expect(window.GOVUK.getCookie('seen_cookie_message')).toBeTruthy()
   })
 

--- a/spec/javascripts/components/cookie-functions-spec.js
+++ b/spec/javascripts/components/cookie-functions-spec.js
@@ -9,6 +9,8 @@ describe('Cookie helper functions', function () {
   'use strict'
 
   beforeEach(function () {
+    spyOn(window.GOVUK, 'setCookie').and.callThrough();
+
     window.GOVUK.cookie('seen_cookie_message', null)
     window.GOVUK.cookie('cookie_policy', null)
   })
@@ -28,6 +30,22 @@ describe('Cookie helper functions', function () {
       window.GOVUK.cookie('seen_cookie_message', 'test')
 
       expect(window.GOVUK.getCookie('seen_cookie_message')).toBe('test')
+    })
+
+    it('sets a default expiry of 30 days if no options are provided', function() {
+      expect(window.GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
+
+      window.GOVUK.cookie('seen_cookie_message', 'test')
+
+      expect(window.GOVUK.setCookie).toHaveBeenCalledWith('seen_cookie_message', 'test', { days: 30 })
+    })
+
+    it('sets the expiry if one is provided', function() {
+      expect(window.GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
+
+      window.GOVUK.cookie('seen_cookie_message', 'test', { days: 100 })
+
+      expect(window.GOVUK.setCookie).toHaveBeenCalledWith('seen_cookie_message', 'test', { days: 100 })
     })
 
     it('can change the value of an existing cookie', function() {
@@ -59,6 +77,7 @@ describe('Cookie helper functions', function () {
 
       window.GOVUK.setDefaultConsentCookie()
 
+      expect(window.GOVUK.setCookie).toHaveBeenCalledWith('cookie_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}', Object({ days: 365 }));
       expect(window.GOVUK.getConsentCookie()).toEqual({'essential': true, 'settings': true, 'usage': true, 'campaigns': true})
     })
 
@@ -70,6 +89,7 @@ describe('Cookie helper functions', function () {
 
       window.GOVUK.approveAllCookieTypes()
 
+      expect(window.GOVUK.setCookie).toHaveBeenCalledWith('cookie_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}', Object({ days: 365 }));
       expect(window.GOVUK.getConsentCookie()).toEqual({'essential': true, 'settings': true, 'usage': true, 'campaigns': true})
     })
 
@@ -92,6 +112,7 @@ describe('Cookie helper functions', function () {
 
       window.GOVUK.setConsentCookie({'essential': false})
 
+      expect(window.GOVUK.setCookie).toHaveBeenCalledWith('cookie_policy', '{"essential":false,"settings":true,"usage":false,"campaigns":true}', Object({ days: 365 }));
       expect(window.GOVUK.getConsentCookie().essential).toBe(false)
       expect(window.GOVUK.cookie('seen_cookie_message')).toBeFalsy()
     })


### PR DESCRIPTION
We added logic in #940 which:

- Set the default expiry of cookies to 30 days, if not explicitly provided. This is because we were caught out by the expiry not being set and ending up with a session cookie instead.
- Set the expiry of the consent cookie to 1 year
- Set the expiry of seen_cookie_message to 1 year, to match the consent cookie

The above change was urgent and we didn't have time to write tests. This PR adds tests for that logic.
