### PR TITLE
Fix cookie banner layout mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Use correct grid row class in cookie banner ([#1233](https://github.com/alphagov/govuk_publishing_components/pull/1233))
 * Fix categorisation of survey cookies ([#1234](https://github.com/alphagov/govuk_publishing_components/pull/1234))
 * Improve cookie deletion code ([#1234](https://github.com/alphagov/govuk_publishing_components/pull/1234))
+* Fix cookie banner layout on mobile ([#1235](https://github.com/alphagov/govuk_publishing_components/pull/1235))
 
 ## 21.15.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -14,9 +14,12 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
 
 .gem-c-cookie-banner__message {
   display: inline-block;
-  @include govuk-font($size: 16);
-  padding-right: govuk-spacing(4);
   padding-bottom: govuk-spacing(2);
+
+  @include govuk-font($size: 16);
+  @include govuk-media-query($from: desktop) {
+    padding-right: govuk-spacing(4);
+  }
 }
 
 .gem-c-cookie-banner__button {
@@ -26,7 +29,9 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
   }
 
   .govuk-button {
-    width: 90%;
+    @include govuk-media-query($from: desktop) {
+      width: 90%;
+    }
 
     @include govuk-media-query($until: desktop) {
       margin-bottom: govuk-spacing(4);
@@ -114,6 +119,10 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
   .gem-c-cookie-banner__confirmation,
   .gem-c-cookie-banner__confirmation-message {
     @include govuk-font($size: 19);
+  }
+
+  .gem-c-cookie-banner__message {
+    margin-bottom: 0;
   }
 
   p {


### PR DESCRIPTION
## What
Remove excessive spacing on the right-hand side of the banner on mobile.

## Why
For visual harmony

## Visual Changes
Before
<img width="381" alt="Screenshot 2019-12-20 at 11 05 52" src="https://user-images.githubusercontent.com/788096/71250896-bb7dea00-2318-11ea-8716-f11aced4ee95.png">

After
<img width="383" alt="Screenshot 2019-12-20 at 11 05 39" src="https://user-images.githubusercontent.com/788096/71250900-bfaa0780-2318-11ea-9f47-7a0e4389fdc3.png">


## View Changes
https://govuk-publishing-compo-pr-1235.herokuapp.com/
