### PR TITLE
Fix image card responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix image card responsiveness (PR #1055)
+
 ## 18.1.2
 
 * Restore jquery as gem dependency (PR #1051)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -1,15 +1,10 @@
 .gem-c-image-card {
   @include govuk-clearfix;
   @include govuk-text-colour;
-
-  margin: 0 (- govuk-spacing(3)) govuk-spacing(6) (- govuk-spacing(3));
   position: relative;
 }
 
 .gem-c-image-card__image-wrapper {
-  @include govuk-grid-column($width: one-third, $at: mobile);
-  @include govuk-grid-column($width: full, $at: tablet);
-
   margin: 0;
 
   @include govuk-media-query($from: tablet) {
@@ -23,14 +18,23 @@
   }
 }
 
+@include govuk-media-query($from: mobile, $until: tablet) {
+  .gem-c-image-card {
+    margin: 0 (- govuk-spacing(3)) govuk-spacing(6) (- govuk-spacing(3));
+  }
+
+  .gem-c-image-card__image-wrapper {
+    @include govuk-grid-column($width: one-third, $at: mobile);
+  }
+
+  .gem-c-image-card__text-wrapper {
+    @include govuk-grid-column($width: two-thirds, $at: mobile);
+  }
+}
+
 .gem-c-image-card__image {
   display: block;
   max-width: 100%;
-}
-
-.gem-c-image-card__text-wrapper {
-  @include govuk-grid-column($width: two-thirds, $at: mobile);
-  @include govuk-grid-column($width: full, $at: tablet);
 }
 
 .gem-c-image-card__title {


### PR DESCRIPTION
## What

- when image card drops below 320px (unlikely, admittedly) it collapses into a single column but the margins are broken
- also the sass is a bit confusing
- this commit restructures the sass to make it more readable and fixes this problem
- behaviour should be (for standard image card): from 320px two columns, from 640px one column
- behaviour is perhaps not ideal (mobile with two columns is a little squished in some cases) but changing it is outside scope
- this commit does not change the behaviour, it only fixes the brokenness below 320px


## Why
The likelihood of anyone using a device narrower than 320px is very low, but this PR also makes the code more readable. Having said that, I'm not 100% sure I understand the new govuk-frontend V3 mixins for breakpoints and columns.

## Visual Changes
Before:

<img width="446" alt="Screen Shot 2019-08-16 at 15 59 26" src="https://user-images.githubusercontent.com/861310/63179644-813bcd80-c044-11e9-9ac7-e31f8bdf8ab5.png">

After:

<img width="397" alt="Screen Shot 2019-08-16 at 16 40 34" src="https://user-images.githubusercontent.com/861310/63179688-9b75ab80-c044-11e9-8dee-17fd7654fc11.png">

I've checked this in collections (component is used on org pages) and the behaviour appears to be as before but includes the fix.

## View Changes
https://govuk-publishing-compo-pr-1055.herokuapp.com/component-guide/image_card
