### PR TITLE
Fieldset legend custom size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fieldset custom legend size ([PR #1134](https://github.com/alphagov/govuk_publishing_components/pull/1134))
+
 ## 21.1.1
 
 * Update cookie banner text ([PR #1136](https://github.com/alphagov/govuk_publishing_components/pull/1136))

--- a/app/views/govuk_publishing_components/components/_fieldset.html.erb
+++ b/app/views/govuk_publishing_components/components/_fieldset.html.erb
@@ -1,8 +1,14 @@
-<% text = text || yield %>
-<% describedby ||= nil %>
-<% role ||= nil %>
+<%
+  text = text || yield
+  describedby ||= nil
+  role ||= nil
+  heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
+
+  legend_classes = %w(govuk-fieldset__legend)
+  legend_classes << "govuk-fieldset__legend--#{heading_size}" if heading_size
+%>
 <%= tag.fieldset class: "gem-c-fieldset govuk-fieldset", aria: { describedby: describedby }, role: role do %>
-  <%= tag.legend class: "govuk-fieldset__legend" do %>
+  <%= tag.legend class: legend_classes do %>
     <%= legend_text %>
   <% end %>
   <%= text %>

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -4,7 +4,7 @@
   label ||= false
   full_width ||= false
   name ||= id
-  heading_size = '' unless ['s', 'm', 'l', 'xl'].include?(heading_size)
+  heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
 
   label_classes = %w(govuk-label)
   label_classes << "govuk-label--#{heading_size}" if heading_size

--- a/app/views/govuk_publishing_components/components/docs/fieldset.yml
+++ b/app/views/govuk_publishing_components/components/docs/fieldset.yml
@@ -17,6 +17,18 @@ examples:
 
         <input type="radio" id="default-no" name="default"t>
         <label for="default-no">No</label>
+  with_custom_legend_size:
+    description: Make the legend different sizes. Valid options are 's', 'm', 'l' and 'xl'.
+    data:
+      legend_text: 'Do you have a driving license?'
+      heading_size: 'l'
+      text: |
+        <!-- Use the radio component, this is hardcoded only for this example -->
+        <input type="radio" id="size-yes" name="default"t>
+        <label for="size-yes">Yes</label>
+
+        <input type="radio" id="size-no" name="default"t>
+        <label for="size-no">No</label>
   with_html_legend:
     description: 'If you only have one fieldset on the page you might want to include the title of the page as the legend text. Used with a [captured](http://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-capture) [title](http://components.publishing.service.gov.uk/component-guide/title)'
     data:

--- a/spec/components/fieldset_spec.rb
+++ b/spec/components/fieldset_spec.rb
@@ -20,4 +20,14 @@ describe "Fieldset", type: :view do
     assert_select ".govuk-fieldset__legend", text: 'Do you have a passport?'
     assert_select ".gem-c-fieldset", text: /Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vel ad neque, maxime est ea laudantium totam fuga!/
   end
+
+  it "renders a fieldset with a custom size legend" do
+    render_component(
+      legend_text: 'Do you have a passport?',
+      heading_size: 'xl',
+      text: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vel ad neque, maxime est ea laudantium totam fuga!'
+    )
+
+    assert_select ".govuk-fieldset__legend.govuk-fieldset__legend--xl"
+  end
 end


### PR DESCRIPTION
## What
Adds a custom legend size option to the fieldset component. Defaults to original size before change.

Also fixes a small bug with the same functionality in the select component.

## Why
Needed for visual consistency in smart-answers.

## Visual Changes
<img width="871" alt="Screen Shot 2019-09-23 at 18 06 18" src="https://user-images.githubusercontent.com/861310/65446723-e1d0de00-de2c-11e9-8e10-b7ad39e1e6a3.png">

## View Changes
https://govuk-publishing-compo-pr-1134.herokuapp.com/component-guide/fieldset
