### PR TITLE
Move tab style overrides to the gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Make some tab component styles more specific to override `.content-block` (PR #978)
+
 ## 17.12.1
 
 * Reset focus when feedback component is closed before submit (PR #975)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
@@ -7,3 +7,20 @@
     border: 0;
   }
 }
+
+// We have some styles within GOVUK (.content-block) which can leak into the list styles for this component.
+// These styles are defined in Static: https://github.com/alphagov/static/blob/a815620cada7ea1c65428c1c3b3ac4dbe28977bf/app/assets/stylesheets/helpers/_text.scss
+// This sets more specific selectors so those unwanted styles are overidden
+// scss-lint:disable QualifyingElement
+// sass-lint:disable no-qualifying-elements
+ul.govuk-tabs__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+li.govuk-tabs__list-item {
+  margin-left: govuk-spacing(5);
+}
+// scss-lint:enable QualifyingElement
+// sass-lint:enable no-qualifying-elements


### PR DESCRIPTION
## What 
Trello: https://trello.com/c/dnszYbmt/7-accessibility-of-tabs-on-govuk

Moves CSS 'overrides' for the tab component from Frontend into the gem.
Follow on PR in Frontend: https://github.com/alphagov/frontend/pull/1898

## Why
The tab styles are affected by `.content-block` styles which are [defined in Static](https://github.com/alphagov/static/blob/a815620cada7ea1c65428c1c3b3ac4dbe28977bf/app/assets/stylesheets/helpers/_text.scss). In Frontend, there are [overrides for this problem](https://github.com/alphagov/frontend/blob/master/app/assets/stylesheets/application.scss#L70). However, they don't work properly with our current tabs on mobile (the left spacing is incorrect). This corrects the overrides and moves them into the gem, so they're in one common place and more visible to those making changes to the tab component.

## Before
<img width="336" alt="Screen Shot 2019-07-10 at 11 20 06" src="https://user-images.githubusercontent.com/29889908/60961716-b138d800-a304-11e9-8cd5-0cbe5350e124.png">

## After
<img width="333" alt="Screen Shot 2019-07-10 at 11 19 56" src="https://user-images.githubusercontent.com/29889908/60961726-b5fd8c00-a304-11e9-8891-fb9017370f5a.png">

__Note: there should be no visible change within the component guide or other apps that don't use `content-block`:__

<img width="515" alt="Screen Shot 2019-07-10 at 11 21 06" src="https://user-images.githubusercontent.com/29889908/60961791-d4638780-a304-11e9-94c8-fc211d19fc4e.png">

https://govuk-publishing-compon-pr-978.herokuapp.com/component-guide/tabs