### PR TITLE
Add GovernmentService schema.org schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Don't include changes that are purely internal. The CHANGELOG should be a
   useful summary for people upgrading their application, not a replication
   of the commit log.
+  
+## Unreleased
+
+* Add GovernmentService schema.org schema to machine readable metadata component ([PR #1177](https://github.com/alphagov/govuk_publishing_components/pull/1177))
 
 ## 21.6.1
 

--- a/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
@@ -62,6 +62,14 @@ examples:
         <p>Your next of kin may need a strong stomach</p>
       schema: :faq
       canonical_url: https://www.gov.uk/how-to-train-your-dragon
+  government_service_schema:
+    data:
+      content_item:
+        title: "Apply for your first dragon"
+        base_path: "/apply-for-your-first-dragon"
+        description: "Apply for your first dragon from the Ministry of Dragons online"
+        details: {}
+      schema: :government_service
   person_schema:
     data:
       content_item:

--- a/lib/govuk_publishing_components/presenters/machine_readable/government_service_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/government_service_schema.rb
@@ -1,0 +1,62 @@
+module GovukPublishingComponents
+  module Presenters
+    class GovernmentServiceSchema
+      attr_reader :page
+
+      def initialize(page)
+        @page = page
+      end
+
+      def structured_data
+        # http://schema.org/GovernmentService
+        {
+          "@context" => "http://schema.org",
+          "@type" => "GovernmentService",
+          "name" => page.title,
+          "description" => page.description,
+          "url" => page.canonical_url
+        }
+          .merge(provider)
+          .merge(related_services)
+      end
+
+    private
+
+      def related_services
+        related_links = page.content_item.dig('links', 'ordered_related_items')
+
+        return {} unless related_links.present?
+
+        {
+          "isRelatedTo" => related_links.each_with_object([]) do |link, items|
+            if link['schema_name'] == 'transaction'
+              items << {
+                "@type" => "GovernmentService",
+                "name" => link['title'],
+                "url" => link['web_url']
+              }
+            end
+          end
+        }
+      end
+
+      def provider
+        organisations = page.content_item.dig('links', 'organisations')
+
+        return {} unless organisations.present?
+
+        providers = organisations.map do |organisation|
+          {
+            "@type" => "GovernmentOrganization",
+            "name" => organisation['title'],
+            "url" => organisation['web_url']
+          }
+        end
+
+        {
+          "provider" => providers
+        }
+      end
+    end
+  end
+end

--- a/lib/govuk_publishing_components/presenters/schema_org.rb
+++ b/lib/govuk_publishing_components/presenters/schema_org.rb
@@ -2,6 +2,7 @@ require 'govuk_publishing_components/presenters/machine_readable/page'
 require 'govuk_publishing_components/presenters/machine_readable/article_schema'
 require 'govuk_publishing_components/presenters/machine_readable/creative_work_schema'
 require 'govuk_publishing_components/presenters/machine_readable/faq_page_schema'
+require 'govuk_publishing_components/presenters/machine_readable/government_service_schema'
 require 'govuk_publishing_components/presenters/machine_readable/has_part_schema'
 require 'govuk_publishing_components/presenters/machine_readable/is_part_of_schema'
 require 'govuk_publishing_components/presenters/machine_readable/news_article_schema'
@@ -24,6 +25,8 @@ module GovukPublishingComponents
           FaqPageSchema.new(page).structured_data
         elsif page.schema == :article
           ArticleSchema.new(page).structured_data
+        elsif page.schema == :government_service
+          GovernmentServiceSchema.new(page).structured_data
         elsif page.schema == :news_article
           NewsArticleSchema.new(page).structured_data
         elsif page.schema == :person


### PR DESCRIPTION
## What

This PR adds a new `GovernmentService` schema to be used by the machine readable metadata component. At the moment this is a basic skeleton of a schema, which will be iterated upon as we build out the data used to power it.

Trello: https://trello.com/c/g6uvswCG/69-add-governmentservice-schema-to-transaction-pages

## Why

So that we can use the `GovernmentService` schema to help improve results shown on search engines.

## Visual Changes

Example outputs of this schema run against Google's Structured Data Testing Tool

Book your driving test

![Screenshot 2019-10-24 at 15 21 20](https://user-images.githubusercontent.com/5422487/67494931-fd204a80-f671-11e9-80d7-7e634ee27426.png)

Apply for or renew a Blue Badge

![Screenshot 2019-10-24 at 15 38 27](https://user-images.githubusercontent.com/5422487/67496638-9e100500-f674-11e9-9efd-5577cf89872f.png)

## View Changes

https://govuk-publishing-compo-pr-1177.herokuapp.com/