### PR TITLE
Adds missing 'threshold' example to character_count component

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/character_count.yml
+++ b/app/views/govuk_publishing_components/components/docs/character_count.yml
@@ -51,3 +51,11 @@ examples:
           text: "Can you provide more detail?"
         name: "more-detail-value"
       maxwords: 10
+  with_threshold:
+    data:
+      textarea:
+        label:
+          text: "Can you provide more detail?"
+        name: "more-detail-with-threshold"
+      threshold: 75
+      maxlength: 20


### PR DESCRIPTION
## What
Adds example showing `threshold` on the `character_count` component.

## Why
There is no mention of this functionality on https://components.publishing.service.gov.uk/component-guide/character_count.

I do wonder if the above page should link to https://design-system.service.gov.uk/components/character-count/, which is a little more fully featured. This feels like a bit of documentation duplication - but better to get govuk_publishing_components up to date and consider a better documentation approach later.

## Visual Changes
N/A