### PR TITLE
Add view changes link to PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -7,3 +7,8 @@
 
 ## Visual Changes
 <!-- If the change results in visual changes, show a before and after -->
+
+<!--
+## View Changes
+https://govuk-publishing-compon-pr-[PR-NUMBER].herokuapp.com/
+-->


### PR DESCRIPTION
## What
Add view changes link to PR template

## Why
This will help users view changes easily, this was included in the template previously but has been removed since.

