### PR TITLE
Add locale option to related navigation component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
 
 ## Unreleased
 
-* Make the gem _slimmer_ by only including GOV.UK Frontend (#1041)
-* Remove unused image assets previously used in the button component and references to zombie image assets (#1042)
-* Fix start button showing SVG code (#1043)
+* Make the gem _slimmer_ by only including GOV.UK Frontend (PR #1041)
+* Remove unused image assets previously used in the button component and references to zombie image assets (PR #1042)
+* Fix start button showing SVG code (PR #1043)
+* Add locale option so `lang` attribute can be used on related links (PR #1026)
 
 ## 18.0.0
 

--- a/app/views/govuk_publishing_components/components/_related_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_related_navigation.html.erb
@@ -7,7 +7,13 @@
     <% if local_assigns[:context] != :footer %>
       <h2 id="related-nav-related_items-<%= random %>"
           class="gem-c-related-navigation__main-heading"
-          data-track-count="sidebarRelatedItemSection">
+          data-track-count="sidebarRelatedItemSection"
+          <%= related_nav_helper.t_lang(
+              "components.related_#{local_assigns[:context]}_navigation.related_content",
+              default: 'components.related_navigation.related_content'
+            )
+          %>
+      >
         <%= t("components.related_#{local_assigns[:context]}_navigation.related_content",
               default: t('components.related_navigation.related_content')) %>
       </h2>

--- a/app/views/govuk_publishing_components/components/docs/related_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/related_navigation.yml
@@ -206,6 +206,52 @@ examples:
             - title: Pest Control
               base_path: /pest-control
               document_type: contact
+  with_different_languages:
+    description: |
+      Each link can have a `locale` parameter to set the correct `lang` attribute.
+
+      If the link locale is the same as the document locale, then the lang attribute won't be used. For example, `lang="en"` won't appear on a page written in English.
+    data:
+      content_item:
+        links:
+          ordered_related_items:
+            - title: Find an apprenticeship (French)
+              base_path: /apply-apprenticeship.fr
+              locale: fr
+          topics:
+            - title: Apprenticeships, 14 to 19 education and training for work (Korean)
+              base_path: /browse/education/find-course.ko
+              document_type: topic
+              locale: ko
+          topical_events:
+            - title: UK-China High-Level People to People Dialogue 2017 (Spanish)
+              base_path: /government/topical-events/uk-china-high-level-people-to-people-dialogue-2017.es
+              document_type: topical_event
+              locale: es
+          related:
+            - title: Jam producers (Spanish)
+              base_path: /jam-producers.es
+              document_type: contact
+              locale: es
+          related_statistical_data_sets:
+            - title: International road fuel prices (Italian)
+              base_path: /government/statistical-data-sets/comparisons-of-industrial-and-domestic-energy-prices-monthly-figures.it
+              document_type: statistical_data_set
+              locale: it
+          document_collections:
+            - title: Recruit an apprentice (formerly apprenticeship vacancies)
+              base_path: /government/collections/apprenticeship-vacancies
+              document_type: document_collection
+              locale: en
+          world_locations:
+            - title: South Sudan (Arabic)
+              base_path: /world/south-sudan/news.ar
+              locale: ar
+        details:
+          external_related_links:
+            - url: "http://media.slc.co.uk/sfe/1718/ft/sfe_terms_and_conditions_guide_1718_d.pdf"
+              title: "Student loans: terms and conditions 2017 to 2018 (PDF, 136KB)"
+              locale: en
   with_all_related-content:
     data:
       content_item:

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -28,6 +28,7 @@
           link[:path],
           class: related_nav_helper.section_css_class("gem-c-related-navigation__section-link", section_title, link),
           rel: link[:rel],
+          lang: related_nav_helper.t_locale_check(link[:locale]),
           data: {
             track_category: 'relatedLinkClicked',
             track_action: "#{section_index}.#{index} #{related_nav_helper.construct_section_heading(section_title) || t('components.related_navigation.related_content')}",

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -90,11 +90,47 @@ module GovukPublishingComponents
         related_navigation.flat_map(&:last).any?
       end
 
+      def t_locale(content, options = {})
+        # Check if the content string has a translation
+        content_translation_available = translation_present?(content)
+
+        # True, return locale
+        this_locale = I18n.locale if content_translation_available
+        # If false, return default locale
+        this_locale = I18n.default_locale unless content_translation_available
+
+        # Check if default string passed in
+        if options[:default].present?
+          # Check if the default string has a translation
+          default_translation_available = translation_present?(options[:default])
+          # If true, return locale
+          this_locale = I18n.locale if default_translation_available
+          # If false, return default_locale
+          this_locale = I18n.default_locale unless default_translation_available
+        end
+
+        this_locale
+      end
+
+      def t_lang(content, options = {})
+        locale = t_locale(content, options)
+        "lang=#{locale}" unless locale.eql?(I18n.locale)
+      end
+
       def t_locale_check(locale)
-        locale.presence unless locale.eql?(I18n.locale.to_s)
+        locale.presence unless locale.to_s.eql?(I18n.locale.to_s)
       end
 
     private
+
+      def translation_present?(content)
+        default_string = 'This is a string to act as a default for the `I18n.translate` method. Comparing the result reveals if there is a translation in the i18n files.'
+        I18n.translate(
+          content,
+          default: default_string,
+          fallback: false
+        ) != default_string
+      end
 
       def related_items
         related_quick_links = content_item_details_for('quick_links')

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -90,6 +90,10 @@ module GovukPublishingComponents
         related_navigation.flat_map(&:last).any?
       end
 
+      def t_locale_check(locale)
+        locale.presence unless locale.eql?(I18n.locale.to_s)
+      end
+
     private
 
       def related_items
@@ -184,7 +188,13 @@ module GovukPublishingComponents
           links = links.find_all { |link| link['document_type'] == only }
         end
 
-        links.map { |link| { path: link['base_path'], text: link['title'] } }
+        links.map { |link|
+          {
+            path: link['base_path'],
+            text: link['title'],
+            locale: link['locale'],
+          }
+        }
       end
     end
   end

--- a/spec/components/related_navigation_spec.rb
+++ b/spec/components/related_navigation_spec.rb
@@ -5,13 +5,14 @@ describe "Related navigation", type: :view do
     "related_navigation"
   end
 
-  def construct_links(type, base_path, title, document_type = nil)
+  def construct_links(type, base_path, title, document_type = nil, locale = nil)
     {
       type => [
         {
           "base_path" => base_path,
           "title" => title,
           "document_type" => document_type,
+          "locale" => locale
         }
       ]
     }
@@ -195,5 +196,35 @@ describe "Related navigation", type: :view do
     assert_select ".gem-c-related-navigation__section-link[data-track-category='relatedLinkClicked']"
     assert_select ".gem-c-related-navigation__section-link[data-track-action='1.1 Explore the topic']"
     assert_select ".gem-c-related-navigation__section-link[data-track-label='/apprenticeships']"
+  end
+
+  it "uses lang when locale is set" do
+    content_item = {}
+    content_item['links'] = construct_links(
+      "topics", "/apprenticeships", "Apprenticeships", "topic", "ko"
+    )
+    render_component(content_item: content_item)
+
+    assert_select ".gem-c-related-navigation__section-link[lang='ko']"
+  end
+
+  it "lang is not used when the same as the app's locale" do
+    content_item = {}
+    content_item['links'] = construct_links(
+      "topics", "/apprenticeships", "Apprenticeships", "topic", I18n.locale
+    )
+    render_component(content_item: content_item)
+
+    assert_select ".gem-c-related-navigation__section-link[lang='#{I18n.locale}']", false
+  end
+
+  it "lang is not used when no locale is set" do
+    content_item = {}
+    content_item['links'] = construct_links(
+      "topics", "/apprenticeships", "Apprenticeships", "topic"
+    )
+    render_component(content_item: content_item)
+
+    assert_select ".gem-c-related-navigation__section-link[lang]", false
   end
 end

--- a/spec/lib/govuk_publishing_components/presenters/related_navigation_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/related_navigation_helper_spec.rb
@@ -113,14 +113,17 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
         })
 
       expected = {
-        "related_items" => [{ path: "/related-item", text: "related item" }],
+        "related_items" => [{ locale: "en", path: "/related-item", text: "related item" }],
         "related_guides" => [],
-        "collections" => [{ path: "/related-collection", text: "related collection" }],
-        "topics" => [{ path: "/browse/something", text: "A mainstream browse page" }, { path: "/related-topic", text: "related topic" }],
+        "collections" => [{ locale: "en", path: "/related-collection", text: "related collection" }],
+        "topics" => [
+          { locale: "en", path: "/browse/something", text: "A mainstream browse page" },
+          { locale: "en", path: "/related-topic", text: "related topic" }
+        ],
         "related_contacts" => [],
         "related_external_links" => [],
-        "topical_events" => [{ path: "/related-topical-event", text: "related topical event" }],
-        "world_locations" => [{ path: "/world/world-location/news", text: "World, ~ (@Location)" }],
+        "topical_events" => [{ locale: "en", path: "/related-topical-event", text: "related topical event" }],
+        "world_locations" => [{ locale: "en", path: "/world/world-location/news", text: "World, ~ (@Location)" }],
         "statistical_data_sets" => [],
       }
 
@@ -153,7 +156,7 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
         })
 
       expect(payload["statistical_data_sets"]).to eql(
-        [{ path: "/related-statistical-data-set", text: "related statistical data set" }]
+        [{ locale: "en", path: "/related-statistical-data-set", text: "related statistical data set" }]
       )
     end
 
@@ -193,7 +196,7 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
         })
 
       expect(payload["topics"]).to eql(
-        [{ text: "Self Assessment", path: "/browse/tax/self-assessment" }]
+        [{ locale: "en", text: "Self Assessment", path: "/browse/tax/self-assessment" }]
       )
     end
 
@@ -201,9 +204,9 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
       example = GovukSchemas::Example.find("guide", example_name: "single-page-guide")
       payload = described_class.new(content_item: example).related_navigation
       expected = [
-        { text: "Travel abroad", path: "/browse/abroad/travel-abroad" },
-        { text: "Arriving in the UK", path: "/browse/visas-immigration/arriving-in-the-uk" },
-        { text: "Pets", path: "/topic/animal-welfare/pets" },
+        { locale: "en", text: "Travel abroad", path: "/browse/abroad/travel-abroad" },
+        { locale: "en", text: "Arriving in the UK", path: "/browse/visas-immigration/arriving-in-the-uk" },
+        { locale: "en", text: "Pets", path: "/topic/animal-welfare/pets" },
       ]
       expect(payload["topics"]).to eql(expected)
     end
@@ -243,7 +246,7 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
         },)
 
       expect(payload["related_contacts"]).to eql(
-        [{ path: "/foo", text: "Foo" }]
+        [{ locale: "en", path: "/foo", text: "Foo" }]
       )
     end
 
@@ -286,8 +289,8 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
 
       expect(payload["topics"]).to eql(
         [
-          { path: "/taxon-b", text: "Taxon B" },
-          { path: "/taxon-a", text: "Taxon A" },
+          { locale: "en", path: "/taxon-b", text: "Taxon B" },
+          { locale: "en", path: "/taxon-a", text: "Taxon A" },
         ]
        )
     end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Adds a `locale` option for the related navigation component so a [BCP47 language tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang#Language_tag_syntax) can be used to show what language the link is in.

If the locale passed for the link is the same as the locale for the page, no `lang` attribute will appear. Only when the locale for the link is different to the locale for the page is the `lang` attribute needed.

Trello card: https://trello.com/c/Cjf9IOHK/26-3-mark-language-on-related-links

## Why
<!-- What are the reasons behind this change being made? -->
The related links can sometimes be in different languages to each other and to the page. The example is taken from [Chinese translation of the PM's statement on the EU referendum outcome](https://gov.uk/government/speeches/eu-referendum-outcome-pm-statement-24-june-2016.zh).

This page is translated into Chinese, so the related links in English need to be have `lang="en"`.

![Screen Shot 2019-08-07 at 17 38 50](https://user-images.githubusercontent.com/1732331/62640795-4518b680-b93a-11e9-9dad-51562dbdebb4.png)



## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

<!--
## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
-->

No visual changes