### PR TITLE
Bring specific org focus states in line with others

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Bring specific org focus states in line with others ([PR #1158](https://github.com/alphagov/govuk_publishing_components/pull/1158))
+
 ## 21.5.0
 
 * Add contextual guidance component ([PR #1156](https://github.com/alphagov/govuk_publishing_components/pull/1156))

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -15,7 +15,7 @@
 
         &:hover,
         &:focus {
-          color: govuk-colour("black");
+          color: $govuk-focus-text-colour;
         }
       }
 
@@ -46,7 +46,7 @@
 
     &:hover,
     &:focus {
-      color: darken(govuk-organisation-colour("office-of-the-leader-of-the-house-of-commons"), 10%);
+      color: $govuk-focus-text-colour;
     }
   }
 
@@ -70,7 +70,7 @@
 
     &:hover,
     &:focus {
-      color: darken(govuk-colour("bright-purple"), 10%);
+      color: $govuk-focus-text-colour;
     }
   }
 


### PR DESCRIPTION
## What
We have some specific organisations which are styled separately. The hover and focus states for these organisations were set to remain as the brand colours, whereas all other organisations have text set to black on hover and focus. This brings those other organisations in line with the rest.

## Why
The branding hover and focus states should be consistent across organisations

## Visual Changes
### Hover state
<img width="588" alt="Screen Shot 2019-10-10 at 14 56 16" src="https://user-images.githubusercontent.com/29889908/66576753-26b87c80-eb70-11e9-8fee-8da152c1c19e.png">
<img width="591" alt="Screen Shot 2019-10-10 at 15 06 48" src="https://user-images.githubusercontent.com/29889908/66576754-26b87c80-eb70-11e9-8b68-14e469ced8f4.png">

### Focus state
<img width="589" alt="Screen Shot 2019-10-10 at 14 56 08" src="https://user-images.githubusercontent.com/29889908/66576795-389a1f80-eb70-11e9-9944-2f63136bfb6b.png">
<img width="592" alt="Screen Shot 2019-10-10 at 15 06 55" src="https://user-images.githubusercontent.com/29889908/66576796-3932b600-eb70-11e9-92db-8f3dc63503b4.png">