### PR TITLE
Release v20.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 20.4.0
 
 * Update ODT guidance link ([PR #906](https://github.com/alphagov/govuk_publishing_components/pull/906))
 * Fix focus states on cookie-banner confirmation message ([PR #1109](https://github.com/alphagov/govuk_publishing_components/pull/1109))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (20.3.0)
+    govuk_publishing_components (20.4.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -263,7 +263,7 @@ GEM
     selenium-webdriver (3.142.3)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
-    sentry-raven (2.11.0)
+    sentry-raven (2.11.1)
       faraday (>= 0.7.6, < 1.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '20.3.0'.freeze
+  VERSION = '20.4.0'.freeze
 end


### PR DESCRIPTION
## 20.4.0

* Update ODT guidance link ([PR #906](https://github.com/alphagov/govuk_publishing_components/pull/906))
* Fix focus states on cookie-banner confirmation message ([PR #1109](https://github.com/alphagov/govuk_publishing_components/pull/1109))
* Allow custom heading size on checkboxes and radios ([PR #1107](https://github.com/alphagov/govuk_publishing_components/pull/1107))
