### PR TITLE
Make the gem smaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Make the gem _slimmer_ by only including GOV.UK Frontend (#1041)
+
 ## 18.0.0
 
 * BREAKING: Update to [govuk-frontend 3.0.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.0.0) (PR #1010)

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/alphagov/govuk_publishing_components"
   s.license     = "MIT"
 
-  s.files = Dir["{node_modules,app,config,db,lib}/**/*", "DEVELOPMENT.md", "LICENCE.md", "Rakefile", "README.md"]
+  s.files = Dir["{node_modules/govuk-frontend,app,config,db,lib}/**/*", "DEVELOPMENT.md", "LICENCE.md", "Rakefile", "README.md"]
 
   s.add_dependency "gds-api-adapters"
   s.add_dependency "govuk_app_config"


### PR DESCRIPTION
We currently ship everything in `node_modules`, which includes the dev dependencies. This changes it to only include in the gem files from govuk-frontend. This will significantly decrease the size of the resulting gem.