### PR TITLE
Fix for select height zoom problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add tests for email feedback form (PR #1017)
 * Add `lang` attribute option to subscription links (PR #1019)
+* Fix for select height zoom problem (PR #1018)
 
 ## 17.20.0
 
@@ -18,6 +19,7 @@
 * Change statistics header link to link to new finder (PR #1015)
 
 ## 17.19.1
+
 * Replace subscription links images with SVG (PR #1008)
 * Change subscription links CSS (PR #1007)
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
@@ -3,3 +3,11 @@
 .gem-c-select__select--full-width {
   width: 100%;
 }
+
+// Solution to text inside selects becoming unreadable if font size in
+// the browser is increased. This is currently a problem in govuk-frontend
+.gem-c-select {
+  .govuk-select {
+    height: 2.14em;
+  }
+}


### PR DESCRIPTION
## What
This is a fix for a problem noticed during user research where a participant had their phone text size set very high. This resulted in the text in the select component being cropped slightly. This can be reproduced using Firefox's 'zoom text only' option, and it looks like this:

<img width="912" alt="Screen Shot 2019-08-02 at 14 18 00" src="https://user-images.githubusercontent.com/861310/62372831-63447800-b530-11e9-8923-1db58e2474b4.png">

I've raised an [issue in govuk-frontend](https://github.com/alphagov/govuk-frontend/issues/1519) but it's likely that their fix will not help on GOV.UK as we're using compatibility mode for elements and toolkit, and this issue apparently relates to the base font size.

The problem is caused by the height of selects being set at 40px. The best solution seems to be to set the height using `em`, so that it scales with the text size of the select. An alternative is to set it using `rem` but since the component guide doesn't set a base font size this results in the height appearing differently there and in finder-frontend.

I think (correct me if I'm wrong) that as long as there's an explicit font size on the select (which there is) even if it's specified using `em` (which it is) as long as the height is greater than `1em` (which it is now) then the height of the select will always exceed the height of the text, so this problem shouldn't occur.

<img width="911" alt="Screen Shot 2019-08-02 at 14 26 32" src="https://user-images.githubusercontent.com/861310/62373379-91768780-b531-11e9-943a-ec11cac04be9.png">

## Why
Well, it's broken.

## Visual Changes
I've overridden the height of `40px` with a height of `2.14em`, which appears to be the same, so there should be no visual changes. I'm pretty sure we're only using this component in finder-frontend, so we only need to test the search and finders pages.

## View Changes
https://govuk-publishing-compo-pr-1018.herokuapp.com/component-guide/select

Trello card: https://trello.com/c/VWJHWlBC/922-fix-facet-text-zoom-problem