### PR TITLE
Clarify table sortable head documentation

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/table.yml
+++ b/app/views/govuk_publishing_components/components/docs/table.yml
@@ -87,6 +87,7 @@ examples:
         - text: £125
           format: numeric
   with_sortable_head:
+    description: This option allows links to be added to the table headers for sorting. Sorting must be handled server side, it is not done by the component.
     data:
       sortable: true
       head:


### PR DESCRIPTION
## What
Adds a description to the 'sortable' option for the table component.

## Why
It wasn't obvious that this is meant to be handled server side and not by the component itself. I thought it was broken.

## Visual Changes
No changes.

## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/component-guide/table

Fixes https://github.com/alphagov/govuk_publishing_components/issues/1031