### PR TITLE
Change attachment request format CTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change attachment request format text to match Whitehall ([PR #1306](https://github.com/alphagov/govuk_publishing_components/pull/1306))
+
 ## 21.23.0
 
 * Enable custom margin top on title component ([PR #1302](https://github.com/alphagov/govuk_publishing_components/pull/1302))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,8 +26,8 @@ en:
     attachment:
       opendocument_html: "This file is in an <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation' target=%{target} class='govuk-link'>OpenDocument</a> format"
       request_format_text: "This file may not be suitable for users of assistive technology."
-      request_format_cta: "Request a different format"
-      request_format_details_html: "If you use assistive technology and need a version of this document in a more accessible format, please email <a href='mailto:%{alternative_format_contact_email}' target='_blank' class='govuk-link'>%{alternative_format_contact_email}</a>. Please tell us what format you need. It will help us if you say what assistive technology you use."
+      request_format_cta: "Request an accessible format."
+      request_format_details_html: "If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email <a href='mailto:%{alternative_format_contact_email}' target='_blank' class='govuk-link'>%{alternative_format_contact_email}</a>. Please tell us what format you need. It will help us if you say what assistive technology you use."
     article_schema:
       scoped_search_description: "Search within %{title}"
     back_link:


### PR DESCRIPTION
## What
This updates the text displayed for users to request an accessible format to be
consistent with the text we use in Whitehall.

## Why
This was flagged as an inconsistency when attempting to import a document from Whitehall to Content Publisher.  Content Publisher uses this component, whereas Whitehall reads from its own locale config file.  After checking with a content designer we have decided to match what Whitehall uses so that the message a) is consistent and b) more precise about what the user can request.

## Visual Changes
**Before**
<img width="909" alt="Screenshot 2020-02-18 at 17 09 50" src="https://user-images.githubusercontent.com/13434452/74759932-7e2ecd80-5271-11ea-87f0-a565a4560163.png">

**After**
<img width="903" alt="Screenshot 2020-02-18 at 17 09 06" src="https://user-images.githubusercontent.com/13434452/74759891-69523a00-5271-11ea-98b9-16c6d9aaf7ab.png">
