### PR TITLE
Stop cookie text appearing in Google snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Configure cookie banner to not appear in Google snippets ([PR #1185](https://github.com/alphagov/govuk_publishing_components/pull/1185))
+
 ## 21.8.0
 
 * Add id option to fieldset ([PR #1183](https://github.com/alphagov/govuk_publishing_components/pull/1183))

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -3,7 +3,7 @@
   message ||= "GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised. By continuing to use this site, you agree to our use of cookies."
 %>
 
-<div id="<%= id %>" class="gem-c-cookie-banner" data-module="cookie-banner" role="region" aria-label="cookie banner">
+<div id="<%= id %>" class="gem-c-cookie-banner" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet>
   <div class="gem-c-cookie-banner__wrapper govuk-width-container">
     <p class="gem-c-cookie-banner__message"><%= message %></p>
     <div class="gem-c-cookie-banner__buttons">


### PR DESCRIPTION
We've noticed that the cookie text appears sometimes in Google results where the search text contains some of the words within (such as https://www.google.com/search?q=government+gateway)

The [nosnippet attribute](https://developers.google.com/search/reference/robots_meta_tag#data-nosnippet-attr) should prevent the cookie banner appearing in snippets such as those where we've implemented the FAQPage schema.

