### PR TITLE
[WIP][DO NOT MERGE] Add public/frontend layout component

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -136,6 +136,10 @@
     background-color: govuk-colour("blue");
   }
 
+  &.black-background {
+    background-color: govuk-colour("black");
+  }
+
   &.component-output {
     padding: 0;
   }

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -55,6 +55,7 @@
 @import "components/label";
 @import "components/layout-footer";
 @import "components/layout-for-admin";
+@import "components/layout-for-public";
 @import "components/layout-header";
 @import "components/lead-paragraph";
 @import "components/metadata";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
@@ -1,1 +1,5 @@
 @import "govuk/components/footer/footer";
+
+.gem-c-layout-footer--border {
+  border-top: govuk-spacing(2) solid govuk-colour("blue");
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
@@ -1,5 +1,4 @@
 .gem-c-layout-for-public {
-  @include govuk-font(16);
   margin: 0;
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
@@ -1,4 +1,5 @@
 .gem-c-layout-for-public {
   margin: 0;
+  font-family: $govuk-font-family;
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
@@ -1,0 +1,4 @@
+.gem-c-layout-for-public {
+  @include govuk-font(16);
+  margin: 0;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
@@ -2,3 +2,4 @@
   @include govuk-font(16);
   margin: 0;
 }
+

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -18,6 +18,12 @@
   border-bottom-color: govuk-colour("dark-grey", $legacy: "grey-1");
 }
 
+.gem-c-layout-header--no-bottom-border,
+.gem-c-layout-header--no-bottom-border .govuk-header__container {
+  margin-bottom: 0;
+  border-bottom: 0;
+}
+
 .gem-c-layout-header__logo,
 .gem-c-layout-header__search {
   padding: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -21,6 +21,7 @@
 .gem-c-layout-header__logo,
 .gem-c-layout-header__search {
   padding: 0;
+  margin-bottom: govuk-spacing(2);
 }
 
 .govuk-header__logo {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -22,12 +22,20 @@
 .gem-c-layout-header--no-bottom-border .govuk-header__container {
   margin-bottom: 0;
   border-bottom: 0;
+
+  @include govuk-media-query($until: tablet) {
+    padding-bottom: govuk-spacing(1);
+  }
 }
 
 .gem-c-layout-header__logo,
 .gem-c-layout-header__search {
   padding: 0;
   margin-bottom: govuk-spacing(2);
+
+  @include govuk-media-query($until: "tablet") {
+    margin-bottom: 0;
+  }
 }
 
 .govuk-header__logo {
@@ -37,7 +45,7 @@
 .govuk-header__product-name {
   display: none;
 
-  @include govuk-media-query($from: tablet) {
+  @include govuk-media-query($from: "tablet") {
     display: inline-block;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -18,6 +18,11 @@
   border-bottom-color: govuk-colour("dark-grey", $legacy: "grey-1");
 }
 
+.gem-c-layout-header__logo,
+.gem-c-layout-header__search {
+  padding: 0;
+}
+
 .govuk-header__logo {
   white-space: nowrap;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -6,6 +6,10 @@ $large-input-size: 50px;
   margin-bottom: 30px;
 }
 
+.gem-c-search--no-margin {
+  margin-bottom: 0;
+}
+
 .gem-c-search__label {
   display: block;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -166,6 +166,12 @@ $large-input-size: 50px;
   }
 }
 
+.gem-c-search--no-border {
+  .gem-c-search__input[type="search"] {
+    border: 0;
+  }
+}
+
 .gem-c-search--large {
   .gem-c-search__label {
     @include govuk-font($size: 19, $line-height: $large-input-size);

--- a/app/models/govuk_publishing_components/component_example.rb
+++ b/app/models/govuk_publishing_components/component_example.rb
@@ -78,6 +78,10 @@ module GovukPublishingComponents
       !!context['dark_background']
     end
 
+    def black_background?
+      !!context['black_background']
+    end
+
     def html_description
       markdown_to_html(description) if description.present?
     end

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
@@ -1,6 +1,7 @@
 <div class="component-guide-preview
             <% if example.right_to_left? %>direction-rtl<% end %>
             <% if example.dark_background? %>dark-background<% end %>
+            <% if example.black_background? %>black-background<% end %>
             <% if preview_page %>component-guide-preview--simple<% end %>" data-content="EXAMPLE">
   <%= render "govuk_publishing_components/component_guide/component_doc/component_output", example: example, component_doc: component_doc %>
 </div>

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -1,8 +1,9 @@
 <%
   meta ||= []
   navigation ||= []
+  with_border ||= false
 %>
-<footer class="gem-c-layout-footer govuk-footer" role="contentinfo">
+<footer class="gem-c-layout-footer govuk-footer <%= "gem-c-layout-footer--border" if with_border %> role="contentinfo">
   <div class="govuk-width-container ">
     <% if navigation.any? %>
       <div class="govuk-footer__navigation">

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -55,6 +55,8 @@
       <%= yield %>
     </main>
 
+    <%= render "govuk_publishing_components/components/feedback", {} %>
+
     <% unless local_assigns[:hide_footer_links] %>
       <%= render "govuk_publishing_components/components/layout_footer", {
         with_border: true,

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -2,6 +2,7 @@
   title ||= "GOV.UK - The best place to find government services and information"
   html_lang ||= "en"
   full_width ||= false
+  without_search ||= false
   body_classes ||= ""
   main_classes ||= ""
 -%>
@@ -48,7 +49,7 @@
 
     <%= render "govuk_publishing_components/components/layout_header", {
       environment: "public",
-      search: true,
+      search: !without_search,
       remove_bottom_border: full_width
     } %>
 

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -416,6 +416,9 @@
         }
       } %>
     <% end %>
+
+    <%# if no GOVUK-namespaced module has loaded we can assume JS has failed and remove the class %>
+    <script>if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');</script>
   </body>
 </html>
 <!-- Thanks Martha -->

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -1,6 +1,7 @@
 <%
   title ||= "GOV.UK - The best place to find government services and information"
   html_lang ||= "en"
+  full_width ||= false
 -%>
 <!DOCTYPE html>
   <!--[if lt IE 9]><html class="lte-ie8" lang="<%= html_lang %>"><![endif]-->
@@ -42,7 +43,7 @@
       search: true,
     } %>
 
-    <main class="govuk-width-container" id="content">
+    <main class="<%= "govuk-width-container" unless full_width %>" id="content">
       <%= yield %>
     </main>
 

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -43,7 +43,7 @@
       search: true,
     } %>
 
-    <main class="<%= "govuk-width-container" unless full_width %>" id="content">
+    <main class="<%= "govuk-width-container govuk-main-wrapper" unless full_width %>" id="content">
       <%= yield %>
     </main>
 

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -20,9 +20,7 @@
     <%# the colour used for theme-color is the standard palette $black from
         https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_palette.scss %>
     <meta name="theme-color" content="#0b0c0c" />
-
     <meta name="viewport" content="width=device-width, initial-scale=1">
-
     <%# The default og:image is added below :head so that scrapers see any custom metatags first, and this is just a fallback %>
     <meta property="og:image" content="<%= asset_path "opengraph-image.png" %>">
 
@@ -36,6 +34,8 @@
     <%= render "govuk_publishing_components/components/skip_link", {
       href: "#content"
     } %>
+
+    <%= render "govuk_publishing_components/components/cookie_banner" %>
 
     <%= render "govuk_publishing_components/components/layout_header", {
       environment: "public",

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -2,6 +2,8 @@
   title ||= "GOV.UK - The best place to find government services and information"
   html_lang ||= "en"
   full_width ||= false
+  body_classes ||= ""
+  main_classes ||= ""
 -%>
 <!DOCTYPE html>
   <!--[if lt IE 9]><html class="lte-ie8" lang="<%= html_lang %>"><![endif]-->
@@ -33,7 +35,7 @@
 
     <%= yield :head %>
   </head>
-  <body class="gem-c-layout-for-public govuk-template__body">
+  <body class="gem-c-layout-for-public govuk-template__body <%= body_classes %>">
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
@@ -49,7 +51,7 @@
       search: true,
     } %>
 
-    <main class="<%= "govuk-width-container govuk-main-wrapper" unless full_width %>" id="content">
+    <main class="<%= "govuk-width-container govuk-main-wrapper" unless full_width %> <%= main_classes %>" id="content">
       <%= yield %>
     </main>
 

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -17,7 +17,6 @@
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_link_tag 'print', media: 'print' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 
     <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
     <link rel="mask-icon" href="<%= asset_path 'govuk-mask-icon.svg' %>" color="#0b0c0c">
@@ -430,9 +429,7 @@
         }
       } %>
     <% end %>
-
-    <%# if no GOVUK-namespaced module has loaded we can assume JS has failed and remove the class %>
-    <script>if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');</script>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </body>
 </html>
 <!-- Thanks Martha -->

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -1,0 +1,416 @@
+<%
+  title ||= "GOV.UK - The best place to find government services and information"
+  html_lang ||= "en"
+%>
+
+<!DOCTYPE html>
+  <!--[if lt IE 9]><html class="lte-ie8" lang="<%= html_lang %>"><![endif]-->
+  <!--[if gt IE 8]><!--><html lang="<%= html_lang %>"><!--<![endif]-->
+  <head>
+    <meta charset="utf-8" />
+    <title><%= title %></title>
+
+    <%= csrf_meta_tags %>
+
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag 'print', media: 'print' %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+
+    <%= stylesheet_link_tag "fonts.css", media: "all", integrity: true, crossorigin: "anonymous" %>
+    <!--[if lt IE 9]><%= javascript_include_tag "ie.js", integrity: true, crossorigin: "anonymous" %><![endif]-->
+
+    <%# the colour used for theme-color is the standard palette $black from
+        https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_palette.scss %>
+    <meta name="theme-color" content="#0b0c0c" />
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <%# The default og:image is added below :head so that scrapers see any custom metatags first, and this is just a fallback %>
+    <meta property="og:image" content="<%= asset_path "opengraph-image.png" %>">
+
+    <%= yield :head %>
+  </head>
+  <body class="gem-c-layout-for-public">
+    <%= render "govuk_publishing_components/components/layout_header", {
+      environment: "public",
+      hide_product_details: true,
+      search: true
+    } %>
+
+    <main class="govuk-width-container">
+      <%= yield %>
+    </main>
+
+    <% unless local_assigns[:hide_footer_links] %>
+      <%= render "govuk_publishing_components/components/layout_footer", {
+        navigation: [
+          {
+            title: "Prepare for Brexit",
+            columns: 2,
+            items: [
+              {
+                href: "/business-uk-leaving-eu",
+                text: "Prepare your business or organisation for Brexit",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "brexitLinks",
+                    track_label: "Prepare your business or organisation for the UK leaving the EU"
+                  }
+                }
+              },
+              {
+                href: "/prepare-eu-exit",
+                text: "Prepare for Brexit if you live in the UK",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "brexitLinks",
+                    track_label: "Prepare for Brexit if you live in the UK"
+                  }
+                }
+              },
+              {
+                href: "/uk-nationals-living-eu",
+                text: "Living in Europe after Brexit",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "brexitLinks",
+                    track_label: "Living in Europe after Brexit"
+                  }
+                }
+              },
+              {
+                href: "/staying-uk-eu-citizen",
+                text: "Continue to live in the UK after Brexit",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "brexitLinks",
+                    track_label: "Continue to live in the UK after Brexit"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            title: "Services and information",
+            columns: 2,
+            items: [
+              {
+                href: "/browse/benefits",
+                text: "Benefits",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Benefits"
+                  }
+                }
+              },
+              {
+                href: "/browse/births-deaths-marriages",
+                text: "Births, deaths, marriages and care",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Births, deaths, marriages and care"
+                  }
+                }
+              },
+              {
+                href: "/browse/business",
+                text: "Business and self-employed",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Business and self-employed"
+                  }
+                }
+              },
+              {
+                href: "/browse/childcare-parenting",
+                text: "Childcare and parenting",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Childcare and parenting"
+                  }
+                }
+              },
+              {
+                href: "/browse/citizenship",
+                text: "Citizenship and living in the UK",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Citizenship and living in the UK"
+                  }
+                }
+              },
+              {
+                href: "/browse/justice",
+                text: "Crime, justice and the law",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Crime, justice and the law"
+                  }
+                }
+              },
+              {
+                href: "/browse/disabilities",
+                text: "Disabled people",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Disabled people"
+                  }
+                }
+              },
+              {
+                href: "/browse/driving",
+                text: "Driving and transport",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Driving and transport"
+                  }
+                }
+              },
+              {
+                href: "/browse/education",
+                text: "Education and learning",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Education and learning"
+                  }
+                }
+              },
+              {
+                href: "/browse/employing-people",
+                text: "Employing people",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Employing people"
+                  }
+                }
+              },
+              {
+                href: "/browse/environment-countryside",
+                text: "Environment and countryside",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Environment and countryside"
+                  }
+                }
+              },
+              {
+                href: "/browse/housing-local-services",
+                text: "Housing and local services",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Housing and local services"
+                  }
+                }
+              },
+              {
+                href: "/browse/tax",
+                text: "Money and tax",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Money and tax"
+                  }
+                }
+              },
+              {
+                href: "/browse/abroad",
+                text: "Passports, travel and living abroad",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Passports, travel and living abroad"
+                  }
+                }
+              },
+              {
+                href: "/browse/visas-immigration",
+                text: "Visas and immigration",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Visas and immigration"
+                  }
+                }
+              },
+              {
+                href: "/browse/working",
+                text: "Working, jobs and pensions",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Working, jobs and pensions"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            title: "Departments and policy",
+            items: [
+              {
+                href: "/government/how-government-works",
+                text: "How government works",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "How government works"
+                  }
+                }
+              },
+              {
+                href: "/government/organisations",
+                text: "Departments",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Departments"
+                  }
+                }
+              },
+              {
+                href: "/world",
+                text: "Worldwide",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Worldwide"
+                  }
+                }
+              },
+              {
+                href: "/search/services",
+                text: "Services",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Services"
+                  }
+                }
+              },
+              {
+                href: "/search/guidance-and-regulation",
+                text: "Guidance and regulation",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Guidance and regulation"
+                  }
+                }
+              },
+              {
+                href: "/search/news-and-communications",
+                text: "News and communications",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "News and communications"
+                  }
+                }
+              },
+              {
+                href: "/search/research-and-statistics",
+                text: "Research and statistics",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Research and statistics"
+                  }
+                }
+              },
+              {
+                href: "/search/policy-papers-and-consultations",
+                text: "Policy papers and consultations",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Policy papers and consultations"
+                  }
+                }
+              },
+              {
+                href: "/search/transparency-and-freedom-of-information-releases",
+                text: "Transparency and freedom of information releases",
+                attributes: {
+                  data: {
+                    track_category: "footerClicked",
+                    track_action: "footerLinks",
+                    track_label: "Transparency and freedom of information releases"
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        meta: {
+          items: [
+            {
+              href: "/help",
+              text: "Help"
+            },
+            {
+              href: "/help/cookies",
+              text: "Cookies"
+            },
+            {
+              href: "/contact",
+              text: "Contact"
+            },
+            {
+              href: "/help/terms-conditions",
+              text: "Terms and conditions"
+            },
+            {
+              href: "/cymraeg",
+              text: "Rhestr o Wasanaethau Cymraeg"
+            },
+            {
+              href: "/government/organisations/government-digital-service",
+              text: "Government Digital Service"
+            }
+          ]
+        }
+      } %>
+    <% end %>
+  </body>
+</html>
+<!-- Thanks Martha -->

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -49,6 +49,7 @@
     <%= render "govuk_publishing_components/components/layout_header", {
       environment: "public",
       search: true,
+      remove_bottom_border: full_width
     } %>
 
     <main class="<%= "govuk-width-container govuk-main-wrapper" unless full_width %> <%= main_classes %>" id="content">

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -57,6 +57,7 @@
 
     <% unless local_assigns[:hide_footer_links] %>
       <%= render "govuk_publishing_components/components/layout_footer", {
+        with_border: true,
         navigation: [
           {
             title: "Prepare for Brexit",

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -16,7 +16,6 @@
     <%= stylesheet_link_tag 'print', media: 'print' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 
-    <%= stylesheet_link_tag "fonts.css", media: "all", integrity: true, crossorigin: "anonymous" %>
     <!--[if lt IE 9]><%= javascript_include_tag "ie.js", integrity: true, crossorigin: "anonymous" %><![endif]-->
 
     <%# the colour used for theme-color is the standard palette $black from

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -18,11 +18,11 @@
 
     <!--[if lt IE 9]><%= javascript_include_tag "ie.js", integrity: true, crossorigin: "anonymous" %><![endif]-->
 
-    <%# the colour used for theme-color is the standard palette $black from
-        https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_palette.scss %>
+    <!-- the colour used for theme-color is the standard palette $black from GOVUK Frontend -->
     <meta name="theme-color" content="#0b0c0c" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <%# The default og:image is added below :head so that scrapers see any custom metatags first, and this is just a fallback %>
+
+    <!-- The default og:image is added below :head so that scrapers see any custom metatags first, and this is just a fallback -->
     <meta property="og:image" content="<%= asset_path "opengraph-image.png" %>">
 
     <%= yield :head %>

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -29,7 +29,11 @@
 
     <%= yield :head %>
   </head>
-  <body class="gem-c-layout-for-public">
+  <body class="gem-c-layout-for-public govuk-template__body">
+    <script>
+      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+    </script>
+
     <%= render "govuk_publishing_components/components/skip_link", {
       href: "#content"
     } %>

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -18,12 +18,18 @@
 
     <!--[if lt IE 9]><%= javascript_include_tag "ie.js", integrity: true, crossorigin: "anonymous" %><![endif]-->
 
-    <!-- the colour used for theme-color is the standard palette $black from GOVUK Frontend -->
+    <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
+    <link rel="mask-icon" href="<%= asset_path 'govuk-mask-icon.svg' %>" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_path "govuk-apple-touch-icon-180x180.png" %>">
+    <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_path "govuk-apple-touch-icon-167x167.png" %>">
+    <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_path "govuk-apple-touch-icon-152x152.png" %>">
+    <link rel="apple-touch-icon" href="<%= asset_path "govuk-apple-touch-icon.png" %>">
+
     <meta name="theme-color" content="#0b0c0c" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- The default og:image is added below :head so that scrapers see any custom metatags first, and this is just a fallback -->
-    <meta property="og:image" content="<%= asset_path "opengraph-image.png" %>">
+    <meta property="og:image" content="<%= asset_path "govuk-opengraph-image.png" %>">
 
     <%= yield :head %>
   </head>

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -16,8 +16,6 @@
     <%= stylesheet_link_tag 'print', media: 'print' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 
-    <!--[if lt IE 9]><%= javascript_include_tag "ie.js", integrity: true, crossorigin: "anonymous" %><![endif]-->
-
     <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
     <link rel="mask-icon" href="<%= asset_path 'govuk-mask-icon.svg' %>" color="#0b0c0c">
     <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_path "govuk-apple-touch-icon-180x180.png" %>">
@@ -27,6 +25,8 @@
 
     <meta name="theme-color" content="#0b0c0c" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- Ensure that older IE versions always render with the correct rendering engine -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <!-- The default og:image is added below :head so that scrapers see any custom metatags first, and this is just a fallback -->
     <meta property="og:image" content="<%= asset_path "govuk-opengraph-image.png" %>">

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -1,8 +1,7 @@
 <%
   title ||= "GOV.UK - The best place to find government services and information"
   html_lang ||= "en"
-%>
-
+-%>
 <!DOCTYPE html>
   <!--[if lt IE 9]><html class="lte-ie8" lang="<%= html_lang %>"><![endif]-->
   <!--[if gt IE 8]><!--><html lang="<%= html_lang %>"><!--<![endif]-->

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -31,13 +31,16 @@
     <%= yield :head %>
   </head>
   <body class="gem-c-layout-for-public">
-    <%= render "govuk_publishing_components/components/layout_header", {
-      environment: "public",
-      hide_product_details: true,
-      search: true
+    <%= render "govuk_publishing_components/components/skip_link", {
+      href: "#content"
     } %>
 
-    <main class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/layout_header", {
+      environment: "public",
+      search: true,
+    } %>
+
+    <main class="govuk-width-container" id="content">
       <%= yield %>
     </main>
 

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -1,13 +1,16 @@
 <%
   full_width ||= false
   product_name ||= "Publishing"
+  public_environment = environment.eql?("public")
   navigation_items ||= []
+
   if full_width
     width_class = "govuk-header__container--full-width"
   else
     width_class = "govuk-width-container"
   end
 %>
+
 <header class="gem-c-layout-header govuk-header gem-c-layout-header--<%= environment %> govuk-grid-row" role="banner" data-module="govuk-header">
   <div class="govuk-header__container <%= width_class %>">
     <div class="govuk-grid-column-two-thirds">
@@ -25,14 +28,14 @@
           </span>
         </span>
 
-        <% unless local_assigns[:hide_product_details] %>
+        <% unless public_environment %>
           <span class="govuk-header__product-name">
             <%= product_name %>
           </span>
 
-        <span class="gem-c-environment-tag govuk-tag gem-c-environment-tag--<%= environment %>">
-          <%= environment %>
-        </span>
+          <span class="gem-c-environment-tag govuk-tag gem-c-environment-tag--<%= environment %>">
+            <%= environment %>
+          </span>
         <% end %>
       </a>
 

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -3,6 +3,7 @@
   product_name ||= "Publishing"
   public_environment = environment.eql?("public")
   navigation_items ||= []
+  remove_bottom_border ||= false
 
   if full_width
     width_class = "govuk-header__container--full-width"
@@ -11,7 +12,7 @@
   end
 %>
 
-<header class="gem-c-layout-header govuk-header gem-c-layout-header--<%= environment %>" role="banner" data-module="govuk-header">
+<header class="gem-c-layout-header govuk-header gem-c-layout-header--<%= environment %> <%= "gem-c-layout-header--no-bottom-border" if remove_bottom_border %>" role="banner" data-module="govuk-header">
   <div class="govuk-header__container <%= width_class %>">
     <div class="gem-c-layout-header__logo govuk-grid-column-two-thirds">
     <div class="govuk-header__logo">

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -11,7 +11,7 @@
   end
 %>
 
-<header class="gem-c-layout-header govuk-header gem-c-layout-header--<%= environment %> govuk-grid-row" role="banner" data-module="govuk-header">
+<header class="gem-c-layout-header govuk-header gem-c-layout-header--<%= environment %>" role="banner" data-module="govuk-header">
   <div class="govuk-header__container <%= width_class %>">
     <div class="gem-c-layout-header__logo govuk-grid-column-two-thirds">
     <div class="govuk-header__logo">

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -8,8 +8,9 @@
     width_class = "govuk-width-container"
   end
 %>
-<header class="gem-c-layout-header govuk-header gem-c-layout-header--<%= environment %>" role="banner" data-module="govuk-header">
+<header class="gem-c-layout-header govuk-header gem-c-layout-header--<%= environment %> govuk-grid-row" role="banner" data-module="govuk-header">
   <div class="govuk-header__container <%= width_class %>">
+    <div class="govuk-grid-column-two-thirds">
     <div class="govuk-header__logo">
       <a href="/" class="govuk-header__link govuk-header__link--homepage">
         <span class="govuk-header__logotype">
@@ -24,13 +25,15 @@
           </span>
         </span>
 
-        <span class="govuk-header__product-name">
-          <%= product_name %>
-        </span>
+        <% unless local_assigns[:hide_product_details] %>
+          <span class="govuk-header__product-name">
+            <%= product_name %>
+          </span>
 
         <span class="gem-c-environment-tag govuk-tag gem-c-environment-tag--<%= environment %>">
           <%= environment %>
         </span>
+        <% end %>
       </a>
 
     </div><div class="govuk-header__content">
@@ -54,5 +57,16 @@
     <% end %>
 
     </div>
+    </div>
+
+    <% if local_assigns[:search] %>
+        <div class="govuk-grid-column-one-third">
+          <%= render "govuk_publishing_components/components/search", {
+            id: "site-search-text",
+            label_text: "Search",
+          } %>
+        </div>
+    <% end %>
+
   </div>
 </header>

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -13,7 +13,7 @@
 
 <header class="gem-c-layout-header govuk-header gem-c-layout-header--<%= environment %> govuk-grid-row" role="banner" data-module="govuk-header">
   <div class="govuk-header__container <%= width_class %>">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="gem-c-layout-header__logo govuk-grid-column-two-thirds">
     <div class="govuk-header__logo">
       <a href="/" class="govuk-header__link govuk-header__link--homepage">
         <span class="govuk-header__logotype">
@@ -63,7 +63,7 @@
     </div>
 
     <% if local_assigns[:search] %>
-        <div class="govuk-grid-column-one-third">
+        <div class="govuk-grid-column-one-third gem-c-layout-header__search">
           <%= render "govuk_publishing_components/components/search", {
             id: "site-search-text",
             label_text: "Search",

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -67,6 +67,7 @@
           <%= render "govuk_publishing_components/components/search", {
             id: "site-search-text",
             label_text: "Search",
+            no_margin: true
           } %>
         </div>
     <% end %>

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -1,6 +1,7 @@
 <%
   full_width ||= false
   product_name ||= "Publishing"
+  search ||= false
   public_environment = environment.eql?("public")
   navigation_items ||= []
   remove_bottom_border ||= false
@@ -63,7 +64,7 @@
     </div>
     </div>
 
-    <% if local_assigns[:search] %>
+    <% if search %>
         <div class="govuk-grid-column-one-third gem-c-layout-header__search">
           <%= render "govuk_publishing_components/components/search", {
             id: "site-search-text",

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -69,6 +69,7 @@
           <%= render "govuk_publishing_components/components/search", {
             id: "site-search-text",
             label_text: "Search",
+            no_border: true,
             no_margin: true
           } %>
         </div>

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -3,6 +3,8 @@
   class_name = "gem-c-search--on-govuk-blue" if local_assigns.include?(:on_govuk_blue)
   size ||= ""
   no_margin ||= false
+  no_border ||= false
+  class_name = "#{class_name} gem-c-search--no-border" if no_border
   class_name = "#{class_name} gem-c-search--large" if size == 'large'
   class_name = "#{class_name} gem-c-search--no-margin" if no_margin
   class_name = "#{class_name} gem-c-search--separate-label" if local_assigns.include?(:inline_label)

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -2,7 +2,9 @@
   class_name = "gem-c-search--on-white"
   class_name = "gem-c-search--on-govuk-blue" if local_assigns.include?(:on_govuk_blue)
   size ||= ""
+  no_margin ||= false
   class_name = "#{class_name} gem-c-search--large" if size == 'large'
+  class_name = "#{class_name} gem-c-search--no-margin" if no_margin
   class_name = "#{class_name} gem-c-search--separate-label" if local_assigns.include?(:inline_label)
 
   value ||= ""

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -138,3 +138,20 @@ examples:
               attributes:
                 data:
                   tracking: GTM-123AB
+  with_border:
+    data:
+      with_border: true
+      meta:
+        items:
+          - href: '/help'
+            text: Help
+          - href: '/help/cookies'
+            text: Cookies
+          - href: '/contact'
+            text: Contact
+          - href: '/help/terms-conditions'
+            text: Terms and conditions
+          - href: '/cymraeg'
+            text: Rhestr o Wasanaethau Cymraeg
+          - href: '/government/organisations/government-digital-service'
+            text: Government Digital Service

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -1,0 +1,13 @@
+name: Public layout
+description: A layout to be used by public-facing applications
+body: |
+  Because it is an entire HTML document, this component can only be [previewed on a separate page](/public).
+
+display_preview: false
+display_html: true
+examples:
+  default:
+    data:
+      title: 'Example layout'
+      block: |
+        <!-- Page content goes here -->

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -5,6 +5,8 @@ body: |
 
 display_preview: false
 display_html: true
+accessibility_criteria: |
+  TBD
 examples:
   default:
     data:

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -13,3 +13,12 @@ examples:
       title: 'Example layout'
       block: |
         <!-- Page content goes here -->
+  full_width:
+    description: By default, the layout applies the `govuk-width-container` class to the main element. We can remove this class by setting `full_width` to `true`
+    data:
+      full_width: true
+  with_additional_classes:
+    description: You are able to pass additional classes to the main and body elements
+    data:
+      main_classes: "homepage test-main-class"
+      body_classes: "mainstream test-body-class"

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -45,6 +45,10 @@ examples:
     data:
       remove_bottom_border: true
       environment: 'public'
+  with_search_bar:
+    data:
+      environment: 'public'
+      search: true
 
 accessibility_criteria: |
   The component must:

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -40,6 +40,11 @@ examples:
     data:
       environment: production
       full_width: true
+  no_bottom_border:
+    description: This is useful for pages where a large full-width banner is the first thing to appear on the page, for example, the [GOV.UK homepage](https://www.gov.uk)
+    data:
+      remove_bottom_border: true
+      environment: 'public'
 
 accessibility_criteria: |
   The component must:

--- a/app/views/govuk_publishing_components/components/docs/search.yml
+++ b/app/views/govuk_publishing_components/components/docs/search.yml
@@ -24,6 +24,12 @@ examples:
   stop_the_label_appearing_inline:
     data:
       inline_label: false
+  no_border:
+    description: Sometimes we don't need the grey border surrounding the input field, such as when the component is used on a black background
+    data:
+      no_border: true
+    context:
+      black_background: true
   for_use_on_govuk_blue_background:
     data:
       on_govuk_blue: true
@@ -42,3 +48,4 @@ examples:
     description: To be used if you need to change the default name 'q'
     data:
       name: "my_own_fieldname"
+

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -24,6 +24,13 @@ Rails.application.config.assets.precompile += %w(
 # GOV.UK Frontend assets
 Rails.application.config.assets.precompile += %w(
   govuk-logotype-crown.png
+  favicon.ico
+  govuk-opengraph-image.png
+  govuk-mask-icon.svg
+  govuk-apple-touch-icon-180x180.png
+  govuk-apple-touch-icon-167x167.png
+  govuk-apple-touch-icon-152x152.png
+  govuk-apple-touch-icon.png
 )
 
 Rails.application.config.assets.paths += %W(

--- a/spec/components/layout_footer_spec.rb
+++ b/spec/components/layout_footer_spec.rb
@@ -83,4 +83,25 @@ describe "Layout footer", type: :view do
       expect(link.attr('rel').to_s).to eq "noopener"
     end
   end
+
+  it 'renders the footer with a top border' do
+    render_component(
+      with_border: true,
+      navigation: [
+        {
+          title: "Services and information",
+          columns: 2,
+          items: [
+            {
+              href: "/browse/benefits",
+              text: "Benefits",
+              attributes: { target: "_blank" }
+            }
+          ]
+        }
+      ]
+    )
+
+    assert_select '.gem-c-layout-footer--border'
+  end
 end

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -22,4 +22,16 @@ describe "Layout for public", type: :view do
 
     assert_select '#content.govuk-width-container', false, 'Should not apply govuk-width-container class when full width'
   end
+
+  it "adds additional main classes if provided" do
+    render_component(main_classes: "homepage test-new-main-class")
+
+    assert_select 'main.homepage, main.test-new-main-class'
+  end
+
+  it "adds additional body classes if provided" do
+    render_component(body_classes: "homepage test-new-body-class")
+
+    assert_select 'body.homepage, main.test-new-body-class'
+  end
 end

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe "Layout for public", type: :view do
+  def component_name
+    "layout_for_public"
+  end
+
+  it "adds a default <title> tag" do
+    render_component({})
+
+    assert_select "title", visible: false, text: "GOV.UK - The best place to find government services and information"
+  end
+
+  it "adds a custom <title> tag" do
+    render_component(title: "Custom GOV.UK Title")
+
+    assert_select "title", visible: false, text: "Custom GOV.UK Title"
+  end
+
+  it "can support full width layouts" do
+    render_component(full_width: true)
+
+    assert_select '#content.govuk-width-container', false, 'Should not apply govuk-width-container class when full width'
+  end
+end

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -34,4 +34,10 @@ describe "Layout for public", type: :view do
 
     assert_select 'body.homepage, main.test-new-body-class'
   end
+
+  it "can display without search bar" do
+    render_component(without_search: true)
+
+    assert_select '.gem-c-layout-for-public .gem-c-search', false
+  end
 end

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -35,8 +35,6 @@ describe "Layout header", type: :view do
     assert_select ".govuk-header__container--full-width"
   end
 
-
-
   it "renders the header with navigation items" do
     navigation_items = [
       { text: "Foo", href: "/foo", active: true },
@@ -49,5 +47,11 @@ describe "Layout header", type: :view do
     assert_select ".govuk-header__navigation-item.govuk-header__navigation-item--active", text: "Foo"
     assert_select ".govuk-header__navigation-item", text: "Bar"
     assert_select ".govuk-header__navigation-item.govuk-header__navigation-item--collapsed-menu-only", text: "Hello"
+  end
+
+  it "renders the header without the bottom border" do
+    render_component(remove_bottom_border: true, environment: 'public')
+
+    assert_select ".gem-c-layout-header--no-bottom-border"
   end
 end

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -54,4 +54,10 @@ describe "Layout header", type: :view do
 
     assert_select ".gem-c-layout-header--no-bottom-border"
   end
+
+  it "renders a search bar" do
+    render_component(environment: 'public', search: true)
+
+    assert_select ".gem-c-layout-header .gem-c-search"
+  end
 end

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -52,4 +52,9 @@ describe "Search", type: :view do
     render_component(name: "my_custom_field")
     assert_select 'input[name="my_custom_field"]'
   end
+
+  it "renders a search box with no margin" do
+    render_component(no_margin: true)
+    assert_select '.gem-c-search--no-margin'
+  end
 end

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -57,4 +57,9 @@ describe "Search", type: :view do
     render_component(no_margin: true)
     assert_select '.gem-c-search--no-margin'
   end
+
+  it "renders a search box with no border" do
+    render_component(no_border: true)
+    assert_select '.gem-c-search--no-border'
+  end
 end

--- a/spec/dummy/app/controllers/welcome_controller.rb
+++ b/spec/dummy/app/controllers/welcome_controller.rb
@@ -20,6 +20,10 @@ class WelcomeController < ApplicationController
     render 'admin_example', layout: 'dummy_admin_layout'
   end
 
+  def public
+    render 'public_example', layout: 'dummy_public_layout'
+  end
+
   def tabsexample
     render 'tabs_example', layout: 'dummy_admin_layout'
   end

--- a/spec/dummy/app/views/layouts/dummy_public_layout.html.erb
+++ b/spec/dummy/app/views/layouts/dummy_public_layout.html.erb
@@ -1,0 +1,5 @@
+<%= render 'govuk_publishing_components/components/layout_for_public', {
+    title: "Example public page"
+} do %>
+  <%= yield %>
+<% end %>

--- a/spec/dummy/app/views/welcome/public_example.html.erb
+++ b/spec/dummy/app/views/welcome/public_example.html.erb
@@ -5,7 +5,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Two-thirds column</h1>
+      <h1 class="govuk-heading-m">Two-thirds column</h1>
       <p class="govuk-body">This is a paragraph inside a two-thirds wide column</p>
     </div>
 

--- a/spec/dummy/app/views/welcome/public_example.html.erb
+++ b/spec/dummy/app/views/welcome/public_example.html.erb
@@ -1,0 +1,17 @@
+<h1 class="govuk-heading-xl">Hello! I am an example public GOV.UK page</h1>
+
+<p class="govuk-body">
+  Pages with the public layout can use some GOV.UK styles. For example, the grid:
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Two-thirds column</h1>
+      <p class="govuk-body">This is a paragraph inside a two-thirds wide column</p>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <h3 class="govuk-heading-m">One-third column</h3>
+      <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
+    </div>
+  </div>
+</p>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   get 'contextual-navigation', to: 'welcome#contextual_navigation'
   get 'contextual-navigation/*base_path', to: 'welcome#contextual_navigation'
   get 'admin', to: 'welcome#admin'
+  get 'public', to: 'welcome#public'
   get 'error-summary', to: 'welcome#errorsummary'
   get 'tabsexample', to: 'welcome#tabsexample'
   get 'table', to: 'welcome#table'


### PR DESCRIPTION
This is very WIP.

http://govuk-publishing-compo-pr-1035.herokuapp.com/public

To Do:

- [x] Add header
- [x] Add footer using layout footer component
- [x] Allow page content to be passed to component
- [x] Add example to docs
- [x] Add a11y criteria
- [ ] Fix logo spacing
- [x] Skip to main page link
- [ ] Compare with layout files in static/rendered html to see what else we might be missing
- [x] Compare with [govuk frontend layout](https://github.com/alphagov/govuk-frontend/blob/899264cd89559d31f0a790682254d94ecf66418b/package/govuk/template.njk)
- [ ] Make Brexit footer links in line with other footer links
- [x] Search bar shouldn't be shown all the time
- [x] Search icon not displaying
- [x] Search bar label not working
- [x] Fix search bar layout
- [x] Ensure we're using gem-c classes
- [ ] Header component displays small border on smaller screen sizes
- [ ] Whitehall layout with different search bar positioning and links to finders ([example](https://www.gov.uk/government/people/boris-johnson))
- [x] Favicon and other assets
- [x] Full width option, e.g: for topic page
- [x] Allow setting of body classes
- [x] Width container (logo lining up with cookie banner?)
- [x] Cookie banner
- [ ] omit_header ?
- [ ] Emergency banners
- [ ] Global banner
- [ ] Survey banner
- [x] Add tests
- [ ] Test responsiveness
- [ ] Browser testing
- [x] Check stylesheet and JS links in `head`
- [ ] Check JS functionality and move into gem if needed
- [ ] Check tracking
- [ ] Test in frontend apps
- [ ] Address comments

## Notes

This implementation makes the following assumptions:

- Expects an `application.js`, `application.css` and `print.css` file. Each Frontend app will have to follow this pattern.
- Meta tags, e.g: for analytics, are not included as a param. Applications can add these by using the [meta tags component](https://components.publishing.service.gov.uk/component-guide/meta_tags) within the `:head` section which this component renders.

To test locally in a frontend app: update the frontend app Gemfile to point to this branch; remove slimmer (and all references to it) from the Gemfile; update the relevant layout file to use the component rather than hardcode the layout.
