### PR TITLE
Restore node_modules gem dependencies

### DIFF
--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/alphagov/govuk_publishing_components"
   s.license     = "MIT"
 
-  s.files = Dir["{node_modules/govuk-frontend,app,config,db,lib}/**/*", "DEVELOPMENT.md", "LICENCE.md", "Rakefile", "README.md"]
+  s.files = Dir["{node_modules/govuk-frontend,node_modules/axe-core,app,config,db,lib}/**/*", "DEVELOPMENT.md", "LICENCE.md", "Rakefile", "README.md"]
 
   s.add_dependency "gds-api-adapters"
   s.add_dependency "govuk_app_config"


### PR DESCRIPTION
## What
Restoring some dependencies from `node_modules` - we used to include everything but this was unnecessary so it was reduced to just `govuk-frontend`, but it looks like some other things are also needed.

- axe-core/axe.js

## Why
The last versions of the gem (18.1.0 and 18.0.1) appear to be broken because of missing files not included from `node_modules`.
