### PR TITLE
Correctly link to the text input component in the Design System

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -16,7 +16,7 @@ accessibility_criteria: |
 
   Avoid using autofocus and tabindex unless you have user research to support this behaviour.
 govuk_frontend_components:
-  - input
+  - text-input
 examples:
   default:
     data:


### PR DESCRIPTION
This link 404s, I'm not sure it ever worked.

