### PR TITLE
Prevent sticky / fixed elements from overlapping feedback component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -1,6 +1,8 @@
 .gem-c-feedback {
-  max-width: $govuk-page-width;
+  background: govuk-colour("white");
   margin: 0 auto;
+  max-width: $govuk-page-width;
+  position: relative;
 
   .visually-hidden {
     @include govuk-visually-hidden;


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Sets the feedback component to be `position: relative` so sticky or fixed elements that precede the feedback component don't overlap it; and sets the feedback element container's background to be white to stop any underlapping elements from showing through.

## Why
<!-- What are the reasons behind this change being made? -->
A sticky or fixed element was overlapping the feedback component on Service Manual Frontend and this would fix it.

Problem can be seen on the [Agile and government services: an introduction](https://www.gov.uk/service-manual/agile-delivery/agile-government-services-introduction) page in the Service Manual. Scroll to the feedback component and open either one of the feedback forms by clicking 'No' or 'Is there anything wrong with this page?'. Once the feedback form has opened, scroll to the bottom of the page to see the sticky menu will overlap with the feedback form.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
Before:
<img width="280" alt="Screen Shot 2019-09-23 at 16 58 44 1" src="https://user-images.githubusercontent.com/1732331/65442324-dfb65180-de23-11e9-955f-c0c8c5ae29f9.png">

After:
<img width="286" alt="Screen Shot 2019-09-23 at 16 58 32" src="https://user-images.githubusercontent.com/1732331/65442356-ee046d80-de23-11e9-9798-5e6365fa358b.png">

<!--
## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
-->
