### PR TITLE
Changes content item to have symbolic keys

### DIFF
--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
     # Only used by the step by step component
     class PageWithStepByStepNavigation
       def initialize(content_store_response, current_path, query_parameters = {})
-        @content_item = content_store_response.to_h
+        @content_item = content_store_response.to_h.deep_symbolize_keys
         @current_path = current_path
         @query_parameters = query_parameters
       end
@@ -152,15 +152,15 @@ module GovukPublishingComponents
       end
 
       def parsed_step_navs
-        content_item.dig("links", "part_of_step_navs").to_a
+        content_item.dig(:links, :part_of_step_navs).to_a
       end
 
       def parsed_related_to_step_navs
-        content_item.dig("links", "related_to_step_navs").to_a
+        content_item.dig(:links, :related_to_step_navs).to_a
       end
 
       def parsed_secondary_to_step_navs
-        content_item.dig("links", "secondary_to_step_navs").to_a
+        content_item.dig(:links, :secondary_to_step_navs).to_a
       end
 
       def configure_for_sidebar(step_nav_content)


### PR DESCRIPTION
## What
Changes content item to have symbolic keys.

## Why
We have to call deep_symbolize_keys because we're often dealing with a
parsed JSON document which will have string keys by default, but our
components use symbol keys and we want consistency.

## Visual Changes
None

## CHANGE NOTE NOT ADDED
This was not added to change notes as this is a bug fix and does not provide any usefulness in change notes


https://trello.com/c/LU6AAcOk/14-step-by-step-set-up-data-tracking-for-navigation-on-secondary-content