### PR TITLE
Version 21.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
   
-## Unreleased
+## 21.7.0
 
 * Add GovernmentService schema.org schema to machine readable metadata component ([PR #1177](https://github.com/alphagov/govuk_publishing_components/pull/1177))
-
-## Unreleased
-
 * Fix print styles applying to all media in admin layout ([PR #1178](https://github.com/alphagov/govuk_publishing_components/pull/1178))
 
 ## 21.6.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.6.1)
+    govuk_publishing_components (21.7.0)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.6.1'.freeze
+  VERSION = '21.7.0'.freeze
 end


### PR DESCRIPTION
This PR bumps govuk_publishing_components to version `21.7.0`.