### PR TITLE
Remove heroku link in PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -7,8 +7,3 @@
 
 ## Visual Changes
 <!-- If the change results in visual changes, show a before and after -->
-
-<!--
-## View Changes
-https://govuk-publishing-compo-pr-[PR-NUMBER].herokuapp.com/
--->


### PR DESCRIPTION
## What
Remove the heroku link in PR templates

## Why
We are using the new heroku review apps, which don't have fixed URLs based on PR number.
