### PR TITLE
Make step by steps resemble related link styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Increase margin between related step by step links and adjust font weight ([#1269](https://github.com/alphagov/govuk_publishing_components/pull/1269))
+
 ## 21.21.2
 
 * Remove limits on showing >5 step by step navigation sidebar elements ([#1267](https://github.com/alphagov/govuk_publishing_components/pull/1267))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-related.scss
@@ -11,7 +11,7 @@
 }
 
 .gem-c-step-nav-related__links {
-  @include govuk-font(16, $weight: bold);
+  @include govuk-font(16);
   margin: 0;
   padding: 0;
 }
@@ -48,10 +48,6 @@
 
 .gem-c-step-nav-related__link-item {
   margin-top: govuk-spacing(3);
-
-  @include govuk-media-query($from: tablet) {
-    margin-top: govuk-spacing(1);
-  }
 }
 
 .gem-c-step-nav-related__link {


### PR DESCRIPTION
We recently relaxed the restriction on multiple related step by step links in sidebar navigation. This meant that they got renewed scrutiny from design folks who have asked that we increase the spacing between the links to related step by step pages so that they are like related links.

This change also removes the bold font weight when multiple related step by steps are shown in the sidebar.  It does not affect the font weight of the title of a step by step if it is the only one (and therefore also renders the full step by step outline).

Using normal font weight means that the links are closer to related links in appearance, thus increasing the consistency of navigation styles.

## Before (mobile)

<img width="370" alt="Screenshot 2020-01-28 12 44 23" src="https://user-images.githubusercontent.com/773037/73265472-f2270a00-41cc-11ea-9f50-921355a5a2a7.png">

## After mobile

<img width="367" alt="Screenshot 2020-01-28 12 43 53" src="https://user-images.githubusercontent.com/773037/73265473-f2270a00-41cc-11ea-96fe-5235ece597cd.png">

## Before (desktop)


<img width="1552" alt="Screenshot 2020-01-28 12 42 23" src="https://user-images.githubusercontent.com/773037/73265475-f2bfa080-41cc-11ea-955b-ad74f4182df4.png">

## After (desktop)

<img width="1552" alt="Screenshot 2020-01-28 12 43 19" src="https://user-images.githubusercontent.com/773037/73265474-f2270a00-41cc-11ea-8ead-43920c907bac.png">

## Before - Single link (mobile)

<img width="373" alt="Screenshot 2020-01-28 12 45 08" src="https://user-images.githubusercontent.com/773037/73265468-f2270a00-41cc-11ea-998f-4caa4fd49dfd.png">

## After - Single link (mobile) - No change

<img width="387" alt="Screenshot 2020-01-28 12 44 48" src="https://user-images.githubusercontent.com/773037/73265471-f2270a00-41cc-11ea-8c71-4506b7c83642.png">


