### PR TITLE
Fix string merge in summary-list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix string merge in summary-list component ([PR #1188](https://github.com/alphagov/govuk_publishing_components/pull/1188))
+
 ## 21.8.1
 
 * Configure cookie banner to not appear in Google snippets ([PR #1185](https://github.com/alphagov/govuk_publishing_components/pull/1185))

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -41,7 +41,7 @@
                                   class: "govuk-link",
                                   title: "Change #{item[:field]}",
                                   data: item[:edit].fetch(:data_attributes, {}) do %>
-                        Change<%= tag.span " " + item[:field], class: "govuk-visually-hidden" %><% end %>
+                        Change<%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" %><% end %>
                     <% end %>
                   <% end %>
                   <% if item.fetch(:delete, {}).any? %>
@@ -50,7 +50,7 @@
                                   class: "govuk-link",
                                   title: "Delete #{item[:field]}",
                                   data: item[:delete].fetch(:data_attributes, {}) do %>
-                        Delete<%= tag.span " " +  item[:field], class: "govuk-visually-hidden" %>
+                        Delete<%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" %>
                       <% end %>
                     <% end %>
                   <% end %>


### PR DESCRIPTION
## What
Replacing `+` operator with string interpolation for Change link strings.

## Why
Some Rails application do not support string merging using the `+` [failing in the CI because of this](https://ci.integration.publishing.service.gov.uk/job/collections-publisher/job/dependabot%252Fbundler%252Fgovuk_publishing_components-21.8.1/).

## Visual Changes
No visual changes