### PR TITLE
Add summary list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fix image card responsiveness (PR #1055)
 * Make contextual title accept and present lang parameter (PR #1056)
+* Add summary-list component based on GOV.UK Frontend (PR #1061)
 
 ## 18.1.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -75,6 +75,7 @@
 @import "components/step-by-step-nav";
 @import "components/subscription-links";
 @import "components/success-alert";
+@import "components/summary-list";
 @import "components/tabs";
 @import "components/table";
 @import "components/taxonomy-list";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_summary-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_summary-list.scss
@@ -1,0 +1,27 @@
+@import "govuk/components/summary-list/summary-list";
+
+.gem-c-summary-list {
+  position: relative;
+  border-bottom: 1px solid $govuk-border-colour;
+
+  @include govuk-font(19);
+  @include govuk-responsive-margin(6, "top");
+
+  &:nth-of-type(1) {
+    margin-top: govuk-spacing(0);
+  }
+
+  &:nth-last-of-type(1) {
+    border-bottom: 0;
+  }
+}
+
+.gem-c-summary-list__edit-section-link {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.gem-c-summary__block {
+  @include govuk-responsive-margin(6, "bottom");
+}

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -1,0 +1,67 @@
+<%
+  id ||= nil
+  title ||= nil
+  edit ||= {}
+  items ||= []
+  block ||= yield
+%>
+<% if title || items.any? %>
+  <%= tag.div class: "gem-c-summary-list", id: id do %>
+    <% if title %>
+      <%= tag.h3 title, class: "govuk-heading-m" %>
+      <% if edit.any? %>
+        <%= tag.ul class: "govuk-summary-list__actions-list" do %>
+          <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
+            <%= link_to edit.fetch(:href),
+                      class: "govuk-link gem-c-summary-list__edit-section-link",
+                      title: "Edit #{title}",
+                      data: edit.fetch(:data_attributes, {}) do %>
+               Edit <%= tag.span title, class: "govuk-visually-hidden" %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% if items.any? %>
+      <%= tag.dl class: "govuk-summary-list" do %>
+        <% items.each do |item| %>
+          <%= tag.div class: "govuk-summary-list__row" do %>
+
+            <%= tag.dt item[:field], class: "govuk-summary-list__key" %>
+            <%= tag.dd item[:value], class: "govuk-summary-list__value" %>
+
+            <% if item.fetch(:edit, {}).any? || item.fetch(:delete, {}).any? %>
+              <%= tag.dd class: "govuk-summary-list__actions" do %>
+                <%= tag.ul class: "govuk-summary-list__actions-list" do %>
+                  <% if item.fetch(:edit, {}).any? %>
+                    <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
+                      <%= link_to item[:edit].fetch(:href),
+                                  class: "govuk-link",
+                                  title: "Edit #{item[:field]}",
+                                  data: item[:edit].fetch(:data_attributes, {}) do %>
+                        Edit <%= tag.span item[:field], class: "govuk-visually-hidden" %>
+                      <% end %>
+                    <% end %>
+                  <% end %>
+                  <% if item.fetch(:delete, {}).any? %>
+                    <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
+                      <%= link_to item[:delete].fetch(:href),
+                                  class: "govuk-link",
+                                  title: "Delete #{item[:field]}",
+                                  data: item[:edit].fetch(:data_attributes, {}) do %>
+                        Delete <%= tag.span item[:field], class: "govuk-visually-hidden" %>
+                      <% end %>
+                    <% end %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= tag.div block, class: "gem-c-summary__block" if block %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/summary_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/summary_list.yml
@@ -1,0 +1,66 @@
+name: Summary list
+description: Use the summary list to summarise information, for example, a user’s responses at the end of a form.
+accessibility_criteria: |
+  Action links in the component must:
+
+  * indicate what the action refers to (e.g. Change _name_)
+shared_accessibility_criteria:
+  - link
+govuk_frontend_components:
+  - summary-list
+examples:
+  default:
+    data:
+      title: "Title, summary and body"
+      items:
+      - field: "Title"
+        value: "Ethical standards for public service providers"
+      - field: "Summary"
+        value: "Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication."
+      - field: "Body"
+        value: "After the government decided in 2013 to expand the remit of the Committee to include public service providers, the Committee on Standards in Public Life produced our first report on the issue: Ethical Standards for Providers of Public Services in 2014."
+
+  with_edit_on_section:
+    data:
+      title: "Title, summary and body"
+      edit:
+        href: "edit-title-summary-body"
+        data_attributes:
+          gtm: "edit-title-summary-body"
+      items:
+      - field: "Title"
+        value: "Ethical standards for public service providers"
+      - field: "Summary"
+        value: "Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication."
+      - field: "Body"
+        value: "After the government decided in 2013 to expand the remit of the Committee to include public service providers, the Committee on Standards in Public Life produced our first report on the issue: Ethical Standards for Providers of Public Services in 2014."
+
+  with_edit_on_individual_items:
+    data:
+      title: "Title, summary and body"
+      items:
+      - field: "Title"
+        value: "Ethical standards for public service providers"
+        edit:
+          href: "edit-title"
+          data_attributes:
+            gtm: "edit-title"
+      - field: "Summary"
+        value: "Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication."
+        edit:
+          href: "edit-summary"
+        delete:
+          href: "delete-summary"
+      - field: "Body"
+        value: "After the government decided in 2013 to expand the remit of the Committee to include public service providers, the Committee on Standards in Public Life produced our first report on the issue: Ethical Standards for Providers of Public Services in 2014."
+        edit:
+          href: "edit-body"
+        delete:
+          href: "delete-body"
+
+  with_block:
+    description: Use the summary list with a block when you need to show an empty state message or load another component.
+    data:
+      title: "Topics"
+      block: |
+        <p class="govuk-body">No topics specified for this document.</p>

--- a/spec/components/summary_list_spec.rb
+++ b/spec/components/summary_list_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+describe "Summary list", type: :view do
+  def component_name
+    'summary_list'
+  end
+
+  it "does not render anything if no data is passed" do
+    test_data = {}
+    assert_empty render_component(test_data)
+  end
+
+  it "renders section title" do
+    render_component(title: 'Title, summary and body')
+    assert_select '.gem-c-summary-list .govuk-heading-m', text: 'Title, summary and body'
+  end
+
+  it "renders section title with edit action" do
+    render_component(
+      title: 'Title, summary and body',
+      edit: {
+        href: "#edit-title-summary-body",
+        data_attributes: {
+          gtm: "edit-title-summary-body"
+        }
+      }
+    )
+    assert_select '.gem-c-summary-list .govuk-heading-m', text: 'Title, summary and body'
+    assert_select '.gem-c-summary-list__edit-section-link[title="Edit Title, summary and body"][href="#edit-title-summary-body"][data-gtm="edit-title-summary-body"]', text: 'Edit Title, summary and body'
+  end
+
+  it "renders section title with block" do
+    render_component(
+      title: 'Title, summary and body',
+      block: sanitize('<p class="govuk-body">Some HTML</p>')
+    )
+    assert_select '.gem-c-summary-list .govuk-heading-m', text: 'Title, summary and body'
+    assert_select '.gem-c-summary__block', text: 'Some HTML'
+  end
+
+  it "renders items" do
+    render_component(
+      items: [
+        {
+          field: "Title",
+          value: "Ethical standards for public service providers"
+        },
+        {
+          field: "Summary",
+          value: "Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication."
+        }
+      ]
+    )
+    assert_select '.govuk-summary-list__row', 2
+    assert_select '.govuk-summary-list__key', text: 'Title'
+    assert_select '.govuk-summary-list__value', text: 'Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication.'
+  end
+
+  it "renders items with edit action" do
+    render_component(
+      items: [
+        {
+          field: "Title",
+          value: "Ethical standards for public service providers",
+          edit: {
+            href: "#edit-title",
+            data_attributes: {
+              gtm: "edit-title"
+            }
+          }
+        }
+      ]
+    )
+    assert_select '.govuk-summary-list__key', text: 'Title'
+    assert_select '.govuk-summary-list__value', text: 'Ethical standards for public service providers'
+    assert_select '.govuk-summary-list__actions-list-item .govuk-link[title="Edit Title"][href="#edit-title"][data-gtm="edit-title"]', text: "Edit Title"
+  end
+end


### PR DESCRIPTION
## What
This component is based on the [summary list component in govuk-frontend](https://design-system.service.gov.uk/components/summary-list/).

The API was modelled after the [summary component in Content Publisher](https://content-publisher.integration.publishing.service.gov.uk/component-guide/summary) as it should be replaced with this component after it gets released.

## Why
This component is used already in Content Publisher and it's needed in Collections Publisher. It's also the only missing component from the Design System

## View Component
https://govuk-publishing-compo-pr-1061.herokuapp.com/component-guide/summary_list

[Trello card](https://trello.com/c/arYq0tST)
