### PR TITLE
[DO NOT MERGE] Change title margin option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove references to old `gem-c-cookie-banner--new` class (PR #972)
+* Change title margin option (PR #969)
 
 ## 17.11.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
@@ -1,21 +1,3 @@
-.gem-c-title {
-  @include responsive-top-margin;
-}
-
-// margins would ideally be handled by a general model for all components
-// but we don't have one yet, so this is in anticipation of that
-// suggested scale is as follows, not fully implemented
-// no margin = 0
-// govuk-spacing(6)= 4
-// responsive-bottom-margin = 5
-.gem-c-title--margin-bottom-4 {
-  margin-bottom: govuk-spacing(6);
-}
-
-.gem-c-title--margin-bottom-5 {
-  @include responsive-bottom-margin;
-}
-
 .gem-c-title--inverse {
   color: govuk-colour("white");
 

--- a/app/views/govuk_publishing_components/components/_title.html.erb
+++ b/app/views/govuk_publishing_components/components/_title.html.erb
@@ -6,12 +6,15 @@
   context_data = context.is_a?(Hash) ? context[:data] : false
 
   inverse ||= false
-  margin_bottom ||= 5
-  margin_bottom_class = "gem-c-title--margin-bottom-#{margin_bottom}" if [4, 5].include? margin_bottom
+  local_assigns[:margin_bottom] ||= 8
+
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+
+  classes = %w(gem-c-title govuk-!-margin-top-8)
+  classes << "gem-c-title--inverse" if inverse
+  classes << (shared_helper.get_margin_bottom)
 %>
-<div class="gem-c-title
-  <% if inverse %>gem-c-title--inverse<% end %>
-  <%= margin_bottom_class %>">
+<%= content_tag(:div, class: classes) do %>
   <% if context %>
     <p class="gem-c-title__context">
       <%= context_href ? link_to(context_text, context_href, class: 'gem-c-title__context-link', data: context_data) : context_text %>
@@ -20,4 +23,4 @@
   <h1 class="gem-c-title__text <% if average_title_length %>gem-c-title__text--<%= average_title_length %><% end %>">
     <%= title %>
   </h1>
-</div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/heading.yml
+++ b/app/views/govuk_publishing_components/components/docs/heading.yml
@@ -43,7 +43,7 @@ examples:
       text: 'Padded'
       padding: true
   with_margin:
-    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](http://govuk-frontend-review.herokuapp.com/docs/#settings/spacing-variable-govuk-spacing-points). It defaults to having no margin bottom.
+    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having no margin bottom.
     data:
       text: 'Really big bottom margin'
       margin_bottom: 9

--- a/app/views/govuk_publishing_components/components/docs/hint.yml
+++ b/app/views/govuk_publishing_components/components/docs/hint.yml
@@ -15,7 +15,7 @@ examples:
     data:
       text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
   with_margin_bottom:
-    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](http://govuk-frontend-review.herokuapp.com/docs/#settings/spacing-variable-govuk-spacing-points). It defaults to a margin bottom of 3 (15px).
+    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to a margin bottom of 3 (15px).
     data:
       text: "You qualify if you were born in the UK before June 1960."
       margin_bottom: 9

--- a/app/views/govuk_publishing_components/components/docs/subscription-links.yml
+++ b/app/views/govuk_publishing_components/components/docs/subscription-links.yml
@@ -20,7 +20,7 @@ examples:
       email_signup_link: '/foreign-travel-advice/singapore/email-signup'
       feed_link: '/foreign-travel-advice/singapore.atom'
   with_margin:
-    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](http://govuk-frontend-review.herokuapp.com/docs/#settings/spacing-variable-govuk-spacing-points). It defaults to having no margin bottom, although some margin is supplied by the links themselves (so that when they stack on mobile there is space between them).
+    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having no margin bottom, although some margin is supplied by the links themselves (so that when they stack on mobile there is space between them).
     data:
       email_signup_link: '/foreign-travel-advice/singapore/email-signup'
       feed_link: '/foreign-travel-advice/singapore.atom'

--- a/app/views/govuk_publishing_components/components/docs/textarea.yml
+++ b/app/views/govuk_publishing_components/components/docs/textarea.yml
@@ -21,7 +21,7 @@ examples:
         text: "Can you provide more detail?"
       name: "more-detail"
   with_margin_bottom:
-    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](http://govuk-frontend-review.herokuapp.com/docs/#settings/spacing-variable-govuk-spacing-points). It defaults to a margin bottom of 6 (30px).
+    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to a margin bottom of 6 (30px).
     data:
       margin_bottom: 9
       label:

--- a/app/views/govuk_publishing_components/components/docs/title.yml
+++ b/app/views/govuk_publishing_components/components/docs/title.yml
@@ -43,12 +43,12 @@ examples:
       average_title_length: long
   with_margin:
     description: |
-      Configurable bottom margin for the component. This has been built in anticipation of being compatible with a theoretical future model for component margins.
+      The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a margin bottom of 50px.
 
-      Accepted parameters for this option are 0 (no margin), 4 (gives a margin of gutter) and 5 ([responsive-margin](https://github.com/alphagov/govuk_publishing_components/blob/a325cbebf93def14a4f8d55e86426ea16b15f2ee/app/assets/stylesheets/govuk_publishing_components/components/mixins/_margins.scss#L1), which is also the default). See the Sass file for more detail.
+      This margin is responsive at certain sizes, see the link above for more detail. Note also that the component has a (responsive) top margin set as well, which cannot be modified.
     data:
-      title: 'Margin bottom of 30px'
-      margin_bottom: 4
+      title: 'Margin bottom of 10px'
+      margin_bottom: 2
   in_html_publication:
     description: Page titles are used in HTML Publications ([see example](https://www.gov.uk/government/publications/fees-for-civil-and-family-courts/court-fees-for-the-high-court-county-court-and-family-court))
     data:

--- a/spec/components/title_spec.rb
+++ b/spec/components/title_spec.rb
@@ -36,19 +36,23 @@ describe "Title", type: :view do
     assert_select ".gem-c-title--inverse", text: "Hello World"
   end
 
+  it "has a default margin of 8" do
+    render_component(title: 'Margin default')
+    assert_select '.gem-c-title.govuk-\!-margin-bottom-8'
+  end
+
   it "adds margin 0" do
     render_component(title: 'Margin 0', margin_bottom: 0)
-    assert_select ".gem-c-title.gem-c-title--margin-bottom-4", false
-    assert_select ".gem-c-title.gem-c-title--margin-bottom-5", false
+    assert_select '.gem-c-title.govuk-\!-margin-bottom-0'
   end
 
-  it "adds margin 4" do
+  it "adds a valid margin" do
     render_component(title: 'Margin 4', margin_bottom: 4)
-    assert_select ".gem-c-title.gem-c-title--margin-bottom-4"
+    assert_select '.gem-c-title.govuk-\!-margin-bottom-4'
   end
 
-  it "adds margin 5" do
-    render_component(title: 'Margin 5', margin_bottom: 5)
-    assert_select ".gem-c-title.gem-c-title--margin-bottom-5"
+  it "ignores an invalid margin" do
+    render_component(title: 'Margin wat', margin_bottom: 17)
+    assert_select "[class='^=govuk-\!-margin-bottom-']", false
   end
 end


### PR DESCRIPTION
**Do not merge this PR until other PRs have been raised to account for the change in this component. Worst case scenario is that some titles won't have the correct bottom margin, so not exactly a breaking change but we want to catch it nonetheless.**

## What

Updates the title component to use the govuk-spacing-scale for bottom margin, instead of using a custom scale previously defined. Uses the `shared_helper` for this.

## Why

This brings this component in line with other components that are now using the same mechanism for a variable bottom margin.

## Visual Changes

The component previously had a default margin top and bottom of 45px, scaling to 15px on mobile. The govuk spacing scale doesn't have an exact equivalent, so I've gone for the nearest, which is 40px, scaling to 25px on mobile.

For reference when updating apps:

- 4 (gutter, 30px) change to 6
- 5 (gutter-half, 15px) change to 3

Related PRs:

- https://github.com/alphagov/collections/pull/1166
- https://github.com/alphagov/finder-frontend/pull/1238
