### PR TITLE
Update cookie banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Allow textarea to be described by an element outside the component ([#1225](https://github.com/alphagov/govuk_publishing_components/pull/1225))
 * Add guidance_id to contextual guidance component ([#1225](https://github.com/alphagov/govuk_publishing_components/pull/1225))
+* Update cookie banner component from an opt-out to an opt-in approach ([#1227](https://github.com/alphagov/govuk_publishing_components/pull/1227))
 
 ## 21.14.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -29,7 +29,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     // Force the new cookie banner to show if we don't think the user has seen it before
     // This involves resetting the seen_cookie_message cookie, which may be set to true if they've seen the old cookie banner
-    if (!window.GOVUK.cookie('cookie_policy')) {
+    if (!window.GOVUK.cookie('cookies_policy')) {
       if (window.GOVUK.cookie('seen_cookie_message') === 'true') {
         window.GOVUK.cookie('seen_cookie_message', false, { days: 365 })
       }
@@ -47,7 +47,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         this.$module.style.display = 'block'
 
         // Set the default consent cookie if it isn't already present
-        if (!window.GOVUK.cookie('cookie_policy')) {
+        if (!window.GOVUK.cookie('cookies_policy')) {
           window.GOVUK.setDefaultConsentCookie()
         }
       } else {

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -27,21 +27,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.$acceptCookiesLink.addEventListener('click', this.$module.setCookieConsent)
     }
 
-    // Force the new cookie banner to show if we don't think the user has seen it before
-    // This involves resetting the seen_cookie_message cookie, which may be set to true if they've seen the old cookie banner
-    if (!window.GOVUK.cookie('cookies_policy')) {
-      if (window.GOVUK.cookie('seen_cookie_message') === 'true') {
-        window.GOVUK.cookie('seen_cookie_message', false, { days: 365 })
-      }
-    }
-
     this.showCookieMessage()
   }
 
   CookieBanner.prototype.showCookieMessage = function () {
     // Show the cookie banner if not in the cookie settings page or in an iframe
     if (!this.isInCookiesPage() && !this.isInIframe()) {
-      var shouldHaveCookieMessage = (this.$module && window.GOVUK.cookie('seen_cookie_message') !== 'true')
+      var shouldHaveCookieMessage = (this.$module && window.GOVUK.cookie('cookie_preferences_set') !== 'true')
 
       if (shouldHaveCookieMessage) {
         this.$module.style.display = 'block'
@@ -61,7 +53,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   CookieBanner.prototype.hideCookieMessage = function (event) {
     if (this.$module) {
       this.$module.style.display = 'none'
-      window.GOVUK.cookie('seen_cookie_message', 'true', { days: 365 })
+      window.GOVUK.cookie('cookie_preferences_set', 'true', { days: 365 })
     }
 
     if (event.target) {
@@ -73,7 +65,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     window.GOVUK.approveAllCookieTypes()
     this.$module.showConfirmationMessage()
     this.$module.cookieBannerConfirmationMessage.focus()
-    window.GOVUK.cookie('seen_cookie_message', 'true', { days: 365 })
+    window.GOVUK.cookie('cookie_preferences_set', 'true', { days: 365 })
   }
 
   CookieBanner.prototype.showConfirmationMessage = function () {

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -33,7 +33,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   CookieBanner.prototype.showCookieMessage = function () {
     // Show the cookie banner if not in the cookie settings page or in an iframe
     if (!this.isInCookiesPage() && !this.isInIframe()) {
-      var shouldHaveCookieMessage = (this.$module && window.GOVUK.cookie('cookie_preferences_set') !== 'true')
+      var shouldHaveCookieMessage = (this.$module && window.GOVUK.cookie('cookies_preferences_set') !== 'true')
 
       if (shouldHaveCookieMessage) {
         this.$module.style.display = 'block'
@@ -53,7 +53,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   CookieBanner.prototype.hideCookieMessage = function (event) {
     if (this.$module) {
       this.$module.style.display = 'none'
-      window.GOVUK.cookie('cookie_preferences_set', 'true', { days: 365 })
+      window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
     }
 
     if (event.target) {
@@ -65,7 +65,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     window.GOVUK.approveAllCookieTypes()
     this.$module.showConfirmationMessage()
     this.$module.cookieBannerConfirmationMessage.focus()
-    window.GOVUK.cookie('cookie_preferences_set', 'true', { days: 365 })
+    window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
   }
 
   CookieBanner.prototype.showConfirmationMessage = function () {

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -6,9 +6,9 @@
 
   var DEFAULT_COOKIE_CONSENT = {
     'essential': true,
-    'settings': true,
-    'usage': true,
-    'campaigns': true
+    'settings': false,
+    'usage': false,
+    'campaigns': false
   }
 
   var COOKIE_CATEGORIES = {

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -14,7 +14,7 @@
   var COOKIE_CATEGORIES = {
     'cookies_policy': 'essential',
     'seen_cookie_message': 'essential',
-    'cookie_preferences_set': 'essential',
+    'cookies_preferences_set': 'essential',
     '_email-alert-frontend_session': 'essential',
     'licensing_session': 'essential',
     'govuk_contact_referrer': 'essential',

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -14,6 +14,7 @@
   var COOKIE_CATEGORIES = {
     'cookies_policy': 'essential',
     'seen_cookie_message': 'essential',
+    'cookie_preferences_set': 'essential',
     'cookies_preferences_set': 'essential',
     '_email-alert-frontend_session': 'essential',
     'licensing_session': 'essential',

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -12,23 +12,23 @@
   }
 
   var COOKIE_CATEGORIES = {
-    'TLSversion': 'usage',
     'cookies_policy': 'essential',
-    'govuk_not_first_visit': 'essential',
-    'govuk_browser_upgrade_dismisssed': 'essential',
     'seen_cookie_message': 'essential',
     'cookie_preferences_set': 'essential',
-    'govuk_surveySeenUserSatisfactionSurvey': 'essential',
-    'govuk_takenUserSatisfactionSurvey': 'essential',
     '_email-alert-frontend_session': 'essential',
-    'global_bar_seen': 'essential',
     'licensing_session': 'essential',
     'govuk_contact_referrer': 'essential',
-    'JS-Detection': 'usage',
+    'global_bar_seen': 'settings',
+    'govuk_browser_upgrade_dismisssed': 'settings',
+    'govuk_not_first_visit': 'settings',
+    'govuk_surveySeenUserSatisfactionSurvey': 'settings',
+    'govuk_takenUserSatisfactionSurvey': 'settings',
+    'analytics_next_page_call': 'usage',
     '_ga': 'usage',
     '_gid': 'usage',
     '_gat': 'usage',
-    'analytics_next_page_call': 'usage'
+    'JS-Detection': 'usage',
+    'TLSversion': 'usage'
   }
 
   /*

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -64,7 +64,7 @@
   }
 
   window.GOVUK.setDefaultConsentCookie = function () {
-    window.GOVUK.setCookie('cookies_policy', JSON.stringify(DEFAULT_COOKIE_CONSENT), { days: 365 })
+    window.GOVUK.setConsentCookie(DEFAULT_COOKIE_CONSENT)
   }
 
   window.GOVUK.approveAllCookieTypes = function () {

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -13,7 +13,7 @@
 
   var COOKIE_CATEGORIES = {
     'TLSversion': 'usage',
-    'cookie_policy': 'essential',
+    'cookies_policy': 'essential',
     'govuk_not_first_visit': 'essential',
     'govuk_browser_upgrade_dismisssed': 'essential',
     'seen_cookie_message': 'essential',
@@ -63,7 +63,7 @@
   }
 
   window.GOVUK.setDefaultConsentCookie = function () {
-    window.GOVUK.setCookie('cookie_policy', JSON.stringify(DEFAULT_COOKIE_CONSENT), { days: 365 })
+    window.GOVUK.setCookie('cookies_policy', JSON.stringify(DEFAULT_COOKIE_CONSENT), { days: 365 })
   }
 
   window.GOVUK.approveAllCookieTypes = function () {
@@ -74,11 +74,11 @@
       'campaigns': true
     }
 
-    window.GOVUK.setCookie('cookie_policy', JSON.stringify(approvedConsent), { days: 365 })
+    window.GOVUK.setCookie('cookies_policy', JSON.stringify(approvedConsent), { days: 365 })
   }
 
   window.GOVUK.getConsentCookie = function () {
-    var consentCookie = window.GOVUK.cookie('cookie_policy')
+    var consentCookie = window.GOVUK.cookie('cookies_policy')
     var consentCookieObj
 
     if (consentCookie) {
@@ -122,7 +122,7 @@
       }
     }
 
-    window.GOVUK.setCookie('cookie_policy', JSON.stringify(cookieConsent), { days: 365 })
+    window.GOVUK.setCookie('cookies_policy', JSON.stringify(cookieConsent), { days: 365 })
   }
 
   window.GOVUK.checkConsentCookieCategory = function (cookieName, cookieCategory) {
@@ -146,7 +146,7 @@
 
   window.GOVUK.checkConsentCookie = function (cookieName, cookieValue) {
     // If we're setting the consent cookie OR deleting a cookie, allow by default
-    if (cookieName === 'cookie_policy' || (cookieValue === null || cookieValue === false)) {
+    if (cookieName === 'cookies_policy' || (cookieValue === null || cookieValue === false)) {
       return true
     }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -35,6 +35,16 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
   }
 }
 
+// Only show accept button if users have js and can accept
+.gem-c-cookie-banner__button-accept {
+  display: none;
+}
+
+.js-enabled .gem-c-cookie-banner__button-accept {
+  display: inline-block;
+}
+
+
 .gem-c-cookie-banner__confirmation {
   display: none;
   position: relative;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -10,57 +10,28 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
   @include govuk-font($size: 16);
   padding: govuk-spacing(2) 0;
   background-color: $govuk-cookie-banner-background;
-  border: 2px solid govuk-colour("black");
 }
 
 .gem-c-cookie-banner__message {
   display: inline-block;
   @include govuk-font($size: 16);
-  margin-bottom: govuk-spacing(1);
   padding-right: govuk-spacing(4);
   padding-bottom: govuk-spacing(2);
 }
 
-.gem-c-cookie-banner__buttons {
-  @include govuk-clearfix;
-
-  @include govuk-media-query($from: desktop) {
-    display: inline-block;
-  }
-}
-
 .gem-c-cookie-banner__button {
-  display: inline-block;
-  width: 100%;
 
-  @include govuk-media-query($from: mobile, $until: desktop) {
-    &.gem-c-cookie-banner__button-accept {
-      float: left;
-      width: 49%;
+  &.govuk-grid-column-one-half-from-desktop {
+    padding:0;
+  }
+
+  .govuk-button {
+    width: 90%;
+
+    @include govuk-media-query($until: desktop) {
+      margin-bottom: govuk-spacing(4);
     }
 
-    &.gem-c-cookie-banner__button-settings {
-      .js-enabled & {
-        float: right;
-        width: 49%;
-      }
-    }
-  }
-
-  @include govuk-media-query($from: desktop) {
-    width: auto;
-  }
-
-  @include govuk-media-query($until: 455px) {
-    width: 100%;
-  }
-}
-
-.gem-c-cookie-banner__button-accept {
-  display: none;
-
-  .js-enabled & {
-    display: inline-block;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -22,7 +22,7 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
 .gem-c-cookie-banner__button {
 
   &.govuk-grid-column-one-half-from-desktop {
-    padding:0;
+    padding: 0;
   }
 
   .govuk-button {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -1,5 +1,4 @@
-$govuk-cookie-banner-background: govuk-colour("white");
-$govuk-cookie-banner-text-green: #00823b;
+$govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
 
 .js-enabled {
   .gem-c-cookie-banner {
@@ -16,10 +15,10 @@ $govuk-cookie-banner-text-green: #00823b;
 
 .gem-c-cookie-banner__message {
   display: inline-block;
+  @include govuk-font($size: 16);
   margin-bottom: govuk-spacing(1);
   padding-right: govuk-spacing(4);
   padding-bottom: govuk-spacing(2);
-  color: $govuk-cookie-banner-text-green;
 }
 
 .gem-c-cookie-banner__buttons {
@@ -137,8 +136,10 @@ $govuk-cookie-banner-text-green: #00823b;
   }
 
   p {
-    margin: 0;
+    @include govuk-font($size: 19);
+    margin: 0 0 govuk-spacing(2) 0;
   }
+
 }
 // sass-lint:enable no-ids
 // scss-lint:enable IdSelector

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -1,6 +1,6 @@
 <%
   id ||= 'global-cookie-message'
-  message ||= "GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised. By continuing to use this site, you agree to our use of cookies."
+  message ||= "GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised."
 %>
 
 <div id="<%= id %>" class="gem-c-cookie-banner" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet>

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -7,12 +7,11 @@
     <div class="govuk-row">
       <div class=" govuk-grid-column-two-thirds">
         <div class="gem-c-cookie-banner__message">
-          <span class="govuk-heading-m">Tell us whether you agree to cookies</span>
-          <p class="govuk-body">We use cookies to help improve government services and make the website work as well as possible.</p>
-          <p class="govuk-body">Do you agree to us using cookies?</p>
+          <span class="govuk-heading-m">Tell us whether you accept cookies</span>
+          <p class="govuk-body">We use cookies to improve government services and make the GOV.UK website work as well as possible.</p>
         </div>
         <div class="gem-c-cookie-banner__buttons">
-          <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept">
+          <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
             <%= render "govuk_publishing_components/components/button", {
               text: "Accept all cookies",
               inline_layout: true,
@@ -24,9 +23,9 @@
               }
             } %>
           </div>
-          <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings">
+          <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
             <%= render "govuk_publishing_components/components/button", {
-              text: "No, take me to cookie settings",
+              text: "Set cookie preferences",
               href: "/help/cookies",
               inline_layout: true,
               data_attributes: {

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -8,7 +8,7 @@
       <div class=" govuk-grid-column-two-thirds">
         <div class="gem-c-cookie-banner__message">
           <span class="govuk-heading-m">Tell us whether you accept cookies</span>
-          <p class="govuk-body">We use cookies to improve government services and make the GOV.UK website work as well as possible.</p>
+          <p class="govuk-body">We use <a class="govuk-link" href="help/cookies">cookies to collect information</a> about how you use GOV.UK. We use this information to make the website work as well as possible and improve government services.</p>
         </div>
         <div class="gem-c-cookie-banner__buttons">
           <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop">

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -1,37 +1,42 @@
 <%
   id ||= 'global-cookie-message'
-  message ||= "GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised."
 %>
 
-<div id="<%= id %>" class="gem-c-cookie-banner" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet>
+<div id="<%= id %>" class="gem-c-cookie-banner govuk-clearfix" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet>
   <div class="gem-c-cookie-banner__wrapper govuk-width-container">
-    <p class="gem-c-cookie-banner__message"><%= message %></p>
-    <div class="gem-c-cookie-banner__buttons">
-      <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept">
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Accept cookies",
-          secondary: true,
-          inline_layout: true,
-          data_attributes: {
-            module: "track-click",
-            "accept-cookies": "true",
-            "track-category": "cookieBanner",
-            "track-action": "Cookie banner accepted"
-          }
-        } %>
-      </div>
-      <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings">
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Cookie settings",
-          href: "/help/cookies",
-          secondary: true,
-          inline_layout: true,
-          data_attributes: {
-            module: "track-click",
-            "track-category": "cookieBanner",
-            "track-action": "Cookie banner settings clicked"
-          }
-        } %>
+    <div class="govuk-row">
+      <div class=" govuk-grid-column-two-thirds">
+        <div class="gem-c-cookie-banner__message">
+          <span class="govuk-heading-m">Tell us whether you agree to cookies</span>
+          <p class="govuk-body">We use cookies to help improve government services and make the website work as well as possible.</p>
+          <p class="govuk-body">Do you agree to us using cookies?</p>
+        </div>
+        <div class="gem-c-cookie-banner__buttons">
+          <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept">
+            <%= render "govuk_publishing_components/components/button", {
+              text: "Accept all cookies",
+              inline_layout: true,
+              data_attributes: {
+                module: "track-click",
+                "accept-cookies": "true",
+                "track-category": "cookieBanner",
+                "track-action": "Cookie banner accepted"
+              }
+            } %>
+          </div>
+          <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings">
+            <%= render "govuk_publishing_components/components/button", {
+              text: "No, take me to cookie settings",
+              href: "/help/cookies",
+              inline_layout: true,
+              data_attributes: {
+                module: "track-click",
+                "track-category": "cookieBanner",
+                "track-action": "Cookie banner settings clicked"
+              }
+            } %>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -17,7 +17,3 @@ accessibility_excluded_rules:
 examples:
   default:
     data: {}
-  custom_message:
-    data:
-      id: custom-message
-      message: GOV.UK uses cookies to make the site simpler. <a class="govuk-link" href="/help/cookies">Find out more about cookies</a>

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -8,9 +8,8 @@ describe "Cookie banner", type: :view do
   it "renders with default values" do
     render_component({})
     assert_select '.gem-c-cookie-banner[id="global-cookie-message"][data-module="cookie-banner"]'
-    assert_select '.govuk-width-container .gem-c-cookie-banner__message', text: "Tell us whether you agree to cookies
-          We use cookies to help improve government services and make the website work as well as possible.
-          Do you agree to us using cookies?"
+    assert_select '.govuk-width-container .gem-c-cookie-banner__message', text: "Tell us whether you accept cookies
+          We use cookies to improve government services and make the GOV.UK website work as well as possible."
     assert_select 'button[data-hide-cookie-banner="true"]'
   end
 
@@ -22,7 +21,7 @@ describe "Cookie banner", type: :view do
 
   it "renders a button for viewing cookie settings" do
     render_component(new_cookie_banner: true)
-    assert_select '.gem-c-cookie-banner__buttons .gem-c-button', text: "No, take me to cookie settings"
+    assert_select '.gem-c-cookie-banner__buttons .gem-c-button', text: "Set cookie preferences"
     assert_select '.gem-c-cookie-banner__buttons .gem-c-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner settings clicked"]'
   end
 

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -9,7 +9,7 @@ describe "Cookie banner", type: :view do
     render_component({})
     assert_select '.gem-c-cookie-banner[id="global-cookie-message"][data-module="cookie-banner"]'
     assert_select '.govuk-width-container .gem-c-cookie-banner__message', text: "Tell us whether you accept cookies
-          We use cookies to improve government services and make the GOV.UK website work as well as possible."
+          We use cookies to collect information about how you use GOV.UK. We use this information to make the website work as well as possible and improve government services."
     assert_select 'button[data-hide-cookie-banner="true"]'
   end
 

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -12,12 +12,6 @@ describe "Cookie banner", type: :view do
     assert_select 'button[data-hide-cookie-banner="true"]'
   end
 
-  it "renders with custom values" do
-    render_component(id: 'custom-cookie-message', message: "Custom message")
-    assert_select '.gem-c-cookie-banner[id="custom-cookie-message"][data-module="cookie-banner"]'
-    assert_select '.govuk-width-container .gem-c-cookie-banner__message', text: "Custom message"
-  end
-
   it "renders a button for accepting cookies" do
     render_component(new_cookie_banner: true)
     assert_select '.gem-c-cookie-banner__buttons .gem-c-button', text: "Accept cookies"

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -8,7 +8,7 @@ describe "Cookie banner", type: :view do
   it "renders with default values" do
     render_component({})
     assert_select '.gem-c-cookie-banner[id="global-cookie-message"][data-module="cookie-banner"]'
-    assert_select '.govuk-width-container .gem-c-cookie-banner__message', text: "GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised. By continuing to use this site, you agree to our use of cookies."
+    assert_select '.govuk-width-container .gem-c-cookie-banner__message', text: "GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised."
     assert_select 'button[data-hide-cookie-banner="true"]'
   end
 

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -8,19 +8,21 @@ describe "Cookie banner", type: :view do
   it "renders with default values" do
     render_component({})
     assert_select '.gem-c-cookie-banner[id="global-cookie-message"][data-module="cookie-banner"]'
-    assert_select '.govuk-width-container .gem-c-cookie-banner__message', text: "GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised."
+    assert_select '.govuk-width-container .gem-c-cookie-banner__message', text: "Tell us whether you agree to cookies
+          We use cookies to help improve government services and make the website work as well as possible.
+          Do you agree to us using cookies?"
     assert_select 'button[data-hide-cookie-banner="true"]'
   end
 
   it "renders a button for accepting cookies" do
     render_component(new_cookie_banner: true)
-    assert_select '.gem-c-cookie-banner__buttons .gem-c-button', text: "Accept cookies"
+    assert_select '.gem-c-cookie-banner__buttons .gem-c-button', text: "Accept all cookies"
     assert_select '.gem-c-cookie-banner__buttons .gem-c-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner accepted"]'
   end
 
   it "renders a button for viewing cookie settings" do
     render_component(new_cookie_banner: true)
-    assert_select '.gem-c-cookie-banner__buttons .gem-c-button', text: "Cookie settings"
+    assert_select '.gem-c-cookie-banner__buttons .gem-c-button', text: "No, take me to cookie settings"
     assert_select '.gem-c-cookie-banner__buttons .gem-c-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner settings clicked"]'
   end
 

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -70,7 +70,7 @@ describe('Cookie banner', function () {
   })
 
   it('should hide the cookie banner when preferences have been actively set', function () {
-    GOVUK.cookie('cookie_preferences_set', 'true', { days: 365 })
+    GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
 
     var element = document.querySelector('[data-module="cookie-banner"]')
 
@@ -83,7 +83,7 @@ describe('Cookie banner', function () {
     var element = document.querySelector('[data-module="cookie-banner"]')
     new GOVUK.Modules.CookieBanner().start($(element))
 
-    expect(GOVUK.getCookie('cookie_preferences_set')).toEqual(null)
+    expect(GOVUK.getCookie('cookies_preferences_set')).toEqual(null)
     expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
   })
 
@@ -100,8 +100,8 @@ describe('Cookie banner', function () {
     var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
     acceptCookiesButton.click()
 
-    expect(GOVUK.setCookie).toHaveBeenCalledWith('cookie_preferences_set', 'true', { days: 365 })
-    expect(GOVUK.getCookie('cookie_preferences_set')).toEqual('true')
+    expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', 'true', { days: 365 })
+    expect(GOVUK.getCookie('cookies_preferences_set')).toEqual('true')
     expect(GOVUK.getCookie('cookies_policy')).toEqual(ALL_COOKIE_CONSENT)
   })
 
@@ -132,7 +132,7 @@ describe('Cookie banner', function () {
     link.dispatchEvent(new window.Event('click'))
 
     expect(element).toBeHidden()
-    expect(GOVUK.getCookie('cookie_preferences_set')).toBeTruthy()
+    expect(GOVUK.getCookie('cookies_preferences_set')).toBeTruthy()
   })
 
   describe('when rendered inside an iframe', function () {

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -30,13 +30,12 @@ describe('Cookie banner', function () {
 
     document.body.appendChild(container)
     // set and store consent for all as a basis of comparison
-    window.GOVUK.setCookie('cookies_policy', "{\"essential\":true,\"settings\":true,\"usage\":true,\"campaigns\":true}")
+    window.GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
     ALL_COOKIE_CONSENT = GOVUK.getCookie('cookies_policy')
 
     // set and store default cookie consent to use as basis of comparison
     window.GOVUK.setDefaultConsentCookie()
     DEFAULT_COOKIE_CONSENT = GOVUK.getCookie('cookies_policy')
-
   })
 
   afterEach(function () {
@@ -52,14 +51,39 @@ describe('Cookie banner', function () {
 
     expect(element).toBeVisible()
     expect(cookieBannerMain).toBeVisible()
-    expect(cookieBannerConfirmation).not.toBeVisible()
+    expect(cookieBannerConfirmation).toBeHidden()
+  })
+
+  it('should show the cookie banner when preferences have not been actively set', function () {
+    GOVUK.setDefaultConsentCookie() // Set default cookies, which are set whether there is any interaction or not.
+
+    var element = document.querySelector('[data-module="cookie-banner"]')
+
+    new GOVUK.Modules.CookieBanner().start($(element))
+
+    var cookieBannerMain = document.querySelector('.gem-c-cookie-banner__wrapper')
+    var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
+
+    expect(element).toBeVisible()
+    expect(cookieBannerMain).toBeVisible()
+    expect(cookieBannerConfirmation).toBeHidden()
+  })
+
+  it('should hide the cookie banner when preferences have been actively set', function () {
+    GOVUK.cookie('cookie_preferences_set', 'true', { days: 365 })
+
+    var element = document.querySelector('[data-module="cookie-banner"]')
+
+    new GOVUK.Modules.CookieBanner().start($(element))
+
+    expect(element).toBeHidden()
   })
 
   it('sets a default consent cookie', function () {
     var element = document.querySelector('[data-module="cookie-banner"]')
     new GOVUK.Modules.CookieBanner().start($(element))
 
-    expect(GOVUK.getCookie('seen_cookie_message')).toEqual(null)
+    expect(GOVUK.getCookie('cookie_preferences_set')).toEqual(null)
     expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
   })
 
@@ -76,7 +100,8 @@ describe('Cookie banner', function () {
     var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
     acceptCookiesButton.click()
 
-    expect(GOVUK.setCookie).toHaveBeenCalledWith('seen_cookie_message', 'true', { days: 365 })
+    expect(GOVUK.setCookie).toHaveBeenCalledWith('cookie_preferences_set', 'true', { days: 365 })
+    expect(GOVUK.getCookie('cookie_preferences_set')).toEqual('true')
     expect(GOVUK.getCookie('cookies_policy')).toEqual(ALL_COOKIE_CONSENT)
   })
 
@@ -89,11 +114,11 @@ describe('Cookie banner', function () {
     var confirmationMessage = document.querySelector('div[data-cookie-banner-confirmation]')
 
     expect(mainCookieBanner).toBeVisible()
-    expect(confirmationMessage).not.toBeVisible()
+    expect(confirmationMessage).toBeHidden()
 
     acceptCookiesButton.click()
 
-    expect(mainCookieBanner).not.toBeVisible()
+    expect(mainCookieBanner).toBeHidden()
     expect(confirmationMessage).toBeVisible()
   })
 
@@ -107,18 +132,7 @@ describe('Cookie banner', function () {
     link.dispatchEvent(new window.Event('click'))
 
     expect(element).toBeHidden()
-    expect(GOVUK.setCookie).toHaveBeenCalledWith('seen_cookie_message', 'true', { days: 365 })
-    expect(GOVUK.getCookie('seen_cookie_message')).toBeTruthy()
-  })
-
-  it('does not show the banner if user has acknowledged the banner previously and consent cookie is present', function () {
-    GOVUK.setCookie('seen_cookie_message', 'true')
-    GOVUK.setDefaultConsentCookie()
-
-    var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner().start($(element))
-
-    expect(element).not.toBeVisible()
+    expect(GOVUK.getCookie('cookie_preferences_set')).toBeTruthy()
   })
 
   describe('when rendered inside an iframe', function () {

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -13,7 +13,7 @@ describe('Cookie banner', function () {
     container.innerHTML =
       '<div id="global-cookie-message" class="gem-c-cookie-banner" data-module="cookie-banner">' +
         '<div class="gem-c-cookie-banner__wrapper govuk-width-container" data-cookie-banner-main="true">' +
-          '<p class="gem-c-cookie-banner__message">GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised. By continuing to use this site, you agree to our use of cookies.</p>' +
+          '<p class="gem-c-cookie-banner__message">GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised.</p>' +
           '<div class="gem-c-cookie-banner__buttons">' +
             '<button class="gem-c-button govuk-button gem-c-button--secondary-quiet gem-c-button--inline" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">Accept cookies</button>' +
             '<a class="gem-c-button govuk-button gem-c-button--secondary-quiet gem-c-button--inline" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="/help/cookies">Cookie settings</a>' +

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -30,12 +30,12 @@ describe('Cookie banner', function () {
 
     document.body.appendChild(container)
     // set and store consent for all as a basis of comparison
-    window.GOVUK.setCookie('cookie_policy', "{\"essential\":true,\"settings\":true,\"usage\":true,\"campaigns\":true}")
-    ALL_COOKIE_CONSENT = GOVUK.getCookie('cookie_policy')
+    window.GOVUK.setCookie('cookies_policy', "{\"essential\":true,\"settings\":true,\"usage\":true,\"campaigns\":true}")
+    ALL_COOKIE_CONSENT = GOVUK.getCookie('cookies_policy')
 
     // set and store default cookie consent to use as basis of comparison
     window.GOVUK.setDefaultConsentCookie()
-    DEFAULT_COOKIE_CONSENT = GOVUK.getCookie('cookie_policy')
+    DEFAULT_COOKIE_CONSENT = GOVUK.getCookie('cookies_policy')
 
   })
 
@@ -60,7 +60,7 @@ describe('Cookie banner', function () {
     new GOVUK.Modules.CookieBanner().start($(element))
 
     expect(GOVUK.getCookie('seen_cookie_message')).toEqual(null)
-    expect(GOVUK.getCookie('cookie_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
+    expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
   })
 
   it('sets consent cookie when accepting cookies', function () {
@@ -70,14 +70,14 @@ describe('Cookie banner', function () {
     new GOVUK.Modules.CookieBanner().start($(element))
 
     // Manually reset the consent cookie so we can check the accept button works as intended
-    expect(GOVUK.getCookie('cookie_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
-    GOVUK.cookie('cookie_policy', null)
+    expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
+    GOVUK.cookie('cookies_policy', null)
 
     var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
     acceptCookiesButton.click()
 
     expect(GOVUK.setCookie).toHaveBeenCalledWith('seen_cookie_message', 'true', { days: 365 })
-    expect(GOVUK.getCookie('cookie_policy')).toEqual(ALL_COOKIE_CONSENT)
+    expect(GOVUK.getCookie('cookies_policy')).toEqual(ALL_COOKIE_CONSENT)
   })
 
   it('shows a confirmation message when cookies have been accepted', function () {

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -7,6 +7,7 @@ describe('Cookie banner', function () {
   var container
 
   var DEFAULT_COOKIE_CONSENT
+  var ALL_COOKIE_CONSENT
 
   beforeEach(function () {
     container = document.createElement('div')
@@ -28,10 +29,14 @@ describe('Cookie banner', function () {
       '</div>'
 
     document.body.appendChild(container)
+    // set and store consent for all as a basis of comparison
+    window.GOVUK.setCookie('cookie_policy', "{\"essential\":true,\"settings\":true,\"usage\":true,\"campaigns\":true}")
+    ALL_COOKIE_CONSENT = GOVUK.getCookie('cookie_policy')
 
     // set and store default cookie consent to use as basis of comparison
     window.GOVUK.setDefaultConsentCookie()
     DEFAULT_COOKIE_CONSENT = GOVUK.getCookie('cookie_policy')
+
   })
 
   afterEach(function () {
@@ -72,7 +77,7 @@ describe('Cookie banner', function () {
     acceptCookiesButton.click()
 
     expect(GOVUK.setCookie).toHaveBeenCalledWith('seen_cookie_message', 'true', { days: 365 })
-    expect(GOVUK.getCookie('cookie_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
+    expect(GOVUK.getCookie('cookie_policy')).toEqual(ALL_COOKIE_CONSENT)
   })
 
   it('shows a confirmation message when cookies have been accepted', function () {

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
@@ -7,61 +7,61 @@ describe('Cookie helper functions', function () {
 
   describe('GOVUK.cookie', function () {
     it('returns the cookie value if not provided with a value to set', function () {
-      GOVUK.cookie('seen_cookie_message', 'testing fetching cookie value')
+      GOVUK.cookie('cookie_preferences_set', 'testing fetching cookie value')
 
-      GOVUK.cookie('seen_cookie_message')
+      GOVUK.cookie('cookie_preferences_set')
 
-      expect(GOVUK.cookie('seen_cookie_message')).toBe('testing fetching cookie value')
+      expect(GOVUK.cookie('cookie_preferences_set')).toBe('testing fetching cookie value')
     })
 
     it('can create a new cookie', function () {
-      expect(GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
+      expect(GOVUK.getCookie('cookie_preferences_set')).toBeFalsy()
 
-      GOVUK.cookie('seen_cookie_message', 'test')
+      GOVUK.cookie('cookie_preferences_set', 'test')
 
-      expect(GOVUK.getCookie('seen_cookie_message')).toBe('test')
+      expect(GOVUK.getCookie('cookie_preferences_set')).toBe('test')
     })
 
     it('sets a default expiry of 30 days if no options are provided', function () {
       spyOn(GOVUK, 'setCookie').and.callThrough()
 
-      expect(GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
+      expect(GOVUK.getCookie('cookie_preferences_set')).toBeFalsy()
 
-      GOVUK.cookie('seen_cookie_message', 'test')
+      GOVUK.cookie('cookie_preferences_set', 'test')
 
-      expect(GOVUK.setCookie).toHaveBeenCalledWith('seen_cookie_message', 'test', { days: 30 })
+      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookie_preferences_set', 'test', { days: 30 })
     })
 
     it('sets the expiry if one is provided', function () {
       spyOn(GOVUK, 'setCookie').and.callThrough()
 
-      expect(GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
+      expect(GOVUK.getCookie('cookie_preferences_set')).toBeFalsy()
 
-      GOVUK.cookie('seen_cookie_message', 'test', { days: 100 })
+      GOVUK.cookie('cookie_preferences_set', 'test', { days: 100 })
 
-      expect(GOVUK.setCookie).toHaveBeenCalledWith('seen_cookie_message', 'test', { days: 100 })
+      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookie_preferences_set', 'test', { days: 100 })
     })
 
     it('can change the value of an existing cookie', function () {
-      GOVUK.cookie('seen_cookie_message', 'test1')
+      GOVUK.cookie('cookie_preferences_set', 'test1')
 
-      expect(GOVUK.getCookie('seen_cookie_message')).toBe('test1')
+      expect(GOVUK.getCookie('cookie_preferences_set')).toBe('test1')
 
-      GOVUK.cookie('seen_cookie_message', 'test2')
+      GOVUK.cookie('cookie_preferences_set', 'test2')
 
-      expect(GOVUK.getCookie('seen_cookie_message')).toBe('test2')
+      expect(GOVUK.getCookie('cookie_preferences_set')).toBe('test2')
     })
 
     it('deletes the cookie if value is set to false', function () {
-      GOVUK.cookie('seen_cookie_message', false)
+      GOVUK.cookie('cookie_preferences_set', false)
 
-      expect(GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
+      expect(GOVUK.getCookie('cookie_preferences_set')).toBeFalsy()
     })
 
     it('deletes the cookie if value is set to null', function () {
-      GOVUK.cookie('seen_cookie_message', null)
+      GOVUK.cookie('cookie_preferences_set', null)
 
-      expect(GOVUK.getCookie('seen_cookie_message')).toBeFalsy()
+      expect(GOVUK.getCookie('cookie_preferences_set')).toBeFalsy()
     })
   })
 
@@ -102,18 +102,18 @@ describe('Cookie helper functions', function () {
     })
 
     it('deletes relevant cookies in that category if consent is set to false', function () {
-      GOVUK.setConsentCookie({ 'essential': true })
+      GOVUK.setConsentCookie({ 'usage': true })
 
-      GOVUK.setCookie('seen_cookie_message', 'this is an essential cookie')
+      GOVUK.setCookie('analytics_next_page_call', 'this is a usage cookie')
 
-      expect(GOVUK.cookie('seen_cookie_message')).toBe('this is an essential cookie')
+      expect(GOVUK.cookie('analytics_next_page_call')).toBe('this is a usage cookie')
 
       spyOn(GOVUK, 'setCookie').and.callThrough()
-      GOVUK.setConsentCookie({ 'essential': false })
+      GOVUK.setConsentCookie({ 'usage': false })
 
-      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}', Object({ days: 365 }))
-      expect(GOVUK.getConsentCookie().essential).toBe(false)
-      expect(GOVUK.cookie('seen_cookie_message')).toBeFalsy()
+      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_policy', '{"essential":true,"settings":false,"usage":false,"campaigns":false}', Object({ days: 365 }))
+      expect(GOVUK.getConsentCookie().usage).toBe(false)
+      expect(GOVUK.cookie('analytics_next_page_call')).toBeFalsy()
     })
   })
 
@@ -130,7 +130,7 @@ describe('Cookie helper functions', function () {
     it('does not set a default consent cookie if one is not present', function () {
       GOVUK.cookie('cookies_policy', null)
 
-      GOVUK.checkConsentCookieCategory('seen_cookie_message', true)
+      GOVUK.checkConsentCookieCategory('cookie_preferences_set', true)
 
       expect(GOVUK.getConsentCookie()).toBeFalsy()
     })
@@ -138,7 +138,7 @@ describe('Cookie helper functions', function () {
     it('returns true if the consent cookie does not exist and the cookie name is recognised', function () {
       expect(GOVUK.getConsentCookie()).toBeFalsy()
 
-      expect(GOVUK.checkConsentCookie('seen_cookie_message', true)).toBe(true)
+      expect(GOVUK.checkConsentCookie('cookie_preferences_set', true)).toBe(true)
     })
 
     it('returns false if the consent cookie does not exist and the cookie name is not recognised', function () {

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
@@ -69,11 +69,11 @@ describe('Cookie helper functions', function () {
     it('can set the consent cookie to default values', function () {
       spyOn(GOVUK, 'setCookie').and.callThrough()
 
-      expect(GOVUK.getCookie('cookie_policy')).toBeFalsy()
+      expect(GOVUK.getCookie('cookies_policy')).toBeFalsy()
 
       GOVUK.setDefaultConsentCookie()
 
-      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookie_policy', '{"essential":true,"settings":false,"usage":false,"campaigns":false}', Object({ days: 365 }))
+      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_policy', '{"essential":true,"settings":false,"usage":false,"campaigns":false}', Object({ days: 365 }))
       expect(GOVUK.getConsentCookie()).toEqual({ 'essential': true, 'settings': false, 'usage': false, 'campaigns': false })
     })
 
@@ -87,7 +87,7 @@ describe('Cookie helper functions', function () {
 
       GOVUK.approveAllCookieTypes()
 
-      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookie_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}', Object({ days: 365 }))
+      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}', Object({ days: 365 }))
       expect(GOVUK.getConsentCookie()).toEqual({ 'essential': true, 'settings': true, 'usage': true, 'campaigns': true })
     })
 
@@ -96,7 +96,7 @@ describe('Cookie helper functions', function () {
     })
 
     it('returns null if the consent cookie is malformed', function () {
-      GOVUK.cookie('cookie_policy', 'malformed consent cookie')
+      GOVUK.cookie('cookies_policy', 'malformed consent cookie')
 
       expect(GOVUK.getConsentCookie()).toBe(null)
     })
@@ -111,7 +111,7 @@ describe('Cookie helper functions', function () {
       spyOn(GOVUK, 'setCookie').and.callThrough()
       GOVUK.setConsentCookie({ 'essential': false })
 
-      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookie_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}', Object({ days: 365 }))
+      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}', Object({ days: 365 }))
       expect(GOVUK.getConsentCookie().essential).toBe(false)
       expect(GOVUK.cookie('seen_cookie_message')).toBeFalsy()
     })
@@ -119,7 +119,7 @@ describe('Cookie helper functions', function () {
 
   describe('check cookie consent', function () {
     it('returns true if trying to set the consent cookie', function () {
-      expect(GOVUK.checkConsentCookie('cookie_policy', { 'essential': true })).toBe(true)
+      expect(GOVUK.checkConsentCookie('cookies_policy', { 'essential': true })).toBe(true)
     })
 
     it('returns true if deleting a cookie', function () {
@@ -128,7 +128,7 @@ describe('Cookie helper functions', function () {
     })
 
     it('does not set a default consent cookie if one is not present', function () {
-      GOVUK.cookie('cookie_policy', null)
+      GOVUK.cookie('cookies_policy', null)
 
       GOVUK.checkConsentCookieCategory('seen_cookie_message', true)
 

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
@@ -77,6 +77,21 @@ describe('Cookie helper functions', function () {
       expect(GOVUK.getConsentCookie()).toEqual({ 'essential': true, 'settings': false, 'usage': false, 'campaigns': false })
     })
 
+    it('deletes cookies after default consent cookie set', function() {
+      var date = new Date();
+      var days = days || 365;
+      date.setTime(+ date + (days * 86400000)); //24 * 60 * 60 * 1000
+
+      document.cookie = 'analytics_next_page_call=test;expires=' + date.toGMTString() + ';domain=.' + window.location.hostname + ';path=/'
+
+      expect(GOVUK.getCookie('analytics_next_page_call')).toBe("test")
+
+      GOVUK.setDefaultConsentCookie()
+
+      expect(GOVUK.getConsentCookie().usage).toBe(false)
+      expect(GOVUK.getCookie('analytics_next_page_call')).toBeFalsy()
+    })
+
     it('can set the consent cookie to approve all cookie categories', function () {
       spyOn(GOVUK, 'setCookie').and.callThrough()
 

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
@@ -7,61 +7,61 @@ describe('Cookie helper functions', function () {
 
   describe('GOVUK.cookie', function () {
     it('returns the cookie value if not provided with a value to set', function () {
-      GOVUK.cookie('cookie_preferences_set', 'testing fetching cookie value')
+      GOVUK.cookie('cookies_preferences_set', 'testing fetching cookie value')
 
-      GOVUK.cookie('cookie_preferences_set')
+      GOVUK.cookie('cookies_preferences_set')
 
-      expect(GOVUK.cookie('cookie_preferences_set')).toBe('testing fetching cookie value')
+      expect(GOVUK.cookie('cookies_preferences_set')).toBe('testing fetching cookie value')
     })
 
     it('can create a new cookie', function () {
-      expect(GOVUK.getCookie('cookie_preferences_set')).toBeFalsy()
+      expect(GOVUK.getCookie('cookies_preferences_set')).toBeFalsy()
 
-      GOVUK.cookie('cookie_preferences_set', 'test')
+      GOVUK.cookie('cookies_preferences_set', 'test')
 
-      expect(GOVUK.getCookie('cookie_preferences_set')).toBe('test')
+      expect(GOVUK.getCookie('cookies_preferences_set')).toBe('test')
     })
 
     it('sets a default expiry of 30 days if no options are provided', function () {
       spyOn(GOVUK, 'setCookie').and.callThrough()
 
-      expect(GOVUK.getCookie('cookie_preferences_set')).toBeFalsy()
+      expect(GOVUK.getCookie('cookies_preferences_set')).toBeFalsy()
 
-      GOVUK.cookie('cookie_preferences_set', 'test')
+      GOVUK.cookie('cookies_preferences_set', 'test')
 
-      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookie_preferences_set', 'test', { days: 30 })
+      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', 'test', { days: 30 })
     })
 
     it('sets the expiry if one is provided', function () {
       spyOn(GOVUK, 'setCookie').and.callThrough()
 
-      expect(GOVUK.getCookie('cookie_preferences_set')).toBeFalsy()
+      expect(GOVUK.getCookie('cookies_preferences_set')).toBeFalsy()
 
-      GOVUK.cookie('cookie_preferences_set', 'test', { days: 100 })
+      GOVUK.cookie('cookies_preferences_set', 'test', { days: 100 })
 
-      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookie_preferences_set', 'test', { days: 100 })
+      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', 'test', { days: 100 })
     })
 
     it('can change the value of an existing cookie', function () {
-      GOVUK.cookie('cookie_preferences_set', 'test1')
+      GOVUK.cookie('cookies_preferences_set', 'test1')
 
-      expect(GOVUK.getCookie('cookie_preferences_set')).toBe('test1')
+      expect(GOVUK.getCookie('cookies_preferences_set')).toBe('test1')
 
-      GOVUK.cookie('cookie_preferences_set', 'test2')
+      GOVUK.cookie('cookies_preferences_set', 'test2')
 
-      expect(GOVUK.getCookie('cookie_preferences_set')).toBe('test2')
+      expect(GOVUK.getCookie('cookies_preferences_set')).toBe('test2')
     })
 
     it('deletes the cookie if value is set to false', function () {
-      GOVUK.cookie('cookie_preferences_set', false)
+      GOVUK.cookie('cookies_preferences_set', false)
 
-      expect(GOVUK.getCookie('cookie_preferences_set')).toBeFalsy()
+      expect(GOVUK.getCookie('cookies_preferences_set')).toBeFalsy()
     })
 
     it('deletes the cookie if value is set to null', function () {
-      GOVUK.cookie('cookie_preferences_set', null)
+      GOVUK.cookie('cookies_preferences_set', null)
 
-      expect(GOVUK.getCookie('cookie_preferences_set')).toBeFalsy()
+      expect(GOVUK.getCookie('cookies_preferences_set')).toBeFalsy()
     })
   })
 
@@ -130,7 +130,7 @@ describe('Cookie helper functions', function () {
     it('does not set a default consent cookie if one is not present', function () {
       GOVUK.cookie('cookies_policy', null)
 
-      GOVUK.checkConsentCookieCategory('cookie_preferences_set', true)
+      GOVUK.checkConsentCookieCategory('cookies_preferences_set', true)
 
       expect(GOVUK.getConsentCookie()).toBeFalsy()
     })
@@ -138,7 +138,7 @@ describe('Cookie helper functions', function () {
     it('returns true if the consent cookie does not exist and the cookie name is recognised', function () {
       expect(GOVUK.getConsentCookie()).toBeFalsy()
 
-      expect(GOVUK.checkConsentCookie('cookie_preferences_set', true)).toBe(true)
+      expect(GOVUK.checkConsentCookie('cookies_preferences_set', true)).toBe(true)
     })
 
     it('returns false if the consent cookie does not exist and the cookie name is not recognised', function () {

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
@@ -73,8 +73,8 @@ describe('Cookie helper functions', function () {
 
       GOVUK.setDefaultConsentCookie()
 
-      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookie_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}', Object({ days: 365 }))
-      expect(GOVUK.getConsentCookie()).toEqual({ 'essential': true, 'settings': true, 'usage': true, 'campaigns': true })
+      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookie_policy', '{"essential":true,"settings":false,"usage":false,"campaigns":false}', Object({ days: 365 }))
+      expect(GOVUK.getConsentCookie()).toEqual({ 'essential': true, 'settings': false, 'usage': false, 'campaigns': false })
     })
 
     it('can set the consent cookie to approve all cookie categories', function () {
@@ -111,7 +111,7 @@ describe('Cookie helper functions', function () {
       spyOn(GOVUK, 'setCookie').and.callThrough()
       GOVUK.setConsentCookie({ 'essential': false })
 
-      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookie_policy', '{"essential":false,"settings":true,"usage":true,"campaigns":true}', Object({ days: 365 }))
+      expect(GOVUK.setCookie).toHaveBeenCalledWith('cookie_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}', Object({ days: 365 }))
       expect(GOVUK.getConsentCookie().essential).toBe(false)
       expect(GOVUK.cookie('seen_cookie_message')).toBeFalsy()
     })

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
@@ -56,7 +56,7 @@ describe('Youtube link enhancement', function () {
     })
 
     it('doesn\'t replace links when a user has revoked campaign cookie consent', function () {
-      window.GOVUK.cookie('cookie_policy', JSON.stringify({ campaigns: false }))
+      window.GOVUK.cookie('cookies_policy', JSON.stringify({ campaigns: false }))
 
       container.innerHTML =
         '<div class="gem-c-govspeak">' +


### PR DESCRIPTION
## What
Update cookie banner to switch from an opt-out to an opt-in approach.

## Why
To give users the power to choose.

## Visual Changes
Before
<img width="898" alt="Screenshot 2019-12-19 at 13 37 16" src="https://user-images.githubusercontent.com/788096/71177838-c8410600-2264-11ea-9234-b4e732bc7c3b.png">

After
<img width="899" alt="Screenshot 2019-12-19 at 13 36 48" src="https://user-images.githubusercontent.com/788096/71177845-cbd48d00-2264-11ea-9f4b-a6ed9d3bf79d.png">


## View Changes
https://govuk-publishing-compo-pr-1228.herokuapp.com/
