### PR TITLE
Fix Jenkins by locking version of selenium-webdriver

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,6 +321,7 @@ DEPENDENCIES
   jasmine (~> 3.4.0)
   pry-byebug
   rspec-rails (~> 3.8)
+  selenium-webdriver (= 3.142.3)
   uglifier (>= 4.1.0)
   webmock (~> 3.6.0)
   yard

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "jasmine", "~> 3.4.0"
   s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rspec-rails", "~> 3.8"
+  s.add_development_dependency "selenium-webdriver", "= 3.142.3"
   s.add_development_dependency "uglifier", ">= 4.1.0"
   # Webmock is needed to load slimmer test helpers
   # https://github.com/alphagov/slimmer/issues/201


### PR DESCRIPTION
Version 3.142.4 of [selenium-webdriver](https://rubygems.org/gems/selenium-webdriver) released on 2nd Sept
has caused problems for one of our tests. Locking into the
previous version (May 21st) fixes the build.

Here is the test this fixes:

```
Failures:

  1) Component example with automated testing shows accessibility violations on the page and through browser console
     Failure/Error: expect(page.driver.browser.manage.logs.get(:browser).map { |e| e.message if e.message.match(/Accessibility issues/) }).not_to be_empty

     Selenium::WebDriver::Error::WebDriverError:
       unexpected response, code=404, content-type="text/plain"
       unknown command: session/80b61401a648837e27061fca0812c0a8/se/log
     # /var/lib/jenkins/bundles/ruby/2.6.0/gems/selenium-webdriver-3.142.4/lib/selenium/webdriver/remote/http/common.rb:98:in `create_response'
     # /var/lib/jenkins/bundles/ruby/2.6.0/gems/selenium-webdriver-3.142.4/lib/selenium/webdriver/remote/http/default.rb:114:in `request'
     # /var/lib/jenkins/bundles/ruby/2.6.0/gems/selenium-webdriver-3.142.4/lib/selenium/webdriver/remote/http/common.rb:64:in `call'
     # /var/lib/jenkins/bundles/ruby/2.6.0/gems/selenium-webdriver-3.142.4/lib/selenium/webdriver/remote/bridge.rb:167:in `execute'
     # /var/lib/jenkins/bundles/ruby/2.6.0/gems/selenium-webdriver-3.142.4/lib/selenium/webdriver/remote/oss/bridge.rb:587:in `execute'
     # /var/lib/jenkins/bundles/ruby/2.6.0/gems/selenium-webdriver-3.142.4/lib/selenium/webdriver/chrome/bridge.rb:55:in `log'
     # /var/lib/jenkins/bundles/ruby/2.6.0/gems/selenium-webdriver-3.142.4/lib/selenium/webdriver/common/logs.rb:32:in `get'
     # ./spec/component_guide/component_example_accessibility_testing_spec.rb:17:in `block (2 levels) in <top (required)>'
```