### PR TITLE
Chevron banner tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Improve chevron banner component ([PR #1098](https://github.com/alphagov/govuk_publishing_components/pull/1098))
+
 ## 20.2.0
 
 * Ensure input styles are not overridden by static ([PR #1094](https://github.com/alphagov/govuk_publishing_components/pull/1094))

--- a/app/assets/images/govuk_publishing_components/chevron-banner/chevron-banner-focus.svg
+++ b/app/assets/images/govuk_publishing_components/chevron-banner/chevron-banner-focus.svg
@@ -1,13 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="0 0 135 109" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<defs>
-<path id="d" d="M0 0h93v109H0z"/>
-</defs>
-<g fill="#FD0" shape-rendering="geometricPrecision" stroke="#000" stroke-width="2.5px" vector-effect="non-scaling-stroke">
-<path d="m91.611 52.664c1.0371 1.1432 1.0375 2.8869 8.02e-4 4.0305l-44.991 49.634c-0.37092 0.40919-0.33989 1.0416 0.069307 1.4125 0.18394 0.16674 0.42334 0.25909 0.6716 0.25909h36.892c0.55978 0 1.0939-0.2346 1.4727-0.6468l46.534-50.643c1.0549-1.148 1.0546-2.9127-7.09e-4 -4.0604l-46.898-51.003c-0.37873-0.41188-0.91268-0.64628-1.4722-0.64628h-36.891c-0.55228 0-1 0.44772-1 1 0 0.24841 0.092454 0.48792 0.25936 0.6719l45.352 49.992z" vector-effect="non-scaling-stroke"/>
-<mask id="c" fill="#fff">
-<use xlink:href="#d"/>
-</mask>
-<path d="m-37.997 1l0.35768 107h40.408c0.55978 0 1.0939-0.2346 1.4727-0.6468l46.534-50.643c1.0549-1.148 1.0546-2.9127-7.095e-4 -4.0604l-46.898-51.003c-0.37873-0.41188-0.91268-0.64628-1.4722-0.64628h-40.402z" mask="url(#c)" vector-effect="non-scaling-stroke"/>
-</g>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 140 109">
+  <defs>
+    <path id="a" d="M0 0h93v109H0z"/>
+  </defs>
+  <g fill="none" fill-rule="evenodd" stroke-width="2" shape-rendering="geometricPrecision" vector-effect="non-scaling-stroke">
+    <path fill="#FD0" fill-rule="nonzero" stroke="#000" stroke-width="2.5" d="M91.611237 52.6639273c1.037118 1.1432316 1.037466 2.8868605.000802 4.0305048L46.6210236 106.328396c-.3709165.409194-.3398864 1.041599.0693073 1.412515.1839444.166737.4233355.259089.6716035.259089H84.254263c.559784 0 1.093946-.234599 1.472697-.646795l46.534281-50.643363c1.054879-1.1480276 1.05457-2.9127296-.000709-4.0603883L85.36275 1.64627982C84.98402 1.23439602 84.450067 1 83.890527 1H47c-.5522848 0-1 .44771525-1 1 0 .24840526.0924536.48791876.2593567.67189844L91.611237 52.6639273z" vector-effect="non-scaling-stroke"/>
+    <mask id="b" fill="#fff">
+      <use xlink:href="#a"/>
+    </mask>
+    <path fill="#FD0" fill-rule="nonzero" stroke="#000" stroke-width="2.5" d="M-37.9966516 1l.3576762 107H2.7689834c.559783 0 1.0939457-.234599 1.4726965-.646795l46.5342804-50.6433632c1.0548793-1.1480275 1.054571-2.9127293-.0007095-4.0603881L3.8774704 1.64628002C3.4987402 1.2343961 2.9647868 1 2.4052469 1h-40.4018985z" mask="url(#b)" vector-effect="non-scaling-stroke"/>
+  </g>
 </svg>

--- a/app/assets/stylesheets/govuk_publishing_components/components/_chevron-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_chevron-banner.scss
@@ -11,8 +11,10 @@ $yellow: #ffdd00;
     background-color: $dark-red;
   }
 
-  .gem-c-chevron-banner__link-container:after {
-    background-image: image-url("govuk_publishing_components/chevron-banner/chevron-banner-hover.svg");
+  @include govuk-media-query($from: mobile) {
+    .gem-c-chevron-banner__link-container:after {
+      background-image: image-url("govuk_publishing_components/chevron-banner/chevron-banner-hover.svg");
+    }
   }
 }
 
@@ -26,8 +28,10 @@ $yellow: #ffdd00;
     }
   }
 
-  .gem-c-chevron-banner__link-container:after {
-    background-image: image-url("govuk_publishing_components/chevron-banner/chevron-banner-hover-border.svg");
+  @include govuk-media-query($from: mobile) {
+    .gem-c-chevron-banner__link-container:after {
+      background-image: image-url("govuk_publishing_components/chevron-banner/chevron-banner-hover-border.svg");
+    }
   }
 }
 
@@ -58,7 +62,12 @@ $yellow: #ffdd00;
 
   @include govuk-media-query($from: mobile) {
     border-radius: 5px 0 0 5px;
-    margin-right: 104px;
+    margin-right: 120px;
+    padding: govuk-spacing(3);
+  }
+
+  @include govuk-media-query($from: desktop) {
+    padding: govuk-spacing(4);
   }
 }
 
@@ -81,7 +90,7 @@ $yellow: #ffdd00;
     top: 0;
     right: 0;
     height: 100%;
-    min-width: 105px;
+    min-width: 120px;
     background-image: image-url("govuk_publishing_components/chevron-banner/chevron-banner.svg");
     background-repeat: no-repeat;
     background-position: -1px center;


### PR DESCRIPTION
## What
Adds the following fixes:

- Reduces the padding in the chevron banner so the chevron is less distorted on smaller screens
- Fixes the hover state so the background image is only replaced mobile and above

## Visual Changes
**Improve layout on smaller screens (before)**
<img width="313" alt="Screen Shot 2019-09-06 at 13 06 19" src="https://user-images.githubusercontent.com/29889908/64426853-9d60e680-d0a7-11e9-8479-1574187f00e2.png"> 

**Improve layout on smaller screens (after)**
<img width="298" alt="Screen Shot 2019-09-06 at 13 07 41" src="https://user-images.githubusercontent.com/29889908/64426854-9d60e680-d0a7-11e9-941f-3c39aa316e2a.png">

**Hover state below 320px (before)**
<img width="231" alt="Screen Shot 2019-09-06 at 13 05 59" src="https://user-images.githubusercontent.com/29889908/64426916-c5e8e080-d0a7-11e9-8ae4-158626ed6dde.png">

**Hover state below 320px (after)**
<img width="225" alt="Screen Shot 2019-09-06 at 13 11 21" src="https://user-images.githubusercontent.com/29889908/64426947-d6995680-d0a7-11e9-96bf-8b852b705cc4.png">

https://govuk-publishing-compo-pr-1098.herokuapp.com/component-guide/chevron_banner