### PR TITLE
Improve suggested sass functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 
 ## Unreleased
 
-* Allow individual components to be imported into apps ([PR #1159](https://github.com/alphagov/govuk_publishing_components/pull/1159))
 * Update Sass documentation ([PR #1321](https://github.com/alphagov/govuk_publishing_components/pull/1321))
+* Improve suggested sass functionality ([PR #1320](https://github.com/alphagov/govuk_publishing_components/pull/1320))
+* Fix layout header width issue ([PR #1319](https://github.com/alphagov/govuk_publishing_components/pull/1319))
 
 ## 21.26.0
 

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -24,14 +24,14 @@
   } do %>
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
-        text: "Add this to your application's main scss file"
+        text: "Add this to your application's main scss file, before your other local imports."
       },
       name: "main-sass",
       value: @components_in_use_sass
     } %>
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
-        text: "Add this to your application's print scss file"
+        text: "Add this to your application's print scss file, before your other local imports."
       },
       name: "print-sass",
       value: @components_in_use_print_sass

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -47,15 +47,22 @@ describe 'Component guide index' do
     visit '/component-guide'
     expected_main_sass = "@import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';
-
+@import 'govuk_publishing_components/components/_breadcrumbs';
 @import 'govuk_publishing_components/components/_contextual-sidebar';
+@import 'govuk_publishing_components/components/_error-message';
 @import 'govuk_publishing_components/components/_error-summary';
 @import 'govuk_publishing_components/components/_govspeak';
+@import 'govuk_publishing_components/components/_hint';
 @import 'govuk_publishing_components/components/_input';
+@import 'govuk_publishing_components/components/_label';
 @import 'govuk_publishing_components/components/_layout-footer';
 @import 'govuk_publishing_components/components/_layout-for-admin';
 @import 'govuk_publishing_components/components/_layout-header';
+@import 'govuk_publishing_components/components/_related-navigation';
 @import 'govuk_publishing_components/components/_skip-link';
+@import 'govuk_publishing_components/components/_step-by-step-nav';
+@import 'govuk_publishing_components/components/_step-by-step-nav-header';
+@import 'govuk_publishing_components/components/_step-by-step-nav-related';
 @import 'govuk_publishing_components/components/_tabs';
 @import 'govuk_publishing_components/components/_title';"
 
@@ -65,6 +72,8 @@ describe 'Component guide index' do
 @import 'govuk_publishing_components/components/print/_layout-footer';
 @import 'govuk_publishing_components/components/print/_layout-header';
 @import 'govuk_publishing_components/components/print/_skip-link';
+@import 'govuk_publishing_components/components/print/_step-by-step-nav';
+@import 'govuk_publishing_components/components/print/_step-by-step-nav-header';
 @import 'govuk_publishing_components/components/print/_title';"
 
     expect(page).to have_selector('.component-doc-h2', text: 'Gem components used by this app (12)')


### PR DESCRIPTION
## What / why

This change relates to the work done in https://github.com/alphagov/govuk_publishing_components/pull/1159 to allow individual components to be imported into an application, specifically relating to an oversight in the 'suggested sass for this application' functionality.

- the component guide was checking for what components are in use, but some components import other components, so it was missing those
- added a check for components within components and added to suggested sass output

![Screenshot 2020-02-24 at 09 47 07](https://user-images.githubusercontent.com/861310/75142269-a3e12a00-56ea-11ea-9027-3163022bbb41.png)


## Visual Changes
No visual changes.
