### PR TITLE
Remove hard limit on step by steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove limits on showing >5 step by step navigation sidebar elements ([#1267](https://github.com/alphagov/govuk_publishing_components/pull/1267))
+
 ## 21.21.1
 
 * Update the text for the Transition contextual sidebar link ([#1264](https://github.com/alphagov/govuk_publishing_components/pull/1264))

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -38,7 +38,7 @@ module GovukPublishingComponents
       def show_related_links?
         if active_step_by_step?
           true
-        elsif step_navs.any? && step_navs.count < 5
+        elsif step_navs.any?
           true
         elsif show_related_links_for_secondary_step_by_steps?
           true
@@ -119,7 +119,7 @@ module GovukPublishingComponents
       end
 
       def show_related_links_for_secondary_step_by_steps?
-        !primary_step_by_steps? && secondary_step_by_step? && secondary_step_by_steps.count < 5
+        !primary_step_by_steps? && secondary_step_by_step?
       end
 
     private

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -8,17 +8,10 @@ describe "Contextual navigation" do
     and_the_step_by_step_header
   end
 
-  scenario "There's between 2-5 step by step lists" do
+  scenario "There's more than one step by step" do
     given_theres_are_two_step_by_step_lists
     and_i_visit_that_page
     then_i_just_see_the_step_by_step_related_links
-    and_no_step_by_step_header
-  end
-
-  scenario "There's 6 or more step by step lists" do
-    given_theres_are_six_step_by_step_lists
-    and_i_visit_that_page
-    then_theres_no_step_by_step_at_all
     and_no_step_by_step_header
   end
 
@@ -71,17 +64,10 @@ describe "Contextual navigation" do
     and_the_step_by_step_header
   end
 
-  scenario "There's between 2-5 secondary step by step lists and no primary step by step list" do
+  scenario "There's more than one secondary step by step list and no primary step by step list" do
     given_there_are_two_secondary_step_by_step_lists
     and_i_visit_that_page
     then_i_just_see_the_step_by_step_related_links
-  end
-
-  scenario "There's 6 or more secondary step by step lists and no primary step by step list" do
-    given_there_are_six_secondary_step_by_step_lists
-    and_i_visit_that_page
-    then_theres_no_step_by_step_at_all
-    and_no_step_by_step_header
   end
 
   scenario "There's 3 secondary step by steps and 2 primary step by step lists" do
@@ -143,20 +129,12 @@ describe "Contextual navigation" do
     content_store_has_random_item(links: { part_of_step_navs: part_of_step_navs })
   end
 
-  def given_theres_are_six_step_by_step_lists
-    content_store_has_random_item(links: { part_of_step_navs: 6.times.map { random_step_nav_item("step_by_step_nav") } })
-  end
-
   def given_theres_a_page_with_a_secondary_step_by_step
     content_store_has_random_item(links: { secondary_to_step_navs: [random_step_nav_item("step_by_step_nav")] })
   end
 
   def given_there_are_two_secondary_step_by_step_lists
     content_store_has_random_item(links: { secondary_to_step_navs: 2.times.map { random_step_nav_item("step_by_step_nav") } })
-  end
-
-  def given_there_are_six_secondary_step_by_step_lists
-    content_store_has_random_item(links: { secondary_to_step_navs: 6.times.map { random_step_nav_item("step_by_step_nav") } })
   end
 
   def given_there_are_three_secondary_step_by_steps_and_two_primary_to_step_navs

--- a/spec/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
         expect(step_nav_links.step_navs.count).to eq(6)
 
         expect(step_nav_links.show_header?).to be false
-        expect(step_nav_links.show_related_links?).to be false
+        expect(step_nav_links.show_related_links?).to be true
         expect(step_nav_links.show_sidebar?).to be false
       end
     end
@@ -575,31 +575,6 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
           expect(step_nav_links.show_sidebar?).to be false
         end
       end
-
-      context "for a content item with many `secondary_to_step_navs` links" do
-        let(:content_store_response) do
-          {
-            "title" => "Book a session in the vomit comet",
-            "document_type" => "transaction",
-            "links" => {
-              "secondary_to_step_navs" => Array.new(6, step_nav),
-            }
-          }
-        end
-
-        it "parses the content item" do
-          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
-
-          expect(step_nav_links.step_navs.count).to eq(0)
-          expect(step_nav_links.secondary_step_by_steps.count).to eq(6)
-
-          expect(step_nav_links.show_secondary_step_by_step?).to be false
-          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
-          expect(step_nav_links.show_header?).to be false
-          expect(step_nav_links.show_related_links?).to be false
-          expect(step_nav_links.show_sidebar?).to be false
-        end
-      end
     end
 
     context "secondary step by steps with primary step by steps" do
@@ -807,32 +782,6 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
           expect(step_nav_links.show_sidebar?).to be false
         end
       end
-
-      context "for a content item with many `secondary_to_step_navs` links and many `part_of_step_navs` link" do
-        let(:content_store_response) do
-          {
-            "title" => "Book a session in the vomit comet",
-            "document_type" => "transaction",
-            "links" => {
-              "part_of_step_navs" => Array.new(6, primary_step_nav),
-              "secondary_to_step_navs" => Array.new(6, step_nav),
-            }
-          }
-        end
-
-        it "parses the content item" do
-          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
-
-          expect(step_nav_links.step_navs.count).to eq(6)
-          expect(step_nav_links.secondary_step_by_steps.count).to eq(6)
-
-          expect(step_nav_links.show_secondary_step_by_step?).to be false
-          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
-          expect(step_nav_links.show_header?).to be false
-          expect(step_nav_links.show_related_links?).to be false
-          expect(step_nav_links.show_sidebar?).to be false
-        end
-      end
     end
 
     context "secondary step by steps with related to step by steps" do
@@ -950,33 +899,6 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
           expect(step_nav_links.step_navs.count).to eq(0)
           expect(step_nav_links.secondary_step_by_steps.count).to eq(2)
           expect(step_nav_links.related_to_step_navs.count).to eq(2)
-
-          expect(step_nav_links.show_secondary_step_by_step?).to be false
-          expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
-          expect(step_nav_links.show_header?).to be false
-          expect(step_nav_links.show_related_links?).to be false
-          expect(step_nav_links.show_sidebar?).to be false
-        end
-      end
-
-      context "for a content item with many `secondary_to_step_navs` links and many `related_to_step_navs` link" do
-        let(:content_store_response) do
-          {
-            "title" => "Book a session in the vomit comet",
-            "document_type" => "transaction",
-            "links" => {
-              "related_to_step_navs" => Array.new(6, related_to_step_nav),
-              "secondary_to_step_navs" => Array.new(6, step_nav),
-            }
-          }
-        end
-
-        it "parses the content item" do
-          step_nav_links = described_class.new(content_store_response, '/vomit-comet-session')
-
-          expect(step_nav_links.step_navs.count).to eq(0)
-          expect(step_nav_links.secondary_step_by_steps.count).to eq(6)
-          expect(step_nav_links.related_to_step_navs.count).to eq(6)
 
           expect(step_nav_links.show_secondary_step_by_step?).to be false
           expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/3884434

We initially had a hard limit on step by step pages to prevent pages that are part of many routes from being overwhelmed with sidebar navigation. We envisaged that https://www.gov.uk/request-copy-criminal-record might be an example of this but the limit was never actually reached at the time.  

This was before the publishing tool and pattern were iterated meaning that publishers had a much finer-grained control over when step by step navigation was shown. 

It appears that this limit may have run its course because we actually want to show 6 step by steps on https://www.gov.uk/eori, so we're going to try removing it for the time being. 

## Before 

<img width="1144" alt="Screenshot 2020-01-24 16 01 19" src="https://user-images.githubusercontent.com/773037/73083325-de289300-3ec2-11ea-9054-a7e62ae9e4b8.png">

## After

<img width="1144" alt="Screenshot 2020-01-24 16 01 09" src="https://user-images.githubusercontent.com/773037/73083354-eed90900-3ec2-11ea-9c98-d69d59cd578a.png">




