### PR TITLE
Add visually hidden text to share links component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow individual components to be imported into apps ([PR #1159](https://github.com/alphagov/govuk_publishing_components/pull/1159))
+
 ## 21.26.0
 
 * Allow individual components to be imported into apps ([PR #1159](https://github.com/alphagov/govuk_publishing_components/pull/1159))

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -24,6 +24,16 @@
 
     <ul class="gem-c-share-links__list">
       <% links.each do |link| %>
+        <% link_text = capture do %>
+          <span class="govuk-visually-hidden">
+            <% if link[:hidden_text] %>
+              <%= link[:hidden_text] %>
+            <% else %>
+              Share on
+            <% end %>
+          </span>
+          <%= link[:text] %>
+        <% end %>
         <li class="gem-c-share-links__list-item">
           <%
             if track_as_sharing
@@ -78,7 +88,7 @@
                 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="9 9 32 32"><path fill="currentColor" d="M9 9h32v32H9V9z"/><path fill="#FFF" d="M12.84 14.12v19.2h5.76l5.76 5.76v-5.76h12.8v-19.2H12.84zm3.2 8.32H28.2V25H16.04v-2.56zm16 7.68h-16v-2.56h16v2.56zm1.92-10.24H16.04v-2.56h17.92v2.56z"/></svg>
 
               <% end %>
-            </span><%= link[:text] %><% end %>
+            </span><%= link_text %><% end %>
         </li>
       <% end %>
     </ul>

--- a/app/views/govuk_publishing_components/components/docs/share_links.yml
+++ b/app/views/govuk_publishing_components/components/docs/share_links.yml
@@ -65,6 +65,20 @@ examples:
           icon: 'facebook'
         }
       ]
+  with_custom_visually_hidden_text:
+    description: |
+      Use this option to specify a visually hidden text for screenreaders to prepend to the link text.
+
+      If omitted, the default text used will be 'Share on'.
+    data:
+      links: [
+        {
+          href: 'share',
+          text: 'Facebook',
+          hidden_text: 'Download from',
+          icon: 'facebook'
+        }
+      ]
   with_branding:
     description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) can be added to the component as shown.
     data:

--- a/spec/components/share_links_spec.rb
+++ b/spec/components/share_links_spec.rb
@@ -15,6 +15,7 @@ describe "ShareLinks", type: :view do
       {
         href: '/twitter',
         text: 'Twitter',
+        hidden_text: 'Tweet to',
         icon: 'twitter'
       },
     ]
@@ -61,5 +62,15 @@ describe "ShareLinks", type: :view do
   it "accepts the stacking option" do
     render_component(links: links, stacked: true)
     assert_select ".gem-c-share-links.gem-c-share-links--stacked"
+  end
+
+  it "displays the visually hidden text 'Share on' if custom hidden_text is not specified" do
+    render_component(links: links)
+    assert_select ".gem-c-share-links .gem-c-share-links__link[href=\"/facebook\"] .govuk-visually-hidden", text: "Share on"
+  end
+
+  it "displays the provided visually hidden text" do
+    render_component(links: links)
+    assert_select ".gem-c-share-links .gem-c-share-links__link[href=\"/twitter\"] .govuk-visually-hidden", text: "Tweet to"
   end
 end


### PR DESCRIPTION
## What
- Adds an `hidden_text` link to specify custom visually hidden link text
- Adds a default 'Share on` visually hidden text to each share link if `hidden_text` value is not provided

## Why
Improve accessibility and remove the need for [workarounds](#1064 )
Fixes #1064 

## Visual Changes
No visual changes

https://govuk-publis-share-link-crmidx.herokuapp.com/component-guide/share_links/with_custom_visually_hidden_text
