### PR TITLE
Update background colour for search buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update background colour for search buttons ([PR #1197](https://github.com/alphagov/govuk_publishing_components/pull/1197))
 * Support document list items without links ([PR #1194](https://github.com/alphagov/govuk_publishing_components/pull/1194))
 
 ## 21.10.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -159,11 +159,11 @@ $large-input-size: 50px;
 .gem-c-search--on-white {
 
   .gem-c-search__submit {
-    background-color: govuk-colour("light-blue");
+    background-color: govuk-colour("blue");
     color: govuk-colour("white");
 
     &:hover {
-      background-color: lighten(govuk-colour("light-blue"), 5%);
+      background-color: lighten(govuk-colour("blue"), 5%);
     }
   }
 


### PR DESCRIPTION
## What
This is the only place where we use the `light-blue` in the library and as far as I know, for no strong reasons.

## Why
Using `blue` increases the contrast with the magnifying glass icon and makes the component more consistent with other elements on the page.

## Visual Changes
Before
<img width="960" alt="Screen Shot 2019-11-14 at 14 14 34" src="https://user-images.githubusercontent.com/788096/68864622-5a477300-06e9-11ea-84fa-c9f4ecd8b6f2.png">

After
<img width="960" alt="Screen Shot 2019-11-14 at 14 14 15" src="https://user-images.githubusercontent.com/788096/68864632-5e739080-06e9-11ea-8e13-2c5d0849f6c7.png">


<!--
## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
-->
