### PR TITLE
Add Code of Conduct, Security, and Support docs

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,5 @@
+# Support for GOV.UK Publishing Components
+
+This gem is provided as-is, with no official support.
+
+If you have a feature request or have found a bug, please raise an issue. We'll do our best to respond to issues raised.


### PR DESCRIPTION
## What

The support notice is brief because, as a community, we can't make promises about how quick we can respond to issues or feature requests.

The support notice should be linked to within the GitHub interface when person raises an issue. For more information, see the [GitHub documentation on SUPPORT.md](https://help.github.com/en/github/building-a-strong-community/adding-support-resources-to-your-project)

## Why

This repository doesn't currently anything around what to expect when raising an issue.

## Visual Changes

None.