### PR TITLE
Removes the inverse flag for contents list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove the inverse flag for contents list component (PR #1090)
 * Set all branded links to correct focus colour (PR #1088)
 * Fix components focus state spacing (PR #1054)
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -10,25 +10,10 @@
   box-shadow: 0 20px 15px -10px govuk-colour("white");
 }
 
-.gem-c-contents-list--inverse {
-  background: transparent;
-  box-shadow: none;
-}
-
 .gem-c-contents-list__title {
   @include govuk-text-colour;
   @include govuk-font($size: 16, $weight: regular, $line-height: 1.5);
   margin: 0;
-}
-
-.gem-c-contents-list--inverse .gem-c-contents-list__title,
-.gem-c-contents-list--inverse .gem-c-contents-list__link:link,
-.gem-c-contents-list--inverse .gem-c-contents-list__link:visited {
-  color: govuk-colour("white");
-}
-
-.gem-c-contents-list--inverse .gem-c-contents-list__link:focus {
-  color: $govuk-focus-text-colour;
 }
 
 .gem-c-contents-list__list,
@@ -88,10 +73,6 @@
       left: auto;
       right: 0;
     }
-  }
-
-  .gem-c-contents-list--inverse &:before {
-    color: govuk-colour("white");
   }
 
   // Focus styles on IE8 and older include the

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -2,7 +2,6 @@
   cl_helper = GovukPublishingComponents::Presenters::ContentsListHelper.new
   format_numbers ||= false
   underline_links ||= false
-  inverse ||= false
   contents ||= []
   aria_label ||= ''
   nested = !!contents.find { |c| c[:items] && c[:items].any? }
@@ -20,10 +19,7 @@
 <% if contents.any? %>
   <nav
     role="navigation"
-    class="gem-c-contents-list
-      <%= 'gem-c-contents-list--inverse' if inverse %>
-      <%= 'gem-c-contents-list--no-underline' unless underline_links %>
-      <%= brand_helper.brand_class %>"
+    class="gem-c-contents-list <%= 'gem-c-contents-list--no-underline' unless underline_links %> <%= brand_helper.brand_class %>"
     data-module="track-click"
     <% if aria_label.present? %>
       aria-label="<%= aria_label %>"

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -215,16 +215,3 @@ examples:
             text: Guidance and regulation
           - href: "#third-thing"
             text: Consultations
-  inverse:
-    description: Displays with no background colour, no box shadow and white text, for use on (for example) the [inverse header](/component-guide/inverse_header)
-    data:
-      inverse: true
-      contents:
-        - href: "#item-1"
-          text: "Item 1"
-        - href: "#item-2"
-          text: "Item 2"
-    context:
-      dark_background: true
-
-

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -137,9 +137,4 @@ describe "Contents list", type: :view do
     render_component(contents: nested_contents_list, hide_title: true)
     assert_select ".gem-c-contents-list__title", false
   end
-
-  it "adds an inverse class if inverse flag is passed" do
-    render_component(contents: nested_contents_list, inverse: true)
-    assert_select ".gem-c-contents-list--inverse"
-  end
 end


### PR DESCRIPTION
## What
Reverts https://github.com/alphagov/govuk_publishing_components/pull/1037
Trello - https://trello.com/c/d9KRrVMb/207-remove-the-contents-list-inverse-option

## Why
We no longer need to use the contents list component in a topic page header
