### PR TITLE
Update govuk-frontend to 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Update govuk-frontend to 3.4.0 ([PR #1204](https://github.com/alphagov/govuk_publishing_components/pull/1204))
+
 * Allow aria-controls attribute on search component ([PR #1203](https://github.com/alphagov/govuk_publishing_components/pull/1203))
 
 ## 21.12.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -867,9 +867,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.2.0.tgz",
-      "integrity": "sha512-OtJozAGMEKFu195fNVVrQHUX7+znCkA4cXDKs4lgFlRQOTzN1ogT9010GBARuoTwbeL0VqQ8nerZYjVxH/wafA=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.4.0.tgz",
+      "integrity": "sha512-rmYPtcCtWgz92QBejYwOnfSxbPGYfvSruLwB4CBk/yJtySHRY0whG1e2/iFRRSj0pMx1Bu+zh/IqCTo+84hbFw=="
     },
     "graceful-fs": {
       "version": "4.1.15",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "axe-core": "3.2.2",
-    "govuk-frontend": "3.2.0",
+    "govuk-frontend": "3.4.0",
     "jquery": "1.12.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Notable change:
 - update hex value for secondary text to improve contrast ([updated from #6f777b to #626a6e](https://github.com/alphagov/govuk-frontend/pull/1609))

## What
Update `govuk_publishing_components` to use [`govuk-frontend` version 3.4.0.](https://github.com/alphagov/govuk-frontend/releases/tag/v3.4.0)

## Why
Keep frontend code in sync with the Design System updates

For more details regarding changes see [govuk-frontend 3.4.0 changelog](https://github.com/alphagov/govuk-frontend/releases/tag/v3.4.0)

## View Changes
https://govuk-publishing-compo-pr-1204.herokuapp.com/

