### PR TITLE
Version 19.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 19.0.0
 
+* **BREAKING:** Remove govuk_frontend_toolkit sass dependencies (PR #1069)
+    * This will break apps that rely on mixins and variables from govuk_frontend_toolkit - you must replace these with mixins and variables from GOV.UK Frontend
 * Restore margin bottom to the image card (PR #1079)
 * Allow summary_list to render without borders (PR #1073)
-* Remove govuk_frontend_toolkit sass dependencies (PR #1069)
 * Explicitly set focus states (PR #1071)
 * Override edit link text on summary-link component (#1076)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (18.3.1)
+    govuk_publishing_components (19.0.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '18.3.1'.freeze
+  VERSION = '19.0.0'.freeze
 end


### PR DESCRIPTION

* **BREAKING:** Remove govuk_frontend_toolkit sass dependencies (PR #1069)
    * This will break apps that rely on mixins and variables from govuk_frontend_toolkit - you must replace these with mixins and variables from GOV.UK Frontend
* Restore margin bottom to the image card (PR #1079)
* Allow summary_list to render without borders (PR #1073)
* Explicitly set focus states (PR #1071)
* Override edit link text on summary-link component (#1076)
<!--
## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
-->