### PR TITLE
Override edit link text on summary-link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@
 * Restore margin bottom to the image card (PR #1079)
 * Allow summary_list to render without borders (PR #1073)
 * Remove govuk_frontend_toolkit sass dependencies (PR #1069)
+<<<<<<< HEAD
 * Explicitly set focus states (PR #1071)
+=======
+* Override edit link text on summary-link component (#1076)
+>>>>>>> 8cbdd3ef... Update CHANGELOG
 
 ## 18.3.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -69,6 +69,7 @@
 @import "components/step-by-step-nav";
 @import "components/subscription-links";
 @import "components/success-alert";
+@import "components/summary-list";
 @import "components/tabs";
 @import "components/table";
 @import "components/taxonomy-list";

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -15,9 +15,9 @@
           <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
             <%= link_to edit.fetch(:href),
                       class: "govuk-link gem-c-summary-list__edit-section-link",
-                      title: "Edit #{title}",
+                      title: "#{edit.fetch(:link_text, "Edit")} #{title}",
                       data: edit.fetch(:data_attributes, {}) do %>
-               Edit <%= tag.span title, class: "govuk-visually-hidden" %>
+               <%= edit.fetch(:link_text, "Edit") %> <%= tag.span title, class: "govuk-visually-hidden" %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/govuk_publishing_components/components/docs/summary_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/summary_list.yml
@@ -41,6 +41,24 @@ examples:
         data_attributes:
           gtm: "edit-title-summary-body"
 
+  with_custom_link_on_section:
+    data:
+      edit:
+        href: "custom-link"
+        link_text: "Reorder"
+      title: "Items"
+      items:
+      - field: "Item 1"
+        value: "Value 2"
+      - field: "Item 2"
+        value: "Value 2"
+      - field: "Item 3"
+        value: "Value 3"
+    accessibility_criteria: |
+      Take care that the provided `link_text` still makes sense to screen readers when combined with the title.
+      For instance, `Reorder` link text and `Items` title becomes `Reorder Items`, which reads fine, but link text
+      of `Summary` would read as `Summary Items`, which does not make sense.
+
   with_edit_on_individual_items:
     data:
       title: "Title, summary and body"

--- a/app/views/govuk_publishing_components/components/docs/summary_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/summary_list.yml
@@ -10,7 +10,7 @@ govuk_frontend_components:
   - summary-list
 examples:
   default:
-    data:
+    data: &default-example-data
       title: "Title, summary and body"
       items:
       - field: "Title"
@@ -30,28 +30,16 @@ examples:
 
   without_borders:
     data:
+      <<: *default-example-data
       borderless: true
-      title: "Title, summary and body"
-      items:
-      - field: "Title"
-        value: "Ethical standards for public service providers"
-      - field: "Summary"
-        value: "Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication."
 
   with_edit_on_section:
     data:
-      title: "Title, summary and body"
+      <<: *default-example-data
       edit:
         href: "edit-title-summary-body"
         data_attributes:
           gtm: "edit-title-summary-body"
-      items:
-      - field: "Title"
-        value: "Ethical standards for public service providers"
-      - field: "Summary"
-        value: "Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication."
-      - field: "Body"
-        value: "After the government decided in 2013 to expand the remit of the Committee to include public service providers, the Committee on Standards in Public Life produced our first report on the issue: Ethical Standards for Providers of Public Services in 2014."
 
   with_edit_on_individual_items:
     data:

--- a/spec/components/summary_list_spec.rb
+++ b/spec/components/summary_list_spec.rb
@@ -29,6 +29,18 @@ describe "Summary list", type: :view do
     assert_select '.gem-c-summary-list__edit-section-link[title="Edit Title, summary and body"][href="#edit-title-summary-body"][data-gtm="edit-title-summary-body"]', text: 'Edit Title, summary and body'
   end
 
+  it "renders section title with custom link text" do
+    render_component(
+      title: 'Items',
+      edit: {
+        href: "#custom-action",
+        link_text: "Reorder"
+      }
+    )
+    assert_select '.gem-c-summary-list .govuk-heading-m', text: 'Items'
+    assert_select '.gem-c-summary-list__edit-section-link[title="Reorder Items"][href="#custom-action"]', text: 'Reorder Items'
+  end
+
   it "renders section title with block" do
     render_component(
       title: 'Title, summary and body',


### PR DESCRIPTION
## What

- Adds option to override 'Edit' link text
- Fixes SASS configuration (looks like it was accidentally removed in #1069)
- Refactors fixture data to use YAML inheritance, as the number of examples are growing

## Why
We have a requirement to render a 'Reorder' link in place of an 'Edit' link.
This still makes sense in the context of the screen reader text.
'Edit' is now the default edit link text if none is specified, but can be
overridden with the new 'edit.link_text' property.

Trello: https://trello.com/c/UlgsMO0Q/45-overhaul-the-steps-section-and-move-the-add-step-button-to-it-and-show-it-in-the-summary-component

## Visual Changes

Fixed CSS import:

|Before|After|
|------|------|
|<img width="973" alt="Screen Shot 2019-09-03 at 08 37 32" src="https://user-images.githubusercontent.com/5111927/64153669-3b924980-ce27-11e9-91ab-fba264907ec4.png">|<img width="973" alt="Screen Shot 2019-09-03 at 08 38 01" src="https://user-images.githubusercontent.com/5111927/64153681-4056fd80-ce27-11e9-867d-c3b4c4dc0155.png">|

Overwritten 'Edit' link text:

<img width="972" alt="Screen Shot 2019-09-03 at 08 46 41" src="https://user-images.githubusercontent.com/5111927/64153745-62e91680-ce27-11e9-8ff2-0d199ce8771f.png">

## View Changes
https://govuk-publishing-compo-pr-1076.herokuapp.com/
