### PR TITLE
Release 21.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.16.3
 
 * Revert 'Simplify document list component markup when having only one item' ([#1244](https://github.com/alphagov/govuk_publishing_components/pull/1244))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.16.2)
+    govuk_publishing_components (21.16.3)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.16.2'.freeze
+  VERSION = '21.16.3'.freeze
 end


### PR DESCRIPTION
## Version 21.16.3

* Revert 'Simplify document list component markup when having only one item' ([#1244](https://github.com/alphagov/govuk_publishing_components/pull/1244))
