### PR TITLE
Version 21.21.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.21.0
 
 * Update govuk-frontend to 3.5.0 ([#1262](https://github.com/alphagov/govuk_publishing_components/pull/1262))
 * Add attribute parameter to meta links in layout footer component ([#1261](https://github.com/alphagov/govuk_publishing_components/pull/1261))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.20.0)
+    govuk_publishing_components (21.21.0)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.20.0'.freeze
+  VERSION = '21.21.0'.freeze
 end


### PR DESCRIPTION
Includes:

* Update govuk-frontend to 3.5.0 ([#1262](https://github.com/alphagov/govuk_publishing_components/pull/1262))
* Add attribute parameter to meta links in layout footer component ([#1261](https://github.com/alphagov/govuk_publishing_components/pull/1261))
* Change the dataset schema description ([#1260](https://github.com/alphagov/govuk_publishing_components/pull/1260))

🚀 

