### PR TITLE
Adjust share links column width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Adjust share links column width (PR #1074)
+
 ## 18.3.0
 
 * `value` and `name` can be set on button component (PR #1059)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -59,16 +59,18 @@ $share-button-height: 32px;
   }
 }
 
+$column-width: 150px;
+
 .gem-c-share-links--columns {
   .gem-c-share-links__list {
     @include govuk-clearfix;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax($column-width, 1fr));
   }
 
   .gem-c-share-links__list-item {
     float: left;
-    min-width: 200px;
+    min-width: $column-width;
   }
 
   .gem-c-share-links__link {

--- a/app/views/govuk_publishing_components/components/docs/share_links.yml
+++ b/app/views/govuk_publishing_components/components/docs/share_links.yml
@@ -93,7 +93,7 @@ examples:
       ]
   arrange_in_columns:
     description: |
-      Share links are arranged in even columns that adjust according to the available space. Note that the column width is based on an assumed width, so if the text in the links is very long it may wrap onto a second line, which is undesirable.
+      Share links are arranged in even columns that adjust according to the available space. Note that the column width is based on an assumed width, so if the link text is long it may wrap (the example below demonstrates this).
 
       This option uses CSS grid, which is not fully supported in IE <= 11, so in those browsers the columns are floated.
     data:
@@ -101,12 +101,12 @@ examples:
       links: [
         {
           href: '/facebook-share-link',
-          text: 'Share on Facebook',
+          text: 'Facebook',
           icon: 'facebook'
         },
         {
           href: '/twitter-share-link',
-          text: 'Share on Twitter',
+          text: 'Twitter',
           icon: 'twitter'
         },
         {
@@ -116,17 +116,17 @@ examples:
         },
         {
           href: '/flickr-share-link',
-          text: 'Share on Flickr',
+          text: 'Flickr',
           icon: 'flickr'
         },
         {
           href: '/instagram-share-link',
-          text: 'Share on Instagram',
+          text: 'Instagram',
           icon: 'instagram'
         },
         {
           href: '/linkedin-share-link',
-          text: 'Share on Linkedin',
+          text: 'Linkedin',
           icon: 'linkedin'
         },
       ]


### PR DESCRIPTION
## What
Make the columns narrower in the 'columns' option for share links.

Before:

<img width="957" alt="Screen Shot 2019-08-29 at 21 20 32" src="https://user-images.githubusercontent.com/861310/63973536-e363ec00-caa2-11e9-9b2b-ab9099616ec8.png">

After:

<img width="967" alt="Screen Shot 2019-08-29 at 21 20 42" src="https://user-images.githubusercontent.com/861310/63973566-eb239080-caa2-11e9-962a-99d89850f144.png">


## Why
This option is only used in one place, where the link text is much smaller and more realistic (e.g. 'Facebook' preceded by 'Share on' in visually hidden text) and this width works much better as the screen gets smaller.

## View Changes
https://govuk-publishing-compo-pr-1074.herokuapp.com/component-guide/share_links/

Trello card: https://trello.com/c/ky5WMr5L/181-look-into-share-links-layout-on-mobile