### PR TITLE
Update Statistics header link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 ## Unreleased
 
 * Add full width option to select component (PR #1012)
+* Change statistics header link to link to new finder (PR #1015)
 
 ## 17.19.1
-
 * Replace subscription links images with SVG (PR #1008)
 * Change subscription links CSS (PR #1007)
 

--- a/app/views/govuk_publishing_components/components/_government_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_government_navigation.html.erb
@@ -30,7 +30,7 @@
       </a>
     </li>
     <li>
-      <a class="<%= 'active' if active == 'statistics' %>" href="/government/statistics">
+      <a class="<%= 'active' if active == 'statistics' %>" href="/search/research-and-statistics">
         <%= t("govuk_component.government_navigation.statistics", default: "Statistics") %>
       </a>
     </li>

--- a/spec/components/government_navigation_spec.rb
+++ b/spec/components/government_navigation_spec.rb
@@ -12,6 +12,7 @@ describe "Government navigation", type: :view do
     assert_link_with_text("/government/organisations", "Departments")
     assert_link_with_text("/news-and-communications", "News and communications")
     assert_link_with_text("/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&amp;content_store_document_type[]=closed_consultations", "Consultations")
+    assert_link_with_text("/search/research-and-statistics", "Statistics")
   end
 
   it "has no active links by default" do


### PR DESCRIPTION
Update Statistics header link to point to the new supergroup statistics finder.

## What
Update the statistics link in the header to point to the new supergroup stats finder.

## Why
Whitehall finders are being replaced by supergroup finders. The stats finder is the last to be transitioned. 

## Visual Changes
None

<!--
## View Changes
https://govuk-publishing-compon-pr-[PR-NUMBER].herokuapp.com/
-->

https://trello.com/c/CAtBdn4k/510-change-whitehall-header-link-to-stats-finder-s