### PR TITLE
Add full width option to select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## 17.9.1
+## Unreleased
+
+* Add full width option to select component (PR #1012)
+
+## 17.19.1
 
 * Replace subscription links images with SVG (PR #1008)
 * Change subscription links CSS (PR #1007)
 
-## 17.9.0
+## 17.19.0
 
 * Remove expectation that sprockets is installed when used in a Rails app (PR #999)
 * Fix tabs list overwrite on mobile (PR #1003)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
@@ -1,1 +1,5 @@
 @import "govuk-frontend/components/select/select";
+
+.gem-c-select__select--full-width {
+  width: 100%;
+}

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -2,6 +2,7 @@
   options ||= []
   id ||= false
   label ||= false
+  full_width ||= false
 
   select_helper = GovukPublishingComponents::Presenters::SelectHelper.new(options)
   data_module = "data-module=track-select-change" unless select_helper.data_tracking?.eql?(false)
@@ -11,7 +12,7 @@
     <label class="govuk-label" for="<%= id %>">
       <%= label %>
     </label>
-    <select class="govuk-select" id="<%= id %>" name="<%= id %>" <%= data_module %> >
+    <select class="govuk-select <%= 'gem-c-select__select--full-width' if full_width %>" id="<%= id %>" name="<%= id %>" <%= data_module %> >
       <%= options_for_select(select_helper.option_markup, select_helper.selected_option) %>
     </select>
   </div>

--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -79,4 +79,17 @@ examples:
         value: 'option2'
       - text: 'Option three'
         value: 'option3'
+  full_width:
+    description: Make the select width 100%. This is used for facets in finder-frontend's search.
+    data:
+      id: 'dropdown5'
+      label: 'Really wide'
+      full_width: true
+      options:
+      - text: 'Option one'
+        value: 'option1'
+      - text: 'Option two'
+        value: 'option2'
+      - text: 'Option three'
+        value: 'option3'
 

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -170,4 +170,21 @@ describe "Select", type: :view do
     assert_select ".gem-c-select [data-module=track-select-change]", false
     assert_select ".gem-c-select [data-another-attribute=test1][data-second-item=item1][data-option=option1]"
   end
+
+  it "renders a select box full width" do
+    render_component(
+      id: "mydropdown",
+      label: "My dropdown",
+      full_width: true,
+      options: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        }
+      ]
+    )
+
+    assert_select "select[name=mydropdown]"
+    assert_select ".gem-c-select .gem-c-select__select--full-width"
+  end
 end


### PR DESCRIPTION
## What
Adds a full width option to the select component, which sets the select element itself to be `width: 100%;`.

<img width="854" alt="Screen Shot 2019-07-31 at 08 23 47" src="https://user-images.githubusercontent.com/861310/62192124-ef0da700-b36c-11e9-9988-a7c6e2d9e671.png">


## Why
This isn't included in the Design System for reasons but we're using this component in finder-frontend's search and adding CSS there to make it full width, so it seemed more in line with our component principles to add it into the component itself.

<img width="846" alt="Screen Shot 2019-07-31 at 08 25 11" src="https://user-images.githubusercontent.com/861310/62192064-ce455180-b36c-11e9-9bee-7e09c2b99b6b.png">


## Visual Changes
No visual changes unless you select this option, obviously.

## View Changes
https://govuk-publishing-compon-pr-1012.herokuapp.com/select

Trello card: https://trello.com/c/w34QlutZ/910-investigate-adding-an-option-to-the-select-component-for-width-100