### PR TITLE
Add error state to select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add error state to select component ([PR #1141](https://github.com/alphagov/govuk_publishing_components/pull/1141))
+
 ## 21.2.0
 
 * Fieldset custom legend size ([PR #1134](https://github.com/alphagov/govuk_publishing_components/pull/1134))

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -6,17 +6,34 @@
   name ||= id
   heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
 
+  error_message ||= nil
+  error_id ||= "error-#{SecureRandom.hex(4)}" if error_message
+  aria_describedby = { describedby: error_id } if error_message
+
+  css_classes = %w(govuk-form-group gem-c-select)
+  css_classes << "govuk-form-group--error" if error_message
+
+  select_classes = %w(govuk-select)
+  select_classes << "gem-c-select__select--full-width" if full_width
+  select_classes << "govuk-select--error" if error_message
+
   label_classes = %w(govuk-label)
   label_classes << "govuk-label--#{heading_size}" if heading_size
 
   select_helper = GovukPublishingComponents::Presenters::SelectHelper.new(options)
-  data_module = "data-module=track-select-change" unless select_helper.data_tracking?.eql?(false)
+  data_module = { module: "track-select-change" } unless select_helper.data_tracking?.eql?(false)
 %>
 <% if options.any? && id && label %>
-  <div class="govuk-form-group gem-c-select">
+  <%= content_tag :div, class: css_classes do %>
     <%= label_tag(id, label, class: label_classes) %>
-    <select class="govuk-select <%= 'gem-c-select__select--full-width' if full_width %>" id="<%= id %>" name="<%= name %>" <%= data_module %> >
-      <%= options_for_select(select_helper.option_markup, select_helper.selected_option) %>
-    </select>
-  </div>
+
+    <% if error_message %>
+      <%= render "govuk_publishing_components/components/error_message", {
+        id: error_id,
+        text: error_message
+      } %>
+    <% end %>
+
+    <%= select_tag name, options_for_select(select_helper.option_markup, select_helper.selected_option), id: id, class: select_classes, data: data_module, aria: aria_describedby %>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -90,6 +90,20 @@ examples:
         value: 'option2'
       - text: 'Option three'
         value: 'option3'
+  with_error:
+    description: If the user has to select an option, it is recommended that a radio button is used instead of a select, but this is not always possible. Note that error_id is optional, if it is not passed one will be generated automatically.
+    data:
+      id: 'dropdown4-1'
+      label: 'How will you be travelling to the conference?'
+      error_message: 'Please choose an option'
+      error_id: 'error_id'
+      options:
+      - text: ""
+        value: ""
+      - text: 'Public transport'
+        value: 'option1'
+      - text: 'Will make own arrangements'
+        value: 'option2'
   full_width:
     description: Make the select width 100%. This is used for facets in finder-frontend's search.
     data:

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -187,6 +187,25 @@ describe "Select", type: :view do
     assert_select ".gem-c-select [data-another-attribute=test1][data-second-item=item1][data-option=option1]"
   end
 
+  it "renders a select box in an error state" do
+    render_component(
+      id: "mydropdown",
+      label: "My dropdown",
+      error_message: "Please choose an option",
+      error_id: "error_id",
+      options: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        }
+      ]
+    )
+
+    assert_select ".govuk-form-group.gem-c-select.govuk-form-group--error"
+    assert_select ".gem-c-error-message.govuk-error-message", text: "Error: Please choose an option"
+    assert_select ".govuk-select.govuk-select--error[aria-describedby=error_id]"
+  end
+
   it "renders a select box full width" do
     render_component(
       id: "mydropdown",


### PR DESCRIPTION
## What
Add an error state to the select component. This [already exists](http://govuk-frontend-review.herokuapp.com/components/select/with-hint-text-and-error-message/preview) in `govuk-frontend`, but isn't documented.

## Why
For the [smart-answers upgrade](https://github.com/alphagov/smart-answers/pull/4132). I can't be certain there isn't a select question that doesn't have a blank answer, so we need an error message.

## Visual Changes
<img width="475" alt="Screen Shot 2019-09-26 at 11 14 37" src="https://user-images.githubusercontent.com/861310/65680443-d9f08400-e04e-11e9-85a1-912cddb42ef8.png">

<!--
## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
-->
