### PR TITLE
Change subscription links CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change subscription links CSS (PR #1007)
+
 ## 17.9.0
 
 * Remove expectation that sprockets is installed when used in a Rails app (PR #999)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -8,7 +8,7 @@
 
   .gem-c-subscription-links__list {
     list-style: none;
-    margin: 0 (- govuk-spacing(3) / 2);
+    margin: 0;
     padding: 0;
   }
 
@@ -18,9 +18,12 @@
 
   .gem-c-subscription-links__list-item {
     display: inline-block;
-    margin-left: govuk-spacing(2);
-    margin-right: govuk-spacing(2);
+    margin-right: govuk-spacing(4);
     margin-bottom: govuk-spacing(3);
+
+    &:last-child {
+      margin-right: 0;
+    }
   }
 
   .gem-c-subscription-links__list-item--small {


### PR DESCRIPTION
## What
Changes the CSS of subscription links to not use a negative margin on the parent list to compensate for the regular margin around the individual list items; instead, apply right margin only to list items to preserve spacing, but use `last-child` to remove it from the last item (this wouldn't be necessary but in finder-frontend they're right-aligned).

## Why
This should fix a long standing issue on finders, where the negative margin causes [this overlap problem](https://www.gov.uk/find-eu-exit-guidance-business?parent=&keywords=&sector_business_area%5B%5D=aerospace&order=topic) on the right of the screen.

![Screen Shot 2019-07-25 at 09 42 19](https://user-images.githubusercontent.com/861310/61859821-c85cf580-aec0-11e9-9610-bdbdde58b6a2.png)


## Visual Changes
There should be no visual changes, however it turns out there's a very small change, because the negative margin on the `ul` was `-7.5px` and the margin on the `li` elements was `10px`. This change evens this out so subscription links line up with the left edge of the screen. It also appears to fix a negative margin bug with the `as small form` option on the component.

Before:

![Screen Shot 2019-07-25 at 09 46 37](https://user-images.githubusercontent.com/861310/61860018-24c01500-aec1-11e9-9d08-7a2d60619d89.png)

After:

![Screen Shot 2019-07-25 at 09 46 47](https://user-images.githubusercontent.com/861310/61860034-2ab5f600-aec1-11e9-8f22-a07edf593633.png)

## Other places this is used

This component is used in a few places so I've checked to make sure these changes don't break it across the site. Since these are in different applications I'm not sure they'll work in the review app but here's some links and some screenshots of local versions of these apps with this change to compare.

[Organisation pages](https://www.gov.uk/government/organisations/office-of-financial-sanctions-implementation)

With new change:

![Screen Shot 2019-07-25 at 10 24 27](https://user-images.githubusercontent.com/861310/61862832-699a7a80-aec6-11e9-9939-1be46aafef6e.png)

Mobile:

![Screen Shot 2019-07-25 at 10 24 59](https://user-images.githubusercontent.com/861310/61862900-7c14b400-aec6-11e9-8e5a-ccf340df2f9e.png)


[Foreign travel advice](https://www.gov.uk/foreign-travel-advice/afghanistan)

With new change:

![Screen Shot 2019-07-25 at 10 31 30](https://user-images.githubusercontent.com/861310/61863407-6e136300-aec7-11e9-912c-afd691009586.png)

Mobile:

![Screen Shot 2019-07-25 at 10 31 44](https://user-images.githubusercontent.com/861310/61863419-7370ad80-aec7-11e9-8369-4eb9b47f0cd0.png)


## View Changes
https://govuk-publishing-compon-pr-1007.herokuapp.com/subscription-links

Trello card: https://trello.com/c/SilU41vx/901-fix-the-overlap-issue-with-subscription-links