### PR TITLE
Add a "use_month_year_dates" option to document lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## unreleased
+
+* Add option to hide day numbers in timestamps in document lists (PR #1053)
+
 ## 18.1.2
 
 * Restore jquery as gem dependency (PR #1051)

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -10,6 +10,9 @@
   within_multitype_list_class = " gem-c-document-list__multi-list" if within_multitype_list
   title_with_context_class = " gem-c-document-list__item-title--context"
 
+  use_month_year_dates ||= false
+  date_format = use_month_year_dates ? "%B %Y" : "%e %B %Y"
+
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
 %>
@@ -46,8 +49,8 @@
             <% item[:metadata].compact.each do |item_metadata_key, item_metadata_value| %>
               <li class="gem-c-document-list__attribute">
                 <% if item_metadata_key.to_s.eql?("public_updated_at") %>
-                  <time datetime="<%= item_metadata_value.iso8601 %>">
-                    <%= l(item_metadata_value, format: '%e %B %Y') %>
+                  <time datetime="<%= use_month_year_dates ? item_metadata_value.strftime('%Y-%m') : item_metadata_value.iso8601 %>">
+                    <%= l(item_metadata_value, format: date_format) %>
                   </time>
                 <% else %>
                   <%= item_metadata_value %>

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -97,6 +97,25 @@ examples:
         metadata:
           public_updated_at: 2017-07-19 15:01:48
           document_type: 'Statutory guidance'
+  with_description_and_month_year_dates:
+    description: Dates can be displayed without the day.
+    data:
+      use_month_year_dates: true
+      items:
+      - link:
+          text: 'School behaviour and attendance: parental responsibility measures'
+          path: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+          description: 'The responsibilities parents have relating to school behaviour and attendance.'
+        metadata:
+          public_updated_at: 2017-01-05 14:50:33
+          document_type: 'Statutory guidance'
+      - link:
+          text: 'School exclusion'
+          path: '/government/publications/school-exclusion'
+          description: 'Rules governing school exclusion.'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Statutory guidance'
   with_branding:
     description: Where this component could be used on an organisation page (such as the [Attorney General's Office](https://www.gov.uk/government/organisations/attorney-generals-office)) branding can be applied for link colours and border colours. See the [branding documentation](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) for more details.
     data:

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -74,6 +74,47 @@ describe "Document list", type: :view do
     assert_select "#{attribute} time[datetime='2017-07-19T15:01:48Z']"
   end
 
+  it "can hide the day in pretty-printed timestamps" do
+    render_component(
+      use_month_year_dates: true,
+      items: [
+        {
+          link: {
+            text: "School behaviour and attendance: parental responsibility measures",
+            path: "/government/publications/parental-responsibility-measures-for-behaviour-and-attendance",
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+            document_type: "Statutory guidance"
+          }
+        },
+        {
+          link: {
+            text: "Become an apprentice",
+            path: "/become-an-apprentice",
+            description: 'Becoming an apprentice - what to expect'
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-07-19 15:01:48 +0000"),
+            document_type: "Statutory guidance"
+          }
+        }
+      ]
+    )
+    li = ".gem-c-document-list__item-title"
+    attribute = ".gem-c-document-list__attribute"
+
+    assert_select "#{li}[href='/government/publications/parental-responsibility-measures-for-behaviour-and-attendance']", text: "School behaviour and attendance: parental responsibility measures"
+    assert_select "#{attribute} time", text: "January 2017"
+    assert_select "#{attribute} time[datetime='2017-01']"
+    assert_select ".gem-c-document-list__attribute", text: "Statutory guidance"
+
+    assert_select "#{li}[href='/become-an-apprentice']", text: "Become an apprentice"
+    assert_select ".gem-c-document-list__item-description", text: 'Becoming an apprentice - what to expect'
+    assert_select "#{attribute} time", text: "July 2017"
+    assert_select "#{attribute} time[datetime='2017-07']"
+  end
+
   it "renders a document list item even when public_updated_at is nil" do
     render_component(
       items: [


### PR DESCRIPTION
## What
Adds an option to change the date format for document lists to only show the month and year.

## Why
We have things where dates are provisional, like statistics announcements.  These all have a timestamp for the 1st of the chosen month, but may not actually be released on that day - they can be released any time in the month.  So displaying the day is incorrect.

Statistics announcements pages display dates like so: https://www.gov.uk/government/statistics/announcements/local-authority-revenue-expenditure-and-financing-england-2019-to-2020-provisional-outturn

This change is so that search pages can be consistent: https://www.gov.uk/search/research-and-statistics?content_store_document_type=upcoming_statistics&organisations%5B%5D=ministry-of-housing-communities-and-local-government

## Visual Changes
No change to existing behaviour.  The new thing looks like this:
<img width="1000" alt="Screen Shot 2019-08-15 at 11 09 39" src="https://user-images.githubusercontent.com/75235/63088607-5b7fcd00-bf4d-11e9-8975-549ac1df83bb.png">

## View Changes
https://govuk-publishing-compo-pr-1053.herokuapp.com/component-guide/document_list
