### PR TITLE
Version 21.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.26.2
 
 * Streamline feedback component ([PR #1327](https://github.com/alphagov/govuk_publishing_components/pull/1327))
 * Dont show breadcrumb item with no url ([PR #1324](https://github.com/alphagov/govuk_publishing_components/pull/1324))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.26.1)
+    govuk_publishing_components (21.26.2)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.26.1'.freeze
+  VERSION = '21.26.2'.freeze
 end


### PR DESCRIPTION
* Streamline feedback component ([PR #1327](https://github.com/alphagov/govuk_publishing_components/pull/1327))
* Dont show breadcrumb item with no url ([PR #1324](https://github.com/alphagov/govuk_publishing_components/pull/1324))
