### PR TITLE
Add inverse option to translation component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add component print styles ([PR #1164](https://github.com/alphagov/govuk_publishing_components/pull/1164))
 * Bring specific org focus states in line with others ([PR #1158](https://github.com/alphagov/govuk_publishing_components/pull/1158))
+* Add inverse option to translation component ([PR #1173](https://github.com/alphagov/govuk_publishing_components/pull/1173))
 
 ## 21.5.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_translation-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_translation-nav.scss
@@ -34,6 +34,19 @@
   @extend %govuk-link;
 }
 
+.gem-c-translation-nav--inverse {
+  border-color: govuk-colour("white");
+
+  .gem-c-translation-nav__list-item,
+  .gem-c-translation-nav__link {
+    color: govuk-colour("white");
+
+    &:focus {
+      color: govuk-colour("black");
+    }
+  }
+}
+
 .gem-c-translation-nav__list-item:last-child {
   border-right: 0;
   border-left: 0;

--- a/app/views/govuk_publishing_components/components/_translation-nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_translation-nav.html.erb
@@ -5,7 +5,7 @@
 %>
 <% if translation_helper.has_translations? %>
   <nav role="navigation"
-    class="gem-c-translation-nav <%= translation_helper.margin_class %> <%= brand_helper.brand_class %>"
+    class="gem-c-translation-nav <%= translation_helper.classes %> <%= brand_helper.brand_class %>"
     aria-label="<%= t("common.translations") %>"
     <%= "data-module=\"track-click\"" if translation_helper.tracking_is_present? %>
   >

--- a/app/views/govuk_publishing_components/components/docs/translation-nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/translation-nav.yml
@@ -107,4 +107,31 @@ examples:
           track_options:
             dimension28: 1
             dimension29: 'dimension29Welsh'
+  inverse:
+    data:
+      inverse: true
+      translations:
+      - locale: 'en'
+        base_path: '/en'
+        text: 'English'
+        active: true
+        data_attributes:
+          track_category: 'categoryEnglish'
+          track_action: 1.1
+          track_label: 'labelEnglish'
+          track_options:
+            dimension28: 1
+            dimension29: 'dimension29English'
+      - locale: 'cy'
+        base_path: '/cy'
+        text: 'Cymraeg'
+        data_attributes:
+          track_category: 'categoryWelsh'
+          track_action: 1.2
+          track_label: 'labelWelsh'
+          track_options:
+            dimension28: 1
+            dimension29: 'dimension29Welsh'
+    context:
+      dark_background: true
 

--- a/lib/govuk_publishing_components/presenters/translation_nav_helper.rb
+++ b/lib/govuk_publishing_components/presenters/translation_nav_helper.rb
@@ -7,6 +7,7 @@ module GovukPublishingComponents
         @translations = []
         @translations = local_assigns[:translations] if local_assigns[:translations]
         @no_margin_top = local_assigns[:no_margin_top]
+        @inverse = local_assigns[:inverse]
       end
 
       def has_translations?
@@ -20,8 +21,19 @@ module GovukPublishingComponents
         false
       end
 
+      def classes
+        classes = %w(gem-c-translation-nav)
+        classes << inverse_class if @inverse
+        classes << margin_class if @no_margin_top
+        classes.join(" ")
+      end
+
+      def inverse_class
+        "gem-c-translation-nav--inverse"
+      end
+
       def margin_class
-        "gem-c-translation-nav--no-margin-top" if @no_margin_top
+        "gem-c-translation-nav--no-margin-top"
       end
     end
   end

--- a/spec/components/translation_nav_spec.rb
+++ b/spec/components/translation_nav_spec.rb
@@ -87,4 +87,9 @@ describe "Translation nav", type: :view do
     render_component(translations: multiple_translations, no_margin_top: true)
     assert_select ".gem-c-translation-nav--no-margin-top"
   end
+
+  it "renders as inverse when option passed" do
+    render_component(translations: multiple_translations, inverse: true)
+    assert_select ".gem-c-translation-nav--inverse"
+  end
 end


### PR DESCRIPTION
## What
Add inverse option to translation component so it displays as white text when the flag is passed. This can be used when using the component on a darker background

## Why
We have a use case for using the translation component on a darker background.

<img width="982" alt="Screen Shot 2019-10-21 at 12 14 00" src="https://user-images.githubusercontent.com/29889908/67200642-49625500-f3fc-11e9-9cdc-62a8950f9df9.png">

https://govuk-publishing-compo-pr-1173.herokuapp.com/component-guide/translation_nav
