### PR TITLE
Allow tracking of the details component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow tracking on the details component ([PR #1187](https://github.com/alphagov/govuk_publishing_components/pull/1187))
+
 ## 21.9.0
 
 * Fix string merge in summary-list component ([PR #1188](https://github.com/alphagov/govuk_publishing_components/pull/1188))

--- a/app/assets/javascripts/govuk_publishing_components/components/details.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/details.js
@@ -1,0 +1,48 @@
+/* eslint-env jquery */
+// = require govuk/components/details/details.js
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  'use strict'
+
+  Modules.GovukDetails = function () {
+    this.start = function (element) {
+      var customTrackLabel = element[0].getAttribute('data-track-label')
+
+      // If a custom label has been provided, we can simply call the tracking module
+      if (customTrackLabel) {
+        var trackDetails = new window.GOVUK.Modules.TrackClick()
+        trackDetails.start(element)
+      } else {
+        // If no custom label is set, we use the open/close status as the label
+        var detailsComponent = element[0]
+        var detailsClick = detailsComponent.querySelector('[data-details-track-click]')
+        var that = this
+
+        $(detailsClick).click(function (e) {
+          that.trackDefault(detailsComponent)
+        })
+      }
+    }
+
+    this.trackDefault = function (element) {
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        var componentStatus = (element.getAttribute('open') == null) ? 'open' : 'closed'
+        var trackCategory = element.getAttribute('data-track-category')
+        var trackAction = element.getAttribute('data-track-action')
+        var trackOptions = element.getAttribute('data-track-options')
+
+        if (typeof trackOptions !== 'object' || trackOptions === null) {
+          trackOptions = {}
+        }
+
+        trackOptions['label'] = componentStatus
+
+        if (trackAction && trackCategory) {
+          window.GOVUK.analytics.trackEvent(trackCategory, trackAction, trackOptions)
+        }
+      }
+    }
+  }
+})(window.GOVUK.Modules)

--- a/app/views/govuk_publishing_components/components/_details.html.erb
+++ b/app/views/govuk_publishing_components/components/_details.html.erb
@@ -10,7 +10,7 @@
   data_attributes[:module] = 'govuk-details'
 %>
 <%= tag.details class: css_classes, data: data_attributes, open: open do %>
-  <summary class="govuk-details__summary">
+  <summary class="govuk-details__summary" data-details-track-click>
     <span class="govuk-details__summary-text">
       <%= title %>
     </span>

--- a/app/views/govuk_publishing_components/components/docs/details.yml
+++ b/app/views/govuk_publishing_components/components/docs/details.yml
@@ -22,6 +22,18 @@ examples:
       block: |
         We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
   with_data_attributes:
+    description: Can be used for tracking. By default, `track-label` is set to the status ("open" or "closed") unless a track_label is passed into the component.
+    data:
+      title: Help with nationality
+      data_attributes:
+        track_category: "checker-qa"
+        track_action: "business-question"
+        track_label: "custom label here"
+        track_options:
+          dimension20: "custom dimension"
+      block: |
+        We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
+  with_GTM_tracking:
     data:
       title: Help with nationality
       data_attributes:

--- a/spec/components/details_spec.rb
+++ b/spec/components/details_spec.rb
@@ -32,6 +32,21 @@ describe "Details", type: :view do
     assert_select '.govuk-details.govuk-\!-margin-bottom-0'
   end
 
+  it "applies data attributes when provided" do
+    render_component(
+      title: "Some title",
+      data_attributes: {
+        track_category: "track-category",
+        track_action: "track-action",
+        track_label: "track-label"
+      }
+    )
+
+    assert_select '.govuk-details[data-track-category="track-category"]'
+    assert_select '.govuk-details[data-track-action="track-action"]'
+    assert_select '.govuk-details[data-track-label="track-label"]'
+  end
+
   it "defaults to the initial bottom margin if an incorrect value is passed" do
     render_component(
       title: "Some title",

--- a/spec/javascripts/components/details-spec.js
+++ b/spec/javascripts/components/details-spec.js
@@ -1,0 +1,79 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+describe('Details component', function () {
+  var FIXTURE
+
+  GOVUK.analytics = {
+    trackEvent: function () {}
+  }
+
+  var callback = jasmine.createSpy()
+  GOVUK.Modules.TrackClick = function () {
+    this.start = function () {
+      callback()
+    }
+  }
+
+  function loadDetailsComponent () {
+    var details = new GOVUK.Modules.GovukDetails()
+    details.start($('.gem-c-details'))
+  }
+
+  beforeEach(function () {
+    spyOn(GOVUK.analytics, 'trackEvent')
+
+    FIXTURE =
+      '<details class="gem-c-details govuk-details govuk-!-margin-bottom-3" data-track-category="track-category" data-track-action="track-action" data-track-label="track-label" data-module="govuk-details">' +
+        '<summary class="govuk-details__summary" data-details-track-click="">' +
+        '<span>Toggle text</span>' +
+        '</summary>' +
+      '</details>'
+
+    window.setFixtures(FIXTURE)
+  })
+
+  afterEach(function () {
+    GOVUK.analytics.trackEvent.calls.reset()
+  })
+
+  it('uses built in tracking module when provided with a track-label', function () {
+    loadDetailsComponent()
+
+    $('.govuk-details__summary').click()
+
+    expect(GOVUK.analytics.trackEvent.calls.count()).toEqual(0)
+    expect(callback).toHaveBeenCalled()
+  })
+
+  it('does not fire an event if track category and track action are not present', function () {
+    $('.gem-c-details').attr('data-track-action', null)
+    $('.gem-c-details').attr('data-track-category', null)
+    $('.gem-c-details').attr('data-track-label', null)
+
+    loadDetailsComponent()
+
+    $('.govuk-details__summary').click()
+
+    expect(GOVUK.analytics.trackEvent.calls.count()).toEqual(0)
+  })
+
+  it('tracks open state by default if no track label provided', function () {
+    $('.gem-c-details').attr('data-track-label', null)
+    loadDetailsComponent()
+
+    $('.govuk-details__summary').click()
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('track-category', 'track-action', { label: 'open' })
+  })
+
+  it('tracks closed state by default if no track label provided', function () {
+    $('.gem-c-details').attr('data-track-label', null)
+    $('.gem-c-details').attr('open', true)
+    loadDetailsComponent()
+
+    $('.govuk-details__summary').click()
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('track-category', 'track-action', { label: 'closed' })
+  })
+})


### PR DESCRIPTION
Trello:
https://trello.com/c/Dtle7GcF/197-modify-details-component-to-enable-tracking-analytics
to unblock https://github.com/alphagov/finder-frontend/pull/1702

## What
Allow tracking of the details component, e.g: on the Brexit checker.
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
The details component, by default, has `data-module="govuk-details` which makes it difficult for us to add our usual `data-module="track-click"`. We also want some more custom tracking of the open and close status of the component. This adds tracking JS to the component. 

Passing all the necessary data attributes, including `track-label` simply passes the details element to our usual [TrackClick method in static](https://github.com/alphagov/static/blob/master/app/assets/javascripts/modules/track-click.js). This then works in exactly the same way as the rest of our tracking.

Passing in all the necessary data attributes **except `track-label** means that the track-label by default becomes the open/close status of the component. In this case, we manually add an event listener and fire a track event on click.

<img width="1003" alt="Screen Shot 2019-11-04 at 15 18 16" src="https://user-images.githubusercontent.com/29889908/68132319-6461b880-ff16-11e9-9d5c-6af3368225aa.png">

https://govuk-publishing-compo-pr-1187.herokuapp.com/
