### PR TITLE
Fix 'Help us improve' feedback form button / link alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Fix 'Help us improve' feedback form button / link alignment ([#1217](https://github.com/alphagov/govuk_publishing_components/pull/1217))
+
 * Simplify CSS Grid on feedback component ([#1216](https://github.com/alphagov/govuk_publishing_components/pull/1216))
 
 * Add finder doc types to things that strip postcodes from GA. ([#1214](https://github.com/alphagov/govuk_publishing_components/pull/1214))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -164,9 +164,9 @@
   display: block;
   margin-top: govuk-spacing(3);
 
-  @include govuk-media-query($from: tablet) {
+  @include govuk-media-query($from: desktop) {
     display: inline-block;
-    margin-top: 0;
+    margin-top: govuk-spacing(2);
     margin-left: govuk-spacing(3);
   }
 }


### PR DESCRIPTION
## What
This updates the button / link alignment so that they are side-by-side only on desktop; otherwise stacked.
It also updates the vertical alignment.

Fixes: #1217

## Why
See #1217 

## View Changes
https://govuk-publishing-compo-pr-1218.herokuapp.com/component-guide/feedback/preview

## Visual Changes

### Before
<img width="703" alt="Screenshot 2019-12-06 at 10 37 36" src="https://user-images.githubusercontent.com/3758555/70316876-8059c200-1814-11ea-9a77-27846e9dd3b8.png">
<img width="526" alt="Screenshot 2019-12-06 at 10 37 44" src="https://user-images.githubusercontent.com/3758555/70316878-8059c200-1814-11ea-8099-6472e100bbb6.png">


### After
<img width="506" alt="Screenshot 2019-12-06 at 10 47 21" src="https://user-images.githubusercontent.com/3758555/70317578-f1e64000-1815-11ea-9bd3-178695425c6e.png">
<img width="578" alt="Screenshot 2019-12-06 at 10 47 58" src="https://user-images.githubusercontent.com/3758555/70317579-f1e64000-1815-11ea-9f22-74215be4f2ce.png">



