### PR TITLE
Update experimental statements

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -3,7 +3,8 @@ description: The accordion component lets users show and hide sections of relate
 govuk_frontend_components:
   - accordion
 body: |
-  This component is based on the [design system accordion component](https://design-system.service.gov.uk/components/accordion/) and is currently experimental. If using this component, please feed back any research findings to the design team.
+  This component is based on the [design system accordion component](https://design-system.service.gov.uk/components/accordion/)
+  and is currently experimental. If using this component, please feed back any research findings to the Design System team.
 
 accessibility_criteria: |
   The accordion must:

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -1,4 +1,4 @@
-name: Layout footer (experimental)
+name: Layout footer
 description: The footer provides copyright, licensing and other information
 govuk_frontend_components:
   - footer

--- a/app/views/govuk_publishing_components/components/docs/layout_for_admin.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_admin.yml
@@ -1,24 +1,11 @@
-name: Admin layout (experimental)
+name: Admin layout
 description: A layout to be used by admin applications
 body: |
-  This component is experimental. Breaking changes are likely and we'll not release
-  major version of the gem for these changes. Typically you'll use this together
-  with the [layout header component](/component-guide/layout_header) and the
+  Typically you'll use this together with the
+  [layout header component](/component-guide/layout_header) and the
   [layout footer component](/component-guide/layout_footer).
 
   Because it is an entire HTML document, this component can only be [previewed on a separate page](/admin).
-
-  Inside this component you can use a number of classes provided by govuk-frontend:
-
-  - [Typography classes](https://design-system.service.gov.uk/styles/typography/) like `.govuk-link`, `.govuk-heading`
-  - [Layout grid classes](https://design-system.service.gov.uk/styles/layout/) like `.govuk-grid-column-two-thirds`
-  - [Spacing classes](https://design-system.service.gov.uk/styles/spacing/) like `.govuk-!-margin-bottom-3`
-  - [List classes](https://design-system.service.gov.uk/styles/typography/#lists) like `.govuk-list` and `.govuk-list--bullet`
-  - [Section break classes](https://design-system.service.gov.uk/styles/typography/#section-break) like `.govuk-section-break`
-  - The `.govuk-visually-hidden` class to hide things
-
-  Be *very* careful when using one of these classes, prefer to use a component
-  instead of consuming govuk-frontend directly.
 
 display_preview: false
 display_html: true

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -1,4 +1,4 @@
-name: Layout header (experimental)
+name: Layout header
 description: The header provides the crown logo, product or service name and navigation
 body: |
   Requires the specification of the environment (development, integration,

--- a/app/views/govuk_publishing_components/components/docs/modal_dialogue.yml
+++ b/app/views/govuk_publishing_components/components/docs/modal_dialogue.yml
@@ -3,9 +3,9 @@ description: Shows only one section, with no other navigation options, until the
 body: |
   Use where the application has gotten into a state from which it shouldn’t or can’t proceed without input from the user or the state of the current page needs to be preserved.
 
-  In a document-centric application, for instance, adding an inline image might need the user to supply an image file, alternative text, caption and credits if not using an existing image. In other context, the user may need to search for a specific item before proceeding.
-
   Modal instances are automatically initialised and their state can be changed programmatically using bounded functions (e.g. `$modalDialogue.open()` and `$modalDialogue.close()`)
+
+  This component is currently experimental. If you are using it, please feed back any research findings to the Content Publisher team.
 accessibility_criteria: |
   The modal dialogue box must:
 

--- a/app/views/govuk_publishing_components/components/docs/skip_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/skip_link.yml
@@ -1,4 +1,4 @@
-name: Skip link (experimental)
+name: Skip link
 description: Skip link component helps keyboard-only users skip to the main content on a page
 govuk_frontend_components:
   - skip-link

--- a/app/views/govuk_publishing_components/components/docs/tabs.yml
+++ b/app/views/govuk_publishing_components/components/docs/tabs.yml
@@ -2,8 +2,7 @@ name: "Tabs (experimental)"
 description: "The tabs component lets users toggle between related sections of content."
 body: |
   This component is based on the [design system tabs component](https://design-system.service.gov.uk/components/tabs/)
-  and is currently experimental. If using this component, please feed back any research findings to the
-  design team.
+  and is currently experimental. If using this component, please feed back any research findings to the Design System team.
 
   The tabs component lets users navigate between related sections of content on a single page,
   displaying one section at a time. Note that they are not intended to be used to navigate

--- a/docs/develop-component.md
+++ b/docs/develop-component.md
@@ -1,5 +1,8 @@
 # Develop a component
 
+Developing a new component should come from a user need identified by at least one team while developing an application.
+Make sure you test new components with users and you mark them as experimental (add `(experimental)` after the component name in the documentation file) until you collect enough feedback to be confident it could be used across applications.
+
 ## Read first
 
 A component must:


### PR DESCRIPTION
## What
- Update documentation around 'experimental' tag
- Remove experimental tag for header, footer, skip link and admin layout (as they have been used by Content Publisher and Content Data for a year now, have been tested with users and been through rounds of user research)
- Align descriptions for experimental components

## Why
Keep the experimental tags up to date.

## Visual Changes
No visual changes.
