### PR TITLE
Correcting input error documentation

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -69,9 +69,7 @@ examples:
       name: "name"
       error_items:
       - text: Descriptive link to the question with an error 1
-        href: '#example-error-1'
       - text: Descriptive link to the question with an error 2
-        href: '#example-error-2'
   with_value:
     data:
       label:


### PR DESCRIPTION
## What
Input component documentation includes a `href` attribute, but this is unused, so removing.

## Why
Because!

## Visual Changes
None.

## View Changes
https://govuk-publishing-compo-pr-1139.herokuapp.com/component-guide/input/with_error_items
