### PR TITLE
Add attribute parameter to meta links in layout footer component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update govuk-frontend to 3.5.0 ([#1262](https://github.com/alphagov/govuk_publishing_components/pull/1262))
+* Add attribute parameter to meta links in layout footer component ([#1261](https://github.com/alphagov/govuk_publishing_components/pull/1261))
 * Change the dataset schema description ([#1260](https://github.com/alphagov/govuk_publishing_components/pull/1260))
 
 

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -40,9 +40,11 @@
           <ul class="govuk-footer__inline-list">
             <% meta[:items].each do |item| %>
               <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="<%= item[:href] %>">
-                  <%= item[:text] %>
-                </a>
+                <%
+                  attributes = { class: "govuk-footer__link" }.merge(item.fetch(:attributes, {}))
+                  attributes[:rel] = "noopener" if attributes[:target] == "_blank" && !attributes[:rel]
+                %>
+                <%= link_to item[:text], item[:href], attributes %>
               </li>
             <% end %>
           </ul>

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -140,3 +140,10 @@ examples:
               attributes:
                 data:
                   tracking: GTM-123AB
+      meta:
+        items:
+          - href: '/cymraeg'
+            text: Rhestr o Wasanaethau Cymraeg
+            attributes:
+              lang: en
+              hreflang: en

--- a/spec/components/layout_footer_spec.rb
+++ b/spec/components/layout_footer_spec.rb
@@ -83,4 +83,73 @@ describe "Layout footer", type: :view do
       expect(link.attr('rel').to_s).to eq "noopener"
     end
   end
+
+  it "renders the footer meta links with attributes" do
+    render_component(
+      navigation: [
+        {
+          title: "Services and information",
+          columns: 2,
+          items: [
+            {
+              href: "/browse/benefits",
+              text: "Benefits",
+            },
+          ]
+        },
+      ],
+      meta: {
+        items: [
+          {
+            href: "/cymraeg",
+            text: "Rhestr o Wasanaethau Cymraeg",
+            attributes: {
+              lang: "cy",
+              hreflang: "cy"
+            },
+          },
+        ]
+      },
+    )
+
+    assert_select '.govuk-footer__meta-item a' do |link|
+      expect(link.attr('class').to_s).to eq "govuk-footer__link"
+      expect(link.attr('lang').to_s).to eq "cy"
+      expect(link.attr('hreflang').to_s).to eq "cy"
+    end
+  end
+
+  it "renders the footer meta link with attributes but will set the rel attribute if target is blank" do
+    render_component(
+      navigation: [
+        {
+          title: "Services and information",
+          columns: 2,
+          items: [
+            {
+              href: "/browse/benefits",
+              text: "Benefits",
+            },
+          ]
+        },
+      ],
+      meta: {
+        items: [
+          {
+            href: "/guidance/keeping-a-pet-pig-or-micropig",
+            text: "Keeping a pet pig or 'micropig'",
+            attributes: {
+              target: "_blank"
+            },
+          },
+        ]
+      },
+    )
+
+    assert_select '.govuk-footer__meta-item a' do |link|
+      expect(link.attr('class').to_s).to eq "govuk-footer__link"
+      expect(link.attr('target').to_s).to eq "_blank"
+      expect(link.attr('rel').to_s).to eq "noopener"
+    end
+  end
 end


### PR DESCRIPTION
## What

Lets you set attributes for the links in the meta part of the footer.

## Why

One of the links in the footer meta required a `lang` and a `hreflang` attribute - but attributes couldn't be added to the meta links. 

## Visual Changes

No visual changes.


## View Changes

https://govuk-publishing-compo-pr-1261.herokuapp.com/component-guide/layout_footer
