### PR TITLE
Trigger search if search query exists in query string on page load

### DIFF
--- a/app/assets/javascripts/component_guide/filter-components.js
+++ b/app/assets/javascripts/component_guide/filter-components.js
@@ -28,5 +28,8 @@
       var searchTerm = searchField.value;
       window.GOVUK.FilterComponents(searchTerm);
     });
+
+    // trigger search if search query exists in query string on page load
+    window.GOVUK.FilterComponents(searchField.value);
   }
 })();


### PR DESCRIPTION
## What
Trigger search if search query exists in the query string on page load

## Why
When you perform a search then use the back button to come back the search does not persist. This is confusing for users as the user now has to trigger an additional change for the list to be filtered.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->


## View Changes
https://govuk-publishing-compo-pr-1196.herokuapp.com/

