### PR TITLE
Fix layout header width issue

### DIFF
--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -16,8 +16,8 @@
     <%= csrf_meta_tags %>
     <%= favicon_link_tag "govuk_publishing_components/favicon-production.png" %>
 
-    <%= stylesheet_link_tag "component_guide/application", media: "screen" %>
     <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_stylesheet}" %>
+    <%= stylesheet_link_tag "component_guide/application", media: "screen" %>
 
     <% if GovukPublishingComponents::Config.application_print_stylesheet %>
       <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_print_stylesheet}", media: "print" %>


### PR DESCRIPTION
## What / why
- the new gem allows individual sass for components to be imported into applications
- this isn't quite perfect yet, because the component guide imports its own sass and the application's sass
- both now import govuk-frontend (this isn't ideal, I realise) but differ in the components they import, the guide imports all, the application imports some
- now that the two are different, including the application's sass after the component guide means that govuk-frontend's styles for the layout header are overridding those in the layout header component
- fix is to swap the ordering of these in the guide markup, but ideally a better solution can be found as clearly some duplication is happening here

## Visual Changes

Component guide should look like this:

<img width="816" alt="Screenshot 2020-02-21 at 16 50 48" src="https://user-images.githubusercontent.com/861310/75054569-3f944f80-54cb-11ea-80e0-d19dece68c8c.png">

but looks like this:

<img width="878" alt="Screenshot 2020-02-21 at 15 55 35" src="https://user-images.githubusercontent.com/861310/75054586-46bb5d80-54cb-11ea-95a9-b965641f3d2a.png">

This PR fixes that.

Just for interest, here's how the CSS should be, but the problem was that the `gem-c-header__logo` class was being overridden. It might also be worth looking into how this CSS works as an alternative option to fix this long term.

<img width="271" alt="Screenshot 2020-02-21 at 16 58 17" src="https://user-images.githubusercontent.com/861310/75054701-7bc7b000-54cb-11ea-9d8a-1466da09100a.png">
