### PR TITLE
Cookie fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## Unreleased
 
 * Use correct grid row class in cookie banner ([#1233](https://github.com/alphagov/govuk_publishing_components/pull/1233))
+* Fix categorisation of survey cookies ([#1234](https://github.com/alphagov/govuk_publishing_components/pull/1234))
+* Improve cookie deletion code ([#1234](https://github.com/alphagov/govuk_publishing_components/pull/1234))
 
 ## 21.15.1
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -114,7 +114,9 @@
             window.GOVUK.cookie(cookie, null)
 
             if (window.GOVUK.cookie(cookie)) {
-              document.cookie = cookie + '=;expires=' + new Date() + ';domain=.' + window.location.hostname + ';path=/'
+              // We need to handle deleting cookies on the domain and the .domain
+              document.cookie = cookie + '=;expires=' + new Date() + ';'
+              document.cookie = cookie + '=;expires=' + new Date() + ';domain=' + window.location.hostname + ';path=/'
             }
           }
         }
@@ -165,7 +167,6 @@
   }
 
   window.GOVUK.setCookie = function (name, value, options) {
-    console.log("setting a cookie", name)
     if (window.GOVUK.checkConsentCookie(name, value)) {
       if (typeof options === 'undefined') {
         options = {}

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -22,8 +22,6 @@
     'global_bar_seen': 'settings',
     'govuk_browser_upgrade_dismisssed': 'settings',
     'govuk_not_first_visit': 'settings',
-    'govuk_surveySeenUserSatisfactionSurvey': 'settings',
-    'govuk_takenUserSatisfactionSurvey': 'settings',
     'analytics_next_page_call': 'usage',
     '_ga': 'usage',
     '_gid': 'usage',
@@ -153,7 +151,7 @@
 
     // Survey cookies are dynamically generated, so we need to check for these separately
     if (cookieName.match('^govuk_surveySeen') || cookieName.match('^govuk_taken')) {
-      return window.GOVUK.checkConsentCookieCategory(cookieName, 'essential')
+      return window.GOVUK.checkConsentCookieCategory(cookieName, 'settings')
     }
 
     if (COOKIE_CATEGORIES[cookieName]) {
@@ -167,6 +165,7 @@
   }
 
   window.GOVUK.setCookie = function (name, value, options) {
+    console.log("setting a cookie", name)
     if (window.GOVUK.checkConsentCookie(name, value)) {
       if (typeof options === 'undefined') {
         options = {}


### PR DESCRIPTION
## What
- Fix categorisation of survey cookies
- Improve cookie deletion code

<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
Survey cookies are dynamically generated, so we can't include them in the static list of cookie categories. We need to modify the existing code the handled these to return "settings" instead.

The existing deletion code wasn't deleting all cookies. Sometimes cookies (e.g: GA cookies) are set on www.gov.uk and .www.gov.uk. Our existing code wasn't deleting both types.