### PR TITLE
Add content security policy

### DIFF
--- a/app/controllers/govuk_publishing_components/application_controller.rb
+++ b/app/controllers/govuk_publishing_components/application_controller.rb
@@ -5,6 +5,17 @@ module GovukPublishingComponents
     before_action :set_x_frame_options_header
     before_action :set_disable_slimmer_header
 
+    content_security_policy do |p|
+      # don't do anything if the app doesn't have a content security policy
+      next unless p.directives.any?
+
+      # Unfortunately the axe core script uses a dependency that uses eval
+      # see: https://github.com/dequelabs/axe-core/issues/1175
+      # Thus all components shown by govuk_publishing_components need this
+      # enabled
+      p.script_src(*p.script_src, :unsafe_eval)
+    end
+
   private
 
     def set_x_frame_options_header

--- a/spec/dummy/config/initializers/content_security_policy.rb
+++ b/spec/dummy/config/initializers/content_security_policy.rb
@@ -1,0 +1,3 @@
+require "govuk_app_config"
+
+GovukContentSecurityPolicy.configure


### PR DESCRIPTION
This adds the GOV.UK security policy to the dummy application of this gem. This means that when using this app in dev or viewing it at https://components.publishing.service.gov.uk/component-guide the GOV.UK CSP will apply.

This also has to unfortunately allow unsafe-eval for JS so that the component-guide browser can use AXE. Relevant project issues:

- dequelabs/axe-core#1175
- olado/doT#276

This PR replaces https://github.com/alphagov/govuk_publishing_components/pull/913 by scaling down the ambition of disallowing inline scripts by the use of a nonce. Removing unsafe-inline will only be possible once we drop jQuery 1.x (this [code](https://github.com/jquery/jquery/blob/e09907ce152fb6ef7537a3733b1d65ead8ee6303/src/event/support.js#L7-L20) causes it).