### PR TITLE
Fixes focus state spacing on 'extensive' related navigation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+* Fixes focus state spacing on 'extensive' related navigation links ([PR #1085](https://github.com/alphagov/govuk_publishing_components/pull/1085))
+
 ## 20.1.0
 
 * Add FAQPage schema ([PR #1087](https://github.com/alphagov/govuk_publishing_components/pull/1087))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
@@ -51,13 +51,17 @@
   @include govuk-template-link-focus-override;
 }
 
+.gem-c-related-navigation__link--truncated-links {
+  margin-top: govuk-spacing(2);
+}
+
 .gem-c-related-navigation__toggle {
   @include govuk-link-common;
   @include govuk-link-style-no-visited-state;
   display: none;
 
   .js-enabled & {
-    display: block;
+    display: inline-block;
    }
 }
 
@@ -79,6 +83,10 @@
   @include govuk-template-link-focus-override;
 }
 
+.gem-c-related-navigation__section-link--inline {
+  line-height: 1.45;
+}
+
 // reset the default browser styles
 .gem-c-related-navigation__link-list {
   padding: 0;
@@ -87,8 +95,16 @@
   margin-bottom: 1.25em;
 }
 
-.gem-c-related-navigation__toggle-more.js-hidden {
-  .js-enabled & {
-    display: none;
+.gem-c-related-navigation__toggle-more {
+  .gem-c-related-navigation__section-link {
+    @include govuk-media-query($from: tablet) {
+      line-height: 1.45;
+    }
+  }
+
+  &.js-hidden {
+    .js-enabled & {
+      display: none;
+    }
   }
 }

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -26,7 +26,7 @@
         link_element = link_to(
           link[:text],
           link[:path],
-          class: related_nav_helper.section_css_class("gem-c-related-navigation__section-link", section_title, link),
+          class: related_nav_helper.section_css_class("gem-c-related-navigation__section-link", section_title, link, (index >= section_link_limit)),
           rel: link[:rel],
           lang: related_nav_helper.t_locale_check(link[:locale]),
           data: {
@@ -60,7 +60,7 @@
         </a>
       </li>
 
-      <li class="gem-c-related-navigation__link">
+      <li class="gem-c-related-navigation__link gem-c-related-navigation__link--truncated-links">
         <span id="toggle_<%= section_title %>" class="gem-c-related-navigation__toggle-more js-hidden">
           <%= to_sentence(constructed_link_array) %>
         </span>

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -60,8 +60,10 @@ module GovukPublishingComponents
         end
       end
 
-      def section_css_class(css_class, section_title, link = {})
-        css_classes = [css_class, "#{css_class}--#{@context}"]
+      def section_css_class(css_class, section_title, link = {}, link_is_inline = false)
+        css_classes = [css_class]
+        css_classes << "#{css_class}--#{@context}" unless @context.nil?
+        css_classes << "#{css_class}--inline" if link_is_inline
 
         unless DEFINED_SECTIONS.include?(section_title) || link.fetch(:finder, false)
           css_classes << " #{css_class}--other"


### PR DESCRIPTION
## What
Increases the line height of the inline links and tweaks the toggle link in the ['extensive' related navigation](https://components.publishing.service.gov.uk/component-guide/related_navigation/with_extensive_world_locations) component.

Partially fixes #1028; and probably shouldn't be merged until #1054 has been merged.

<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->

The overlap of the focus state made it look broken and having the focus state of the toggle link stretch across the entire parent element looks slightly odd, as no other link had that behaviour.

## Visual Changes
Toggle link before:
![Screen Shot 2019-09-03 at 14 54 34](https://user-images.githubusercontent.com/1732331/64193762-5db2b880-ce75-11e9-9cfd-ac5c491c868c.png)

Toggle link after:
![Screen Shot 2019-09-03 at 14 53 51](https://user-images.githubusercontent.com/1732331/64193795-6b683e00-ce75-11e9-8eb4-0f5be28b7195.png)

Inline links before:
![Screen Shot 2019-09-03 at 14 54 20](https://user-images.githubusercontent.com/1732331/64193815-7ae78700-ce75-11e9-9cfc-aa3c09a07584.png)

Inline links after:
![Screen Shot 2019-09-03 at 14 53 58](https://user-images.githubusercontent.com/1732331/64193826-8044d180-ce75-11e9-86f0-ba32f7668092.png)

<!--
## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
-->
