### PR TITLE
Refactor contents list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add font-size option to contents list component ([PR #1112](https://github.com/alphagov/govuk_publishing_components/pull/1112))
+
 ## 20.4.0
 
 * Update ODT guidance link ([PR #906](https://github.com/alphagov/govuk_publishing_components/pull/906))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -10,6 +10,16 @@
   box-shadow: 0 20px 15px -10px govuk-colour("white");
 }
 
+.gem-c-contents-list--font-size-19 .gem-c-contents-list__title,
+.gem-c-contents-list--font-size-19 .gem-c-contents-list__list {
+  @include govuk-font($size: 19, $line-height: 1.5);
+}
+
+.gem-c-contents-list--font-size-24 .gem-c-contents-list__title,
+.gem-c-contents-list--font-size-24 .gem-c-contents-list__list {
+  @include govuk-font($size: 24, $line-height: 1.5);
+}
+
 .gem-c-contents-list__title {
   @include govuk-text-colour;
   @include govuk-font($size: 16, $weight: regular, $line-height: 1.5);

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -29,7 +29,7 @@
         <li class="<%= cl_helper.list_item_classes(contents_item, false) %>" <%= "aria-current=true" if contents_item[:active] %>>
           <% link_text = format_numbers ? cl_helper.wrap_numbers_with_spans(contents_item[:text]) : contents_item[:text] %>
           <%= link_to_if !contents_item[:active], link_text, contents_item[:href],
-            class: "gem-c-contents-list__link #{brand_helper.color_class}",
+            class: "gem-c-contents-list__link govuk-link #{brand_helper.color_class}",
             data: {
               track_category: 'contentsClicked',
               track_action: "content_item #{position}",
@@ -45,7 +45,7 @@
               <% contents_item[:items].each.with_index(1) do |nested_contents_item, nested_position| %>
                 <li class="<%= cl_helper.list_item_classes(nested_contents_item, true) %>" <%= "aria-current=true" if nested_contents_item[:active] %>>
                   <%= link_to_if !nested_contents_item[:active], nested_contents_item[:text], nested_contents_item[:href],
-                    class: "gem-c-contents-list__link #{brand_helper.color_class}",
+                    class: "gem-c-contents-list__link govuk-link #{brand_helper.color_class}",
                     data: {
                       track_category: 'contentsClicked',
                       track_action: "nested_content_item #{position}:#{nested_position}",

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -1,44 +1,32 @@
-<%
-  cl_helper = GovukPublishingComponents::Presenters::ContentsListHelper.new
+<%-
+  cl_helper = GovukPublishingComponents::Presenters::ContentsListHelper.new(local_assigns)
+  aria_label ||= nil
   format_numbers ||= false
-  underline_links ||= false
-  contents ||= []
-  aria_label ||= ''
-  nested = !!contents.find { |c| c[:items] && c[:items].any? }
-  parent_list_item_modifier = if nested
-                                'parent'
-                              elsif format_numbers
-                                'numbered'
-                              else
-                                'dashed'
-                              end
+  hide_title ||= false
+
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
-  hide_title ||= false
-%>
-<% if contents.any? %>
-  <nav
-    role="navigation"
-    class="gem-c-contents-list <%= 'gem-c-contents-list--no-underline' unless underline_links %> <%= brand_helper.brand_class %>"
-    data-module="track-click"
-    <% if aria_label.present? %>
-      aria-label="<%= aria_label %>"
-    <% end %>
-  >
+
+  classes = cl_helper.classes
+  classes << brand_helper.brand_class
+-%>
+<% if cl_helper.contents.any? %>
+  <%= content_tag(
+    :nav,
+    class: classes,
+    "aria-label": aria_label,
+    role: "navigation",
+    data: {
+      module: "track-click"
+    }
+  ) do %>
     <% unless hide_title %>
       <h2 class="gem-c-contents-list__title"><%= t("components.contents_list.contents") %></h2>
     <% end %>
 
     <ol class="gem-c-contents-list__list">
       <% contents.each.with_index(1) do |contents_item, position| %>
-        <%
-          active_class = "gem-c-contents-list__list-item--active" if contents_item[:active]
-          aria_current = "aria-current = true" if contents_item[:active]
-        %>
-        <li
-          class="gem-c-contents-list__list-item gem-c-contents-list__list-item--<%= parent_list_item_modifier %> <%= active_class %>"
-          <%= aria_current %>
-        >
+        <li class="<%= cl_helper.list_item_classes(contents_item, false) %>" <%= "aria-current=true" if contents_item[:active] %>>
           <% link_text = format_numbers ? cl_helper.wrap_numbers_with_spans(contents_item[:text]) : contents_item[:text] %>
           <%= link_to_if !contents_item[:active], link_text, contents_item[:href],
             class: "gem-c-contents-list__link #{brand_helper.color_class}",
@@ -51,17 +39,11 @@
               }
             }
           %>
+
           <% if contents_item[:items] && contents_item[:items].any? %>
             <ol class="gem-c-contents-list__nested-list">
               <% contents_item[:items].each.with_index(1) do |nested_contents_item, nested_position| %>
-              <%
-                active_class = "gem-c-contents-list__list-item--active" if nested_contents_item[:active]
-                aria_current = "aria-current = true" if nested_contents_item[:active]
-              %>
-                <li
-                  class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed <%= active_class %>"
-                  <%= aria_current %>
-                >
+                <li class="<%= cl_helper.list_item_classes(nested_contents_item, true) %>" <%= "aria-current=true" if nested_contents_item[:active] %>>
                   <%= link_to_if !nested_contents_item[:active], nested_contents_item[:text], nested_contents_item[:href],
                     class: "gem-c-contents-list__link #{brand_helper.color_class}",
                     data: {
@@ -76,9 +58,9 @@
                 </li>
               <% end %>
             </ol>
-          <% end %>
+            <% end %>
         </li>
       <% end %>
     </ol>
-  </nav>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -215,3 +215,14 @@ examples:
             text: Guidance and regulation
           - href: "#third-thing"
             text: Consultations
+  with_different_font_size:
+    description: Choose a different font size. Valid options are 24 (24px) and 19 (19px), with the component defaulting to 16px.
+    data:
+      font_size: 24
+      contents:
+        - href: "#first-thing"
+          text: Community best practice
+        - href: "#second-thing"
+          text: Guidance and regulation
+        - href: "#third-thing"
+          text: Consultations

--- a/lib/govuk_publishing_components/presenters/contents_list_helper.rb
+++ b/lib/govuk_publishing_components/presenters/contents_list_helper.rb
@@ -11,9 +11,11 @@ module GovukPublishingComponents
         @contents = options[:contents] || []
         @nested = !!@contents.find { |c| c[:items] && c[:items].any? }
         @format_numbers = options[:format_numbers]
+        @font_size = options[:font_size]
 
         @classes = %w(gem-c-contents-list)
         @classes << " gem-c-contents-list--no-underline" unless options[:underline_links]
+        @classes << " gem-c-contents-list--font-size-#{@font_size}" if [24, 19].include? @font_size
       end
 
       def list_item_classes(list_item, nested)

--- a/lib/govuk_publishing_components/presenters/contents_list_helper.rb
+++ b/lib/govuk_publishing_components/presenters/contents_list_helper.rb
@@ -5,6 +5,26 @@ module GovukPublishingComponents
     class ContentsListHelper
       include ActionView::Helpers::SanitizeHelper
 
+      attr_reader :classes, :contents
+
+      def initialize(options)
+        @contents = options[:contents] || []
+        @nested = !!@contents.find { |c| c[:items] && c[:items].any? }
+        @format_numbers = options[:format_numbers]
+
+        @classes = %w(gem-c-contents-list)
+        @classes << " gem-c-contents-list--no-underline" unless options[:underline_links]
+      end
+
+      def list_item_classes(list_item, nested)
+        list_item_classes = "gem-c-contents-list__list-item"
+        list_item_classes << " gem-c-contents-list__list-item--#{parent_modifier}" unless nested
+        list_item_classes << " gem-c-contents-list__list-item--dashed" if nested
+        list_item_classes << " gem-c-contents-list__list-item--active" if list_item[:active]
+
+        list_item_classes
+      end
+
       def wrap_numbers_with_spans(content_item_link)
         content_item_text = strip_tags(content_item_link) #just the text of the link
 
@@ -20,6 +40,18 @@ module GovukPublishingComponents
           content_item_link.sub(content_item_text, "<span class=\"gem-c-contents-list__number\">#{number} </span><span class=\"gem-c-contents-list__numbered-text\">#{words}</span>").squish.html_safe
         else
           content_item_link
+        end
+      end
+
+    private
+
+      def parent_modifier
+        if @nested
+          'parent'
+        elsif @format_numbers
+          'numbered'
+        else
+          'dashed'
         end
       end
     end

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -137,4 +137,12 @@ describe "Contents list", type: :view do
     render_component(contents: nested_contents_list, hide_title: true)
     assert_select ".gem-c-contents-list__title", false
   end
+
+  it "can render the component in different font sizes" do
+    render_component(contents: contents_list, font_size: 24)
+    assert_select ".gem-c-contents-list--font-size-24"
+
+    render_component(contents: contents_list, font_size: 19)
+    assert_select ".gem-c-contents-list--font-size-19"
+  end
 end

--- a/spec/lib/govuk_publishing_components/components/contents_list_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/contents_list_helper_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentsListHelper do
     end
 
     it "keeps a space between number and text for screen reader pronunciation" do
-      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new
+      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
       # 1.Thing can be pronounced "1 dot Thing"
       # 1. Thing is always pronounced "1 Thing"
       text = "1. Thing"
@@ -29,21 +29,21 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentsListHelper do
     end
 
     it "does nothing if no number is found" do
-      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new
+      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
       input = '<a href="#vision">Vision</a>'
       expected = '<a href="#vision">Vision</a>'
       expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
     end
 
     it "does nothing if it's just a number" do
-      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new
+      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
       input = '<a href="#first">1</a>'
       expected = '<a href="#first">1</a>'
       expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
     end
 
     it "does nothing if the number is part of the word" do
-      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new
+      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
       input = '<a href="#vision">1Vision</a>'
       expected = '<a href="#vision">1Vision</a>'
       expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
@@ -54,7 +54,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentsListHelper do
     end
 
     it "does nothing if it starts with a number longer than 3 digits" do
-      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new
+      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
       input = '<a href="#vision">2014 Vision</a>'
       expected = '<a href="#vision">2014 Vision</a>'
       expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
@@ -69,7 +69,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentsListHelper do
     end
 
     it "does nothing if a number is present but not at the start" do
-      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new
+      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
       input = '<a href="#run-an-effective-welfare-system">Run an effective welfare system part 1. Social Care</a>'
       expected = '<a href="#run-an-effective-welfare-system">Run an effective welfare system part 1. Social Care</a>'
       expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
@@ -77,7 +77,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentsListHelper do
   end
 
   def assert_split_number_and_text(number_and_text, number, text)
-    cl = GovukPublishingComponents::Presenters::ContentsListHelper.new
+    cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
     number_class = "gem-c-contents-list__number"
     numbered_text_class = "gem-c-contents-list__numbered-text"
 


### PR DESCRIPTION
## What
First commit: refactors the contents list component to move more logic out of the view and into the helper. This makes it easier for us to add another option to the component in the second commit.

Second commit: Adds an option to the component to set a font-size other than the default 16px.

## Why
On the new [Brexit landing page](https://www.gov.uk/brexit), we want the contents list to match the font-size of the surrounding text, which is 19px. At the moment, we are overriding the `gem-c-contents-list__link` class within Collections, which isn't ideal. This adds the option to the component itself, so we can remove the override.

## Visual Changes
<img width="884" alt="Screen Shot 2019-09-11 at 12 06 09" src="https://user-images.githubusercontent.com/29889908/64692261-901f6f80-d48c-11e9-8797-78f6ed91bfe7.png">

https://govuk-publishing-compo-pr-1112.herokuapp.com/component-guide/contents_list
