### PR TITLE
Add option to omit header

### DIFF
--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -3,6 +3,7 @@
   html_lang ||= "en"
   full_width ||= false
   without_search ||= false
+  omit_header ||= false
   body_classes ||= ""
   main_classes ||= ""
 -%>
@@ -46,11 +47,13 @@
 
     <%= render "govuk_publishing_components/components/cookie_banner" %>
 
-    <%= render "govuk_publishing_components/components/layout_header", {
-      environment: "public",
-      search: !without_search,
-      remove_bottom_border: full_width,
-    } %>
+    <% unless omit_header %>
+      <%= render "govuk_publishing_components/components/layout_header", {
+        environment: "public",
+        search: !without_search,
+        remove_bottom_border: full_width,
+      } %>
+    <% end %>
 
     <main class="<%= "govuk-width-container govuk-main-wrapper" unless full_width %> <%= main_classes %>" id="content">
       <%= yield %>

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -22,3 +22,7 @@ examples:
     data:
       main_classes: "homepage test-main-class"
       body_classes: "mainstream test-body-class"
+  omit_header:
+    description: This allows the header to be omitted which is currently used when rendering CSV previews from Whitehall
+    data:
+      omit_header: true

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -40,4 +40,10 @@ describe "Layout for public", type: :view do
 
     assert_select '.gem-c-layout-for-public .gem-c-search', false
   end
+
+  it "can omit the header" do
+    render_component(omit_header: true)
+
+    assert_select '.gem-c-layout-for-public .gem-c-layout-header', false
+  end
 end


### PR DESCRIPTION
https://trello.com/c/i18ikmOk/214-omit-header-for-htmlpublications

**This PR is against rebased-add-layout and not against master.**

## What
Duplicate the functionality from govuk_template in static. This
is used to render previews of CSV files from Whitehall.

## Why
This is used to render previews of CSV files from Whitehall. I'm unclear on why we still show the footer and don't have a flag for that but this is being kept to the scope of the original.

## Visual Changes
When implemented in the component guide only the footer is shown visibly on the page:
![Screenshot 2020-02-17 at 08 47 56](https://user-images.githubusercontent.com/31649453/74637610-32d9c980-5162-11ea-9aaa-8eeedff4de54.png)

