### PR TITLE
Fix feedback component layout on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Fix Feedback component layout on mobile ([#1211](https://github.com/alphagov/govuk_publishing_components/pull/1207))
+
 * Fix header environment label layout on mobile ([PR #1212](https://github.com/alphagov/govuk_publishing_components/pull/1212))
 
 ## 21.13.2

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -64,11 +64,9 @@
 .gem-c-feedback__prompt-link {
   @include govuk-link-common;
   @include govuk-font(19);
-  margin-left: govuk-spacing(3);
 
   @include govuk-media-query($from: tablet) {
     @include govuk-font(16);
-    float: left; // needed to ensure vertical alignment consistent with prompt-link--wrong
     margin-left: govuk-spacing(2);
   }
 }
@@ -79,20 +77,6 @@
 
   &:focus {
     color: $govuk-focus-text-colour;
-  }
-}
-
-.gem-c-feedback__prompt-link--wrong {
-  display: block;
-  clear: both;
-  margin-top: govuk-spacing(3);
-  margin-left: 0;
-
-  @include govuk-media-query($from: tablet) {
-    float: right;
-    clear: none;
-    margin-top: 0;
-    margin-left: govuk-spacing(2);
   }
 }
 
@@ -202,4 +186,79 @@
   list-style-type: none;
   margin: 0;
   padding: 0;
+}
+
+
+.js-enabled {
+  .gem-c-feedback__js-prompt-questions {
+    @include govuk-media-query($until: tablet) {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(150px, 140));
+      grid-template-rows: repeat(2, auto);
+    }
+  }
+
+  .gem-c-feedback__prompt-question {
+    @include govuk-media-query($until: tablet) {
+      grid-area: 1 / 1;
+    }
+  }
+
+  .gem-c-feedback__option-list {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+
+    @include govuk-media-query($until: tablet) {
+      grid-area: 1 / 1 / 2 / 3;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(140px, 140px));
+      grid-template-rows: repeat(2, auto);
+      // older grid spec
+      grid-row-gap: govuk-spacing(3);
+      // newer grid spec
+      row-gap: govuk-spacing(3); // sass-lint:disable-line no-misspelled-properties
+    }
+  }
+
+  .gem-c-feedback__option-list-item {
+    @include govuk-media-query($from: tablet) {
+      float: left;
+    }
+  }
+
+  .gem-c-feedback__option-list-item--useful {
+    @include govuk-media-query($until: tablet) {
+      display: inline-block;
+      @supports (display: grid) {
+        grid-area: 1 / 2;
+        padding-left: govuk-spacing(3);
+      }
+    }
+  }
+
+  .gem-c-feedback__option-list-item--not-useful {
+    @include govuk-media-query($until: tablet) {
+      display: inline-block;
+      @supports (display: grid) {
+        grid-area: 1 / 2;
+        padding-left: 50px;
+      }
+    }
+  }
+
+  .gem-c-feedback__option-list-item--wrong {
+    @include govuk-media-query($until: tablet) {
+      display: block;
+      margin-top: govuk-spacing(3);
+      @supports (display: grid) {
+        margin-top: 0;
+        grid-area: 2 / 1 / 2 / 3;
+      }
+    }
+
+    @include govuk-media-query($from: tablet) {
+      float: right;
+    }
+  }
 }

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -20,9 +20,9 @@
         Maybe
     <% end %>
     <ul class="gem-c-feedback__option-list">
-      <li class="gem-c-feedback__option-list-item">
+      <li class="gem-c-feedback__option-list-item gem-c-feedback__option-list-item--useful">
         <%= link_to contact_govuk_path, {
-          class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful',
+          class: 'gem-c-feedback__prompt-link js-page-is-useful',
           data: {
             'track-category' => 'yesNoFeedbackForm',
             'track-action' => 'ffYesClick'
@@ -33,7 +33,7 @@
           Yes <span class="visually-hidden">this page is useful</span>
         <% end %>
       </li>
-      <li class="gem-c-feedback__option-list-item">
+      <li class="gem-c-feedback__option-list-item gem-c-feedback__option-list-item--not-useful">
         <%= link_to contact_govuk_path, {
           class: 'gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful',
           data: {
@@ -47,9 +47,9 @@
           No <span class="visually-hidden">this page is not useful</span>
         <% end %>
       </li>
-      <li class="gem-c-feedback__option-list-item">
+      <li class="gem-c-feedback__option-list-item gem-c-feedback__option-list-item--wrong">
         <%= link_to contact_govuk_path, {
-          class: 'gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong',
+          class: 'gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong',
           data: {
             'track-category' => 'Onsite Feedback',
             'track-action' => 'GOV.UK Open Form'

--- a/spec/components/feedback_spec.rb
+++ b/spec/components/feedback_spec.rb
@@ -8,14 +8,14 @@ describe "Feedback", type: :view do
   it "asks the user if the page is useful without javascript enabled" do
     render_component({})
 
-    assert_select ".gem-c-feedback .gem-c-feedback__prompt-link--useful[href='/contact/govuk']", text: 'Yes this page is useful'
+    assert_select ".gem-c-feedback .gem-c-feedback__option-list-item--useful a[href='/contact/govuk']", text: 'Yes this page is useful'
     assert_select ".gem-c-feedback .gem-c-feedback__prompt-link.js-page-is-not-useful[href='/contact/govuk']", text: 'No this page is not useful'
   end
 
   it "asks the user if there is anything wrong with the page without javascript enabled" do
     render_component({})
 
-    assert_select ".gem-c-feedback .gem-c-feedback__prompt-link--wrong[href='/contact/govuk']", text: 'Is there anything wrong with this page?'
+    assert_select ".gem-c-feedback .gem-c-feedback__option-list-item--wrong a[href='/contact/govuk']", text: 'Is there anything wrong with this page?'
   end
 
   it "removes top margin when margin_top flag is set" do

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -7,11 +7,24 @@ describe('Feedback component', function () {
     '<div class="gem-c-feedback__prompt js-prompt" tabindex="-1">' +
       '<div class="js-prompt-questions">' +
         '<h3 class="gem-c-feedback__is-useful-question">Is this page useful?</h3>' +
-        '<a href="/contact/govuk" class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">Yes <span class="visually-hidden">this page is useful</span></a>' +
-        '<a href="/contact/govuk" class="gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">No <span class="visually-hidden">this page is not useful</span></a>' +
-        '<a href="/contact/govuk" class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV.UK Open Form" aria-controls="something-is-wrong" aria-expanded="false">Is there anything wrong with this page?</a>' +
+        '<ul class="gem-c-feedback__option-list">' +
+          '<li class="gem-c-feedback__option-list-item gem-c-feedback__option-list-item--useful">' +
+              '<a class="gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick" aria-expanded="false" role="button" href="/contact/govuk">' +
+                  'Yes <span class="visually-hidden">this page is useful</span>' +
+              '</a>' +
+          '</li>' +
+          '<li class="gem-c-feedback__option-list-item gem-c-feedback__option-list-item--not-useful">' +
+            '<a class="gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false" role="button" href="/contact/govuk">' +
+              'No <span class="visually-hidden">this page is not useful</span>' +
+            '</a>' +
+          '</li>' +
+          '<li class="gem-c-feedback__option-list-item gem-c-feedback__option-list-item--wrong">' +
+            '<a class="gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV.UK Open Form" aria-controls="something-is-wrong" aria-expanded="false" role="button" href="/contact/govuk">' +
+              'Is there anything wrong with this page?' +
+            '</a>' +
+          '</li>' +
+        '</ul>' +
       '</div>' +
-
       '<div class="gem-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">' +
         'Thanks for your feedback.' +
       '</div>' +


### PR DESCRIPTION
## What
Fix Feedback component layout on mobile.
- uses CSS grid for mobile viewport. Grid is supported in at least two previous mobile browsers - Safari, Chrome, Firefox, Samsung internet that we a majority of users on
- moves link classes to list elements and introduces additional classes to use with the grid positioning

## Why
With #1207 we inadvertently broke the component's layout on mobile.

### Before #1207
See: https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style

### After #1207

See: https://www.gov.uk/change-name-deed-poll

### After this change
https://govuk-publishing-compo-pr-1211.herokuapp.com/component-guide/feedback

## Alternative options

- rollback #1207 and think of a better no-css approach
- keep #1207 and just with the Yes/no that sit underneath the heading

[Trello ticket](https://trello.com/c/DyaJaUmQ/1185-fix-feedback-component-layout-on-mobile)