### PR TITLE
Fix IE specific CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix IE-specific CSS for chevron banner ([PR #1116](https://github.com/alphagov/govuk_publishing_components/pull/1116))
+
 ## 20.5.0
 
 * Add font-size option to contents list component ([PR #1112](https://github.com/alphagov/govuk_publishing_components/pull/1112))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_chevron-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_chevron-banner.scss
@@ -98,8 +98,20 @@ $yellow: #ffdd00;
   }
 
   // Target IE 9-11
-  @media screen and (min-width: 0\0) {
-    background-position: -8px center;
+  @media screen and (min-width: 0\0) and (min-width: 320px) and (max-width: 364px) {
+    background-position: -15px center;
+  }
+
+  @media screen and (min-width: 0\0) and (min-width: 365px) and (max-width: 640px) {
+    background-position: -28px center;
+  }
+
+  @media screen and (min-width: 0\0) and (min-width: 641px) and (max-width: 769px) {
+    background-position: -20px center;
+  }
+
+  @media screen and (min-width: 0\0) and (min-width: 770px) {
+    background-position: -14px center;
   }
 }
 


### PR DESCRIPTION
## What
Adjusts the IE-specific CSS for the chevron banner so that it displays without a left-side gap on the chevron:

<img width="360" alt="screen_shot_2019-09-12_at_09 44 23_720" src="https://user-images.githubusercontent.com/29889908/64778673-33878780-d554-11e9-8507-d8509f47bfa7.png">

<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
We adjusted the layout for the chevron banner, but forgot to adjust the IE-specific CSS to match.

https://govuk-publishing-compo-pr-1116.herokuapp.com/
