### PR TITLE
Set all branded links to correct focus colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Set all branded links to correct focus colour (PR #1088)
 * Fix components focus state spacing (PR #1054)
 
 ## 19.0.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -15,7 +15,7 @@
 
         &:hover,
         &:focus {
-          color: darken(govuk-organisation-colour($organisation), 10%);
+          color: govuk-colour("black");
         }
       }
 


### PR DESCRIPTION
## What
Set the colour of branded links on focus to black, to match the `govuk-frontend` styles.

Fixes https://github.com/alphagov/govuk_publishing_components/issues/1086

## Why
Focus states on branded links were incorrect, before:

<img width="373" alt="Screen Shot 2019-09-04 at 15 31 06" src="https://user-images.githubusercontent.com/861310/64319264-d324a300-cfb3-11e9-8f56-26055f548fc8.png">

After:

<img width="661" alt="Screen Shot 2019-09-05 at 08 05 49" src="https://user-images.githubusercontent.com/861310/64319336-00715100-cfb4-11e9-9a40-c0c36bb80b06.png">

## View Changes
https://govuk-publishing-compo-pr-1088.herokuapp.com/component-guide/image_card
