### PR TITLE
Remove cross origin approach and detect parent document location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Replace accessible media player with Youtube player (PR #908)
+* Prevent the cookie banner component from rendering when in an iframe (PR #995)
 
 ## 17.17.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -39,11 +39,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   CookieBanner.prototype.showCookieMessage = function () {
-    // Hide the cookie banner on the cookie settings page, to avoid circular journeys
-    // or when presented in an iframe by a publishing application
-    if (this.isInCookiesPage() || (this.isInIframe() && this.parentIsPublishingDomain())) {
-      this.$module.style.display = 'none'
-    } else {
+    // Show the cookie banner if not in the cookie settings page or in an iframe
+    if (!this.isInCookiesPage() && !this.isInIframe()) {
       var shouldHaveCookieMessage = (this.$module && window.GOVUK.cookie('seen_cookie_message') !== 'true')
 
       if (shouldHaveCookieMessage) {
@@ -92,17 +89,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   CookieBanner.prototype.isInIframe = function () {
     return window.parent && window.location !== window.parent.location
-  }
-
-  CookieBanner.prototype.parentIsPublishingDomain = function () {
-    var publishingDomain = 'publishing.service.gov.uk'
-    var currentDomain = window.parent.location.origin
-
-    // Polyfill currentDomain.endsWith(publishingDomain) for IE
-    var offset = currentDomain.length - publishingDomain.length
-    var domainMatch = offset >= 0 && currentDomain.lastIndexOf(publishingDomain, offset) === offset
-
-    return domainMatch
   }
 
   Modules.CookieBanner = CookieBanner

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -113,20 +113,4 @@ describe('Cookie banner', function () {
 
     expect(newCookieBanner).not.toBeVisible()
   })
-
-  it('hides the cookie banner if a cross-origin messages says so', function () {
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    var cookieBannerModule = new GOVUK.Modules.CookieBanner()
-    cookieBannerModule.start($(element))
-
-    var mockMessage = {
-      data: JSON.stringify({ 'hideCookieBanner': 'true' }),
-      origin: 'https://content-publisher.publishing.service.gov.uk'
-    }
-
-    cookieBannerModule.receiveMessage(mockMessage)
-
-    var newCookieBanner = document.querySelector('.gem-c-cookie-banner')
-    expect(newCookieBanner).not.toBeVisible()
-  })
 })

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -36,11 +36,10 @@ describe('Cookie banner', function () {
     var element = document.querySelector('[data-module="cookie-banner"]')
     new GOVUK.Modules.CookieBanner().start($(element))
 
-    var newCookieBanner = document.querySelector('.gem-c-cookie-banner')
     var cookieBannerMain = document.querySelector('.gem-c-cookie-banner__wrapper')
     var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
 
-    expect(newCookieBanner).toBeVisible()
+    expect(element).toBeVisible()
     expect(cookieBannerMain).toBeVisible()
     expect(cookieBannerConfirmation).not.toBeVisible()
   })
@@ -93,11 +92,10 @@ describe('Cookie banner', function () {
     var element = document.querySelector('[data-module="cookie-banner"]')
     new GOVUK.Modules.CookieBanner().start($(element))
 
-    var banner = document.querySelector('[data-module="cookie-banner"]')
     var link = document.querySelector('button[data-hide-cookie-banner="true"]')
     link.dispatchEvent(new window.Event('click'))
 
-    expect(banner).toBeHidden()
+    expect(element).toBeHidden()
     expect(GOVUK.setCookie).toHaveBeenCalledWith('seen_cookie_message', 'true', { days: 365 })
     expect(GOVUK.getCookie('seen_cookie_message')).toBeTruthy()
   })
@@ -109,8 +107,25 @@ describe('Cookie banner', function () {
     var element = document.querySelector('[data-module="cookie-banner"]')
     new GOVUK.Modules.CookieBanner().start($(element))
 
-    var newCookieBanner = document.querySelector('.gem-c-cookie-banner')
+    expect(element).not.toBeVisible()
+  })
 
-    expect(newCookieBanner).not.toBeVisible()
+  describe('when rendered inside an iframe', function () {
+    var windowParent = window.parent
+    var mockWindowParent = {} // window.parent would be different than window when used inside an iframe
+
+    beforeEach(function () {
+      window.parent = mockWindowParent
+    })
+
+    afterEach(function () {
+      window.parent = windowParent
+    })
+
+    it('should hide the cookie banner', function () {
+      var element = document.querySelector('[data-module="cookie-banner"]')
+      new GOVUK.Modules.CookieBanner().start($(element))
+      expect(element).toBeHidden()
+    })
   })
 })


### PR DESCRIPTION
## What
This is an alternative to the approach taken on #988 (which causes the cookie banner to flicker before removing it). This approach checks if the component is rendered in an iframe and the parent document location is a publishing domain (*.publishing.service.gov.uk) to prevent the cookie banner from being displayed.

## Why
This behaviour is required for [previewing GOV.UK pages from draft stack in Content Publisher without obstructing the view](https://github.com/alphagov/content-publisher/pull/1240).

## Visual Changes
No visual changes

[Trello card](https://trello.com/c/QXbQKBG3)