### PR TITLE
Remove Brexit CTA link from checker start page

### DIFF
--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -79,7 +79,10 @@ module GovukPublishingComponents
       def show_brexit_cta?
         # If tagged directly to /brexit or /world/brexit
         # Or if tagged to a taxon which has /brexit as a parent
-        tagged_to_brexit?
+        # And is not the brexit checker start page
+        brexit_start_page_content_id = "58d093a1-787d-4f36-a568-86da23a7b884"
+        page_content_id = content_item["content_id"]
+        tagged_to_brexit? && (page_content_id != brexit_start_page_content_id)
       end
 
       def step_by_step_count


### PR DESCRIPTION
## Why
Currently we want to show a contextual Brexit sidebar on start pages for any content that is tagged to /brexit or /world/brexit.
This link serves as a call to action to bring people back to the Brexit landing page.
The landing page in turn links to the checker as a major feature, which itself has a start page.
Currently that start page shows this sidebar, putting the user in a loop between the start page and landing page.

## What
To prevent this we add an additional condition to the show_brexit_cta? method, only used in this repo in _show_contextual_sidebar.html.erb,
causing it to return false if the content_id matches the content_id for the Brexit checker start page

## Visual Changes
Tested:
Example of startup page
![Screenshot_2020-01-06 Brexit check what you need to do if there is no deal](https://user-images.githubusercontent.com/3694062/71819038-a1673a00-3082-11ea-890f-a50d508d0e08.png)

Example of other Brexit taxon page
![Screenshot_2020-01-06 How to prepare if the UK leaves the EU with no deal](https://user-images.githubusercontent.com/3694062/71819042-a4622a80-3082-11ea-874d-685cb7d89488.png)