### PR TITLE
Add special case for 'UK mission in the European Union'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add cookie category lookup function ([#1272](https://github.com/alphagov/govuk_publishing_components/pull/1272))
+* Fix a world location link for 'UK mission in the European Union' ([#1274](https://github.com/alphagov/govuk_publishing_components/pull/1274))
 
 ## 21.21.3
 

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -12,6 +12,9 @@ module GovukPublishingComponents
         world_locations
         statistical_data_sets
       ).freeze
+      WORLD_LOCATION_SPECIAL_CASES = {
+        'UK Mission to the European Union' => 'uk-mission-to-the-eu',
+      }.freeze
 
       def initialize(options = {})
         @content_item = options.fetch(:content_item) { raise ArgumentError, 'missing argument: content_item' }
@@ -146,7 +149,10 @@ module GovukPublishingComponents
 
       def related_world_locations
         content_item_links_for('world_locations')
-          .map { |link| link.merge(path: "/world/#{link[:text].parameterize}/news") }
+          .map do |link|
+            slug = WORLD_LOCATION_SPECIAL_CASES[link[:text]] || link[:text].parameterize
+            link.merge(path: "/world/#{slug}/news")
+          end
       end
 
       def related_statistical_data_sets

--- a/spec/components/related_navigation_spec.rb
+++ b/spec/components/related_navigation_spec.rb
@@ -78,6 +78,15 @@ describe "Related navigation", type: :view do
     assert_select ".gem-c-related-navigation__section-link[href=\"/world/usa/news\"]", text: 'USA'
   end
 
+  it "renders world locations section when passed special case world location items" do
+    content_item = {}
+    content_item["links"] = construct_links("world_locations", nil, "UK Mission to the European Union")
+    render_component(content_item: content_item)
+
+    assert_select ".gem-c-related-navigation__sub-heading", text: 'World locations'
+    assert_select ".gem-c-related-navigation__section-link[href=\"/world/uk-mission-to-the-eu/news\"]", text: 'UK Mission to the European Union'
+  end
+
   it "renders collection section when passed collection items" do
     content_item = {}
     content_item["links"] = construct_links(


### PR DESCRIPTION
The slug for the world location 'UK mission in the European Union' doesn't match exactly the title of the world location. Instead the slug shortens 'European Union' to 'EU'.

This means that links to this world location are currently broken (for example
https://www.gov.uk/government/speeches/triggering-the-jcpoa-dispute-resolution-mechanism-foreign-secretarys-commons-statement (see section at the bottom of the page).

This is similar to the special cases that we used to have in government-frontend before they were removed and moved into govuk_publishing_components: https://github.com/alphagov/government-frontend/pull/1035 (see the comment there for more details on why we generate the base paths for world locations based on their slugs).

[Zendesk Ticket](https://govuk.zendesk.com/agent/tickets/3908003)