### PR TITLE
Bump to 21.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.17.0
 
 * Add Dataset schema.org schema to machine readable metadata component ([#1247](https://github.com/alphagov/govuk_publishing_components/pull/1247))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.16.3)
+    govuk_publishing_components (21.17.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -82,7 +82,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.8.0)
     execjs (2.7.0)
-    faraday (0.17.1)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     foreman (0.85.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.16.3'.freeze
+  VERSION = '21.17.0'.freeze
 end


### PR DESCRIPTION
Adds the schema.org Dataset machine readable schema

https://trello.com/c/0W3LfcGl/1232-implement-schemaorg-dataset-schema-on-published-statistics-document-types