### PR TITLE
Make contextual title accept and present lang parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix image card responsiveness (PR #1055)
+* Make contextual title accept and present lang parameter (PR #1056)
 
 ## 18.1.2
 

--- a/app/views/govuk_publishing_components/components/_title.html.erb
+++ b/app/views/govuk_publishing_components/components/_title.html.erb
@@ -1,6 +1,7 @@
 <%
   average_title_length ||= false
   context ||= false
+  context_locale ||= false
   context_text = context.is_a?(Hash) ? context[:text] : context
   context_href = context.is_a?(Hash) ? context[:href] : false
   context_data = context.is_a?(Hash) ? context[:data] : false
@@ -13,10 +14,11 @@
   classes = %w(gem-c-title govuk-!-margin-top-8)
   classes << "gem-c-title--inverse" if inverse
   classes << (shared_helper.get_margin_bottom)
+
 %>
 <%= content_tag(:div, class: classes) do %>
   <% if context %>
-    <p class="gem-c-title__context">
+    <p class="gem-c-title__context" <%= "lang=#{context_locale}" if context_locale.present? %>>
       <%= context_href ? link_to(context_text, context_href, class: 'gem-c-title__context-link govuk-link', data: context_data) : context_text %>
     </p>
   <% end %>

--- a/app/views/govuk_publishing_components/components/docs/title.yml
+++ b/app/views/govuk_publishing_components/components/docs/title.yml
@@ -24,6 +24,15 @@ examples:
     data:
       context: Publication
       title: My page title
+  with_context_language_labelled:
+    description: |
+      Sometimes this component appears on a page that has been translated. The title will naturally be supplied in the required language but the context string may fall back to the default. In these instances we need to label the language so the page remains semantic and screenreaders can handle the switch.
+
+      The `lang` attribute **must** be set to a [valid BCP47 string](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang#Language_tag_syntax). A valid code can be the two or three letter language code - for example, English is `en` or `eng`, Korean is `ko` or `kor` - but if in doubt please check.
+    data:
+      context: Publication
+      context_locale: en
+      title: My page title
   with_context_link:
     description: |
       It’s unclear if links in the context of a title are useful and are being clicked by users. Data attributes are included to track this behaviour.
@@ -69,3 +78,4 @@ examples:
       margin_bottom: 0
     context:
       dark_background: true
+

--- a/spec/components/title_spec.rb
+++ b/spec/components/title_spec.rb
@@ -26,6 +26,11 @@ describe "Title", type: :view do
     assert_select ".gem-c-title__context-link[href='/format'][data-tracking]", text: "Format"
   end
 
+  it "applies context language if supplied to a context string" do
+    render_component(title: "Bonjour Monde", context: "hello", context_locale: 'en')
+    assert_select ".gem-c-title__context[lang='en']"
+  end
+
   it "applies title length if supplied" do
     render_component(title: "Hello World", context: "format", average_title_length: 'long')
     assert_select ".gem-c-title .gem-c-title__text--long", text: "Hello World"
@@ -54,5 +59,10 @@ describe "Title", type: :view do
   it "ignores an invalid margin" do
     render_component(title: 'Margin wat', margin_bottom: 17)
     assert_select "[class='^=govuk-\!-margin-bottom-']", false
+  end
+
+  it "applies context language if supplied to a context link" do
+    render_component(title: "Bonjour", context: { text: "Format", href: "/format" }, context_locale: "en")
+    assert_select ".gem-c-title__context[lang='en']"
   end
 end


### PR DESCRIPTION
## What
Add ability to pass in a language param for 

## Why
Sometimes the page is translated but we don't have a translation for the page type string used in the contextual header, we need to mark this up for semantics and accessibility

## View Changes
https://govuk-publishing-compo-pr-1056.herokuapp.com/

