### PR TITLE
Make focus state on attachment thumbnails visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Make focus state on attachment thumbnails visible
+
 ## 18.3.0
 
 * `value` and `name` can be set on button component (PR #1059)

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -56,6 +56,10 @@
       }
     }
 
+    .attachment-thumb a:focus img {
+      outline: $govuk-border-width solid $govuk-focus-colour;
+    }
+
     .attachment-details {
       h2 {
         @include govuk-font($size: 27);


### PR DESCRIPTION
## What
https://trello.com/c/W3UJPgdZ/62-2-fix-focus-state-for-attachment-icons
This makes the focus state visible when applied to attachment thumbnails

## Why
Currently the document images have a decorative outline applied which sits in front of any visible state applied to the surrounding anchor tag. This PR changes the outline colour of the image to match the focus state colour if the parent anchor has focus. It is a requirement for accessibility that the part of the page that has focus can be identified.

## Visual Changes
### Before
![Screen Shot 2019-08-29 at 13 54 10](https://user-images.githubusercontent.com/31649453/63942961-a0842300-ca66-11e9-94fa-06b53c7df3e9.png)

### After
![Screen Shot 2019-08-29 at 13 54 21](https://user-images.githubusercontent.com/31649453/63942970-a548d700-ca66-11e9-99d6-9411f8435c7f.png)

## View Changes
https://govuk-publishing-compo-pr-1072.herokuapp.com/

