### PR TITLE
Fix duplicate link bug with feedback form and fix spacing on small viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Stop duplicate links within feedback form (PR #981)
+* Add spacing to the feedback form (PR #981)
+
 ## 17.12.2
 
 * Make some tab component styles more specific to override `.content-block` (PR #978)

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -109,8 +109,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var currentPathName = window.location.pathname.replace(/[^\s=?&]+(?:@|%40)[^\s=?&]+/, '[email]')
         var finalPathName = encodeURI(currentPathName)
 
-        that.$surveyForm.append($('<input name="email_survey_signup[ga_client_id]" type="hidden">').val(gaClientId || '0'))
-        that.$surveyWrapper.append('<a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=' + finalPathName + '&amp;gcl=' + gaClientId + '" class="gem-c-feedback__email-link govuk-link" id="take-survey" target="_blank" rel="noopener noreferrer">Don’t have an email address?</a>')
+        if (document.querySelectorAll('[name="email_survey_signup[ga_client_id]"]').length === 0) {
+          that.$surveyForm.append($('<input name="email_survey_signup[ga_client_id]" type="hidden">').val(gaClientId || '0'))
+        }
+
+        if (document.querySelectorAll('.gem-c-feedback__email-link#take-survey').length === 0) {
+          that.$surveyWrapper.append('<a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=' + finalPathName + '&amp;gcl=' + gaClientId + '" class="gem-c-feedback__email-link govuk-link" id="take-survey" target="_blank" rel="noopener noreferrer">Don’t have an email address?</a>')
+        }
       }
 
       function updateAriaAttributes (linkClicked) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -140,8 +140,14 @@
   color: $govuk-error-colour;
 }
 
+.gem-c-feedback__survey-container {
+  @include govuk-media-query($until: tablet) {
+    padding: govuk-spacing(4);
+  }
+}
+
 .gem-c-feedback__form {
-  margin-top: govuk-spacing(3);
+  margin: govuk-spacing(3) govuk-spacing(2) 0 govuk-spacing(2);
   padding: govuk-spacing(3) 0;
   border-top: govuk-spacing(2) solid govuk-colour("blue");
 
@@ -173,7 +179,7 @@
   @include govuk-link-style-default;
   @include govuk-font(19);
   float: right;
-  margin: 0 0 govuk-spacing(2) 0;
+  margin: 0 govuk-spacing(1) govuk-spacing(2) 0;
 
   @include govuk-media-query($from: tablet) {
     padding-top: 0;

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -12,7 +12,7 @@
     aria-expanded="true"
     role="button">Close</a>
 
-  <div class="gem-c-feedback__grid-row">
+  <div class="gem-c-feedback__grid-row gem-c-feedback__survey-container">
     <div class="gem-c-feedback__column-two-thirds">
       <div class="gem-c-feedback__error-summary gem-c-feedback__js-show js-hidden js-errors" tabindex="-1"></div>
 

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -12,7 +12,7 @@
     aria-expanded="true"
     role="button">Close</a>
 
-  <div class="gem-c-feedback__grid-row">
+  <div class="gem-c-feedback__grid-row gem-c-feedback__survey-container">
     <div class="gem-c-feedback__column-two-thirds" id="survey-wrapper">
       <div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>
 


### PR DESCRIPTION
# Fix duplicate link bug with feedback form
## What
Add a check to the feedback form logic so that we don't insert the links if they're already present, to avoid duplication.
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
The hidden input for GA ID and the "Don't have an email address?" link are inserted using Javascript. This is done when the user clicks 'No' within the feedback form and the form opens. However, there is no check for whether the links have already been inserted. This means that the links are appended each time the user opens the 'No' form.

*Replication Steps:*

- Click "No" on the feedback form.
- Without interacting with the form itself, close the form via the Close button
- Click "No" on the feedback form again
- Duplicate 'Don't have an email address?' links will be visible

## Before
<img width="1010" alt="Screen Shot 2019-07-11 at 09 31 15" src="https://user-images.githubusercontent.com/29889908/61035663-7e074f00-a3bf-11e9-83dc-3326b205f89e.png">

## After
<img width="924" alt="Screen Shot 2019-07-11 at 09 37 37" src="https://user-images.githubusercontent.com/29889908/61035698-8a8ba780-a3bf-11e9-9618-bb50f41ad849.png">

# Fix spacing on small viewport
## What
Add spacing around the feedback form on small screen sizes

## Before
<img width="371" alt="Screen Shot 2019-07-11 at 09 52 17" src="https://user-images.githubusercontent.com/29889908/61036748-98422c80-a3c1-11e9-90f1-49bea042b6da.png">

## After
<img width="439" alt="Screen Shot 2019-07-11 at 10 08 05" src="https://user-images.githubusercontent.com/29889908/61037865-ccb6e800-a3c3-11e9-8ec1-7560c3b19c37.png">
