### PR TITLE
Fix conventions link

### DIFF
--- a/docs/component_principles.md
+++ b/docs/component_principles.md
@@ -8,7 +8,7 @@ A component is a package comprised of template, style, behaviour and documentati
 
 * is accessible
 * is documented
-* [follows convention](component_conventions.md)
+* [follows convention](/docs/component_conventions.md)
 * is isolated
 * is tested
 * can be translated

--- a/docs/generate-a-new-component.md
+++ b/docs/generate-a-new-component.md
@@ -14,7 +14,7 @@ This will create a template, scss file and yml documentation file for a new comp
 
 ## Option 2: create a component in the gem
 
-Currently components in the gem must be manually created. File naming conventions should follow those in the [component conventions](docs/component_conventions.md), but a slightly different directory structure is required to avoid conflicts with components in applications.
+Currently components in the gem must be manually created. File naming conventions should follow those in the [component conventions](/docs/component_conventions.md), but a slightly different directory structure is required to avoid conflicts with components in applications.
 
 * Stylesheets go in `app/assets/stylesheets/govuk_publishing_components/components`
 * Print stylesheets go in `app/assets/stylesheets/govuk_publishing_components/components/print`

--- a/docs/publishing-to-rubygems.md
+++ b/docs/publishing-to-rubygems.md
@@ -5,7 +5,7 @@ Before publishing a new version [check the open and approved pull requests](http
 1. Checkout **master** and pull latest changes.
 
 2. Create and checkout a new branch (`release-[version-number]`).
-  The version number is determined by looking at the [current "Unreleased" changes in CHANGELOG](../CHANGELOG.md) and updating the previous release number depending on the kind of entries:
+  The version number is determined by looking at the [current "Unreleased" changes in CHANGELOG](/CHANGELOG.md) and updating the previous release number depending on the kind of entries:
 
   - `Breaking changes` corresponds to a `major` (1.X.X) change.
   - `New features` corresponds to a `minor` (X.1.X) change.
@@ -15,16 +15,16 @@ Before publishing a new version [check the open and approved pull requests](http
 
   See [Semantic Versioning](https://semver.org/) for more information.
 
-3. Update [`CHANGELOG.md`](../CHANGELOG.md) "Unreleased" heading with the new version number and [review the latest commits](https://github.com/alphagov/govuk_publishing_components/commits/master) to make sure the latest changes are correctly reflected in the [CHANGELOG]((../CHANGELOG.md)).
+3. Update [`CHANGELOG.md`](/CHANGELOG.md) "Unreleased" heading with the new version number and [review the latest commits](https://github.com/alphagov/govuk_publishing_components/commits/master) to make sure the latest changes are correctly reflected in the [CHANGELOG]((/CHANGELOG.md)).
 
-4. Update [`lib/govuk_publishing_components/version.rb`](../lib/govuk_publishing_components/version.rb) version with the new version number.
+4. Update [`lib/govuk_publishing_components/version.rb`](/lib/govuk_publishing_components/version.rb) version with the new version number.
 
 5. Run `bundle install && npm install` to ensure you have the latest dependencies installed.
 
 6. Commit changes. These should include updates in the following files:
-  - [`CHANGELOG.md`](../CHANGELOG.md)
-  - [`lib/govuk_publishing_components/version.rb`](../lib/govuk_publishing_components/version.rb)
-  - [`Gemfile.lock`](../Gemfile.lock)
+  - [`CHANGELOG.md`](/CHANGELOG.md)
+  - [`lib/govuk_publishing_components/version.rb`](/lib/govuk_publishing_components/version.rb)
+  - [`Gemfile.lock`](/Gemfile.lock)
 
 7. Create a pull request and copy the changelog text for the current version in the pull request description.
 


### PR DESCRIPTION
## What
Fix component conventions link in [`generate-a-new-component.md`](https://github.com/alphagov/govuk_publishing_components/blob/fix-conventions-link/docs/generate-a-new-component.md)
Update md paths to be absolute so we're not affected by the folder structure

## Why
Make sure we don't have broken links in our docs

## Visual Changes
No visual changes
