### PR TITLE
Add finders to doc types that have postcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add finder doc types to things that strip postcodes from GA. ([#1214](https://github.com/alphagov/govuk_publishing_components/pull/1214))
+
 ## 21.13.3
 
 * Fix Feedback component layout on mobile ([#1211](https://github.com/alphagov/govuk_publishing_components/pull/1207))

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -147,7 +147,7 @@ module GovukPublishingComponents
         # document_type
         return local_assigns[:strip_postcode_pii] if local_assigns.key?(:strip_postcode_pii)
 
-        formats_that_might_include_postcodes = %w[smart_answer search]
+        formats_that_might_include_postcodes = %w[smart_answer finder]
         formats_that_might_include_postcodes.include?(content_item[:document_type])
       end
     end

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -371,8 +371,8 @@ describe "Meta tags", type: :view do
     assert_meta_tag("govuk:static-analytics:strip-postcodes", "true")
   end
 
-  it "renders the static-analytics:strip-postcodes tag if the content item is a 'search'" do
-    render_component(content_item: { document_type: 'search' })
+  it "renders the static-analytics:strip-postcodes tag if the content item is a 'finder'" do
+    render_component(content_item: { document_type: 'finder' })
     assert_meta_tag("govuk:static-analytics:strip-postcodes", "true")
   end
 


### PR DESCRIPTION
Search pages have the document type finder now.

Setting this value invokes this [code from static](https://github.com/alphagov/static/blob/ce77c63aad26f8a408230f30faf7920d45588eaf/app/assets/javascripts/analytics/pii.js#L6) which strips things that look like postcodes from GA.

It's a little heavy handed apparently, so does things like converting 'p800refund' into '[postcode]fund', so we might want to look at it a little more.
