### PR TITLE
Add an inverse mode for the phase banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unpublished
+
+* Add an inverse flag to the phase banner
+
 ## 17.6.1
+
 * Fix confirmation message being read to screenreaders (PR #952)
 * Hide 'Accept Cookies' button when Javascript not available (PR #948)
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_phase-banner.scss
@@ -6,3 +6,22 @@
     margin-right: govuk-spacing(2);
   }
 }
+
+.gem-c-phase-banner--inverse {
+  background: $govuk-brand-colour;
+
+  .govuk-phase-banner__content__tag {
+    background: govuk-colour("white");
+    color: $govuk-brand-colour;
+  }
+
+  .govuk-phase-banner__content__app-name,
+  .govuk-phase-banner__text,
+  .govuk-link {
+    color: govuk-colour("white");
+
+    &:focus {
+      color: govuk-colour("black");
+    }
+  }
+}

--- a/app/views/govuk_publishing_components/components/_phase_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_phase_banner.html.erb
@@ -1,7 +1,8 @@
 <%
 app_name ||= nil
 phase ||= nil
-message ||= nil 
+message ||= nil
+inverse ||= false
 
 unless phase.in?(%w[alpha beta])
   raise ArgumentError, "The phase banner component expects a `phase` (`beta` or `alpha`), #{phase.inspect} given"
@@ -9,14 +10,17 @@ end
 
 unless message.present?
   if phase == "beta"
-    message = raw("This part of GOV.UK is being rebuilt &ndash; <a href=\"/help/beta\">find out what beta means</a>")
+    message = raw("This part of GOV.UK is being rebuilt &ndash; <a class=\"govuk-link\" href=\"/help/beta\">find out what beta means</a>")
   elsif phase == "alpha"
-    message = raw("This part of GOV.UK is being built &ndash; <a href=\"/service-manual/phases/ideal-alphas\">find out what alpha means</a>")
+    message = raw("This part of GOV.UK is being built &ndash; <a class=\"govuk-link\" href=\"/service-manual/phases/ideal-alphas\">find out what alpha means</a>")
   end
-end 
+end
+
+container_css_classes = %w(gem-c-phase-banner govuk-phase-banner)
+container_css_classes << "gem-c-phase-banner--inverse" if inverse
 %>
 
-<%= tag.div class: "gem-c-phase-banner govuk-phase-banner" do %>
+<%= tag.div class: container_css_classes do %>
   <%= tag.p class: "govuk-phase-banner__content" do %>
     <%= tag.strong app_name, class: "govuk-phase-banner__content__app-name" if app_name %>
     <%= tag.strong phase, class: "govuk-tag govuk-phase-banner__content__tag" %>

--- a/app/views/govuk_publishing_components/components/docs/phase_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/phase_banner.yml
@@ -18,8 +18,17 @@ examples:
     data:
       phase: beta
       message: This is an optional different message to explain what the state means in this
-        context which can take <a href='https://www.gov.uk'>HTML</a>
+        context which can take <a class="govuk-link" href='https://www.gov.uk'>HTML</a>
   with_app_name:
     data:
       app_name: Skittles Maker
       phase: beta
+  inverse_for_blue_background:
+    data:
+      phase: beta
+      inverse: true
+  inverse_for_blue_background_with_app_name:
+    data:
+      app_name: Skittles Maker
+      phase: beta
+      inverse: true

--- a/spec/components/phase_banner_spec.rb
+++ b/spec/components/phase_banner_spec.rb
@@ -47,4 +47,9 @@ describe "Phase banner", type: :view do
     assert_select ".govuk-phase-banner__content__app-name", text: "Skittles Maker"
     assert_select ".govuk-phase-banner__content__tag", text: "beta"
   end
+
+  it "correctly uses inverse mode " do
+    render_component(phase: "beta", inverse: true)
+    assert_select ".gem-c-phase-banner--inverse"
+  end
 end


### PR DESCRIPTION
## What
This adds an inverse mode to the phase banner so it can be used on a blue background.

## Why
The phase banner could be displayed over a blue background in an upcoming update to the topic finders ([finder-frontend#1204](https://github.com/alphagov/finder-frontend/pull/1204)). A `inverse` flag has been added that makes the phase banner legible when placed on a blue background.
