### PR TITLE
Restore jquery as gem dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Restore jquery as gem dependency (PR #1051)
 * Fix share links columns option layout (PR #1050)
 
 ## 18.1.1

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/alphagov/govuk_publishing_components"
   s.license     = "MIT"
 
-  s.files = Dir["{node_modules/govuk-frontend,node_modules/axe-core,app,config,db,lib}/**/*", "DEVELOPMENT.md", "LICENCE.md", "Rakefile", "README.md"]
+  s.files = Dir["{node_modules/govuk-frontend,node_modules/axe-core,node_modules/jquery,app,config,db,lib}/**/*", "DEVELOPMENT.md", "LICENCE.md", "Rakefile", "README.md"]
 
   s.add_dependency "gds-api-adapters"
   s.add_dependency "govuk_app_config"


### PR DESCRIPTION
## What
Restoring some dependencies from `node_modules` - we used to include everything but this was unnecessary so it was reduced to just `govuk-frontend`, but it looks like some other things are also needed.

- jquery

Follows on from https://github.com/alphagov/govuk_publishing_components/pull/1048

## Why
Previous versions of the gem (18.1.0 and 18.0.1) appear to be broken because of missing files not included from `node_modules`. This was fixed in 18.1.1 but investigation suggests that even though jquery wasn't included it is needed. I think it's working without jquery in apps because the apps already pull in jquery from another source, but we should include this for the future.

