### PR TITLE
Fix header environment label layout on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix header environment label layout on mobile ([PR #1212](https://github.com/alphagov/govuk_publishing_components/pull/1212))
+
 ## 21.13.2
 
 * Change tags and styling for feedback component ([PR #1207](https://github.com/alphagov/govuk_publishing_components/pull/1207))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -19,7 +19,6 @@
 }
 
 .gem-c-header__logo {
-  white-space: nowrap;
   width: auto;
 }
 


### PR DESCRIPTION
## What
Fixes #1029 

## Why
Currently headers with environment label on mobile overlap the menu button if it exists.

This is caused by `white-space: nowrap;` on the `.gem-c-header__logo`.

This property doesn't exist in the GOV.UK Design system code and removing doesn't look to cause any issues.

## Preview
- https://govuk-publishing-compo-pr-1212.herokuapp.com/component-guide/layout_header

## Visual Changes

### Before
![before](https://user-images.githubusercontent.com/3758555/69859353-e631d100-128b-11ea-9661-7742b64ac1f5.png)

### After
![after](https://user-images.githubusercontent.com/3758555/69859352-e631d100-128b-11ea-9828-11ea7b463110.png)

