### PR TITLE
Fix image card overlay link in large mode

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -154,6 +154,13 @@
     padding-bottom: govuk-spacing(2);
   }
 
+  .gem-c-image-card__title-link {
+    &:after {
+      left: 0;
+      right: 0;
+    }
+  }
+
   .gem-c-image-card__description {
     @include govuk-font(19);
   }


### PR DESCRIPTION
## What
- in small mode (default) overlaying :after link element needs to be positioned 15px from left and right, because small image cards sit next to each other and include their own spacing
- in large mode image card is full width so :after link overlay should be full width, not 15px from left and right

## Why
Link overlay in large mode doesn't quite cover the image.

## Visual Changes

Before (:after element highlighted)

<img width="577" alt="Screen Shot 2019-08-09 at 12 16 51" src="https://user-images.githubusercontent.com/861310/62775471-a27a4800-ba9f-11e9-8d86-777a498c3a92.png">

After:

<img width="595" alt="Screen Shot 2019-08-09 at 12 12 50" src="https://user-images.githubusercontent.com/861310/62775477-a9a15600-ba9f-11e9-8f22-6563fb0ef6fc.png">


## View Changes
https://govuk-publishing-compo-pr-1039.herokuapp.com/component-guide/image_card
