### PR TITLE
Related links focus state fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Expand share links component (PR #1046)
 * Add locale option so `lang` attribute can be used on related links (PR #1026)
+* Rejigs related navigation line height to avoid focus state overlap (PR #1045)
 
 ## 18.0.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
@@ -42,10 +42,10 @@
 .gem-c-related-navigation__link {
   list-style-type: none;
   margin-top: govuk-spacing(3);
-  @include govuk-font($size: 16, $weight: regular, $line-height: 1.5);
+  @include govuk-font($size: 16, $weight: regular, $line-height: 1.45);
 
   @include govuk-media-query($from: tablet) {
-    margin-top: 5px;
+    line-height: 1.28;
   }
 }
 


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
The line height has been reduced from 1.5 to 1.28 for larger screens and to 1.45 for smaller screens to remove the half overlap when a link ran over two lines. Part of #1028.

## Why
<!-- What are the reasons behind this change being made? -->
When a link stretched over two lines, the yellow background of the lower line partially covered the black underline of the upper line. After discussion with @soniaturcotte it was decided that it would be better to reduce the line height to overlap the upper black line completely - increasing the line height to show both the upper and lower underlines led to a set of links with too much space between them.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
Before:
![Screen Shot 2019-08-13 at 15 13 56](https://user-images.githubusercontent.com/1732331/62948849-08870800-bddd-11e9-9718-8b7558149828.png)

After:
<img width="282" alt="Screen Shot 2019-08-13 at 15 12 54" src="https://user-images.githubusercontent.com/1732331/62948756-e2f9fe80-bddc-11e9-9ea6-a38b518adb8a.png">


<!--
## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
-->