### PR TITLE
Add margin bottom option to lead para

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add font-size option to contents list component ([PR #1112](https://github.com/alphagov/govuk_publishing_components/pull/1112))
+* Add margin-bottom option to lead paragraph component ([PR #1114](https://github.com/alphagov/govuk_publishing_components/pull/1114))
 
 ## 20.4.0
 

--- a/app/views/govuk_publishing_components/components/_lead_paragraph.html.erb
+++ b/app/views/govuk_publishing_components/components/_lead_paragraph.html.erb
@@ -1,10 +1,15 @@
 <%
   text ||= ""
   inverse ||= false
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+
+  custom_margin_bottom_class =  shared_helper.get_margin_bottom if [*0..9].include?(local_assigns[:margin_bottom])
+
+  classes = %w(gem-c-lead-paragraph)
+  classes << "gem-c-lead-paragraph--inverse" if inverse
+  classes << custom_margin_bottom_class if local_assigns[:margin_bottom]
 %>
 
 <% if text.present? %>
-  <p class="gem-c-lead-paragraph <% if inverse %>gem-c-lead-paragraph--inverse<% end %>">
-    <%= text %>
-  </p>
+  <%= content_tag :p, text, class: classes %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/lead_paragraph.yml
+++ b/app/views/govuk_publishing_components/components/docs/lead_paragraph.yml
@@ -20,3 +20,8 @@ examples:
       inverse: true
     context:
       dark_background: true
+  custom_margin_bottom:
+    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a margin bottom of 45px.
+    data:
+      text: This is some example text for a lead paragraph
+      margin_bottom: 6

--- a/spec/components/lead_paragraph_spec.rb
+++ b/spec/components/lead_paragraph_spec.rb
@@ -18,4 +18,9 @@ describe "Lead paragraph", type: :view do
     render_component(text: 'UK Visas and Immigration is making changes to the Immigration Rules affecting various categories.')
     assert_select ".gem-c-lead-paragraph", text: "UK Visas and Immigration is making changes to the Immigration Rules affecting various categories."
   end
+
+  it "sets a custom margin bottom" do
+    render_component(text: "This is a lead paragraph", margin_bottom: 3)
+    assert_select '.gem-c-lead-paragraph.govuk-\!-margin-bottom-3'
+  end
 end


### PR DESCRIPTION
## What
Add a margin_bottom option to the lead paragraph component. 

## Why
We may sometimes want the margin bottom on the component to be different to the default 45px. Specifically, this change is being made now for the Brexit landing page.

## Visual Changes
<img width="991" alt="Screen Shot 2019-09-11 at 13 59 02" src="https://user-images.githubusercontent.com/29889908/64699269-55253800-d49c-11e9-99e4-019a3ce3f408.png">

https://govuk-publishing-compo-pr-1114.herokuapp.com/component-guide/lead_paragraph
