### PR TITLE
Use shared_helper for heading margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use shared_helper for heading margin (PR #958)
+
 ## 17.8.0
 
 * Remove old cookie banner code and new_cookie_banner flag (PR #959)
 
 ## 17.7.0
 
-* Add an inverse flag to the phase banner
+* Add an inverse flag to the phase banner (PR #954)
 
 ## 17.6.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
@@ -28,21 +28,6 @@
   padding: govuk-spacing(3) 0;
 }
 
-// margins would ideally be handled by a general model for all components
-// but we don't have one yet, so this is in anticipation of that
-// suggested scale is as follows, not fully implemented
-// govuk-spacing(6)= 4
-// govuk-spacing(4) = 3
-// govuk-spacing(3) = 2
-// govuk-spacing(2) = 1
-.gem-c-heading--margin-bottom-4 {
-  margin-bottom: govuk-spacing(6);
-}
-
-.gem-c-heading--margin-bottom-2 {
-  margin-bottom: govuk-spacing(3);
-}
-
 // border color will default to black
 // can be changed using the branding functionality
 .gem-c-heading--border-top-1 {

--- a/app/views/govuk_publishing_components/components/_heading.html.erb
+++ b/app/views/govuk_publishing_components/components/_heading.html.erb
@@ -3,8 +3,14 @@
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
   heading_helper = GovukPublishingComponents::Presenters::HeadingHelper.new(local_assigns)
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+
+  classes = %w(gem-c-heading)
+  classes << heading_helper.classes
+  classes << brand_helper.brand_class
+  classes << brand_helper.border_color_class
+  classes << (shared_helper.get_margin_bottom) if [*0..9].include?(local_assigns[:margin_bottom])
 %>
 <%= content_tag(shared_helper.get_heading_level, text,
-    class: "gem-c-heading #{heading_helper.classes} #{brand_helper.brand_class} #{brand_helper.border_color_class}",
+    class: classes,
     id: heading_helper.id
 ) %>

--- a/app/views/govuk_publishing_components/components/docs/heading.yml
+++ b/app/views/govuk_publishing_components/components/docs/heading.yml
@@ -43,13 +43,10 @@ examples:
       text: 'Padded'
       padding: true
   with_margin:
-    description: |
-      Configurable bottom margin for the component. This has been built in anticipation of being compatible with a theoretical future model for component margins.
-
-      Accepted parameters for this option are 2 (gives a margin of gutter-half) and 4 (gutter). See the Sass file for more detail.
+    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](http://govuk-frontend-review.herokuapp.com/docs/#settings/spacing-variable-govuk-spacing-points). It defaults to having no margin bottom.
     data:
       text: 'Really big bottom margin'
-      margin_bottom: 4
+      margin_bottom: 9
   with_mobile_top_margin:
     description: |
       On publications and consultations the layout of the page requires that the heading component have spacing above it on mobile. Since this is a specific use case, this is now an option on the component rather than the default behaviour.

--- a/lib/govuk_publishing_components/presenters/heading_helper.rb
+++ b/lib/govuk_publishing_components/presenters/heading_helper.rb
@@ -10,7 +10,6 @@ module GovukPublishingComponents
         @classes << " gem-c-heading--font-size-#{options[:font_size]}" if [24, 19].include? options[:font_size]
         @classes << " gem-c-heading--mobile-top-margin" if options[:mobile_top_margin]
         @classes << " gem-c-heading--padding" if options[:padding]
-        @classes << " gem-c-heading--margin-bottom-#{options[:margin_bottom]}" if [2, 4].include? options[:margin_bottom]
         @classes << " gem-c-heading--border-top-#{options[:border_top]}" if [1, 2, 5].include? options[:border_top]
       end
     end

--- a/spec/components/heading_spec.rb
+++ b/spec/components/heading_spec.rb
@@ -46,14 +46,19 @@ describe "Heading", type: :view do
     assert_select ".gem-c-heading.gem-c-heading--padding"
   end
 
-  it "adds margin 2" do
-    render_component(text: 'Margin 2', margin_bottom: 2)
-    assert_select ".gem-c-heading.gem-c-heading--margin-bottom-2"
+  it "adds margin" do
+    render_component(text: 'Margin 7', margin_bottom: 7)
+    assert_select '.gem-c-heading.govuk-\!-margin-bottom-7'
   end
 
-  it "adds margin 4" do
-    render_component(text: 'Margin 4', margin_bottom: 4)
-    assert_select ".gem-c-heading.gem-c-heading--margin-bottom-4"
+  it "defaults to no bottom margin if an incorrect value is passed" do
+    render_component(text: 'Margin wat', margin_bottom: 20)
+    assert_select "[class='^=govuk-\!-margin-bottom-']", false
+  end
+
+  it "has no margin class added by default" do
+    render_component(text: 'No margin')
+    assert_select "[class='^=govuk-\!-margin-bottom-']", false
   end
 
   it "adds border 1" do


### PR DESCRIPTION
**This change must not be merged until other PRs are raised to account for the sort-of-but-not-really breaking change that this PR represents. Turns out it's only a problem in collections, have [raised a PR ready for this change](https://github.com/alphagov/collections/pull/1160).**

## What

- component previously used a custom scale to provide a variable bottom margin
- replacing this with the now-standard shared_helper way of doing this
- default options remain the same so there is no visual change in the component
- since the numbers in the two scales are different this will mean updating any instance of the component where a specific margin is called

## Why

This change is being done to remove redundant code and standardise how margin bottom is added to components.

## Visual Changes

No visual changes, but some PRs in other applications will need to be raised as the new spacing scale uses different numbers from the old one. Worst case scenario - a heading will have slightly less bottom margin than it had before (previously accepted options were 2 (gutter-half or 15px) and 4 (gutter or 30px), which will now correspond to gutter-one-third (10px) and gutter-two-thirds (20px), respectively).

Note to self:

- change 4 to 6
- change 2 to 3
