### PR TITLE
Version 21.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.26.1
 
 * Update Sass documentation ([PR #1321](https://github.com/alphagov/govuk_publishing_components/pull/1321))
 * Improve suggested sass functionality ([PR #1320](https://github.com/alphagov/govuk_publishing_components/pull/1320))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## 21.26.1
 
+* Add visually hidden text to share links component ([PR #1286](https://github.com/alphagov/govuk_publishing_components/pull/1286/))
 * Update Sass documentation ([PR #1321](https://github.com/alphagov/govuk_publishing_components/pull/1321))
 * Improve suggested sass functionality ([PR #1320](https://github.com/alphagov/govuk_publishing_components/pull/1320))
 * Fix layout header width issue ([PR #1319](https://github.com/alphagov/govuk_publishing_components/pull/1319))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.26.0)
+    govuk_publishing_components (21.26.1)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.26.0'.freeze
+  VERSION = '21.26.1'.freeze
 end


### PR DESCRIPTION
* Update Sass documentation ([PR #1321](https://github.com/alphagov/govuk_publishing_components/pull/1321))
* Improve suggested sass functionality ([PR #1320](https://github.com/alphagov/govuk_publishing_components/pull/1320))
* Fix layout header width issue ([PR #1319](https://github.com/alphagov/govuk_publishing_components/pull/1319))
* Add visually hidden text to share links component ([PR #1286](https://github.com/alphagov/govuk_publishing_components/pull/1286/))
