### PR TITLE
Fix checkbox small option

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -1,5 +1,7 @@
 name: Form checkboxes
 description: Let users select one or more options with checkboxes.
+body: |
+  If there is more than one checkbox they are rendered in a list. If there is only one, the markup is simplified to a single div and a heading attribute is not required.
 govuk_frontend_components:
   - checkboxes
 accessibility_criteria: |

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -11,10 +11,10 @@ module GovukPublishingComponents
         @name = options[:name]
         @css_classes = %w(gem-c-checkboxes govuk-form-group)
         @css_classes << "govuk-form-group--error" if options[:error]
+        @css_classes << "govuk-checkboxes--small" if options[:small]
         @error = true if options[:error]
 
         @list_classes = %w(govuk-checkboxes gem-c-checkboxes__list)
-        @list_classes << "govuk-checkboxes--small" if options[:small]
 
         # check if any item is set as being conditional
         @has_conditional = options[:items].any? { |item| item.is_a?(Hash) && item[:conditional] }

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -46,7 +46,7 @@ describe "Checkboxes", type: :view do
         { label: "Green", value: "green" },
       ]
     )
-    assert_select ".govuk-checkboxes.govuk-checkboxes--small"
+    assert_select ".gem-c-checkboxes.govuk-checkboxes--small"
   end
 
   it "renders nothing if no heading is supplied" do


### PR DESCRIPTION
## What
Fix the option for small checkboxes. The relevant class was only being applied to the component when more than one checkbox was present. This change moves the class into the parent element, so it applies in both situations. I've also added a note to the documentation to clarify the one box/more than one box thing.

## Why
One small checkbox is required in [finder-frontend](https://github.com/alphagov/finder-frontend/pull/1798)

## Visual Changes
None.

## View Changes
https://govuk-publishing-compo-pr-1221.herokuapp.com/
