### PR TITLE
Use div elements for hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use div elements for hint messages (PR #996)
+
 ## 17.16.0
 
 * Track when primary or secondary step by step are shown (PR #989)

--- a/app/views/govuk_publishing_components/components/_hint.html.erb
+++ b/app/views/govuk_publishing_components/components/_hint.html.erb
@@ -6,6 +6,6 @@
   css_classes << (shared_helper.get_margin_bottom)
 %>
 
-<%= tag.span id: id, class: css_classes do %>
+<%= tag.div id: id, class: css_classes do %>
   <%= text %>
 <% end %>

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -289,7 +289,7 @@ describe "Radio", type: :view do
     assert_select ".govuk-hint", text: "You’ll need to prove your identity using one of the following methods"
 
     dom = Nokogiri::HTML(rendered)
-    hint_id = dom.xpath('//span')[0].attr('id')
+    hint_id = dom.xpath('//div[contains(@class, "govuk-hint")]')[0].attr('id')
     assert_select ".govuk-fieldset[aria-describedby='#{hint_id}']"
   end
 
@@ -336,8 +336,8 @@ describe "Radio", type: :view do
     assert_select ".govuk-error-message", text: "Error: Please select one option"
 
     dom = Nokogiri::HTML(rendered)
-    hint_id = dom.xpath('//span')[0].attr('id')
-    error_id = dom.xpath('//span')[1].attr('id')
+    hint_id = dom.xpath('//div[contains(@class, "govuk-hint")]')[0].attr('id')
+    error_id = dom.xpath('//span')[0].attr('id')
     ids = hint_id + " " + error_id
     assert_select ".govuk-fieldset[aria-describedby='#{ids}']"
   end


### PR DESCRIPTION
## What
Use a block-element for the hint message component.

## Why
Enable the component to have either block or non-block elements inside.
The current need is to render a list of items in the hint message for Content Publisher.

## Visual Changes
No visual changes

[Trello card](https://trello.com/c/OJwGOdvd)