### PR TITLE
Add contextual guidance component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add contextual guidance component ([PR #1156](https://github.com/alphagov/govuk_publishing_components/pull/1156))
+
 ## 21.4.1
 
 * Add warning, file download and numbered steps icons that were originally fetched from govuk_frontend_toolkit ([PR #1154](https://github.com/alphagov/govuk_publishing_components/pull/1154))

--- a/app/assets/javascripts/govuk_publishing_components/components/contextual-guidance.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/contextual-guidance.js
@@ -6,28 +6,25 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   ContextualGuidance.prototype.start = function ($module) {
     this.$module = $module[0]
-
-    var fields = document.querySelectorAll(
-      '[data-contextual-guidance="' + this.$module.id + '"]'
-    )
-
-    for (var i = 0; i < fields.length; i++) {
-      fields[i].addEventListener('focus', this.handleFocus.bind(this))
-    }
+    this.$guidance = this.$module.querySelector('.gem-c-contextual-guidance__wrapper')
+    this.$inputId = this.$guidance.getAttribute('for')
+    this.$input = this.$module.querySelector('#' + this.$inputId)
+    if (!this.$input) return
+    this.$input.addEventListener('focus', this.handleFocus.bind(this))
   }
 
   ContextualGuidance.prototype.handleFocus = function (event) {
     this.hideAllGuidance()
     if (!event.target.dataset.contextualGuidanceHideOnly) {
-      this.$module.style.display = 'block'
+      this.$guidance.style.display = 'block'
     }
   }
 
   ContextualGuidance.prototype.hideAllGuidance = function () {
-    var guidances = document.querySelectorAll('[data-module="contextual-guidance"]')
+    var $guidances = document.querySelectorAll('.gem-c-contextual-guidance__wrapper')
 
-    for (var i = 0; i < guidances.length; i++) {
-      guidances[i].style.display = 'none'
+    for (var i = 0; i < $guidances.length; i++) {
+      $guidances[i].style.display = 'none'
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/components/contextual-guidance.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/contextual-guidance.js
@@ -11,9 +11,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       '[data-contextual-guidance="' + this.$module.id + '"]'
     )
 
-    fields.forEach(function (field) {
-      field.addEventListener('focus', this.handleFocus.bind(this))
-    }, this)
+    for (var i = 0; i < fields.length; i++) {
+      fields[i].addEventListener('focus', this.handleFocus.bind(this))
+    }
   }
 
   ContextualGuidance.prototype.handleFocus = function (event) {
@@ -26,9 +26,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   ContextualGuidance.prototype.hideAllGuidance = function () {
     var guidances = document.querySelectorAll('[data-module="contextual-guidance"]')
 
-    guidances.forEach(function (guidance) {
-      guidance.style.display = 'none'
-    })
+    for (var i = 0; i < guidances.length; i++) {
+      guidances[i].style.display = 'none'
+    }
   }
 
   Modules.ContextualGuidance = ContextualGuidance

--- a/app/assets/javascripts/govuk_publishing_components/components/contextual-guidance.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/contextual-guidance.js
@@ -1,0 +1,35 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function ContextualGuidance () { }
+
+  ContextualGuidance.prototype.start = function ($module) {
+    this.$module = $module[0]
+
+    var fields = document.querySelectorAll(
+      '[data-contextual-guidance="' + this.$module.id + '"]'
+    )
+
+    fields.forEach(function (field) {
+      field.addEventListener('focus', this.handleFocus.bind(this))
+    }, this)
+  }
+
+  ContextualGuidance.prototype.handleFocus = function (event) {
+    this.hideAllGuidance()
+    if (!event.target.dataset.contextualGuidanceHideOnly) {
+      this.$module.style.display = 'block'
+    }
+  }
+
+  ContextualGuidance.prototype.hideAllGuidance = function () {
+    var guidances = document.querySelectorAll('[data-module="contextual-guidance"]')
+
+    guidances.forEach(function (guidance) {
+      guidance.style.display = 'none'
+    })
+  }
+
+  Modules.ContextualGuidance = ContextualGuidance
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -27,6 +27,7 @@
 @import "components/checkboxes";
 @import "components/chevron-banner";
 @import "components/contents-list";
+@import "components/contextual-guidance";
 @import "components/cookie-banner";
 @import "components/copy-to-clipboard";
 @import "components/date-input";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-guidance.scss
@@ -1,0 +1,40 @@
+.govuk-grid-row:last-of-type .gem-c-contextual-guidance__wrapper {
+  position: relative;
+}
+
+.gem-c-contextual-guidance__wrapper {
+  position: relative;
+
+  @include govuk-font(19);
+
+  margin-bottom: govuk-spacing(7);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(7);
+    padding-top: govuk-spacing(6);
+  }
+}
+
+.js-enabled {
+  .gem-c-contextual-guidance__wrapper {
+    display: none;
+
+    @include govuk-media-query($from: tablet) {
+      position: absolute;
+      width: calc(100% - #{govuk-spacing(6)});
+    }
+  }
+}
+
+.gem-c-contextual-guidance {
+  padding-left: govuk-spacing(3);
+  border-left: 4px solid $govuk-focus-colour;
+  background: govuk-colour("white");
+
+  @include govuk-media-query($from: tablet) {
+    padding-top: govuk-spacing(5);
+    padding-left: 0;
+    border-top: 5px solid $govuk-focus-colour;
+    border-left: 0;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-guidance.scss
@@ -1,5 +1,14 @@
-.govuk-grid-row:last-of-type .gem-c-contextual-guidance__wrapper {
-  position: relative;
+.gem-c-contextual-guidance {
+  .govuk-grid-column-one-third {
+    position: relative;
+  }
+
+  &:last-of-type {
+    .gem-c-contextual-guidance__wrapper {
+      position: relative;
+      width: 100%;
+    }
+  }
 }
 
 .gem-c-contextual-guidance__wrapper {
@@ -26,7 +35,7 @@
   }
 }
 
-.gem-c-contextual-guidance {
+.gem-c-contextual-guidance__guidance {
   padding-left: govuk-spacing(3);
   border-left: 4px solid $govuk-focus-colour;
   background: govuk-colour("white");

--- a/app/views/govuk_publishing_components/components/_contextual_guidance.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_guidance.html.erb
@@ -6,17 +6,19 @@
   data_attributes[:module] = "contextual-guidance"
 %>
 
-<%= tag.div class: "govuk-grid-row" do %>
-  <%= tag.div class: "govuk-grid-column-two-thirds" do %>
-    <%= tag.div class: "gem-c-contextual-guidance__input-field" do %>
-      <%= yield %>
+<%= tag.div class: "gem-c-contextual-guidance", id: id, data: data_attributes do %>
+  <%= tag.div class: "govuk-grid-row" do %>
+    <%= tag.div class: "govuk-grid-column-two-thirds" do %>
+      <%= tag.div class: "gem-c-contextual-guidance__input-field" do %>
+        <%= yield %>
+      <% end %>
     <% end %>
-  <% end %>
-  <%= tag.div class: "govuk-grid-column-one-third" do %>
-    <%= tag.div class: "gem-c-contextual-guidance__wrapper", id: id, data: data_attributes do %>
-      <%= tag.div class: "gem-c-contextual-guidance" do %>
-        <%= tag.h2 title, class: "govuk-heading-s" %>
-        <%= content %>
+    <%= tag.div class: "govuk-grid-column-one-third" do %>
+      <%= tag.div class: "gem-c-contextual-guidance__wrapper", for: html_for do %>
+        <%= tag.div class: "gem-c-contextual-guidance__guidance" do %>
+          <%= tag.h2 title, class: "govuk-heading-s" %>
+          <%= content %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/_contextual_guidance.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_guidance.html.erb
@@ -1,13 +1,23 @@
 <%
   id ||= nil
   title ||= nil
+  content ||= nil
   data_attributes ||= {}
   data_attributes[:module] = "contextual-guidance"
 %>
 
-<%= tag.div class: "gem-c-contextual-guidance__wrapper", id: id, data: data_attributes do %>
-  <%= tag.div class: "gem-c-contextual-guidance" do %>
-    <%= tag.h2 title, class: "govuk-heading-s" %>
-    <%= yield %>
+<%= tag.div class: "govuk-grid-row" do %>
+  <%= tag.div class: "govuk-grid-column-two-thirds" do %>
+    <%= tag.div class: "gem-c-contextual-guidance__input-field" do %>
+      <%= yield %>
+    <% end %>
+  <% end %>
+  <%= tag.div class: "govuk-grid-column-one-third" do %>
+    <%= tag.div class: "gem-c-contextual-guidance__wrapper", id: id, data: data_attributes do %>
+      <%= tag.div class: "gem-c-contextual-guidance" do %>
+        <%= tag.h2 title, class: "govuk-heading-s" %>
+        <%= content %>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_contextual_guidance.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_guidance.html.erb
@@ -1,0 +1,13 @@
+<%
+  id ||= nil
+  title ||= nil
+  data_attributes ||= {}
+  data_attributes[:module] = "contextual-guidance"
+%>
+
+<%= tag.div class: "gem-c-contextual-guidance__wrapper", id: id, data: data_attributes do %>
+  <%= tag.div class: "gem-c-contextual-guidance" do %>
+    <%= tag.h2 title, class: "govuk-heading-s" %>
+    <%= yield %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/contextual_guidance.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_guidance.yml
@@ -1,10 +1,7 @@
 name: Contextual guidance
 description: Provides a container with additional information when focusing an input field (e.g. input, textarea)
 body: |
-  This component is build to be used with a focusable elements that refers to it.
-
-  The contextual guidance must have an id. The input must refer the contextual guidance using a `data-contextual-guidance`
-  attribute (e.g. `<input data-contextual-guidance="my-contextual-guidance-id">`).
+  This component is build to be used with an input field passed in as a block and must reference its ID using the `html_for` attribute.
 
   On tablet and desktop, the guidance container is set to float on the page and prevent other elements from moving around (e.g. pushing next fields down the page).
 part_of_admin_layout: true
@@ -20,10 +17,12 @@ examples:
   default:
     description: Reveals a contextul guidance on the side overflowing the container
     data:
-      id: news-title-guidance
+      html_for: news-title
       title: Writing a news title
       content: |
         <p>The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.</p>
       block: |
-        <label class="gem-c-label govuk-label" for="news-title">News title</label>
-        <input id="news-title" type="text" class="gem-c-input govuk-input" data-contextual-guidance="news-title-guidance">
+        <div class="govuk-form-group">
+          <label class="gem-c-label govuk-label" for="news-title">News title</label>
+          <input id="news-title" type="text" class="gem-c-input govuk-input">
+        </div>

--- a/app/views/govuk_publishing_components/components/docs/contextual_guidance.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_guidance.yml
@@ -1,0 +1,44 @@
+name: Contextual guidance
+description: Provides a container with additional information when focusing an input field (e.g. input, textarea)
+body: |
+  This component is build to be used with a focusable elements that refers to it.
+
+  The contextual guidance must have an id. The input must refer the contextual guidance using a `data-contextual-guidance`
+  attribute (e.g. `<input data-contextual-guidance="my-contextual-guidance-id">`).
+
+  On tablet and desktop, the guidance container is set to float on the page and prevent other elements from moving around (e.g. pushing next fields down the page).
+
+  To use this component in a form built using a grid layout, an `gem-c-contextual-guidance__form` class needs to be added to the wrapping `<form>` element.
+  When used like this the last guidance won't overflow in order to prevent it from overlapping with the footer.
+
+part_of_admin_layout: true
+accessibility_criteria: |
+  The component must:
+
+  * be hidden by default
+  * be visible when the associated input field if focused
+  * stay visible until another input field with guidance is being focused
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    description: Reveals a contextul guidance on the side overflowing the container
+    embed: |
+      <form class="gem-c-contextual-guidance__form">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-form-group">
+              <label for="title" class="govuk-label govuk-label--s">Title</label>
+              <input class="govuk-input" id="title" data-contextual-guidance="news-title-guidance" placeholder="Focus to reveal">
+            </div>
+          </div>
+          <div class="govuk-grid-column-one-third">
+            <%= component %>
+          </div>
+        </div>
+      </form>
+    data:
+      title: Writing a news title
+      id: news-title-guidance
+      block: |
+        The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.

--- a/app/views/govuk_publishing_components/components/docs/contextual_guidance.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_guidance.yml
@@ -7,10 +7,6 @@ body: |
   attribute (e.g. `<input data-contextual-guidance="my-contextual-guidance-id">`).
 
   On tablet and desktop, the guidance container is set to float on the page and prevent other elements from moving around (e.g. pushing next fields down the page).
-
-  To use this component in a form built using a grid layout, an `gem-c-contextual-guidance__form` class needs to be added to the wrapping `<form>` element.
-  When used like this the last guidance won't overflow in order to prevent it from overlapping with the footer.
-
 part_of_admin_layout: true
 accessibility_criteria: |
   The component must:
@@ -23,22 +19,11 @@ shared_accessibility_criteria:
 examples:
   default:
     description: Reveals a contextul guidance on the side overflowing the container
-    embed: |
-      <form class="gem-c-contextual-guidance__form">
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-form-group">
-              <label for="title" class="govuk-label govuk-label--s">Title</label>
-              <input class="govuk-input" id="title" data-contextual-guidance="news-title-guidance" placeholder="Focus to reveal">
-            </div>
-          </div>
-          <div class="govuk-grid-column-one-third">
-            <%= component %>
-          </div>
-        </div>
-      </form>
     data:
-      title: Writing a news title
       id: news-title-guidance
+      title: Writing a news title
+      content: |
+        <p>The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.</p>
       block: |
-        The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.
+        <label class="gem-c-label govuk-label" for="news-title">News title</label>
+        <input id="news-title" type="text" class="gem-c-input govuk-input" data-contextual-guidance="news-title-guidance">

--- a/spec/components/contextual_guidance_spec.rb
+++ b/spec/components/contextual_guidance_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe "Contextual guidance", type: :view do
+  def component_name
+    "contextual_guidance"
+  end
+
+  it "renders the contextual guidance" do
+    render_component({})
+
+    assert_select ".gem-c-contextual-guidance"
+  end
+
+  it "renders the contextual guidance with title and content" do
+    render_component(id: 'news-title-guidance', title: 'Writing a news title') do
+      tag.p "The title must make clear what the content offers users"
+    end
+
+    assert_select '.gem-c-contextual-guidance .govuk-heading-s', text: 'Writing a news title'
+    assert_select '.gem-c-contextual-guidance p', text: 'The title must make clear what the content offers users'
+  end
+end

--- a/spec/components/contextual_guidance_spec.rb
+++ b/spec/components/contextual_guidance_spec.rb
@@ -11,12 +11,17 @@ describe "Contextual guidance", type: :view do
     assert_select ".gem-c-contextual-guidance"
   end
 
-  it "renders the contextual guidance with title and content" do
-    render_component(id: 'news-title-guidance', title: 'Writing a news title') do
-      tag.p "The title must make clear what the content offers users"
+  it "renders the contextual guidance with input, title and content" do
+    render_component(
+      id: "news-title-guidance",
+      title: "Writing a news title",
+      content: sanitize("<p>The title must make clear what the content offers users</p>")
+    ) do
+      tag.input name: "news-title", type: "text", data: { "contextual-guidance": "news-title-guidance" }
     end
 
-    assert_select '.gem-c-contextual-guidance .govuk-heading-s', text: 'Writing a news title'
-    assert_select '.gem-c-contextual-guidance p', text: 'The title must make clear what the content offers users'
+    assert_select "input[name='news-title'][type='text'][data-contextual-guidance='news-title-guidance']"
+    assert_select ".gem-c-contextual-guidance .govuk-heading-s", text: "Writing a news title"
+    assert_select ".gem-c-contextual-guidance p", text: "The title must make clear what the content offers users"
   end
 end

--- a/spec/components/contextual_guidance_spec.rb
+++ b/spec/components/contextual_guidance_spec.rb
@@ -5,23 +5,24 @@ describe "Contextual guidance", type: :view do
     "contextual_guidance"
   end
 
-  it "renders the contextual guidance" do
-    render_component({})
-
-    assert_select ".gem-c-contextual-guidance"
+  it "fails to render when no html_for is given" do
+    assert_raises do
+      render_component({})
+    end
   end
 
   it "renders the contextual guidance with input, title and content" do
     render_component(
-      id: "news-title-guidance",
+      html_for: "news-title",
       title: "Writing a news title",
       content: sanitize("<p>The title must make clear what the content offers users</p>")
     ) do
-      tag.input name: "news-title", type: "text", data: { "contextual-guidance": "news-title-guidance" }
+      tag.input id: "news-title", name: "news-title", type: "text"
     end
 
-    assert_select "input[name='news-title'][type='text'][data-contextual-guidance='news-title-guidance']"
-    assert_select ".gem-c-contextual-guidance .govuk-heading-s", text: "Writing a news title"
-    assert_select ".gem-c-contextual-guidance p", text: "The title must make clear what the content offers users"
+    assert_select ".gem-c-contextual-guidance__input-field input[id='news-title'][name='news-title'][type='text']"
+    assert_select ".gem-c-contextual-guidance__wrapper[for='news-title']"
+    assert_select ".gem-c-contextual-guidance__guidance .govuk-heading-s", text: "Writing a news title"
+    assert_select ".gem-c-contextual-guidance__guidance p", text: "The title must make clear what the content offers users"
   end
 end

--- a/spec/javascripts/components/contextual-guidance-spec.js
+++ b/spec/javascripts/components/contextual-guidance-spec.js
@@ -9,21 +9,25 @@ describe('Contextual guidance component', function () {
   beforeEach(function () {
     container = document.createElement('div')
     container.innerHTML =
-      '<input id="document-title" type="text" class="gem-c-input govuk-input" data-contextual-guidance="document-title-guidance">' +
+      '<div id="document-title-guidance" class="gem-c-contextual-guidance" data-module="contextual-guidance">' +
+        '<input id="document-title" type="text" class="gem-c-input govuk-input">' +
 
-      '<div id="document-title-guidance" class="gem-c-contextual-guidance__wrapper" data-module="contextual-guidance">' +
-        '<div class="gem-c-contextual-guidance">' +
-        '<h2 class="govuk-heading-s">Title</h2>' +
-        '<p>The title should be unique and specific. It must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.</p>' +
+        '<div class="gem-c-contextual-guidance__wrapper" for="document-title">' +
+          '<div class="gem-c-contextual-guidance__guidance">' +
+            '<h2 class="govuk-heading-s">Title</h2>' +
+            '<p>The title should be unique and specific. It must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.</p>' +
+          '</div>' +
         '</div>' +
       '</div>' +
 
-      '<textarea id="document-summary" class="gem-c-textarea govuk-textarea" data-contextual-guidance="document-summary-guidance"></textarea>' +
+      '<div id="document-summary-guidance" class="gem-c-contextual-guidance" data-module="contextual-guidance">' +
+        '<textarea id="document-summary" class="gem-c-textarea govuk-textarea"></textarea>' +
 
-      '<div id="document-summary-guidance" class="gem-c-contextual-guidance__wrapper" data-module="contextual-guidance">' +
-        '<div class="gem-c-contextual-guidance">' +
-        '<h2 class="govuk-heading-s">Summary</h2>' +
-        '<p>The summary should explain the main point of the story. It is the first line of the story so don’t repeat it in the body and end with a full stop.</p>' +
+        '<div class="gem-c-contextual-guidance__wrapper" for="document-summary">' +
+          '<div class="gem-c-contextual-guidance__guidance">' +
+            '<h2 class="govuk-heading-s">Summary</h2>' +
+            '<p>The summary should explain the main point of the story. It is the first line of the story so don’t repeat it in the body and end with a full stop.</p>' +
+          '</div>' +
         '</div>' +
       '</div>'
 
@@ -41,9 +45,9 @@ describe('Contextual guidance component', function () {
 
   it('should show associated guidance on focus', function () {
     var title = document.getElementById('document-title')
-    var titleGuidance = document.getElementById('document-title-guidance')
+    var titleGuidance = document.querySelector('#document-title-guidance .gem-c-contextual-guidance__wrapper')
 
-    var summaryGuidance = document.getElementById('document-summary-guidance')
+    var summaryGuidance = document.querySelector('#document-summary-guidance .gem-c-contextual-guidance__wrapper')
 
     title.dispatchEvent(new window.Event('focus'))
 
@@ -53,10 +57,10 @@ describe('Contextual guidance component', function () {
 
   it('should hide associated guidance when another element is focused', function () {
     var title = document.getElementById('document-title')
-    var titleGuidance = document.getElementById('document-title-guidance')
+    var titleGuidance = document.querySelector('#document-title-guidance .gem-c-contextual-guidance__wrapper')
 
     var summary = document.getElementById('document-summary')
-    var summaryGuidance = document.getElementById('document-summary-guidance')
+    var summaryGuidance = document.querySelector('#document-summary-guidance .gem-c-contextual-guidance__wrapper')
 
     title.dispatchEvent(new window.Event('focus'))
     summary.dispatchEvent(new window.Event('focus'))

--- a/spec/javascripts/components/contextual-guidance-spec.js
+++ b/spec/javascripts/components/contextual-guidance-spec.js
@@ -1,0 +1,67 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+describe('Contextual guidance component', function () {
+  'use strict'
+
+  var container
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML =
+      '<input id="document-title" type="text" class="gem-c-input govuk-input" data-contextual-guidance="document-title-guidance">' +
+
+      '<div id="document-title-guidance" class="gem-c-contextual-guidance__wrapper" data-module="contextual-guidance">' +
+        '<div class="gem-c-contextual-guidance">' +
+        '<h2 class="govuk-heading-s">Title</h2>' +
+        '<p>The title should be unique and specific. It must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.</p>' +
+        '</div>' +
+      '</div>' +
+
+      '<textarea id="document-summary" class="gem-c-textarea govuk-textarea" data-contextual-guidance="document-summary-guidance"></textarea>' +
+
+      '<div id="document-summary-guidance" class="gem-c-contextual-guidance__wrapper" data-module="contextual-guidance">' +
+        '<div class="gem-c-contextual-guidance">' +
+        '<h2 class="govuk-heading-s">Summary</h2>' +
+        '<p>The summary should explain the main point of the story. It is the first line of the story so don’t repeat it in the body and end with a full stop.</p>' +
+        '</div>' +
+      '</div>'
+
+    document.body.classList.add('js-enabled')
+    document.body.appendChild(container)
+    var titleContextualGuidance = document.getElementById('document-title-guidance')
+    var summaryContextualGuidance = document.getElementById('document-summary-guidance')
+    new GOVUK.Modules.ContextualGuidance().start($(titleContextualGuidance))
+    new GOVUK.Modules.ContextualGuidance().start($(summaryContextualGuidance))
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
+  it('should show associated guidance on focus', function () {
+    var title = document.getElementById('document-title')
+    var titleGuidance = document.getElementById('document-title-guidance')
+
+    var summaryGuidance = document.getElementById('document-summary-guidance')
+
+    title.dispatchEvent(new window.Event('focus'))
+
+    expect(titleGuidance.style.display).toEqual('block')
+    expect(summaryGuidance.style.display).toEqual('none')
+  })
+
+  it('should hide associated guidance when another element is focused', function () {
+    var title = document.getElementById('document-title')
+    var titleGuidance = document.getElementById('document-title-guidance')
+
+    var summary = document.getElementById('document-summary')
+    var summaryGuidance = document.getElementById('document-summary-guidance')
+
+    title.dispatchEvent(new window.Event('focus'))
+    summary.dispatchEvent(new window.Event('focus'))
+
+    expect(titleGuidance.style.display).toEqual('none')
+    expect(summaryGuidance.style.display).toEqual('block')
+  })
+})


### PR DESCRIPTION
## What
This PR:
- moves the [contextual-guidance component from Content Publisher](https://content-publisher.integration.publishing.service.gov.uk/component-guide/contextual_guidance) to this gem.
- updates the component as follows:
  - ensures the component generates the required layout (2/3 for input 1/3 for guidance) - instead of relying on manually placing the components in the right structure
  - refactors the code so that the guidance refers to the input using a `for` attribute - instead of defining for each input what's the associated guidance and then querying it from there. This helps improving isolation for this component as no special attributes are need for the input fields.

### Notes to reviewer
The component was ported as-is in the first commit then updated on the following ones to make the refactor clearer. If you're not familiar with how the component worked in Content Publisher it may be a better idea to review the final changes. The updated version of this component was [tested in Content Publisher](https://github.com/alphagov/content-publisher/compare/contextual-guidance?expand=1) to ensure a clear upgrade path.

## Why
This component is needed in Collection Publisher to show guidance for various input fields.

## Visual Changes
No visual changes

## View Changes
https://govuk-publishing-compo-pr-1156.herokuapp.com/component-guide/contextual_guidance

[Trello card](https://trello.com/c/Ju8oaE5y)