### PR TITLE
Add no underline option to document list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add no underline option to document list component (PR #990)
+
 ## 17.14.0
 
 * Update cookie banner component to hide if cross-origin message has `hideCookieBanner` set to `true` (PR #988)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -24,6 +24,12 @@
   display: inline-block;
 }
 
+.gem-c-document-list--no-underline {
+  .gem-c-document-list__item-title {
+    text-decoration: none;
+  }
+}
+
 .gem-c-document-list__item-title--context {
   margin-right: govuk-spacing(2);
 

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -1,9 +1,13 @@
 <%
   items ||= []
+
+  classes = "gem-c-document-list"
+  classes << " gem-c-document-list--top-margin" if local_assigns[:margin_top]
+  classes << " gem-c-document-list--bottom-margin" if local_assigns[:margin_bottom]
+  classes << " gem-c-document-list--no-underline" if local_assigns[:remove_underline]
+
   within_multitype_list ||= false
   within_multitype_list_class = " gem-c-document-list__multi-list" if within_multitype_list
-  margin_top_class = " gem-c-document-list--top-margin" if local_assigns[:margin_top]
-  margin_bottom_class = " gem-c-document-list--bottom-margin" if local_assigns[:margin_bottom]
   title_with_context_class = " gem-c-document-list__item-title--context"
 
   brand ||= false
@@ -11,7 +15,7 @@
 %>
 <% if items.any? %>
   <% unless within_multitype_list %>
-    <ol class="gem-c-document-list<%= margin_bottom_class %><%= margin_top_class %>">
+    <ol class="<%= classes %>">
   <% end %>
     <% items.each do |item| %>
       <% highlight_class = " gem-c-document-list__item--highlight" if item[:highlight] %>

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -156,6 +156,27 @@ examples:
           public_updated_at: 2017-07-19 15:01:48
           document_type: 'Statistical data set'
         subtext: 'First published during the 1996 Conservative Government'
+  without_underline:
+    description: The current search design does not include underlines on links and has been tested without underlines. Other uses will require further user testing.
+    data:
+      remove_underline: true
+      items:
+      - link:
+          text: 'Department for Education – Statistics at DfE'
+          path: '/government/organisations/department-for-education/about/statistics'
+          description: 'The Department for Education publishes official statistics on education and children.'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Corporate information'
+        subtext: 'First published during the 2007 Labour Government'
+      - link:
+          text: 'State-funded school inspections and outcomes: management information'
+          path: '/government/organisations/department-for-education/about/statistics'
+          description: 'Management information published monthly and a one-off publication of inspections and outcomes from 2005 to 2015.'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Statistical data set'
+        subtext: 'First published during the 1996 Conservative Government'
   highlighted_result:
     description: Highlight one or more of the items in the list. This is used on finders to provide a 'top result' for a search. The `highlight_text` parameter is optional.
     data:

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -223,6 +223,22 @@ describe "Document list", type: :view do
     assert_select '.gem-c-document-list__subtext', text: 'This is some subtext'
   end
 
+  it "removes underline from links" do
+    render_component(
+      remove_underline: true,
+      items: [
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+          }
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list.gem-c-document-list--no-underline'
+  end
+
   it "highlights items" do
     render_component(
       items: [


### PR DESCRIPTION
## What

Add an option to the document list component to remove underlines from links.

## Why

We intend to use the component for search results in finder-frontend, but the current design doesn't have underlines on the links. Adding them adds to the visual clutter of the search results pages and leads to a much bigger conversation, so it seems more sensible to have this option available.

## Visual Changes

Option to not have underlines looks like this:

![Screen Shot 2019-07-15 at 14 49 48](https://user-images.githubusercontent.com/861310/61221289-18dd9180-a710-11e9-84b7-e1cb575ced02.png)

