### PR TITLE
Version 21.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.1.1
 
 * Update cookie banner text ([PR #1136](https://github.com/alphagov/govuk_publishing_components/pull/1136))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.1.0)
+    govuk_publishing_components (21.1.1)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -271,7 +271,7 @@ GEM
     statsd-ruby (1.4.0)
     thor (0.19.4)
     thread_safe (0.3.6)
-    tilt (2.0.9)
+    tilt (2.0.10)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.20)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.1.0'.freeze
+  VERSION = '21.1.1'.freeze
 end


### PR DESCRIPTION
Includes:

* Update cookie banner text ([PR #1136](https://github.com/alphagov/govuk_publishing_components/pull/1136))