### PR TITLE
Fix focus style on page title context link

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
@@ -19,15 +19,15 @@
   &:link,
   &:visited {
     color: inherit;
-
-    &:focus {
-      color: $govuk-focus-text-colour;
-    }
   }
 
-  &:hover,
-  &:focus {
+  &:hover {
     text-decoration: underline;
+  }
+
+  &:focus {
+    text-decoration: none;
+    color: $govuk-focus-text-colour;
   }
 }
 

--- a/app/views/govuk_publishing_components/components/_title.html.erb
+++ b/app/views/govuk_publishing_components/components/_title.html.erb
@@ -17,7 +17,7 @@
 <%= content_tag(:div, class: classes) do %>
   <% if context %>
     <p class="gem-c-title__context">
-      <%= context_href ? link_to(context_text, context_href, class: 'gem-c-title__context-link', data: context_data) : context_text %>
+      <%= context_href ? link_to(context_text, context_href, class: 'gem-c-title__context-link govuk-link', data: context_data) : context_text %>
     </p>
   <% end %>
   <h1 class="gem-c-title__text <% if average_title_length %>gem-c-title__text--<%= average_title_length %><% end %>">


### PR DESCRIPTION
## What
Fix focus styles on page title component context link. Fixes https://github.com/alphagov/govuk_publishing_components/issues/1030

## Why
They were wrong.

## Visual Changes
Before:

<img width="549" alt="Screen Shot 2019-08-09 at 07 45 00" src="https://user-images.githubusercontent.com/861310/62759698-f4a87280-ba79-11e9-8028-7fe6f946c598.png">

<img width="719" alt="Screen Shot 2019-08-09 at 07 45 07" src="https://user-images.githubusercontent.com/861310/62759671-e6f2ed00-ba79-11e9-9282-1fa87f4676ce.png">

After:

<img width="513" alt="Screen Shot 2019-08-09 at 07 45 23" src="https://user-images.githubusercontent.com/861310/62759668-e65a5680-ba79-11e9-800e-41f38e262398.png">
<img width="711" alt="Screen Shot 2019-08-09 at 07 45 31" src="https://user-images.githubusercontent.com/861310/62759666-e5c1c000-ba79-11e9-90b2-27e658da2b98.png">

## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/component-guide/title
