### PR TITLE
Allow inset-text to take a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Remove govuk_frontend_toolkit sass dependencies (PR #1069)
 * Explicitly set focus states (PR #1071)
 * Override edit link text on summary-link component (#1076)
+* Allow inset-text to take a block (PR #1078)
 
 ## 18.3.1
 

--- a/app/views/govuk_publishing_components/components/_inset_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_inset_text.html.erb
@@ -1,7 +1,10 @@
 <%
   id ||= "inset-text-#{SecureRandom.hex(4)}"
 %>
-
 <%= tag.div id: id, class: "gem-c-inset-text govuk-inset-text" do %>
-  <%= text %>
+  <% if defined? text %>
+    <%= text %>
+  <% elsif block_given? %>
+    <%= yield %>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/inset_text.yml
+++ b/app/views/govuk_publishing_components/components/docs/inset_text.yml
@@ -8,3 +8,13 @@ examples:
   default:
     data:
       text: "It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application."
+
+  with_block:
+    description: |
+      Note that the contents should be styled separately from the component, which takes no responsibility for what it is passed.
+    data:
+      block: |
+        <div>
+          <h2 id='heading'>To publish this step by step you need to</h2>
+          <a href='/foo'>Check for broken links</a>
+        </div>

--- a/spec/components/inset_text_spec.rb
+++ b/spec/components/inset_text_spec.rb
@@ -10,4 +10,23 @@ describe "Inset text", type: :view do
 
     assert_select(".govuk-inset-text", text: "It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.")
   end
+
+  it "renders a block" do
+    block = "
+      <h2 id='heading'>To publish this step by step you need to</h2>
+      <a href='/foo'>Check for broken links</a>
+    ".html_safe
+    render_component({}) { block }
+
+    assert_select(".govuk-inset-text h2#heading", text: "To publish this step by step you need to")
+    assert_select(".govuk-inset-text a[href='/foo']", text: "Check for broken links")
+  end
+
+  it "renders only the text if both text and block are provided" do
+    block = "<p id='foo'>Foo</p>".html_safe
+    render_component(text: 'Bar') { block }
+
+    assert_select(".govuk-inset-text", text: "Bar")
+    assert_select(".govuk-inset-text p#foo", false, "Block should not have rendered")
+  end
 end


### PR DESCRIPTION
## What

Can now pass an arbitrary block to the inset-text component to
have content rendered inset. If both 'text' and a block are
provided, 'text' takes precedence (mutually exclusive).

## Why

This is a compromise solution, rather than copying the inset-prompt
component from content-publisher (for use in collections-publisher),
for the reason that under current GOV.UK architecture the component
CSS would be added to the stylesheets for our end users (not just
the users using the publishing app). See:
https://github.com/alphagov/govuk_publishing_components/pull/1077

Once merged, we will use this latest inset-text component and
manually recreate what the inset-prompt component looks like by
passing components to the inset-text component as a block.

Trello: https://trello.com/c/TcBpLRuC/48-add-inset-prompt-component-to-govukpublishingcomponents

## Visual Changes

![Screen Shot 2019-08-30 at 15 43 56](https://user-images.githubusercontent.com/5111927/64029675-ffb46700-cb3c-11e9-9465-09b5d2f0b846.png)

## View Changes
https://govuk-publishing-compo-pr-1078.herokuapp.com/
