### PR TITLE
Add name option to select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update search component styles [PR #1128](https://github.com/alphagov/govuk_publishing_components/pull/1128)
+* Add name option to select component ([PR #1130](https://github.com/alphagov/govuk_publishing_components/pull/1130))
 
 ## 21.0.0
 

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -3,6 +3,7 @@
   id ||= false
   label ||= false
   full_width ||= false
+  name ||= id
 
   select_helper = GovukPublishingComponents::Presenters::SelectHelper.new(options)
   data_module = "data-module=track-select-change" unless select_helper.data_tracking?.eql?(false)
@@ -12,7 +13,7 @@
     <label class="govuk-label" for="<%= id %>">
       <%= label %>
     </label>
-    <select class="govuk-select <%= 'gem-c-select__select--full-width' if full_width %>" id="<%= id %>" name="<%= id %>" <%= data_module %> >
+    <select class="govuk-select <%= 'gem-c-select__select--full-width' if full_width %>" id="<%= id %>" name="<%= name %>" <%= data_module %> >
       <%= options_for_select(select_helper.option_markup, select_helper.selected_option) %>
     </select>
   </div>

--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -19,6 +19,17 @@ examples:
         value: 'option2'
       - text: 'Option three'
         value: 'option3'
+  with_different_id_and_name:
+    description: If no name is provided, name defaults to the (required) value of id.
+    data:
+      id: 'dropdown1-1'
+      label: 'My Dropdown'
+      name: 'dropdown[1]'
+      options:
+      - text: 'Option one'
+        value: 'option1'
+      - text: 'Option two'
+        value: 'option2'
   with_preselect:
     data:
       id: 'dropdown2'

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -50,7 +50,7 @@ describe "Select", type: :view do
       ]
     )
 
-    assert_select "select[name=mydropdown]"
+    assert_select "select[name=mydropdown][id=mydropdown]"
     assert_select ".govuk-label[for=mydropdown]", text: "My dropdown"
     assert_select ".govuk-select option[value=government-gateway]"
   end
@@ -78,6 +78,22 @@ describe "Select", type: :view do
     assert_select ".govuk-select option[value=big]"
     assert_select ".govuk-select option[value=small]"
     assert_select ".govuk-select option[value=medium]"
+  end
+
+  it "can accept an id and a name" do
+    render_component(
+      id: "mydropdown",
+      label: "My dropdown",
+      name: "somethingelse",
+      options: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        }
+      ]
+    )
+
+    assert_select "select[name=somethingelse][id=mydropdown]"
   end
 
   it "renders a select a preselected item" do


### PR DESCRIPTION
## What
Adds an option to the select component to add a 'name' attribute that is different from the 'id' attribute. If none is passed, 'name' defaults to 'id' (as before this change was made).

## Why
Smart answers is being converted to use components and the selects for dates have differing 'id' and 'name' attributes.

## Visual Changes
No visual changes.

## View Changes
https://govuk-publishing-compo-pr-1130.herokuapp.com/component-guide/select
