### PR TITLE
Fix cookie confirmation for screenreaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix confirmation message being read to screenreaders (PR #952)
+
 ## 17.6.0
 
 * Add landmark to cookie banner (PR #949)

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -9,7 +9,7 @@
   message = cookie_banner_helper.message
 %>
 
-<div id="<%= id %>" class="<%= cookie_banner_class %>" data-module="cookie-banner" aria-live="polite" role="region" aria-label="cookie banner">
+<div id="<%= id %>" class="<%= cookie_banner_class %>" data-module="cookie-banner" role="region" aria-label="cookie banner">
   <div class="gem-c-cookie-banner__wrapper govuk-width-container">
     <p class="gem-c-cookie-banner__message"><%= message %></p>
     <% if new_cookie_banner %>


### PR DESCRIPTION
## What
Removes `aria-live="polite"` as we are now explicitly setting focus on the confirmation message after accepting cookies (done in https://github.com/alphagov/govuk_publishing_components/pull/949).

## Why
The combination of `aria-live="polite"` and `aria-label="cookie banner"` doesn't seem to work well together - instead of announcing the confirmation message when accepting cookies, it read out the aria-label instead.
