### PR TITLE
Restore missing field to feedback survey form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Restore missing field to feedback survey form (PR #998)
 * Use div elements for hint messages (PR #996)
 
 ## 17.16.0

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -165,6 +165,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         // for all other, show generic error
         if (typeof (error.responseJSON) !== 'undefined') {
           error = typeof (error.responseJSON.message) === 'undefined' ? genericError : error.responseJSON.message
+
+          if (error === 'email survey sign up failure') {
+            error = genericError
+          }
         } else {
           error = genericError
         }

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -14,5 +14,5 @@
 <div class="gem-c-feedback <%= margin_top_class %>" data-module="feedback">
   <%= render "govuk_publishing_components/components/feedback/yes_no_banner" %>
   <%= render "govuk_publishing_components/components/feedback/problem_form", url_without_pii: url_without_pii %>
-  <%= render "govuk_publishing_components/components/feedback/survey_signup_form"%>
+  <%= render "govuk_publishing_components/components/feedback/survey_signup_form", path_without_pii: path_without_pii %>
 </div>

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -17,6 +17,7 @@
       <div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>
 
       <input name="email_survey_signup[survey_id]" type="hidden" value="footer_satisfaction_survey">
+      <input name="email_survey_signup[survey_source]" type="hidden" value="<%= path_without_pii %>">
 
       <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
       <p id="survey_explanation" class="gem-c-feedback__form-paragraph">To help us improve GOV.UK, we’d like to know more about your visit today. We’ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don’t worry we won’t send you spam or share your email address with anyone.</p>

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -54,7 +54,7 @@ describe('Feedback component', function () {
       '<div class="grid-row">' +
         '<div class="column-two-thirds">' +
           '<div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>' +
-          '<input name="email_survey_signup[survey_source]" type="hidden" value="<%= path_without_pii %>">' +
+          '<input name="email_survey_signup[survey_source]" type="hidden" value="a_source">' +
 
           '<h2 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h2>' +
           '<p class="gem-c-feedback__form-paragraph">To help us improve GOV.UK, we\'d like to know more about your visit today. We\'ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don\'t worry we won\'t send you spam or share your email address with anyone.</p>' +
@@ -384,11 +384,11 @@ describe('Feedback component', function () {
       expect(request.url).toBe('/contact/govuk/page_improvements')
       expect(request.method).toBe('POST')
       expect(request.data()).toEqual({
-        url: ['http://example.com/path/to/page'],
-        what_doing: ['I was looking for some information about local government.'],
-        what_wrong: ['The background should be green.'],
-        referrer: ['unknown'],
-        javascript_enabled: ['true']
+        'url': ['http://example.com/path/to/page'],
+        'what_doing': ['I was looking for some information about local government.'],
+        'what_wrong': ['The background should be green.'],
+        'referrer': ['unknown'],
+        'javascript_enabled': ['true']
       })
     })
 
@@ -486,7 +486,8 @@ describe('Feedback component', function () {
       expect(request.method).toBe('POST')
       expect(request.data()).toEqual({
         'email_survey_signup[email_address]': ['test@test.com'],
-        'email_survey_signup[ga_client_id]': ['111111111.1111111111']
+        'email_survey_signup[ga_client_id]': ['111111111.1111111111'],
+        'email_survey_signup[survey_source]': ['a_source']
       })
     })
 
@@ -681,6 +682,34 @@ describe('Feedback component', function () {
       })
 
       expect(document.activeElement).toBe($('#page-is-not-useful .js-errors').get(0))
+    })
+  })
+
+  describe('submitting a form that fails because email_survey_signup[survey_source] is missing', function () {
+    beforeEach(function () {
+      jasmine.Ajax.install()
+
+      loadFeedbackComponent()
+      fillAndSubmitSomethingIsWrongForm()
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"message":"email survey sign up failure","errors":{"survey_source":["can\'t be blank"]}}'
+      })
+    })
+
+    afterEach(function () {
+      jasmine.Ajax.uninstall()
+    })
+
+    it('displays the generic error message in place of the less helpful "email survey sign up failure"', function () {
+      expect($('.gem-c-feedback__error-summary').html()).toContainText(
+        'Sorry, we’re unable to receive your message right now. ' +
+        'If the problem persists, we have other ways for you to provide ' +
+        'feedback on the contact page.'
+      )
+      expect($('.gem-c-feedback__error-summary').html()).not.toContainText('email survey sign up failure')
     })
   })
 

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -54,6 +54,7 @@ describe('Feedback component', function () {
       '<div class="grid-row">' +
         '<div class="column-two-thirds">' +
           '<div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>' +
+          '<input name="email_survey_signup[survey_source]" type="hidden" value="<%= path_without_pii %>">' +
 
           '<h2 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h2>' +
           '<p class="gem-c-feedback__form-paragraph">To help us improve GOV.UK, we\'d like to know more about your visit today. We\'ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don\'t worry we won\'t send you spam or share your email address with anyone.</p>' +


### PR DESCRIPTION
## What

The feedback form, when the user clicks 'no' and inputs their email address to receive a survey, is broken, as documented [in this issue](https://github.com/alphagov/govuk_publishing_components/issues/997). This PR restores the missing field.

## Why

Feedback form isn't working properly across GOV.UK.

## Visual Changes

No visual changes.

Fixes https://github.com/alphagov/govuk_publishing_components/issues/997

