### PR TITLE
Update edit link text on summary-list

### DIFF
--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -41,8 +41,7 @@
                                   class: "govuk-link",
                                   title: "Change #{item[:field]}",
                                   data: item[:edit].fetch(:data_attributes, {}) do %>
-                        Change <%= tag.span item[:field], class: "govuk-visually-hidden" %>
-                      <% end %>
+                        Change<%= tag.span " " + item[:field], class: "govuk-visually-hidden" %><% end %>
                     <% end %>
                   <% end %>
                   <% if item.fetch(:delete, {}).any? %>
@@ -51,7 +50,7 @@
                                   class: "govuk-link",
                                   title: "Delete #{item[:field]}",
                                   data: item[:delete].fetch(:data_attributes, {}) do %>
-                        Delete <%= tag.span item[:field], class: "govuk-visually-hidden" %>
+                        Delete<%= tag.span " " +  item[:field], class: "govuk-visually-hidden" %>
                       <% end %>
                     <% end %>
                   <% end %>

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -15,9 +15,9 @@
           <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
             <%= link_to edit.fetch(:href),
                       class: "govuk-link gem-c-summary-list__edit-section-link",
-                      title: "#{edit.fetch(:link_text, "Edit")} #{title}",
+                      title: "#{edit.fetch(:link_text, "Change")} #{title}",
                       data: edit.fetch(:data_attributes, {}) do %>
-               <%= edit.fetch(:link_text, "Edit") %> <%= tag.span title, class: "govuk-visually-hidden" %>
+               <%= edit.fetch(:link_text, "Change") %> <%= tag.span title, class: "govuk-visually-hidden" %>
             <% end %>
           <% end %>
         <% end %>
@@ -39,9 +39,9 @@
                     <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
                       <%= link_to item[:edit].fetch(:href),
                                   class: "govuk-link",
-                                  title: "Edit #{item[:field]}",
+                                  title: "Change #{item[:field]}",
                                   data: item[:edit].fetch(:data_attributes, {}) do %>
-                        Edit <%= tag.span item[:field], class: "govuk-visually-hidden" %>
+                        Change <%= tag.span item[:field], class: "govuk-visually-hidden" %>
                       <% end %>
                     <% end %>
                   <% end %>

--- a/spec/components/summary_list_spec.rb
+++ b/spec/components/summary_list_spec.rb
@@ -26,7 +26,7 @@ describe "Summary list", type: :view do
       }
     )
     assert_select '.gem-c-summary-list .govuk-heading-m', text: 'Title, summary and body'
-    assert_select '.gem-c-summary-list__edit-section-link[title="Edit Title, summary and body"][href="#edit-title-summary-body"][data-gtm="edit-title-summary-body"]', text: 'Edit Title, summary and body'
+    assert_select '.gem-c-summary-list__edit-section-link[title="Change Title, summary and body"][href="#edit-title-summary-body"][data-gtm="edit-title-summary-body"]', text: 'Change Title, summary and body'
   end
 
   it "renders section title with custom link text" do
@@ -93,7 +93,7 @@ describe "Summary list", type: :view do
     )
     assert_select '.govuk-summary-list__key', text: 'Title'
     assert_select '.govuk-summary-list__value', text: 'Ethical standards for public service providers'
-    assert_select '.govuk-summary-list__actions-list-item .govuk-link[title="Edit Title"][href="#edit-title"][data-gtm="edit-title"]', text: "Edit Title"
+    assert_select '.govuk-summary-list__actions-list-item .govuk-link[title="Change Title"][href="#edit-title"][data-gtm="edit-title"]', text: "Change Title"
   end
 
   it "renders items with delete action" do


### PR DESCRIPTION
## What
- Update "Edit" link text on summary-list component to be "Change".
- Fix exceeding underline on "Edit" links when used inline with "Delete" link.

## Why
We've found in research for Content Publisher that users are confused by the "Edit" action on sections that they haven't yet filled in/haven't interacted with. [The Design System component](https://design-system.service.gov.uk/components/summary-list/) was updated to use "Change" as primary action link so we're updating this one to match the reference. This change is also required for the "Check your answers page" on "Register as an organisation getting funding directly from the EU".

## Visual Changes
Before
<img width="132" alt="Screen Shot 2019-10-29 at 09 55 36" src="https://user-images.githubusercontent.com/788096/67756849-a8dee700-fa32-11e9-93c1-207d42409800.png">

After
<img width="163" alt="Screen Shot 2019-10-29 at 09 55 07" src="https://user-images.githubusercontent.com/788096/67756840-a3819c80-fa32-11e9-99c1-ac6b1f4b5ccc.png">

## View Changes
https://govuk-publishing-compo-pr-1182.herokuapp.com/summary_list/with_edit_on_individual_items/preview

[Trello card](https://trello.com/c/bjsifdKZ)