### PR TITLE
Add Brexit call-to-action link as a related link in the contextual sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix string merge in summary-list component ([PR #1188](https://github.com/alphagov/govuk_publishing_components/pull/1188))
+* Add Brexit call-to-action link as a related link in the contextual sidebar ([PR #1189](https://github.com/alphagov/govuk_publishing_components/pull/1189))
 
 ## 21.8.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -28,6 +28,7 @@
 @import "components/chevron-banner";
 @import "components/contents-list";
 @import "components/contextual-guidance";
+@import "components/contextual-sidebar";
 @import "components/cookie-banner";
 @import "components/copy-to-clipboard";
 @import "components/date-input";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -1,0 +1,9 @@
+.gem-c-contextual-sidebar__brexit-cta {
+  border-top: 2px solid $govuk-brand-colour;
+}
+
+.gem-c-contextual-sidebar__brexit-heading {
+  @include govuk-font(19, $weight: bold);
+  padding-top: govuk-spacing(3);
+  margin-bottom: govuk-spacing(2);
+}

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -1,6 +1,10 @@
 <% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request) %>
 
 <div class="gem-c-contextual-sidebar">
+  <% if navigation.show_brexit_cta? && navigation.step_by_step_count.eql?(0) %>
+    <%= render 'govuk_publishing_components/components/contextual_sidebar/brexit_cta' %>
+  <% end %>
+
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
     <%# Rendering step by step related items because there are a few but not too many of them %>
     <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links %>
@@ -17,9 +21,13 @@
   <% if navigation.content_tagged_to_other_step_by_steps? %>
     <%# Rendering step by step related items because there are a few but not too many of them %>
     <%= render 'govuk_publishing_components/components/step_by_step_nav_related', {
-      pretitle: "Also part of", 
+      pretitle: "Also part of",
       links: navigation.step_nav_helper.also_part_of_step_nav,
       always_display_as_list: true
     } %>
+  <% end %>
+
+  <% if navigation.show_brexit_cta? && navigation.step_by_step_count > 0 %>
+    <%= render 'govuk_publishing_components/components/contextual_sidebar/brexit_cta' %>
   <% end %>
 </div>

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
@@ -1,0 +1,4 @@
+<div class="gem-c-contextual-sidebar__brexit-cta govuk-!-margin-bottom-6" data-module="track-click">
+  <h2 class="gem-c-contextual-sidebar__brexit-heading">Brexit</h2>
+  <a href="/brexit" class="govuk-link" data-track-category="relatedLinkClicked" data-track-action="1.0 Brexit" data-track-label="/brexit" data-track-options='{"dimension29":"Check what you need to do"}'>Check what you need to do</a>
+</div>

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -51,3 +51,24 @@ examples:
           ordered_related_items:
             - title: "Find an apprenticeship"
               base_path: "/apply-apprenticeship"
+  with_brexit_call_to_action:
+    data:
+      content_item:
+        title: "A content item"
+        links:
+          taxons:
+            - content_id: "test"
+              title: "Not Brexit"
+              phase: "live"
+              links:
+                parent_taxons:
+                  - content_id: "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+                    title: "Brexit"
+          ordered_related_items:
+            - title: "Find an apprenticeship"
+              base_path: "/apply-apprenticeship"
+          part_of_step_navs:
+            - title: "Choosing a micropig or micropug: step by step"
+              base_path: "/micropigs-vs-micropugs"
+            - title: "Walk your micropig: step by step"
+              base_path: "/porgs-step-by-step"

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -38,7 +38,7 @@ examples:
           - title: The future of jobs and skills
             base_path: /government/collections/the-future-of-jobs-and-skills
             document_type: document_collection
-  with_step_by_step:
+  with_part_of_step_by_step:
     data:
       content_item:
         title: "A content item"
@@ -51,7 +51,39 @@ examples:
           ordered_related_items:
             - title: "Find an apprenticeship"
               base_path: "/apply-apprenticeship"
-  with_brexit_call_to_action:
+  with_current_step_by_step:
+    data:
+      content_item:
+        title: "A content item"
+        links:
+          part_of_step_navs:
+            - title: "Choosing a micropig or micropug: step by step"
+              base_path: "/micropigs-vs-micropugs"
+              details:
+                step_by_step_nav:
+                  title: 'Stay in the UK after it leaves the EU (''settled status''): step by step'
+                  steps:
+                  - title: Check if you need to apply to the EU Settlement Scheme
+                    contents:
+                    - type: paragraph
+                      text: 'You may need to apply to the EU Settlement Scheme to continue living
+                        in the UK. '
+                    - type: list
+                      contents:
+                      - text: Check if you need to apply
+                        href: "/settled-status-eu-citizens-families/eligibility"
+                    optional: false
+                  - title: Find out what status you’ll get
+                    contents:
+                    - type: paragraph
+                      text: You’ll get settled or pre-settled status depending on how long you’ve
+                        been living in the UK. This might affect when you choose to apply.
+                    - type: list
+                      contents:
+                      - text: Find out what you’ll get
+                        href: "/settled-status-eu-citizens-families/what-settled-and-presettled-status-means"
+                    optional: false
+  with_brexit_cta_and_related_links:
     data:
       content_item:
         title: "A content item"
@@ -65,10 +97,53 @@ examples:
                   - content_id: "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
                     title: "Brexit"
           ordered_related_items:
-            - title: "Find an apprenticeship"
-              base_path: "/apply-apprenticeship"
+          - title: Find an apprenticeship
+            base_path: /apply-apprenticeship
+          - title: Training and study at work
+            base_path: /training-study-work-your-rights
+          - title: Careers helpline for teenagers
+            base_path: /careers-helpline-for-teenagers
+          document_collections:
+          - title: Recruit an apprentice (formerly apprenticeship vacancies)
+            base_path: /government/collections/apprenticeship-vacancies
+            document_type: document_collection
+          - title: The future of jobs and skills
+            base_path: /government/collections/the-future-of-jobs-and-skills
+            document_type: document_collection
+  with_brexit_cta_and_step_by_steps:
+    data:
+      content_item:
+        title: "A content item"
+        links:
+          taxons:
+            - content_id: "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+              title: "Brexit"
+              phase: "live"
           part_of_step_navs:
             - title: "Choosing a micropig or micropug: step by step"
               base_path: "/micropigs-vs-micropugs"
-            - title: "Walk your micropig: step by step"
-              base_path: "/porgs-step-by-step"
+              details:
+                step_by_step_nav:
+                  title: 'Stay in the UK after it leaves the EU (''settled status''): step by step'
+                  steps:
+                  - title: Check if you need to apply to the EU Settlement Scheme
+                    contents:
+                    - type: paragraph
+                      text: 'You may need to apply to the EU Settlement Scheme to continue living
+                        in the UK. '
+                    - type: list
+                      contents:
+                      - text: Check if you need to apply
+                        href: "/settled-status-eu-citizens-families/eligibility"
+                    optional: false
+                  - title: Find out what status you’ll get
+                    contents:
+                    - type: paragraph
+                      text: You’ll get settled or pre-settled status depending on how long you’ve
+                        been living in the UK. This might affect when you choose to apply.
+                    - type: list
+                      contents:
+                      - text: Find out what you’ll get
+                        href: "/settled-status-eu-citizens-families/what-settled-and-presettled-status-means"
+                    optional: false
+

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -60,6 +60,32 @@ module GovukPublishingComponents
         content_item["schema_name"] == "specialist_document"
       end
 
+      def tagged_to_brexit?
+        taxons = content_item.dig("links", "taxons").to_a
+        brexit_taxon = "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+        world_brexit_taxon = "d4c4d91d-fbe7-4eff-bd57-189138c626c9"
+
+        taxons.each do |taxon|
+          if taxon["content_id"].eql?(brexit_taxon) ||
+              taxon["content_id"].eql?(world_brexit_taxon) ||
+              taxon.dig("links", "parent_taxons").to_a.any? { |taxon_item| taxon_item["content_id"].eql?(brexit_taxon) }
+            return true
+          end
+        end
+
+        false
+      end
+
+      def show_brexit_cta?
+        # If tagged directly to /brexit or /world/brexit
+        # Or if tagged to a taxon which has /brexit as a parent
+        tagged_to_brexit?
+      end
+
+      def step_by_step_count
+        step_nav_helper.step_navs.count
+      end
+
       def content_tagged_to_current_step_by_step?
         # TODO: remove indirection here
         step_nav_helper.show_header?


### PR DESCRIPTION
Trello: https://trello.com/c/AksjKWzc/212-create-frontend-landing-page-link-on-sidebar

## What
Adds a "Brexit call-to-action" section to the contextual sidebar component.

## Why
We want to signpost people to the Brexit landing page from Brexit-related content. This has been built onto the contextual sidebar component instead of the related navigation component because it needs to be displayed in different positions depending on if the page has related links, step-by-steps or both.

Brexit related content is defined here as: anything tagged to /brexit, /world/brexit or tagged to a taxon which has /brexit as a parent taxon.

## Visual Changes
**With current step-by-step**
<img width="932" alt="Screen Shot 2019-11-05 at 10 06 36" src="https://user-images.githubusercontent.com/29889908/68206529-d1338c00-ffc4-11e9-8a3c-8dbe0a61cff0.png">

**With related links**
<img width="449" alt="Screen Shot 2019-11-05 at 09 57 36" src="https://user-images.githubusercontent.com/29889908/68206543-e14b6b80-ffc4-11e9-9ae0-fba804abd163.png">

**With part of step-by-steps**
<img width="380" alt="Screen Shot 2019-11-05 at 09 57 20" src="https://user-images.githubusercontent.com/29889908/68206566-f0321e00-ffc4-11e9-9d11-59022f537f81.png">

https://govuk-publishing-compo-pr-1189.herokuapp.com/component-guide/contextual_sidebar
