### PR TITLE
Remove ie-lte mixin from clearfix helper

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_clearfix.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_clearfix.scss
@@ -5,8 +5,4 @@
     display: block;
     clear: both;
   }
-
-  @include ie-lte(7) {
-    zoom: 1;
-  }
 }


### PR DESCRIPTION
## What
Remove [ie-lte](https://github.com/alphagov/govuk_frontend_toolkit/blob/03204449dcbf28c2d48e7f6dd217f6abe9b3a518/stylesheets/_conditionals.scss#L67) mixin from clearfix helper.

## Why
The mixin coming from govuk_frontend_toolkit which is not imported anymore.

<!--
## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
-->
