### PR TITLE
bump version to 17.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 17.16.0
+
+* Track when primary or secondary step by step are shown (PR #989)
+* Update image-card to use govuk-frontend (PR #967)
+* Update search to use govuk-frontend (PR #977)
+
 ## 17.15.0
 
 * Add no underline option to document list component (PR #990)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (17.15.0)
+    govuk_publishing_components (17.16.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '17.15.0'.freeze
+  VERSION = '17.16.0'.freeze
 end


### PR DESCRIPTION
Includes:
* Track when primary or secondary step by step are shown (PR #989)
* Update image-card to use govuk-frontend (PR #967)
* Update search to use govuk-frontend (PR #977)