### PR TITLE
Update image-card to use govuk-frontend

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -1,22 +1,23 @@
 .gem-c-image-card {
-  // if this extends grid-row a margin-bottom can't
-  // be applied as the extend overrides it
-  @extend %contain-floats;
-  margin: 0 (-$gutter-half) $gutter (-$gutter-half);
-  position: relative;
+  @include govuk-clearfix;
   @include govuk-text-colour;
+
+  margin: 0 (- govuk-spacing(3)) govuk-spacing(6) (- govuk-spacing(3));
+  position: relative;
 }
 
 .gem-c-image-card__image-wrapper {
-  @include grid-column(1 / 3, mobile);
+  @include govuk-grid-column(one-third, $class: false, $at: mobile);
+  @include govuk-grid-column(full, $class: false, $at: tablet);
+
   margin: 0;
 
-  @include media(tablet) {
-    margin-bottom: $gutter-one-third;
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(2);
   }
 
   + .gem-c-image-card__text-wrapper {
-    @include media(mobile) {
+    @include govuk-media-query($until: tablet) {
       padding-left: 0;
     }
   }
@@ -28,11 +29,12 @@
 }
 
 .gem-c-image-card__text-wrapper {
-  @include grid-column(2 / 3, mobile);
+  @include govuk-grid-column(two-thirds, $class: false, $at: mobile);
+  @include govuk-grid-column(full, $class: false, $at: tablet);
 }
 
 .gem-c-image-card__title {
-  @include bold-19;
+  @include govuk-font(19, $weight: bold);
   margin: 0;
 }
 
@@ -52,8 +54,8 @@
     position: absolute;
     z-index: 1;
     top: 0;
-    left: $gutter-half;
-    right: $gutter-half;
+    left: govuk-spacing(3);
+    right: govuk-spacing(3);
     height: 100%;
     $ie-background: rgba(255, 255, 255, 0);
     background: $ie-background; // because internet explorer
@@ -69,18 +71,18 @@
 
 .gem-c-image-card__context,
 .gem-c-image-card__metadata {
-  @include core-14;
-  margin: 0 0 $gutter-one-quarter;
-  color: $grey-1;
+  @include govuk-font(14);
+  margin: 0 0 (govuk-spacing(3) / 2);
+  color: govuk-colour("grey-1");
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     margin-bottom: 0;
   }
 }
 
 .gem-c-image-card__description {
   @include govuk-font($size: 16);
-  padding-top: $gutter-one-quarter;
+  padding-top: (govuk-spacing(3) / 2);
   word-wrap: break-word;
 }
 
@@ -88,7 +90,7 @@
   @include govuk-font($size: 16);
   position: relative;
   z-index: 2;
-  padding: $gutter-one-quarter 0 0 0;
+  padding: (govuk-spacing(3) / 2) 0 0 0;
   margin: 0;
   list-style: none;
 
@@ -97,7 +99,7 @@
   }
 
   &.gem-c-image-card__list--indented {
-    padding-left: $gutter-half;
+    padding-left: govuk-spacing(3);
 
     .gem-c-image-card__list-item {
       position: relative;
@@ -105,50 +107,50 @@
       &:before {
         content: "-";
         position: absolute;
-        left: -$gutter-half;
+        left: (- govuk-spacing(3));
       }
     }
   }
 }
 
 .gem-c-image-card--large.gem-c-image-card {
-  margin: 0 0 30px 0;
+  margin: 0 0 govuk-spacing(6) 0;
 }
 
 .gem-c-image-card--large {
   .gem-c-image-card__image-wrapper {
-    padding: 0 $gutter-one-third 0 0;
-    margin: 0;
-    float: left;
-    max-width: 66.66%;
-  }
+    @include govuk-grid-column(two-thirds, $class: false, $at: tablet);
 
-  .gem-c-image-card__text-wrapper {
-    overflow: hidden;
-  }
+    margin-bottom: govuk-spacing(2);
+    float: none;
+    width: auto;
+    max-width: 100%;
+    padding: 0;
 
-  .gem-c-image-card__image-wrapper {
-    @include media(mobile) {
-      margin-bottom: $gutter-one-third;
-      padding: 0;
+    @include govuk-media-query($from: tablet) {
+      padding: 0 govuk-spacing(2) 0 0;
+      margin-bottom: 0;
     }
   }
 
-  .gem-c-image-card__image-wrapper,
   .gem-c-image-card__text-wrapper {
-    @include media(mobile) {
-      float: none;
-      width: auto;
-      max-width: 100%;
+    @include govuk-grid-column(one-third, $class: false, $at: tablet);
+
+    padding: 0;
+    overflow: hidden;
+
+    @include govuk-media-query($from: tablet) {
+      padding: 0 govuk-spacing(3);
+      margin-bottom: 0;
     }
   }
 
   .gem-c-image-card__title {
-    @include bold-24;
-    padding-bottom: $gutter-one-third;
+    @include govuk-font(24, $weight: bold);
+    padding-bottom: govuk-spacing(2);
   }
 
   .gem-c-image-card__description {
-    @include core-19;
+    @include govuk-font(19);
   }
 }

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -150,7 +150,7 @@ examples:
     data:
       large: true
       href: "/still-not-a-page"
-      image_src: "https://assets.publishing.service.gov.uk/frontend/homepage/leaving-the-eu-bc9992ee672a30d8e8a3e195c9afa750e618748130a4e073a593ba36dfc29af9.jpg"
+      image_src: "https://assets.publishing.service.gov.uk/frontend/homepage/uk-leaves-the-eu-d84d2981a9953d8b1261c9d25016223b0a8af3c096fa2d5e03510d73a78e3c60.jpg"
       image_alt: "some meaningful alt text please"
       context:
         date: 2017-06-14 11:30:00
@@ -204,4 +204,3 @@ examples:
         }
       ]
       extra_links_no_indent: true
-


### PR DESCRIPTION
## What
Update `image-card.scss` to use govuk-frontend mixins and variables and refactor code to be mobile first
Fix source path for [missing image](https://govuk-publishing-components.herokuapp.com/component-guide/image_card/large_version/preview).

## Why
To help [removing the dependency on the deprecated govuk_frontend_toolkit package](https://trello.com/c/ajPzDAOX).

## Visual Changes
No visual changes. Attached desktop and mobile diff (left is master, right is current branch)

### Desktop
![image-card-desktop](https://user-images.githubusercontent.com/788096/60672389-258afb80-9e6d-11e9-8ae4-a280a512e5f5.png)

### Mobile
![image-card-mobile](https://user-images.githubusercontent.com/788096/60672393-27ed5580-9e6d-11e9-9880-60f561ebddfb.png)
