### PR TITLE
Stop the hardcoding of a google client ID in the feedback footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Stop the hardcoding of a google client ID in the feedback footer (PR #957)
+
 ## 17.10.0
 
 * Enable data attributes for table header links (PR #962)

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -20,6 +20,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.$promptQuestions = $element.find('.js-prompt-questions')
       this.$promptSuccessMessage = $element.find('.js-prompt-success')
       this.$somethingIsWrongForm = $element.find('#something-is-wrong')
+      this.$surveyForm = $element.find('#page-is-not-useful')
+      this.$surveyWrapper = $element.find('#survey-wrapper')
 
       var that = this
       var jshiddenClass = 'js-hidden'
@@ -47,6 +49,17 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         trackEvent(getTrackEventParams(that.$pageIsUsefulButton))
         showFormSuccess()
         revealInitialPrompt()
+      })
+
+      this.$pageIsNotUsefulButton.on('click', function (e) {
+        var gaClientId
+        var dummyGaClientId = '111111111.1111111111'
+        if (window.GOVUK.cookie('_ga') === null || window.GOVUK.cookie('_ga') === '') {
+          gaClientId = dummyGaClientId
+        } else {
+          gaClientId = window.GOVUK.cookie('_ga').split('.').slice(-2).join('.')
+        }
+        setHiddenValuesNotUsefulForm(gaClientId)
       })
 
       $element.find('form').on('submit', function (e) {
@@ -88,6 +101,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       function setHiddenValues () {
         that.$somethingIsWrongForm.append('<input type="hidden" name="javascript_enabled" value="true"/>')
         that.$somethingIsWrongForm.append($('<input type="hidden" name="referrer">').val(document.referrer || 'unknown'))
+      }
+
+      function setHiddenValuesNotUsefulForm (gaClientId) {
+        var currentPathName = window.location.pathname.replace(/[^\s=?&]+(?:@|%40)[^\s=?&]+/, '[email]')
+        var finalPathName = encodeURI(currentPathName)
+
+        that.$surveyForm.append($('<input name="email_survey_signup[ga_client_id]" type="hidden">').val(gaClientId || '0'))
+        that.$surveyWrapper.append('<a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=' + finalPathName + '&amp;gcl=' + gaClientId + '" class="gem-c-feedback__email-link govuk-link" id="take-survey" target="_blank" rel="noopener noreferrer">Don’t have an email address?</a>')
       }
 
       function updateAriaAttributes (linkClicked) {

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -14,5 +14,5 @@
 <div class="gem-c-feedback <%= margin_top_class %>" data-module="feedback">
   <%= render "govuk_publishing_components/components/feedback/yes_no_banner" %>
   <%= render "govuk_publishing_components/components/feedback/problem_form", url_without_pii: url_without_pii %>
-  <%= render "govuk_publishing_components/components/feedback/survey_signup_form", path_without_pii: path_without_pii %>
+  <%= render "govuk_publishing_components/components/feedback/survey_signup_form"%>
 </div>

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -13,12 +13,10 @@
     role="button">Close</a>
 
   <div class="gem-c-feedback__grid-row">
-    <div class="gem-c-feedback__column-two-thirds">
+    <div class="gem-c-feedback__column-two-thirds" id="survey-wrapper">
       <div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>
 
       <input name="email_survey_signup[survey_id]" type="hidden" value="footer_satisfaction_survey">
-      <input name="email_survey_signup[survey_source]" type="hidden" value="<%= path_without_pii %>">
-      <input name="email_survey_signup[ga_client_id]" type="hidden" value="1627485790.1515403243">
 
       <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
       <p id="survey_explanation" class="gem-c-feedback__form-paragraph">To help us improve GOV.UK, we’d like to know more about your visit today. We’ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don’t worry we won’t send you spam or share your email address with anyone.</p>
@@ -34,9 +32,8 @@
       } %>
 
       <%= render "govuk_publishing_components/components/button", {
-        text: "Send me the survey"
+        text: "Send me the survey",
       } %>
-      <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=<%= path_without_pii %>&amp;gcl=1627485790.1515403243" class="gem-c-feedback__email-link govuk-link" id="take-survey" target="_blank" rel="noopener noreferrer">Don’t have an email address?</a>
     </div>
   </div>
 </form>

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -18,7 +18,7 @@ describe("Feedback component", function () {
         '<a href="#" class="gem-c-feedback__close js-close-form" aria-controls="something-is-wrong" aria-expanded="true" data-track-category="Onsite Feedback" data-track-action="GOV.UK Close Form">Close</a>' +
 
         '<div class="grid-row">' +
-          '<div class="column-two-thirds">' +
+          '<div class="column-two-thirds" id="survey-wrapper">' +
             '<div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>' +
 
             '<input type="hidden" name="url" value="http://example.com/path/to/page">' +
@@ -63,7 +63,6 @@ describe("Feedback component", function () {
             '<input class="gem-c-input " id="input-111111" name="email_survey_signup[email_address]" type="text">' +
 
             '<input class="gem-c-feedback__submit" type="submit" value="Send me the survey">' +
-            '<a href="FIXME" class="">Don\'t have an email address?</a>' +
           '</div>' +
         '</div>' +
       '</form>' +
@@ -104,6 +103,27 @@ describe("Feedback component", function () {
     loadFeedbackComponent();
 
     expect($('#something-is-wrong').find("[name=referrer]").val()).toBe("unknown");
+  });
+
+  it("should append a hidden 'ga_client_id' field to the form with the appropriate value", function() {
+    loadFeedbackComponent();
+    window.GOVUK.setCookie('_ga', 'GA1.3.512324446.1561716924', {})
+    $('.js-page-is-not-useful').click();
+    expect($('#page-is-not-useful').find("[name='email_survey_signup[ga_client_id]']").val()).toBe("512324446.1561716924");
+  });
+
+  it("should append a hidden 'ga_client_id' field to the from with a default value if no client id is present", function() {
+    loadFeedbackComponent();
+    window.GOVUK.setCookie('_ga', '', {})
+    $('.js-page-is-not-useful').click();
+    expect($('#page-is-not-useful').find("[name='email_survey_signup[ga_client_id]']").val()).toBe("111111111.1111111111");
+  });
+
+  it("should append the \'Don’t have an email address?\' link at the bottom of the form", function(){
+    loadFeedbackComponent();
+    $('.js-page-is-not-useful').click();
+
+    expect($('#survey-wrapper').find('#take-survey').length).toBe(1);
   });
 
   describe("clicking the 'page was useful' link", function () {
@@ -460,6 +480,7 @@ describe("Feedback component", function () {
     });
 
     it("submits the feedback to the feedback frontend", function () {
+      window.GOVUK.setCookie('_ga', '', {})
       loadFeedbackComponent();
       fillAndSubmitPageIsNotUsefulForm();
 
@@ -467,7 +488,8 @@ describe("Feedback component", function () {
       expect(request.url).toBe('/contact/govuk/email-survey-signup');
       expect(request.method).toBe('POST');
       expect(request.data()).toEqual({
-        'email_survey_signup[email_address]': ["test@test.com"]
+        'email_survey_signup[email_address]': ["test@test.com"],
+        'email_survey_signup[ga_client_id]': ['111111111.1111111111']
       });
     });
 


### PR DESCRIPTION
## What
Stop hardcoding a GA Client ID

## Why
As it stands the hardcoding of a google client id in the feedback footer is making it impossible to link feedback data to GA.

## Visual Changes
No changes. The only thing that this could have changed would be the no email survey link but I've checked to make sure that it won't. 