### PR TITLE
Version 17.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 17.9.0
 
 * Use shared_helper for heading margin (PR #958)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (17.8.0)
+    govuk_publishing_components (17.9.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '17.8.0'.freeze
+  VERSION = '17.9.0'.freeze
 end


### PR DESCRIPTION
* Use shared_helper for heading margin (PR #958) - slightly breaking change for collections, but there's a [PR in place to deal with it](https://github.com/alphagov/collections/pull/1160).