### PR TITLE
Make preview all link more prominent

### DIFF
--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -23,7 +23,9 @@
     </div>
   </div>
 
-  <h2 class="component-doc-h2">How it looks</h2>
+  <h2 class="component-doc-h2">How it looks
+    <small>(<a href="<%= component_preview_all_path(@component_doc.id) %>" class="govuk-link">preview all</a>)</small>
+  </h2>
   <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, example: @component_doc.example %>
 
   <h2 class="component-doc-h2">How to call this component</h2>
@@ -55,9 +57,7 @@
 
   <% if @component_doc.other_examples.any? %>
     <div class="examples">
-      <h2 class="component-doc-h2">Other examples
-        <small>(<a href="<%= component_preview_all_path(@component_doc.id) %>" class="govuk-link">preview all</a>)</small>
-      </h2>
+      <h2 class="component-doc-h2">Other examples</h2>
       <% @component_doc.other_examples.each do |example| %>
         <div class="component-example">
           <h3 class="example-title">


### PR DESCRIPTION
## What
Move the 'preview all' link to the first 'How it looks' heading, rather than the 'Other examples' heading.

## Why
Whenever I want to find this link I find it difficult. Also it previews all states of the component, not just the other examples.

## Visual Changes
It's now here:

![Screen Shot 2019-10-02 at 15 53 08](https://user-images.githubusercontent.com/861310/66055184-12033580-e52d-11e9-9c00-2e1b0d46d0ff.png)


## View Changes
https://govuk-publishing-compo-pr-1148.herokuapp.com/component-guide
