### PR TITLE
Fix data attributes on delete summary list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix data attributes in delete summary list item ([PR #1103](https://github.com/alphagov/govuk_publishing_components/pull/1103))
+
 ## 20.2.1
 
 * Improve chevron banner component ([PR #1098](https://github.com/alphagov/govuk_publishing_components/pull/1098))

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -50,7 +50,7 @@
                       <%= link_to item[:delete].fetch(:href),
                                   class: "govuk-link",
                                   title: "Delete #{item[:field]}",
-                                  data: item[:edit].fetch(:data_attributes, {}) do %>
+                                  data: item[:delete].fetch(:data_attributes, {}) do %>
                         Delete <%= tag.span item[:field], class: "govuk-visually-hidden" %>
                       <% end %>
                     <% end %>

--- a/spec/components/summary_list_spec.rb
+++ b/spec/components/summary_list_spec.rb
@@ -95,4 +95,24 @@ describe "Summary list", type: :view do
     assert_select '.govuk-summary-list__value', text: 'Ethical standards for public service providers'
     assert_select '.govuk-summary-list__actions-list-item .govuk-link[title="Edit Title"][href="#edit-title"][data-gtm="edit-title"]', text: "Edit Title"
   end
+
+  it "renders items with delete action" do
+    render_component(
+      items: [
+        {
+          field: "Title",
+          value: "Ethical standards for public service providers",
+          delete: {
+            href: "#delete-title",
+            data_attributes: {
+              gtm: "delete-title"
+            }
+          }
+        }
+      ]
+    )
+    assert_select '.govuk-summary-list__key', text: 'Title'
+    assert_select '.govuk-summary-list__value', text: 'Ethical standards for public service providers'
+    assert_select '.govuk-summary-list__actions-list-item .govuk-link[title="Delete Title"][href="#delete-title"][data-gtm="delete-title"]', text: "Delete Title"
+  end
 end


### PR DESCRIPTION
## What
Fix `data_attributes` on delete summary list item

## Why
Because we need data attributes to work on this element

## Visual Changes
No