### PR TITLE
Replace regex with similar method from Rails

### DIFF
--- a/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
+++ b/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
@@ -18,9 +18,8 @@ module GovukPublishingComponents
         end
       end
 
-      # id should be lowercase, contain only numbers and letters and replace spaces with dashes
       def generate_step_nav_id(step_title)
-        step_title.downcase.tr(" ", "-").gsub(/[^a-z0-9\-\s]/i, '')
+        step_title.parameterize
       end
 
     private

--- a/spec/components/step_by_step_nav_spec.rb
+++ b/spec/components/step_by_step_nav_spec.rb
@@ -165,7 +165,7 @@ describe "step nav", type: :view do
 
     assert_select step1 + " #step-panel-step-1-1.gem-c-step-nav__panel"
     assert_select step1and + " #step-panel-step-1-and-2.gem-c-step-nav__panel"
-    assert_select step3 + "#step-3"
+    assert_select step3 + "#step-3-_"
   end
 
   it "renders correct list elements and includes length of lists" do

--- a/spec/lib/govuk_publishing_components/components/step_by_step_nav_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/step_by_step_nav_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GovukPublishingComponents::Presenters::StepByStepNavHelper do
 
     it "generates step nav ids correctly" do
       id = step_helper.generate_step_nav_id("This isn't a real step title - numb3rs okay?")
-      expect(id).to eql('this-isnt-a-real-step-title---numb3rs-okay')
+      expect(id).to eql('this-isn-t-a-real-step-title-numb3rs-okay')
     end
 
     it "generates a paragraph" do


### PR DESCRIPTION
https://apidock.com/rails/ActiveSupport/Inflector/parameterize

We want to be able to generate links to steps from other places on the site. Using the rails builtin methods for doing this seems like an easy way to converge - even if one of the existing tests does end up looking a little weird. (I'm not sure that 'Step 3?"`_!' is a piece of text that we're likely to see for real.)
