### PR TITLE
Allow individual components to be imported into apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow individual components to be imported into apps ([PR #1159](https://github.com/alphagov/govuk_publishing_components/pull/1159))
+
 ## 21.25.0
 
 * Make cookie banner text and preferences URL customisable ([PR #1310](https://github.com/alphagov/govuk_publishing_components/pull/1310))

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -7,6 +7,8 @@
 @import "govuk/helpers/all";
 @import "govuk/core/all";
 
+@import "govuk_publishing_components/all_components";
+
 $gem-guide-border-width: 1px;
 
 .component-list {

--- a/app/assets/stylesheets/govuk_publishing_components/component_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/component_support.scss
@@ -1,0 +1,11 @@
+// This file should be included in an application prior to specific components
+// It provides govuk-frontend and supporting gem component helpers and mixins
+
+@import "govuk/all";
+@import "govuk_publishing_components/components/helpers/variables";
+@import "govuk_publishing_components/components/helpers/brand-colours";
+@import "govuk_publishing_components/components/mixins/govuk-template-link-focus-override";
+@import "govuk_publishing_components/components/mixins/media-down";
+@import "govuk_publishing_components/components/mixins/margins";
+@import "govuk_publishing_components/components/mixins/clearfix";
+@import "govuk_publishing_components/components/mixins/css3";

--- a/app/assets/stylesheets/govuk_publishing_components/component_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/component_support.scss
@@ -1,7 +1,12 @@
 // This file should be included in an application prior to specific components
-// It provides govuk-frontend and supporting gem component helpers and mixins
+// It provides supporting gem component helpers and mixins
+// and everything else from govuk-frontend not included in govuk_frontend_support
+@import "govuk/core/all";
+@import "govuk/objects/all";
+@import "govuk/components/all";
+@import "govuk/utilities/all";
+@import "govuk/overrides/all";
 
-@import "govuk/all";
 @import "govuk_publishing_components/components/helpers/variables";
 @import "govuk_publishing_components/components/helpers/brand-colours";
 @import "govuk_publishing_components/components/mixins/govuk-template-link-focus-override";

--- a/app/assets/stylesheets/govuk_publishing_components/govuk-frontend.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/govuk-frontend.scss
@@ -1,0 +1,1 @@
+@import "govuk/all";

--- a/app/assets/stylesheets/govuk_publishing_components/govuk-frontend.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/govuk-frontend.scss
@@ -1,6 +1,0 @@
-@import "govuk_publishing_components/components/helpers/govuk-frontend-settings";
-@import "govuk_publishing_components/components/helpers/markdown-typography";
-@import "govuk/settings/all";
-@import "govuk/tools/all";
-@import "govuk/helpers/all";
-@import "govuk/core/all";

--- a/app/assets/stylesheets/govuk_publishing_components/govuk-frontend.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/govuk-frontend.scss
@@ -1,1 +1,6 @@
-@import "govuk/all";
+@import "govuk_publishing_components/components/helpers/govuk-frontend-settings";
+@import "govuk_publishing_components/components/helpers/markdown-typography";
+@import "govuk/settings/all";
+@import "govuk/tools/all";
+@import "govuk/helpers/all";
+@import "govuk/core/all";

--- a/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
@@ -1,0 +1,6 @@
+// This file should be included in an application prior to specific components
+// It provides govuk-frontend but adds no weight to the compiled CSS
+@import "components/helpers/govuk-frontend-settings";
+@import "govuk/settings/all";
+@import "govuk/tools/all";
+@import "govuk/helpers/all";

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -40,8 +40,8 @@ module GovukPublishingComponents
 
     def components_in_use_sass
       components_in_use.map { |component|
-        "@import 'govuk_publishing_components/components/#{component}';"
-      }.join("\n").prepend("@import 'govuk_publishing_components/govuk-frontend';\n")
+        "@import 'govuk_publishing_components/components/_#{component.gsub('_', '-')}';" if component_has_sass_file(component.gsub('_', '-'))
+      }.join("\n").squeeze("\n").prepend("@import 'govuk_publishing_components/component_support';\n")
     end
 
   private
@@ -64,10 +64,14 @@ module GovukPublishingComponents
       files = Dir["#{Rails.root}/app/views/**/*.html.erb"]
       files.each do |file|
         data = File.read(file)
-        matches << data.scan(/(govuk_publishing_components\/components\/[a-z_]+)/)
+        matches << data.scan(/(govuk_publishing_components\/components\/[a-z_-]+)/)
       end
 
-      matches.flatten.uniq.map(&:to_s).sort.map{ |m| m.gsub('govuk_publishing_components/components/', '') }
+      matches.flatten.uniq.map(&:to_s).sort.map { |m| m.gsub('govuk_publishing_components/components/', '') }
+    end
+
+    def component_has_sass_file(component)
+      Pathname.new(__dir__ + "/../../assets/stylesheets/govuk_publishing_components/components/_#{component}.scss").exist?
     end
 
     def index_breadcrumb

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -6,6 +6,7 @@ module GovukPublishingComponents
       @component_docs = component_docs.all
       @gem_component_docs = gem_component_docs.all
       @components_in_use_docs = components_in_use_docs.used_in_this_app
+      @components_in_use_sass = components_in_use_sass
     end
 
     def show
@@ -37,6 +38,12 @@ module GovukPublishingComponents
       end
     end
 
+    def components_in_use_sass
+      components_in_use.map { |component|
+        "@import 'govuk_publishing_components/components/#{component}';"
+      }.join("\n").prepend("@import 'govuk_publishing_components/govuk-frontend';\n")
+    end
+
   private
 
     def component_docs
@@ -60,7 +67,7 @@ module GovukPublishingComponents
         matches << data.scan(/(govuk_publishing_components\/components\/[a-z_]+)/)
       end
 
-      matches.flatten.uniq.map(&:to_s).map{ |m| m.gsub('govuk_publishing_components/components/', '') }
+      matches.flatten.uniq.map(&:to_s).sort.map{ |m| m.gsub('govuk_publishing_components/components/', '') }
     end
 
     def index_breadcrumb

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -6,7 +6,8 @@ module GovukPublishingComponents
       @component_docs = component_docs.all
       @gem_component_docs = gem_component_docs.all
       @components_in_use_docs = components_in_use_docs.used_in_this_app
-      @components_in_use_sass = components_in_use_sass
+      @components_in_use_sass = components_in_use_sass(false)
+      @components_in_use_print_sass = components_in_use_sass(true)
     end
 
     def show
@@ -38,9 +39,10 @@ module GovukPublishingComponents
       end
     end
 
-    def components_in_use_sass
+    def components_in_use_sass(print_styles)
+      print_path = "print/" if print_styles
       components_in_use.map { |component|
-        "@import 'govuk_publishing_components/components/_#{component.gsub('_', '-')}';" if component_has_sass_file(component.gsub('_', '-'))
+        "@import 'govuk_publishing_components/components/#{print_path}_#{component.gsub('_', '-')}';" if component_has_sass_file(component.gsub('_', '-'), print_styles)
       }.join("\n").squeeze("\n").prepend("@import 'govuk_publishing_components/component_support';\n")
     end
 
@@ -70,8 +72,9 @@ module GovukPublishingComponents
       matches.flatten.uniq.map(&:to_s).sort.map { |m| m.gsub('govuk_publishing_components/components/', '') }
     end
 
-    def component_has_sass_file(component)
-      Pathname.new(__dir__ + "/../../assets/stylesheets/govuk_publishing_components/components/_#{component}.scss").exist?
+    def component_has_sass_file(component, print_styles)
+      print_path = "print/" if print_styles
+      Pathname.new(__dir__ + "/../../assets/stylesheets/govuk_publishing_components/components/#{print_path}_#{component}.scss").exist?
     end
 
     def index_breadcrumb

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -41,9 +41,12 @@ module GovukPublishingComponents
 
     def components_in_use_sass(print_styles)
       print_path = "print/" if print_styles
+      additional_files = "@import 'govuk_publishing_components/govuk_frontend_support';\n"
+      additional_files << "@import 'govuk_publishing_components/component_support';\n" unless print_styles
+
       components_in_use.map { |component|
         "@import 'govuk_publishing_components/components/#{print_path}_#{component.gsub('_', '-')}';" if component_has_sass_file(component.gsub('_', '-'), print_styles)
-      }.join("\n").squeeze("\n").prepend("@import 'govuk_publishing_components/govuk_frontend_support';\n@import 'govuk_publishing_components/component_support';\n")
+      }.join("\n").squeeze("\n").prepend(additional_files)
     end
 
   private

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -43,7 +43,7 @@ module GovukPublishingComponents
       print_path = "print/" if print_styles
       components_in_use.map { |component|
         "@import 'govuk_publishing_components/components/#{print_path}_#{component.gsub('_', '-')}';" if component_has_sass_file(component.gsub('_', '-'), print_styles)
-      }.join("\n").squeeze("\n").prepend("@import 'govuk_publishing_components/component_support';\n")
+      }.join("\n").squeeze("\n").prepend("@import 'govuk_publishing_components/govuk_frontend_support';\n@import 'govuk_publishing_components/component_support';\n")
     end
 
   private

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -5,6 +5,7 @@ module GovukPublishingComponents
     def index
       @component_docs = component_docs.all
       @gem_component_docs = gem_component_docs.all
+      @components_in_use_docs = components_in_use_docs.used_in_this_app
     end
 
     def show
@@ -44,6 +45,22 @@ module GovukPublishingComponents
 
     def gem_component_docs
       @gem_component_docs ||= ComponentDocs.new(gem_components: true)
+    end
+
+    def components_in_use_docs
+      @components_in_use_docs ||= ComponentDocs.new(gem_components: true, limit_to: components_in_use)
+    end
+
+    def components_in_use
+      matches = []
+
+      files = Dir["#{Rails.root}/app/views/**/*.html.erb"]
+      files.each do |file|
+        data = File.read(file)
+        matches << data.scan(/(govuk_publishing_components\/components\/[a-z_]+)/)
+      end
+
+      matches.flatten.uniq.map(&:to_s).map{ |m| m.gsub('govuk_publishing_components/components/', '') }
     end
 
     def index_breadcrumb

--- a/app/models/govuk_publishing_components/component_docs.rb
+++ b/app/models/govuk_publishing_components/component_docs.rb
@@ -1,7 +1,8 @@
 module GovukPublishingComponents
   # @private
   class ComponentDocs
-    def initialize(gem_components: false)
+    def initialize(gem_components: false, limit_to: false)
+      @limit_to = limit_to
       @documentation_directory = gem_components ? gem_documentation_directory : app_documentation_directory
     end
 
@@ -14,6 +15,10 @@ module GovukPublishingComponents
       fetch_component_docs.map { |component| build(component) }.sort_by(&:name)
     end
 
+    def used_in_this_app
+      fetch_component_docs.map { |component| build(component) if component_in_use(component[:id]) }.compact.sort_by(&:name)
+    end
+
   private
 
     def build(component)
@@ -23,6 +28,10 @@ module GovukPublishingComponents
     def fetch_component_docs
       doc_files = Rails.root.join(@documentation_directory, "*.yml")
       Dir[doc_files].sort.map { |file| parse_documentation(file) }
+    end
+
+    def component_in_use(component)
+      return true if @limit_to.include?(component)
     end
 
     def fetch_component_doc(id)

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -17,8 +17,22 @@
 </form>
 
 <% unless ENV["MAIN_COMPONENT_GUIDE"] %>
-  <h2 class="component-doc-h2">Components in this application</h2>
+  <h2 class="component-doc-h2">Gem components used by this app (<%= @components_in_use_docs.length %>)</h2>
 
+  <ul class="component-list">
+    <% @components_in_use_docs.each do |component_doc| %>
+      <li>
+        <%= link_to component_doc.name, component_doc_path(component_doc.id), class: "govuk-link" %>
+        <p>
+          <%= component_doc.description %>
+        </p>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% unless ENV["MAIN_COMPONENT_GUIDE"] %>
+  <h2 class="component-doc-h2">Components in this application (<%= @component_docs.length %>)</h2>
   <ul class="component-list">
     <% @component_docs.each do |component_doc| %>
       <li>
@@ -30,7 +44,7 @@
     <% end %>
   </ul>
 
-  <h2 class="component-doc-h2">Components in the gem</h2>
+  <h2 class="component-doc-h2">All gem components (<%= @gem_component_docs.length %>)</h2>
 <% end %>
 
 <ul class="component-list">

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -19,6 +19,15 @@
 <% unless ENV["MAIN_COMPONENT_GUIDE"] %>
   <h2 class="component-doc-h2">Gem components used by this app (<%= @components_in_use_docs.length %>)</h2>
 
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Suggested Sass for this application"
+  } do %>
+    <pre><%= @components_in_use_sass %></pre>
+  <% end %>
+<pre>
+
+</pre>
+
   <ul class="component-list">
     <% @components_in_use_docs.each do |component_doc| %>
       <li>

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -22,7 +22,13 @@
   <%= render "govuk_publishing_components/components/details", {
     title: "Suggested Sass for this application"
   } do %>
-    <pre><%= @components_in_use_sass %></pre>
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: "Add this to your application's main scss file"
+      },
+      name: "more-detail",
+      value: @components_in_use_sass
+    } %>
   <% end %>
 <pre>
 

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -26,8 +26,15 @@
       label: {
         text: "Add this to your application's main scss file"
       },
-      name: "more-detail",
+      name: "main-sass",
       value: @components_in_use_sass
+    } %>
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: "Add this to your application's print scss file"
+      },
+      name: "print-sass",
+      value: @components_in_use_print_sass
     } %>
   <% end %>
 <pre>

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -43,6 +43,37 @@ describe 'Component guide index' do
     expect(page).to have_selector('script[src*="/assets/application"]', visible: false)
   end
 
+  it 'includes suggested sass for the application' do
+    visit '/component-guide'
+    expected_main_sass = "@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/component_support';
+
+@import 'govuk_publishing_components/components/_contextual-sidebar';
+@import 'govuk_publishing_components/components/_error-summary';
+@import 'govuk_publishing_components/components/_govspeak';
+@import 'govuk_publishing_components/components/_input';
+@import 'govuk_publishing_components/components/_layout-footer';
+@import 'govuk_publishing_components/components/_layout-for-admin';
+@import 'govuk_publishing_components/components/_layout-header';
+@import 'govuk_publishing_components/components/_skip-link';
+@import 'govuk_publishing_components/components/_tabs';
+@import 'govuk_publishing_components/components/_title';"
+
+    expected_print_sass = "@import 'govuk_publishing_components/govuk_frontend_support';
+
+@import 'govuk_publishing_components/components/print/_govspeak';
+@import 'govuk_publishing_components/components/print/_layout-footer';
+@import 'govuk_publishing_components/components/print/_layout-header';
+@import 'govuk_publishing_components/components/print/_skip-link';
+@import 'govuk_publishing_components/components/print/_title';"
+
+    expect(page).to have_selector('.component-doc-h2', text: 'Gem components used by this app (12)')
+    expect(page).to have_selector('.govuk-details__summary-text', text: 'Suggested Sass for this application')
+
+    expect(page.find(:css, 'textarea[name="main-sass"]', visible: false).value).to eq(expected_main_sass)
+    expect(page.find(:css, 'textarea[name="print-sass"]', visible: false).value).to eq(expected_print_sass)
+  end
+
   it 'creates a page for the component' do
     visit '/component-guide/test-component'
     expect(body).to include('A test component for the dummy app')


### PR DESCRIPTION
## What
Change the components gem to support the model proposed in [RFC 108](https://github.com/alphagov/govuk-rfcs/pull/110) where individual components are included in an application rather than all of them.

The Sass now contains two additional files necessary for applications when importing individual components:

- `govuk_frontend_support`, which contains general settings from the gem plus everything from govuk-frontend that adds no weight to the compiled CSS (settings, tools and helpers)
- `component_support`, which contains everything else from govuk-frontend, plus helpers and mixins from the gem used by various components

So an application would import both of these files, then the sass for the components it needs. This has been split into two files like this so that static can import the first one without incurring additional CSS size or duplication, while still being able to make use of govuk-frontend mixins and variables (we need this now we're removing toolkit from static).

The component guide's sass is separate and has been updated to include all components, since several are used.

The previous mechanism for including the gem's Sass is untouched, so this change should be backwards compatible.

## Why
See the RFC.

## Visual Changes

Visual changes to a component guide inside an application. Now generates a list of components at the top that are used by this application. Also added numbers to all of the headings.

<img width="938" alt="Screen Shot 2019-10-11 at 16 55 16" src="https://user-images.githubusercontent.com/861310/66666231-1a9fee00-ec48-11e9-9962-0790d615ace9.png">

Underneath this heading is a snippet of Sass that can be used in the app to replace the `@import all_components` line, again generated.

<img width="983" alt="Screenshot 2020-02-14 at 14 25 39" src="https://user-images.githubusercontent.com/861310/74539423-e9a53200-4f35-11ea-9c78-40c2e451d364.png">

## View Changes
https://govuk-publishing-compo-pr-1159.herokuapp.com/component-guide

## Impact of the change

I've done some testing to see what impact these changes have on CSS files in applications. Here's some early results.

Application | application.css | print.css
----------- | --------------- | ---------
finder-frontend | Before: 678 KB | Before: 36 KB
finder-frontend | After: 474 KB | After: 9 KB
government-frontend | Before: 692 KB | Before: 36 KB
government-frontend | After: 551 KB | After: 10 KB
collections | Before: 703 KB | Before: 35.6 KB
collections | After: 580 KB | After: 16.4 KB

We also want to check how long the Sass takes to compile compared to previously. Here are some numbers, but they seem to vary considerably between tests with the same app, so they may not be reliable.

These tests are done by:

- `bundle exec rake assets:clean`
- `rm -rf public/NAME-OF-APP/*`
- `time bundle exec rake assets:precompile`

Application | Current compile time | New compile time
----------- | --------------------- | ------------------
government-frontend | 1m57.699s | 0m36.342s
finder-frontend | 0m10.247s | 0m10.957s
collections | 1m3.144s | 1m23.469s

## The cookie banner question

The cookie banner is displayed from static. Currently, since every application pulls in every component, when a page is rendered the markup for the cookie banner comes from static but the styles come from the gem, via the app.

The new auto-generated list of sass files needed by an app therefore doesn't include the cookie banner, because the app doesn't use it. So I'm seeing the cookie banner unstyled when testing. There are two solutions:

- hard code the cookie banner sass into the suggested sass for every application
- import the cookie banner sass into static (this should be possible without extra imports, the sass seems to only depend on some govuk-frontend mixins, which static would have at that point)

Importing the cookie banner sass into static seems like the best option - it avoids duplication and puts the sass where it's actually used. This might need documenting somewhere when we change static to include these changes, I'm writing this to remind myself.