### PR TITLE
Release version 21.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.13.1
 
-* Add a condition to check that we can use the content_security_policy feature supported from Rails 5.2.
+* Add a condition to check that we can use the content_security_policy feature supported from Rails 5.2. ([PR #1206](https://github.com/alphagov/govuk_publishing_components/pull/1206))
 
 ## 21.13.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.13.0)
+    govuk_publishing_components (21.13.1)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -211,7 +211,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.12.0)
+    rouge (3.13.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.6)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.13.0'.freeze
+  VERSION = '21.13.1'.freeze
 end


### PR DESCRIPTION
* Add a condition to check that we can use the content_security_policy feature supported from Rails 5.2. ([PR #1206](https://github.com/alphagov/govuk_publishing_components/pull/1206))