### PR TITLE
Remove new cookie banner references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove references to old `gem-c-cookie-banner--new` class (PR #972)
+
 ## 17.11.0
 
 * Stop the hardcoding of a google client ID in the feedback footer (PR #957)

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -10,7 +10,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.showConfirmationMessage = this.showConfirmationMessage.bind(this)
     this.$module.setCookieConsent = this.setCookieConsent.bind(this)
 
-    this.$module.newCookieBanner = document.querySelectorAll('.gem-c-cookie-banner--new, .gem-c-cookie-banner')
+    this.$module.cookieBanner = document.querySelector('.gem-c-cookie-banner')
     this.$module.cookieBannerConfirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
 
     // Temporary check while we have 2 banners co-existing.
@@ -43,7 +43,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   CookieBanner.prototype.showCookieMessage = function () {
     // Hide the cookie banner on the cookie settings page, to avoid circular journeys
-    if (this.$module.newCookieBanner && window.location.pathname === '/help/cookies') {
+    if (this.$module.cookieBanner && window.location.pathname === '/help/cookies') {
       this.$module.style.display = 'none'
     } else {
       var shouldHaveCookieMessage = (this.$module && window.GOVUK.cookie('seen_cookie_message') !== 'true')

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -2,8 +2,7 @@ $govuk-cookie-banner-background: govuk-colour("white");
 $govuk-cookie-banner-text-green: #00823b;
 
 .js-enabled {
-  .gem-c-cookie-banner,
-  .gem-c-cookie-banner--new {
+  .gem-c-cookie-banner {
     display: none; // shown with JS, always on for non-JS
   }
 }
@@ -12,12 +11,6 @@ $govuk-cookie-banner-text-green: #00823b;
   @include govuk-font($size: 16);
   padding: govuk-spacing(2) 0;
   background-color: $govuk-cookie-banner-background;
-  border: 2px solid govuk-colour("black");
-}
-
-// Styles for the new version of the cookie banner
-.gem-c-cookie-banner--new {
-  @include govuk-font($size: 16);
   border: 2px solid govuk-colour("black");
 }
 
@@ -121,7 +114,6 @@ $govuk-cookie-banner-text-green: #00823b;
 // Override the styles from govuk_template
 // scss-lint:disable IdSelector
 // sass-lint:disable no-ids
-.gem-c-cookie-banner--new#global-cookie-message,
 .gem-c-cookie-banner#global-cookie-message {
   background-color: $govuk-cookie-banner-background;
   padding: govuk-spacing(4) 0;


### PR DESCRIPTION
## What
Removes all references to `gem-c-cookie-banner--new`
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
Some places in the code still reference the class `gem-c-cookie-banner--new` because we had to deploy with that code in place due to caching and the way static and frontend apps interact.

It has been a week since we removed the old code, so `gem-c-cookie-banner--new` should no longer be being used anywhere.
