### PR TITLE
Release 22.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 22.0.0
+
+* BREAKING: Update to Sprockets 4 ([PR #1160](https://github.com/alphagov/govuk_publishing_components/pull/1160))
+  You must make the following changes when you migrate to this release:
+  - Check application assets and make sure they are [declared in the `manifest.js`](https://github.com/rails/sprockets/blob/master/UPGRADING.md#manifestjs)
+  - Check reference paths against [assets.paths declarations in govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/blob/master/config/initializers/assets.rb#L15-L19) and update accordingly.
+
 ## 21.5.1
 
 * Bring specific org focus states in line with others ([PR #1158](https://github.com/alphagov/govuk_publishing_components/pull/1158))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.5.1)
+    govuk_publishing_components (22.0.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -245,7 +245,7 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    rubocop (0.75.0)
+    rubocop (0.75.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
@@ -273,8 +273,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.58.0)
-      rake (>= 0.9, < 13)
+    scss_lint (0.59.0)
       sass (~> 3.5, >= 3.5.5)
     selenium-webdriver (3.142.3)
       childprocess (>= 0.5, < 2.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.5.1'.freeze
+  VERSION = '22.0.0'.freeze
 end


### PR DESCRIPTION
## 22.0.0

* BREAKING: Update to Sprockets 4 ([PR #1160](https://github.com/alphagov/govuk_publishing_components/pull/1160))
  You must make the following changes when you migrate to this release:
  - Check application assets and make sure they are [declared in the `manifest.js`](https://github.com/rails/sprockets/blob/master/UPGRADING.md#manifestjs)
  - Check reference paths against [assets.paths declarations in govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/blob/master/config/initializers/assets.rb#L15-L19) and update accordingly.

This release was tested locally with: [calendars](https://github.com/alphagov/calendars), [collections](https://github.com/alphagov/collections), [email-alert-frontend](https://github.com/alphagov/email-alert-frontend), [feedback](https://github.com/alphagov/feedback) and [finder-frontend](https://github.com/alphagov/finder-frontend).