### PR TITLE
bump to version 17.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 17.14.0
 
 * Update cookie banner component to hide if cross-origin message has `hideCookieBanner` set to `true` (PR #988)
 * Change paragraph to div for descriptions to support govspeak description in checkboxes and radios (PR #985)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (17.13.0)
+    govuk_publishing_components (17.14.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '17.13.0'.freeze
+  VERSION = '17.14.0'.freeze
 end


### PR DESCRIPTION
Includes:
* Change paragraph to div for descriptions to support govspeak (PR #985)
* Update cookie banner component to hide if cross-origin message has `hideCookieBanner` set to `true` (PR #988)

