### PR TITLE
Remove govuk_frontend_toolkit sass dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## unreleased
+## Unreleased
 
 * Allow summary_list to render without borders (PR #1073)
+* Remove govuk_frontend_toolkit sass dependencies (PR #1069)
 
 ## 18.3.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -8,13 +8,6 @@
 // Include common imports used by many components
 @import "govuk/all";
 
-// `govuk_frontend_toolkit`
-@import "measurements";
-@import "grid_layout";
-@import "typography";
-@import "colours";
-@import "css3";
-
 @import "components/helpers/variables";
 @import "components/helpers/brand-colours";
 @import "components/mixins/media-down";
@@ -75,7 +68,6 @@
 @import "components/step-by-step-nav";
 @import "components/subscription-links";
 @import "components/success-alert";
-@import "components/summary-list";
 @import "components/tabs";
 @import "components/table";
 @import "components/taxonomy-list";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -3,12 +3,6 @@
 
 @import "components/helpers/govuk-frontend-settings";
 
-// `govuk_frontend_toolkit`
-@import "measurements";
-@import "grid_layout";
-@import "typography";
-@import "colours";
-
 @import "components/print/accordion";
 @import "components/print/contents-list";
 @import "components/print/feedback";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -2,7 +2,7 @@ $stroke-width: 2px;
 $stroke-width-large: 3px;
 $number-circle-size: 26px;
 $number-circle-size-large: 35px;
-$top-border: solid 2px $grey-3;
+$top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 
 @mixin step-nav-vertical-line ($line-style: solid) {
   content: "";
@@ -10,8 +10,8 @@ $top-border: solid 2px $grey-3;
   z-index: 2;
   width: 0;
   height: 100%;
-  border-left: $line-style $stroke-width $grey-2;
-  background: $white;
+  border-left: $line-style $stroke-width govuk-colour("mid-grey", $legacy: "grey-2");
+  background: govuk-colour("white");
 }
 
 @mixin step-nav-line-position {
@@ -25,12 +25,27 @@ $top-border: solid 2px $grey-3;
   border-width: $stroke-width-large;
 }
 
+// custom mixin as govuk-font does undesirable things at different breakpoints
+// we want to ensure that both large and small step navs have the same size font on mobile
+// this will stop text resizing if compatibility mode is turned off
+@mixin step-nav-font($size, $tablet-size: $size, $weight: normal, $line-height: 1.3, $tablet-line-height: $line-height) {
+  @include govuk-typography-common();
+  font-size: $size + px;
+  font-weight: $weight;
+  line-height: $line-height;
+
+  @include govuk-media-query($from: tablet) {
+    font-size: $tablet-size + px;
+    line-height: $tablet-line-height;
+  }
+}
+
 .gem-c-step-nav {
-  margin-bottom: $gutter;
+  margin-bottom: govuk-spacing(6);
 
   &.gem-c-step-nav--large {
-    @include media(tablet) {
-      margin-bottom: $gutter * 2;
+    @include govuk-media-query($from: tablet) {
+      margin-bottom: govuk-spacing(9);
     }
   }
 
@@ -45,7 +60,7 @@ $top-border: solid 2px $grey-3;
 }
 
 .gem-c-step-nav__button {
-  color: $link-colour;
+  color: $govuk-link-colour;
   cursor: pointer;
   background: none;
   border: 0;
@@ -63,30 +78,26 @@ $top-border: solid 2px $grey-3;
 }
 
 .gem-c-step-nav__button--title {
-  @include _core-font-generator(19px, 19px, 19px, 1.4, 1.4, false, bold);
+  @include step-nav-font(19, $weight: bold, $line-height: 1.4);
   display: inline-block;
   padding: 0;
   text-align: left;
-  color: $black;
+  color: govuk-colour("black");
 
   .gem-c-step-nav--large & {
-    @include _core-font-generator(24px, 19px, 24px, 1.4, 1.4, false, bold);
+    @include step-nav-font(19, $tablet-size: 24, $weight: bold, $line-height: 1.4);
   }
 }
 
 .gem-c-step-nav__button--controls {
-  @include _core-font-generator(14px, 14px, 14px, 1, 1, false);
+  @include step-nav-font(14, $line-height: 1);
   position: relative;
   z-index: 1; // this and relative position stops focus outline underlap with border of accordion
   padding: .5em 0;
   text-decoration: underline;
 
-  &:hover {
-    color: $link-hover-colour;
-  }
-
   .gem-c-step-nav--large & {
-    @include _core-font-generator(16px, 14px, 16px, 1, 1, false);
+    @include step-nav-font(14, $tablet-size: 16, $line-height: 1);
   }
 }
 
@@ -97,23 +108,23 @@ $top-border: solid 2px $grey-3;
 
 .gem-c-step-nav__step {
   position: relative;
-  padding-left: $gutter + $gutter-half;
+  padding-left: govuk-spacing(6) + govuk-spacing(3);
   list-style: none;
 
   // line down the side of a step
   &:after {
     @include step-nav-vertical-line;
     @include step-nav-line-position;
-    top: $gutter-half;
+    top: govuk-spacing(3);
   }
 
   .gem-c-step-nav--large & {
-    @include media(tablet) {
-      padding-left: $gutter * 2;
+    @include govuk-media-query($from: tablet) {
+      padding-left: govuk-spacing(9);
 
       &:after {
         @include step-nav-line-position-large;
-        top: $gutter;
+        top: govuk-spacing(6);
       }
     }
   }
@@ -130,14 +141,14 @@ $top-border: solid 2px $grey-3;
     margin-left: $number-circle-size / 4;
     width: $number-circle-size / 2;
     height: 0;
-    border-bottom: solid $stroke-width $grey-2;
+    border-bottom: solid $stroke-width govuk-colour("mid-grey", $legacy: "grey-2");
   }
 
   &:after {
     // scss-lint:disable DuplicateProperty
     // sass-lint:disable no-duplicate-properties
-    height: -webkit-calc(100% - #{$gutter-half}); // fallback for iphone 4
-    height: calc(100% - #{$gutter-half});
+    height: -webkit-calc(100% - #{govuk-spacing(3)}); // fallback for iphone 4
+    height: calc(100% - #{govuk-spacing(3)});
     // sass-lint:enable no-duplicate-properties
     // scss-lint:enable DuplicateProperty
   }
@@ -147,7 +158,7 @@ $top-border: solid 2px $grey-3;
   }
 
   .gem-c-step-nav--large & {
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       &:before {
         margin-left: $number-circle-size-large / 4;
         width: $number-circle-size-large / 2;
@@ -155,7 +166,7 @@ $top-border: solid 2px $grey-3;
       }
 
       &:after {
-        height: calc(100% - #{$gutter});
+        height: calc(100% - #{govuk-spacing(6)});
       }
     }
   }
@@ -166,26 +177,26 @@ $top-border: solid 2px $grey-3;
   .gem-c-step-nav__circle--number,
   &:after,
   .gem-c-step-nav__help:after {
-    border-color: $black;
+    border-color: govuk-colour("black");
   }
 }
 
 .gem-c-step-nav__circle {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   position: absolute;
   z-index: 5;
-  top: $gutter-half;
+  top: govuk-spacing(3);
   left: 0;
   width: $number-circle-size;
   height: $number-circle-size;
-  color: $black;
-  background: $white;
+  color: govuk-colour("black");
+  background: govuk-colour("white");
   border-radius: 100px;
   text-align: center;
 
   .gem-c-step-nav--large & {
-    @include media(tablet) {
-      top: $gutter;
+    @include govuk-media-query($from: tablet) {
+      top: govuk-spacing(6);
       width: $number-circle-size-large;
       height: $number-circle-size-large;
     }
@@ -193,23 +204,23 @@ $top-border: solid 2px $grey-3;
 }
 
 .gem-c-step-nav__circle--number {
-  @include _core-font-generator(16px, 16px, 16px, 23px, 23px, false, bold);
-  border: solid $stroke-width $grey-2;
+  @include step-nav-font(16, $weight: bold, $line-height: 23px);
+  border: solid $stroke-width govuk-colour("mid-grey", $legacy: "grey-2");
 
   .gem-c-step-nav--large & {
-    @include _core-font-generator(19px, 16px, 19px, 30px, 23px, false, bold);
+    @include step-nav-font(16, $tablet-size: 19, $weight: bold, $line-height: 23px, $tablet-line-height: 30px);
 
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       border-width: $stroke-width-large;
     }
   }
 }
 
 .gem-c-step-nav__circle--logic {
-  @include _core-font-generator(16px, 16px, 16px, 28px, 28px, false, bold);
+  @include step-nav-font(16, $weight: bold, $line-height: 28px);
 
   .gem-c-step-nav--large & {
-    @include _core-font-generator(19px, 16px, 19px, 34px, 28px, false, bold);
+    @include step-nav-font(16, $tablet-size: 19, $weight: bold, $line-height: 28px, $tablet-line-height: 34px);
   }
 }
 
@@ -221,7 +232,7 @@ $top-border: solid 2px $grey-3;
 
 .gem-c-step-nav__circle-background {
   $shadow-offset: .1em;
-  $shadow-colour: $white;
+  $shadow-colour: govuk-colour("white");
 
   // to make numbers readable for users zooming text only in browsers such as Firefox
   text-shadow: 0 -#{$shadow-offset} 0 $shadow-colour, $shadow-offset 0 0 $shadow-colour, 0 $shadow-offset 0 $shadow-colour, -#{$shadow-offset} 0 0 $shadow-colour;
@@ -233,7 +244,7 @@ $top-border: solid 2px $grey-3;
 }
 
 .gem-c-step-nav__header {
-  padding: $gutter-half 0;
+  padding: govuk-spacing(3) 0;
   border-top: $top-border;
 
   .gem-c-step-nav--active & {
@@ -253,7 +264,7 @@ $top-border: solid 2px $grey-3;
   &:hover {
     .gem-c-step-nav__button,
     .gem-c-step-nav__circle {
-      color: $link-colour;
+      color: $govuk-link-colour;
     }
 
     .gem-c-step-nav__toggle-link {
@@ -268,40 +279,39 @@ $top-border: solid 2px $grey-3;
   }
 
   .gem-c-step-nav--large & {
-    @include media(tablet) {
-      padding: $gutter 0;
+    @include govuk-media-query($from: tablet) {
+      padding: govuk-spacing(6) 0;
     }
   }
 }
 
 .gem-c-step-nav__title {
   @include govuk-text-colour;
-  @include _core-font-generator(19px, 19px, 19px, 1.4, 1.4, false, bold);
+  @include step-nav-font(19, $weight: bold, $line-height: 1.4);
   margin: 0;
 
   .gem-c-step-nav--large & {
-    @include _core-font-generator(24px, 19px, 24px, 1.4, 1.4, false, bold);
+    @include step-nav-font(19, $tablet-size: 24, $weight: bold, $line-height: 1.4);
   }
 }
 
 .gem-c-step-nav__toggle-link {
-  @include _core-font-generator(14px, 14px, 14px, 1.2, 1.2, false);
+  @include step-nav-font(14, $line-height: 1.2);
   display: block;
-  color: $link-colour;
-  // core-font-generator sets this to none, so we need to override
-  text-transform: capitalize !important;
+  color: $govuk-link-colour;
+  text-transform: capitalize;
 
   .gem-c-step-nav--large & {
-    @include _core-font-generator(16px, 14px, 16px, 1.2, 1.2, false);
+    @include step-nav-font(14, $tablet-size: 16, $line-height: 1.2);
   }
 }
 
 .gem-c-step-nav__panel {
   @include govuk-text-colour;
-  @include _core-font-generator(16px, 16px, 16px);
+  @include step-nav-font(16);
 
   .gem-c-step-nav--large & {
-    @include _core-font-generator(19px, 16px, 19px);
+    @include step-nav-font(16, $tablet-size: 19);
   }
 
   .js-enabled &.js-hidden {
@@ -312,7 +322,7 @@ $top-border: solid 2px $grey-3;
 // contents of the steps, such as paragraphs and links
 
 .gem-c-step-nav__paragraph {
-  padding-bottom: $gutter-half;
+  padding-bottom: govuk-spacing(3);
   margin: 0;
   font-size: inherit;
 
@@ -320,15 +330,15 @@ $top-border: solid 2px $grey-3;
     margin-top: -5px;
 
     .gem-c-step-nav--large & {
-      @include media(tablet) {
-        margin-top: -$gutter-half;
+      @include govuk-media-query($from: tablet) {
+        margin-top: -govuk-spacing(3);
       }
     }
   }
 
   .gem-c-step-nav--large & {
-    @include media(tablet) {
-      padding-bottom: $gutter;
+    @include govuk-media-query($from: tablet) {
+      padding-bottom: govuk-spacing(6);
     }
   }
 }
@@ -339,7 +349,7 @@ $top-border: solid 2px $grey-3;
   list-style: none;
 
   .gem-c-step-nav--large & {
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       padding-bottom: 20px;
     }
   }
@@ -352,13 +362,13 @@ $top-border: solid 2px $grey-3;
   list-style: disc;
 
   .gem-c-step-nav__list-item--active:before {
-    left: -($gutter + $gutter-half) - $links-margin;
+    left: -(govuk-spacing(6) + govuk-spacing(3)) - $links-margin;
   }
 
   .gem-c-step-nav--large & {
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       .gem-c-step-nav__list-item--active:before {
-        left: -($gutter * 2) - $links-margin;
+        left: -(govuk-spacing(9)) - $links-margin;
       }
     }
   }
@@ -381,23 +391,23 @@ $top-border: solid 2px $grey-3;
   position: relative;
 
   &:before {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     content: "";
     position: absolute;
     z-index: 5;
     top: .6em; // position the dot to align with the first row of text in the link
-    left: -($gutter + $gutter-half);
+    left: -(govuk-spacing(6) + govuk-spacing(3));
     margin-top: -($stroke-width / 2);
     margin-left: ($number-circle-size / 2);
     width: $number-circle-size / 2;
     height: $stroke-width;
-    background: $black;
+    background: govuk-colour("black");
   }
 
   .gem-c-step-nav--large & {
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       &:before {
-        left: -($gutter * 2);
+        left: -(govuk-spacing(9));
         margin-left: ($number-circle-size-large / 2);
         height: $stroke-width-large;
       }
@@ -412,7 +422,7 @@ $top-border: solid 2px $grey-3;
 .gem-c-step-nav__context {
   display: inline-block;
   font-weight: normal;
-  color: $grey-1;
+  color: govuk-colour("dark-grey", $legacy: "grey-1");
 
   &:before {
     content: " \2013\00a0"; // dash followed by &nbsp;

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_variables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_variables.scss
@@ -10,7 +10,7 @@ $gem-spacing-scale-6: 40px;
 $gem-spacing-scale-7: 50px;
 $gem-spacing-scale-8: 60px;
 
-$gem-text-colour: $text-colour;
+$gem-text-colour: $govuk-text-colour;
 $gem-secondary-text-colour: $govuk-secondary-text-colour;
 
 // Border widths
@@ -21,7 +21,7 @@ $gem-border-width-error: 4px;
 
 // Focus
 $gem-focus-width: 3px;
-$gem-focus-colour: $focus-colour;
+$gem-focus-colour: $govuk-focus-colour;
 
-$gem-error-colour: $red;
-$gem-success-colour: $button-colour;
+$gem-error-colour: govuk-colour("red");
+$gem-success-colour: govuk-colour("green");

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_margins.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_margins.scss
@@ -1,16 +1,16 @@
 @mixin responsive-bottom-margin {
-  margin-bottom: $gutter-half;
+  margin-bottom: govuk-spacing(3);
 
-  @include media(tablet) {
-    margin-bottom: $gutter * 1.5;
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(6) * 1.5;
   }
 }
 
 @mixin responsive-top-margin {
-  margin-top: $gutter-half;
+  margin-top: govuk-spacing(3);
 
-  @include media(tablet) {
-    margin-top: $gutter * 1.5;
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(6) * 1.5;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_step-by-step-nav.scss
@@ -49,16 +49,18 @@ $stroke-width: 3px;
 }
 
 .gem-c-step-nav__circle {
-  @include _core-font-generator(19px, 16px, 19px, 30px, 23px, false, bold);
   box-sizing: border-box;
   position: absolute;
   top: 0;
   left: 0;
   width: $number-circle-size;
   height: $number-circle-size;
-  background: $white;
+  background: govuk-colour("white");
   border-radius: 100px;
   text-align: center;
+  font-size: 19px;
+  font-weight: bold;
+  line-height: 1.5;
 }
 
 .gem-c-step-nav__circle--number {
@@ -68,7 +70,7 @@ $stroke-width: 3px;
 .gem-c-step-nav__step,
 .gem-c-step-nav__paragraph,
 .gem-c-step-nav__links {
-  @include core-16;
+  @include govuk-font(16);
   padding-bottom: 1em;
 }
 
@@ -78,13 +80,13 @@ $stroke-width: 3px;
 }
 
 .gem-c-step-nav__title {
-  @include bold-19;
+  @include govuk-font(19, $weight: bold);
   margin: 0 0 .5em 0;
   padding: 0;
 }
 
 .gem-c-step-nav__button--title {
-  @include bold-19;
+  @include govuk-font(19, $weight: bold);
   padding: 0;
   border: 0;
   background: none;
@@ -112,6 +114,11 @@ $stroke-width: 3px;
 
 .gem-c-step-nav__link {
   margin-bottom: .3em;
+}
+
+.gem-c-step-nav__circle-step-label,
+.gem-c-step-nav__circle-step-colon {
+  display: none;
 }
 
 // scss-lint:enable SelectorFormat


### PR DESCRIPTION
## What
@alex-ju i needed to do this for another reason, apologies if I'm duplicating work you've already done.

Remove the last sass dependencies from the gem, which were in the step by step component. Due to the slightly complex nature of this component I've had to write a custom font mixin, as the govuk-frontend mixins have undesired responsive font-sizing behaviour.

The gem still seems to require `govuk_frontend_toolkit` to initialise the JS properly, so I've not removed it fully.

Also improves the print styles for the step nav component.

## Why
We want to remove this dependency.

## Visual Changes
Changes should only affect the step by step navigation component. Visually should be identical, but there do seem to be some very minor differences, which I think is probably due to the font face change. Also had to choose a different grey for the horizontal line dividing steps, so it's now darker than before (I believe this is preferable to it being much lighter).

Before:

<img width="842" alt="Screen Shot 2019-08-27 at 15 17 32" src="https://user-images.githubusercontent.com/861310/63779084-dba71a80-c8dd-11e9-872d-5e9684428832.png">

After:

<img width="841" alt="Screen Shot 2019-08-27 at 15 17 39" src="https://user-images.githubusercontent.com/861310/63779099-e19cfb80-c8dd-11e9-9a3f-e8f8c073d093.png">

## View Changes
https://govuk-publishing-compo-pr-1069.herokuapp.com/component-guide/step_by_step_nav
