### PR TITLE
Release 18.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 18.0.1
 
 * Make the gem _slimmer_ by only including GOV.UK Frontend (#1041)
 * Remove unused image assets previously used in the button component and references to zombie image assets (#1042)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (18.0.0)
+    govuk_publishing_components (18.0.1)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '18.0.0'.freeze
+  VERSION = '18.0.1'.freeze
 end


### PR DESCRIPTION
## 18.0.1
Contains a few fixes:
* Make the gem _slimmer_ by only including GOV.UK Frontend (#1041)
* Remove unused image assets previously used in the button component and references to zombie image assets (#1042)
* Fix start button showing SVG code (#1043)
