### PR TITLE
Add inverse flag to contents list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Update feedback component to use govuk-frontend layout classes (PR #1010)
 * Fix focus and hover states for breadcrumbs, contents-list, highlight-boxes, modal-dialogue, step-by-step-nav, previous-and-next-navigation and title component (PR #1010)
 * Normalise falsey values to nil for subscription links component (PR #1021)
+* Add inverse flag to contents list components (PR #1037)
 
 ## 17.21.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -10,10 +10,25 @@
   box-shadow: 0 20px 15px -10px govuk-colour("white");
 }
 
+.gem-c-contents-list--inverse {
+  background: transparent;
+  box-shadow: none;
+}
+
 .gem-c-contents-list__title {
   @include govuk-text-colour;
   @include govuk-font($size: 16, $weight: regular, $line-height: 1.5);
   margin: 0;
+}
+
+.gem-c-contents-list--inverse .gem-c-contents-list__title,
+.gem-c-contents-list--inverse .gem-c-contents-list__link:link,
+.gem-c-contents-list--inverse .gem-c-contents-list__link:visited {
+  color: govuk-colour("white");
+}
+
+.gem-c-contents-list--inverse .gem-c-contents-list__link:focus {
+  color: $govuk-focus-text-colour;
 }
 
 .gem-c-contents-list__list,
@@ -74,6 +89,10 @@
       left: auto;
       right: 0;
     }
+  }
+
+  .gem-c-contents-list--inverse &:before {
+    color: govuk-colour("white");
   }
 
   // Focus styles on IE8 and older include the

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -2,6 +2,7 @@
   cl_helper = GovukPublishingComponents::Presenters::ContentsListHelper.new
   format_numbers ||= false
   underline_links ||= false
+  inverse ||= false
   contents ||= []
   aria_label ||= ''
   nested = !!contents.find { |c| c[:items] && c[:items].any? }
@@ -19,7 +20,10 @@
 <% if contents.any? %>
   <nav
     role="navigation"
-    class="gem-c-contents-list <%= 'gem-c-contents-list--no-underline' unless underline_links %> <%= brand_helper.brand_class %>"
+    class="gem-c-contents-list
+      <%= 'gem-c-contents-list--inverse' if inverse %>
+      <%= 'gem-c-contents-list--no-underline' unless underline_links %>
+      <%= brand_helper.brand_class %>"
     data-module="track-click"
     <% if aria_label.present? %>
       aria-label="<%= aria_label %>"

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -215,4 +215,16 @@ examples:
             text: Guidance and regulation
           - href: "#third-thing"
             text: Consultations
+  inverse:
+    description: Displays with no background colour, no box shadow and white text, for use on (for example) the [inverse header](/component-guide/inverse_header)
+    data:
+      inverse: true
+      contents:
+        - href: "#item-1"
+          text: "Item 1"
+        - href: "#item-2"
+          text: "Item 2"
+    context:
+      dark_background: true
+
 

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -137,4 +137,9 @@ describe "Contents list", type: :view do
     render_component(contents: nested_contents_list, hide_title: true)
     assert_select ".gem-c-contents-list__title", false
   end
+
+  it "adds an inverse class if inverse flag is passed" do
+    render_component(contents: nested_contents_list, inverse: true)
+    assert_select ".gem-c-contents-list--inverse"
+  end
 end


### PR DESCRIPTION
## What
<img width="991" alt="Screen Shot 2019-08-09 at 12 09 58" src="https://user-images.githubusercontent.com/29889908/62775094-a0fc5000-ba9e-11e9-9ab5-94ef2fd60ba3.png">

## Why
We have a need for using the contents list component within a topic page header, which is blue.

https://govuk-publishing-compo-pr-1037.herokuapp.com/component-guide/contents_list/inverse
