### PR TITLE
Use components.publishing.service.gov.uk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1020,7 +1020,7 @@ Your tests are likely to need updating as well.
 * Fix visited link colour on focus for white feedback links (PR #239)
 * Fix input error colour (PR #241)
 * Add helper for generating breadcrumbs on taxon and taxonomy-based finder pages (PR #242)
-* BREAKING: merge the [govuk_navigation_helpers][] gem into this project (#244). To upgrade, you will have to use the contextual navigation components ([sidebar](https://govuk-publishing-components.herokuapp.com/component-guide/contextual_sidebar) and [breadcrumbs](https://govuk-publishing-components.herokuapp.com/component-guide/contextual_breadcrumbs)) .
+* BREAKING: merge the [govuk_navigation_helpers][] gem into this project (#244). To upgrade, you will have to use the contextual navigation components ([sidebar](https://components.publishing.service.gov.uk/component-guide/contextual_sidebar) and [breadcrumbs](https://components.publishing.service.gov.uk/component-guide/contextual_breadcrumbs)) .
 
 [govuk_navigation_helpers]: https://github.com/alphagov/govuk_navigation_helpers
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -1,5 +1,5 @@
 // Govspeak attachment
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/block_attachments
+// https://components.publishing.service.gov.uk/component-guide/govspeak/block_attachments
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_call-to-action.scss
@@ -1,5 +1,5 @@
 // Govspeak call to action
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/call_to_action
+// https://components.publishing.service.gov.uk/component-guide/govspeak/call_to_action
 //
 // Support:
 //

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -1,5 +1,5 @@
 // Govspeak charts
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/charts
+// https://components.publishing.service.gov.uk/component-guide/govspeak/charts
 // Uses Magna Charta (https://github.com/alphagov/magna-charta)
 //
 // Support:

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_contact.scss
@@ -1,5 +1,5 @@
 // Govspeak contact
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/contact
+// https://components.publishing.service.gov.uk/component-guide/govspeak/contact
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_example.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_example.scss
@@ -1,5 +1,5 @@
 // Govspeak example callout
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/example
+// https://components.publishing.service.gov.uk/component-guide/govspeak/example
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
@@ -1,5 +1,5 @@
 // Govspeak footnotes callout
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/footnotes
+// https://components.publishing.service.gov.uk/component-guide/govspeak/footnotes
 //
 // Support:
 //

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_fraction.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_fraction.scss
@@ -1,6 +1,6 @@
 // Govspeak fractions
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/image_fractions
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/text_fractions
+// https://components.publishing.service.gov.uk/component-guide/govspeak/image_fractions
+// https://components.publishing.service.gov.uk/component-guide/govspeak/text_fractions
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_information-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_information-callout.scss
@@ -1,5 +1,5 @@
 // Govspeak information callout
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/information_callout
+// https://components.publishing.service.gov.uk/component-guide/govspeak/information_callout
 //
 // Support:
 //

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_legislative-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_legislative-list.scss
@@ -1,5 +1,5 @@
 // Govspeak legislative list
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/legislative_lists
+// https://components.publishing.service.gov.uk/component-guide/govspeak/legislative_lists
 
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_media-player.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_media-player.scss
@@ -1,5 +1,5 @@
 // Govspeak media player
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/with_youtube_embed
+// https://components.publishing.service.gov.uk/component-guide/govspeak/with_youtube_embed
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_stat-headline.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_stat-headline.scss
@@ -1,5 +1,5 @@
 // Govspeak statistic headline
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/statistic_headlines
+// https://components.publishing.service.gov.uk/component-guide/govspeak/statistic_headlines
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -1,5 +1,5 @@
 // Govspeak tables
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/tables
+// https://components.publishing.service.gov.uk/component-guide/govspeak/tables
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -1,9 +1,9 @@
 @import "../helpers/markdown-typography";
 // Govspeak typography
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/heading_levels
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/lists
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/nested_lists
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/blockquote
+// https://components.publishing.service.gov.uk/component-guide/govspeak/heading_levels
+// https://components.publishing.service.gov.uk/component-guide/govspeak/lists
+// https://components.publishing.service.gov.uk/component-guide/govspeak/nested_lists
+// https://components.publishing.service.gov.uk/component-guide/govspeak/blockquote
 //
 // Support:
 // - alphagov/whitehall: ✔︎

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
@@ -1,5 +1,5 @@
 // Govspeak warning callout
-// https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/warning_callout
+// https://components.publishing.service.gov.uk/component-guide/govspeak/warning_callout
 //
 // Support:
 //

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -3,7 +3,7 @@ description: Use buttons to move though a transaction, aim to use only one butto
 body: |
   Button text should be short and describe the action the button performs.
 
-  This component is also [extended for use in govspeak](https://govuk-publishing-components.herokuapp.com/component-guide/govspeak/button).
+  This component is also [extended for use in govspeak](https://components.publishing.service.gov.uk/component-guide/govspeak/button).
 
   These instances of buttons are added by Content Designers, ideally this duplication would not exist but we currently don't have shared markup
   via our components within the generated [govspeak](https://github.com/alphagov/govspeak).

--- a/app/views/govuk_publishing_components/components/docs/contextual_breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_breadcrumbs.yml
@@ -16,7 +16,7 @@ body: |
   [header]: /component-guide/step_by_step_nav_header
   [footer]: /component-guide/contextual_footer
   [sidebar]: /component-guide/contextual_sidebar
-  [breadcrumbs]: https://govuk-publishing-components.herokuapp.com/component-guide/breadcrumbs
+  [breadcrumbs]: https://components.publishing.service.gov.uk/component-guide/breadcrumbs
 accessibility_criteria: |
   Components called by this component must be accessible
 examples:

--- a/app/views/govuk_publishing_components/components/docs/fieldset.yml
+++ b/app/views/govuk_publishing_components/components/docs/fieldset.yml
@@ -18,7 +18,7 @@ examples:
         <input type="radio" id="default-no" name="default"t>
         <label for="default-no">No</label>
   with_html_legend:
-    description: 'If you only have one fieldset on the page you might want to include the title of the page as the legend text. Used with a [captured](http://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-capture) [title](http://govuk-publishing-components.herokuapp.com/component-guide/title)'
+    description: 'If you only have one fieldset on the page you might want to include the title of the page as the legend text. Used with a [captured](http://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-capture) [title](http://components.publishing.service.gov.uk/component-guide/title)'
     data:
       legend_text: |
         <!-- Use the title component, this is hardcoded only for this example -->

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -51,7 +51,7 @@ Example:
 <% endif %>
 ```
 
-If a component includes a heading, consider including an option to control the heading level (see the [heading component](https://govuk-publishing-components.herokuapp.com/component-guide/heading/specific_heading_level) for example).
+If a component includes a heading, consider including an option to control the heading level (see the [heading component](https://components.publishing.service.gov.uk/component-guide/heading/specific_heading_level) for example).
 
 Components can use other components within their template, if required (see the [input component](https://github.com/alphagov/govuk_publishing_components/blob/master/app/views/govuk_publishing_components/components/_input.html.erb#L37) for example).
 
@@ -252,7 +252,7 @@ Follow the [GOV.UK Frontend JS conventions](https://github.com/alphagov/govuk-fr
 
 Scripts should use the [module pattern provided by govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/javascript.md#modules) and be linted using [StandardJS](https://standardjs.com/).
 
-Most components should have an option to include arbitrary data attributes (see the [checkboxes component](https://govuk-publishing-components.herokuapp.com/component-guide/checkboxes/checkboxes_with_data_attributes) for example). These can be used for many purposes including tracking (see the [select component](https://govuk-publishing-components.herokuapp.com/component-guide/select/with_tracking) for [example code](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/components/select.js)) but specific tracking should only be added to a component where there is a real need for it.
+Most components should have an option to include arbitrary data attributes (see the [checkboxes component](https://components.publishing.service.gov.uk/component-guide/checkboxes/checkboxes_with_data_attributes) for example). These can be used for many purposes including tracking (see the [select component](https://components.publishing.service.gov.uk/component-guide/select/with_tracking) for [example code](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/components/select.js)) but specific tracking should only be added to a component where there is a real need for it.
 
 Some [common Javascript modules](https://github.com/alphagov/govuk_publishing_components/tree/master/app/assets/javascripts/govuk_publishing_components/lib) are available. If new functionality is required, consider adding it as a common module.
 

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,4 +1,12 @@
 Rails.application.routes.draw do
+  if Rails.env.production?
+    constraints(host: "govuk-publishing-components.herokuapp.com") do
+      match "/(*path)" => redirect { |params, _req|
+                            "https://components.publishing.service.gov.uk/#{params[:path]}"
+                          }, via: %i[get post]
+    end
+  end
+
   mount GovukPublishingComponents::Engine, at: "/component-guide"
   root to: redirect('/component-guide')
   get 'test', to: 'welcome#index'


### PR DESCRIPTION
## What

The main component guide is now hosted on https://components.publishing.service.gov.uk.

## Why

We can't use the crown and font on non *.gov.uk sites. It looks better.