### PR TITLE
Fix components focus state spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix components focus state spacing (PR #1054)
+
 ## 19.0.0
 
 * **BREAKING:** Remove govuk_frontend_toolkit sass dependencies (PR #1069)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -48,6 +48,10 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey", $legacy: "grey-3");
   margin: 0 0 govuk-spacing(3);
 }
 
+.gem-c-attachment__link {
+  line-height: 1.29;
+}
+
 .gem-c-attachment__metadata {
   @include govuk-font($size: 14);
   margin: 0 0 govuk-spacing(3);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -45,7 +45,7 @@
 
 .gem-c-document-list__item-description {
   @include govuk-text-colour;
-  margin: 0 0 5px 0;
+  margin: govuk-spacing(1) 0;
 }
 
 .gem-c-document-list__subtext {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -110,8 +110,13 @@
   margin: 0;
   list-style: none;
 
+  .gem-c-image-card__list-item {
+    margin-bottom: govuk-spacing(1);
+  }
+
   .gem-c-image-card__list-item-link {
     @extend %govuk-link;
+    line-height: 1.35em;
   }
 
   &.gem-c-image-card__list--indented {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss
@@ -31,7 +31,7 @@
 
 .gem-c-metadata__term {
   margin-top: .5em;
-  line-height: normal;
+  line-height: 1.4;
 
   @include govuk-media-query($from: tablet) {
     box-sizing: border-box;
@@ -56,7 +56,7 @@
 
 .gem-c-metadata__definition {
   margin: 0;
-  line-height: normal;
+  line-height: 1.4;
 
   @include govuk-media-query($from: tablet) {
     float: left;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -56,9 +56,12 @@
   @include govuk-link-style-text;
   font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
 
-  &:hover,
-  &:focus {
+  &:hover {
     text-decoration: underline;
+  }
+
+  &:focus {
+    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-colour, 0 8px $govuk-focus-text-colour;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
@@ -1,5 +1,11 @@
 @import "govuk/components/textarea/textarea";
 
-.gem-c-textarea .govuk-textarea {
-  margin-bottom: 0;
+.gem-c-textarea {
+  .govuk-textarea {
+    margin-bottom: 0;
+
+    + .govuk-hint {
+      margin-top: govuk-spacing(1);
+    }
+  }
 }

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -51,7 +51,7 @@
   <%= tag.div class: "gem-c-attachment__details" do %>
     <%= tag.h2 class: "gem-c-attachment__title" do %>
       <%= link_to attachment.title, attachment.url,
-            class: "govuk-link",
+            class: "govuk-link gem-c-attachment__link",
             target: target,
             data: data_attributes %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -29,7 +29,7 @@ examples:
   with_number_of_pages:
     data:
       attachment:
-        title: "Temporary snow ploughs: guidance note"
+        title: "Department for Transport, temporary snow ploughs: guidance note"
         url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/259634/temporary-snow-ploughs.pdf
         filename: temporary-snow-ploughs.pdf
         content_type: application/pdf

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -57,7 +57,7 @@ examples:
           href: "/1"
         },
         {
-          text: "Prime Minister's and Cabinet Office ministers' transparency publications",
+          text: "Prime Minister's and Cabinet Office ministers' transparency publications relating to freedom of information requests for general consumption and the public interest in general",
           href: "/2"
         },
         {


### PR DESCRIPTION
## What
Some of the components have spacing issues with focus states since the `govuk-frontend` V3 changes, as detailed [in this issue](https://github.com/alphagov/govuk_publishing_components/issues/1028). This PR includes fixes for  those issues.

Changes the following components:

- [x] image card
- [x] attachment
- [x] textarea
- [x] metadata
- [x] organisation logo
- [x] related navigation
- [x] [document list](https://github.com/alphagov/finder-frontend/pull/1307#issuecomment-521974898)

## Why
Fixes https://github.com/alphagov/govuk_publishing_components/issues/1028

## Visual Changes

Document list before:

<img width="861" alt="Screen Shot 2019-08-16 at 14 30 20" src="https://user-images.githubusercontent.com/861310/63170958-6eb89880-c032-11e9-8b5c-06c01ac4ba83.png">

Document list after:

<img width="858" alt="Screen Shot 2019-08-16 at 14 30 29" src="https://user-images.githubusercontent.com/861310/63170970-74ae7980-c032-11e9-91b3-5cb242016686.png">

Image card before:

<img width="866" alt="Screen Shot 2019-08-16 at 15 02 58" src="https://user-images.githubusercontent.com/861310/63173079-04562700-c037-11e9-97fd-c9d7ca5db923.png">

Image card after:

<img width="850" alt="Screen Shot 2019-08-16 at 15 03 51" src="https://user-images.githubusercontent.com/861310/63173125-1637ca00-c037-11e9-90b3-04df3fe6d3ab.png">

Textarea before:

<img width="801" alt="Screen Shot 2019-08-23 at 15 15 33" src="https://user-images.githubusercontent.com/861310/63599198-05e49980-c5b9-11e9-8406-e3b28b768ed7.png">

Textarea after:

<img width="793" alt="Screen Shot 2019-08-23 at 15 15 40" src="https://user-images.githubusercontent.com/861310/63599218-0ed56b00-c5b9-11e9-9f26-b3191c4efb23.png">

Metadata before:

<img width="812" alt="Screen Shot 2019-08-23 at 15 22 28" src="https://user-images.githubusercontent.com/861310/63599909-717b3680-c5ba-11e9-9c5f-92c3eb2b17a3.png">

Metadata after:

<img width="770" alt="Screen Shot 2019-08-23 at 15 25 25" src="https://user-images.githubusercontent.com/861310/63599918-78a24480-c5ba-11e9-9373-f86713d45cb5.png">

Organisation logo before:

<img width="1080" alt="Screen Shot 2019-08-23 at 15 40 39" src="https://user-images.githubusercontent.com/861310/63601225-eea7ab00-c5bc-11e9-9695-aa6f26cfe49a.png">

Organisation logo after:

<img width="858" alt="Screen Shot 2019-08-23 at 15 40 55" src="https://user-images.githubusercontent.com/861310/63601240-f5362280-c5bc-11e9-8b89-026b408e6fdc.png">



## View Changes
https://govuk-publishing-compo-pr-1054.herokuapp.com/component-guide/
