### PR TITLE
Show code after preview in component guide

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -7,6 +7,8 @@
 @import "govuk/helpers/all";
 @import "govuk/core/all";
 
+$gem-guide-border-width: 1px;
+
 .component-guide-wrapper {
   padding-bottom: $govuk-gutter * 1.5;
 }
@@ -32,10 +34,6 @@
     display: block;
     margin-top: $govuk-gutter * 2;
   }
-}
-
-.component-body {
-  margin-bottom: $govuk-gutter * 1.5;
 }
 
 .component-guide-hidden {
@@ -86,13 +84,13 @@
 }
 
 .component-call {
-  margin-top: $govuk-gutter-half;
+  margin-top: -$gem-guide-border-width;
   margin-bottom: $govuk-gutter-half;
 
   font-family: Consolas, Monaco, "Andale Mono", monospace;
   font-size: 16px;
   line-height: 1.5;
-  border: 1px solid $govuk-border-colour;
+  border: $gem-guide-border-width solid $govuk-border-colour;
 
   &[contenteditable]:hover {
     cursor: text;
@@ -124,7 +122,7 @@
 
 .component-guide-preview {
   padding: ($govuk-gutter * 1.5) $govuk-gutter $govuk-gutter;
-  border: 1px solid $govuk-border-colour;
+  border: $gem-guide-border-width solid $govuk-border-colour;
   position: relative;
 
   &.direction-rtl {
@@ -165,7 +163,7 @@
 .component-guide-preview--violation,
 .component-guide-preview--warning {
   @include govuk-text-colour;
-  margin-top: $govuk-gutter-half;
+  margin-top: -$gem-guide-border-width;
 
   @include govuk-font($size: 19);
 

--- a/app/views/govuk_publishing_components/component_guide/example.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/example.html.erb
@@ -6,10 +6,10 @@
     <div class="component-markdown">
       <%= raw(@component_example.html_description) %>
     </div>
-    <h2 class="component-doc-h2">How to call this example</h2>
-    <%= render partial: "govuk_publishing_components/component_guide/component_doc/call", locals: { component_doc: @component_doc, example: @component_example } %>
-
     <h2 class="component-doc-h2">How it looks</h2>
     <%= render partial: "govuk_publishing_components/component_guide/component_doc/preview", locals: { component_doc: @component_doc, example: @component_example } %>
+
+    <h2 class="component-doc-h2">How to call this example</h2>
+    <%= render partial: "govuk_publishing_components/component_guide/component_doc/call", locals: { component_doc: @component_doc, example: @component_example } %>
   </div>
 </div>

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -16,19 +16,18 @@
           <div class="component-markdown">
             <%= raw(@component_doc.html_body) %>
           </div>
+
+          <p class="govuk-body"><%= link_to "Search for usage of this component on GitHub", @component_doc.github_search_url, class: "govuk-link" %></p>
         </div>
       <% end %>
     </div>
   </div>
 
-  <div class="component-doc">
-    <h2 class="component-doc-h2">How to call this component</h2>
-    <%= render "govuk_publishing_components/component_guide/component_doc/call", component_doc: @component_doc, example: @component_doc.example %>
-    <%= link_to "Search for usage on GitHub", @component_doc.github_search_url, class: "govuk-link" %>
-    <h2 class="component-doc-h2">How it looks</h2>
-  </div>
-
+  <h2 class="component-doc-h2">How it looks</h2>
   <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, example: @component_doc.example %>
+
+  <h2 class="component-doc-h2">How to call this component</h2>
+  <%= render "govuk_publishing_components/component_guide/component_doc/call", component_doc: @component_doc, example: @component_doc.example %>
 
   <% if @component_doc.govuk_frontend_components.any? %>
     <h2 class="component-doc-h2">GOV.UK Design System</h2>
@@ -68,8 +67,8 @@
           <div class="component-markdown">
             <%= raw(example.html_description) %>
           </div>
-          <%= render "govuk_publishing_components/component_guide/component_doc/call", component_doc: @component_doc, example: example %>
           <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, example: example %>
+          <%= render "govuk_publishing_components/component_guide/component_doc/call", component_doc: @component_doc, example: example %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
## What
This reorders the code and example blocks on the component guide page.

## Why
Because it matches the way examples are presented in the Design System and matches my mental model. I'm raising this with the assumption that this matches other peoples' mental model too 🙂

## Visual Changes

Live preview:
- [Before](https://components.publishing.service.gov.uk/component-guide/accordion)
- [After](https://govuk-publishing-compo-pr-1147.herokuapp.com/component-guide/accordion)

or scroll below:
<table>
  <tr><th>Before</th><th>After</ht></tr>
  <tr><td>

![components publishing service gov uk_component-guide_accordion](https://user-images.githubusercontent.com/788096/66031646-bf5d5580-e4fb-11e9-879c-50ec14a4811d.png)

</td><td>

![localhost_3212_component-guide_accordion](https://user-images.githubusercontent.com/788096/66031670-c8e6bd80-e4fb-11e9-8655-7cd529519ddf.png)


</td></tr>
</table>



## View Changes
https://govuk-publishing-compo-pr-1147.herokuapp.com/
