### PR TITLE
Fix manifest.js name in assets reference

### DIFF
--- a/app/assets/javascripts/component_guide/accessibility-test.js
+++ b/app/assets/javascripts/component_guide/accessibility-test.js
@@ -1,4 +1,4 @@
-//= require axe-core/axe.js
+//= require axe.js
 
 (function (window, document, axe) {
   window.GOVUK = window.GOVUK || {}

--- a/app/assets/javascripts/govuk_publishing_components/dependencies.js
+++ b/app/assets/javascripts/govuk_publishing_components/dependencies.js
@@ -2,7 +2,7 @@
 
 // This adds in javascript that initialises components and dependencies
 // that are provided by Slimmer in public frontend applications.
-// = require jquery/dist/jquery
+// = require jquery.js
 // = require ./modules.js
 
 $(document).ready(function () {

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,7 +1,10 @@
 return unless Rails.application.config.respond_to?(:assets)
 
 # GOV.UK Publishing Components assets
-Rails.application.config.assets.precompile  = %w( manifest.js )
+Rails.application.config.assets.precompile  += %w(
+  govuk_publishing_components_manifest.js
+  manifest.js
+)
 
 # GOV.UK Frontend assets
 Rails.application.config.assets.precompile += %w(

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,7 +1,7 @@
 return unless Rails.application.config.respond_to?(:assets)
 
 # GOV.UK Publishing Components assets
-Rails.application.config.assets.precompile  += %w(
+Rails.application.config.assets.precompile += %w(
   govuk_publishing_components_manifest.js
   manifest.js
 )
@@ -14,6 +14,7 @@ Rails.application.config.assets.precompile += %w(
 Rails.application.config.assets.paths += %W(
   #{__dir__}/../../node_modules/govuk-frontend/govuk/assets/images
   #{__dir__}/../../node_modules/govuk-frontend/govuk/assets/fonts
-  #{__dir__}/../../node_modules/govuk-frontend/
-  #{__dir__}/../../node_modules/
+  #{__dir__}/../../node_modules/govuk-frontend
+  #{__dir__}/../../node_modules/jquery/dist
+  #{__dir__}/../../node_modules/axe-core
 )


### PR DESCRIPTION
## What
This gem's `manifest.js` is used for the dummy app that runs the tests, for the gem assets it has a custom manifest [`govuk_publishing_components_manifest.js`](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/config/govuk_publishing_components_manifest.js) (presumably not to be confused with the other `manifest.js`), which is something that I've missed in #1160.

Since we're doing an assets clean-up I reference axe-core and jquery directly instead of adding the entire `node_modules` to the paths (which makes searching for assets exponentially longer).

## Why
To help all all apps (except for those who depend on `govuk_frontend_toolkit`) to render assets correctly and pass all tests.

## Visual Changes
None.