### PR TITLE
Add size option to label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add error state to select component ([PR #1141](https://github.com/alphagov/govuk_publishing_components/pull/1141))
+* Add size option to label ([PR #1140](https://github.com/alphagov/govuk_publishing_components/pull/1140))
 
 ## 21.2.0
 

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -21,6 +21,7 @@
   hint_id = "hint-#{SecureRandom.hex(4)}"
   error_id = "error-#{SecureRandom.hex(4)}"
   search_icon ||= nil
+  heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
 
   css_classes = %w(gem-c-input govuk-input)
   css_classes << "govuk-input--error" if has_error
@@ -42,7 +43,8 @@
 <%= content_tag :div, class: form_group_css_classes do %>
   <% if label %>
     <%= render "govuk_publishing_components/components/label", {
-      html_for: id
+      html_for: id,
+      heading_size: heading_size
     }.merge(label.symbolize_keys) %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/_label.html.erb
+++ b/app/views/govuk_publishing_components/components/_label.html.erb
@@ -2,10 +2,12 @@
   hint_text ||= ''
   is_radio_label ||= false
   bold ||= false
+  heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
 
   css_classes = %w( gem-c-label govuk-label )
   css_classes << "govuk-label--s" if bold
   css_classes << "govuk-radios__label" if is_radio_label
+  css_classes << "govuk-label--#{heading_size}" if heading_size
 
   hint_text_css_classes = %w( govuk-hint )
   hint_text_css_classes << "govuk-radios__hint" if is_radio_label

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -118,3 +118,10 @@ examples:
       name: "search-box"
       type: "search"
       search_icon: true
+  with_custom_label_size:
+    description: Make the label different sizes. Valid options are 's', 'm', 'l' and 'xl'.
+    data:
+      label:
+        text: "What is your name?"
+      name: "name"
+      heading_size: "l"

--- a/app/views/govuk_publishing_components/components/docs/label.yml
+++ b/app/views/govuk_publishing_components/components/docs/label.yml
@@ -27,6 +27,12 @@ examples:
       html_for: "id-that-matches-input"
       hint_id: "should-match-aria-describedby-input"
       hint_text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+  with_custom_label_size:
+    description: Make the label different sizes. Valid options are 's', 'm', 'l' and 'xl'.
+    data:
+      text: "Surname"
+      html_for: "id-that-matches-input"
+      heading_size: "xl"
   bold_with_hint:
     data:
       bold: true

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -194,4 +194,14 @@ describe "Input", type: :view do
       assert_select ".govuk-input[aria-describedby='#{error_id}']"
     end
   end
+
+  it "renders text input different sized labels" do
+    render_component(
+      label: { text: "What is your email address?" },
+      name: "email-address",
+      heading_size: "xl"
+    )
+
+    assert_select ".govuk-label.govuk-label--xl"
+  end
 end

--- a/spec/components/label_spec.rb
+++ b/spec/components/label_spec.rb
@@ -39,6 +39,16 @@ describe "Label", type: :view do
     assert_select ".govuk-hint[id=should-match-aria-describedby-input]"
   end
 
+  it "renders label with different label sizes" do
+    render_component(
+      text: "National Insurance number",
+      html_for: "id-that-matches-input",
+      heading_size: "m",
+    )
+
+    assert_select ".gem-c-label.govuk-label.govuk-label--m"
+  end
+
   it "renders label with bold text" do
     render_component(
       text: "National Insurance number",


### PR DESCRIPTION
## What
Use the govuk-frontend classes for labels to provide a size option for labels, and use this in the label component and the input component.

## Why
This is needed for the upgrade of [smart-answers to use components](https://github.com/alphagov/smart-answers/pull/4132) where we want a consistent, large and bold style for labels. Other components already have this.

There are potentially some additional bits of work to come out of this...

- could this be done using the shared helper?
- some components kind of already do this, but use a `bold` flag to set `govuk-label--s`. We should remove this in favour of the more flexible `heading_size` option. Components are radio and label.
- the component uses the option `heading_size` for the label style, but this is also used by the radio component to set the size of the legend, this could be confusing.

## Visual Changes
<img width="862" alt="Screen Shot 2019-09-26 at 10 12 37" src="https://user-images.githubusercontent.com/861310/65675540-4024d900-e046-11e9-9464-2475c9e82e81.png">

<img width="865" alt="Screen Shot 2019-09-26 at 10 12 58" src="https://user-images.githubusercontent.com/861310/65675553-46b35080-e046-11e9-9cfd-c3af338e6923.png">

## View Changes
https://govuk-publishing-compo-pr-1140.herokuapp.com/component-guide/
