### PR TITLE
Revert "Downgrade 'rouge' to a development_dependency"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
-
-* Downgrade 'rouge' to a development_dependency ([PR #1288](https://github.com/alphagov/govuk_publishing_components/pull/1288))
-
 ## 21.22.1
 
 * Update govspeak button styles ([PR #1282](https://github.com/alphagov/govuk_publishing_components/pull/1282))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ PATH
       plek
       rails (>= 5.0.0.1)
       rake
+      rouge
       sassc-rails (>= 2.0.1)
       sprockets (< 4)
 
@@ -99,7 +100,7 @@ GEM
       rubocop (~> 0.64)
       rubocop-rspec (~> 1.28)
       scss_lint
-    govuk_app_config (2.0.3)
+    govuk_app_config (2.0.2)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.14.0)
       statsd-ruby (~> 1.4.0)
@@ -310,7 +311,6 @@ DEPENDENCIES
   govuk_test (~> 1)
   jasmine (~> 3.4.0)
   pry-byebug
-  rouge
   rspec-rails (~> 3.8)
   selenium-webdriver (= 3.142.3)
   uglifier (>= 4.1.0)

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "plek"
   s.add_dependency "rails", ">= 5.0.0.1"
   s.add_dependency "rake"
+  s.add_dependency "rouge"
   s.add_dependency "sassc-rails", ">= 2.0.1"
   s.add_dependency "sprockets", "< 4"
 
@@ -33,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "govuk_test", "~> 1"
   s.add_development_dependency "jasmine", "~> 3.4.0"
   s.add_development_dependency "pry-byebug"
-  s.add_development_dependency "rouge"
   s.add_development_dependency "rspec-rails", "~> 3.8"
   s.add_development_dependency "selenium-webdriver", "= 3.142.3"
   s.add_development_dependency "uglifier", ">= 4.1.0"


### PR DESCRIPTION
Reverts alphagov/govuk_publishing_components#1288

I didn't realise apps use govuk_publishing_components as a component viewer, as well as for its components. Looks like this change would affect lots of apps: https://github.com/search?q=mount+GovukPublishingComponents%3A%3AEngine&type=Code

See problems caused: https://github.com/alphagov/govuk_publishing_components/pull/1288#issuecomment-585667251

Long term we should probably think about splitting out govuk_publishing_components into components and viewer, rather than bundle it all together.