### PR TITLE
Resolve incorrect URLs in chapters using FAQ schemas

### DIFF
--- a/lib/govuk_publishing_components/presenters/machine_readable/faq_page_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/faq_page_schema.rb
@@ -42,10 +42,14 @@ module GovukPublishingComponents
 
       def part_url(part, index)
         if index.zero?
-          page.canonical_url
+          guide_url
         else
-          page.canonical_url + "/" + part["slug"]
+          guide_url + "/" + part["slug"]
         end
+      end
+
+      def guide_url
+        Plek.new.website_root + page.base_path
       end
     end
   end

--- a/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
@@ -63,7 +63,10 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
     end
 
     it "generates schema.org FAQPages" do
-      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "guide") do |random_item|
+      content_item = GovukSchemas::RandomExample.for_schema(
+        frontend_schema: "guide",
+        canonical_url: "http://www.dev.gov.uk/how-to-train-your-dragon/insurance"
+      ) do |random_item|
         random_item.merge(
           "base_path" => "/how-to-train-your-dragon",
           "details" => {


### PR DESCRIPTION
We show the whole of a guide's FAQ schema on each of its chapters.  I think this is OK, as long as the URLs that refer to the questions and answers are correct.  (We might change this at some point though)

The canonical URL of each part of a guide is set (correctly) to [the URL of the part](https://tools.ietf.org/html/rfc6596).

The FAQ schema was appending the part slugs to the canonical URL of the page that it was displayed on.  This works well for the default page in a guide, but less well for other chapters in the guide because we end up appending the part slug to the wrong base URL.

## When viewing default page in a guide (correct):

When you view https://www.gov.uk/christmas-bonus you get links in the structured
data like:
- https://www.gov.uk/christmas-bonus/eligibility
- https://www.gov.uk/christmas-bonus/how-to-claim

## When viewing sub chapter in a guide (incorrect):

When you view https://www.gov.uk/christmas-bonus/eligibility
you get links in the structured data like:
- https://www.gov.uk/christmas-bonus/eligibility/eligibility
- https://www.gov.uk/christmas-bonus/eligibility/how-to-claim

This fix should get us links like:
- https://www.gov.uk/christmas-bonus/eligibility
- https://www.gov.uk/christmas-bonus/how-to-claim
