### PR TITLE
Mobile breadcrumb to show first and last items only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+
+
+## Unreleased
+
+* Mobile breadcrumb to show first and last items only ([PR #1290](https://github.com/alphagov/govuk_publishing_components/pull/1290))
+
 ## 21.22.1
 
 * Update govspeak button styles ([PR #1282](https://github.com/alphagov/govuk_publishing_components/pull/1282))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -20,3 +20,28 @@
 .gem-c-breadcrumbs--inverse .govuk-breadcrumbs__list-item:before {
   border-color: govuk-colour("white");
 }
+
+@include govuk-media-query($until: tablet) {
+
+  .govuk-breadcrumbs__list-item:not(:last-child):not(:first-child) {
+    display: none;
+  }
+
+  .govuk-breadcrumbs__list-item {
+    padding-top: 14px;
+    padding-bottom: 14px;
+  }
+
+  .govuk-breadcrumbs__link {
+    position: relative;
+  }
+
+  .govuk-breadcrumbs__link::after {
+    content: "";
+    position: absolute;
+    top: -14px;
+    right: 0;
+    left: 0;
+    bottom: -14px;
+  }
+}

--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -1,8 +1,6 @@
 <%
   breadcrumbs ||= []
-  collapse_on_mobile ||= false
   inverse ||= false
-  collapse_class =  collapse_on_mobile && breadcrumbs.any? { |crumb| crumb[:is_page_parent] } ? "gem-c-breadcrumbs--collapse-on-mobile" : ""
   invert_class = inverse ? "gem-c-breadcrumbs--inverse" : ""
   breadcrumb_presenter = GovukPublishingComponents::Presenters::Breadcrumbs.new(breadcrumbs, request.path)
 %>
@@ -33,4 +31,3 @@
     <% end %>
   </ol>
 </div>
-

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -15,7 +15,6 @@
           and we want to prioritise them over all other breadcrumbs %>
     <%= render 'govuk_publishing_components/components/breadcrumbs',
                breadcrumbs: navigation.taxon_breadcrumbs[:breadcrumbs],
-               collapse_on_mobile: true,
                inverse: inverse %>
   <% elsif navigation.content_tagged_to_mainstream_browse_pages? %>
     <%# Rendering parent-based breadcrumbs because the page is tagged to mainstream browse %>
@@ -27,7 +26,6 @@
     <%# Rendering taxonomy breadcrumbs because the page is tagged to live taxons %>
     <%= render 'govuk_publishing_components/components/breadcrumbs',
       breadcrumbs: navigation.taxon_breadcrumbs[:breadcrumbs],
-      collapse_on_mobile: true,
       inverse: inverse %>
   <% elsif navigation.breadcrumbs.any? %>
     <%# Rendering parent-based breadcrumbs because no browse, no related links, no live taxons %>


### PR DESCRIPTION
On mobile devices update breadcrumb behaviour as per :

https://trello.com/c/YuObLgSq/10-fix-breadcrumbs-on-mobile

## What
Apply mobile enhancement designs to the GOV.UK Breadcrumb component, specifically:

- Collapse breadcrumb to show only the first and last item (the parent item) on devices less than 640px wide
- Increase the touch target padding on mobile devices
- Collapse on Mobile to be de facto behaviour

## Why


The reasoning is taken from this snippet in the trello card:

> This [article by NNG](https://www.nngroup.com/articles/breadcrumbs/) lays out the pros and cons of showing a full breadcrumb path on mobile. In short, the drawbacks of having a multi-line breadcrumb, and the need to save space on mobile, make it less useful to users. By truncating the breadcrumb we at least allow users to go backwards by one level, or home.


## Visual Changes
![Screenshot 2020-02-05 at 14 57 28](https://user-images.githubusercontent.com/54625020/74435767-22250d00-4e5d-11ea-8f6c-1719a206d193.png)
Before Change

![Screenshot 2020-02-05 at 14 56 20](https://user-images.githubusercontent.com/54625020/74435827-3a952780-4e5d-11ea-81b7-90f3f4aa0af6.png)
After Change