### PR TITLE
Reset focus when user closes feedback form before submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## UNRELEASED
+
+* Reset focus when feedback component is closed before submit (PR #975)
+
 ## 17.12.0
 
 * Remove references to old `gem-c-cookie-banner--new` class (PR #972)

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -42,6 +42,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         trackEvent(getTrackEventParams($(this)))
         setInitialAriaAttributes()
         revealInitialPrompt()
+        var refocusClass = '.js-' + $(e.target).attr('aria-controls')
+        $element.find(refocusClass).focus()
       })
 
       this.$pageIsUsefulButton.on('click', function (e) {

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -276,7 +276,7 @@ describe('Feedback component', function () {
 
     it('shows the prompt', function () {
       expect($('.gem-c-feedback .js-prompt')).not.toHaveClass('js-hidden')
-      expect(document.activeElement).toBe($('.gem-c-feedback .js-prompt').get(0))
+      expect(document.activeElement).toBe($('.js-something-is-wrong').get(0))
     })
 
     it('conveys that the feedback form is hidden', function () {
@@ -318,7 +318,7 @@ describe('Feedback component', function () {
 
     it('shows the prompt', function () {
       expect($('.gem-c-feedback .js-prompt')).not.toHaveClass('js-hidden')
-      expect(document.activeElement).toBe($('.gem-c-feedback .js-prompt').get(0))
+      expect(document.activeElement).toBe($('.js-page-is-not-useful').get(0))
     })
 
     it('conveys that the feedback form is hidden', function () {


### PR DESCRIPTION
https://trello.com/c/RVYM3DPP/1-3-survey-focus-skipping-content-12
## What
This resets the focus back to the link that was activated to
open the form when it is closed.

## Why
Currently if the user closes the "not useful" or "something is wrong" feedback
form the focus is lost. This is an accessibility issue as keyboard users end up
back at the start of the page, and screenreader users are unaware of where they
are on the page. 

## Visual Changes
### Before
![Screen Shot 2019-07-09 at 08 57 23](https://user-images.githubusercontent.com/31649453/60869860-aa886300-a227-11e9-8a54-200230263f69.png)
 

### After
![Screen Shot 2019-07-09 at 08 57 33](https://user-images.githubusercontent.com/31649453/60869872-b2e09e00-a227-11e9-830d-907400e33e14.png)

