### PR TITLE
Version 21.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.22.0
 
 * Add cookie category lookup function ([#1272](https://github.com/alphagov/govuk_publishing_components/pull/1272))
 * Fix a world location link for 'UK mission in the European Union' ([#1274](https://github.com/alphagov/govuk_publishing_components/pull/1274))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.21.3)
+    govuk_publishing_components (21.22.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -280,7 +280,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
-    unicorn (5.5.2)
+    unicorn (5.5.3)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     webdrivers (4.1.3)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.21.3'.freeze
+  VERSION = '21.22.0'.freeze
 end


### PR DESCRIPTION
Includes:


* Add cookie category lookup function ([#1272](https://github.com/alphagov/govuk_publishing_components/pull/1272))
* Fix a world location link for 'UK mission in the European Union' ([#1274](https://github.com/alphagov/govuk_publishing_components/pull/1274))