### PR TITLE
Name and value can be set on button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+* `value` and `name` can be set on button component (PR #1059)
+
 ## 18.2.0
 
 * Fix nested checkboxes js (PR #1065)

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -99,7 +99,10 @@ examples:
       text: "Second button"
       inline_layout: true
   with_name_and_value_set:
-    description: By default, the button has no value or name set so it will not pass information when the form is submitted. This allows a name and value to be added so a button can add information to the form submission.
+    description: |
+      By default, the button has no value or name set so it will not pass information when the form is submitted. This allows a name and value to be added so a button can add information to the form submission.
+
+      Please note that Internet Explorer 6 and 7 have **breaking bugs** when submitting a form with multiple buttons - this can [change what value is submitted by the button](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Notes). Make sure to check your user needs and browser usage.
     data:
       text: "This is the button text"
       value: "this_is_the_value"

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -98,4 +98,10 @@ examples:
     data:
       text: "Second button"
       inline_layout: true
+  with_name_and_value_set:
+    description: By default, the button has no value or name set so it will not pass information when the form is submitted. This allows a name and value to be added so a button can add information to the form submission.
+    data:
+      text: "This is the button text"
+      value: "this_is_the_value"
+      name: "this_is_the_name"
 

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -5,7 +5,7 @@ module GovukPublishingComponents
     class ButtonHelper
       attr_reader :href, :text, :title, :info_text, :rel, :data_attributes,
                   :margin_bottom, :inline_layout, :target, :type, :start,
-                  :secondary, :secondary_quiet, :destructive
+                  :secondary, :secondary_quiet, :destructive, :name, :value
 
       def initialize(local_assigns)
         @href = local_assigns[:href]
@@ -22,6 +22,8 @@ module GovukPublishingComponents
         @secondary = local_assigns[:secondary]
         @secondary_quiet = local_assigns[:secondary_quiet]
         @destructive = local_assigns[:destructive]
+        @name = local_assigns[:name]
+        @value = local_assigns[:value]
       end
 
       def link?
@@ -36,6 +38,8 @@ module GovukPublishingComponents
         options[:data] = data_attributes if data_attributes
         options[:title] = title if title
         options[:target] = target if target
+        options[:name] = name if name.present? && value.present?
+        options[:value] = value if name.present? && value.present?
         options
       end
 

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -141,4 +141,32 @@ describe "Button", type: :view do
 
     assert_select ".gem-c-button--inline", text: "Button one"
   end
+
+  it "renders with a name and a value attribute when name and value are set" do
+    render_component(text: "Button one", value: "this_value", name: "this_name")
+
+    assert_select ".gem-c-button[name='this_name']", 1
+    assert_select ".gem-c-button[value='this_value']", 1
+  end
+
+  it "renders without a name or a value attribute when only value is set" do
+    render_component(text: "Button one", value: "this_value")
+
+    assert_select ".gem-c-button[name]", 0
+    assert_select ".gem-c-button[value]", 0
+  end
+
+  it "renders without a name or a value attribute when only name is set" do
+    render_component(text: "Button one", name: "this_name")
+
+    assert_select ".gem-c-button[name]", 0
+    assert_select ".gem-c-button[value]", 0
+  end
+
+  it "renders without a name or a value attribute neither name or value is set" do
+    render_component(text: "Button one")
+
+    assert_select ".gem-c-button[name]", 0
+    assert_select ".gem-c-button[value]", 0
+  end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Adds two optional parameters to the button component to let the `value` and `name` attributes be set.

## Why
<!-- What are the reasons behind this change being made? -->
A button's value is only sent as part of a form when the button is used to submit the form - having multiple buttons set with different values means that we can tell which button submitted a form. 

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

No visual changes - just code changes.

Before:
```html
<button class="gem-c-button govuk-button" type="submit">
  This is the button text
</button>
```

After:
```html
<button 
  class="gem-c-button govuk-button" 
  type="submit" 
  name="this_is_the_name" 
  value="this_is_the_value"
>
  This is the button text
</button>
```

## View Changes
https://govuk-publishing-compo-pr-1059.herokuapp.com/component-guide/button/with_name_and_value_set