### PR TITLE
Allow custom heading size on checkboxes and radios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix focus states on cookie-banner confirmation message ([PR #1109](https://github.com/alphagov/govuk_publishing_components/pull/1109))
+* Allow custom heading size on checkboxes and radios ([PR #1107](https://github.com/alphagov/govuk_publishing_components/pull/1107))
 
 ## 20.3.0
 

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -33,7 +33,7 @@
 
     <% if heading.present? %>
       <% if is_page_heading %>
-        <%= tag.legend class: "govuk-fieldset__legend govuk-fieldset__legend--xl gem-c-title gem-c-title--margin-bottom-5" do %>
+        <%= tag.legend class: "govuk-fieldset__legend govuk-fieldset__legend--xl gem-c-title" do %>
           <%= tag.h1 heading, class: "gem-c-title__text" %>
         <% end %>
       <% else %>

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -7,6 +7,8 @@
   small ||= false
   inline ||= false
   is_page_heading ||= false
+  heading_size = 'm' unless ['s', 'm', 'l', 'xl'].include?(heading_size)
+
   description ||= nil
   hint ||= nil
   error_message ||= nil
@@ -23,6 +25,9 @@
   radio_classes << "govuk-radios--small" if small
   radio_classes << "govuk-radios--inline" if inline
 
+  legend_classes = %w(govuk-fieldset__legend)
+  legend_classes << "govuk-fieldset__legend--#{heading_size}"
+
   aria = "#{hint_id} #{"#{error_id}" if has_error}".strip if hint or has_error
 
   # check if any item is set as being conditional
@@ -37,7 +42,7 @@
           <%= tag.h1 heading, class: "gem-c-title__text" %>
         <% end %>
       <% else %>
-        <%= tag.legend heading, class: "govuk-fieldset__legend govuk-fieldset__legend--m" %>
+        <%= tag.legend heading, class: legend_classes %>
       <% end %>
     <% end %>
 

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -73,7 +73,7 @@ examples:
       heading: "Choose your favourite skittles"
       description: |
         Skittles consist of hard sugar shells imprinted with the letter "S".
-        The interior consists mainly of sugar, corn syrup, and hydrogenated 
+        The interior consists mainly of sugar, corn syrup, and hydrogenated
         palm kernel oil along with fruit juice, citric acid, natural and artificial flavors.
       hint_text: "Taste the rainbow"
       items:
@@ -94,7 +94,7 @@ examples:
       is_page_heading: true
       description: |
         Skittles consist of hard sugar shells imprinted with the letter "S".
-        The interior consists mainly of sugar, corn syrup, and hydrogenated 
+        The interior consists mainly of sugar, corn syrup, and hydrogenated
         palm kernel oil along with fruit juice, citric acid, natural and artificial flavors.
       hint_text: "Taste the rainbow"
       items:
@@ -157,6 +157,18 @@ examples:
       name: "favourite_colour"
       heading: "What is your favourite colour?"
       is_page_heading: true
+      items:
+        - label: "Red"
+          value: "red"
+        - label: "Green"
+          value: "green"
+        - label: "Blue"
+          value: "blue"
+  with_custom_heading_size:
+    data:
+      name: "favourite_colour"
+      heading: "What is your favourite colour?"
+      heading_size: "s"
       items:
         - label: "Red"
           value: "red"

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -126,7 +126,7 @@ examples:
       heading: "What is your favourite colour?"
       description: |
         Skittles consist of hard sugar shells imprinted with the letter "S".
-        The interior consists mainly of sugar, corn syrup, and hydrogenated 
+        The interior consists mainly of sugar, corn syrup, and hydrogenated
         palm kernel oil along with fruit juice, citric acid, natural and artificial flavors.
       items:
       - value: "red"
@@ -141,7 +141,7 @@ examples:
       heading: "What is your favourite colour?"
       description: |
         Skittles consist of hard sugar shells imprinted with the letter "S".
-        The interior consists mainly of sugar, corn syrup, and hydrogenated 
+        The interior consists mainly of sugar, corn syrup, and hydrogenated
         palm kernel oil along with fruit juice, citric acid, natural and artificial flavors.
       hint: "Choose the colour"
       items:
@@ -158,7 +158,7 @@ examples:
       is_page_heading: true
       description: |
         Skittles consist of hard sugar shells imprinted with the letter "S".
-        The interior consists mainly of sugar, corn syrup, and hydrogenated 
+        The interior consists mainly of sugar, corn syrup, and hydrogenated
         palm kernel oil along with fruit juice, citric acid, natural and artificial flavors.
       hint: "Choose the colour"
       items:
@@ -168,6 +168,19 @@ examples:
         text: "Green"
       - value: "blue"
         text: "Blue"
+  with_custom_heading_size:
+    data:
+      name: "radio-group-description"
+      heading: "What is your favourite colour?"
+      heading_size: "s"
+      items:
+      - value: "red"
+        text: "Red"
+      - value: "green"
+        text: "Green"
+      - value: "blue"
+        text: "Blue"
+
   with_hint_text_on_radios:
     data:
       name: "radio-group-hint-text"
@@ -308,4 +321,3 @@ examples:
           text: "On"
         - value: "off"
           text: "Off"
-

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -50,7 +50,7 @@ module GovukPublishingComponents
         if @is_page_heading
           content_tag(
             :legend,
-            class: "govuk-fieldset__legend govuk-fieldset__legend--xl gem-c-title gem-c-title--margin-bottom-5"
+            class: "govuk-fieldset__legend govuk-fieldset__legend--xl gem-c-title"
           ) do
             content_tag(:h1, @heading, class: "gem-c-title__text")
           end

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
       include ActionView::Helpers
       include ActionView::Context
 
-      attr_reader :items, :name, :css_classes, :list_classes, :error, :has_conditional, :has_nested, :id, :hint_text, :description
+      attr_reader :items, :name, :css_classes, :list_classes, :error, :has_conditional, :has_nested, :id, :hint_text, :description, :heading_size
 
       def initialize(options)
         @items = options[:items] || []
@@ -22,6 +22,8 @@ module GovukPublishingComponents
 
         @id = options[:id] || "checkboxes-#{SecureRandom.hex(4)}"
         @heading = options[:heading] || nil
+        @heading_size = options[:heading_size]
+        @heading_size = 'm' unless %w(s m l xl).include?(@heading_size)
         @is_page_heading = options[:is_page_heading]
         @description = options[:description] || nil
         @no_hint_text = options[:no_hint_text]
@@ -55,7 +57,8 @@ module GovukPublishingComponents
             content_tag(:h1, @heading, class: "gem-c-title__text")
           end
         else
-          classes = %w(govuk-fieldset__legend govuk-fieldset__legend--m)
+          classes = %w(govuk-fieldset__legend)
+          classes << "govuk-fieldset__legend--#{@heading_size}"
           classes << "gem-c-checkboxes__legend--hidden" if @visually_hide_heading
 
           content_tag(:legend, @heading, class: classes)

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -181,6 +181,34 @@ describe "Checkboxes", type: :view do
     assert_select "legend h1", "What is your favourite skittle?"
   end
 
+  it "renders checkboxes with custom heading size" do
+    render_component(
+      name: "favourite-skittle",
+      heading: "What is your favourite skittle?",
+      heading_size: "s",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+        { label: "Blue", value: "blue" }
+      ]
+    )
+    assert_select ".govuk-fieldset__legend.govuk-fieldset__legend--s", "What is your favourite skittle?"
+  end
+
+  it "renders checkboxes with default heading size when passing an undefined size" do
+    render_component(
+      name: "favourite-skittle",
+      heading: "What is your favourite skittle?",
+      heading_size: "x",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+        { label: "Blue", value: "blue" }
+      ]
+    )
+    assert_select ".govuk-fieldset__legend.govuk-fieldset__legend--m", "What is your favourite skittle?"
+  end
+
   it "renders checkboxes with aria-controls attributes" do
     render_component(
       name: "favourite_colour",

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -119,6 +119,34 @@ describe "Radio", type: :view do
     assert_select "legend h1", "What is your favourite skittle?"
   end
 
+  it "renders radio-group with custom heading size" do
+    render_component(
+      name: "favourite-skittle",
+      heading: "What is your favourite skittle?",
+      heading_size: "s",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+        { label: "Blue", value: "blue" }
+      ]
+    )
+    assert_select ".govuk-fieldset__legend.govuk-fieldset__legend--s", "What is your favourite skittle?"
+  end
+
+  it "renders radio-group with default heading size when passing an undefined size" do
+    render_component(
+      name: "favourite-skittle",
+      heading: "What is your favourite skittle?",
+      heading_size: "x",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+        { label: "Blue", value: "blue" }
+      ]
+    )
+    assert_select ".govuk-fieldset__legend.govuk-fieldset__legend--m", "What is your favourite skittle?"
+  end
+
   it "renders radio-group with bold labels" do
     render_component(
       name: "radio-group-bold-labels",


### PR DESCRIPTION
## What
Add support for custom heading size on checkboxes and radios when not being used as page heading.

## Why
Because we currently hardcode the `--m` size for legends and we need to support `--s` size too for when the components are being used on a page with multiple input groups.

When using checkboxes/radios on a page with more than one form group the headings should match the styling of the labels with the rest of the inputs on the page (which can be achieved by setting an `--s` size to the heading).

## Visual Changes
Added examples with custom heading size for checkboxes and radio component

## View Changes
https://govuk-publishing-compo-pr-1107.herokuapp.com/component-guide/checkboxes/with_custom_heading_size

https://govuk-publishing-compo-pr-1107.herokuapp.com/component-guide/radio/with_custom_heading_size

[Trello card](https://trello.com/c/ZB4lH4G8)
