### PR TITLE
Fix start button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Make the gem _slimmer_ by only including GOV.UK Frontend (#1041)
 * Remove unused image assets previously used in the button component and references to zombie image assets (#1042)
+* Fix start button showing SVG code (#1043)
 
 ## 18.0.0
 

--- a/app/views/govuk_publishing_components/components/_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_button.html.erb
@@ -1,6 +1,7 @@
 <% button = GovukPublishingComponents::Presenters::ButtonHelper.new(local_assigns) %>
 
-<% start_icon = capture do %>
+<% start_button_text = capture do %>
+  <%= button.text %>
   <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
     <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
   </svg>
@@ -8,7 +9,7 @@
 
 <%
   if button.start
-    button_text = button.text + start_icon
+    button_text = start_button_text
   else
     button_text = button.text
   end


### PR DESCRIPTION
## What
Fix how SVG is being rendered in a start button

## Why
Because it's currently encoding the SVG tags and it's showing it as code

## Visual Changes
No visual change in the gem, but in applications:

### Before
<img width="641" alt="Screen Shot 2019-08-12 at 16 13 42" src="https://user-images.githubusercontent.com/788096/62876112-2476a500-bd1c-11e9-9cd2-1ea6e0d055ae.png">

### After
<img width="168" alt="Screen Shot 2019-08-12 at 16 12 24" src="https://user-images.githubusercontent.com/788096/62876127-2b051c80-bd1c-11e9-9b75-e3b03f5b52ff.png">

## View Changes
https://govuk-publishing-compo-pr-1043.herokuapp.com/

Thanks @andysellick for reporting this.