### PR TITLE
Bump gem version to 17.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 17.19.0
 
 * Remove expectation that sprockets is installed when used in a Rails app (PR #999)
 * Fix tabs list overwrite on mobile (PR #1003)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (17.18.0)
+    govuk_publishing_components (17.19.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -161,7 +161,7 @@ GEM
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     null_logger (0.0.1)
-    oj (3.8.0)
+    oj (3.8.1)
     parallel (1.17.0)
     parser (2.6.3.0)
       ast (~> 2.4.0)
@@ -218,7 +218,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.6.0)
+    rouge (3.7.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.3)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '17.18.0'.freeze
+  VERSION = '17.19.0'.freeze
 end


### PR DESCRIPTION
Includes:

* Remove expectation that sprockets is installed when used in a Rails app (PR #999)
* Changes content item to have symbolic keys (PR #1002)
* Fix tabs list overwrite on mobile (PR #1003)
* Set the origin when rendering the YouTube player (PR #1004)
