### PR TITLE
Version 20.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 20.5.1
 
 * Fix IE-specific CSS for chevron banner ([PR #1116](https://github.com/alphagov/govuk_publishing_components/pull/1116))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (20.5.0)
+    govuk_publishing_components (20.5.1)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -316,10 +316,6 @@ DEPENDENCIES
   uglifier (>= 4.1.0)
   webmock (~> 3.6.0)
   yard
-
-RUBY VERSION
-  ruby 2.6.3p62
-
 
 BUNDLED WITH
    1.17.3

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '20.5.0'.freeze
+  VERSION = '20.5.1'.freeze
 end


### PR DESCRIPTION
Includes:

* Fix IE-specific CSS for chevron banner ([PR #1116](https://github.com/alphagov/govuk_publishing_components/pull/1116))
