### PR TITLE
Improve accessibility of the cookie banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add landmark to cookie banner (PR #949)
+* Cookie banner confirmation message is read automatically to screenreaders (PR #949)
+
 ## 17.5.0
 
 * Increase spacing between inline buttons on desktop (PR #946)

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -95,6 +95,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   CookieBanner.prototype.setCookieConsent = function () {
     window.GOVUK.approveAllCookieTypes()
     this.$module.showConfirmationMessage()
+    document.querySelector('.gem-c-cookie-banner__confirmation').focus()
     window.GOVUK.cookie('seen_cookie_message', 'true', { days: 365 })
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -11,6 +11,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.setCookieConsent = this.setCookieConsent.bind(this)
 
     this.$module.newCookieBanner = document.querySelector('.gem-c-cookie-banner--new')
+    this.$module.cookieBannerConfirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
 
     // Temporary check while we have 2 banners co-existing.
     // Once the new banner has been deployed, we will be able to remove code relating to the old banner
@@ -62,10 +63,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   CookieBanner.prototype.showNewCookieMessage = function () {
-    var newCookieBanner = document.querySelector('.gem-c-cookie-banner--new')
-
     // Hide the cookie banner on the cookie settings page, to avoid circular journeys
-    if (newCookieBanner && window.location.pathname === '/help/cookies') {
+    if (this.$module.newCookieBanner && window.location.pathname === '/help/cookies') {
       this.$module.style.display = 'none'
     } else {
       var shouldHaveCookieMessage = (this.$module && window.GOVUK.cookie('seen_cookie_message') !== 'true')
@@ -95,16 +94,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   CookieBanner.prototype.setCookieConsent = function () {
     window.GOVUK.approveAllCookieTypes()
     this.$module.showConfirmationMessage()
-    document.querySelector('.gem-c-cookie-banner__confirmation').focus()
+    this.$module.cookieBannerConfirmationMessage.focus()
     window.GOVUK.cookie('seen_cookie_message', 'true', { days: 365 })
   }
 
   CookieBanner.prototype.showConfirmationMessage = function () {
     this.$cookieBannerMainContent = document.querySelector('.gem-c-cookie-banner__wrapper')
-    this.$cookieBannerConfirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
 
     this.$cookieBannerMainContent.style.display = 'none'
-    this.$cookieBannerConfirmationMessage.style.display = 'block'
+    this.$module.cookieBannerConfirmationMessage.style.display = 'block'
   }
 
   Modules.CookieBanner = CookieBanner

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -45,7 +45,7 @@
   </div>
 
   <% if new_cookie_banner %>
-    <div class="gem-c-cookie-banner__confirmation govuk-width-container">
+    <div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1">
       <p class="gem-c-cookie-banner__confirmation-message">
         You&#8217;ve accepted all cookies. You can <a class="govuk-link" href="/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.
       </p>

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -9,7 +9,7 @@
   message = cookie_banner_helper.message
 %>
 
-<div id="<%= id %>" class="<%= cookie_banner_class %>" data-module="cookie-banner" aria-live="polite">
+<div id="<%= id %>" class="<%= cookie_banner_class %>" data-module="cookie-banner" aria-live="polite" role="region" aria-label="cookie banner">
   <div class="gem-c-cookie-banner__wrapper govuk-width-container">
     <p class="gem-c-cookie-banner__message"><%= message %></p>
     <% if new_cookie_banner %>


### PR DESCRIPTION
## What
- Adding `role="region"` and `aria-label="cookie banner"` to the cookie banner.
- Switching focus to the cookie banner confirmation message automatically once a user has clicked "Accept Cookies", to enable the confirmation message to be read automatically to screen-readers.

## Why
**Adding `role=region` and `aria-label=cookie banner`:** When running our [accessibility review](https://trello.com/c/X7EnjPLR/192-accessibility-review), we had a warning about the cookie banner not being included in any landmark region. This meant that a user navigating the page by landmark would miss the cookie banner. 

Note: Other landmark roles didn't seem to fit this use case, so I've gone for a generic 'region' with aria-label, but happy to take other suggestions!

**Confirmation message**: without this change, a screen-reader user clicking on "Accept cookies" would have no automatic feedback of anything happening.

## Before (landmarks on GOV.UK homepage)
<img width="418" alt="Screen Shot 2019-06-24 at 11 27 22" src="https://user-images.githubusercontent.com/29889908/60012309-88adae80-9673-11e9-9a37-dcc438f6ce9b.png">

## After (landmarks on GOV.UK homepage)
<img width="421" alt="Screen Shot 2019-06-24 at 11 28 25" src="https://user-images.githubusercontent.com/29889908/60012315-8d726280-9673-11e9-981e-682098dc7ce2.png">