### PR TITLE
Version 21.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.22.1
 
 * Update govspeak button styles ([PR #1282](https://github.com/alphagov/govuk_publishing_components/pull/1282))
 * Make maxlength or maxwords required ([#1276](https://github.com/alphagov/govuk_publishing_components/pull/1276))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.22.0)
+    govuk_publishing_components (21.22.1)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.22.0'.freeze
+  VERSION = '21.22.1'.freeze
 end


### PR DESCRIPTION
## 21.22.1

* Update govspeak button styles ([PR #1282](https://github.com/alphagov/govuk_publishing_components/pull/1282))
* Make maxlength or maxwords required ([#1276](https://github.com/alphagov/govuk_publishing_components/pull/1276))
