### PR TITLE
Add label size option for select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add label size option for select ([PR #1131](https://github.com/alphagov/govuk_publishing_components/pull/1131))
 * Update search component styles [PR #1128](https://github.com/alphagov/govuk_publishing_components/pull/1128)
 * Add name option to select component ([PR #1130](https://github.com/alphagov/govuk_publishing_components/pull/1130))
 

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -4,15 +4,17 @@
   label ||= false
   full_width ||= false
   name ||= id
+  heading_size = '' unless ['s', 'm', 'l', 'xl'].include?(heading_size)
+
+  label_classes = %w(govuk-label)
+  label_classes << "govuk-label--#{heading_size}" if heading_size
 
   select_helper = GovukPublishingComponents::Presenters::SelectHelper.new(options)
   data_module = "data-module=track-select-change" unless select_helper.data_tracking?.eql?(false)
 %>
 <% if options.any? && id && label %>
   <div class="govuk-form-group gem-c-select">
-    <label class="govuk-label" for="<%= id %>">
-      <%= label %>
-    </label>
+    <%= label_tag(id, label, class: label_classes) %>
     <select class="govuk-select <%= 'gem-c-select__select--full-width' if full_width %>" id="<%= id %>" name="<%= name %>" <%= data_module %> >
       <%= options_for_select(select_helper.option_markup, select_helper.selected_option) %>
     </select>

--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -103,4 +103,16 @@ examples:
         value: 'option2'
       - text: 'Option three'
         value: 'option3'
-
+  with_custom_label_size:
+    description: Make the label different sizes. Valid options are 's', 'm', 'l' and 'xl'.
+    data:
+      id: 'dropdown6'
+      label: 'Bigger!'
+      heading_size: 'xl'
+      options:
+      - text: 'Option one'
+        value: 'option1'
+      - text: 'Option two'
+        value: 'option2'
+      - text: 'Option three'
+        value: 'option3'

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -203,4 +203,20 @@ describe "Select", type: :view do
     assert_select "select[name=mydropdown]"
     assert_select ".gem-c-select .gem-c-select__select--full-width"
   end
+
+  it "renders a select box with a custom label size" do
+    render_component(
+      id: "mydropdown",
+      label: "My dropdown",
+      heading_size: "s",
+      options: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        }
+      ]
+    )
+
+    assert_select ".govuk-label.govuk-label--s"
+  end
 end


### PR DESCRIPTION
## What
Adds an option to the select component to give it a custom-sized label. Component defaults to the existing label style unless specified.

## Why
Smart answers needs this - the question text for a select is currently smaller and not-bold compared to all the other component labels.

## Visual Changes
![Screen Shot 2019-09-23 at 16 23 45](https://user-images.githubusercontent.com/861310/65439092-8ac40c80-de1e-11e9-9e06-9e8b4e513615.png)

## View Changes
https://govuk-publishing-compo-pr-1131.herokuapp.com/component-guide/select
