### PR TITLE
Update govspeak button styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update govspeak button styles ([PR #1282](https://github.com/alphagov/govuk_publishing_components/pull/1282))
 * Make maxlength or maxwords required ([#1276](https://github.com/alphagov/govuk_publishing_components/pull/1276))
 
 ## 21.22.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
@@ -4,7 +4,8 @@
 // sass-lint:disable placeholder-in-extend
 .gem-c-govspeak {
   .button,
-  .govuk-button {
+  .govuk-button,
+  .gem-c-button {
     @extend .govuk-button;
   }
 

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -672,9 +672,22 @@ examples:
         <div class="summary">
           <p>This is a summary</p>
         </div>
-  button:
+  buttons:
+    description: |
+      We're in process of migrating govspeak from using the old (toolkit) button styles to using the (govuk-frontend) button component from this gem. The example below demonstrates both kinds of buttons.
+
+      This documentation will be updated once that work is complete.
     data:
       block: |
-        <a href="#" class="button button-start" role="button">
-          Start now
-        </a>
+        <p>
+          <a href="#" class="button" role="button">
+            Old button
+          </a>
+          <a href="#" class="button button-start" role="button">
+            Old start button
+          </a>
+        </p>
+        <p>
+          <a role="button" class="gem-c-button govuk-button" href="https://gov.uk/random">New button</a>
+          <a class="gem-c-button govuk-button govuk-button--start" role="button" href="https://gov.uk/random"> New start button <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path></svg></a>
+        </p>


### PR DESCRIPTION
## What
- include 'gem-c-button' class in extend for govuk-button
- this is here to prevent buttons (with white text) from being styled by top level selectors for links, by nesting the styles beneath 'gem-c-govspeak'
- this change relates to a pending update of govspeak to switch to the govuk-frontend button classes for buttons
- once that change is complete the .button class can be removed from here and the example updated

## Why
We're trying to remove the toolkit `.button` styles from static.

## Visual Changes
<img width="408" alt="Screenshot 2020-02-07 at 12 20 26" src="https://user-images.githubusercontent.com/861310/74029856-8c453a00-49a5-11ea-9a59-04c6fb3e5f03.png">
