### PR TITLE
Add description text

### DIFF
--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -10,6 +10,10 @@
       <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": cb_helper.fieldset_describedby do %>
         <%= cb_helper.heading_markup %>
 
+        <% if cb_helper.description %>
+          <%= tag.p cb_helper.description, class: "govuk-body" %>
+        <% end %>
+
         <% if cb_helper.hint_text %>
           <%= tag.span cb_helper.hint_text, id: "#{id}-hint", class: "govuk-hint" %>
         <% end %>

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -7,6 +7,7 @@
   small ||= false
   inline ||= false
   is_page_heading ||= false
+  description ||= nil
   hint ||= nil
   error_message ||= nil
   error_items ||= []
@@ -38,6 +39,10 @@
       <% else %>
         <%= tag.legend heading, class: "govuk-fieldset__legend govuk-fieldset__legend--m" %>
       <% end %>
+    <% end %>
+
+    <% if description.present? %>
+      <%= tag.p description, class: "govuk-body" %>
     <% end %>
 
     <% if hint %>

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -63,6 +63,47 @@ examples:
           value: "green"
         - label: "Blue"
           value: "blue"
+  with_description_text:
+    description: |
+      If a description text is added, it is displayed under the legend but before the hint text.
+      The description text can only render text and not govspeak specific syntax.
+      This is a pattern that is used across GOV.UK where a question is followed by a description.
+    data:
+      name: "favourite_skittle"
+      heading: "Choose your favourite skittles"
+      description: |
+        Skittles consist of hard sugar shells imprinted with the letter "S".
+        The interior consists mainly of sugar, corn syrup, and hydrogenated 
+        palm kernel oil along with fruit juice, citric acid, natural and artificial flavors.
+      hint_text: "Taste the rainbow"
+      items:
+        - label: "Red"
+          value: "red"
+        - label: "Green"
+          value: "green"
+        - label: "Blue"
+          value: "blue"
+  with_description_text_and_header:
+    description: |
+      If a description text is added with a page heading, it is displayed under the heading but before the hint text.
+      The description text can only render text and not govspeak specific syntax.
+      This is a pattern that is used across GOV.UK where a question is followed by a description.
+    data:
+      name: "favourite_skittle"
+      heading: "Choose your favourite skittles"
+      is_page_heading: true
+      description: |
+        Skittles consist of hard sugar shells imprinted with the letter "S".
+        The interior consists mainly of sugar, corn syrup, and hydrogenated 
+        palm kernel oil along with fruit juice, citric acid, natural and artificial flavors.
+      hint_text: "Taste the rainbow"
+      items:
+        - label: "Red"
+          value: "red"
+        - label: "Green"
+          value: "green"
+        - label: "Blue"
+          value: "blue"
   without_hint_text:
     description: Hint text can be removed entirely with this option. Note that this option can be combined with the visually_hide_heading option.
     data:

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -120,6 +120,54 @@ examples:
         text: "Yes"
       - value: "no"
         text: "No"
+  with_description_only:
+    data:
+      name: "radio-group-description"
+      heading: "What is your favourite colour?"
+      description: |
+        Skittles consist of hard sugar shells imprinted with the letter "S".
+        The interior consists mainly of sugar, corn syrup, and hydrogenated 
+        palm kernel oil along with fruit juice, citric acid, natural and artificial flavors.
+      items:
+      - value: "red"
+        text: "Red"
+      - value: "green"
+        text: "Green"
+      - value: "blue"
+        text: "Blue"
+  with_description_and_hint:
+    data:
+      name: "radio-group-description"
+      heading: "What is your favourite colour?"
+      description: |
+        Skittles consist of hard sugar shells imprinted with the letter "S".
+        The interior consists mainly of sugar, corn syrup, and hydrogenated 
+        palm kernel oil along with fruit juice, citric acid, natural and artificial flavors.
+      hint: "Choose the colour"
+      items:
+      - value: "red"
+        text: "Red"
+      - value: "green"
+        text: "Green"
+      - value: "blue"
+        text: "Blue"
+  with_description_and_page_heading:
+    data:
+      name: "radio-group-description"
+      heading: "What is your favourite colour?"
+      is_page_heading: true
+      description: |
+        Skittles consist of hard sugar shells imprinted with the letter "S".
+        The interior consists mainly of sugar, corn syrup, and hydrogenated 
+        palm kernel oil along with fruit juice, citric acid, natural and artificial flavors.
+      hint: "Choose the colour"
+      items:
+      - value: "red"
+        text: "Red"
+      - value: "green"
+        text: "Green"
+      - value: "blue"
+        text: "Blue"
   with_hint_text_on_radios:
     data:
       name: "radio-group-hint-text"

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
       include ActionView::Helpers
       include ActionView::Context
 
-      attr_reader :items, :name, :css_classes, :list_classes, :error, :has_conditional, :has_nested, :id, :hint_text
+      attr_reader :items, :name, :css_classes, :list_classes, :error, :has_conditional, :has_nested, :id, :hint_text, :description
 
       def initialize(options)
         @items = options[:items] || []
@@ -23,6 +23,7 @@ module GovukPublishingComponents
         @id = options[:id] || "checkboxes-#{SecureRandom.hex(4)}"
         @heading = options[:heading] || nil
         @is_page_heading = options[:is_page_heading]
+        @description = options[:description] || nil
         @no_hint_text = options[:no_hint_text]
         @hint_text = options[:hint_text] || "Select all that apply." unless @no_hint_text
         @visually_hide_heading = options[:visually_hide_heading]

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -337,4 +337,17 @@ describe "Checkboxes", type: :view do
     assert_select ".govuk-checkboxes.govuk-checkboxes--nested"
     assert_select ".govuk-checkboxes.govuk-checkboxes--nested input[value=light_red]"
   end
+
+  it "renders checkboxes with a description text" do
+    render_component(
+      name: "favourite_colour",
+      heading: "What is your favourite skittle?",
+      description: "This is a description about skittles.",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+      ]
+    )
+    assert_select ".govuk-body", text: "This is a description about skittles."
+  end
 end

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -411,6 +411,19 @@ describe "Radio", type: :view do
     assert_select ".govuk-radios input[data-tracking-url='#{gateway_url}']"
     assert_select ".govuk-radios input[data-tracking-url='#{verify_url}']"
   end
+
+  it "renders description text" do
+    render_component(
+      name: "favourite-skittle",
+      heading: "What is your favourite skittle?",
+      description: "This is a description about skittles.",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Blue", value: "blue" }
+      ]
+    )
+    assert_select ".govuk-body", "This is a description about skittles."
+  end
 end
 
 # This component can be interacted with, so use integration tests for these cases.


### PR DESCRIPTION
## What
Add support for description text

## Why
A lot of "one question per page" views on GOV.UK have a description under the title. This means that "hacks" are being put in place to deliver user need.

Example:
https://www.gov.uk/prepare-business-uk-leaving-eu?page=2

## Visual Changes
![Screen Shot 2019-07-03 at 12 55 44](https://user-images.githubusercontent.com/4599889/60589815-51857e80-9d92-11e9-82b4-1fb62d3ac2e4.png)

<img width="1009" alt="Screen Shot 2019-07-03 at 15 10 19" src="https://user-images.githubusercontent.com/4599889/60598496-b649d480-9da4-11e9-9317-bbf05e41554a.png">
