### PR TITLE
Make it possible to render a document list without links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Support document list items without links ([PR #1194](https://github.com/alphagov/govuk_publishing_components/pull/1194))
+
 ## 21.10.0
 
 * Allow tracking on the details component ([PR #1187](https://github.com/alphagov/govuk_publishing_components/pull/1187))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -18,10 +18,13 @@
 }
 
 .gem-c-document-list__item-title {
-  @include govuk-link-common;
-  @include govuk-link-style-default;
   @include govuk-font($size: 19, $weight: bold);
   display: inline-block;
+}
+
+.gem-c-document-list__item-link {
+  @include govuk-link-common;
+  @include govuk-link-style-default;
 }
 
 .gem-c-document-list--no-underline {

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -24,13 +24,25 @@
         <% if item[:highlight] && item[:highlight_text] %>
           <p class='gem-c-document-list__highlight-text'><%= item[:highlight_text] %></p>
         <% end %>
+
         <%=
-          link_to(
-            item[:link][:text],
-            item[:link][:path],
-            data: item[:link][:data_attributes],
-            class: "gem-c-document-list__item-title #{brand_helper.color_class} #{title_with_context_class if item[:link][:context]}"
-          )
+          class_str = "gem-c-document-list__item-title #{brand_helper.color_class} #{title_with_context_class if item[:link][:context]}"
+
+          if item[:link][:path]
+            link_to(
+              item[:link][:text],
+              item[:link][:path],
+              data: item[:link][:data_attributes],
+              class: "#{class_str} gem-c-document-list__item-link",
+            )
+          else
+            content_tag(
+              "span",
+              item[:link][:text],
+              data: item[:link][:data_attributes],
+              class: class_str,
+            )
+          end
         %>
 
         <% if item[:link][:context] %>

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -1,10 +1,10 @@
 name: Document list
-description: An ordered list of links to documents including document type and when updated.
+description: An ordered list of documents including a document type, when updated and a link.
 body: |
-  Outputs a list of links to documents, based on an array of document data. This must include:
+  Outputs a list to documents, based on an array of document data. This may include:
 
-  * link text
-  * link href
+  * document title
+  * link to the document
   * last updated date object
   * document type
 
@@ -36,6 +36,24 @@ examples:
       - link:
           text: 'Children missing education'
           path: '/government/publications/children-missing-education'
+        metadata:
+          public_updated_at: 2016-09-05 16:48:27
+          document_type: 'Statutory guidance'
+  without_links:
+    data:
+      items:
+      - link:
+          text: 'Alternative provision'
+        metadata:
+          public_updated_at: 2016-06-27 10:29:44
+          document_type: 'Statutory guidance'
+      - link:
+          text: 'Behaviour and discipline in schools: guide for governing bodies'
+        metadata:
+          public_updated_at: 2015-09-24 16:42:48
+          document_type: 'Statutory guidance'
+      - link:
+          text: 'Children missing education'
         metadata:
           public_updated_at: 2016-09-05 16:48:27
           document_type: 'Statutory guidance'

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -138,7 +138,8 @@ describe "Document list", type: :view do
         }
       ]
     )
-    li = ".gem-c-document-list__item-title"
+
+    li = "a.gem-c-document-list__item-title"
 
     assert_select "#{li}[href='/link1']", text: "Link 1"
     assert_select "#{li}[data-track-category='navDocumentCollectionLinkClicked']", text: "Link 1"
@@ -151,6 +152,28 @@ describe "Document list", type: :view do
     assert_select "#{li}[data-track-action='1.2']", text: "Link 2"
     assert_select "#{li}[data-track-label='/link2']", text: "Link 2"
     assert_select "#{li}[data-track-options='{\"dimension28\":\"2\",\"dimension29\":\"Link 2\"}']", text: "Link 2"
+  end
+
+  it "renders a document list without links" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "School behaviour and attendance: parental responsibility measures",
+          },
+        },
+        {
+          link: {
+            text: "Become an apprentice",
+          },
+        }
+      ]
+    )
+
+    span = "span.gem-c-document-list__item-title"
+
+    assert_select "#{span}:first-of-type", text: "School behaviour and attendance: parental responsibility measures"
+    assert_select "#{span}:last-of-type", text: "Become an apprentice"
   end
 
   it "adds branding correctly" do


### PR DESCRIPTION
This is needed to support using the document list for roles in Whitehall. Some roles don't have their own URLs (they are base path less editions) so it doesn't make sense to render a link.

There is some confusion over whether the name of the component "document list" makes sense with this feature. We've decided that it should be fine as long as we make it clear that this is a list of documents, not a list of links (as it is currently written in the description).

https://govuk-publishing-compo-pr-1194.herokuapp.com/component-guide/document_list

[Trello Card](https://trello.com/c/bkZh5sS4/862-update-document-list-component-to-support-documents-without-links)