### PR TITLE
Fix feedback component tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove font_size option on contents list ([PR #1325](https://github.com/alphagov/govuk_publishing_components/pull/1325))
+* Fix feedback component tests ([PR #1329](https://github.com/alphagov/govuk_publishing_components/pull/1329))
 
 ## 21.26.2
 

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -208,9 +208,11 @@ describe('Feedback component', function () {
 
     it('focusses the first field in the form', function () {
       loadFeedbackComponent()
+      var $input = $('#page-is-not-useful .gem-c-input')[0]
+      spyOn($input, 'focus')
       $('a.js-page-is-not-useful').click()
 
-      expect(document.activeElement).toBe($('#page-is-not-useful .gem-c-input').get(0))
+      expect($input.focus).toHaveBeenCalled()
     })
 
     it('triggers a Google Analytics event', function () {
@@ -259,9 +261,11 @@ describe('Feedback component', function () {
 
     it('focusses the first field in the form', function () {
       loadFeedbackComponent()
+      var $input = $('#something-is-wrong .gem-c-input')[0]
+      spyOn($input, 'focus')
       $('a.js-something-is-wrong').click()
 
-      expect(document.activeElement).toBe($('#something-is-wrong .gem-c-input').get(0))
+      expect($input.focus).toHaveBeenCalled()
     })
 
     it('triggers a Google Analytics event', function () {
@@ -619,6 +623,8 @@ describe('Feedback component', function () {
 
     it('focusses the error message', function () {
       loadFeedbackComponent()
+      var $input = $('#something-is-wrong .js-errors')[0]
+      spyOn($input, 'focus')
       fillAndSubmitSomethingIsWrongForm()
 
       jasmine.Ajax.requests.mostRecent().respondWith({
@@ -627,8 +633,7 @@ describe('Feedback component', function () {
         responseText: '{}'
       })
 
-      var $shouldBe = $('#something-is-wrong .js-errors').get(0)
-      expect(document.activeElement).toBe($shouldBe)
+      expect($input.focus).toHaveBeenCalled()
     })
   })
 
@@ -688,6 +693,8 @@ describe('Feedback component', function () {
 
     it('focusses the generic error', function () {
       loadFeedbackComponent()
+      var $input = $('#page-is-not-useful .js-errors')[0]
+      spyOn($input, 'focus')
       fillAndSubmitPageIsNotUsefulForm()
 
       jasmine.Ajax.requests.mostRecent().respondWith({
@@ -696,7 +703,7 @@ describe('Feedback component', function () {
         responseText: '{"errors": {"path": ["can\'t be blank"], "description": ["can\'t be blank"]}}'
       })
 
-      expect(document.activeElement).toBe($('#page-is-not-useful .js-errors').get(0))
+      expect($input.focus).toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
## What
- there are several tests in the feedback component to check that when parts of the component are interacted with specific inputs or error messages receive focus
- these tests were failing intermittently, despite not having changed recently
- unsure of the cause of this, but the result was that the body was focussed and not the intended input
- changing the tests to check that focus is called on the correct elements instead of checking to see what the activeElement is seems to work

## Why
These errors have been causing builds to fail for days. Hopefully this has fixed them.

## Visual Changes
None.
