### PR TITLE
change dataset schema description to use body primarily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## Unreleased
 
 * Update govuk-frontend to 3.5.0 ([#1262](https://github.com/alphagov/govuk_publishing_components/pull/1262))
+* Change the dataset schema description ([#1260](https://github.com/alphagov/govuk_publishing_components/pull/1260))
+
 
 ## 21.20.0
 

--- a/lib/govuk_publishing_components/presenters/machine_readable/dataset_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/dataset_schema.rb
@@ -20,7 +20,7 @@ module GovukPublishingComponents
 
       def description
         {
-          "description" => page.description || page.body
+          "description" => (page.body || page.description).slice(0..4999)
         }
       end
 

--- a/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
       content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "statistical_data_set") do |random_item|
         random_item.merge(
           "details" => {
-            "body" => "Dataset body",
+            "body" => "Dataset body" + ("a" * 5001),
             "political": false,
               "government": {
               "title": "Government title",
@@ -75,7 +75,7 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
 
       expect(structured_data['@type']).to eql("Dataset")
       expect(structured_data['name']).to eql("Dataset Title")
-      expect(structured_data['description']).to eql("Dataset description")
+      expect(structured_data['description'].length).to eql(5000)
     end
 
     context "schema.org GovernmentService" do


### PR DESCRIPTION
This is related to the ticket [here](https://trello.com/c/5sN5oxbt/1288-fix-errors-in-dataset-schema), and is aiming to mitigate the errors we've seen with descriptions being bad lengths. 