### PR TITLE
Ensure input styles are not overridden by static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   of the commit log.
 
 ## Unreleased
+
+* Ensure input styles are not overridden by static ([PR #1094](https://github.com/alphagov/govuk_publishing_components/pull/1094))
 * Fixes focus state spacing on 'extensive' related navigation links ([PR #1085](https://github.com/alphagov/govuk_publishing_components/pull/1085))
 
 ## 20.1.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -4,3 +4,9 @@
   background: govuk-colour("white") url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='currentColor'%3E%3C/path%3E%3C/svg%3E") no-repeat -5px -3px;
   padding-left: govuk-spacing(6);
 }
+
+// this overrides styles from static that break the look of the component
+.gem-c-input.govuk-input {
+  margin: 0;
+  padding: govuk-spacing(1);
+}


### PR DESCRIPTION
## What
- static has some base styles for input[type="text"], input[type="search"] {} that alter the margin and padding of this component in ways we don't want
- this change overrides those specifically for this component only
- hopefully at some point in the future this can be removed

## Why
The input component in `frontend` looks like this, and this change fixes that.

<img width="268" alt="Screen Shot 2019-09-06 at 10 32 28" src="https://user-images.githubusercontent.com/861310/64417810-aba40800-d091-11e9-9a46-340e1e7abfb4.png">

## View Changes
https://govuk-publishing-compo-pr-1094.herokuapp.com/component-guide

