### PR TITLE
Add Dataset schema.org schema to machine readable metadata component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add Dataset schema.org schema to machine readable metadata component ([#1247](https://github.com/alphagov/govuk_publishing_components/pull/1247))
+
 ## 21.16.3
 
 * Revert 'Simplify document list component markup when having only one item' ([#1244](https://github.com/alphagov/govuk_publishing_components/pull/1244))

--- a/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
@@ -127,3 +127,10 @@ examples:
         base_path: "/finder/all"
         details: {}
       schema: :search_results_page
+  dataset_schema:
+    data:
+      content_item:
+        title: "All the data about Hogwarts"
+        base_path: "government/statistical-data-sets/hogwarts-data"
+        details: {}
+      schema: :dataset

--- a/lib/govuk_publishing_components/presenters/machine_readable/dataset_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/dataset_schema.rb
@@ -1,0 +1,34 @@
+module GovukPublishingComponents
+  module Presenters
+    class DatasetSchema
+      attr_reader :page
+
+      def initialize(page)
+        @page = page
+      end
+
+      def structured_data
+        # http://schema.org/Dataset
+        data = CreativeWorkSchema.new(@page).structured_data
+          .merge(description)
+          .merge(name)
+        data["@type"] = "Dataset"
+        data
+      end
+
+    private
+
+      def description
+        {
+          "description" => page.description || page.body
+        }
+      end
+
+      def name
+        {
+          "name" => page.title
+        }
+      end
+    end
+  end
+end

--- a/lib/govuk_publishing_components/presenters/schema_org.rb
+++ b/lib/govuk_publishing_components/presenters/schema_org.rb
@@ -10,6 +10,7 @@ require 'govuk_publishing_components/presenters/machine_readable/organisation_sc
 require 'govuk_publishing_components/presenters/machine_readable/person_schema'
 require 'govuk_publishing_components/presenters/machine_readable/potential_search_action_schema'
 require 'govuk_publishing_components/presenters/machine_readable/search_results_page_schema'
+require 'govuk_publishing_components/presenters/machine_readable/dataset_schema'
 
 module GovukPublishingComponents
   module Presenters
@@ -35,6 +36,8 @@ module GovukPublishingComponents
           OrganisationSchema.new(page).structured_data
         elsif page.schema == :search_results_page
           SearchResultsPageSchema.new(page).structured_data
+        elsif page.schema == :dataset
+          DatasetSchema.new(page).structured_data
         else
           raise "#{page.schema} is not supported"
         end

--- a/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
@@ -51,6 +51,33 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
       expect(structured_data['potentialAction']).to eql(search_action)
     end
 
+    it "generates schema.org Datasets" do
+      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "statistical_data_set") do |random_item|
+        random_item.merge(
+          "details" => {
+            "body" => "Dataset body",
+            "political": false,
+              "government": {
+              "title": "Government title",
+              "slug": "government-title",
+              "current": false
+            },
+          },
+          "description" => "Dataset description",
+          "title" => "Dataset Title"
+        )
+      end
+
+      structured_data = generate_structured_data(
+        content_item: content_item,
+        schema: :dataset,
+      ).structured_data
+
+      expect(structured_data['@type']).to eql("Dataset")
+      expect(structured_data['name']).to eql("Dataset Title")
+      expect(structured_data['description']).to eql("Dataset description")
+    end
+
     context "schema.org GovernmentService" do
       before(:each) do
         @organisations = [


### PR DESCRIPTION
## What

Add Dataset schema.org schema to machine readable metadata component.

## Why

Things that appear in the published statistics list in the [research and stats finder](https://www.gov.uk/search/research-and-statistics) can be marked up with structured data so that they are recognised as statistical datasets (https://developers.google.com/search/docs/data-types/dataset).

One benefit of this is that they might appear in Google's dataset search tool: https://toolbox.google.com/datasetsearch.

## Trello card

https://trello.com/c/0W3LfcGl/1232-implement-schemaorg-dataset-schema-on-published-statistics-document-types