### PR TITLE
Add data.gov.uk (DGU) cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 * Make cookie banner text and preferences URL customisable [PR #1310](https://github.com/alphagov/govuk_publishing_components/pull/1310)
+* Add DGU-specific cookie ([PR #1315](https://github.com/alphagov/govuk_publishing_components/pull/1315))
 
 ## 21.24.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@
   of the commit log.
 
 ## Unreleased
-* Make cookie banner text and preferences URL customisable [PR #1310](https://github.com/alphagov/govuk_publishing_components/pull/1310)
+* Make cookie banner text and preferences URL customisable ([PR #1310](https://github.com/alphagov/govuk_publishing_components/pull/1310))
 * Add DGU-specific cookie ([PR #1315](https://github.com/alphagov/govuk_publishing_components/pull/1315))
 
 ## 21.24.0
 
-* Change back link arrow to chevron [PR #1299](https://github.com/alphagov/govuk_publishing_components/pull/1299)
-* Mobile breadcrumb update guidance [PR #1298](https://github.com/alphagov/govuk_publishing_components/pull/1298)
+* Change back link arrow to chevron ([PR #1299](https://github.com/alphagov/govuk_publishing_components/pull/1299))
+* Mobile breadcrumb update guidance ([PR #1298](https://github.com/alphagov/govuk_publishing_components/pull/1298))
 * Add page heading captions to checkboxes and radio boxes components ([PR #1304](https://github.com/alphagov/govuk_publishing_components/pull/1304))
 
 ## 21.23.1

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -19,6 +19,7 @@
     '_email-alert-frontend_session': 'essential',
     'licensing_session': 'essential',
     'govuk_contact_referrer': 'essential',
+    'dgu_beta_banner_dismissed': 'settings',
     'global_bar_seen': 'settings',
     'govuk_browser_upgrade_dismisssed': 'settings',
     'govuk_not_first_visit': 'settings',


### PR DESCRIPTION
## What
Add DGU-specific cookies to the list of cookie categories.

## Why
This cookie isn't actually being used on data.gov.uk any more, but it needs to be added to the list so it can be removed when the default cookie consent is set.
