### PR TITLE
Updates to previous and next navigation component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* UI Updates to previous and next navigation component ([PR #1305](https://github.com/alphagov/govuk_publishing_components/pull/1305))
 * Update Sass documentation ([PR #1321](https://github.com/alphagov/govuk_publishing_components/pull/1321))
 * Improve suggested sass functionality ([PR #1320](https://github.com/alphagov/govuk_publishing_components/pull/1320))
 * Fix layout header width issue ([PR #1319](https://github.com/alphagov/govuk_publishing_components/pull/1319))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
@@ -1,6 +1,6 @@
 .gem-c-pagination {
   display: block;
-  margin: govuk-spacing(6) (- govuk-spacing(3) );
+  margin: govuk-spacing(7) 0;
 }
 
 .gem-c-pagination__list {
@@ -11,12 +11,14 @@
 .gem-c-pagination__item {
   @include govuk-font($size: 16, $line-height: (20 / 16));
   list-style: none;
+  border-top: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(3);
 }
 
 .gem-c-pagination__link {
   @extend %govuk-link;
   display: block;
-  padding: govuk-spacing(3);
+  padding: govuk-spacing(3) 0 govuk-spacing(4) 0;
   text-decoration: none;
 
   &:hover,
@@ -37,6 +39,7 @@
 
 .gem-c-pagination__link-title {
   display: block;
+  color: $govuk-text-colour;
 }
 
 .gem-c-pagination__link-divider {
@@ -54,6 +57,7 @@
   margin-bottom: 1px;
   height: .482em;
   width: .63em;
+  color: $govuk-secondary-text-colour;
 }
 
 .gem-c-pagination__link-label {


### PR DESCRIPTION
Update previous and next navigation component

Design Document to illustrate the required changes:
https://docs.google.com/document/d/1ryu7LdOiJdKGqG_lUZOwDPOpLpSNw0MVAGaWx6ocmuw

Trello card:
https://trello.com/c/4ZsqNg3r/11-multi-page-pagination-fix

## What
- Change colour of link title
- Change color of arrow icon
- Add top border
- Adjust component padding
- Adjust link padding

## Why
Good touch target areas are vital for mobile users to select the correct component on a small screen. We should make it easier for mobile users to use this component.

## Visual Changes
<img width="473" alt="Screenshot 2020-02-18 at 15 07 03" src="https://user-images.githubusercontent.com/54625020/74758107-cac4d980-526e-11ea-9e80-dd4d486c083b.png">
Before change

<img width="430" alt="Screenshot 2020-02-18 at 15 03 38" src="https://user-images.githubusercontent.com/54625020/74758164-dfa16d00-526e-11ea-8a3d-10fc9280cfe0.png">
After change