### PR TITLE
Version 17.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 17.12.2
 
 * Make some tab component styles more specific to override `.content-block` (PR #978)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (17.12.1)
+    govuk_publishing_components (17.12.2)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -218,7 +218,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.5.1)
+    rouge (3.6.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.3)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '17.12.1'.freeze
+  VERSION = '17.12.2'.freeze
 end


### PR DESCRIPTION
Includes:

* Make some tab component styles more specific to override `.content-block` (PR #978)