### PR TITLE
Add cookie category list override functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   of the commit log.
 
 ## Unreleased
+
+* Add cookie category override function [PR #1312](https://github.com/alphagov/govuk_publishing_components/pull/1312)
 * Make cookie banner text and preferences URL customisable [PR #1310](https://github.com/alphagov/govuk_publishing_components/pull/1310)
 
 ## 21.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@
 
 ## Unreleased
 
-* Add cookie category override function [PR #1312](https://github.com/alphagov/govuk_publishing_components/pull/1312)
-* Make cookie banner text and preferences URL customisable [PR #1310](https://github.com/alphagov/govuk_publishing_components/pull/1310)
+* Add cookie category override function ([PR #1312](https://github.com/alphagov/govuk_publishing_components/pull/1312))
+* Make cookie banner text and preferences URL customisable ([PR #1310](https://github.com/alphagov/govuk_publishing_components/pull/1310))
 
 ## 21.24.0
 
-* Change back link arrow to chevron [PR #1299](https://github.com/alphagov/govuk_publishing_components/pull/1299)
-* Mobile breadcrumb update guidance [PR #1298](https://github.com/alphagov/govuk_publishing_components/pull/1298)
+* Change back link arrow to chevron ([PR #1299](https://github.com/alphagov/govuk_publishing_components/pull/1299))
+* Mobile breadcrumb update guidance ([PR #1298](https://github.com/alphagov/govuk_publishing_components/pull/1298))
 * Add page heading captions to checkboxes and radio boxes components ([PR #1304](https://github.com/alphagov/govuk_publishing_components/pull/1304))
 
 ## 21.23.1

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -11,7 +11,7 @@
     'campaigns': false
   }
 
-  var COOKIE_CATEGORIES = {
+  var DEFAULT_COOKIE_CATEGORIES = {
     'cookies_policy': 'essential',
     'seen_cookie_message': 'essential',
     'cookie_preferences_set': 'essential',
@@ -99,6 +99,7 @@
 
   window.GOVUK.setConsentCookie = function (options) {
     var cookieConsent = window.GOVUK.getConsentCookie()
+    var cookieCategories = window.GOVUK.cookieCategories()
 
     if (!cookieConsent) {
       cookieConsent = JSON.parse(JSON.stringify(DEFAULT_COOKIE_CONSENT))
@@ -109,8 +110,8 @@
 
       // Delete cookies of that type if consent being set to false
       if (!options[cookieType]) {
-        for (var cookie in COOKIE_CATEGORIES) {
-          if (COOKIE_CATEGORIES[cookie] === cookieType) {
+        for (var cookie in cookieCategories) {
+          if (cookieCategories[cookie] === cookieType) {
             window.GOVUK.deleteCookie(cookie)
           }
         }
@@ -122,9 +123,10 @@
 
   window.GOVUK.checkConsentCookieCategory = function (cookieName, cookieCategory) {
     var currentConsentCookie = window.GOVUK.getConsentCookie()
+    var cookieCategories = window.GOVUK.cookieCategories()
 
     // If the consent cookie doesn't exist, but the cookie is in our known list, return true
-    if (!currentConsentCookie && COOKIE_CATEGORIES[cookieName]) {
+    if (!currentConsentCookie && cookieCategories[cookieName]) {
       return true
     }
 
@@ -140,6 +142,8 @@
   }
 
   window.GOVUK.checkConsentCookie = function (cookieName, cookieValue) {
+    var cookieCategories = window.GOVUK.cookieCategories()
+
     // If we're setting the consent cookie OR deleting a cookie, allow by default
     if (cookieName === 'cookies_policy' || (cookieValue === null || cookieValue === false)) {
       return true
@@ -150,8 +154,8 @@
       return window.GOVUK.checkConsentCookieCategory(cookieName, 'settings')
     }
 
-    if (COOKIE_CATEGORIES[cookieName]) {
-      var cookieCategory = COOKIE_CATEGORIES[cookieName]
+    if (cookieCategories[cookieName]) {
+      var cookieCategory = cookieCategories[cookieName]
 
       return window.GOVUK.checkConsentCookieCategory(cookieName, cookieCategory)
     } else {
@@ -194,7 +198,7 @@
   }
 
   window.GOVUK.getCookieCategory = function (cookie) {
-    return COOKIE_CATEGORIES[cookie]
+    return window.GOVUK.cookieCategories()[cookie]
   }
 
   window.GOVUK.deleteCookie = function (cookie) {
@@ -207,14 +211,23 @@
     }
   }
 
+  window.GOVUK.cookieCategories = function () {
+    if (window.GOVUK.overrideCookieCategories) {
+      return window.GOVUK.overrideCookieCategories()
+    } else {
+      return DEFAULT_COOKIE_CATEGORIES
+    }
+  }
+
   window.GOVUK.deleteUnconsentedCookies = function () {
     var currentConsent = window.GOVUK.getConsentCookie()
+    var cookieCategories = window.GOVUK.cookieCategories()
 
     for (var cookieType in currentConsent) {
       // Delete cookies of that type if consent being set to false
       if (!currentConsent[cookieType]) {
-        for (var cookie in COOKIE_CATEGORIES) {
-          if (COOKIE_CATEGORIES[cookie] === cookieType) {
+        for (var cookie in cookieCategories) {
+          if (cookieCategories[cookie] === cookieType) {
             window.GOVUK.deleteCookie(cookie)
           }
         }

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -1,6 +1,8 @@
 name: Cookie banner
 description: Help users manage their personal data by telling them when you store cookies on their device.
 body: |
+  __If you are using this component within a government service, please read the [documentation on how to use the banner](https://github.com/alphagov/govuk_publishing_components/tree/master/docs/using-cookie-banner.md).__
+
   Setting `data-hide-cookie-banner="true"` on any link inside the banner will overwrite the default action and when clicked will dismiss the cookie banner for a period of 365 days (approx. 1 year).
 
   If the examples below are not showing the banner, make sure the `cookies_preferences_set` cookie is not present or is set to false.

--- a/docs/using-cookie-banner.md
+++ b/docs/using-cookie-banner.md
@@ -1,0 +1,33 @@
+# Using the cookie banner within a government service
+
+The cookie banner and cookie functions in this gem can be used for cookie consent mechanisms on other government services.
+
+To use these, you will need to [install the `govuk_publishing_components` gem](/docs/install-and-use.md) in your application.
+
+
+To include the cookie banner component in your layout:
+
+```erb
+<%= render "govuk_publishing_components/components/cookie_banner" %>
+```
+
+> Note: this will use the default cookie banner text and also assumes you have a cookie settings page at /help/cookies. See the [component documentation](https://components.publishing.service.gov.uk/component-guide/cookie_banner) for details on how to change this.
+
+The cookie consent mechanism is bundled in with the cookie banner. It sets a `cookies_policy` cookie containing a user's cookie preferences. It is your responsibility to add checks to your application to ensure this consent cookie is checked each time you set any cookies. A quick way to do this is by setting all cookies using our helper methods, for example:
+
+```javascript
+window.GOVUK.setCookie('cookie_name', 'cookie-value')
+```
+
+This gem includes a default list of all cookies we explicitly allow on GOV.UK. If using this in your own service, you __must__ define your own list. You can do this by adding the following Javascript to your application:
+
+```javascript
+window.GOVUK.overrideCookieCategories = function () {
+    var cookieCategories = {
+      'cookies_policy': 'essential',
+      'cookies_preferences_set': 'essential',
+      // include any other cookies specific to your service here
+      // there are 4 categories these cookies can fall into: essential; settings; usage; campaign
+    }
+}
+```

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
@@ -176,4 +176,28 @@ describe('Cookie helper functions', function () {
       expect(GOVUK.checkConsentCookie('fake_cookie', 'just for testing')).toBeFalsy()
     })
   })
+
+  describe('cookie override function', function () {
+    beforeEach(function() {
+      window.GOVUK.overrideCookieCategories = function() {
+        return {
+          'cookies_policy': 'essential',
+          'cookies_preferences_set': 'essential',
+          'custom_allowed_cookie': 'settings'
+        }
+      }
+    })
+
+    afterEach(function() {
+      window.GOVUK.overrideCookieCategories = undefined
+    })
+
+    it('can define own cookies to allow', function () {
+      GOVUK.approveAllCookieTypes()
+
+      GOVUK.setCookie("custom_allowed_cookie", "this is an allowed cookie")
+
+      expect(GOVUK.getCookie('custom_allowed_cookie')).toEqual("this is an allowed cookie")
+    })
+  })
 })


### PR DESCRIPTION
**Note: this change is up for debate - it's just my best guess at how we could approach this, but I'm open to other ideas.**

## What
Adds cookie function which allows a service to override the default list of cookies and categories allowed on the site. Here is an example of how this might be used:

```
# Defining the override method within the service
window.GOVUK.overrideCookieCategories = function() {
  var cookieCategories = {
    'cookies_policy': 'essential',
    'cookies_preferences_set': 'essential',
    'cookie_specific_to_service': 'settings',
  }

  return cookieCategories
}
```

## Why
If other services want to use the cookie banner functionality, they will want to define their own cookies to allow. In this specific case, we want to use the cookie banner on data.gov.uk.

Documentation added here:

- https://govuk-publis-spike-cook-hptqol.herokuapp.com/component-guide/cookie_banner
- https://github.com/alphagov/govuk_publishing_components/blob/8eeecba8ee89fbf27ebbe55170ed7a3d6adbc30a/docs/using-cookie-banner.md