### PR TITLE
Set up data tracking for navigation on secondary content

### DIFF
--- a/app/views/govuk_publishing_components/components/_meta_tags.html.erb
+++ b/app/views/govuk_publishing_components/components/_meta_tags.html.erb
@@ -1,4 +1,4 @@
-<% meta_tags = GovukPublishingComponents::Presenters::MetaTags.new(content_item, local_assigns).meta_tags %>
+<% meta_tags = GovukPublishingComponents::Presenters::MetaTags.new(content_item, local_assigns, request).meta_tags %>
 
 <% meta_tags.each do |name, content| %>
   <meta name="<%= name %>" content="<%= content %>">

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -1,9 +1,9 @@
 module GovukPublishingComponents
   module Presenters
     class MetaTags
-      attr_reader :content_item, :details, :links, :local_assigns
+      attr_reader :content_item, :details, :links, :local_assigns, :request
 
-      def initialize(content_item, local_assigns)
+      def initialize(content_item, local_assigns, request)
         # We have to call deep_symbolize_keys because we're often dealing with a
         # parsed JSON document which will have string keys by default, but our
         # components use symbol keys and we want consistency.
@@ -11,6 +11,7 @@ module GovukPublishingComponents
         @details = @content_item[:details] || {}
         @links = @content_item[:links] || {}
         @local_assigns = local_assigns
+        @request = request
       end
 
       def meta_tags
@@ -98,6 +99,14 @@ module GovukPublishingComponents
         stepnavs = links[:part_of_step_navs] || []
         stepnavs_content = stepnavs.map { |stepnav| stepnav[:content_id] }.join(",")
         meta_tags["govuk:stepnavs"] = stepnavs_content if stepnavs_content.present?
+
+        step_nav_helper = PageWithStepByStepNavigation.new(content_item, request.path, request.query_parameters)
+        if step_nav_helper.show_secondary_step_by_step?
+          meta_tags["govuk:navigation-page-type"] = "Secondary step by step shown"
+        elsif step_nav_helper.show_header?
+          meta_tags["govuk:navigation-page-type"] = "Primary step by step shown"
+        end
+
         meta_tags
       end
 


### PR DESCRIPTION
## What

**Note: this card is for setting up data tracking, it is not about doing the analysis**

We want to be able to track usage of the step by step side bar and the breadcrumb on secondary content.

Is the data tracking in place? What are the metrics we are trying to measure?

Would we be able to answer these questions:

- Does adding step by step navigation make a difference to user journeys (eg next page paths, exits) for *users who land directly* (eg from Google) on a secondary content page with step by step navigation? And compared to users who come from GOV.UK pages?
- Does the step by step navigation being closed make a difference to user journeys compared to the step by step being opened at a certain step, for secondary content?

## Why
We want to add a new feature to 'step by step publisher' that makes it possible to add step by step navigation to secondary content. (Secondary content = content that is about the service but is not useful enough to include in the step by step).

https://trello.com/c/LU6AAcOk/14-step-by-step-set-up-data-tracking-for-navigation-on-secondary-content