### PR TITLE
Increase notice border size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Increase notice border size ([#1254](https://github.com/alphagov/govuk_publishing_components/pull/1254))
+
 ## 21.19.0
 
 * Add print icons ([#1251](https://github.com/alphagov/govuk_publishing_components/pull/1251))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
@@ -4,7 +4,7 @@
   @include govuk-responsive-margin(8, "bottom");
 
   clear: both;
-  border: 2px solid govuk-colour("blue");
+  border: $govuk-border-width solid govuk-colour("blue");
 
   .govuk-govspeak, {
     p:last-child {


### PR DESCRIPTION
## What
Increase notice border size from 2px to 5px.

## Why

- Makes the notice more visually prominent
- Brings the component in line with other types of notice/alert, e.g: [error summary](https://components.publishing.service.gov.uk/component-guide/error_summary) and [success alert](https://components.publishing.service.gov.uk/component-guide/success_alert)

## Before
<img width="920" alt="Screenshot 2020-01-14 at 13 33 18" src="https://user-images.githubusercontent.com/29889908/72348573-993a7a80-36d2-11ea-8cad-fd234dd208b8.png">

## After
<img width="920" alt="Screenshot 2020-01-14 at 13 41 23" src="https://user-images.githubusercontent.com/29889908/72349006-92603780-36d3-11ea-9997-d38888951116.png">

https://govuk-publishing-compo-pr-1254.herokuapp.com/component-guide/notice
