### PR TITLE
Remove false positive accessibility errors

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -215,7 +215,7 @@ examples:
   different_heading_level:
     description: This will alter the level of the heading, not the appearance of the heading.
     data:
-      heading_level: 5
+      heading_level: 3
       items:
         - heading:
             text: "Writing well for the web"

--- a/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
@@ -8,6 +8,8 @@ shared_accessibility_criteria:
 accessibility_criteria:
   The breadcrumb links must have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
   (this especially applies when [using the inverse flag](/component-guide/breadcrumbs/inverse)).
+accessibility_excluded_rules:
+  - skip-link # This component is creating a reference to #content which is part of the layout
 display_html: true
 examples:
   default:

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -24,6 +24,8 @@ accessibility_criteria: |
   Links with formatted numbers must separate the number and text with a space for correct screen reader pronunciation. This changes pronunciation from "1 dot Item" to "1 Item".
 shared_accessibility_criteria:
   - link
+accessibility_excluded_rules:
+  - skip-link # The examples for this component are using references to sections on the page that do not exist in examples
 examples:
   default:
     data:

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -57,31 +57,29 @@ examples:
         title: "A content item"
         links:
           part_of_step_navs:
-            - title: "Choosing a micropig or micropug: step by step"
+            - title: "Learn to drive a car: step by step"
               base_path: "/micropigs-vs-micropugs"
               details:
                 step_by_step_nav:
                   title: 'Stay in the UK after it leaves the EU (''settled status''): step by step'
                   steps:
-                  - title: Check if you need to apply to the EU Settlement Scheme
+                  - title: Check you're allowed to drive
                     contents:
                     - type: paragraph
-                      text: 'You may need to apply to the EU Settlement Scheme to continue living
-                        in the UK. '
+                      text: Most people can start learning to drive when they’re 17.
                     - type: list
                       contents:
-                      - text: Check if you need to apply
-                        href: "/settled-status-eu-citizens-families/eligibility"
+                      - text: Check what age you can drive
+                        href: "/vehicles-can-drive"
                     optional: false
-                  - title: Find out what status you’ll get
+                  - title: Driving lessons and practice
                     contents:
                     - type: paragraph
-                      text: You’ll get settled or pre-settled status depending on how long you’ve
-                        been living in the UK. This might affect when you choose to apply.
+                      text: You need a provisional driving licence to take lessons or practice.
                     - type: list
                       contents:
-                      - text: Find out what you’ll get
-                        href: "/settled-status-eu-citizens-families/what-settled-and-presettled-status-means"
+                      - text: The Highway Code
+                        href: "/guidance/the-highway-code"
                     optional: false
   with_brexit_cta_and_related_links:
     data:

--- a/app/views/govuk_publishing_components/components/docs/error_summary.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_summary.yml
@@ -5,6 +5,8 @@ accessibility_criteria: |
   - list of errors should be clickable and focus the inputs with errors
 shared_accessibility_criteria:
   - link
+accessibility_excluded_rules:
+  - skip-link # This component is creating references to to sections on the page that do not exist in examples
 examples:
   default:
     data:

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -17,6 +17,8 @@ accessibility_criteria: |
   - text should have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
 shared_accessibility_criteria:
   - link
+accessibility_excluded_rules:
+  - landmark-complementary-is-top-level # Statistic headlines are generating an aside element which can not be a top level in the examples
 examples:
   basic_content:
     data:

--- a/app/views/govuk_publishing_components/components/docs/inverse_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/inverse_header.yml
@@ -9,6 +9,8 @@ accessibility_criteria: |
   * be used in conjunction with content that renders a text contrast ratio higher than 4.5:1
   against the header colour to meet WCAG AA.
 
+accessibility_excluded_rules:
+  - skip-link # Examples of this component contain breadcrumbs, creating a reference to #content which is part of the layout
 examples:
   default:
     data:

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -36,6 +36,8 @@ accessibility_criteria: |
     Assumption made is that is most predictable for users of assistive technologies.
     The spec indicates that `contentinfo` is useful for "Examples of information included in this region of the page are copyrights and links to privacy statements.", which may indicate that it might be better placed around the 'meta' section of this component.
     Should be challenged if user research indicates this is an issue.
+accessibility_excluded_rules:
+  - landmark-contentinfo-is-top-level # The footer element can not be top level in the examples
 examples:
   default:
     data: {}

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -29,12 +29,12 @@ examples:
       environment: production
       navigation_items:
       - text: Navigation item 1
-        href: "#1"
+        href: "item-1"
         active: true
       - text: Navigation item 2
-        href: "#2"
+        href: "item-2"
       - text: Hidden on desktop
-        href: "#3"
+        href: "item-3"
         show_only_in_collapsed_menu: true
   full_width:
     description: |

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -5,6 +5,8 @@ body: |
   staging or production).
 govuk_frontend_components:
   - header
+accessibility_excluded_rules:
+  - landmark-banner-is-top-level # The header element can not be top level in the examples
 examples:
   default:
     data:

--- a/app/views/govuk_publishing_components/components/docs/metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/metadata.yml
@@ -9,6 +9,8 @@ accessibility_criteria: |
 
 shared_accessibility_criteria:
   - link
+accessibility_excluded_rules:
+  - skip-link # This component is creating a reference to sections of the page that are not part of the examples.
 examples:
   from_only:
     data:

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -31,8 +31,7 @@ accessibility_criteria: |
   - Left Arrow and Up Arrow: move focus to the previous radio button in the group, uncheck the previously focused button, and check the newly focused button. If focus is on the first button, focus moves to the last button.
 
 accessibility_excluded_rules:
-- radiogroup # Since this is in isolation we don't want to wrap a fieldset here.
-- aria-expanded # We use aria expanded to reflect the state of a conditionally revealed radio content even if this attribute is not officially supported on this element.
+  - aria-expanded # We use aria expanded to reflect the state of a conditionally revealed radio content even if this attribute is not officially supported on this element.
 govuk_frontend_components:
   - radios
 examples:

--- a/app/views/govuk_publishing_components/components/docs/skip_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/skip_link.yml
@@ -9,6 +9,8 @@ accessibility_criteria: |
   - indicate when they have focus
   - becomes visible when pressing tab
   - is the first items that screen readers hear and that keyboard users tab to
+accessibility_excluded_rules:
+  - skip-link # This component is creating a reference to #content which is part of the layout
 examples:
   default:
     data:


### PR DESCRIPTION
## What
Update `accessibility_excluded_rules` on a few components to remove false positives from the component guide.

## Why
Our components have fair few accessibility issues, but having not-so-relevant errors makes it harder to focus on those that actually need to be addressed.

## Visual Changes
No visual changes

https://govuk-publishing-compo-pr-1200.herokuapp.com/component-guide