### PR TITLE
Add assets paths to precompile config

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -6,6 +6,37 @@ Rails.application.config.assets.precompile += %w(
   manifest.js
 )
 
+Rails.application.config.assets.precompile += %w(
+  component_guide/accessibility-test.js
+  component_guide/application.css
+  component_guide/application.js
+  component_guide/filter-components.js
+  component_guide/visual-regression.js
+  govuk_publishing_components/all_components.js
+  govuk_publishing_components/modules.js
+  govuk_publishing_components/vendor/modernizr.js
+  govuk_publishing_components/component_guide.css
+  govuk_publishing_components/favicon-development.png
+  govuk_publishing_components/favicon-example.png
+  govuk_publishing_components/favicon-integration.png
+  govuk_publishing_components/favicon-production.png
+  govuk_publishing_components/favicon-staging.png
+  govuk_publishing_components/govuk-logo.png
+  govuk_publishing_components/govuk-schema-placeholder-1x1.png
+  govuk_publishing_components/govuk-schema-placeholder-4x3.png
+  govuk_publishing_components/govuk-schema-placeholder-16x9.png
+  govuk_publishing_components/search-button.png
+  govuk_publishing_components/icon-file-download.svg
+  govuk_publishing_components/icon-important.svg
+  govuk_publishing_components/chevron-banner.svg
+  govuk_publishing_components/chevron-banner-focus.svg
+  govuk_publishing_components/chevron-banner-hover-border.svg
+  govuk_publishing_components/chevron-banner-hover.svg
+  govuk_publishing_components/chevron-banner-small.svg
+  govuk_publishing_components/chevron-banner-small-focus.svg
+  govuk_publishing_components/crests/*.png
+)
+
 # GOV.UK Frontend assets
 Rails.application.config.assets.precompile += %w(
   govuk-logotype-crown.png


### PR DESCRIPTION
## What
Add back assets removed in #1160 until we have a thorough understanding of how `manifest.js` works.

## Why
To make sure we don't end up with broken references in other apps.

## Visual Changes
No visual change

<!--
## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
-->
