### PR TITLE
Hide test components in the dummy app

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rackup spec/dummy/config.ru -p $PORT
+web: MAIN_COMPONENT_GUIDE=true bundle exec rackup spec/dummy/config.ru -p $PORT

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -16,20 +16,22 @@
   } %>
 </form>
 
-<h2 class="component-doc-h2">Components in this application</h2>
+<% unless ENV["MAIN_COMPONENT_GUIDE"] %>
+  <h2 class="component-doc-h2">Components in this application</h2>
 
-<ul class="component-list">
-  <% @component_docs.each do |component_doc| %>
-    <li>
-      <%= link_to component_doc.name, component_doc_path(component_doc.id), class: "govuk-link" %>
-      <p>
-        <%= component_doc.description %>
-      </p>
-    </li>
-  <% end %>
-</ul>
+  <ul class="component-list">
+    <% @component_docs.each do |component_doc| %>
+      <li>
+        <%= link_to component_doc.name, component_doc_path(component_doc.id), class: "govuk-link" %>
+        <p>
+          <%= component_doc.description %>
+        </p>
+      </li>
+    <% end %>
+  </ul>
 
-<h2 class="component-doc-h2">Components in the gem</h2>
+  <h2 class="component-doc-h2">Components in the gem</h2>
+<% end %>
 
 <ul class="component-list">
   <% @gem_component_docs.each do |component_doc| %>

--- a/startup.sh
+++ b/startup.sh
@@ -3,6 +3,8 @@
 npm install
 bundle check || bundle install
 
+export MAIN_COMPONENT_GUIDE=true
+
 if [[ $1 == "--live" ]] ; then
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \


### PR DESCRIPTION
The dummy app in `spec/dummy` has 2 purposes.

First, it's a sample app that is used in tests to check the functionality of having components inside the application.

Secondly, it is hosted on https://components.publishing.service.gov.uk as  a reference.

This adds a environment variable to the startup scripts for the reference app, so that we can hide the components that are only used for testing.

## Before

<img width="1458" alt="Screen Shot 2019-08-07 at 16 11 18" src="https://user-images.githubusercontent.com/233676/62634554-02e97800-b92e-11e9-91ca-dcaf123136fb.png">

## After

<img width="1458" alt="Screen Shot 2019-08-07 at 16 10 56" src="https://user-images.githubusercontent.com/233676/62634561-07159580-b92e-11e9-94ea-98892a720adb.png">
