### PR TITLE
Enable custom margin top on title component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Enable custom margin top on title component ([PR #1302](https://github.com/alphagov/govuk_publishing_components/pull/1302))
 * Enable aria-label on modal dialogue component ([PR #1300](https://github.com/alphagov/govuk_publishing_components/pull/1300))
 
 ## 21.22.2

--- a/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
@@ -32,11 +32,10 @@
 }
 
 .gem-c-title__text {
-  @include govuk-text-colour;
-  @include govuk-font(48, $weight: bold);
+  @extend %govuk-heading-xl;
   margin: 0;
 }
 
 .gem-c-title__text--long {
-  @include govuk-font(36, $weight: bold);
+  @extend %govuk-heading-l;
 }

--- a/app/views/govuk_publishing_components/components/_title.html.erb
+++ b/app/views/govuk_publishing_components/components/_title.html.erb
@@ -7,14 +7,15 @@
   context_data = context.is_a?(Hash) ? context[:data] : false
 
   inverse ||= false
+  local_assigns[:margin_top] ||= 8
   local_assigns[:margin_bottom] ||= 8
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
-  classes = %w(gem-c-title govuk-!-margin-top-8)
+  classes = %w(gem-c-title)
   classes << "gem-c-title--inverse" if inverse
+  classes << (shared_helper.get_margin_top)
   classes << (shared_helper.get_margin_bottom)
-
 %>
 <%= content_tag(:div, class: classes) do %>
   <% if context %>

--- a/app/views/govuk_publishing_components/components/docs/title.yml
+++ b/app/views/govuk_publishing_components/components/docs/title.yml
@@ -50,7 +50,7 @@ examples:
       context: Publication
       title: My page title which is often really long and verbose and has lots of extra words it doesn't need
       average_title_length: long
-  with_margin:
+  with_margin_bottom:
     description: |
       The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a margin bottom of 50px.
 
@@ -78,4 +78,13 @@ examples:
       margin_bottom: 0
     context:
       dark_background: true
-
+  using_design_system_template:
+    description: |
+      This option allows the removal of top margin from the component so that it works within a [Design System page template](https://design-system.service.gov.uk/styles/page-template/default/index.html), where spacing above the title is already provided by padding on the wrapping div.
+    embed: |
+      <main class="govuk-main-wrapper">
+        <%= component %>
+      </main>
+    data:
+      title: My page title
+      margin_top: 0

--- a/lib/govuk_publishing_components/presenters/shared_helper.rb
+++ b/lib/govuk_publishing_components/presenters/shared_helper.rb
@@ -1,12 +1,17 @@
 module GovukPublishingComponents
   module Presenters
     class SharedHelper
-      attr_reader :options, :margin_bottom, :heading_level
+      attr_reader :options, :margin_top, :margin_bottom, :heading_level
 
       def initialize(local_assigns)
         @options = local_assigns
+        @margin_top = @options[:margin_top] || nil
         @margin_bottom = @options[:margin_bottom] || 3
         @heading_level = @options[:heading_level] || 2
+      end
+
+      def get_margin_top
+        [*0..9].include?(@margin_top) ? "govuk-!-margin-top-#{margin_top}" : ""
       end
 
       def get_margin_bottom

--- a/spec/components/title_spec.rb
+++ b/spec/components/title_spec.rb
@@ -41,24 +41,44 @@ describe "Title", type: :view do
     assert_select ".gem-c-title--inverse", text: "Hello World"
   end
 
-  it "has a default margin of 8" do
+  it "has a default margin bottom of 8" do
     render_component(title: 'Margin default')
     assert_select '.gem-c-title.govuk-\!-margin-bottom-8'
   end
 
-  it "adds margin 0" do
+  it "applies a margin bottom of 0" do
     render_component(title: 'Margin 0', margin_bottom: 0)
     assert_select '.gem-c-title.govuk-\!-margin-bottom-0'
   end
 
-  it "adds a valid margin" do
+  it "applies a valid margin bottom" do
     render_component(title: 'Margin 4', margin_bottom: 4)
     assert_select '.gem-c-title.govuk-\!-margin-bottom-4'
   end
 
-  it "ignores an invalid margin" do
+  it "ignores an invalid margin bottom" do
     render_component(title: 'Margin wat', margin_bottom: 17)
     assert_select "[class='^=govuk-\!-margin-bottom-']", false
+  end
+
+  it "has a default margin top of 8" do
+    render_component(title: 'Margin default')
+    assert_select '.gem-c-title.govuk-\!-margin-top-8'
+  end
+
+  it "applies a margin top of 0" do
+    render_component(title: 'Margin 0', margin_top: 0)
+    assert_select '.gem-c-title.govuk-\!-margin-top-0'
+  end
+
+  it "applies a valid margin top" do
+    render_component(title: 'Margin 4', margin_top: 4)
+    assert_select '.gem-c-title.govuk-\!-margin-top-4'
+  end
+
+  it "ignores an invalid margin top" do
+    render_component(title: 'Margin wat', margin_top: 17)
+    assert_select "[class='^=govuk-\!-margin-top-']", false
   end
 
   it "applies context language if supplied to a context link" do


### PR DESCRIPTION
## What
Allow setting a custom margin-top on title component.

## Why
This change will allow the title component to be used in a [Design System page template](https://design-system.service.gov.uk/styles/page-template/) (which sets the padding on the main container – see examples below) by specifying a `margin_top: 0`. This property is introduced to avoid a breaking change and ease the transition to the new page template. When all applications will be using the Design System page template the component will be updated, specifying `margin_top: 0` will not be required and this example will be removed.

### Title in a Design System-based page template
<img width="1439" alt="design-system-main" src="https://user-images.githubusercontent.com/788096/74734133-dbad2500-5245-11ea-8ead-42346880dc17.png">

<img width="1439" alt="design-system-title" src="https://user-images.githubusercontent.com/788096/74734143-df40ac00-5245-11ea-9b22-e8cbeddad6f8.png">

### Title in the current GOV.UK page template
<img width="1441" alt="govuk-title" src="https://user-images.githubusercontent.com/788096/74734108-cc2ddc00-5245-11ea-945f-ff8db9a13470.png">

## Visual Changes
No visual changes

https://github.com/alphagov/govuk_publishing_components/pull/1293 is currently dependent on this change and presumably the new layout/template change too.

