### PR TITLE
Fix nested checkboxes js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix nested checkboxes js (PR #1065)
 * Fix image card responsiveness (PR #1055)
 * Make contextual title accept and present lang parameter (PR #1056)
 * Add summary-list component based on GOV.UK Frontend (PR #1061)

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -6,7 +6,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   'use strict'
 
-  Modules.Checkboxes = function () {
+  Modules.GovukCheckboxes = function () {
     this.start = function (scope) {
       var _this = this
       this.applyAriaControlsAttributes(scope)

--- a/spec/javascripts/components/checkboxes-spec.js
+++ b/spec/javascripts/components/checkboxes-spec.js
@@ -3,12 +3,12 @@
 
 describe('Checkboxes component', function () {
   function loadCheckboxesComponent () {
-    var checkboxes = new GOVUK.Modules.Checkboxes()
+    var checkboxes = new GOVUK.Modules.GovukCheckboxes()
     checkboxes.start($('.gem-c-checkboxes'))
   }
 
   var FIXTURE =
-  '<div id="checkboxes-1ac8e5cf" class="gem-c-checkboxes govuk-form-group " data-module="checkboxes">' +
+  '<div id="checkboxes-1ac8e5cf" class="gem-c-checkboxes govuk-form-group " data-module="govuk-checkboxes">' +
      '<fieldset class="govuk-fieldset" aria-describedby="checkboxes-1ac8e5cf-hint ">' +
         '<legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">' +
            '<h1 class="govuk-fieldset__heading">What is your favourite colour?</h1>' +


### PR DESCRIPTION
##  What
Checkboxes javascript is broken - checking a parent of a nested group should check all the children, and checking a child should uncheck the parent:

![Screen Shot 2019-08-22 at 14 27 40](https://user-images.githubusercontent.com/861310/63518497-12012600-c4e9-11e9-8c2f-940881f41f09.png)


## Why
`govuk-frontend` V3 introduced namespacing for component JS prefixed with `govuk-`. We have custom js that acts on that module call, but it wasn't updated.

## Visual Changes
No visual changes.

## View Changes
https://govuk-publishing-compo-pr-1065.herokuapp.com/checkboxes/checkbox_items_with_nested_checkboxes/
