### PR TITLE
Version 20.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 20.5.0
 
 * Add font-size option to contents list component ([PR #1112](https://github.com/alphagov/govuk_publishing_components/pull/1112))
 * Add margin-bottom option to lead paragraph component ([PR #1114](https://github.com/alphagov/govuk_publishing_components/pull/1114))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (20.4.0)
+    govuk_publishing_components (20.5.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -322,7 +322,8 @@ DEPENDENCIES
   yard
 
 RUBY VERSION
-   ruby 2.6.3p62
+  ruby 2.6.3p62
+
 
 BUNDLED WITH
    1.17.3

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '20.4.0'.freeze
+  VERSION = '20.5.0'.freeze
 end


### PR DESCRIPTION
Includes:

* Add font-size option to contents list component ([PR #1112](https://github.com/alphagov/govuk_publishing_components/pull/1112))
* Add margin-bottom option to lead paragraph component ([PR #1114](https://github.com/alphagov/govuk_publishing_components/pull/1114))