### PR TITLE
Allow summary_list to render without borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## unreleased
+
+* Allow summary_list to render without borders (PR #1073)
+
 ## 18.3.1
 
 * Adjust share links column width (PR #1074)

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -1,12 +1,13 @@
 <%
   id ||= nil
   title ||= nil
+  borderless ||= false
   edit ||= {}
   items ||= []
   block ||= yield
 %>
 <% if title || items.any? %>
-  <%= tag.div class: "gem-c-summary-list", id: id do %>
+  <%= tag.div class: "gem-c-summary-list #{"govuk-summary-list--no-border" if borderless}", id: id do %>
     <% if title %>
       <%= tag.h3 title, class: "govuk-heading-m" %>
       <% if edit.any? %>

--- a/app/views/govuk_publishing_components/components/docs/summary_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/summary_list.yml
@@ -28,6 +28,16 @@ examples:
       - field: "Summary"
         value: "Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication."
 
+  without_borders:
+    data:
+      borderless: true
+      title: "Title, summary and body"
+      items:
+      - field: "Title"
+        value: "Ethical standards for public service providers"
+      - field: "Summary"
+        value: "Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication."
+
   with_edit_on_section:
     data:
       title: "Title, summary and body"

--- a/spec/components/summary_list_spec.rb
+++ b/spec/components/summary_list_spec.rb
@@ -38,6 +38,14 @@ describe "Summary list", type: :view do
     assert_select '.gem-c-summary__block', text: 'Some HTML'
   end
 
+  it "renders without borders" do
+    render_component(
+      title: 'Title, summary and body',
+      borderless: true
+    )
+    assert_select '.gem-c-summary-list.govuk-summary-list--no-border'
+  end
+
   it "renders items" do
     render_component(
       items: [


### PR DESCRIPTION
The Design System implementation of summary_list allows rendering
without borders between the summary_list rows:
https://design-system.service.gov.uk/components/summary-list#summary-list-without-borders

However, govuk_publishing_components implementation didn't provide
a way of hooking into this. I have now added a 'borderless' field
which defaults to 'false', but when 'true' will add the necessary
class to remove borders.

This is depended on by https://github.com/alphagov/collections-publisher/pull/703 (Trello: https://trello.com/c/qXVCEouI/23-show-the-content-title-slug-introduction-description-using-the-summary-component)

## Visual Changes
![Screen Shot 2019-08-29 at 16 11 29](https://user-images.githubusercontent.com/5111927/63952542-afbf9c80-ca77-11e9-83b5-26d9988f57f8.png)

## View Changes
https://govuk-publishing-compo-pr-1073.herokuapp.com/component-guide/summary_list

