### PR TITLE
Allow language to be set on subscription links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add tests for email feedback form (PR #1017)
+* Add `lang` attribute option to subscription links (PR #1019)
 
 ## 17.20.0
 

--- a/app/views/govuk_publishing_components/components/_subscription-links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription-links.html.erb
@@ -1,6 +1,7 @@
 <%
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
+
   sl_helper = GovukPublishingComponents::Presenters::SubscriptionLinksHelper.new(local_assigns)
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
@@ -10,8 +11,13 @@
   css_classes = %w( gem-c-subscription-links )
   css_classes << (shared_helper.get_margin_bottom) unless local_assigns[:margin_bottom] == 0
   css_classes << brand_helper.brand_class
+
   data = {"module": "gem-toggle"} if sl_helper.feed_link_box_value
+
   hide_heading ||= false
+
+  email_signup_link_text_locale = local_assigns[:email_signup_link_text_locale]
+  feed_link_text_locale = local_assigns[:feed_link_text_locale]
 %>
 <% if sl_helper.component_data_is_valid? %>
   <%= tag.section class: css_classes, data: data do %>
@@ -25,10 +31,11 @@
       <% if sl_helper.email_signup_link.present? %>
         <li class="gem-c-subscription-links__list-item<%= ' gem-c-subscription-links__list-item--small' if local_assigns[:small_form] == true %>" >
           <svg xmlns="http://www.w3.org/2000/svg" width="21" height="15.75" class="gem-c-subscription-links__icon" focusable="false" fill="currentColor" aria-hidden="true"><path d="M19.687 0H1.312C.589 0 0 .587 0 1.313v13.124c0 .726.588 1.313 1.313 1.313h18.374c.725 0 1.313-.587 1.313-1.313V1.313C21 .587 20.412 0 19.687 0zm-2.625 2.625L10.5 7.875l-6.563-5.25h13.126zm1.313 10.5H2.625V3.937L10.5 10.5l7.875-6.563v9.188z"/></svg>
-          <%= link_to sl_helper.email_signup_link_text, sl_helper.email_signup_link,
+          <%= link_to sl_helper.email_signup_link_text, sl_helper.email_signup_link, {
             class: "gem-c-subscription-links__link #{brand_helper.color_class}",
-            data: sl_helper.email_signup_link_data_attributes
-          %>
+            data: sl_helper.email_signup_link_data_attributes,
+            lang: email_signup_link_text_locale
+          } %>
         </li>
       <% end %>
 
@@ -36,8 +43,11 @@
         <li class="gem-c-subscription-links__list-item<%= ' gem-c-subscription-links__list-item--small' if local_assigns[:small_form] == true %>">
           <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" class="gem-c-subscription-links__icon" focusable="false" fill="currentColor" aria-hidden="true"><path d="M1.996 11A2 2 0 0 0 0 12.993c0 1.101.895 1.99 1.996 1.99 1.106 0 2-.889 2-1.99a2 2 0 0 0-2-1.993zM.002 5.097V7.97c1.872 0 3.632.733 4.958 2.059A6.984 6.984 0 0 1 7.015 15h2.888c0-5.461-4.443-9.903-9.9-9.903zM.006 0v2.876c6.676 0 12.11 5.44 12.11 12.124H15C15 6.731 8.273 0 .006 0z"/></svg>
           <%= link_to sl_helper.feed_link_text, sl_helper.feed_link,
-            class: "gem-c-subscription-links__link #{brand_helper.color_class}",
-            data: sl_helper.feed_link_data_attributes
+            {
+              class: "gem-c-subscription-links__link #{brand_helper.color_class}",
+              data: sl_helper.feed_link_data_attributes,
+              lang: feed_link_text_locale
+            }
           %>
         </li>
       <% end %>

--- a/app/views/govuk_publishing_components/components/docs/subscription-links.yml
+++ b/app/views/govuk_publishing_components/components/docs/subscription-links.yml
@@ -89,10 +89,12 @@ examples:
   with_a_different_language:
     data:
       email_signup_link: '/foreign-travel-advice/singapore/email-signup'
-      email_signup_link_text: 'Get notifications'
-      email_signup_link_text_locale: 'en'
+      email_signup_link_text: 'Recevez des notifications'
+      email_signup_link_text_locale: 'fr'
       feed_link: '/foreign-travel-advice/singapore.atom'
-      feed_link_text: 'View feed'
-      feed_link_text_locale: 'en'
+      feed_link_text: 'Flux RSS'
+      feed_link_text_locale: 'fr'
     description: |
       The component is used on translated pages that don't have a translation for the text strings. This means that it could display the fallback English string if the translate method can't find an appropriate translation. This makes sure that the `lang` can be set to ensure that browsers understand which parts of the page are in each language.
+
+      The `lang` attribute **must** be set to a [valid BCP47 string](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang#Language_tag_syntax). A valid code can be the two or three letter language code - for example, English is `en` or `eng`, Korean is `ko` or `kor` - but if in doubt please check.

--- a/app/views/govuk_publishing_components/components/docs/subscription-links.yml
+++ b/app/views/govuk_publishing_components/components/docs/subscription-links.yml
@@ -81,9 +81,18 @@ examples:
       small_form: true
   without_heading:
     description: |
-      By default the component includes an h2 heading. The component could be used anywhere on the page and could mean
-      that it produces invalid markup or make the site unaccessible.
+      By default the component includes an h2 heading. The component could be used anywhere on the page and could mean that it produces invalid markup or make the site unaccessible.
     data:
       email_signup_link: '/foreign-travel-advice/singapore/email-signup'
       feed_link: '/foreign-travel-advice/singapore.atom'
       hide_heading: true
+  with_a_different_language:
+    data:
+      email_signup_link: '/foreign-travel-advice/singapore/email-signup'
+      email_signup_link_text: 'Get notifications'
+      email_signup_link_text_locale: 'en'
+      feed_link: '/foreign-travel-advice/singapore.atom'
+      feed_link_text: 'View feed'
+      feed_link_text_locale: 'en'
+    description: |
+      The component is used on translated pages that don't have a translation for the text strings. This means that it could display the fallback English string if the translate method can't find an appropriate translation. This makes sure that the `lang` can be set to ensure that browsers understand which parts of the page are in each language.

--- a/spec/components/subscription_links_spec.rb
+++ b/spec/components/subscription_links_spec.rb
@@ -101,4 +101,26 @@ describe "subscription links", type: :view do
       assert_select "h2.gem-c-subscription-links__hidden-header", false
     end
   end
+
+  it "adds a lang attribute when set" do
+    render_component(
+      email_signup_link: 'email-signup',
+      email_signup_link_text: 'Get email!',
+      email_signup_link_text_locale: 'en',
+      feed_link: 'singapore.atom',
+      feed_link_text: 'View feed!',
+      feed_link_text_locale: 'en',
+    )
+    assert_select ".gem-c-subscription-links__link[lang='en']", 2
+  end
+
+  it "no lang attribute is added when not set" do
+    render_component(
+      email_signup_link: 'email-signup',
+      email_signup_link_text: 'Get email!',
+      feed_link: 'singapore.atom',
+      feed_link_text: 'View feed!',
+    )
+    assert_select ".gem-c-subscription-links__link[lang]", false
+  end
 end


### PR DESCRIPTION
## What
Adds a setting to set the lang attribute set on each link in the 'Subscription links' component.

## Why
Subscription links can appear on translated pages, but if there's no available translation when using `t()` it falls back to English. When this is the middle of a section thats marked up as being in another language it causes problems - the screenreaders try to parse the English as another language.

For example - the [Korean version of the page for Scott Wightman](https://www.gov.uk/government/people/scott-wightman.ko)

![Screen Shot 2019-08-02 at 15 03 21](https://user-images.githubusercontent.com/1732331/62375671-b3bed400-b536-11e9-9fc1-881a16a2e262.png)

![Screen Shot 2019-08-02 at 15 05 15](https://user-images.githubusercontent.com/1732331/62375913-511a0800-b537-11e9-84c5-d4d375b209ca.png)

The circled 'Get email alerts' parent link should have `lang="en"`.

## Visual Changes
No visual changes - only reflected in the markup.

Before:
![Screen Shot 2019-08-02 at 15 00 40](https://user-images.githubusercontent.com/1732331/62375502-532f9700-b536-11e9-8ad0-1c6f5f342841.png)


After:
![Screen Shot 2019-08-02 at 14 59 20](https://user-images.githubusercontent.com/1732331/62375416-2a0f0680-b536-11e9-93ea-34253b44159f.png)

## View Changes
 - https://govuk-publishing-compo-pr-1019.herokuapp.com/component-guide/subscription-links