### PR TITLE
Fix indent bug for wrapped content list links

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -60,19 +60,20 @@
 
 .gem-c-contents-list__list-item--dashed {
   $contents-spacing: govuk-spacing(5);
-  margin-left: $contents-spacing;
+  position: relative;
+  padding-left: $contents-spacing;
   padding-right: $contents-spacing;
 
   &:before {
-    content: "— ";
-    margin-left: -$contents-spacing;
-    padding-right: 5px;
+    content: "—";
+    position: absolute;
+    left: 0;
+    width: govuk-spacing(4);
+    overflow: hidden;
 
     .direction-rtl & {
-      margin-left: 0;
-      margin-right: -$contents-spacing;
-      padding-right: 0;
-      padding-left: 5px;
+      left: auto;
+      right: 0;
     }
   }
 


### PR DESCRIPTION
## What
Fixes https://github.com/alphagov/govuk_publishing_components/issues/1032

The dash in contents lists was previously added using a before element containing a dash and a space character, with a negative margin left to draw it out of the containing element and leave the rest of the text indented. Unfortunately this was never quite precise enough and so the first line was indented less than any lines that wrapped below, resulting in the layout inconsistency here (note that 'Lorem' is a few px further left than the lines below).

<img width="962" alt="Screen Shot 2019-08-08 at 15 02 06" src="https://user-images.githubusercontent.com/861310/62709562-85853c80-b9ed-11e9-82f0-ebb04277dbfe.png">

This change applies absolute positioning to the same element and changes the left margin on the surrounding list element to padding. This removes the inconsistent indenting.

<img width="897" alt="Screen Shot 2019-08-08 at 15 03 16" src="https://user-images.githubusercontent.com/861310/62709722-d5640380-b9ed-11e9-885d-e0e626e5335a.png">

In addition, the before element is given a width smaller than the parent left padding and overflow is turned off. The reason for this is so that the dash scales well when zoomed and neither extends out of the boundary of the component or overlaps the link (this would be a particular problem if only the font size is increased in the browser).

Before:

<img width="945" alt="Screen Shot 2019-08-08 at 15 05 15" src="https://user-images.githubusercontent.com/861310/62709771-f4fb2c00-b9ed-11e9-992b-b01f71ea094b.png">

After:

<img width="932" alt="Screen Shot 2019-08-08 at 15 06 11" src="https://user-images.githubusercontent.com/861310/62709841-165c1800-b9ee-11e9-90cd-5ce1487e5dbd.png">

## Why
The indent was already there, but the new govuk-frontend focus styles make it even more obvious.

## View Changes
https://govuk-publishing-compo-pr-1034.herokuapp.com/component-guide/contents_list/
