### PR TITLE
Allow describedby on textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow textarea to be described by an element outside the component ([#1225](https://github.com/alphagov/govuk_publishing_components/pull/1225))
+* Add guidance_id to contextual guidance component ([#1225](https://github.com/alphagov/govuk_publishing_components/pull/1225))
+
 ## 21.14.0
 
 * Allow custom heading size on fieldset component ([#1223](https://github.com/alphagov/govuk_publishing_components/pull/1223))

--- a/app/views/govuk_publishing_components/components/_contextual_guidance.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_guidance.html.erb
@@ -4,6 +4,7 @@
   content ||= nil
   data_attributes ||= {}
   data_attributes[:module] = "contextual-guidance"
+  guidance_id ||= nil
 %>
 
 <%= tag.div class: "gem-c-contextual-guidance", id: id, data: data_attributes do %>
@@ -14,7 +15,7 @@
       <% end %>
     <% end %>
     <%= tag.div class: "govuk-grid-column-one-third" do %>
-      <%= tag.div class: "gem-c-contextual-guidance__wrapper", for: html_for do %>
+      <%= tag.div class: "gem-c-contextual-guidance__wrapper", for: html_for, id: guidance_id do %>
         <%= tag.div class: "gem-c-contextual-guidance__guidance" do %>
           <%= tag.h2 title, class: "govuk-heading-s" %>
           <%= content %>

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -2,6 +2,7 @@
   id ||= "textarea-#{SecureRandom.hex(4)}"
   value ||= nil
   rows ||= 5
+  describedby ||= nil
   data ||= nil
   spellcheck ||= "true"
 
@@ -27,10 +28,11 @@
   form_group_css_classes << (shared_helper.get_margin_bottom)
 
   aria_described_by ||= nil
-  if hint || has_error
+  if hint || has_error || describedby
     aria_described_by = []
     aria_described_by << hint_id if hint
     aria_described_by << error_id if has_error
+    aria_described_by << describedby if describedby
     aria_described_by = aria_described_by.join(" ")
   end
 %>

--- a/app/views/govuk_publishing_components/components/docs/contextual_guidance.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_guidance.yml
@@ -19,10 +19,11 @@ examples:
     data:
       html_for: news-title
       title: Writing a news title
+      guidance_id: news-title-guidance
       content: |
         <p>The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.</p>
       block: |
         <div class="govuk-form-group">
           <label class="gem-c-label govuk-label" for="news-title">News title</label>
-          <input id="news-title" type="text" class="gem-c-input govuk-input">
+          <input id="news-title" type="text" class="gem-c-input govuk-input" aria-describedby="news-title-guidance">
         </div>

--- a/app/views/govuk_publishing_components/components/docs/textarea.yml
+++ b/app/views/govuk_publishing_components/components/docs/textarea.yml
@@ -76,3 +76,15 @@ examples:
       name: "maxlength"
       value: "You can't type more"
       maxlength: 19
+  with_aria_attributes:
+    description: Use `describedby` when the textarea is described by an element outside the component; for example, when used in conjunction with a [contextual guidance](/component-guide/contextual_guidance).
+    embed: |
+      <%= component %>
+      <p class="govuk-body" id="contextual-guidance">The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.</p>
+    data:
+      label:
+        text: "Title"
+        bold: true
+      name: "described"
+      rows: 2
+      describedby: "contextual-guidance"

--- a/spec/components/contextual_guidance_spec.rb
+++ b/spec/components/contextual_guidance_spec.rb
@@ -15,13 +15,14 @@ describe "Contextual guidance", type: :view do
     render_component(
       html_for: "news-title",
       title: "Writing a news title",
+      guidance_id: 'news-title-guidance',
       content: sanitize("<p>The title must make clear what the content offers users</p>")
     ) do
       tag.input id: "news-title", name: "news-title", type: "text"
     end
 
     assert_select ".gem-c-contextual-guidance__input-field input[id='news-title'][name='news-title'][type='text']"
-    assert_select ".gem-c-contextual-guidance__wrapper[for='news-title']"
+    assert_select ".gem-c-contextual-guidance__wrapper[for='news-title'][id='news-title-guidance']"
     assert_select ".gem-c-contextual-guidance__guidance .govuk-heading-s", text: "Writing a news title"
     assert_select ".gem-c-contextual-guidance__guidance p", text: "The title must make clear what the content offers users"
   end

--- a/spec/components/textarea_spec.rb
+++ b/spec/components/textarea_spec.rb
@@ -42,6 +42,16 @@ describe "Textarea", type: :view do
     assert_select ".govuk-textarea[data-module='contextual-guidance']"
   end
 
+  it "renders textarea with aria describedby attribute if provided" do
+    render_component(
+      label: { text: "Title" },
+      name: "described",
+      describedby: "contextual-guidance",
+    )
+
+    assert_select ".govuk-textarea[aria-describedby='contextual-guidance']"
+  end
+
   it "renders textarea with disabled spellcheck" do
     render_component(
       spellcheck: "false",
@@ -137,6 +147,20 @@ describe "Textarea", type: :view do
 
       assert_select ".govuk-textarea[aria-describedby='#{error_id}']"
     end
+  end
+
+  it "renders multiple aria describedby" do
+    render_component(
+      label: { text: "Title" },
+      name: "with-multiple-aria-describedby",
+      hint: "Don’t include personal or financial information.",
+      error_message: "Please enter more detail",
+      describedby: "contextual-guidance",
+    )
+    hint_id = css_select(".govuk-hint").attr("id")
+    error_id = css_select(".govuk-error-message").attr("id")
+
+    assert_select ".govuk-textarea[aria-describedby='#{hint_id} #{error_id} contextual-guidance']"
   end
 
   context "when error_items are provided" do


### PR DESCRIPTION
## What
Allow `aria-describedby` on textarea component (similarly to input).
Update the contextual-guidance component to be able to specify an `id` for the guidance content.

## Why
To be able to provide descriptions to inputs/textarea to screen readers using the contextual-guidance content.

## Visual Changes
No visual change.

https://govuk-publishing-compo-pr-1225.herokuapp.com/

[Trello card](https://trello.com/c/LQIMhHs0)