### PR TITLE
Bump govuk-frontend to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update to [govuk-frontend to 3.2.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.2.0) ([PR #1113](https://github.com/alphagov/govuk_publishing_components/pull/1113))
 * Fix focus state on step by step nav when header element is hovered [PR #1119](https://github.com/alphagov/govuk_publishing_components/pull/1119)
 
 ## 20.5.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -867,9 +867,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.0.0.tgz",
-      "integrity": "sha512-GCrEeaQZEnsthNtfmOUFlgsieNjHOeoamSWMdD4Gdq0RPxCA9uzfrT2i3jVnlBORekKjOL0C8eFZQBSNnjtz2A=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.2.0.tgz",
+      "integrity": "sha512-OtJozAGMEKFu195fNVVrQHUX7+znCkA4cXDKs4lgFlRQOTzN1ogT9010GBARuoTwbeL0VqQ8nerZYjVxH/wafA=="
     },
     "graceful-fs": {
       "version": "4.1.15",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "axe-core": "3.2.2",
-    "govuk-frontend": "3.0.0",
+    "govuk-frontend": "3.2.0",
     "jquery": "1.12.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Update `govuk_publishing_components` to use [`govuk-frontend` version 3.2.0.](https://github.com/alphagov/govuk-frontend/releases/tag/v3.2.0)

## Why

Keep frontend code in sync with the Design System updates

## Notes

For more details regarding changes see [govuk-frontend 3.2.0 changelog](https://github.com/alphagov/govuk-frontend/releases/tag/v3.2.0)

## View Changes
https://govuk-publishing-compo-pr-1113.herokuapp.com/
