### PR TITLE
Normalise falsey values to nil to prevent `lang="false"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+* Normalise falsey values to nil for subscription links component (PR #1021)
+
 ## 17.21.0
 
 * Add tests for email feedback form (PR #1017)

--- a/app/views/govuk_publishing_components/components/_subscription-links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription-links.html.erb
@@ -16,8 +16,8 @@
 
   hide_heading ||= false
 
-  email_signup_link_text_locale = local_assigns[:email_signup_link_text_locale]
-  feed_link_text_locale = local_assigns[:feed_link_text_locale]
+  email_signup_link_text_locale = local_assigns[:email_signup_link_text_locale].present? ? local_assigns[:email_signup_link_text_locale] : nil
+  feed_link_text_locale = local_assigns[:feed_link_text_locale].present? ? local_assigns[:feed_link_text_locale] : nil
 %>
 <% if sl_helper.component_data_is_valid? %>
   <%= tag.section class: css_classes, data: data do %>

--- a/app/views/govuk_publishing_components/components/_subscription-links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription-links.html.erb
@@ -16,8 +16,8 @@
 
   hide_heading ||= false
 
-  email_signup_link_text_locale = local_assigns[:email_signup_link_text_locale].present? ? local_assigns[:email_signup_link_text_locale] : nil
-  feed_link_text_locale = local_assigns[:feed_link_text_locale].present? ? local_assigns[:feed_link_text_locale] : nil
+  email_signup_link_text_locale = local_assigns[:email_signup_link_text_locale].presence
+  feed_link_text_locale = local_assigns[:feed_link_text_locale].presence
 %>
 <% if sl_helper.component_data_is_valid? %>
   <%= tag.section class: css_classes, data: data do %>

--- a/spec/components/subscription_links_spec.rb
+++ b/spec/components/subscription_links_spec.rb
@@ -106,12 +106,13 @@ describe "subscription links", type: :view do
     render_component(
       email_signup_link: 'email-signup',
       email_signup_link_text: 'Get email!',
-      email_signup_link_text_locale: 'en',
+      email_signup_link_text_locale: 'es',
       feed_link: 'singapore.atom',
       feed_link_text: 'View feed!',
-      feed_link_text_locale: 'en',
+      feed_link_text_locale: 'fr',
     )
-    assert_select ".gem-c-subscription-links__link[lang='en']", 2
+    assert_select ".gem-c-subscription-links__link[lang='es']", 1
+    assert_select ".gem-c-subscription-links__link[lang='fr']", 1
   end
 
   it "no lang attribute is added when not set" do
@@ -120,6 +121,36 @@ describe "subscription links", type: :view do
       email_signup_link_text: 'Get email!',
       feed_link: 'singapore.atom',
       feed_link_text: 'View feed!',
+    )
+    assert_select ".gem-c-subscription-links__link[lang]", false
+  end
+
+  it "no lang attribute set when locale is set but empty" do
+    render_component(
+      email_signup_link: 'email-signup',
+      email_signup_link_text_locale: '',
+      feed_link: 'singapore.atom',
+      feed_link_text_locale: '',
+    )
+    assert_select ".gem-c-subscription-links__link[lang]", false
+  end
+
+  it "no lang attribute set when locale is false" do
+    render_component(
+      email_signup_link: 'email-signup',
+      email_signup_link_text_locale: false,
+      feed_link: 'singapore.atom',
+      feed_link_text_locale: false,
+    )
+    assert_select ".gem-c-subscription-links__link[lang]", false
+  end
+
+  it "no lang attribute set when locale is nil" do
+    render_component(
+      email_signup_link: 'email-signup',
+      email_signup_link_text_locale: nil,
+      feed_link: 'singapore.atom',
+      feed_link_text_locale: nil,
     )
     assert_select ".gem-c-subscription-links__link[lang]", false
   end


### PR DESCRIPTION
## What
Checks that the locale attributes being passed into the subscription links components are falsey - if falsey then `nil` is used.

## Why
When a `false` was being used as a parameter in the subscription components, it was being cast and used as a string - leading to `lang="false"`. Not a big deal, since (according to the spec) this should be ignored, but worth fixing.

## Visual Changes
None.

## View Changes
https://govuk-publishing-compo-pr-1021.herokuapp.com/

