### PR TITLE
Version 21.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 21.18.0
+
+* Remove Brexit CTA link from checker start page ([#1249](https://github.com/alphagov/govuk_publishing_components/pull/1249))
+
 ## 21.17.0
 
 * Add Dataset schema.org schema to machine readable metadata component ([#1247](https://github.com/alphagov/govuk_publishing_components/pull/1247))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.17.0)
+    govuk_publishing_components (21.18.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -126,7 +126,7 @@ GEM
     jasmine-core (3.4.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    kgio (2.11.2)
+    kgio (2.11.3)
     kramdown (2.1.0)
     link_header (0.0.8)
     logstash-event (1.2.02)
@@ -199,7 +199,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
-    raindrops (0.19.0)
+    raindrops (0.19.1)
     rake (12.3.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.17.0'.freeze
+  VERSION = '21.18.0'.freeze
 end


### PR DESCRIPTION
Includes:

* Remove Brexit CTA link from checker start page ([#1249](https://github.com/alphagov/govuk_publishing_components/pull/1249))