### PR TITLE
Make maxlength or maxwords required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Make maxlength or maxwords required ([#1276](https://github.com/alphagov/govuk_publishing_components/pull/1276))
+
 ## 21.22.0
 
 * Add cookie category lookup function ([#1272](https://github.com/alphagov/govuk_publishing_components/pull/1272))

--- a/app/views/govuk_publishing_components/components/_character_count.html.erb
+++ b/app/views/govuk_publishing_components/components/_character_count.html.erb
@@ -5,19 +5,20 @@
   threshold ||= nil
   textarea ||= {}
 %>
+<% if maxlength || maxwords %>
+  <%= content_tag :div,
+    class: "gem-c-character-count govuk-character-count",
+    data: {
+      module: "govuk-character-count",
+      maxlength: maxlength,
+      maxwords: maxwords,
+      threshold: threshold
+    } do %>
 
-<%= content_tag :div,
-  class: "gem-c-character-count govuk-character-count",
-  data: {
-    module: "govuk-character-count",
-    maxlength: maxlength,
-    maxwords: maxwords,
-    threshold: threshold
-  } do %>
+    <%= render "govuk_publishing_components/components/textarea", { id: id, character_count: true }.merge(textarea.symbolize_keys) %>
 
-  <%= render "govuk_publishing_components/components/textarea", { id: id, character_count: true }.merge(textarea.symbolize_keys) %>
-
-  <span id="<%= id %>-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
-    You can enter up to <%= maxlength || maxwords %> <%= maxwords ? 'words' : 'characters' %>
-  </span>
+    <span id="<%= id %>-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
+      You can enter up to <%= maxlength || maxwords %> <%= maxwords ? 'words' : 'characters' %>
+    </span>
+  <% end %>
 <% end %>

--- a/spec/components/character_count_spec.rb
+++ b/spec/components/character_count_spec.rb
@@ -5,6 +5,10 @@ describe "Character count", type: :view do
     "character_count"
   end
 
+  it "fails to render if maxlength or maxwords are not passed" do
+    assert_empty render_component({})
+  end
+
   it "renders character count with textarea" do
     render_component(
       name: "character-count",
@@ -14,8 +18,8 @@ describe "Character count", type: :view do
       },
       data: {
         module: "character-count",
-        maxlength: "100",
-      }
+      },
+      maxlength: "100"
     )
 
     assert_select ".govuk-character-count .govuk-textarea"


### PR DESCRIPTION
## What
Make number passed to the character count component (either `maxlength` or `maxwords`) required, render nothing if not passed.

## Why
I just tried to use this component and got the maxlength parameter in the wrong place, but instead of failing gracefully the component loaded and then broke, which was briefly very confusing. If one of these parameters is required, let's make it required.

## Visual Changes
No changes.
