### PR TITLE
Add component print styles

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -5,6 +5,7 @@
 
 @import "components/print/accordion";
 @import "components/print/attachment";
+@import "components/print/back-link";
 @import "components/print/contents-list";
 @import "components/print/feedback";
 @import "components/print/govspeak-html-publication";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -16,4 +16,5 @@
 @import "components/print/share-links";
 @import "components/print/step-by-step-nav-header";
 @import "components/print/step-by-step-nav";
+@import "components/print/textarea";
 @import "components/print/title";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -16,6 +16,7 @@
 @import "components/print/metadata";
 @import "components/print/search";
 @import "components/print/share-links";
+@import "components/print/skip-link";
 @import "components/print/step-by-step-nav-header";
 @import "components/print/step-by-step-nav";
 @import "components/print/textarea";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -19,5 +19,6 @@
 @import "components/print/skip-link";
 @import "components/print/step-by-step-nav-header";
 @import "components/print/step-by-step-nav";
+@import "components/print/subscription-links";
 @import "components/print/textarea";
 @import "components/print/title";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -12,6 +12,7 @@
 @import "components/print/govspeak-html-publication";
 @import "components/print/govspeak";
 @import "components/print/layout-header";
+@import "components/print/layout-footer";
 @import "components/print/search";
 @import "components/print/share-links";
 @import "components/print/step-by-step-nav-header";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -8,6 +8,7 @@
 @import "components/print/feedback";
 @import "components/print/govspeak-html-publication";
 @import "components/print/govspeak";
+@import "components/print/layout-header";
 @import "components/print/search";
 @import "components/print/share-links";
 @import "components/print/step-by-step-nav-header";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -8,6 +8,7 @@
 @import "components/print/feedback";
 @import "components/print/govspeak-html-publication";
 @import "components/print/govspeak";
+@import "components/print/search";
 @import "components/print/share-links";
 @import "components/print/step-by-step-nav-header";
 @import "components/print/step-by-step-nav";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -4,6 +4,7 @@
 @import "components/helpers/govuk-frontend-settings";
 
 @import "components/print/accordion";
+@import "components/print/attachment";
 @import "components/print/contents-list";
 @import "components/print/feedback";
 @import "components/print/govspeak-html-publication";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -22,3 +22,4 @@
 @import "components/print/subscription-links";
 @import "components/print/textarea";
 @import "components/print/title";
+@import "components/print/translation-nav";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -13,6 +13,7 @@
 @import "components/print/govspeak";
 @import "components/print/layout-header";
 @import "components/print/layout-footer";
+@import "components/print/metadata";
 @import "components/print/search";
 @import "components/print/share-links";
 @import "components/print/step-by-step-nav-header";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -6,6 +6,7 @@
 @import "components/print/accordion";
 @import "components/print/attachment";
 @import "components/print/back-link";
+@import "components/print/button";
 @import "components/print/contents-list";
 @import "components/print/feedback";
 @import "components/print/govspeak-html-publication";

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_attachment.scss
@@ -1,0 +1,3 @@
+.gem-c-attachment__thumbnail-image {
+  display: none;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_back-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_back-link.scss
@@ -1,0 +1,3 @@
+.gem-c-back-link {
+  display: none;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_button.scss
@@ -1,0 +1,12 @@
+.gem-c-button {
+  @include govuk-font(14);
+  display: inline-block;
+  padding: govuk-spacing(1);
+  border: solid 1px govuk-colour("black");
+  color: $govuk-text-colour;
+  text-decoration: none;
+}
+
+.govuk-button__start-icon {
+  display: none;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_layout-footer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_layout-footer.scss
@@ -1,0 +1,6 @@
+.gem-c-layout-footer {
+  .govuk-footer__inline-list,
+  .govuk-footer__section {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_layout-header.scss
@@ -1,0 +1,3 @@
+.gem-c-header__menu-button {
+  display: none;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_metadata.scss
@@ -1,0 +1,6 @@
+.gem-c-metadata {
+  .gem-c-metadata__definition-link,
+  .gem-c-metadata__toggle-wrap {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_search.scss
@@ -1,0 +1,3 @@
+.gem-c-search {
+  display: none;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_skip-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_skip-link.scss
@@ -1,0 +1,3 @@
+.gem-c-skip-link {
+  display: none;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_subscription-links.scss
@@ -1,0 +1,3 @@
+.gem-c-subscription-links {
+  display: none;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_textarea.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_textarea.scss
@@ -1,0 +1,13 @@
+.gem-c-textarea {
+  .gem-c-label,
+  .gem-c-error-message,
+  .govuk-hint,
+  .govuk-character-count__message {
+    display: block;
+  }
+
+  .govuk-textarea {
+    width: 400px;
+    height: 40px;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_translation-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_translation-nav.scss
@@ -1,0 +1,3 @@
+.gem-c-translation-nav {
+  display: none;
+}

--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -10,6 +10,7 @@
     <%= csrf_meta_tags %>
     <%= favicon_link_tag "govuk_publishing_components/favicon-#{environment}.png" %>
     <%= stylesheet_link_tag "application" %>
+    <%= stylesheet_link_tag "print", media: print %>
     <%= javascript_include_tag "govuk_publishing_components/vendor/modernizr" %>
     <%= yield :head %>
   </head>


### PR DESCRIPTION
## What
We seem to be missing some print stylesheets for some components, where print styles would be sensible. This PR adds some.

## Why
People print pages on GOV.UK.

## Visual Changes
Screenshots are a bit pointless because most of these changes involve hiding things, but here's a summary.

- [attachment](https://govuk-publishing-compo-pr-1164.herokuapp.com/component-guide/attachment/preview): hide the icon (not sure about this one, should we hide the entire component?)
- [back link](https://govuk-publishing-compo-pr-1164.herokuapp.com/component-guide/back_link/preview): hide completely
- [button](https://govuk-publishing-compo-pr-1164.herokuapp.com/component-guide/button/preview): make all buttons look the same (and like buttons, see below)
- [textarea](https://govuk-publishing-compo-pr-1164.herokuapp.com/component-guide/textarea/preview): general tidy (see below)
- [layout footer](https://govuk-publishing-compo-pr-1164.herokuapp.com/component-guide/layout_footer/preview): hide everything but the OGL and copyright lines
- [layout header](https://govuk-publishing-compo-pr-1164.herokuapp.com/component-guide/layout_header/preview): minor change, hide the 'menu' button
- [metadata](https://govuk-publishing-compo-pr-1164.herokuapp.com/component-guide/metadata/preview): hide toggle and show all updates links
- [search component](https://govuk-publishing-compo-pr-1164.herokuapp.com/component-guide/search/preview): hide completely when printed
- [skip link](https://govuk-publishing-compo-pr-1164.herokuapp.com/component-guide/skip_link/preview): hide it
- [subscription links](https://govuk-publishing-compo-pr-1164.herokuapp.com/component-guide/subscription-links/preview): hide them
- [translation nav](https://govuk-publishing-compo-pr-1164.herokuapp.com/component-guide/translation-nav/preview): hide them

Things I've not added print styles for:

- I was originally going to hide all form elements (particularly the file upload component) but then realised people might actually want to print a form so they can see what fields they need so decided it was better to leave them all visible
- I wanted to add print styles for the details component (the contents of a collapsed one are not shown in print) but apparently this isn't as simple as it might sound, so I've not done that for now
- in theory if a modal dialog is open and someone prints the page it should be visible but as I don't think this is being used on public GOV.UK I don't think it's important right now
- I assumed next and previous navigation wouldn't be needed when printed but it can contain information about the following and preceding pages, so I've left it visible
- I wanted to hide the tabs part of the tabs component (but leave the content visible) but for some reason I can't fathom that caused a test to fail. I wasn't 100% sure about the change anyway, so I've not gone ahead with it for now

## Screenshots

Component | Before | After
------ | ------- | -------
Button | <img width="409" alt="Screen Shot 2019-10-16 at 08 42 54" src="https://user-images.githubusercontent.com/861310/66898610-6c05ff80-eff1-11e9-99db-d723d76f6e3a.png"> | <img width="354" alt="Screen Shot 2019-10-16 at 08 42 30" src="https://user-images.githubusercontent.com/861310/66898711-9952ad80-eff1-11e9-8865-e0b03e4c3967.png">
Textarea | <img width="418" alt="Screen Shot 2019-10-16 at 09 17 52" src="https://user-images.githubusercontent.com/861310/66925179-dd5ea600-f023-11e9-8dc3-72fa44266f7a.png"> | <img width="469" alt="Screen Shot 2019-10-16 at 09 18 06" src="https://user-images.githubusercontent.com/861310/66925194-e2bbf080-f023-11e9-9de0-f796826df3ca.png">




## View Changes
https://govuk-publishing-compo-pr-1164.herokuapp.com/component-guide

This PR is related to https://github.com/alphagov/govuk-frontend/issues/573