### PR TITLE
Version 21.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.9.0
 
 * Fix string merge in summary-list component ([PR #1188](https://github.com/alphagov/govuk_publishing_components/pull/1188))
 * Add Brexit call-to-action link as a related link in the contextual sidebar ([PR #1189](https://github.com/alphagov/govuk_publishing_components/pull/1189))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.8.1)
+    govuk_publishing_components (21.9.0)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.8.1'.freeze
+  VERSION = '21.9.0'.freeze
 end


### PR DESCRIPTION
Includes:
* Fix string merge in summary-list component ([PR #1188](https://github.com/alphagov/govuk_publishing_components/pull/1188))
* Add Brexit call-to-action link as a related link in the contextual sidebar ([PR #1189](https://github.com/alphagov/govuk_publishing_components/pull/1189))
