### PR TITLE
Add id option to fieldset

### DIFF
--- a/app/views/govuk_publishing_components/components/_fieldset.html.erb
+++ b/app/views/govuk_publishing_components/components/_fieldset.html.erb
@@ -5,6 +5,7 @@
   heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
   error_message ||= nil
   error_id ||= nil
+  id ||= nil
 
   if error_message
     error_id = "error-#{SecureRandom.hex(4)}" unless error_id
@@ -20,7 +21,7 @@
   legend_classes << "govuk-fieldset__legend--#{heading_size}" if heading_size
 %>
 <%= tag.div class: css_classes do %>
-  <%= tag.fieldset class: fieldset_classes, aria: { describedby: describedby }, role: role do %>
+  <%= tag.fieldset class: fieldset_classes, aria: { describedby: describedby }, role: role, id: id do %>
     <%= tag.legend class: legend_classes do %>
       <%= legend_text %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/fieldset.yml
+++ b/app/views/govuk_publishing_components/components/docs/fieldset.yml
@@ -17,6 +17,17 @@ examples:
 
         <input type="radio" id="default-no" name="default">
         <label for="default-no">No</label>
+  with_id_attribute:
+    data:
+      legend_text: 'Do you have a passport?'
+      id: passports
+      text: |
+        <!-- Use the radio component, this is hardcoded only for this example -->
+        <input type="radio" id="passport-yes" name="default">
+        <label for="passport-yes">Yes</label>
+
+        <input type="radio" id="passport-no" name="default">
+        <label for="passport-no">No</label>
   with_custom_legend_size:
     description: Make the legend different sizes. Valid options are 's', 'm', 'l' and 'xl'.
     data:

--- a/spec/components/fieldset_spec.rb
+++ b/spec/components/fieldset_spec.rb
@@ -21,6 +21,16 @@ describe "Fieldset", type: :view do
     assert_select ".gem-c-fieldset", text: /Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vel ad neque, maxime est ea laudantium totam fuga!/
   end
 
+  it "renders a fieldset with an id" do
+    render_component(
+      legend_text: 'Do you have a passport?',
+      id: 'passports',
+      text: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vel ad neque, maxime est ea laudantium totam fuga!'
+    )
+
+    assert_select ".govuk-fieldset#passports"
+  end
+
   it "renders a fieldset with a custom size legend" do
     render_component(
       legend_text: 'Do you have a passport?',


### PR DESCRIPTION
## What
Adds an option to the fieldset component to specify an id for the fieldset.

## Why
Needed for calculators, where groups of form elements are wrapped in a fieldset and then linked to using jump links in the event of an error. 

## Visual Changes
None.

<!--
## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
-->
