### PR TITLE
Add heading and inline options to organisation logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update background colour for search buttons ([PR #1197](https://github.com/alphagov/govuk_publishing_components/pull/1197))
+* Add option to wrap the organisation logo with a heading, and for the organisation logo to not take up the entire width of the parent element ([PR #1198](https://github.com/alphagov/govuk_publishing_components/pull/1198))
 * Support document list items without links ([PR #1194](https://github.com/alphagov/govuk_publishing_components/pull/1194))
 
 ## 21.10.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -67,6 +67,7 @@
 
   &:focus {
     box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-colour, 0 8px $govuk-focus-text-colour;
+    text-decoration: none;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -22,6 +22,11 @@
   direction: ltr;
 }
 
+.gem-c-organisation-logo__container--inline {
+  display: inline-block;
+  padding-right: govuk-spacing(1);
+}
+
 // Scale images on smaller viewports
 .gem-c-organisation-logo__image {
   max-width: 100%;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -66,6 +66,9 @@
   }
 
   &:focus {
+    // Using `@include govuk-focused-text;` would obscure the text. Tweaked
+    // spacing needed to prevent overlap of the text and the focus state's thick
+    // black line.
     box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-colour, 0 8px $govuk-focus-text-colour;
     text-decoration: none;
   }

--- a/app/views/govuk_publishing_components/components/_organisation_logo.html.erb
+++ b/app/views/govuk_publishing_components/components/_organisation_logo.html.erb
@@ -1,21 +1,41 @@
 <%
   logo_helper = GovukPublishingComponents::Presenters::OrganisationLogoHelper.new(local_assigns)
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(organisation[:brand])
+
   organisation ||= {}
+  heading_level ||= false
+  inline ||= false
+
+  # Check if `heading_level` is a number; if so, check if it's an appropriate
+  # number.
+  use_heading = heading_level.is_a?(Integer) ?
+                  (heading_level >= 1 && heading_level <= 6) :
+                  false
+
+  # Set the wrapping element to be a heading or a `div`
+  wrapping_element = use_heading ? "h#{heading_level}" : "div"
+
+  wrapper_classes = %w(gem-c-organisation-logo)
+  wrapper_classes << brand_helper.brand_class
+
+  container_classes = [
+    logo_helper.logo_container_class,
+    brand_helper.border_color_class
+  ]
 %>
-<div
-  class="gem-c-organisation-logo <%= brand_helper.brand_class %>"
+<<%= wrapping_element %>
+  class="<%= wrapper_classes.join(" ") %>"
   <%= "data-module=track-click" if organisation[:data_attributes] %>
 >
   <% if organisation[:url] %>
     <%= link_to organisation[:url],
-      class: "#{logo_helper.logo_container_class} #{brand_helper.border_color_class}",
+      class: container_classes.join(" "),
       data: organisation[:data_attributes] do %>
       <%= logo_helper.logo_content %>
     <% end %>
   <% else %>
-    <div class="<%= logo_helper.logo_container_class %> <%= brand_helper.border_color_class %>">
+    <div class="<%= container_classes.join(" ") %>">
       <%= logo_helper.logo_content %>
     </div>
   <% end %>
-</div>
+</<%= wrapping_element %>>

--- a/app/views/govuk_publishing_components/components/_organisation_logo.html.erb
+++ b/app/views/govuk_publishing_components/components/_organisation_logo.html.erb
@@ -22,6 +22,7 @@
     logo_helper.logo_container_class,
     brand_helper.border_color_class
   ]
+  container_classes << "gem-c-organisation-logo__container--inline" if inline
 %>
 <<%= wrapping_element %>
   class="<%= wrapper_classes.join(" ") %>"

--- a/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
+++ b/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
@@ -10,6 +10,8 @@ body: |
 
   The logo can optionally be wrapped in a heading.
 
+  The logo can be set to not take up the full width of the parent container with the `inline` option.
+
 accessibility_criteria: |
   The crest image itself must be presentational and ignored by screen readers.
 
@@ -180,3 +182,12 @@ examples:
         brand: cabinet-office
         crest: 'single-identity'
       heading_level: 1
+  inline-block:
+    description: This option is useful to stop a large selectable area.
+    data:
+      organisation:
+        name: Cabinet Office
+        url: '/government/organisations/cabinet-office'
+        brand: cabinet-office
+        crest: 'single-identity'
+      inline: true

--- a/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
+++ b/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
@@ -6,8 +6,10 @@ body: |
 
   Alternatively a custom organisation logo can be provided as an image.
 
-  Data tracking attributes can be provided to add tracking to each organisation logo.
-  This will only apply to organisations with a link. Example here: [with_data_attributes](/component-guide/organisation_logo/with_data_attributes)
+  Data tracking attributes can be provided to add tracking to each organisation logo. This will only apply to organisations with a link. Example here: [with_data_attributes](/component-guide/organisation_logo/with_data_attributes)
+
+  The logo can optionally be wrapped in a heading.
+
 accessibility_criteria: |
   The crest image itself must be presentational and ignored by screen readers.
 
@@ -162,3 +164,19 @@ examples:
         name: Cabinet Office
         brand: cabinet-office
         crest: 'single-identity'
+  as_a_heading:
+    description: The `heading_level` option takes a number from 1 to 6.
+    data:
+      organisation:
+        name: Cabinet Office
+        url: '/government/organisations/cabinet-office'
+        brand: cabinet-office
+        crest: 'single-identity'
+      heading_level: 1
+  as_a_heading_without_a_link:
+    data:
+      organisation:
+        name: Cabinet Office
+        brand: cabinet-office
+        crest: 'single-identity'
+      heading_level: 1

--- a/spec/components/organisation_logo_spec.rb
+++ b/spec/components/organisation_logo_spec.rb
@@ -27,7 +27,7 @@ describe "Organisation logo", type: :view do
   end
 
   it "doesn't include a link when a URL is not provided" do
-    render_component(organisation: { name: "Linked" })
+    render_component(organisation: { name: "Not linked" })
     assert_select "a.gem-c-organisation-logo__container.gem-c-organisation-logo__link[href='/somewhere']", false
     assert_select ".gem-c-organisation-logo__container"
   end

--- a/spec/components/organisation_logo_spec.rb
+++ b/spec/components/organisation_logo_spec.rb
@@ -90,4 +90,14 @@ describe "Organisation logo", type: :view do
     render_component(organisation: { name: "Name" }, heading_level: 'm')
     assert_select "div.gem-c-organisation-logo"
   end
+
+  it "renders a inline container when set" do
+    render_component(organisation: { name: "Name" }, inline: true)
+    assert_select "div.gem-c-organisation-logo__container--inline"
+  end
+
+  it "renders inline link when set" do
+    render_component(organisation: { name: "Name", url: "/some-link" }, inline: true)
+    assert_select "a.gem-c-organisation-logo__container--inline"
+  end
 end

--- a/spec/components/organisation_logo_spec.rb
+++ b/spec/components/organisation_logo_spec.rb
@@ -70,4 +70,24 @@ describe "Organisation logo", type: :view do
     render_component(organisation: { data_attributes: data_attributes })
     assert_select ".gem-c-organisation-logo a.gem-c-organisation-logo__container.gem-c-organisation-logo__link[data-track-category='someLinkClicked']", false
   end
+
+  it "uses a div by default" do
+    render_component(organisation: { name: "Name" })
+    assert_select "div.gem-c-organisation-logo"
+  end
+
+  it "uses a heading when specified" do
+    render_component(organisation: { name: "Name" }, heading_level: 3)
+    assert_select "h3.gem-c-organisation-logo"
+  end
+
+  it "uses a div when a inappropriate heading level is used" do
+    render_component(organisation: { name: "Name" }, heading_level: 7)
+    assert_select "div.gem-c-organisation-logo"
+  end
+
+  it "uses a div when a inappropriate parameter is passed" do
+    render_component(organisation: { name: "Name" }, heading_level: 'm')
+    assert_select "div.gem-c-organisation-logo"
+  end
 end


### PR DESCRIPTION
## What
This adds an extra configuration option to set the wrapping element of the organisation logo to be a heading.

This also adds the option to make that element not fill up as wide as the parent element. Since this could break things, this option is off by default.

<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->

Wrapping the organisation logo in a heading allows it to be part of the content of the page, as required by the [Ministers page](https://www.gov.uk/government/ministers). 

Making the component inline removes a large invisible area that users could mistakenly tap and trigger the link. It also makes the focus state more consistent.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

No visual changes when changing the wrapping element.

### Inline before:
![image](https://user-images.githubusercontent.com/1732331/68873206-325f0c00-06f7-11ea-9cac-85ad44b58078.png)

### Inline after:
![image](https://user-images.githubusercontent.com/1732331/68873244-430f8200-06f7-11ea-85e1-c93521e963fd.png)

## View Changes
https://govuk-publishing-compo-pr-1198.herokuapp.com/component-guide/organisation_logo
