### PR TITLE
Add origin to YouTube Player API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Remove expectation that sprockets is installed when used in a Rails app (PR #999)
 * Fix tabs list overwrite on mobile (PR #1003)
+* Set the origin when rendering the YouTube player (PR #1004)
 
 ## 17.18.0
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -55,6 +55,7 @@
         playerVars: {
           // enables the player to be controlled via IFrame or JavaScript Player API calls
           enablejsapi: 1,
+          origin: window.location.origin,
           // don't show related videos
           rel: 0,
           // disable option to allow single key shortcuts due to (WCAG SC 2.1.4)


### PR DESCRIPTION
The documentation for the YouTube Player API states that:

> If you are using the IFrame API, which means you are setting the enablejsapi parameter value to 1, you should always specify your domain as the origin parameter value.

https://developers.google.com/youtube/player_parameters#origin

We're currently seeing a Smokey error that suggests the origin is not being set correctly for the player:

```
https://s.ytimg.com/yts/jsbin/www-widgetapi-vfl2284kc/www-widgetapi.js 105 Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('https://www.youtube-nocookie.com') does not match the recipient window's origin ('https://draft-origin.publishing.service.gov.uk'). (Capybara::Chromedriver::Logger::JsError)
```

I'm not sure if this change will fix the Smokey error, but the documentation suggests that we should be setting `origin` and I've found other references online to that being a solution to this problem: https://stackoverflow.com/a/50518247