### PR TITLE
Fix changelog heading for v 20.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 * Fix IE-specific CSS for chevron banner ([PR #1116](https://github.com/alphagov/govuk_publishing_components/pull/1116))
 
-## 20.5.0
+## 20.5.0
 
 * Add font-size option to contents list component ([PR #1112](https://github.com/alphagov/govuk_publishing_components/pull/1112))
 * Add margin-bottom option to lead paragraph component ([PR #1114](https://github.com/alphagov/govuk_publishing_components/pull/1114))


### PR DESCRIPTION
## What
Fix changelog heading for version 20.5.0. Replacing a non-standard spacing character with the standard one.

## Why
Because it doesn't allow the heading to be rendered correctly