### PR TITLE
Fix share links columns option layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix share links columns option layout (PR #1050)
+
 ## 18.1.1
 
 * Restore node_modules gem dependencies (PR #1048)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -13,7 +13,7 @@ $share-button-height: 32px;
   display: inline-block;
   min-height: $share-button-height;
   padding-left: ($share-button-width + govuk-spacing(2));
-  padding-right: govuk-spacing(1);
+  padding-right: govuk-spacing(2);
   margin-bottom: govuk-spacing(2);
   font-size: $share-button-height / 2;
   line-height: $share-button-height;
@@ -49,7 +49,7 @@ $share-button-height: 32px;
   }
 
   .gem-c-share-links__list-item {
-    padding-left: govuk-spacing(1);
+    padding-left: govuk-spacing(2);
     padding-right: ($share-button-width + govuk-spacing(2));
   }
 
@@ -61,12 +61,18 @@ $share-button-height: 32px;
 
 .gem-c-share-links--columns {
   .gem-c-share-links__list {
-    display: flex;
-    flex-wrap: wrap;
+    @include govuk-clearfix;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
 
   .gem-c-share-links__list-item {
-    flex: 0 0 200px;
+    float: left;
+    min-width: 200px;
+  }
+
+  .gem-c-share-links__link {
+    margin: 0;
   }
 }
 

--- a/app/views/govuk_publishing_components/components/docs/share_links.yml
+++ b/app/views/govuk_publishing_components/components/docs/share_links.yml
@@ -92,38 +92,41 @@ examples:
         },
       ]
   arrange_in_columns:
-    description: Share links are arranged in even columns that adjust according to the available space. This option uses flexbox, which is not fully supported in IE <= 10, so in those browsers the columns are not even.
+    description: |
+      Share links are arranged in even columns that adjust according to the available space. Note that the column width is based on an assumed width, so if the text in the links is very long it may wrap onto a second line, which is undesirable.
+
+      This option uses CSS grid, which is not fully supported in IE <= 11, so in those browsers the columns are floated.
     data:
       columns: true
       links: [
         {
           href: '/facebook-share-link',
-          text: 'Facebook',
+          text: 'Share on Facebook',
           icon: 'facebook'
         },
         {
           href: '/twitter-share-link',
-          text: 'Twitter',
+          text: 'Share on Twitter',
           icon: 'twitter'
         },
         {
           href: '/email-share-link',
-          text: 'Email',
+          text: 'Share on email to someone you know',
           icon: 'email'
         },
         {
           href: '/flickr-share-link',
-          text: 'Flickr',
+          text: 'Share on Flickr',
           icon: 'flickr'
         },
         {
           href: '/instagram-share-link',
-          text: 'Instagram',
+          text: 'Share on Instagram',
           icon: 'instagram'
         },
         {
           href: '/linkedin-share-link',
-          text: 'Linkedin',
+          text: 'Share on Linkedin',
           icon: 'linkedin'
         },
       ]


### PR DESCRIPTION
## What
It turns out the use of flexbox in this component wasn't quite working as intended. While it was providing some evenly sized columns, the options I'd chosen meant that there was no difference between that and using `float: left` with a fixed width.

New plan: CSS grid with a fallback. This now uses columns that have a minimum width of 200px but expand equally to fill the remaining space, collapsing into fewer columns as the page gets narrower.

CSS grid isn't supported by any version of IE, so the fallback there is to set a min-width of 200px and float each of the column items (and clearfix the parent). There's no browser hack involved, the grid styles override the floating if the browser recognises them and the clearfix is irrelevant.

This PR also simplifies the spacing between the links (regardless of the column option) by replacing the margin-right on the inner link and the small padding-right on the list item with just padding on the list item.

## Why
My previous implementation was flawed.

## Visual Changes
Showing columns in a modern browser as the window width is gradually decreased.

![Screen Shot 2019-08-15 at 09 30 34](https://user-images.githubusercontent.com/861310/63082962-751a1800-bf3f-11e9-8b0a-3fba781afa8d.png)

![Screen Shot 2019-08-15 at 09 30 41](https://user-images.githubusercontent.com/861310/63082970-7a776280-bf3f-11e9-86ca-ec41172a66fe.png)

![Screen Shot 2019-08-15 at 09 30 48](https://user-images.githubusercontent.com/861310/63082984-806d4380-bf3f-11e9-886f-f6757c0ef52f.png)

![Screen Shot 2019-08-15 at 09 30 55](https://user-images.githubusercontent.com/861310/63082990-84996100-bf3f-11e9-8514-1c7561374403.png)

Example from IE9 (all IEs look like this)

![Screen Shot 2019-08-15 at 09 10 07](https://user-images.githubusercontent.com/861310/63082884-4d2ab480-bf3f-11e9-9df4-fe152b9f171d.png)

## View Changes
https://govuk-publishing-compo-pr-1050.herokuapp.com/component-guide/share_links/
