### PR TITLE
Increase padding and margin for document list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-
-
 ## Unreleased
 
 * Mobile breadcrumb to show first and last items only ([PR #1290](https://github.com/alphagov/govuk_publishing_components/pull/1290))
+* Increases spacing between document links ([PR #1294](https://github.com/alphagov/govuk_publishing_components/pull/1294))
 
 ## 21.22.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -7,8 +7,8 @@
 
 .gem-c-document-list__item {
   overflow: hidden;
-  margin-bottom: govuk-spacing(2);
-  padding-bottom: govuk-spacing(2);
+  margin-bottom: govuk-spacing(4);
+  padding-bottom: govuk-spacing(4);
   border-bottom: 1px solid $govuk-border-colour;
   list-style: none;
 


### PR DESCRIPTION
Trello: https://trello.com/c/6bJCf1zv/472-increase-spacing-in-document-list-component

## What

Increase margin bottom and padding for broader spacing between document list items.

## Why
Flagged through the use of this component on the [GOV.UK transition page](https://www.gov.uk/transition) where the new news section appeared cramped.

The proposal is to increase the amount of spacing, not just for that component but across the site.

## Visual Changes
Examples:

- Left had side is current,
- Right hand side is proposed change,

<img width="1421" alt="Screenshot 2020-02-14 at 13 14 32" src="https://user-images.githubusercontent.com/3694062/74534911-ae523580-4f2c-11ea-96fb-60ca49b57296.png">
<img width="1421" alt="Screenshot 2020-02-14 at 13 17 54" src="https://user-images.githubusercontent.com/3694062/74534915-b01bf900-4f2c-11ea-8b8d-cf6b8ae5a8b3.png">
<img width="1421" alt="Screenshot 2020-02-14 at 13 17 38" src="https://user-images.githubusercontent.com/3694062/74534917-b0b48f80-4f2c-11ea-8593-688b9d9fe497.png">
<img width="1421" alt="Screenshot 2020-02-14 at 13 17 26" src="https://user-images.githubusercontent.com/3694062/74534918-b14d2600-4f2c-11ea-98de-e3d859bc7ecc.png">
<img width="1421" alt="Screenshot 2020-02-14 at 13 17 15" src="https://user-images.githubusercontent.com/3694062/74534919-b14d2600-4f2c-11ea-8df7-9b1cf58cf464.png">
<img width="1421" alt="Screenshot 2020-02-14 at 13 17 01" src="https://user-images.githubusercontent.com/3694062/74534923-b1e5bc80-4f2c-11ea-9a3e-3a69aa4e689e.png">
<img width="1421" alt="Screenshot 2020-02-14 at 13 16 48" src="https://user-images.githubusercontent.com/3694062/74534924-b1e5bc80-4f2c-11ea-930d-0c97d18bfb5d.png">
<img width="1421" alt="Screenshot 2020-02-14 at 13 16 24" src="https://user-images.githubusercontent.com/3694062/74534925-b27e5300-4f2c-11ea-8645-c293c36779df.png">
<img width="1421" alt="Screenshot 2020-02-14 at 13 15 57" src="https://user-images.githubusercontent.com/3694062/74534926-b316e980-4f2c-11ea-9a84-6063e53e7193.png">
<img width="1421" alt="Screenshot 2020-02-14 at 13 15 18" src="https://user-images.githubusercontent.com/3694062/74534927-b316e980-4f2c-11ea-815c-8bf96e0844b9.png">
<img width="1421" alt="Screenshot 2020-02-14 at 13 14 52" src="https://user-images.githubusercontent.com/3694062/74534928-b3af8000-4f2c-11ea-969e-5ed1eba498ec.png">

Sorry this one was at the bottom of my page, couldn't make them level:
<img width="1421" alt="Screenshot 2020-02-14 at 13 18 18" src="https://user-images.githubusercontent.com/3694062/74534913-af836280-4f2c-11ea-98d4-b747c78d0492.png">
