### PR TITLE
Release 21.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.13.4
 
 * Fix 'Help us improve' feedback form button / link alignment ([#1217](https://github.com/alphagov/govuk_publishing_components/pull/1217))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.13.3)
+    govuk_publishing_components (21.13.4)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.13.3'.freeze
+  VERSION = '21.13.4'.freeze
 end


### PR DESCRIPTION
Contains:

* Fix 'Help us improve' feedback form button / link alignment ([#1217](https://github.com/alphagov/govuk_publishing_components/pull/1217))

* Simplify CSS Grid on feedback component ([#1216](https://github.com/alphagov/govuk_publishing_components/pull/1216))

* Add finder doc types to things that strip postcodes from GA. ([#1214](https://github.com/alphagov/govuk_publishing_components/pull/1214))
