### PR TITLE
Add lang attribute to heading component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add ability to pass language to heading component ([PR #1102](https://github.com/alphagov/govuk_publishing_components/pull/1102))
+
 ## 20.2.2
 
 * Fix data attributes in delete summary list item ([PR #1103](https://github.com/alphagov/govuk_publishing_components/pull/1103))

--- a/app/views/govuk_publishing_components/components/_heading.html.erb
+++ b/app/views/govuk_publishing_components/components/_heading.html.erb
@@ -1,5 +1,7 @@
 <%
   brand ||= false
+  lang = local_assigns[:lang].presence
+
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
   heading_helper = GovukPublishingComponents::Presenters::HeadingHelper.new(local_assigns)
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
@@ -12,5 +14,6 @@
 %>
 <%= content_tag(shared_helper.get_heading_level, text,
     class: classes,
-    id: heading_helper.id
+    id: heading_helper.id,
+    lang: lang
 ) %>

--- a/app/views/govuk_publishing_components/components/docs/heading.yml
+++ b/app/views/govuk_publishing_components/components/docs/heading.yml
@@ -68,3 +68,11 @@ examples:
       brand: 'department-for-environment-food-rural-affairs'
       padding: true
       border_top: 5
+  with_lang_attribute:
+    description: |
+      The component is used on translated pages that don’t have a translation for the text strings. This means that it could display the fallback English string if the translate method can’t find an appropriate translation. This makes sure that the lang can be set to ensure that browsers understand which parts of the page are in each language.
+
+      The lang attribute must be set to a [valid BCP47 string](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang#Language_tag_syntax). A valid code can be the two or three letter language code - for example, English is en or eng, Korean is ko or kor - but if in doubt please check.
+    data:
+      text: "Ein gweinidogion"
+      lang: "cy"

--- a/spec/components/heading_spec.rb
+++ b/spec/components/heading_spec.rb
@@ -80,4 +80,9 @@ describe "Heading", type: :view do
     render_component(text: 'Branded', brand: 'attorney-generals-office')
     assert_select ".gem-c-heading.brand--attorney-generals-office.brand__border-color"
   end
+
+  it "adds a lang attribute if passed" do
+    render_component(text: 'Branded', lang: "cy")
+    assert_select ".gem-c-heading[lang=cy]"
+  end
 end


### PR DESCRIPTION
<img width="1014" alt="Screen Shot 2019-09-06 at 15 59 24" src="https://user-images.githubusercontent.com/29889908/64438066-51ba3700-d0bf-11e9-89a7-0c837d7fde13.png">

## What
Add the ability to pass a language into the heading component, which is added as a `lang` attribute.

## Why
In some apps we are passing in a translated string which is falling back to the default (normally English) because the translation does not exist in the chosen language. In these cases, we want to mark these strings as not being in the chosen language.

https://govuk-publishing-compo-pr-1102.herokuapp.com/
