### PR TITLE
Restore margin bottom to the image card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## unreleased
+## Unreleased
 
+* Restore margin bottom to the image card (PR #1079)
 * Allow summary_list to render without borders (PR #1073)
 
 ## 18.3.1

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -2,6 +2,7 @@
   @include govuk-clearfix;
   @include govuk-text-colour;
   position: relative;
+  margin-bottom: govuk-spacing(6);
 }
 
 .gem-c-image-card__image-wrapper {
@@ -62,11 +63,18 @@
     position: absolute;
     z-index: 1;
     top: 0;
-    left: govuk-spacing(3);
-    right: govuk-spacing(3);
+    left: 0;
+    right: 0;
     height: 100%;
     $ie-background: rgba(255, 255, 255, 0);
     background: $ie-background; // because internet explorer
+  }
+
+  @include govuk-media-query($from: mobile, $until: tablet) {
+    &:after {
+      left: govuk-spacing(3);
+      right: govuk-spacing(3);
+    }
   }
 }
 
@@ -158,11 +166,9 @@
     padding-bottom: govuk-spacing(2);
   }
 
-  .gem-c-image-card__title-link {
-    &:after {
-      left: 0;
-      right: 0;
-    }
+  .gem-c-image-card__title-link:after {
+    left: 0;
+    right: 0;
   }
 
   .gem-c-image-card__description {


### PR DESCRIPTION
## What
Fixes the missing margin beneath the component, as shown here:

<img width="1078" alt="Screen Shot 2019-08-30 at 17 46 25" src="https://user-images.githubusercontent.com/861310/64037696-2b8c1880-cb4e-11e9-8cfc-054fe38f33d6.png">

<!--
## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
-->
