### PR TITLE
Remove font-size option for contents list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove font_size option on contents list ([PR #1325](https://github.com/alphagov/govuk_publishing_components/pull/1325))
+
 ## 21.26.2
 
 * Streamline feedback component ([PR #1327](https://github.com/alphagov/govuk_publishing_components/pull/1327))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -10,16 +10,6 @@
   box-shadow: 0 20px 15px -10px govuk-colour("white");
 }
 
-.gem-c-contents-list--font-size-19 .gem-c-contents-list__title,
-.gem-c-contents-list--font-size-19 .gem-c-contents-list__list {
-  @include govuk-font($size: 19, $line-height: 1.5);
-}
-
-.gem-c-contents-list--font-size-24 .gem-c-contents-list__title,
-.gem-c-contents-list--font-size-24 .gem-c-contents-list__list {
-  @include govuk-font($size: 24, $line-height: 1.5);
-}
-
 .gem-c-contents-list__title {
   @include govuk-text-colour;
   @include govuk-font($size: 16, $weight: regular, $line-height: 1.5);

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -217,14 +217,3 @@ examples:
             text: Guidance and regulation
           - href: "#third-thing"
             text: Consultations
-  with_different_font_size:
-    description: Choose a different font size. Valid options are 24 (24px) and 19 (19px), with the component defaulting to 16px.
-    data:
-      font_size: 24
-      contents:
-        - href: "#first-thing"
-          text: Community best practice
-        - href: "#second-thing"
-          text: Guidance and regulation
-        - href: "#third-thing"
-          text: Consultations

--- a/lib/govuk_publishing_components/presenters/contents_list_helper.rb
+++ b/lib/govuk_publishing_components/presenters/contents_list_helper.rb
@@ -11,11 +11,9 @@ module GovukPublishingComponents
         @contents = options[:contents] || []
         @nested = !!@contents.find { |c| c[:items] && c[:items].any? }
         @format_numbers = options[:format_numbers]
-        @font_size = options[:font_size]
 
         @classes = %w(gem-c-contents-list)
         @classes << " gem-c-contents-list--no-underline" unless options[:underline_links]
-        @classes << " gem-c-contents-list--font-size-#{@font_size}" if [24, 19].include? @font_size
       end
 
       def list_item_classes(list_item, nested)

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -137,12 +137,4 @@ describe "Contents list", type: :view do
     render_component(contents: nested_contents_list, hide_title: true)
     assert_select ".gem-c-contents-list__title", false
   end
-
-  it "can render the component in different font sizes" do
-    render_component(contents: contents_list, font_size: 24)
-    assert_select ".gem-c-contents-list--font-size-24"
-
-    render_component(contents: contents_list, font_size: 19)
-    assert_select ".gem-c-contents-list--font-size-19"
-  end
 end


### PR DESCRIPTION
## What
Remove `font_size` option on the contents list component.

## Why

- We added this option to the component for one iteration of the Brexit landing page, but it ended up not being used.
- The mobile team are looking at making font-sizes more consistent across GOVUK so page hierarchy is clearer. 
- The font-size flag on this component isn't being used yet and we probably don't want to encourage its use. We may as well remove it for now.
