### PR TITLE
Disable concurrent export

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -49,3 +49,9 @@ Rails.application.config.assets.paths += %W(
   #{__dir__}/../../node_modules/jquery/dist
   #{__dir__}/../../node_modules/axe-core
 )
+
+# Disable concurency otherwise the assets will be compiled in a random order
+# resulting in failures where, for example, a mixin is called but not yet compiled
+Rails.application.config.assets.configure do |environment|
+  environment.export_concurrent = false
+end


### PR DESCRIPTION
## What
Disable concurrent export.

## Why
Otherwise the assets will be compiled in a random order resulting in failures where, for example, a mixin is called but not yet compiled.

Our [current issue in the CI](https://github.com/sass/sassc-rails/issues/121)
Other [issues related to concurrency in Sprockets 4](https://github.com/rails/sprockets/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+thread+OR+concurrent)