### PR TITLE
Simplify document list component markup when having only one item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Delete unconsented cookies automatically ([#1239](https://github.com/alphagov/govuk_publishing_components/pull/1239))
+* Simplify document list component markup when having only one item ([#1226](https://github.com/alphagov/govuk_publishing_components/pull/1226))
 
 ## 21.15.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -62,6 +62,8 @@
 
 .gem-c-document-list__item-metadata {
   padding: 0;
+  margin: 0;
+  @include govuk-font(19);
 }
 
 .gem-c-document-list__attribute {

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -8,71 +8,73 @@
 
   within_multitype_list ||= false
   within_multitype_list_class = " gem-c-document-list__multi-list" if within_multitype_list
-  title_with_context_class = " gem-c-document-list__item-title--context"
 
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
 %>
+<% def document(item, brand_helper) %>
+  <% title_with_context_class = " gem-c-document-list__item-title--context" %>
+  <% if item[:highlight] && item[:highlight_text] %>
+    <p class='gem-c-document-list__highlight-text'><%= item[:highlight_text] %></p>
+  <% end %>
+  <%=
+    item_classes = "gem-c-document-list__item-title #{brand_helper.color_class} #{title_with_context_class if item[:link][:context]}"
+
+    if item[:link][:path]
+      link_to(
+        item[:link][:text],
+        item[:link][:path],
+        data: item[:link][:data_attributes],
+        class: "#{item_classes} gem-c-document-list__item-link",
+      )
+    else
+      content_tag(
+        "span",
+        item[:link][:text],
+        data: item[:link][:data_attributes],
+        class: item_classes,
+      )
+    end
+  %>
+  <% if item[:link][:context] %>
+    <span class="gem-c-document-list__item-context"><%= item[:link][:context] %></span>
+  <% end %>
+  <% if item[:link][:description] %>
+    <p class="gem-c-document-list__item-description" ><%= item[:link][:description] %></p>
+  <% end %>
+  <% if item[:metadata] %>
+    <ul class="gem-c-document-list__item-metadata">
+      <% item[:metadata].compact.each do |item_metadata_key, item_metadata_value| %>
+        <li class="gem-c-document-list__attribute">
+          <% if item_metadata_key.to_s.eql?("public_updated_at") %>
+            <time datetime="<%= item_metadata_value.iso8601 %>">
+              <%= l(item_metadata_value, format: '%e %B %Y') %>
+            </time>
+          <% else %>
+            <%= item_metadata_value %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+  <% if item[:subtext] %>
+    <p class="gem-c-document-list__subtext"><%= item[:subtext] %></p>
+  <% end %>
+<% end %>
 <% if items.any? %>
-  <% unless within_multitype_list %>
+  <% unless within_multitype_list || items.one? %>
     <ol class="<%= classes %>">
   <% end %>
     <% items.each do |item| %>
       <% highlight_class = " gem-c-document-list__item--highlight" if item[:highlight] %>
 
-      <li class="gem-c-document-list__item<%= within_multitype_list_class %> <%= brand_helper.brand_class %> <%= highlight_class %>">
-        <% if item[:highlight] && item[:highlight_text] %>
-          <p class='gem-c-document-list__highlight-text'><%= item[:highlight_text] %></p>
-        <% end %>
-
-        <%=
-          item_classes = "gem-c-document-list__item-title #{brand_helper.color_class} #{title_with_context_class if item[:link][:context]}"
-
-          if item[:link][:path]
-            link_to(
-              item[:link][:text],
-              item[:link][:path],
-              data: item[:link][:data_attributes],
-              class: "#{item_classes} gem-c-document-list__item-link",
-            )
-          else
-            content_tag(
-              "span",
-              item[:link][:text],
-              data: item[:link][:data_attributes],
-              class: item_classes,
-            )
-          end
-        %>
-
-        <% if item[:link][:context] %>
-          <span class="gem-c-document-list__item-context"><%= item[:link][:context] %></span>
-        <% end %>
-
-        <% if item[:link][:description] %>
-          <p class="gem-c-document-list__item-description" ><%= item[:link][:description] %></p>
-        <% end %>
-
-        <% if item[:metadata] %>
-          <ul class="gem-c-document-list__item-metadata">
-            <% item[:metadata].compact.each do |item_metadata_key, item_metadata_value| %>
-              <li class="gem-c-document-list__attribute">
-                <% if item_metadata_key.to_s.eql?("public_updated_at") %>
-                  <time datetime="<%= item_metadata_value.iso8601 %>">
-                    <%= l(item_metadata_value, format: '%e %B %Y') %>
-                  </time>
-                <% else %>
-                  <%= item_metadata_value %>
-                <% end %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
-
-        <% if item[:subtext] %>
-          <p class="gem-c-document-list__subtext"><%= item[:subtext] %></p>
-        <% end %>
-      </li>
+      <% if items.one? %>
+        <% document(item, brand_helper) %>
+      <% else %>
+        <li class="gem-c-document-list__item<%= within_multitype_list_class %> <%= brand_helper.brand_class %> <%= highlight_class %>">
+          <% document(item, brand_helper) %>
+        </li>
+      <% end %>
     <% end %>
   <% unless within_multitype_list %>
     </ol>

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -236,3 +236,12 @@ examples:
           document_type: 'Organisation'
     context:
       right_to_left: true
+  with_a_single_item:
+    data:
+      items:
+      - link:
+          text: 'Alternative provision'
+          path: '/government/publications/alternative-provision'
+        metadata:
+          public_updated_at: 2016-06-27 10:29:44
+          document_type: 'Statutory guidance'

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -27,6 +27,16 @@ describe "Document list", type: :view do
             public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
             document_type: "Statutory guidance"
           }
+        },
+        {
+          link: {
+            text: "Become an apprentice",
+            path: "/become-an-apprentice",
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-07-19 15:01:48 +0000"),
+            document_type: "Statutory guidance"
+          }
         }
       ]
     )
@@ -189,6 +199,16 @@ describe "Document list", type: :view do
             public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
             document_type: "Statutory guidance"
           }
+        },
+        {
+          link: {
+            text: "Become an apprentice",
+            path: "/become-an-apprentice",
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-07-19 15:01:48 +0000"),
+            document_type: "Statutory guidance"
+          }
         }
       ]
     )
@@ -200,6 +220,12 @@ describe "Document list", type: :view do
   it "does not wrap link in heading element if no description or metadata provided" do
     render_component(
       items: [
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+          }
+        },
         {
           link: {
             text: "Link Title",
@@ -250,6 +276,12 @@ describe "Document list", type: :view do
     render_component(
       remove_underline: true,
       items: [
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+          }
+        },
         {
           link: {
             text: "Link Title",


### PR DESCRIPTION
## What
Update the document list component so that a document is presented without a wrapping list when only one item is provided.

## Why
When using the document list component in conjunction with a table we end up with a list of one item in each cell which makes it harder to navigate using assistive tech. This u

## Visual Changes
No visual changes

## View Changes
https://govuk-publishing-compo-pr-1226.herokuapp.com/

[Trello card](https://trello.com/c/pJHJYOcK/1256-document-list-markup-should-be-simplified)
