### PR TITLE
Version 17.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 17.9.0
 
 * Remove expectation that sprockets is installed when used in a Rails app (PR #999)
 * Fix tabs list overwrite on mobile (PR #1003)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (17.18.0)
+    govuk_publishing_components (17.19.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '17.18.0'.freeze
+  VERSION = '17.19.0'.freeze
 end


### PR DESCRIPTION
Includes:

* Remove expectation that sprockets is installed when used in a Rails app (PR #999)
* Fix tabs list overwrite on mobile (PR #1003)
* Set the origin when rendering the YouTube player (PR #1004)