### PR TITLE
Simplify CSS Grid on feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Simplify CSS Grid on feedback component ([#1216](https://github.com/alphagov/govuk_publishing_components/pull/1216))
+
 * Add finder doc types to things that strip postcodes from GA. ([#1214](https://github.com/alphagov/govuk_publishing_components/pull/1214))
 
 ## 21.13.3

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -193,8 +193,6 @@
   .gem-c-feedback__js-prompt-questions {
     @include govuk-media-query($until: tablet) {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(150px, 140));
-      grid-template-rows: repeat(2, auto);
     }
   }
 
@@ -210,10 +208,9 @@
     padding: 0;
 
     @include govuk-media-query($until: tablet) {
-      grid-area: 1 / 1 / 2 / 3;
+      grid-area: 1 / 1 / 2 / 2;
       display: grid;
-      grid-template-columns: repeat(2, minmax(140px, 140px));
-      grid-template-rows: repeat(2, auto);
+      grid-template-columns: 140px 1fr;
       // older grid spec
       grid-row-gap: govuk-spacing(3);
       // newer grid spec


### PR DESCRIPTION
## What
- remove redundant row definitions and use the implicit rows.

- remove grid column and row definitions from the parent container,
as they're inherited from the child when needed

- replace column definition with a simple two width definitions,
as we only care about the minimum width of the first column

## Why
Remove redundant declarations. Keep it simple.

## View Changes

https://govuk-publishing-compo-pr-1216.herokuapp.com/component-guide/feedback/preview

## Visual Changes
No visual changes

### iOS Safari 12 (iphone 8)
<img width="477" alt="Screenshot 2019-12-06 at 08 37 43" src="https://user-images.githubusercontent.com/3758555/70308684-b6db1100-1803-11ea-89f9-3ec92d1b7fd2.png">

### Desktop Firefox, Safari, Chrome
<img width="1179" alt="Screenshot 2019-12-06 at 08 22 30" src="https://user-images.githubusercontent.com/3758555/70308431-243a7200-1803-11ea-8000-c55e6a5bffd7.png">

### Mobile Chrome and Samsung internet
<img width="437" alt="Screenshot 2019-12-06 at 08 23 43" src="https://user-images.githubusercontent.com/3758555/70308622-901cda80-1803-11ea-98a5-82830d618a97.png">
<img width="461" alt="Screenshot 2019-12-06 at 08 36 38" src="https://user-images.githubusercontent.com/3758555/70308623-901cda80-1803-11ea-862f-c311016e0089.png">






