### PR TITLE
Check if CSP is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add a condition to check that we can use the content_security_policy feature supported from Rails 5.2.
+
 ## 21.13.0
 
 * Update govuk-frontend to 3.4.0 ([PR #1204](https://github.com/alphagov/govuk_publishing_components/pull/1204))

--- a/app/controllers/govuk_publishing_components/application_controller.rb
+++ b/app/controllers/govuk_publishing_components/application_controller.rb
@@ -5,15 +5,17 @@ module GovukPublishingComponents
     before_action :set_x_frame_options_header
     before_action :set_disable_slimmer_header
 
-    content_security_policy do |p|
-      # don't do anything if the app doesn't have a content security policy
-      next unless p.directives.any?
+    if defined? content_security_policy
+      content_security_policy do |p|
+        # don't do anything if the app doesn't have a content security policy
+        next unless p.directives.any?
 
-      # Unfortunately the axe core script uses a dependency that uses eval
-      # see: https://github.com/dequelabs/axe-core/issues/1175
-      # Thus all components shown by govuk_publishing_components need this
-      # enabled
-      p.script_src(*p.script_src, :unsafe_eval)
+        # Unfortunately the axe core script uses a dependency that uses eval
+        # see: https://github.com/dequelabs/axe-core/issues/1175
+        # Thus all components shown by govuk_publishing_components need this
+        # enabled
+        p.script_src(*p.script_src, :unsafe_eval)
+      end
     end
 
   private


### PR DESCRIPTION
This is causing tests to fail for apps that use the gem but not
on Rails 5.2, which is where CSP is introduced as a feature.