### PR TITLE
Make cookie banner text and preferences URL customisable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+* Make cookie banner text and preferences URL customisable [PR #1310](https://github.com/alphagov/govuk_publishing_components/pull/1310)
+
 ## 21.24.0
 
 * Change back link arrow to chevron [PR #1299](https://github.com/alphagov/govuk_publishing_components/pull/1299)

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -1,6 +1,7 @@
 <%
   id ||= 'global-cookie-message'
   text ||= raw("We use <a class='govuk-link' href='/help/cookies'>cookies to collect information</a> about how you use GOV.UK. We use this information to make the website work as well as possible and improve government services.")
+  cookie_preferences_href ||= "/help/cookies"
 %>
 
 <div id="<%= id %>" class="gem-c-cookie-banner govuk-clearfix" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet>
@@ -27,7 +28,7 @@
           <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
             <%= render "govuk_publishing_components/components/button", {
               text: "Set cookie preferences",
-              href: "/help/cookies",
+              href: cookie_preferences_href,
               inline_layout: true,
               data_attributes: {
                 module: "track-click",
@@ -43,7 +44,7 @@
 
   <div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1">
     <p class="gem-c-cookie-banner__confirmation-message">
-      You&#8217;ve accepted all cookies. You can <a class="govuk-link" href="/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.
+      You&#8217;ve accepted all cookies. You can <a class="govuk-link" href="<%= cookie_preferences_href %>" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.
     </p>
     <button class="gem-c-cookie-banner__hide-button" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide</button>
   </div>

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -1,5 +1,6 @@
 <%
   id ||= 'global-cookie-message'
+  text ||= raw("We use <a class='govuk-link' href='/help/cookies'>cookies to collect information</a> about how you use GOV.UK. We use this information to make the website work as well as possible and improve government services.")
 %>
 
 <div id="<%= id %>" class="gem-c-cookie-banner govuk-clearfix" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet>
@@ -8,7 +9,7 @@
       <div class=" govuk-grid-column-two-thirds">
         <div class="gem-c-cookie-banner__message">
           <span class="govuk-heading-m">Tell us whether you accept cookies</span>
-          <p class="govuk-body">We use <a class="govuk-link" href="/help/cookies">cookies to collect information</a> about how you use GOV.UK. We use this information to make the website work as well as possible and improve government services.</p>
+          <p class="govuk-body"><%= text %></p>
         </div>
         <div class="gem-c-cookie-banner__buttons">
           <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop">

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -17,3 +17,6 @@ accessibility_excluded_rules:
 examples:
   default:
     data: {}
+  with_custom_text:
+    data:
+      text: "This is some custom text in my cookie banner which lets users know what we're using cookies for. I can also include a link to the <a class='govuk-link' href='/cookies'>cookies page</a>"

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -20,3 +20,6 @@ examples:
   with_custom_text:
     data:
       text: "This is some custom text in my cookie banner which lets users know what we're using cookies for. I can also include a link to the <a class='govuk-link' href='/cookies'>cookies page</a>"
+  with_custom_cookie_preferences_href:
+    data:
+      cookie_preferences_href: "/cookies"

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -14,30 +14,30 @@ describe "Cookie banner", type: :view do
   end
 
   it "renders a button for accepting cookies" do
-    render_component(new_cookie_banner: true)
+    render_component({})
     assert_select '.gem-c-cookie-banner__buttons .gem-c-button', text: "Accept all cookies"
     assert_select '.gem-c-cookie-banner__buttons .gem-c-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner accepted"]'
   end
 
   it "renders a button for viewing cookie settings" do
-    render_component(new_cookie_banner: true)
+    render_component({})
     assert_select '.gem-c-cookie-banner__buttons .gem-c-button', text: "Set cookie preferences"
     assert_select '.gem-c-cookie-banner__buttons .gem-c-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner settings clicked"]'
   end
 
   it "renders a confirmation message" do
-    render_component(new_cookie_banner: true)
+    render_component({})
     assert_select '.gem-c-cookie-banner__confirmation-message', text: "You’ve accepted all cookies. You can change your cookie settings at any time."
   end
 
   it "renders a link to the settings page within the confirmation message" do
-    render_component(new_cookie_banner: true)
+    render_component({})
     assert_select '.gem-c-cookie-banner__confirmation-message a', text: "change your cookie settings"
     assert_select '.gem-c-cookie-banner__confirmation-message a[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner settings clicked from confirmation"]'
   end
 
   it "renders a hide link within the confirmation banner" do
-    render_component(new_cookie_banner: true)
+    render_component({})
 
     assert_select '.gem-c-cookie-banner__confirmation .gem-c-cookie-banner__hide-button', text: "Hide"
     assert_select '.gem-c-cookie-banner__hide-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Hide cookie banner"]'

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -48,4 +48,14 @@ describe "Cookie banner", type: :view do
     assert_select ".gem-c-cookie-banner__message .govuk-body", text: "This is some custom text with a link to the cookies page"
     assert_select ".govuk-link[href='/cookies']", text: "cookies page"
   end
+
+  it "renders with a custom preferences page link" do
+    render_component(cookie_preferences_href: "/cookies")
+    assert_select ".gem-c-cookie-banner__button-settings a[href='/cookies']", text: "Set cookie preferences"
+    assert_select '.gem-c-cookie-banner__button-settings a[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner settings clicked"]'
+
+    # Check that the confirmation message also includes the custom URL
+    assert_select ".gem-c-cookie-banner__confirmation-message a[href='/cookies']", text: "change your cookie settings"
+    assert_select '.gem-c-cookie-banner__confirmation-message a[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner settings clicked from confirmation"]'
+  end
 end

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -42,4 +42,10 @@ describe "Cookie banner", type: :view do
     assert_select '.gem-c-cookie-banner__confirmation .gem-c-cookie-banner__hide-button', text: "Hide"
     assert_select '.gem-c-cookie-banner__hide-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Hide cookie banner"]'
   end
+
+  it "renders with custom text" do
+    render_component(text: sanitize("This is some custom text with a link to the <a href='/cookies' class='govuk-link'>cookies page</a>"))
+    assert_select ".gem-c-cookie-banner__message .govuk-body", text: "This is some custom text with a link to the cookies page"
+    assert_select ".govuk-link[href='/cookies']", text: "cookies page"
+  end
 end


### PR DESCRIPTION
## What
Adds the ability to pass the following into the cookie banner and override the default:

- Cookie banner message
- The URL on the 'set cookie preferences' button

## Why
This makes the banner more usable by other services which may have their own cookie settings pages and want to remove references to "GOV.UK" in the cookie banner messaging.

Our specific use case at the moment is data.gov.uk, which is GDS-owned but lives on a separate URL.

## Visual Changes
<img width="995" alt="Screenshot 2020-02-20 at 11 17 00" src="https://user-images.githubusercontent.com/29889908/74929019-91a57a00-53d2-11ea-9d19-2acd46e9aa31.png">
<img width="984" alt="Screenshot 2020-02-20 at 11 17 06" src="https://user-images.githubusercontent.com/29889908/74929024-92d6a700-53d2-11ea-86e7-ac52c2ea22ff.png">

Heroku: https://govuk-publis-make-cooki-p0dhlc.herokuapp.com/component-guide/cookie_banner