### PR TITLE
Change back link arrow to chevron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Change back link arrow to chevron [PR #1299](https://github.com/alphagov/govuk_publishing_components/pull/1299)
 * Mobile breadcrumb update guidance [PR #1298](https://github.com/alphagov/govuk_publishing_components/pull/1298)
 * Add page heading captions to checkboxes and radio boxes components ([PR #1304](https://github.com/alphagov/govuk_publishing_components/pull/1304))
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_back-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_back-link.scss
@@ -1,1 +1,38 @@
 @import "govuk/components/back-link/back-link";
+
+.govuk-back-link {
+  &[href] {
+    text-decoration: underline;
+    border-bottom: 1px solid transparent;
+
+    &:focus {
+      text-decoration: none;
+    }
+  }
+
+  &:before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 1px;
+    left: 3px;
+    width: 7px;
+    height: 7px;
+    -webkit-transform: rotate(225deg);
+    -ms-transform: rotate(225deg);
+    transform: rotate(225deg);
+    border: solid;
+    border-width: 1px 1px 0 0;
+    clip-path: inherit;
+  }
+}
+
+.govuk-back-link::after {
+  content: "";
+  position: absolute;
+  top: -14px;
+  right: 0;
+  left: 0;
+  bottom: -14px;
+}


### PR DESCRIPTION
Update styling of back link component

https://trello.com/c/ZYJ7nnYt/21-make-back-icon-more-consistent-on-mobiles

## What
Update styling on back link component and increase touch target on mobile devices

## Why
Back links use an inconsistent icon from the breadcrumbs, The link also has a small touch target on mobiles. We should have consistent design patterns across GOV.UK. 

## Visual Changes
![Screenshot 2020-02-17 at 13 43 32](https://user-images.githubusercontent.com/54625020/74659295-f6bb5e80-518b-11ea-926d-9ee80ae44c7a.png)
Before change - mobile

![Screenshot 2020-02-17 at 13 44 11](https://user-images.githubusercontent.com/54625020/74659311-fde26c80-518b-11ea-8013-f655945b0347.png)
Before Change - desktop


![Screenshot 2020-02-17 at 13 42 50](https://user-images.githubusercontent.com/54625020/74659322-033fb700-518c-11ea-956b-9818de91e0be.png)
After change - mobile

![Screenshot 2020-02-17 at 13 44 54](https://user-images.githubusercontent.com/54625020/74659330-06d33e00-518c-11ea-9fd9-f73b280939ee.png)
After Change - desktop
<!-- If the change results in visual changes, show a before and after -->
