### PR TITLE
Fix focus state on step by step nav when header element is hovered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix focus state on step by step nav when header element is hovered [PR #1119](https://github.com/alphagov/govuk_publishing_components/pull/1119)
+
 ## 20.5.1
 
 * Fix IE-specific CSS for chevron banner ([PR #1116](https://github.com/alphagov/govuk_publishing_components/pull/1116))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -262,7 +262,7 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
   }
 
   &:hover {
-    .gem-c-step-nav__button,
+    .gem-c-step-nav__button:not(:focus),
     .gem-c-step-nav__circle {
       color: $govuk-link-colour;
     }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -272,12 +272,6 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
     }
   }
 
-  &:focus {
-    .gem-c-step-nav__button {
-      color: $govuk-focus-text-colour;
-    }
-  }
-
   .gem-c-step-nav--large & {
     @include govuk-media-query($from: tablet) {
       padding: govuk-spacing(6) 0;


### PR DESCRIPTION
## What
Fix the focus state of navigation button when a step-by-step header is hovered. Fixes #1058

## Why
Because it doesn't meet the required contrast ratio.

## Visual Changes
Before
<img width="223" alt="Screen Shot 2019-09-13 at 15 30 20" src="https://user-images.githubusercontent.com/788096/64870528-5e98d680-d63b-11e9-9fe5-f8d32e405c99.png">

After
<img width="226" alt="Screen Shot 2019-09-13 at 15 28 54" src="https://user-images.githubusercontent.com/788096/64870541-622c5d80-d63b-11e9-9af0-1e906328ea26.png">

## View Changes
https://govuk-publishing-compo-pr-1119.herokuapp.com/component-guide/step_by_step_nav
