### PR TITLE
Update cookie banner text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update cookie banner text ([PR #1136](https://github.com/alphagov/govuk_publishing_components/pull/1136))
+
 ## 21.1.0
 
 * Add label size option for select ([PR #1131](https://github.com/alphagov/govuk_publishing_components/pull/1131))

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -1,6 +1,6 @@
 <%
   id ||= 'global-cookie-message'
-  message ||= "GOV.UK uses cookies to make the site simpler."
+  message ||= "GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised. By continuing to use this site, you agree to our use of cookies."
 %>
 
 <div id="<%= id %>" class="gem-c-cookie-banner" data-module="cookie-banner" role="region" aria-label="cookie banner">

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -8,7 +8,7 @@ describe "Cookie banner", type: :view do
   it "renders with default values" do
     render_component({})
     assert_select '.gem-c-cookie-banner[id="global-cookie-message"][data-module="cookie-banner"]'
-    assert_select '.govuk-width-container .gem-c-cookie-banner__message', text: "GOV.UK uses cookies to make the site simpler."
+    assert_select '.govuk-width-container .gem-c-cookie-banner__message', text: "GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised. By continuing to use this site, you agree to our use of cookies."
     assert_select 'button[data-hide-cookie-banner="true"]'
   end
 

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -13,7 +13,7 @@ describe('Cookie banner', function () {
     container.innerHTML =
       '<div id="global-cookie-message" class="gem-c-cookie-banner" data-module="cookie-banner">' +
         '<div class="gem-c-cookie-banner__wrapper govuk-width-container" data-cookie-banner-main="true">' +
-          '<p class="gem-c-cookie-banner__message">GOV.UK uses cookies to make the site simpler.</p>' +
+          '<p class="gem-c-cookie-banner__message">GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised. By continuing to use this site, you agree to our use of cookies.</p>' +
           '<div class="gem-c-cookie-banner__buttons">' +
             '<button class="gem-c-button govuk-button gem-c-button--secondary-quiet gem-c-button--inline" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">Accept cookies</button>' +
             '<a class="gem-c-button govuk-button gem-c-button--secondary-quiet gem-c-button--inline" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="/help/cookies">Cookie settings</a>' +


### PR DESCRIPTION
This commit updates the cookie banner text to reflect our use of cookies and analytics on GOV.UK

Note: the spacing looks wrong in the screenshots because this is how the cookie banner renders in the component guide. Left and right spacing is visible on the live site.

## Before
<img width="917" alt="Screen Shot 2019-09-24 at 11 40 11" src="https://user-images.githubusercontent.com/29889908/65504965-1641aa00-dec0-11e9-9628-2c8c5067f4b3.png">

## After
<img width="920" alt="Screen Shot 2019-09-24 at 11 39 33" src="https://user-images.githubusercontent.com/29889908/65504938-01fdad00-dec0-11e9-814d-631407d87c02.png">
