### PR TITLE
Delete unconsented cookies before explicit preferences set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Delete unconsented cookies automatically ([#1239](https://github.com/alphagov/govuk_publishing_components/pull/1239))
+
 ## 21.15.2
 
 * Use correct grid row class in cookie banner ([#1233](https://github.com/alphagov/govuk_publishing_components/pull/1233))

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -42,6 +42,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         if (!window.GOVUK.cookie('cookies_policy')) {
           window.GOVUK.setDefaultConsentCookie()
         }
+
+        window.GOVUK.deleteUnconsentedCookies()
       } else {
         this.$module.style.display = 'none'
       }

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -111,13 +111,7 @@
       if (!options[cookieType]) {
         for (var cookie in COOKIE_CATEGORIES) {
           if (COOKIE_CATEGORIES[cookie] === cookieType) {
-            window.GOVUK.cookie(cookie, null)
-
-            if (window.GOVUK.cookie(cookie)) {
-              // We need to handle deleting cookies on the domain and the .domain
-              document.cookie = cookie + '=;expires=' + new Date() + ';'
-              document.cookie = cookie + '=;expires=' + new Date() + ';domain=' + window.location.hostname + ';path=/'
-            }
+            window.GOVUK.deleteCookie(cookie)
           }
         }
       }
@@ -197,5 +191,30 @@
       }
     }
     return null
+  }
+
+  window.GOVUK.deleteCookie = function (cookie) {
+    window.GOVUK.cookie(cookie, null)
+
+    if (window.GOVUK.cookie(cookie)) {
+      // We need to handle deleting cookies on the domain and the .domain
+      document.cookie = cookie + '=;expires=' + new Date() + ';'
+      document.cookie = cookie + '=;expires=' + new Date() + ';domain=' + window.location.hostname + ';path=/'
+    }
+  }
+
+  window.GOVUK.deleteUnconsentedCookies = function () {
+    var currentConsent = window.GOVUK.getConsentCookie()
+
+    for (var cookieType in currentConsent) {
+      // Delete cookies of that type if consent being set to false
+      if (!currentConsent[cookieType]) {
+        for (var cookie in COOKIE_CATEGORIES) {
+          if (COOKIE_CATEGORIES[cookie] === cookieType) {
+            window.GOVUK.deleteCookie(cookie)
+          }
+        }
+      }
+    }
   }
 }(window))

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -87,6 +87,18 @@ describe('Cookie banner', function () {
     expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
   })
 
+  it('deletes unconsented cookies if cookie preferences not explicitly set', function () {
+    window.GOVUK.setCookie('_ga', 'this is not allowed!')
+    spyOn(GOVUK, 'deleteUnconsentedCookies').and.callThrough()
+
+    var element = document.querySelector('[data-module="cookie-banner"]')
+    new GOVUK.Modules.CookieBanner().start($(element))
+
+    expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
+    expect(GOVUK.deleteUnconsentedCookies).toHaveBeenCalled()
+    expect(GOVUK.getCookie('_ga', null))
+  })
+
   it('sets consent cookie when accepting cookies', function () {
     spyOn(GOVUK, 'setCookie').and.callThrough()
 


### PR DESCRIPTION
At the moment, if a user had visited GOVUK recently and had cookies set, and they also visited yesterday and got the new default consent cookie, all their existing cookies would remain and not be deleted. This is because the cookie deletion wasn't quite working and cookies are only deleted when setting the consent cookie. The only way for this person to delete their cookies would be for them to 1) manually delete them or 2) for them to set their preferences on the settings page.

This commit adds a method to delete all unconsented cookies when the cookie banner is present, so people in the above position will have previously set cookies deleted for them rather than having to manually delete them.

## Before
We can see a GA cookie set before `cookies_policy` was set is never deleted, even on page refresh.
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/29889908/71254026-888c2400-2321-11ea-9395-2101c3a502ee.gif)

## After
GA cookie now being deleted on page refresh.
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/29889908/71254101-cbe69280-2321-11ea-8e1c-f25a781c8490.gif)

