### PR TITLE
Dont show breadcrumb item with no url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Dont show breadcrumb item with no url ([PR #1324](https://github.com/alphagov/govuk_publishing_components/pull/1324))
+
 ## 21.26.1
 
 * Add visually hidden text to share links component ([PR #1286](https://github.com/alphagov/govuk_publishing_components/pull/1286/))

--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -13,21 +13,19 @@
   <ol class="govuk-breadcrumbs__list">
     <% breadcrumbs.each_with_index do |crumb, index| %>
       <% breadcrumb = GovukPublishingComponents::Presenters::Breadcrumb.new(crumb, index) %>
-      <li class="govuk-breadcrumbs__list-item" aria-current="<%= breadcrumb.aria_current %>">
         <% if breadcrumb.is_link? %>
-          <%= link_to(
-            breadcrumb[:title],
-            breadcrumb.path,
-            data: breadcrumb.tracking_data(breadcrumbs.length),
-            class: "govuk-breadcrumbs__link",
-            aria: {
-              current: breadcrumb.aria_current,
-            }
-          ) %>
-        <% else %>
-          <%= breadcrumb[:title] %>
+          <li class="govuk-breadcrumbs__list-item" aria-current="<%= breadcrumb.aria_current %>">
+              <%= link_to(
+                breadcrumb[:title],
+                breadcrumb.path,
+                data: breadcrumb.tracking_data(breadcrumbs.length),
+                class: "govuk-breadcrumbs__link",
+                aria: {
+                  current: breadcrumb.aria_current,
+                }
+              ) %>
+          </li>
         <% end %>
-      </li>
     <% end %>
   </ol>
 </div>

--- a/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
@@ -71,7 +71,6 @@ examples:
   long_taxon_on_mobile:
     description: This is an example of a breadcrumb (specifically for mobile) with long taxons on the the parent item and a greater touch target area
     data:
-      collapse_on_mobile: true
       breadcrumbs:
       - title: 'Home'
         url: '/'

--- a/spec/components/breadcrumbs_spec.rb
+++ b/spec/components/breadcrumbs_spec.rb
@@ -128,13 +128,13 @@ describe "Breadcrumbs", type: :view do
     assert_select ".gem-c-breadcrumbs--inverse"
   end
 
-  it "allows the last breadcrumb to be text only" do
+  it "ignore breadcrumb items without url" do
     render_component(
       breadcrumbs: [
         { title: 'Topic', url: '/topic' },
         { title: 'Current Page' },
       ]
     )
-    assert_select('.govuk-breadcrumbs__list-item:last-child', 'Current Page')
+    assert_select('.govuk-breadcrumbs__list-item:last-child', 'Topic')
   end
 end


### PR DESCRIPTION
Part of updating breadcrumb behaviour as per :
https://trello.com/c/YuObLgSq/10-fix-breadcrumbs-on-mobile

https://docs.google.com/document/d/1OFG1Ln6VeCR_bc0qmUtRwMJU62Ljw4F3HO6hq2yloXk/

## What
Add logic to check for breadcrumb item to not show if it does not have a corresponding "url" 

## Why
Breadcrumb items with no "url", do not aid navigation. Specifically, when a breadcrumb is collapsed on a mobile device to show only first and last items, there is no method to navigate to the parent page

