### PR TITLE
Add missing margin to the tabs list overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove expectation that sprockets is installed when used in a Rails app (PR #999)
+* Fix tabs list overwrite on mobile (PR #1003)
 
 ## 17.18.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
@@ -14,13 +14,22 @@
 // scss-lint:disable QualifyingElement
 // sass-lint:disable no-qualifying-elements
 ul.govuk-tabs__list {
-  list-style: none;
   margin: 0;
   padding: 0;
+  list-style: none;
+  @include govuk-responsive-margin(6, "bottom");
 }
 
 li.govuk-tabs__list-item {
   margin-left: govuk-spacing(5);
+}
+
+.js-enabled {
+  @include govuk-media-query($from: tablet) {
+    ul.govuk-tabs__list {
+      margin-bottom: 0;
+    }
+  }
 }
 // scss-lint:enable QualifyingElement
 // sass-lint:enable no-qualifying-elements


### PR DESCRIPTION
## What
When we added an overwrite that deals with styles leaking from static, we only did the overwrite for the desktop mode.

It is currently missing the [default margin bottom](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/tabs/_tabs.scss#L22) and the [JS-enabled desktop style that removes the default margin](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/tabs/_tabs.scss#L61) resulting in a lack of spacing (see visual changes) between `govuk-tabs__list` and the first container. This PR replicates the code from govuk-frontend in this overwrite (with the hope that at some point will not be needed anymore).

## Why
We want to keep the styles in sync with govuk-frontend. 

## Visual Changes
Before fix
![localhost_3212_component-guide_tabs_default_preview](https://user-images.githubusercontent.com/788096/61714857-c0cc0e00-ad53-11e9-9177-fe7e2773e809.png)

After fix
![localhost_3212_component-guide_tabs_default_preview (1)](https://user-images.githubusercontent.com/788096/61714861-c295d180-ad53-11e9-9aeb-964031ba0353.png)

[Trello card](https://trello.com/c/95Mdb8FV)