### PR TITLE
Consolidate input aria documentation and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
   of the commit log.
 
 ## Unreleased
+
 * `value` and `name` can be set on button component (PR #1059)
+* Consolidate input aria documentation and tests (PR #1062)
 
 ## 18.2.0
 

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -37,22 +37,18 @@ examples:
         text: "Has an id"
       name: "hasid"
       id: "hasid"
-  aria_described_by:
+  with_aria_attributes:
     description: |
-      Allows the addition of an aria-describedby attribute. Note that this will be overridden in the event of an error, where the error will be used for the describedby attribute value.
+      The component accepts two possible aria attributes: aria-describedby and aria-controls.
 
-      The example below uses the ID of the main container for demonstration purposes as there aren't any useful elements with IDs in the component guide. In real use this would be passed the ID of an element that correctly described the input.
+      [aria-describedby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute) is used to indicate the ID of the element that describes the input. This will be overridden in the event of an error, where the error will be used for the describedby attribute value. This example uses the ID of the main container for demonstration purposes as there aren't any useful elements with IDs in the component guide. In real use this would be passed the ID of an element that correctly described the input.
+
+      aria-controls allows the addition of an aria-controls attribute, for use in places like the finders where the page is updated dynamically after value changes to the input.
     data:
       label:
         text: "This is an example only and may not work with a screen reader"
       name: "labelledby"
       describedby: "wrapper"
-  aria_controls:
-    description: Allows the addition of an aria-controls attribute, for use in places like the finders where the page is updated dynamically after value changes to the input.
-    data:
-      label:
-        text: "This is an example only and will not work with a screen reader as intended"
-      name: "controls"
       controls: "wrapper"
   with_hint:
     data:

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -64,24 +64,15 @@ describe "Input", type: :view do
     assert_select ".govuk-input[value='example@example.com']"
   end
 
-  it "renders inputs with an aria-describedby if provided" do
+  it "renders inputs with aria attributes if provided" do
     render_component(
       label: { text: "What is your email address?" },
       name: "email-address",
-      describedby: "some-other-element"
+      describedby: "something",
+      controls: "something-else"
     )
 
-    assert_select ".govuk-input[aria-describedby='some-other-element']"
-  end
-
-  it "renders inputs with an aria-controls if provided" do
-    render_component(
-      label: { text: "What is your postcode?" },
-      name: "postcode",
-      controls: "another-element"
-    )
-
-    assert_select ".govuk-input[aria-controls='another-element']"
+    assert_select ".govuk-input[aria-describedby='something'][aria-controls='something-else']"
   end
 
   it "renders inputs with an autocomplete attribute if provided" do


### PR DESCRIPTION
**This PR has been updated and no longer does what it originally did.**

## What
Consolidate the aria attribute documentation for the input component.

A possible future change (for more than just this component) could be to pass any required aria attributes to components rather than having to add new options for each new use case, as below.

```
<%= render "govuk_publishing_components/components/input", {
  label: {
    text: "This is an example only and may not work with a screen reader"
  },
  name: "labelledby",
  aria: {
    describedby: "wrapper",
    controls: "wrapper"
  }
} %>
```

```
aria ||= []
<%= tag.input name: name,
    aria: aria
%>
```

## Visual Changes
No visual changes.

## View Changes
https://govuk-publishing-compo-pr-1062.herokuapp.com/component-guide/input
