### PR TITLE
Fix focus states on cookie-banner confirmation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix focus states on cookie-banner confirmation message ([PR #1109](https://github.com/alphagov/govuk_publishing_components/pull/1109))
+
 ## 20.3.0
 
 * Add ability to pass language to heading component ([PR #1102](https://github.com/alphagov/govuk_publishing_components/pull/1102))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -69,6 +69,13 @@ $govuk-cookie-banner-text-green: #00823b;
   display: none;
   position: relative;
   padding: govuk-spacing(1);
+
+
+  // This element is focused using JavaScript so that it's being read out by screen readers
+  // for this reason we don't want to show the default outline or emphasise it visually using `govuk-focused-text`
+  &:focus {
+    outline: none;
+  }
 }
 
 .gem-c-cookie-banner__confirmation-message,
@@ -98,10 +105,13 @@ $govuk-cookie-banner-text-green: #00823b;
   padding: govuk-spacing(0);
   margin-top: govuk-spacing(2);
 
-
   &:hover {
     color: $govuk-link-hover-colour;
     cursor: pointer;
+  }
+
+  &:focus {
+    @include govuk-focused-text;
   }
 
   @include govuk-media-query($from: desktop) {


### PR DESCRIPTION
## What
Remove the outline when the element is focused to be read out by screen readers and update the focus state on the hide confirmation message button.

## Why
To fix #1014

## Visual Changes
### Before (confirmation message)
<img width="960" alt="Screen Shot 2019-09-09 at 15 39 16" src="https://user-images.githubusercontent.com/788096/64540554-5168a880-d318-11e9-8a50-31724ea4c081.png">

### After (confirmation message)
<img width="960" alt="Screen Shot 2019-09-09 at 15 38 19" src="https://user-images.githubusercontent.com/788096/64540568-56c5f300-d318-11e9-9060-a761dd9a96e8.png">

### Before (hide message button) - no, it's not a mistake, it really looks like the screen capture above
<img width="960" alt="Screen Shot 2019-09-09 at 15 38 19" src="https://user-images.githubusercontent.com/788096/64540598-5cbbd400-d318-11e9-8338-9a05edc7eb3c.png">

### After (hide message button)
<img width="960" alt="Screen Shot 2019-09-09 at 15 38 32" src="https://user-images.githubusercontent.com/788096/64540643-6c3b1d00-d318-11e9-98bc-8e8db07ee02e.png">

### View Changes
https://govuk-publishing-compo-pr-1109.herokuapp.com/component-guide/cookie_banner
