### PR TITLE
Extend document-list component to show parts of a document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Make feedback component more responsive and usable on mobile ([PR #1346](https://github.com/alphagov/govuk_publishing_components/pull/1346))
+* Extend document-list component to show parts of a document ([PR #1326](https://github.com/alphagov/govuk_publishing_components/pull/1326))
 
 ## 21.28.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -105,3 +105,32 @@
   margin: 0 0 govuk-spacing(3) 0;
 
 }
+
+.gem-c-document-list__children {
+  margin-bottom: 0;
+  margin-top: govuk-spacing(3);
+}
+
+.gem-c-document-list-child {
+  @include govuk-font($size: 16);
+}
+
+.gem-c-document-list-child__heading {
+  @include govuk-typography-weight-bold;
+}
+
+.gem-c-document-list-child__link {
+  @include govuk-link-common;
+  @include govuk-link-style-default;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.gem-c-document-list-child__description {
+  @include govuk-text-colour;
+  margin-top: govuk-spacing(1);
+  margin-bottom: govuk-spacing(1);
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -103,20 +103,50 @@
 .gem-c-document-list__highlight-text {
   @include govuk-font(16, bold);
   margin: 0 0 govuk-spacing(3) 0;
-
 }
 
 .gem-c-document-list__children {
   margin-bottom: 0;
-  margin-top: govuk-spacing(3);
+
+  @include govuk-media-query($from: desktop) {
+    margin-left: govuk-spacing(4);
+    margin-top: govuk-spacing(4);
+
+    @supports (display: grid) {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      column-gap: govuk-spacing(3);
+    }
+  }
 }
 
 .gem-c-document-list-child {
   @include govuk-font($size: 16);
+  position: relative;
+  padding-left: govuk-spacing(5);
+  padding-top: govuk-spacing(2);
+
+  &:before {
+    content: "—";
+    position: absolute;
+    left: 0;
+    overflow: hidden;
+  }
+
+  @include govuk-media-query($from: desktop) {
+    padding: 0;
+    padding-bottom: govuk-spacing(2);
+
+    &:before {
+      display: none;
+    }
+  }
 }
 
 .gem-c-document-list-child__heading {
-  @include govuk-typography-weight-bold;
+  @include govuk-media-query($from: tablet) {
+    @include govuk-typography-weight-bold;
+  }
 }
 
 .gem-c-document-list-child__link {
@@ -131,6 +161,10 @@
 
 .gem-c-document-list-child__description {
   @include govuk-text-colour;
-  margin-top: govuk-spacing(1);
+  margin-top: 0;
   margin-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($until: tablet) {
+    display: none;
+  }
 }

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -71,27 +71,25 @@
         <% if item[:subtext] %>
           <p class="gem-c-document-list__subtext"><%= item[:subtext] %></p>
         <% end %>
-        
-        <% if item.include?(:parts) && item[:parts].any? %>
+
+        <% if item[:parts] && item[:parts].any? %>
           <ul class="gem-c-document-list__children govuk-list">
             <% item[:parts].each do |part| %>
               <li class="gem-c-document-list-child">
                 <%=
-                  item_classes = "gem-c-document-list-child__heading #{brand_helper.color_class}"
-
                   if part[:link][:path]
                     link_to(
                       part[:link][:text],
                       part[:link][:path],
                       data: part[:link][:data_attributes],
-                      class: "#{item_classes} gem-c-document-list-child__link",
+                      class: "gem-c-document-list-child__heading #{brand_helper.color_class} gem-c-document-list-child__link",
                     )
                   else
                     content_tag(
                       "span",
                       part[:link][:text],
                       data: part[:link][:data_attributes],
-                      class: "gem-c-document-list-child__heading", 
+                      class: "gem-c-document-list-child__heading",
                     )
                   end
                 %>

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -19,7 +19,6 @@
   <% end %>
     <% items.each do |item| %>
       <% highlight_class = " gem-c-document-list__item--highlight" if item[:highlight] %>
-
       <li class="gem-c-document-list__item<%= within_multitype_list_class %> <%= brand_helper.brand_class %> <%= highlight_class %>">
         <% if item[:highlight] && item[:highlight_text] %>
           <p class='gem-c-document-list__highlight-text'><%= item[:highlight_text] %></p>
@@ -71,6 +70,37 @@
 
         <% if item[:subtext] %>
           <p class="gem-c-document-list__subtext"><%= item[:subtext] %></p>
+        <% end %>
+        
+        <% if item.include?(:parts) && item[:parts].any? %>
+          <ul class="gem-c-document-list__children govuk-list">
+            <% item[:parts].each do |part| %>
+              <li class="gem-c-document-list-child">
+                <%=
+                  item_classes = "gem-c-document-list-child__heading #{brand_helper.color_class}"
+
+                  if part[:link][:path]
+                    link_to(
+                      part[:link][:text],
+                      part[:link][:path],
+                      data: part[:link][:data_attributes],
+                      class: "#{item_classes} gem-c-document-list-child__link",
+                    )
+                  else
+                    content_tag(
+                      "span",
+                      part[:link][:text],
+                      data: part[:link][:data_attributes],
+                      class: "gem-c-document-list-child__heading", 
+                    )
+                  end
+                %>
+                <% if part[:link][:description] %>
+                  <p class="gem-c-document-list-child__description"><%= part[:link][:description] %></p>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
         <% end %>
       </li>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -236,3 +236,30 @@ examples:
           document_type: 'Organisation'
     context:
       right_to_left: true
+  with_parts:
+    description: Display child items, such as parts of guides or travel advice. Child items accept the same paramaters as parent items.
+    data:
+      items:
+      - link:
+          text: 'Universal credit'
+          path: '/universal-credit'
+          description: 'Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare'
+        parts:
+        - link:
+            text: 'What universal credit is'
+            path: '/universal-credit/what-it-is'
+            description: 'Universal Credit is a payment to help with your living costs. It’s paid monthly - or twice a month for some people in Scotland.'
+        - link:
+            text: 'Elegibility'
+            path: '/universal-credit/eligibility'
+            description: 'You may be able to get Universal Credit if: you’re on a low income or out...'
+            data_attributes:
+              track_category: 'resultPart'
+              track_action: 2
+              track_label: 'Result part 2'
+              track_options:
+                dimension82: 2
+        - link:
+            text: 'Criteria'
+            description: 'no url provided, just text'
+  

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -262,4 +262,3 @@ examples:
         - link:
             text: 'Criteria'
             description: 'no url provided, just text'
-  

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -295,29 +295,29 @@ describe "Document list", type: :view do
           link: {
             text: "Universal credit",
             path: "/universal-credit",
-            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare"
+            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare",
           },
           parts: [
             {
               link: {
                 text: "What universal credit is",
                 path: "/universal-credit/what-it-is",
-                description: "Universal Credit is a payment to help with your living costs. It’s paid monthly - or twice a month for some people in Scotland."
-              }
+                description: "Universal Credit is a payment to help with your living costs. It’s paid monthly - or twice a month for some people in Scotland.",
+              },
             },
             {
               link: {
                 text: "Elegibility",
                 path: "/universal-credit/eligibility",
                 description: "You may be able to get Universal Credit if: you’re on a low income or out...",
-              }
-            }
-          ]
-        }
-      ]
+              },
+            },
+          ],
+        },
+      ],
     )
 
-    assert_select '.gem-c-document-list__item .gem-c-document-list-child', count: 2
+    assert_select ".gem-c-document-list__item .gem-c-document-list-child", count: 2
   end
 
   it "adds branding to document part link correctly" do
@@ -328,22 +328,22 @@ describe "Document list", type: :view do
           link: {
             text: "Universal credit",
             path: "/universal-credit",
-            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare"
+            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare",
           },
           parts: [
             {
               link: {
                 text: "What universal credit is",
                 path: "/universal-credit/what-it-is",
-                description: "Universal Credit is a payment to help with your living costs. It’s paid monthly - or twice a month for some people in Scotland."
-              }
-            }
-          ]
-        }
-      ]
+                description: "Universal Credit is a payment to help with your living costs. It’s paid monthly - or twice a month for some people in Scotland.",
+              },
+            },
+          ],
+        },
+      ],
     )
 
-    assert_select '.gem-c-document-list .gem-c-document-list-child__link.brand__color'
+    assert_select ".gem-c-document-list .gem-c-document-list-child__link.brand__color"
   end
 
   it "renders document part without link" do
@@ -353,18 +353,18 @@ describe "Document list", type: :view do
           link: {
             text: "Universal credit",
             path: "/universal-credit",
-            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare"
+            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare",
           },
           parts: [
             {
               link: {
                 text: "Criteria",
-                description: "no url provided, just text"
-              }
-            }
-          ]
-        }
-      ]
+                description: "no url provided, just text",
+              },
+            },
+          ],
+        },
+      ],
     )
 
     assert_select ".gem-c-document-list span.gem-c-document-list-child__heading", text: "Criteria"
@@ -377,22 +377,22 @@ describe "Document list", type: :view do
           link: {
             text: "Universal credit",
             path: "/universal-credit",
-            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare"
+            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare",
           },
           parts: [
             {
               link: {
                 text: "What universal credit is",
                 path: "/universal-credit/what-it-is",
-                description: "Universal Credit is a payment to help with your living costs. It’s paid monthly - or twice a month for some people in Scotland."
-              }
-            }
-          ]
-        }
-      ]
+                description: "Universal Credit is a payment to help with your living costs. It’s paid monthly - or twice a month for some people in Scotland.",
+              },
+            },
+          ],
+        },
+      ],
     )
 
-    assert_select '.gem-c-document-list__item .gem-c-document-list-child__description', text: "Universal Credit is a payment to help with your living costs. It’s paid monthly - or twice a month for some people in Scotland."
+    assert_select ".gem-c-document-list__item .gem-c-document-list-child__description", text: "Universal Credit is a payment to help with your living costs. It’s paid monthly - or twice a month for some people in Scotland."
   end
 
   it "renders document part with link tracking" do
@@ -402,7 +402,7 @@ describe "Document list", type: :view do
           link: {
             text: "Universal credit",
             path: "/universal-credit",
-            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare"
+            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare",
           },
           parts: [
             {
@@ -415,14 +415,14 @@ describe "Document list", type: :view do
                   track_action: 1,
                   track_label: "part 1",
                   track_options: {
-                    dimension82: 1
-                  }
-                }
-              }
-            }
-          ]
-        }
-      ]
+                    dimension82: 1,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
     )
 
     link = ".gem-c-document-list-child__link"

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -287,4 +287,150 @@ describe "Document list", type: :view do
     assert_select ".gem-c-document-list__item:nth-child(1) .gem-c-document-list__highlight-text", text: "Most relevant result"
     assert_select ".gem-c-document-list__item:nth-child(2) .gem-c-document-list__highlight-text", false
   end
+
+  it "renders document parts if available" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Universal credit",
+            path: "/universal-credit",
+            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare"
+          },
+          parts: [
+            {
+              link: {
+                text: "What universal credit is",
+                path: "/universal-credit/what-it-is",
+                description: "Universal Credit is a payment to help with your living costs. It’s paid monthly - or twice a month for some people in Scotland."
+              }
+            },
+            {
+              link: {
+                text: "Elegibility",
+                path: "/universal-credit/eligibility",
+                description: "You may be able to get Universal Credit if: you’re on a low income or out...",
+              }
+            }
+          ]
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list__item .gem-c-document-list-child', count: 2
+  end
+
+  it "adds branding to document part link correctly" do
+    render_component(
+      brand: "attorney-generals-office",
+      items: [
+        {
+          link: {
+            text: "Universal credit",
+            path: "/universal-credit",
+            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare"
+          },
+          parts: [
+            {
+              link: {
+                text: "What universal credit is",
+                path: "/universal-credit/what-it-is",
+                description: "Universal Credit is a payment to help with your living costs. It’s paid monthly - or twice a month for some people in Scotland."
+              }
+            }
+          ]
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list .gem-c-document-list-child__link.brand__color'
+  end
+
+  it "renders document part without link" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Universal credit",
+            path: "/universal-credit",
+            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare"
+          },
+          parts: [
+            {
+              link: {
+                text: "Criteria",
+                description: "no url provided, just text"
+              }
+            }
+          ]
+        }
+      ]
+    )
+
+    assert_select ".gem-c-document-list span.gem-c-document-list-child__heading", text: "Criteria"
+  end
+
+  it "renders document part description" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Universal credit",
+            path: "/universal-credit",
+            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare"
+          },
+          parts: [
+            {
+              link: {
+                text: "What universal credit is",
+                path: "/universal-credit/what-it-is",
+                description: "Universal Credit is a payment to help with your living costs. It’s paid monthly - or twice a month for some people in Scotland."
+              }
+            }
+          ]
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list__item .gem-c-document-list-child__description', text: "Universal Credit is a payment to help with your living costs. It’s paid monthly - or twice a month for some people in Scotland."
+  end
+
+  it "renders document part with link tracking" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Universal credit",
+            path: "/universal-credit",
+            description: "Universal Credit is replacing 6 other benefits with a single monthly payment if you are out of work or on a low income - eligibility, how to prepare"
+          },
+          parts: [
+            {
+              link: {
+                text: "Elegibility",
+                path: "/universal-credit/eligibility",
+                description: "You may be able to get Universal Credit if: you’re on a low income or out...",
+                data_attributes: {
+                  track_category: "part",
+                  track_action: 1,
+                  track_label: "part 1",
+                  track_options: {
+                    dimension82: 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    )
+
+    link = ".gem-c-document-list-child__link"
+
+    assert_select "#{link}[href='/universal-credit/eligibility']", text: "Elegibility"
+    assert_select "#{link}[data-track-category='part']", text: "Elegibility"
+    assert_select "#{link}[data-track-action='1']", text: "Elegibility"
+    assert_select "#{link}[data-track-label='part 1']", text: "Elegibility"
+    assert_select "#{link}[data-track-options='{\"dimension82\":1}']", text: "Elegibility"
+  end
 end


### PR DESCRIPTION
## What

Extend the document-list component to allow parts of documents to be displayed.

Some documents such as guides and travel advice contain parts.
This extends the document-list component to display those parts. 

## Why
In finder-frontend we're testing with users showing [document parts in search results](https://github.com/alphagov/finder-frontend/pull/1877). 

For the test we vendored-in the component and extended it and this is upstreaming the change.

## Visual Changes

The layout uses grid at desktop, if grid isn't supported the parts are collapsed into a list like structure.

**Desktop:**
<img width="848" alt="Screenshot 2020-03-06 at 14 58 48" src="https://user-images.githubusercontent.com/861310/76094854-38853b00-5fbb-11ea-8b84-80670a5b0caa.png">

**Tablet:**
<img width="697" alt="Screenshot 2020-03-06 at 14 58 56" src="https://user-images.githubusercontent.com/861310/76094867-3d49ef00-5fbb-11ea-8da4-eacd3dc32491.png">

**Mobile:**
<img width="402" alt="Screenshot 2020-03-06 at 14 59 04" src="https://user-images.githubusercontent.com/861310/76094873-41760c80-5fbb-11ea-8b4b-8d1cd589c730.png">

**With branding:**
<img width="390" alt="Screenshot 2020-03-06 at 15 00 16" src="https://user-images.githubusercontent.com/861310/76094888-48048400-5fbb-11ea-842d-f64c2c2b5d18.png">
