### PR TITLE
Remove dependency on GOV.UK Frontend Toolkit 🎉

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     govuk_publishing_components (20.3.0)
       gds-api-adapters
       govuk_app_config
-      govuk_frontend_toolkit
       kramdown
       plek
       rails (>= 5.0.0.1)
@@ -105,9 +104,6 @@ GEM
       sentry-raven (>= 2.7.1, < 2.12.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_frontend_toolkit (9.0.0)
-      railties (>= 3.1.0)
-      sass (>= 3.2.0)
     govuk_schemas (3.2.0)
       json-schema (~> 2.8.0)
     govuk_test (1.0.0)
@@ -320,9 +316,6 @@ DEPENDENCIES
   uglifier (>= 4.1.0)
   webmock (~> 3.6.0)
   yard
-
-RUBY VERSION
-   ruby 2.6.3p62
 
 BUNDLED WITH
    1.17.3

--- a/app/assets/javascripts/govuk_publishing_components/dependencies.js
+++ b/app/assets/javascripts/govuk_publishing_components/dependencies.js
@@ -3,7 +3,7 @@
 // This adds in javascript that initialises components and dependencies
 // that are provided by Slimmer in public frontend applications.
 // = require jquery/dist/jquery
-// = require govuk/modules
+// = require ./modules.js
 
 $(document).ready(function () {
   'use strict'

--- a/app/assets/javascripts/govuk_publishing_components/modules.js
+++ b/app/assets/javascripts/govuk_publishing_components/modules.js
@@ -1,0 +1,61 @@
+;(function (global) {
+  'use strict'
+
+  var $ = global.jQuery
+  var GOVUK = global.GOVUK || {}
+  GOVUK.Modules = GOVUK.Modules || {}
+
+  GOVUK.modules = {
+    find: function (container) {
+      container = container || $('body')
+
+      var modules
+      var moduleSelector = '[data-module]'
+
+      modules = container.find(moduleSelector)
+
+      // Container could be a module too
+      if (container.is(moduleSelector)) {
+        modules = modules.add(container)
+      }
+
+      return modules
+    },
+
+    start: function (container) {
+      var modules = this.find(container)
+
+      for (var i = 0, l = modules.length; i < l; i++) {
+        var module
+        var element = $(modules[i])
+        var type = camelCaseAndCapitalise(element.data('module'))
+        var started = element.data('module-started')
+
+        if (typeof GOVUK.Modules[type] === 'function' && !started) {
+          module = new GOVUK.Modules[type]()
+          module.start(element)
+          element.data('module-started', true)
+        }
+      }
+
+      // eg selectable-table to SelectableTable
+      function camelCaseAndCapitalise (string) {
+        return capitaliseFirstLetter(camelCase(string))
+      }
+
+      // http://stackoverflow.com/questions/6660977/convert-hyphens-to-camel-case-camelcase
+      function camelCase (string) {
+        return string.replace(/-([a-z])/g, function (g) {
+          return g.charAt(1).toUpperCase()
+        })
+      }
+
+      // http://stackoverflow.com/questions/1026069/capitalize-the-first-letter-of-string-in-javascript
+      function capitaliseFirstLetter (string) {
+        return string.charAt(0).toUpperCase() + string.slice(1)
+      }
+    }
+  }
+
+  global.GOVUK = GOVUK
+})(window)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,6 +7,7 @@ Rails.application.config.assets.precompile += %w(
   component_guide/filter-components.js
   component_guide/visual-regression.js
   govuk_publishing_components/all_components.js
+  govuk_publishing_components/modules.js
   govuk_publishing_components/vendor/modernizr.js
   govuk_publishing_components/component_guide.css
   govuk_publishing_components/favicon-development.png

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "gds-api-adapters"
   s.add_dependency "govuk_app_config"
-  s.add_dependency "govuk_frontend_toolkit"
   s.add_dependency "kramdown"
   s.add_dependency "plek"
   s.add_dependency "rails", ">= 5.0.0.1"

--- a/lib/govuk_publishing_components/engine.rb
+++ b/lib/govuk_publishing_components/engine.rb
@@ -4,7 +4,6 @@ require "action_dispatch"
 module GovukPublishingComponents
   class Engine < ::Rails::Engine
     isolate_namespace GovukPublishingComponents
-    require 'govuk_frontend_toolkit'
     require 'kramdown'
   end
 end

--- a/spec/javascripts/govuk_publishing_components/FilterComponentsSpec.js
+++ b/spec/javascripts/govuk_publishing_components/FilterComponentsSpec.js
@@ -8,6 +8,11 @@ function addFormInput() {
   document.body.appendChild(form);
 };
 
+function removeFormInput() {
+  form = document.querySelector('form')
+  document.body.removeChild(form)
+}
+
 function addComponents() {
   var list = document.createElement('ul');
   list.classList.add("component-list");
@@ -43,6 +48,10 @@ describe('FilterComponents', function() {
     addFormInput();
     addComponents();
   });
+
+  afterAll(function() {
+    removeFormInput();
+  })
 
   it('hides all components that do not match search criteria', function() {
     FilterComponents("Accordion");

--- a/spec/javascripts/govuk_publishing_components/modules.spec.js
+++ b/spec/javascripts/govuk_publishing_components/modules.spec.js
@@ -1,0 +1,95 @@
+/* eslint-env jasmine, jquery */
+
+var $ = window.jQuery
+
+describe('GOVUK Modules', function () {
+  'use strict'
+  var GOVUK = window.GOVUK
+
+  it('finds modules', function () {
+    var module = $('<div data-module="a-module"></div>')
+    $('body').append(module)
+
+    expect(GOVUK.modules.find().length).toBe(1)
+    expect(GOVUK.modules.find().eq(0).is('[data-module="a-module"]')).toBe(true)
+    module.remove()
+  })
+
+  it('finds modules in a container', function () {
+    var module = $('<div data-module="a-module"></div>')
+    var container = $('<div></div>').append(module)
+
+    expect(GOVUK.modules.find(container).length).toBe(1)
+    expect(GOVUK.modules.find(container).eq(0).data('module')).toBe('a-module')
+    container.remove()
+  })
+
+  it('finds modules that are a container', function () {
+    var module = $('<div data-module="a-module"></div>')
+    var container = $('<div data-module="container-module"></div>').append(module)
+
+    expect(GOVUK.modules.find(container).length).toBe(2)
+    expect(GOVUK.modules.find(container).eq(0).data('module')).toBe('container-module')
+    expect(GOVUK.modules.find(container).eq(1).data('module')).toBe('a-module')
+    container.remove()
+  })
+
+  describe('when a module exists', function () {
+    var callback
+
+    beforeEach(function () {
+      callback = jasmine.createSpy()
+      GOVUK.Modules.TestAlertModule = function () {
+        var that = this
+        that.start = function (element) {
+          callback(element)
+        }
+      }
+    })
+
+    afterEach(function () {
+      delete GOVUK.Modules.TestAlertModule
+    })
+
+    it('starts modules within a container', function () {
+      var module = $('<div data-module="test-alert-module"></div>')
+      var container = $('<div></div>').append(module)
+
+      GOVUK.modules.start(container)
+      expect(callback).toHaveBeenCalled()
+    })
+
+    it('does not start modules that are already started', function () {
+      var module = $('<div data-module="test-alert-module"></div>')
+      $('<div></div>').append(module)
+
+      GOVUK.modules.start(module)
+      GOVUK.modules.start(module)
+      expect(callback.calls.count()).toBe(1)
+    })
+
+    it('passes the HTML element to the module\'s start method', function () {
+      var module = $('<div data-module="test-alert-module"></div>')
+      var container = $('<h1></h1>').append(module)
+
+      GOVUK.modules.start(container)
+
+      var args = callback.calls.argsFor(0)
+      expect(args[0].is('div[data-module="test-alert-module"]')).toBe(true)
+    })
+
+    it('starts all modules that are on the page', function () {
+      var modules = $(
+        '<div data-module="test-alert-module"></div>' +
+        '<strong data-module="test-alert-module"></strong>' +
+        '<span data-module="test-alert-module"></span>'
+      )
+
+      $('body').append(modules)
+      GOVUK.modules.start()
+      expect(callback.calls.count()).toBe(3)
+
+      modules.remove()
+    })
+  })
+})

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -18,6 +18,7 @@ src_files:
 
   # Include the components that we want to test (this is what apps do)
   - assets/govuk_publishing_components/all_components.js
+  - assets/govuk_publishing_components/modules.js
 
   # Use some of the assets from the component guide for testing
   - assets/component_guide/visual-regression.js


### PR DESCRIPTION
## What
Move `modules.js` from `govuk_frontend_toolkit` into `govuk_publishing_components` (without changes - for now) and remove dependency on `govuk_frontend_toolkit`.

It's been a bit over an year since we started to slowly migrate from `govuk_frontend_toolkit` to `govuk-frontend` and this is the last final bit. The migration was a collective effort, so thanks a lot to everyone who contributed to this and made it possible! 🙌 

## Why
[Remove dependency on deprecated projects](https://trello.com/c/ajPzDAOX)
Fixes #500

## Visual Changes
No visual changes.

## Notes
This is not a breaking change, nor a feature - more of an internal change.

~~The tests for this seem to be flaky, so I'd like to have a look at them and try to fix them up before merging. Will do this in a separate commit to ease the review.~~ Fixed the `FilterComponents` spec - no flaky tests anymore.
