### PR TITLE
Prevent header navigation and title overlapping

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -18,11 +18,20 @@
   border-bottom-color: govuk-colour("dark-grey", $legacy: "grey-1");
 }
 
-.govuk-header__logo {
+.gem-c-header__logo {
   white-space: nowrap;
+  width: auto;
 }
 
-.govuk-header__product-name {
+.gem-c-header__content {
+  width: auto;
+
+  @include govuk-media-query($from: desktop) {
+    float: right;
+  }
+}
+
+.gem-c-header__product-name {
   display: none;
 
   @include govuk-media-query($from: tablet) {

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -10,7 +10,7 @@
 %>
 <header class="gem-c-layout-header govuk-header gem-c-layout-header--<%= environment %>" role="banner" data-module="govuk-header">
   <div class="govuk-header__container <%= width_class %>">
-    <div class="govuk-header__logo">
+    <div class="govuk-header__logo gem-c-header__logo">
       <a href="/" class="govuk-header__link govuk-header__link--homepage">
         <span class="govuk-header__logotype">
           <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
@@ -24,7 +24,7 @@
           </span>
         </span>
 
-        <span class="govuk-header__product-name">
+        <span class="govuk-header__product-name gem-c-header__product-name">
           <%= product_name %>
         </span>
 
@@ -33,11 +33,11 @@
         </span>
       </a>
 
-    </div><div class="govuk-header__content">
+    </div><div class="govuk-header__content gem-c-header__content">
 
     <% if navigation_items.any? %>
-    <button role="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-    <nav>
+    <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+    <nav class="gem-c-header__nav">
       <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
         <% navigation_items.each_with_index do |item, index| %>
           <li class="govuk-header__navigation-item <%= "govuk-header__navigation-item--active" if item[:active] %>


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Prevents the header title and logo from overlapping. Partially mends #1029 (this pull request doesn't fix the overlap of the 'Menu' button).

## Why
<!-- What are the reasons behind this change being made? -->
The overlap looked broken and made it difficult to read the links. 

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
Before:
![image](https://user-images.githubusercontent.com/1732331/63331817-5e543680-c32e-11e9-9990-c5403ccb857f.png)
![image](https://user-images.githubusercontent.com/1732331/63332331-4e892200-c32f-11e9-853f-17920315fb3f.png)

After:
![image](https://user-images.githubusercontent.com/1732331/63331866-72983380-c32e-11e9-9801-82f7e6c5e843.png)
![image](https://user-images.githubusercontent.com/1732331/63332342-56e15d00-c32f-11e9-94be-2f0f59ac6fa0.png)


## View Changes
https://govuk-publishing-compo-pr-1057.herokuapp.com/component-guide/layout_header/with_navigation/preview