### PR TITLE
Add caption to question forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Mobile breadcrumb update guidance [PR #1298](https://github.com/alphagov/govuk_publishing_components/pull/1298)
+* Add page heading captions to checkboxes and radio boxes components ([PR #1304](https://github.com/alphagov/govuk_publishing_components/pull/1304))
 
 ## 21.23.1
 

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -4,6 +4,7 @@
 
   label ||= nil
   heading ||= nil
+  heading_caption ||= nil
   small ||= false
   inline ||= false
   is_page_heading ||= false
@@ -39,6 +40,7 @@
     <% if heading.present? %>
       <% if is_page_heading %>
         <%= tag.legend class: "govuk-fieldset__legend govuk-fieldset__legend--xl gem-c-title" do %>
+          <%= tag.span(heading_caption, class: "govuk-caption-xl") if heading_caption.present? %>
           <%= tag.h1 heading, class: "gem-c-title__text" %>
         <% end %>
       <% else %>

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -106,6 +106,23 @@ examples:
           value: "green"
         - label: "Blue"
           value: "blue"
+  with_page_header_and_caption:
+    description: |
+      If a caption text is provided with a page heading, it will be displayed above the heading.
+      A caption can only be used with a page heading. If a heading is not provided the caption will not render.
+      The pattern is used across GOV.UK to show a high-level section that this page question falls into.
+    data:
+      name: "favourite_skittle"
+      heading: "Choose your favourite skittles"
+      heading_caption: "Question 3 of 9"
+      is_page_heading: true
+      items:
+        - label: "Red"
+          value: "red"
+        - label: "Green"
+          value: "green"
+        - label: "Blue"
+          value: "blue"
   without_hint_text:
     description: Hint text can be removed entirely with this option. Note that this option can be combined with the visually_hide_heading option.
     data:

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -108,6 +108,21 @@ examples:
         text: "Yes"
       - value: "no"
         text: "No"
+  with_page_header_and_caption:
+    description: |
+      If a caption text is provided with a page heading, it will be displayed above the heading.
+      A caption can only be used with a page heading. If a heading is not provided the caption will not render.
+      The pattern is used across GOV.UK to show a high-level section that this page question falls into.
+    data:
+      name: "radio-group-heading"
+      heading: "Is it snowing?"
+      heading_caption: "Question 3 of 9"
+      is_page_heading: true
+      items:
+        - value: "yes"
+          text: "Yes"
+        - value: "no"
+          text: "No"
   with_page_heading_and_hint:
     data:
       name: "radio-group-heading"

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -194,7 +194,6 @@ examples:
         text: "Green"
       - value: "blue"
         text: "Blue"
-
   with_hint_text_on_radios:
     data:
       name: "radio-group-hint-text"

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -4,7 +4,8 @@ module GovukPublishingComponents
       include ActionView::Helpers
       include ActionView::Context
 
-      attr_reader :items, :name, :css_classes, :list_classes, :error, :has_conditional, :has_nested, :id, :hint_text, :description, :heading_size
+      attr_reader :items, :name, :css_classes, :list_classes, :error, :has_conditional,
+                  :has_nested, :id, :hint_text, :description, :heading_size, :heading_caption
 
       def initialize(options)
         @items = options[:items] || []
@@ -24,6 +25,7 @@ module GovukPublishingComponents
         @heading = options[:heading] || nil
         @heading_size = options[:heading_size]
         @heading_size = 'm' unless %w(s m l xl).include?(@heading_size)
+        @heading_caption = options[:heading_caption] || nil
         @is_page_heading = options[:is_page_heading]
         @description = options[:description] || nil
         @no_hint_text = options[:no_hint_text]
@@ -54,7 +56,8 @@ module GovukPublishingComponents
             :legend,
             class: "govuk-fieldset__legend govuk-fieldset__legend--xl gem-c-title"
           ) do
-            content_tag(:h1, @heading, class: "gem-c-title__text")
+            concat content_tag(:span, heading_caption, class: "govuk-caption-xl") if heading_caption.present?
+            concat content_tag(:h1, @heading, class: "gem-c-title__text")
           end
         else
           classes = %w(govuk-fieldset__legend)

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -52,6 +52,7 @@ describe "Checkboxes", type: :view do
   it "renders nothing if no heading is supplied" do
     render_component(
       name: "favourite_colour",
+      heading_caption: "Question 3 of 9",
       items: [
         { label: "Red", value: "red" },
         { label: "Green", value: "green" },
@@ -60,6 +61,7 @@ describe "Checkboxes", type: :view do
     assert_select "fieldset.govuk-fieldset", false
     assert_select "legend", false
     assert_select "legend h1", false
+    assert_select "legend span.govuk-caption-xl", false
     assert_select ".govuk-hint", false
     assert_select ".govuk-checkboxes", false
   end
@@ -377,6 +379,37 @@ describe "Checkboxes", type: :view do
       ]
     )
     assert_select ".govuk-body", text: "This is a description about skittles."
+  end
+
+  it "renders checkboxes with a page heading and caption" do
+    render_component(
+      name: "favourite_colour",
+      heading_caption: "Question 3 of 9",
+      heading: "What is your favourite skittle?",
+      is_page_heading: true,
+      description: "This is a description about skittles.",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+      ]
+    )
+    assert_select "legend span.govuk-caption-xl", text: "Question 3 of 9"
+    assert_select "legend h1", text: "What is your favourite skittle?"
+  end
+
+  it "renders no caption if the header is not a page heading" do
+    render_component(
+      name: "favourite_colour",
+      heading_caption: "Question 3 of 9",
+      heading: "What is your favourite skittle?",
+      description: "This is a description about skittles.",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+      ]
+    )
+    assert_select "legend span.govuk-caption-xl", false
+    assert_select "legend h1", false
   end
 
   it "renders checkboxes with a govspeak description text" do

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -119,6 +119,36 @@ describe "Radio", type: :view do
     assert_select "legend h1", "What is your favourite skittle?"
   end
 
+  it "renders radio-group with a page heading caption" do
+    render_component(
+      name: "favourite-skittle",
+      heading: "What is your favourite skittle?",
+      heading_caption: "Question 3 of 9",
+      is_page_heading: true,
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Blue", value: "blue" }
+      ]
+    )
+    assert_select ".govuk-radios"
+    assert_select "legend h1", text: "What is your favourite skittle?"
+    assert_select "legend span.govuk-caption-xl", "Question 3 of 9"
+  end
+
+  it "renders no caption if the header is not a page heading" do
+    render_component(
+      name: "favourite-skittle",
+      heading_caption: "Question 3 of 9",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+      ]
+    )
+    assert_select ".govuk-radios"
+    assert_select "legend h1", false
+    assert_select "legend span.govuk-caption-xl", false
+  end
+
   it "renders radio-group with custom heading size" do
     render_component(
       name: "favourite-skittle",


### PR DESCRIPTION
Trello: https://trello.com/c/aMTEk0vX/263-add-govuk-caption-style-to-questions

## What
Checkbox and radio components provide a form with an optional page header.
In the design system, question page headings can have a caption, describing the high level category this page fits into ([example](https://design-system.service.gov.uk/patterns/question-pages/section-headings/index.html) | [question pages](https://design-system.service.gov.uk/patterns/question-pages/))

This PR adds the ability for radio and checkbox forms to receive a caption variable that will be rendered as `govuk-caption-xl`.

As captions should describe high level sections on page headers, I have assumed they should not be applied to any other kinds of header.

Even if captions are passed to components, if `is_page_header` is not true, then they will not be shown.

## Why
Checkbox and Radio components are used in the transition checker, where there are sections for both individual and business actions.

Testing has shown confusion when users answer questions in a section they do not see as relevant to them. We are using captions to increase the visibility of these sections so users have a better understanding of who the intended audience is, and can continue past irrelevant questions.

As we use GOV.UK publishing components for that section, and given it is something that could have wider use, this change has been made ehre.

## Visual Changes
### Checkbox
![Screenshot_2020-02-18 Form checkboxes With page header and caption preview - Component Guide](https://user-images.githubusercontent.com/3694062/74756918-360dac00-526d-11ea-80ba-86ed1c09e005.png)

### Radio Buttons
![Screenshot_2020-02-18 Form radio button With page header and caption preview - Component Guide](https://user-images.githubusercontent.com/3694062/74756924-38700600-526d-11ea-9d53-dcc3212224bd.png)
