### PR TITLE
Mobile breadcrumb to wrap long taxon and correctly align chevron top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Unreleased
 
+* Mobile breadcrumb to wrap long taxon and correctly align chevron top ([PR #1296](https://github.com/alphagov/govuk_publishing_components/pull/1296))
 * Mobile breadcrumb to show first and last items only ([PR #1290](https://github.com/alphagov/govuk_publishing_components/pull/1290))
 
 ## 21.22.1

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -23,6 +23,10 @@
 
 @include govuk-media-query($until: tablet) {
 
+  .govuk-breadcrumbs__list {
+    display: flex;
+  }
+
   .govuk-breadcrumbs__list-item:not(:last-child):not(:first-child) {
     display: none;
   }
@@ -30,6 +34,11 @@
   .govuk-breadcrumbs__list-item {
     padding-top: 14px;
     padding-bottom: 14px;
+  }
+
+  .govuk-breadcrumbs__list-item:before {
+    margin: 0;
+    top: 18px;
   }
 
   .govuk-breadcrumbs__link {


### PR DESCRIPTION
On mobile devices update breadcrumb behaviour for long taxons to wrap and appear aligned with horizontally. Ensure chevron appears aligned correctly. As per trello card:

https://trello.com/c/YuObLgSq/10-fix-breadcrumbs-on-mobile

## What
Apply mobile enhancement designs to the GOV.UK Breadcrumb component, specifically:

- Breadcrumb to display first and last items horizontally on devices less than 640px wide
- Ensure the chevron is aligned to the top of the horizontal breadcrumb

## Why
The reasoning is taken from this snippet in the trello card:

> This [article by NNG](https://www.nngroup.com/articles/breadcrumbs/) lays out the pros and cons of showing a full breadcrumb path on mobile. In short, the drawbacks of having a multi-line breadcrumb, and the need to save space on mobile, make it less useful to users. By truncating the breadcrumb we at least allow users to go backwards by one level, or home.

Long taxons currently wrap beneath the first item.

## Visual Changes

![Screenshot 2020-02-14 at 16 11 34](https://user-images.githubusercontent.com/54625020/74548923-a2736d00-4f46-11ea-82ab-f72d5214b563.png)

![Screenshot 2020-02-14 at 16 12 11](https://user-images.githubusercontent.com/54625020/74548980-b4551000-4f46-11ea-8bee-416972cc731f.png)

