### PR TITLE
Create pageview on cookie consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Create pageview on cookie consent ([#1238](https://github.com/alphagov/govuk_publishing_components/pull/1238))
 * Use correct grid row class in cookie banner ([#1233](https://github.com/alphagov/govuk_publishing_components/pull/1233))
 * Fix categorisation of survey cookies ([#1234](https://github.com/alphagov/govuk_publishing_components/pull/1234))
 * Improve cookie deletion code ([#1234](https://github.com/alphagov/govuk_publishing_components/pull/1234))

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -66,6 +66,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.showConfirmationMessage()
     this.$module.cookieBannerConfirmationMessage.focus()
     window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
+    if (window.GOVUK.analyticsInit) {
+      window.GOVUK.analyticsInit()
+    }
   }
 
   CookieBanner.prototype.showConfirmationMessage = function () {

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -88,6 +88,8 @@ describe('Cookie banner', function () {
   })
 
   it('sets consent cookie when accepting cookies', function () {
+    GOVUK.analyticsInit = function () {}
+    spyOn(GOVUK, 'analyticsInit')
     spyOn(GOVUK, 'setCookie').and.callThrough()
 
     var element = document.querySelector('[data-module="cookie-banner"]')
@@ -103,6 +105,7 @@ describe('Cookie banner', function () {
     expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', 'true', { days: 365 })
     expect(GOVUK.getCookie('cookies_preferences_set')).toEqual('true')
     expect(GOVUK.getCookie('cookies_policy')).toEqual(ALL_COOKIE_CONSENT)
+    expect(GOVUK.analyticsInit).toHaveBeenCalled()
   })
 
   it('shows a confirmation message when cookies have been accepted', function () {


### PR DESCRIPTION
## What / why
Fire a pageview when a user clicks to accept cookies. This enables us to capture the landing page, which is critical information in the user journey.

This works by calling the analyticsInit function, which initialises all of the analytics and fires a pageview for both the standard and shared properties.

## Visual Changes
None.

## View Changes
https://govuk-publishing-compo-pr-1238.herokuapp.com/
