### PR TITLE
Change tags and styling for feedback component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -197,3 +197,9 @@
   // scss-lint:enable PlaceholderInExtend
   margin: 0;
 }
+
+.gem-c-feedback__option-list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -5,8 +5,7 @@
 <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
   <div class="gem-c-feedback__js-prompt-questions js-prompt-questions">
     <h2 class="gem-c-feedback__prompt-question">Is this page useful?</h2>
-    <ul class="gem-c-feedback__option-list">
-      <%= link_to contact_govuk_path, {
+    <%= link_to contact_govuk_path, {
         class: 'gem-c-feedback__prompt-link',
         data: {
           'track-category' => 'yesNoFeedbackForm',
@@ -19,7 +18,8 @@
         'aria-hidden': 'true',
       } do %>
         Maybe
-      <% end %>
+    <% end %>
+    <ul class="gem-c-feedback__option-list">
       <li class="gem-c-feedback__option-list-item">
         <%= link_to contact_govuk_path, {
           class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful',

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -5,59 +5,63 @@
 <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
   <div class="gem-c-feedback__js-prompt-questions js-prompt-questions">
     <h2 class="gem-c-feedback__prompt-question">Is this page useful?</h2>
-
-    <%= link_to contact_govuk_path, {
-      class: 'gem-c-feedback__prompt-link',
-      data: {
-        'track-category' => 'yesNoFeedbackForm',
-        'track-action' => 'ffMaybeClick'
-      },
-      'aria-expanded': false,
-      role: 'button',
-      style: 'display: none;',
-      hidden: 'hidden',
-      'aria-hidden': 'true',
-    } do %>
-      Maybe
-    <% end %>
-
-    <%= link_to contact_govuk_path, {
-      class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful',
-      data: {
-        'track-category' => 'yesNoFeedbackForm',
-        'track-action' => 'ffYesClick'
-      },
-      'aria-expanded': false,
-      role: 'button',
-    } do %>
-      Yes <span class="visually-hidden">this page is useful</span>
-    <% end %>
-
-    <%= link_to contact_govuk_path, {
-      class: 'gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful',
-      data: {
-        'track-category' => 'yesNoFeedbackForm',
-        'track-action' => 'ffNoClick'
-      },
-      'aria-controls': 'page-is-not-useful',
-      'aria-expanded': false,
-      role: 'button',
-    } do %>
-      No <span class="visually-hidden">this page is not useful</span>
-    <% end %>
-
-    <%= link_to contact_govuk_path, {
-      class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong',
-      data: {
-        'track-category' => 'Onsite Feedback',
-        'track-action' => 'GOV.UK Open Form'
-      },
-      'aria-controls': 'something-is-wrong',
-      'aria-expanded': false,
-      role: 'button',
-    } do %>
-      Is there anything wrong with this page?
-    <% end %>
+    <ul class="gem-c-feedback__option-list">
+      <%= link_to contact_govuk_path, {
+        class: 'gem-c-feedback__prompt-link',
+        data: {
+          'track-category' => 'yesNoFeedbackForm',
+          'track-action' => 'ffMaybeClick'
+        },
+        'aria-expanded': false,
+        role: 'button',
+        style: 'display: none;',
+        hidden: 'hidden',
+        'aria-hidden': 'true',
+      } do %>
+        Maybe
+      <% end %>
+      <li class="gem-c-feedback__option-list-item">
+        <%= link_to contact_govuk_path, {
+          class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful',
+          data: {
+            'track-category' => 'yesNoFeedbackForm',
+            'track-action' => 'ffYesClick'
+          },
+          'aria-expanded': false,
+          role: 'button',
+        } do %>
+          Yes <span class="visually-hidden">this page is useful</span>
+        <% end %>
+      </li>
+      <li class="gem-c-feedback__option-list-item">
+        <%= link_to contact_govuk_path, {
+          class: 'gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful',
+          data: {
+            'track-category' => 'yesNoFeedbackForm',
+            'track-action' => 'ffNoClick'
+          },
+          'aria-controls': 'page-is-not-useful',
+          'aria-expanded': false,
+          role: 'button',
+        } do %>
+          No <span class="visually-hidden">this page is not useful</span>
+        <% end %>
+      </li>
+      <li class="gem-c-feedback__option-list-item">
+        <%= link_to contact_govuk_path, {
+          class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong',
+          data: {
+            'track-category' => 'Onsite Feedback',
+            'track-action' => 'GOV.UK Open Form'
+          },
+          'aria-controls': 'something-is-wrong',
+          'aria-expanded': false,
+          role: 'button',
+        } do %>
+          Is there anything wrong with this page?
+        <% end %>
+      </li>
+    </ul>
   </div>
 
   <div class="gem-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">


### PR DESCRIPTION
This change addresses the issue encountered when a user that has blocked
css styling sees the feedback component. Originally, the options
presented to the user are all strung together in one line, making it
potentially confusing. This change separates them out into a list,
meaning that when there is no styling for the page, each option is on
its own separate row.

The styling is effectively neutralised if css is turned on, and all of
the default behaviours for the lists are removed.

See this [Trello card](https://trello.com/c/otALwPuk/1170-y-n-links-not-obvious-when-styles-are-removed) for more details
