### PR TITLE
Enable aria-label on modal dialogue component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Enable aria-label on modal dialogue component ([PR #1300](https://github.com/alphagov/govuk_publishing_components/pull/1300))
+
 ## 21.22.2
 
 * Mobile breadcrumb to wrap long taxon and correctly align chevron top ([PR #1296](https://github.com/alphagov/govuk_publishing_components/pull/1296))

--- a/app/views/govuk_publishing_components/components/_modal_dialogue.html.erb
+++ b/app/views/govuk_publishing_components/components/_modal_dialogue.html.erb
@@ -2,13 +2,14 @@
   id ||= "modal-dialogue-#{SecureRandom.hex(4)}"
   wide ||= false
   data_attributes = {}
+  aria_label ||= nil
   dialog_classes = ["gem-c-modal-dialogue__box"]
   dialog_classes << "gem-c-modal-dialogue__box--wide" if wide
 %>
 
 <%= tag.div class: "gem-c-modal-dialogue", data: { module: "modal-dialogue" }, id: id do %>
   <%= tag.div class: "gem-c-modal-dialogue__overlay" %>
-  <%= tag.dialog class: dialog_classes, data: data_attributes, aria: { modal: true }, role: "dialog", tabindex: 0 do %>
+  <%= tag.dialog class: dialog_classes, data: data_attributes, aria: { modal: true, label: aria_label }, role: "dialog", tabindex: 0 do %>
     <%= tag.div class: "gem-c-modal-dialogue__header" do %>
       <svg role="presentation" focusable="false" class="gem-c-modal-dialogue__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="26" width="30">
         <path fill="currentColor" fill-rule="evenodd"

--- a/app/views/govuk_publishing_components/components/docs/modal_dialogue.yml
+++ b/app/views/govuk_publishing_components/components/docs/modal_dialogue.yml
@@ -3,7 +3,10 @@ description: Shows only one section, with no other navigation options, until the
 body: |
   Use where the application has gotten into a state from which it shouldn’t or can’t proceed without input from the user or the state of the current page needs to be preserved.
 
-  Modal instances are automatically initialised and their state can be changed programmatically using bounded functions (e.g. `$modalDialogue.open()` and `$modalDialogue.close()`)
+  Modal instances are automatically initialised and their state can be changed programmatically using bounded functions (e.g. `$modalDialogue.open()` and `$modalDialogue.close()`).
+
+  When the component is not limited to presenting information (e.g. an alert dialog or an informative dialog) and it contains interactive elements (e.g. form elements) you should use the `aria_label` attribute.
+  This will provide context around what the modal dialogue is about and will prevent it from being too verbose for screen reader users (if `aria_label` is not specified the whole modal content will be read out).
 
   This component is currently experimental. If you are using it, please feed back any research findings to the Content Publisher team.
 accessibility_criteria: |
@@ -48,6 +51,7 @@ examples:
       <%= component %>
     data:
       id: modal-with-form
+      aria_label: Search contacts
       block: |
         <h1 class="govuk-heading-l">Search contacts</h1>
           <label class="govuk-label govuk-visually-hidden" for="contacts">Search contacts</label>

--- a/spec/components/modal_dialogue_spec.rb
+++ b/spec/components/modal_dialogue_spec.rb
@@ -20,4 +20,12 @@ describe 'Modal dialogue', type: :view do
 
     assert_select '.gem-c-modal-dialogue__box.gem-c-modal-dialogue__box--wide', count: 1
   end
+
+  it 'applies aria-label to the dialog element' do
+    render_component(id: 'my-modal', aria_label: "My modal") do
+      "Content"
+    end
+
+    assert_select '.gem-c-modal-dialogue__box[aria-label="My modal"]'
+  end
 end


### PR DESCRIPTION
## What
Enable `aria-label` attribute on `<dialog>` element to be used to summarise what the modal is about.

## Why
The modal dialogue component is too verbose when it contains complex content.

## Proposed guidance
When the component is not limited to presenting information (e.g. an alert dialog or an informative dialog) and it contains interactive elements (e.g. form elements) you should use the `aria_label` attribute. This will provide context around what the modal dialogue is about and will prevent it from being too verbose for screen reader users (if `aria_label` is not specified the whole modal content will be read out).

## Usage scenarios
### Informative purpose
An example in Content Data where the modal dialogue component is used to provide additional information about what a metric means. In this case, reading the whole modal content is helpful.

<img width="1440" alt="Screenshot 2020-02-17 at 16 48 26" src="https://user-images.githubusercontent.com/788096/74672608-90433a00-51a5-11ea-9711-82aeacc11e06.png">

### Interactive purpose
An example in Content Publisher where the modal dialogue component is used to prompt users in providing information that is required to complete the immediate task. In this case the user is overloaded with information by the screen reader when the modal is opened.

<img width="1437" alt="Screenshot 2020-02-17 at 16 49 14" src="https://user-images.githubusercontent.com/788096/74672770-dd271080-51a5-11ea-811f-8e47f928bddc.png">

## Test results

The following tests were conducted using the [modal dialogue with form](https://components.publishing.service.gov.uk/component-guide/modal_dialogue/with_form/preview) example in the component guide.

### JAWS 15+ on IE11
This example is the one that made us introduce this change in the first place: JAWS reads the dialog content twice – and the first time as raw content.

Before
> Search contacts, Search contacts, Insert contact times dialogue. Search contacts, Search contacts, Insert contact close modal dialogue heading level 1.

After
> Search contacts, modal dialogue, to navigate use tab.

### NVDA 2016+ on Firefox/Chrome
NVDA's behavior doesn't change much. The major difference compared to JAWS is that the content is only being read out once, with a pause between the label and the modal content, allowing users to continue their navigation (which leads to reaching the first element within the modal).

Before
> [Starts reading content, once]
[Tab] Search contacts edit, has autocomplete. Blank.

After
> Search contacts. [pauses, then starts reading content, once]
[Tab] Search contacts edit, has autocomplete. Blank.

### VoiceOver 7+ on Chrome/Safari
Before
> Search contacts Search contacts Search contacts Insert contact Close modal dialogue, dialog with 6 items.

After
> Search contacts, dialog with 6 items.

## Visual Changes
No visual changes

[Trello card](https://trello.com/c/xZwFwpul)