### PR TITLE
Add cookie category lookup function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add cookie category lookup function ([#1272](https://github.com/alphagov/govuk_publishing_components/pull/1272))
+
 ## 21.21.3
 
 * Increase margin between related step by step links and adjust font weight ([#1269](https://github.com/alphagov/govuk_publishing_components/pull/1269))

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -193,6 +193,10 @@
     return null
   }
 
+  window.GOVUK.getCookieCategory = function (cookie) {
+    return COOKIE_CATEGORIES[cookie]
+  }
+
   window.GOVUK.deleteCookie = function (cookie) {
     window.GOVUK.cookie(cookie, null)
 


### PR DESCRIPTION
Trello: https://trello.com/c/3rncf9Pt/439-tech-debt-global-bar-logic-assumes-cookie-category

## What
Given a cookie name, look up the category that this cookie is in.
Good for checking if a cookie has been consented to in advance of doing cookie-based logic.
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
This will be used to replace [this line](https://github.com/alphagov/static/pull/2019/files#diff-146dfe5256358c4209bb150ac180fabeR15) in Static which assumes the `global_bar_seen` is in the "settings" category. We don't want to make this assumption as the category could change.

<!--
## View Changes
https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
-->
