### PR TITLE
FAQPage schema fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix some minor issues with the FAQPage schema ([PR #1142](https://github.com/alphagov/govuk_publishing_components/pull/1142))
 * Add error state to select component ([PR #1141](https://github.com/alphagov/govuk_publishing_components/pull/1141))
 * Add size option to label ([PR #1140](https://github.com/alphagov/govuk_publishing_components/pull/1140))
 

--- a/lib/govuk_publishing_components/presenters/machine_readable/faq_page_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/faq_page_schema.rb
@@ -24,7 +24,9 @@ module GovukPublishingComponents
       end
 
       def questions_and_answers_markup
-        question_and_answers(page.body).map do |question, value|
+        question_and_answers(page.body)
+          .select { |_, value| value[:answer].present? }
+          .map do |question, value|
           q_and_a_url = section_url(value[:anchor])
 
           {

--- a/lib/govuk_publishing_components/presenters/machine_readable/faq_page_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/faq_page_schema.rb
@@ -44,7 +44,7 @@ module GovukPublishingComponents
 
       # Generates a hash of questions and associated information:
       # - question: the text in the h2 tag preceding other markup. Questions are
-      #             used to key the hash. "Summary" is set as the default, as
+      #             used to key the hash. The page title is set as the default, as
       #             there is often a preamble in guides before any h2 is set.
       #
       # - :answer: the markup that is not an h2 tag. It is associated with the
@@ -55,7 +55,7 @@ module GovukPublishingComponents
       def question_and_answers(html)
         doc = Nokogiri::HTML(html)
 
-        question = "Summary"
+        question = page.title
 
         # rubocop:disable Style/IfInsideElse
         doc.xpath("html/body").children.each_with_object({}) do |element, q_and_as|

--- a/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
@@ -103,7 +103,6 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
 
         content_item = dragon_guide
 
-
         q_and_a = generate_structured_data(
           content_item: content_item,
           schema: :faq,
@@ -113,6 +112,24 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
         expect(q_and_a.first["name"]).to eq("Summary")
         expect(q_and_a.first["url"]).to eq("http://www.dev.gov.uk/how-to-train-your-dragon")
         expect(q_and_a.first["acceptedAnswer"]["text"].strip).to eq("<p>First catch your dragon</p>")
+      end
+
+      it "does not include questions when there is no associated answer" do
+        part_body = "<p>First catch your dragon</p>
+                     <h2 id='step-two'>Step two</h2>
+                     <h2 id='step-three'>Step three</h2>
+                     <p>Give it a pat (wear gloves)</p>"
+
+        content_item = dragon_guide
+
+        q_and_a = generate_structured_data(
+          content_item: content_item,
+          schema: :faq,
+          body: part_body
+        ).structured_data['mainEntity']
+
+        expect(q_and_a.count).to eq(2)
+        expect(q_and_a.map { |faq| faq["name"] }).to_not include("Step two")
       end
 
       it "handles an empty body to ensure that preview works OK" do

--- a/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
         expect(q_and_a.second["acceptedAnswer"]["text"].strip).to eq("<p>Give it a treat</p>")
       end
 
-      it "handles missing h2s at the start of the body" do
+      it "handles missing h2s at the start of the body by using the page title" do
         part_body = "<p>First catch your dragon</p>
                      <h2 id='step-two'>Step two</h2>
                      <p>Give it a treat</p>
@@ -109,7 +109,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
           body: part_body
         ).structured_data['mainEntity']
 
-        expect(q_and_a.first["name"]).to eq("Summary")
+        expect(q_and_a.first["name"]).to eq("How to train your dragon")
         expect(q_and_a.first["url"]).to eq("http://www.dev.gov.uk/how-to-train-your-dragon")
         expect(q_and_a.first["acceptedAnswer"]["text"].strip).to eq("<p>First catch your dragon</p>")
       end
@@ -151,6 +151,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
           canonical_url: "http://www.dev.gov.uk/how-to-train-your-dragon/insurance"
         ) do |random_item|
           random_item.merge(
+            "title" => "How to train your dragon",
             "base_path" => "/how-to-train-your-dragon"
           )
         end


### PR DESCRIPTION
## What
FAQPage schemas are used to help us get rich results on Google for queries like https://www.google.com/search?q=apply+for+uk+visa

FAQPages have lists of question and answer pairs.  We generate "questions" from h2 tag text, and the "answers" are the html content that follows (until the next h2).  We've noticed a couple of glitches:

### Missing first section in rich results

We knew that a lot of pages don't have an initial h2, so we defaulted to using "Summary" as the initial content was often just that.  Unfortunately, Google doesn't seem to like this if the word "Summary" is not in the right place.  We'll try using the page title instead, because this should be on the page in a relevant place.

### Missing answer text causing indexing errors

When there is no content between h2 tags, we shouldn't generate a question and answer pair, because we'll have an empty answer.

An example page is https://www.gov.uk/check-a-university-is-officially-recognised/listed-bodies
where there is an A-Z list with no content between the V and W h2 titles.

