### PR TITLE
Add select component error state without message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix some minor issues with the FAQPage schema ([PR #1142](https://github.com/alphagov/govuk_publishing_components/pull/1142))
+* Add select component error state without message ([PR #1143](https://github.com/alphagov/govuk_publishing_components/pull/1143))
 * Add error state to select component ([PR #1141](https://github.com/alphagov/govuk_publishing_components/pull/1141))
 * Add size option to label ([PR #1140](https://github.com/alphagov/govuk_publishing_components/pull/1140))
 

--- a/app/views/govuk_publishing_components/components/_fieldset.html.erb
+++ b/app/views/govuk_publishing_components/components/_fieldset.html.erb
@@ -3,13 +3,33 @@
   describedby ||= nil
   role ||= nil
   heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
+  error_message ||= nil
+  error_id ||= nil
+
+  if error_message
+    error_id = "error-#{SecureRandom.hex(4)}" unless error_id
+    describedby = error_id
+  end
+
+  css_classes = %w(gem-c-fieldset govuk-form-group)
+  css_classes << "govuk-form-group--error" if error_message
+
+  fieldset_classes = %w(govuk-fieldset)
 
   legend_classes = %w(govuk-fieldset__legend)
   legend_classes << "govuk-fieldset__legend--#{heading_size}" if heading_size
 %>
-<%= tag.fieldset class: "gem-c-fieldset govuk-fieldset", aria: { describedby: describedby }, role: role do %>
-  <%= tag.legend class: legend_classes do %>
-    <%= legend_text %>
+<%= tag.div class: css_classes do %>
+  <%= tag.fieldset class: fieldset_classes, aria: { describedby: describedby }, role: role do %>
+    <%= tag.legend class: legend_classes do %>
+      <%= legend_text %>
+    <% end %>
+    <% if error_message %>
+      <%= render "govuk_publishing_components/components/error_message", {
+        text: error_message,
+        id: error_id
+      } %>
+    <% end %>
+    <%= text %>
   <% end %>
-  <%= text %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -5,17 +5,20 @@
   full_width ||= false
   name ||= id
   heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
-
   error_message ||= nil
-  error_id ||= "error-#{SecureRandom.hex(4)}" if error_message
-  aria_describedby = { describedby: error_id } if error_message
+  error_id ||= nil
+
+  if error_message || error_id
+    error_id = "error-#{SecureRandom.hex(4)}" unless error_id
+    aria_describedby = { describedby: error_id }
+  end
 
   css_classes = %w(govuk-form-group gem-c-select)
   css_classes << "govuk-form-group--error" if error_message
 
   select_classes = %w(govuk-select)
   select_classes << "gem-c-select__select--full-width" if full_width
-  select_classes << "govuk-select--error" if error_message
+  select_classes << "govuk-select--error" if error_id
 
   label_classes = %w(govuk-label)
   label_classes << "govuk-label--#{heading_size}" if heading_size

--- a/app/views/govuk_publishing_components/components/docs/error_message.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_message.yml
@@ -7,13 +7,14 @@ accessibility_criteria: |
 
   Error message must:
 
-  - be associated with an input. The `error_message_id` must match the `aria-describedby` property on the input your label is associated with.
+  - be associated with an input. The `error_message_id` must match the `aria-describedby` property on the input your label is associated with. Note that if `id` is not passed to the component an id will be generated automatically.
 
   If error message is within a label it will be announced in its entirety by screen readers. By associating error messages with inputs using `aria-describedby`, then screen readers will read the label, describe the type of input (eg radio) and then read additional text. It means users of screen readers can scan and skip options as easy as people making choices with sight.
 examples:
   default:
     data:
       text: "Please enter your National Insurance Number"
+      id: "error_id"
   with_items:
     description: Error items are a common pattern where a collection of error is passed with each item having a text attribute of the error
     data:

--- a/app/views/govuk_publishing_components/components/docs/fieldset.yml
+++ b/app/views/govuk_publishing_components/components/docs/fieldset.yml
@@ -12,10 +12,10 @@ examples:
       legend_text: 'Do you have a passport?'
       text: |
         <!-- Use the radio component, this is hardcoded only for this example -->
-        <input type="radio" id="default-yes" name="default"t>
+        <input type="radio" id="default-yes" name="default">
         <label for="default-yes">Yes</label>
 
-        <input type="radio" id="default-no" name="default"t>
+        <input type="radio" id="default-no" name="default">
         <label for="default-no">No</label>
   with_custom_legend_size:
     description: Make the legend different sizes. Valid options are 's', 'm', 'l' and 'xl'.
@@ -24,10 +24,10 @@ examples:
       heading_size: 'l'
       text: |
         <!-- Use the radio component, this is hardcoded only for this example -->
-        <input type="radio" id="size-yes" name="default"t>
+        <input type="radio" id="size-yes" name="default">
         <label for="size-yes">Yes</label>
 
-        <input type="radio" id="size-no" name="default"t>
+        <input type="radio" id="size-no" name="default">
         <label for="size-no">No</label>
   with_html_legend:
     description: 'If you only have one fieldset on the page you might want to include the title of the page as the legend text. Used with a [captured](http://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-capture) [title](http://components.publishing.service.gov.uk/component-guide/title)'
@@ -44,3 +44,15 @@ examples:
 
         <input type="radio" id="html-legend-no" name="html-legend">
         <label for="html-legend-no">No</label>
+  with_error_message:
+    description: The component also accepts an error_id, or generates one automatically.
+    data:
+      legend_text: 'Do you have a passport?'
+      error_message: 'Please choose an option'
+      text: |
+        <!-- Use the radio component, this is hardcoded only for this example -->
+        <input type="radio" id="default2-yes" name="default2">
+        <label for="default2-yes">Yes</label>
+
+        <input type="radio" id="default2-no" name="default2">
+        <label for="default2-no">No</label>

--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -104,6 +104,19 @@ examples:
         value: 'option1'
       - text: 'Will make own arrangements'
         value: 'option2'
+  with_error_id_but_no_message:
+    description: For some selects the error message should be rendered separately but an error state is still required (currently required in smart answers). In this scenario an error_id can be passed without an error_message to highlight the component and set aria-describedby correctly.
+    data:
+      id: 'dropdown4-2'
+      label: 'What lunch option would you like?'
+      error_id: 'error_id'
+      options:
+      - text: ""
+        value: ""
+      - text: 'Vegetarian'
+        value: 'option1'
+      - text: 'Meat'
+        value: 'option2'
   full_width:
     description: Make the select width 100%. This is used for facets in finder-frontend's search.
     data:

--- a/spec/components/error_message_spec.rb
+++ b/spec/components/error_message_spec.rb
@@ -11,6 +11,12 @@ describe "Error message", type: :view do
     assert_select(".govuk-error-message", text: "Error: Please enter your National Insurance number")
   end
 
+  it "renders error message with a given ID" do
+    render_component(text: "Please enter your National Insurance number", id: "error_id")
+
+    assert_select(".govuk-error-message[id=error_id]")
+  end
+
   it "escapes HTML in items and allows HTML safe strings" do
     render_component(items: [
       { text: "Error where HTML is <strong>escaped</strong>" },

--- a/spec/components/fieldset_spec.rb
+++ b/spec/components/fieldset_spec.rb
@@ -30,4 +30,17 @@ describe "Fieldset", type: :view do
 
     assert_select ".govuk-fieldset__legend.govuk-fieldset__legend--xl"
   end
+
+  it "renders a fieldset with an error correctly" do
+    render_component(
+      legend_text: 'Do you have a passport?',
+      error_message: 'uh oh',
+      error_id: "error_id",
+      text: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vel ad neque, maxime est ea laudantium totam fuga!'
+    )
+
+    assert_select ".gem-c-fieldset.govuk-form-group.govuk-form-group--error"
+    assert_select ".govuk-fieldset[aria-describedby=error_id]"
+    assert_select ".gem-c-error-message[id=error_id]", text: 'Error: uh oh'
+  end
 end

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -206,6 +206,23 @@ describe "Select", type: :view do
     assert_select ".govuk-select.govuk-select--error[aria-describedby=error_id]"
   end
 
+  it "applies aria-describedby if an error is is given" do
+    render_component(
+      id: "mydropdown",
+      label: "My dropdown",
+      error_id: "error_id",
+      options: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway"
+        }
+      ]
+    )
+
+    assert_select ".gem-c-error-message.govuk-error-message", false
+    assert_select ".govuk-select.govuk-select--error[aria-describedby=error_id]"
+  end
+
   it "renders a select box full width" do
     render_component(
       id: "mydropdown",


### PR DESCRIPTION
## What
Allows the select component to appear in an error state and accept a given id for an error element (used for aria-describedby) but without an error message appearing. 

This PR also updates the doc and tests for the error message component - I needed to be able to pass an ID to it, it turns out you can already do that but it wasn't documented.

This PR also adds an error state to the fieldset component.

## Why
This is intended for use where the select component error message should be rendered separately from the component, which is needed in the [smart answers upgrade](https://github.com/alphagov/smart-answers/pull/4132).


## Visual Changes
This is the select component in the new state:

<img width="383" alt="Screen Shot 2019-09-26 at 16 12 59" src="https://user-images.githubusercontent.com/861310/65701030-8dba3980-e078-11e9-8824-3d81cb09bb88.png">

This the fieldset error state:

<img width="872" alt="Screen Shot 2019-09-26 at 16 06 27" src="https://user-images.githubusercontent.com/861310/65700578-d02f4680-e077-11e9-877a-3955e5edd1f2.png">

This is how all of this combined will look in smart answers:

<img width="589" alt="Screen Shot 2019-09-26 at 15 32 31" src="https://user-images.githubusercontent.com/861310/65700527-c0176700-e077-11e9-91b6-32d5466cca1f.png">

This change brings the component markup slightly more in line with the [markup from govuk-frontend](https://design-system.service.gov.uk/components/date-input/#error-messages), which wraps the fieldset element in a div. This has had the consequence of giving the component a bottom margin, but since this is a change from govuk-frontend I'm assuming it's okay.

## View Changes
https://govuk-publishing-compo-pr-1143.herokuapp.com/component-guide
