### PR TITLE
Check for ordered related items and parent in breadcrumb logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Check for ordered related items and parent in breadcrumb logic ([#1257](https://github.com/alphagov/govuk_publishing_components/pull/1257))
+
 ## 21.19.1
 
 * Increase notice border size ([#1254](https://github.com/alphagov/govuk_publishing_components/pull/1254))

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -49,7 +49,7 @@ module GovukPublishingComponents
       end
 
       def content_has_curated_related_items?
-        content_item.dig("links", "ordered_related_items").present?
+        content_item.dig("links", "ordered_related_items").present? && content_item.dig("links", "parent").present?
       end
 
       def content_is_tagged_to_a_live_taxon?


### PR DESCRIPTION
Zendesk: https://govuk.zendesk.com/agent/tickets/3890644
Trello: https://trello.com/c/wP0pwnM3/824-related-links-impacting-visibility-of-breadcrumbs-on-guidance

## What
The current ordered_related_items breadcrumb logic relies on having a parent in the links hash, but we don't actually check for this until we try to add breadcrumbs. This adds a check early on, so we don't end up with empty breadcrumbs.

## Why
The ordered related items breadcrumbs logic relies on the content item having a parent in the links hash. This isn't always present (in fact, it seems to be a feature of mainstream browse and HTML attachments rather than ordered_related_items).
This means documents with ordered_related_items have empty breadcrumbs, which isn't ideal, especially when they're tagged to taxons which could be shown.
This is more of a temporary fix/workaround until we make a decision on what we expect the breadcrumb behaviour to be when ordered_related_items are present, but parent items aren't.

## Before
<img width="995" alt="Screenshot 2020-01-16 at 09 55 38" src="https://user-images.githubusercontent.com/29889908/72514321-5dc0bd00-3846-11ea-9d1c-2a536a49c66f.png">

## After
<img width="1026" alt="Screenshot 2020-01-16 at 09 55 29" src="https://user-images.githubusercontent.com/29889908/72514416-7af58b80-3846-11ea-8656-6f659ca1857e.png">



<!--
## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
-->
