### PR TITLE
Only setup asset precompilation when assets are available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove expectation that sprockets is installed when used in a Rails app (PR #999)
+
 ## 17.18.0
 
 * Replace accessible media player with Youtube player (PR #908)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+return unless Rails.application.config.respond_to?(:assets)
+
 Rails.application.config.assets.precompile += %w(
   component_guide/accessibility-test.js
   component_guide/application.js


### PR DESCRIPTION
## What

This removes the expectation that sprockets is available when the Rails initializers run

## Why

Not all applications that consume govuk_publishing_components have sprockets installed. [Publishing API](https://github.com/alphagov/publishing-api/pull/1549) is one of those.

## Visual Changes

None
