### PR TITLE
Release v21.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.8.0
 
 * Add id option to fieldset ([PR #1183](https://github.com/alphagov/govuk_publishing_components/pull/1183))
+* Fix edit link on summary-list component ([PR #1182](https://github.com/alphagov/govuk_publishing_components/pull/1182))
 * Make chevron component more resilient ([PR #1181](https://github.com/alphagov/govuk_publishing_components/pull/1181))
 
 ## 21.7.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.7.0)
+    govuk_publishing_components (21.8.0)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.7.0'.freeze
+  VERSION = '21.8.0'.freeze
 end


### PR DESCRIPTION
## 21.8.0

* Add `id` option to fieldset ([PR #1183](https://github.com/alphagov/govuk_publishing_components/pull/1183))
* Fix edit link on summary-list component ([PR #1182](https://github.com/alphagov/govuk_publishing_components/pull/1182))
* Make chevron component more resilient ([PR #1181](https://github.com/alphagov/govuk_publishing_components/pull/1181))
