### PR TITLE
Hide 'Accept Cookies' button when Javascript not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix confirmation message being read to screenreaders (PR #952)
+* Hide 'Accept Cookies' button when Javascript not available (PR #948)
 
 ## 17.6.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -55,14 +55,16 @@ $govuk-cookie-banner-text-green: #00823b;
   width: 100%;
 
   @include govuk-media-query($from: mobile, $until: desktop) {
-    width: 49%;
-
     &.gem-c-cookie-banner__button-accept {
       float: left;
+      width: 49%;
     }
 
     &.gem-c-cookie-banner__button-settings {
-      float: right;
+      .js-enabled & {
+        float: right;
+        width: 49%;
+      }
     }
   }
 
@@ -72,6 +74,14 @@ $govuk-cookie-banner-text-green: #00823b;
 
   @include govuk-media-query($until: 455px) {
     width: 100%;
+  }
+}
+
+.gem-c-cookie-banner__button-accept {
+  display: none;
+
+  .js-enabled & {
+    display: inline-block;
   }
 }
 


### PR DESCRIPTION
## What
Hide the "Accept Cookies" button in the cookie banner when Javascript is not available

This change ties in with https://github.com/alphagov/frontend/pull/1881

## Why
At the moment, when Javascript is not enabled the cookie banner looks no different. However, the 'Accept Cookies' button does not work without Javascript - our cookie consent mechanism is based on Javascript at the moment. We therefore want to hide the "Accept Cookies" button. Users can still click "Cookie Settings" to go to `/help/cookies` and get more information.

## Visual Changes
![no-js](https://user-images.githubusercontent.com/29889908/59923127-84db1b80-942a-11e9-9dbb-59123b08ed40.gif)