### PR TITLE
Add "Button looks like a link" variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add "Button looks like a link" variant [#PR 1135](https://github.com/alphagov/govuk_publishing_components/pull/1135)
+
 ## 21.2.0
 
 * Fieldset custom legend size ([PR #1134](https://github.com/alphagov/govuk_publishing_components/pull/1134))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -107,3 +107,45 @@ $gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
     content: none;
   }
 }
+
+.gem-c-button--as-link {
+  padding: 0;
+  border-width: 0;
+  box-shadow: none;
+  color: $govuk-link-colour;
+  background: none;
+  cursor: pointer;
+  -webkit-appearance: none;
+  text-decoration: underline;
+
+  @include govuk-link-common;
+  @include govuk-link-style-default;
+
+  // Remove default button focus outline in Firefox
+  &::-moz-focus-inner {
+    padding: 0;
+    border: 0;
+  }
+
+  // very specific to combat .govuk-button styles from
+  // https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/button/_button.scss#L112
+  &:focus:not(:active):not(:hover) {
+    @include govuk-focused-text;
+  }
+
+  &:hover {
+    color: $govuk-link-hover-colour;
+    text-decoration: underline;
+    background: none;
+    box-shadow: none;
+  }
+
+  &:active {
+    color: $govuk-link-active-colour;
+    text-decoration: underline;
+  }
+
+  &:before {
+    content: none;
+  }
+}

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -56,6 +56,10 @@ examples:
     data:
       text: "Destructive button"
       destructive: true
+  button_looks_like_link:
+    data:
+      text: "Button, but look like a link"
+      as_link: true
   start_now_button_with_info_text:
     data:
       text: "Start now"

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -5,7 +5,7 @@ module GovukPublishingComponents
     class ButtonHelper
       attr_reader :href, :text, :title, :info_text, :rel, :data_attributes,
                   :margin_bottom, :inline_layout, :target, :type, :start,
-                  :secondary, :secondary_quiet, :destructive, :name, :value
+                  :secondary, :secondary_quiet, :destructive, :name, :value, :as_link
 
       def initialize(local_assigns)
         @href = local_assigns[:href]
@@ -24,15 +24,20 @@ module GovukPublishingComponents
         @destructive = local_assigns[:destructive]
         @name = local_assigns[:name]
         @value = local_assigns[:value]
+        @as_link = local_assigns[:as_link]
       end
 
       def link?
         href.present?
       end
 
+      def as_link?
+        as_link.present?
+      end
+
       def html_options
         options = { class: css_classes }
-        options[:role] = "button" if link?
+        options[:role] = "button" if link? || as_link?
         options[:type] = button_type
         options[:rel] = rel if rel
         options[:data] = data_attributes if data_attributes
@@ -44,7 +49,7 @@ module GovukPublishingComponents
       end
 
       def button_type
-        type || "submit" unless link?
+        type || "submit" unless link? || as_link?
       end
 
     private
@@ -57,6 +62,7 @@ module GovukPublishingComponents
         classes << "govuk-button--warning" if destructive
         classes << "gem-c-button--bottom-margin" if margin_bottom
         classes << "gem-c-button--inline" if inline_layout
+        classes << "gem-c-button--as-link" if as_link
         classes.join(" ")
       end
     end

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -70,6 +70,12 @@ describe "Button", type: :view do
     assert_select "a.govuk-button", false
   end
 
+  it "renders a button that looks like a link" do
+    render_component(text: "Button, but looks like a link", as_link: true)
+    assert_select "button.gem-c-button--as-link", text: "Button, but looks like a link"
+    assert_select "button.gem-c-button--as-link[role=button]", true
+  end
+
   it "renders info text" do
     render_component(text: "Start now", info_text: "Information text")
     assert_select ".govuk-button", text: "Start now"


### PR DESCRIPTION
## What
Add button that looks like a link variant of a button 

## Why
The toggle to expand content, such as [show updates](https://www.gov.uk/government/publications/sample-accessible-document-policy#history) are links but should be buttons, like[ "Show more search options" ](https://www.gov.uk/search/all) which we updated thanks to some [prodding](https://github.com/alphagov/finder-frontend/issues/1323) 

## View Changes
https://govuk-publishing-compo-pr-1135.herokuapp.com/component-guide/button/button_looks_like_link/preview

