### PR TITLE
Add essential cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## UNRELEASED
+
+* Add a new essential cookie to the acceptance list ([PR #1175](https://github.com/alphagov/govuk_publishing_components/pull/1175))
+
 ## 21.6.0
 
 * Add component print styles ([PR #1164](https://github.com/alphagov/govuk_publishing_components/pull/1164))

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -17,6 +17,7 @@
     'govuk_not_first_visit': 'essential',
     'govuk_browser_upgrade_dismisssed': 'essential',
     'seen_cookie_message': 'essential',
+    'cookie_preferences_set': 'essential',
     'govuk_surveySeenUserSatisfactionSurvey': 'essential',
     'govuk_takenUserSatisfactionSurvey': 'essential',
     '_email-alert-frontend_session': 'essential',


### PR DESCRIPTION
It is now necessary to not pre-select options on the cookie preferences
form unless the user has explicitly set them. This cookie is used to
check whether they have done so.
