### PR TITLE
Version 17.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 17.11.0
 
 * Stop the hardcoding of a google client ID in the feedback footer (PR #957)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (17.10.0)
+    govuk_publishing_components (17.11.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '17.10.0'.freeze
+  VERSION = '17.11.0'.freeze
 end


### PR DESCRIPTION
## 17.11.0

* Stop the hardcoding of a google client ID in the feedback footer (PR #957)
