### PR TITLE
Update govuk-frontend to 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update govuk-frontend to 3.5.0 ([#1262](https://github.com/alphagov/govuk_publishing_components/pull/1262))
+
 ## 21.20.0
 
 * Check for ordered related items and parent in breadcrumb logic ([#1257](https://github.com/alphagov/govuk_publishing_components/pull/1257))

--- a/package-lock.json
+++ b/package-lock.json
@@ -867,9 +867,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.4.0.tgz",
-      "integrity": "sha512-rmYPtcCtWgz92QBejYwOnfSxbPGYfvSruLwB4CBk/yJtySHRY0whG1e2/iFRRSj0pMx1Bu+zh/IqCTo+84hbFw=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.5.0.tgz",
+      "integrity": "sha512-4tNKgcChO1bMNsrTz2UsK4fDMmU9R87UDxy/KhKIMbnhsuJLVuArDveYLkZuUsZ6B3eaCbl5gmI8i/Q/Mi680A=="
     },
     "graceful-fs": {
       "version": "4.1.15",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "axe-core": "^3.4.1",
-    "govuk-frontend": "^3.4.0",
+    "govuk-frontend": "^3.5.0",
     "jquery": "1.12.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## What
Update govuk-frontend dependency to 3.5.0

## Why
Keeping dependencies up to date.

## Changes
Change log: https://github.com/alphagov/govuk-frontend/releases/tag/v3.5.0
