### PR TITLE
(DNM until design consensus) - Replace govspeak steps background images with css counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Replace govspeak steps background images with css counters (PR #993)
+
 ## 17.16.0
 
 * Track when primary or secondary step by step are shown (PR #989)

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_steps.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_steps.scss
@@ -1,23 +1,36 @@
 .gem-c-govspeak .steps {
   padding-left: 0;
   margin-left: 0;
+  counter-reset: step-counter;
   overflow: hidden;
 
   > li {
-    background-position: 0 .87em;
-    background-repeat: no-repeat;
+    counter-increment: step-counter;
     list-style-type: decimal;
     margin-left: 0;
     padding: .75em 0 .75em 2.2em;
+    position: relative;
+    // fixes :before positioning in IE
+    // occurs due to text being wrapped in p tag (block element)
+    display: block;
 
-    @for $i from 1 through 14 {
-      &:nth-child(#{$i}) {
-        background-image: image-url("icon-steps/icon-step-#{$i}.png");
+    &:before {
+      position: absolute;
+      height: 1em;
+      width: 1em;
+      content: counter(step-counter);
+      left: 0;
+      // match top padding
+      top: .75em;
+      padding: .3em .3em .25em .3em;
+      @include govuk-font($size: 16);
+      border-radius: 50%;
+      color: govuk-colour("white");
+      background: govuk-colour("black");
+      text-align: center;
 
-        @include govuk-device-pixel-ratio {
-          background-image: image-url("icon-steps/icon-step-#{$i}-2x.png");
-          background-size: 24px 24px;
-        }
+      @include govuk-media-query($from: tablet) {
+        padding: .25em;
       }
     }
   }

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -637,6 +637,33 @@ examples:
           </li>
           <li>
             <p>Love numbers.</p>
+            <li>
+            <p>Add numbers.</p>
+          </li>
+          <li>
+            <p>Check numbers.</p>
+          </li>
+          <li>
+            <p>Love numbers.</p>
+          </li>
+          <li>
+            <p>Add numbers.</p>
+          </li>
+          <li>
+            <p>Check numbers.</p>
+          </li>
+          <li>
+            <p>Love numbers.</p>
+          </li>
+          <li>
+            <p>Add numbers.</p>
+          </li>
+          <li>
+            <p>Check numbers.</p>
+          </li>
+          <li>
+            <p>Love numbers.</p>
+          </li>
           </li>
         </ol>
   highlight_answer:


### PR DESCRIPTION
## What
Replace the use of background images with CSS to indicate step numbers.
Component preview: https://govuk-publishing-compon-pr-993.herokuapp.com/component-guide/govspeak/steps/preview

## Why
CSS counters are supported on IE8 and above so we can safely use them
to visually indicate the steps instead of images.

Added bonus is that numbers retain crispness with zoom :)
## Bonus
- numbers retain crispness with zoom :)
- as images are part of _govuk_frontend_toolkit_ this further reduces the dependency on it

## Visual Changes

### There are minor visual difference, so needs a designer consultation.

**Old:**
<img width="646" alt="Screen Shot 2019-07-17 at 10 34 30" src="https://user-images.githubusercontent.com/3758555/61365261-56146180-a87f-11e9-954e-9cc0558428e0.png">

**New:**
<img width="404" alt="Screen Shot 2019-07-17 at 10 34 26" src="https://user-images.githubusercontent.com/3758555/61365260-56146180-a87f-11e9-84d6-5f4cd8c15399.png">

**New with long text:**
<img width="665" alt="Screen Shot 2019-07-18 at 12 05 18" src="https://user-images.githubusercontent.com/3758555/61452845-a27da100-a954-11e9-9114-61ef52e6891f.png">


**New (left) vs old (right):**
<img width="856" alt="Screen Shot 2019-07-17 at 10 44 39" src="https://user-images.githubusercontent.com/3758555/61365916-77298200-a880-11e9-87f2-e37143cbcd84.png">





