### PR TITLE
Fix component guide layout in IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Enable custom margin top on title component ([PR #1302](https://github.com/alphagov/govuk_publishing_components/pull/1302))
 * Enable aria-label on modal dialogue component ([PR #1300](https://github.com/alphagov/govuk_publishing_components/pull/1300))
+* Fix component guide layout in IE11 ([PR #1293](https://github.com/alphagov/govuk_publishing_components/pull/1293))
 
 ## 21.22.2
 
@@ -189,7 +190,7 @@
 
 * Add warning, file download and numbered steps icons that were originally fetched from govuk_frontend_toolkit ([PR #1154](https://github.com/alphagov/govuk_publishing_components/pull/1154))
 
-## 21.4.0
+## 21.4.0
 
 * Move organisation crest images into the gem ([PR #1149](https://github.com/alphagov/govuk_publishing_components/pull/1149))
 

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -9,10 +9,6 @@
 
 $gem-guide-border-width: 1px;
 
-.component-guide-wrapper {
-  padding-bottom: $govuk-gutter * 1.5;
-}
-
 .component-list {
   @include govuk-text-colour;
   @extend %govuk-list--bullet;

--- a/app/views/govuk_publishing_components/component_guide/example.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/example.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "#{@component_example.name} example - #{@component_doc.name} component" %>
-<%= render 'govuk_publishing_components/components/title', title: @component_example.name, context: "#{@component_doc.name} example" %>
+<%= render 'govuk_publishing_components/components/title', title: @component_example.name, context: "#{@component_doc.name} example", margin_top: 0 %>
 
 <div class="component-show">
   <div class="component-doc">

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'govuk_publishing_components/components/title', title: GovukPublishingComponents::Config.component_guide_title %>
+<%= render 'govuk_publishing_components/components/title', title: GovukPublishingComponents::Config.component_guide_title, margin_top: 0 %>
 
 <div class="component-markdown">
   <p>Components are packages of template, style, behaviour and documentation that live in your application.</p>

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "#{@component_doc.name} component" %>
-<%= render 'govuk_publishing_components/components/title', title: @component_doc.name, context: "Component" %>
+<%= render 'govuk_publishing_components/components/title', title: @component_doc.name, context: "Component", margin_top: 0; %>
 
 <div class="component-show">
   <div class="govuk-grid-row">

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -32,21 +32,22 @@
     </script>
     <% if @preview %>
       <main id="wrapper" class="govuk-width-container">
+        <%= yield %>
+      </main>
     <% else %>
       <%= render "govuk_publishing_components/components/layout_header", {
         environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
         product_name: GovukPublishingComponents::Config.component_guide_title,
         href: component_guide_path
       } %>
-
-      <main id="wrapper" class="govuk-width-container component-guide-wrapper">
-      <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @guide_breadcrumbs  %>
-    <% end %>
-
-    <%= yield %>
-    </main>
-
-    <% unless @preview %>
+      <div class="govuk-width-container app-width-container--wide">
+        <% if @guide_breadcrumbs %>
+          <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @guide_breadcrumbs  %>
+        <% end %>
+        <main id="wrapper" class="govuk-main-wrapper">
+          <%= yield %>
+        </main>
+      </div>
       <%= render "govuk_publishing_components/components/layout_footer" %>
     <% end %>
 


### PR DESCRIPTION
## What
Fix component guide layout in IE11 by using [the Design System page template](https://design-system.service.gov.uk/styles/page-template/) and render breadcrumbs only if there are items.

## Why
@tombye said it's broken while testing at the Empathy lab – and it was bugging me for a while

## Visual Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="1440" alt="Screenshot 2020-02-13 at 15 27 48" src="https://user-images.githubusercontent.com/788096/74450735-7e485b00-4e76-11ea-9e64-6bc92f38ffc7.png">

</td><td>

<img width="1440" alt="Screenshot 2020-02-13 at 15 28 08" src="https://user-images.githubusercontent.com/788096/74450753-84d6d280-4e76-11ea-93c0-8497446e74e0.png">

</td></tr>
</table>