### PR TITLE
Version 21.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.6.0
 
 * Add component print styles ([PR #1164](https://github.com/alphagov/govuk_publishing_components/pull/1164))
 * Bring specific org focus states in line with others ([PR #1158](https://github.com/alphagov/govuk_publishing_components/pull/1158))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.5.0)
+    govuk_publishing_components (21.6.0)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.5.0'.freeze
+  VERSION = '21.6.0'.freeze
 end


### PR DESCRIPTION
Includes:
* Add component print styles ([PR #1164](https://github.com/alphagov/govuk_publishing_components/pull/1164))
* Bring specific org focus states in line with others ([PR #1158](https://github.com/alphagov/govuk_publishing_components/pull/1158))
* Add inverse option to translation component ([PR #1173](https://github.com/alphagov/govuk_publishing_components/pull/1173))

This version also contains the rollback of the sprockets update, as it was causing problems in our frontend applications.