### PR TITLE
Adds inset-prompt component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## unreleased
 
 * Allow summary_list to render without borders (PR #1073)
+* Adds inset-prompt component (PR #1077)
 
 ## 18.3.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -50,6 +50,7 @@
 @import "components/hint";
 @import "components/image-card";
 @import "components/input";
+@import "components/inset-prompt";
 @import "components/inset-text";
 @import "components/inverse-header";
 @import "components/label";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inset-prompt.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inset-prompt.scss
@@ -1,0 +1,48 @@
+.gem-c-inset-prompt {
+  @include govuk-text-colour;
+  @include govuk-responsive-padding(4);
+  @include govuk-responsive-margin(6, "bottom");
+
+  border-left: $govuk-border-width-narrow solid govuk-colour("dark-grey");
+
+  @include govuk-media-query($from: tablet) {
+    border-left: $govuk-border-width solid govuk-colour("dark-grey");
+  }
+
+  background-color: govuk-colour("light-grey");
+}
+
+.gem-c-inset-prompt--error {
+  border-color: $govuk-error-colour;
+  background-color: govuk-tint($govuk-error-colour, 90%);
+}
+
+.gem-c-inset-prompt__title {
+  @include govuk-font($size: 24, $weight: bold);
+
+  margin-top: 0;
+  @include govuk-responsive-margin(4, "bottom");
+}
+
+.gem-c-inset-prompt__body {
+  @include govuk-font($size: 19);
+
+  p {
+    margin-top: 0;
+    @include govuk-responsive-margin(4, "bottom");
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.gem-c-inset-prompt__list {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.gem-c-inset-prompt__list a {
+  @include govuk-link-common;
+  @include govuk-link-style-default;
+}

--- a/app/views/govuk_publishing_components/components/_inset_prompt.html.erb
+++ b/app/views/govuk_publishing_components/components/_inset_prompt.html.erb
@@ -1,0 +1,36 @@
+<%
+  title ||= false
+  description ||= false
+  items ||= []
+  id ||= nil
+  error = false if error.nil?
+  data_attributes ||= {}
+  root_classes = %w[gem-c-inset-prompt]
+  root_classes << "gem-c-inset-prompt--error" if error
+
+  if title
+%>
+  <%= tag.div class: root_classes, id: id, data: data_attributes do %>
+    <%= tag.h3 title, class: "gem-c-inset-prompt__title" %>
+
+    <%= tag.div class: "gem-c-inset-prompt__body" do %>
+      <%= description if description %>
+
+      <% if items.any? %>
+        <%= tag.ul class: "govuk-list gem-c-inset-prompt__list" do %>
+          <% items.each_with_index do |item, index| %>
+            <%= tag.li do %>
+              <% if item[:href] %>
+                <%= link_to(item[:text], item[:href], data: item[:data_attributes], class: "govuk-link govuk-link--no-visited-state") %>
+              <% else %>
+                <%= tag.span data: item[:data_attributes] do %>
+                  <%= item[:text] %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/inset_prompt.yml
+++ b/app/views/govuk_publishing_components/components/docs/inset_prompt.yml
@@ -1,0 +1,38 @@
+name: Inset prompt
+description: A prompt to users represented as inset content
+body: |
+  This is similar to the [inset text][] component, however it has more of an
+  emphasis of informing a user they need to take an action.
+
+  [inset text]: https://design-system.service.gov.uk/components/inset-text/
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      title: Please meet these requirements before publishing
+      description: Document needs a summary before publishing (at least 10 characters)
+  with_items:
+    data:
+      title: Message to alert the user to a problem goes here
+      items:
+      - text: Document needs a title before publishing (at least 10 characters)
+        href: '#content'
+        data_attributes:
+          tracking: GTM-123AA
+      - text: Document needs a summary before publishing (at least 10 characters)
+        data_attributes:
+          tracking: GTM-123AB
+  error:
+    data:
+      error: true
+      title: There is a problem
+      description: |
+        <p class="govuk-body">&lsquo;Title here&rsquo; was not published</p>
+  with_data_attributes:
+    data:
+      title: Message to alert the user to a problem goes here
+      data_attributes:
+        tracking: GTM-123AB
+      items:
+      - text: Descriptive link to the question with an error 1

--- a/spec/components/inset_prompt_spec.rb
+++ b/spec/components/inset_prompt_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+describe "Inset prompt", type: :view do
+  def component_name
+    "inset_prompt"
+  end
+
+  it "does not render anything if no data is passed" do
+    test_data = {}
+    assert_empty render_component(test_data)
+  end
+
+  it "renders a title" do
+    test_data = { title: "Foo" }
+    render_component(test_data)
+
+    assert_select(".gem-c-inset-prompt__title", text: "Foo")
+  end
+
+  it "renders a title and description" do
+    test_data = { title: "Foo", description: "Bar" }
+    render_component(test_data)
+
+    assert_select(".gem-c-inset-prompt__title", text: "Foo")
+    assert_select(".gem-c-inset-prompt__body", text: "Bar")
+  end
+
+  it "renders text items" do
+    test_data = {
+      title: "Foo",
+      items: [
+        {
+          text: "Ordinary text item"
+        },
+        {
+          text: "Text item with data attributes",
+          data_attributes: {
+            tracking: 'ABC123'
+          }
+        }
+      ]
+    }
+    render_component(test_data)
+
+    assert_select(".gem-c-inset-prompt__list li:first-child span", text: "Ordinary text item")
+    assert_select(".gem-c-inset-prompt__list li:last-child span[data-tracking='ABC123']", text: "Text item with data attributes")
+  end
+
+  it "renders link items" do
+    test_data = {
+      title: "Foo",
+      items: [
+        {
+          text: "Ordinary link",
+          href: "https://gov.uk"
+        },
+        {
+          text: "Link with data attributes",
+          href: "https://gov.uk",
+          data_attributes: {
+            tracking: 'ABC123'
+          }
+        }
+      ]
+    }
+    render_component(test_data)
+
+    assert_select(".gem-c-inset-prompt__list li:first-child a[href='https://gov.uk']", text: "Ordinary link")
+    assert_select(".gem-c-inset-prompt__list li:last-child a[href='https://gov.uk'][data-tracking='ABC123']", text: "Link with data attributes")
+  end
+
+  it "renders an error state" do
+    test_data = { title: "Error", description: "Please fix the date!", error: true }
+    render_component(test_data)
+
+    assert_select(".gem-c-inset-prompt--error")
+  end
+end


### PR DESCRIPTION
## What

This was copied from the inset-prompt component in content-publisher:
https://content-publisher.integration.publishing.service.gov.uk/component-guide/inset_prompt

...but with the following modifications:

- CSS migrated to work with v18 of govuk_publishing_components
- Added tests
- Make component render nothing if no data passed

## Why

The component is now needed by collections-publisher, so it makes sense
to extract it out into the shared component library here.

Trello: https://trello.com/c/TcBpLRuC/

## View Changes

https://govuk-publishing-compo-pr-1077.herokuapp.com/component-guide/inset_prompt
