### PR TITLE
Migrate primary-links JavaScript from frontend_toolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Migrate primary-links.js from frontend_toolkit ([PR #1201](https://github.com/alphagov/govuk_publishing_components/pull/1201))
+
 ## 21.11.0
 
 * Update background colour for search buttons ([PR #1197](https://github.com/alphagov/govuk_publishing_components/pull/1197))

--- a/app/assets/javascripts/govuk_publishing_components/lib/primary-links.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/primary-links.js
@@ -1,0 +1,58 @@
+// migrated from govuk_frontend_toolkit
+;(function (global) {
+  'use strict'
+
+  var $ = global.jQuery
+  var GOVUK = global.GOVUK || {}
+
+  // Only show the first {n} items in a list, documentation is in the README.md
+  var PrimaryList = function (el, selector) {
+    this.$el = $(el)
+    this.$extraLinks = this.$el.find('li:not(' + selector + ')')
+    // only hide more than one extra link
+    if (this.$extraLinks.length > 1) {
+      this.addToggleLink()
+      this.hideExtraLinks()
+    }
+  }
+
+  PrimaryList.prototype = {
+    toggleText: function () {
+      if (this.$extraLinks.length > 1) {
+        return '+' + this.$extraLinks.length + ' others'
+      } else {
+        return '+' + this.$extraLinks.length + ' other'
+      }
+    },
+    addToggleLink: function () {
+      this.$toggleLink = $('<a href="#">' + this.toggleText() + '</a>')
+      this.$toggleLink.click($.proxy(this.toggleLinks, this))
+      this.$toggleLink.insertAfter(this.$el)
+    },
+    toggleLinks: function (e) {
+      e.preventDefault()
+      this.$toggleLink.remove()
+      this.showExtraLinks()
+    },
+    hideExtraLinks: function () {
+      this.$extraLinks.addClass('visuallyhidden')
+      $(window).trigger('govuk.pageSizeChanged')
+    },
+    showExtraLinks: function () {
+      this.$extraLinks.removeClass('visuallyhidden')
+      $(window).trigger('govuk.pageSizeChanged')
+    }
+  }
+
+  GOVUK.PrimaryList = PrimaryList
+
+  GOVUK.primaryLinks = {
+    init: function (selector) {
+      $(selector).parent().each(function (i, el) {
+        new GOVUK.PrimaryList(el, selector) // eslint-disable-line no-new
+      })
+    }
+  }
+
+  global.GOVUK = GOVUK
+})(window)

--- a/spec/javascripts/govuk_publishing_components/lib/primary-links.spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/primary-links.spec.js
@@ -1,0 +1,55 @@
+/* global describe it expect beforeEach spyOn */
+
+var $ = window.jQuery
+
+describe('primary-links', function () {
+  'use strict'
+  var GOVUK = window.GOVUK
+
+  var shortList, mediumList
+
+  beforeEach(function () {
+    shortList = $('<ul><li class="primary">one</li><li>two</li></ul>')
+    mediumList = $('<ul><li class="primary">one</li><li>two</li><li>three</li></ul>')
+  })
+
+  it('visually hides extra links', function () {
+    new GOVUK.PrimaryList(mediumList, '.primary') // eslint-disable-line no-new
+
+    expect(mediumList.find('.visuallyhidden').length).toBe(2)
+  })
+
+  it('creates appropriate toggle text', function () {
+    var short = new GOVUK.PrimaryList(shortList, '.primary')
+    var medium = new GOVUK.PrimaryList(mediumList, '.primary')
+
+    expect(short.toggleText()).toEqual('+1 other')
+    expect(medium.toggleText()).toEqual('+2 others')
+  })
+
+  it('add a toggle link', function () {
+    var container = $('<div>').append(mediumList)
+    new GOVUK.PrimaryList(mediumList, '.primary') // eslint-disable-line no-new
+
+    expect(container.find('a').length).toBe(1)
+  })
+
+  it('show extra links when toggled', function () {
+    var list = new GOVUK.PrimaryList(mediumList, '.primary')
+    var event = { preventDefault: function () {} }
+    spyOn(event, 'preventDefault')
+    spyOn(list, 'showExtraLinks')
+
+    list.toggleLinks(event)
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(list.showExtraLinks).toHaveBeenCalled()
+  })
+
+  it('only adds toggle if more than one extra link', function () {
+    new GOVUK.PrimaryList(shortList, '.primary') // eslint-disable-line no-new
+    new GOVUK.PrimaryList(mediumList, '.primary') // eslint-disable-line no-new
+
+    expect(shortList.find('.visuallyhidden').length).toBe(0)
+    expect(mediumList.find('.visuallyhidden').length).toBe(2)
+  })
+})


### PR DESCRIPTION
## What
Migrate primary-links.js from govuk_frontend_toolkit.
Currently used by manuals-frontend and manuals-publisher

## Why
[Part of the work to migrate away from govuk_frontend_toolkit](https://trello.com/c/fxfRx7dQ/95-remove-govukfrontendtoolkit-from-static)


<!--
## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
-->
