### PR TITLE
Version 21.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.15.2
 
 * Use correct grid row class in cookie banner ([#1233](https://github.com/alphagov/govuk_publishing_components/pull/1233))
 * Fix categorisation of survey cookies ([#1234](https://github.com/alphagov/govuk_publishing_components/pull/1234))
 * Improve cookie deletion code ([#1234](https://github.com/alphagov/govuk_publishing_components/pull/1234))
-* Fix cookie banner layout on mobile ([#1235](https://github.com/alphagov/govuk_publishing_components/pull/1235))
+* Fix cookie banner layout on mobile ([#1237](https://github.com/alphagov/govuk_publishing_components/pull/1237))
 
 ## 21.15.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.15.1)
+    govuk_publishing_components (21.15.2)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -280,7 +280,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
-    unicorn (5.5.1)
+    unicorn (5.5.2)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     webdrivers (4.1.3)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.15.1'.freeze
+  VERSION = '21.15.2'.freeze
 end


### PR DESCRIPTION
Includes:

* Use correct grid row class in cookie banner ([#1233](https://github.com/alphagov/govuk_publishing_components/pull/1233))
* Fix categorisation of survey cookies ([#1234](https://github.com/alphagov/govuk_publishing_components/pull/1234))
* Improve cookie deletion code ([#1234](https://github.com/alphagov/govuk_publishing_components/pull/1234))