### PR TITLE
Use correct grid row class in cookie banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use correct grid row class in cookie banner ([#1233](https://github.com/alphagov/govuk_publishing_components/pull/1233))
+
 ## 21.15.1
 
 * Fix URL in cookie banner component ([#1228](https://github.com/alphagov/govuk_publishing_components/pull/1228))

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -4,7 +4,7 @@
 
 <div id="<%= id %>" class="gem-c-cookie-banner govuk-clearfix" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet>
   <div class="gem-c-cookie-banner__wrapper govuk-width-container">
-    <div class="govuk-row">
+    <div class="govuk-grid-row">
       <div class=" govuk-grid-column-two-thirds">
         <div class="gem-c-cookie-banner__message">
           <span class="govuk-heading-m">Tell us whether you accept cookies</span>


### PR DESCRIPTION
## What
Replace `.govuk-row` CSS class with `.govuk-grid-row`

## Why
Fixes content alignment

## Visual Changes

### Before
<img width="686" alt="Screenshot 2019-12-19 at 22 12 15" src="https://user-images.githubusercontent.com/3758555/71214141-d74ba680-22ac-11ea-864a-f8edc4a07121.png">

### After
<img width="648" alt="Screenshot 2019-12-19 at 22 19 13" src="https://user-images.githubusercontent.com/3758555/71214574-a15af200-22ad-11ea-9c34-c5456e8ab0fa.png">


## View Changes
https://govuk-publishing-compo-pr-1233.herokuapp.com/component-guide/cookie_banner

