### PR TITLE
Add tracking to home link

### DIFF
--- a/app/views/govuk_publishing_components/components/layout_header/_header_logo.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_header_logo.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-header__logo gem-c-header__logo">
-  <a href="/" class="govuk-header__link govuk-header__link--homepage">
+  <a href="/" class="govuk-header__link govuk-header__link--homepage" data-module="track-click" data-track-category="homeLinkClicked" data-track-action="homeHeader">
     <span class="govuk-header__logotype">
       <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
         <path fill="currentColor" fill-rule="evenodd"


### PR DESCRIPTION
**Note this PR is not raised against master**
https://trello.com/c/Evatcpym/216-check-tracking-for-the-public-template

## What
This adds tracking to the home link in the header

## Why
This replicates what is currently live in the static template. No visible changes are introduced. No other links are tracked in the original.