### PR TITLE
Change paragraph to div for descriptions to support govspeak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased changes
+
+* Change paragraph to div for descriptions to support govspeak (PR #985)
+
 ## 17.13.0
 
 * Add support for description text (PR #971)

--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -11,7 +11,7 @@
         <%= cb_helper.heading_markup %>
 
         <% if cb_helper.description %>
-          <%= tag.p cb_helper.description, class: "govuk-body" %>
+          <%= tag.div cb_helper.description, class: "govuk-body" %>
         <% end %>
 
         <% if cb_helper.hint_text %>

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -42,7 +42,7 @@
     <% end %>
 
     <% if description.present? %>
-      <%= tag.p description, class: "govuk-body" %>
+      <%= tag.div description, class: "govuk-body" %>
     <% end %>
 
     <% if hint %>

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -350,4 +350,18 @@ describe "Checkboxes", type: :view do
     )
     assert_select ".govuk-body", text: "This is a description about skittles."
   end
+
+  it "renders checkboxes with a govspeak description text" do
+    render_component(
+      name: "favourite_colour",
+      heading: "What is your favourite skittle?",
+      description: render("govuk_publishing_components/components/govspeak",
+        content: "<p>This is a description about skittles.</p>".html_safe),
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+      ]
+    )
+    assert_select ".govuk-body", text: "This is a description about skittles."
+  end
 end

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -424,6 +424,20 @@ describe "Radio", type: :view do
     )
     assert_select ".govuk-body", "This is a description about skittles."
   end
+
+  it "renders govspeak description text" do
+    render_component(
+      name: "favourite-skittle",
+      heading: "What is your favourite skittle?",
+      description: render("govuk_publishing_components/components/govspeak",
+        content: "<p>This is a description about skittles.</p>".html_safe),
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Blue", value: "blue" }
+      ]
+    )
+    assert_select ".govuk-body", "This is a description about skittles."
+  end
 end
 
 # This component can be interacted with, so use integration tests for these cases.


### PR DESCRIPTION
## What
Change paragraph to div for descriptions to support govspeak

## Why
Some descriptions that are rendered need to use govspeak to render them.

Having a paragraph breaks the following tests:

```
 Scenario: Arrive at the business finder through Q&A              # features/finders.feature:245
    Given the business finder QA exists                            # features/step_definitions/filtering_steps.rb:13
    When I visit the business finder Q&A                           # features/step_definitions/qa_steps.rb:82
    And I select choice "Aerospace"                                # features/step_definitions/qa_steps.rb:94
    And I submit my answer                                         # features/step_definitions/qa_steps.rb:56
      In backend response: '54:5: ERROR: Unexpected end tag : p' at line 54 col 5 (code 76).
      Add ?skip_slimmer=1 to the url to show the raw backend request.

        49:           <p class="govuk-body">
        50: <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak">
        51:       <p>Doing business abroad includes exporting and going for meetings or taking goods to a trade fair.</p>
        52: 
        53: </div>
          -----v
        54: </p>
        55: 
        56:           <span id="checkboxes-59aebfa3-hint" class="govuk-hint">Select all that apply.</span>
        57: 
        58: 
        59:         <ul class="govuk-checkboxes gem-c-checkboxes__list"> (RuntimeError)
      ./features/step_definitions/qa_steps.rb:57:in `/^I submit my answer/'
      features/finders.feature:249:in `And I submit my answer'
    And I select choice "Sell goods or provide services in the UK" # features/step_definitions/qa_steps.rb:94
    And I submit my answer                                         # features/step_definitions/qa_steps.rb:56
    And I skip the rest of the questions                           # features/step_definitions/qa_steps.rb:103
    Then I should be on the business finder page                   # features/step_definitions/qa_steps.rb:109
    And the correct facets have been pre-selected                  # features/step_definitions/qa_steps.rb:113
```

## Visual Changes
None