### PR TITLE
Explicitly set focus states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Restore margin bottom to the image card (PR #1079)
 * Allow summary_list to render without borders (PR #1073)
 * Remove govuk_frontend_toolkit sass dependencies (PR #1069)
+* Explicitly set focus states (PR #1071)
 
 ## 18.3.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -10,6 +10,7 @@
 
 @import "components/helpers/variables";
 @import "components/helpers/brand-colours";
+@import "components/mixins/govuk-template-link-focus-override";
 @import "components/mixins/media-down";
 @import "components/mixins/margins";
 @import "components/mixins/clearfix";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -40,11 +40,6 @@
   list-style-type: none;
 }
 
-.gem-c-contents-list__link {
-  @include govuk-link-common;
-  @include govuk-link-style-default;
-}
-
 .gem-c-contents-list--no-underline {
   .gem-c-contents-list__link {
     text-decoration: none;
@@ -53,6 +48,8 @@
     &:active {
       text-decoration: underline;
     }
+
+    @include govuk-template-link-focus-override;
   }
 }
 
@@ -60,6 +57,8 @@
   .gem-c-contents-list__list-item--parent > & {
     font-weight: bold;
   }
+
+  @include govuk-template-link-focus-override;
 }
 
 .gem-c-contents-list__list-item {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
@@ -47,6 +47,8 @@
   @include govuk-media-query($from: tablet) {
     line-height: 1.28;
   }
+
+  @include govuk-template-link-focus-override;
 }
 
 .gem-c-related-navigation__toggle {
@@ -62,10 +64,19 @@
 .gem-c-related-navigation__section-link {
   @extend %govuk-link;
   font-weight: bold;
+
+  @include govuk-template-link-focus-override;
 }
 
 .gem-c-related-navigation__section-link--other {
   font-weight: normal;
+
+  @include govuk-template-link-focus-override;
+}
+
+.gem-c-related-navigation__section-link--footer {
+
+  @include govuk-template-link-focus-override;
 }
 
 // reset the default browser styles

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -24,6 +24,8 @@ $share-button-height: 32px;
   @include govuk-font(16, $weight: bold);
   margin-right: govuk-spacing(6);
   text-decoration: none;
+
+  @include govuk-template-link-focus-override;
 }
 
 .gem-c-share-links__title {

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_govuk-template-link-focus-override.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_govuk-template-link-focus-override.scss
@@ -1,0 +1,14 @@
+// TODO: Remove when appropriate
+// govuk_template overrides the styles set by
+// govuk-frontend 3.0.0. This mixin is intended as a temporary fix
+// to ensure focus styles are as expected in apps using govuk_template
+
+@mixin govuk-template-link-focus-override {
+  &:focus,
+  &:active:focus,
+  &:link:focus,
+  &:visited:focus {
+    @include govuk-focused-text;
+    color: govuk-colour("black") !important;
+  }
+}


### PR DESCRIPTION
## What
This explicitly sets the focus state for some links that otherwise don't inherit all of the necessary styles.

## Why
This is to support the work in government-frontend detailed here: https://trello.com/c/0OfIgpul/51-5-update-government-frontend-to-govukpublishingcomponents-v18-with-compatibility-mode-on

## Visual Changes
Screenshots are taken from examples of the component in use on gov.uk

### Before:
![Screen Shot 2019-08-29 at 09 50 44](https://user-images.githubusercontent.com/31649453/63926495-d95ed080-ca43-11e9-9f8c-17740fd98c31.png)

### After:
![Screen Shot 2019-08-29 at 09 49 07](https://user-images.githubusercontent.com/31649453/63926508-e11e7500-ca43-11e9-93f5-5be1ee048f24.png)

### Before:
![Screen Shot 2019-08-29 at 09 48 21](https://user-images.githubusercontent.com/31649453/63926567-f7c4cc00-ca43-11e9-8511-18e041cd9616.png)
### After:
![Screen Shot 2019-08-29 at 09 49 29](https://user-images.githubusercontent.com/31649453/63926596-04492480-ca44-11e9-8253-77cea10e0f57.png)
### Before:
![Screen Shot 2019-08-29 at 09 48 54](https://user-images.githubusercontent.com/31649453/63926650-175bf480-ca44-11e9-878d-d52ecd303893.png)
### After:
![Screen Shot 2019-08-29 at 10 03 48](https://user-images.githubusercontent.com/31649453/63926768-4e320a80-ca44-11e9-9c1e-16d993c18e2c.png)

## View Changes
https://govuk-publishing-compo-pr-1071.herokuapp.com/

Note: The black colour is not coming through on some of these components and I'm still trying to track down why. This PR fixes the contents list including colour, and also fixes the underlines for the other components so seemed worth raising on the way to that full fix.