### PR TITLE
Fix media print for admin layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix print styles applying to all media in admin layout ([PR #1178](https://github.com/alphagov/govuk_publishing_components/pull/1178))
+
 ## 21.6.1
 
 * Add a new essential cookie to the acceptance list ([PR #1175](https://github.com/alphagov/govuk_publishing_components/pull/1175))

--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -10,7 +10,7 @@
     <%= csrf_meta_tags %>
     <%= favicon_link_tag "govuk_publishing_components/favicon-#{environment}.png" %>
     <%= stylesheet_link_tag "application" %>
-    <%= stylesheet_link_tag "print", media: print %>
+    <%= stylesheet_link_tag "print", media: "print" %>
     <%= javascript_include_tag "govuk_publishing_components/vendor/modernizr" %>
     <%= yield :head %>
   </head>


### PR DESCRIPTION
This was previously referring to an uninitialised variable and thus had
a value of nil meaning no media type was being set.

This had the effect of overwriting button styling causing broken looking pages.

## What
This fixes a bug where the print stylesheet was not having the media set to "print" was instead set to an uninitialised variable.

## Why

This was breaking apps that use the admin layout.

## Visual Changes

Before:

<img width="1552" alt="Screenshot 2019-10-24 at 12 56 06" src="https://user-images.githubusercontent.com/282717/67483635-233bef80-f65e-11e9-8274-be305185b164.png">


After:

<img width="1552" alt="Screenshot 2019-10-24 at 12 58 41" src="https://user-images.githubusercontent.com/282717/67483633-20d99580-f65e-11e9-9f36-983949d6dcb2.png">