### PR TITLE
Increase inline button desktop spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Increase spacing between inline buttons on desktop (PR #946)
+
 ## 17.4.0
 
 * Add inverse option to contextual breadcrumbs (PR #943)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -32,6 +32,7 @@ $gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
     display: inline-block;
     width: auto;
     vertical-align: baseline;
+    margin-right: govuk-spacing(2);
   }
 }
 


### PR DESCRIPTION
## What
Inline buttons did not have any explicit spacing set between them. The only small spacing that appeared was down to (potentially) HTML whitespace.

This sets a margin-right of 10px on inline buttons, forcing the spacing to increase on desktop.
Mobile spacing should remain unchanged.

## Why
The spacing between the inline buttons used on the new cookie banner was too small.

## Before
<img width="281" alt="Screen Shot 2019-06-20 at 14 29 40" src="https://user-images.githubusercontent.com/29889908/59852978-db335600-9367-11e9-9181-61fae8c690af.png">

## After
<img width="289" alt="Screen Shot 2019-06-20 at 14 29 26" src="https://user-images.githubusercontent.com/29889908/59852989-dec6dd00-9367-11e9-8822-2269e80f7c61.png">

**Link:** https://govuk-publishing-compon-pr-946.herokuapp.com/component-guide/cookie-banner