### PR TITLE
Add input style override override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Improve chevron banner component ([PR #1098](https://github.com/alphagov/govuk_publishing_components/pull/1098))
+* Add input style override override ([PR #1099](https://github.com/alphagov/govuk_publishing_components/pull/1099))
 
 ## 20.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -6,7 +6,13 @@
 }
 
 // this overrides styles from static that break the look of the component
+// unfortunately we then need to override the override for the search icon variant
+// TODO: remove these styles once static is made less aggressive
 .gem-c-input.govuk-input {
   margin: 0;
   padding: govuk-spacing(1);
+
+  &.gem-c-input--search-icon {
+    padding-left: govuk-spacing(6);
+  }
 }


### PR DESCRIPTION
## What
Fixing this:

<img width="268" alt="Screen Shot 2019-09-06 at 10 32 28" src="https://user-images.githubusercontent.com/861310/64430455-3ac01880-d0b0-11e9-9873-2cd87255d588.png">

Caused this:

<img width="815" alt="Screen Shot 2019-09-06 at 14 12 15" src="https://user-images.githubusercontent.com/861310/64430532-5d523180-d0b0-11e9-944a-84af85c5100c.png">

Fixed by adding an override for the override.

## Why
Because I didn't think of this earlier.

## View Changes
https://govuk-publishing-compo-pr-1099.herokuapp.com/component-guide/input
