### PR TITLE
Make breadcrumb component more flexible to support different uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 * Remove font_size option on contents list ([PR #1325](https://github.com/alphagov/govuk_publishing_components/pull/1325))
 * Fix feedback component tests ([PR #1329](https://github.com/alphagov/govuk_publishing_components/pull/1329))
+* Revert 'Dont show breadcrumb item with no url' ([PR #1330](https://github.com/alphagov/govuk_publishing_components/pull/1330))
+* Make breadcrumb collapsing behaviour opt-in and provide `collapse_on_mobile` flag ([PR #1330](https://github.com/alphagov/govuk_publishing_components/pull/1330))
 
 ## 21.26.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -21,36 +21,37 @@
   border-color: govuk-colour("white");
 }
 
-@include govuk-media-query($until: tablet) {
+.gem-c-breadcrumbs--collapse-on-mobile {
+  @include govuk-media-query($until: tablet) {
+    .govuk-breadcrumbs__list {
+      display: flex;
+    }
 
-  .govuk-breadcrumbs__list {
-    display: flex;
-  }
+    .govuk-breadcrumbs__list-item:not(:last-child):not(:first-child) {
+      display: none;
+    }
 
-  .govuk-breadcrumbs__list-item:not(:last-child):not(:first-child) {
-    display: none;
-  }
+    .govuk-breadcrumbs__list-item {
+      padding-top: 14px;
+      padding-bottom: 14px;
+    }
 
-  .govuk-breadcrumbs__list-item {
-    padding-top: 14px;
-    padding-bottom: 14px;
-  }
+    .govuk-breadcrumbs__list-item:before {
+      margin: 0;
+      top: 18px;
+    }
 
-  .govuk-breadcrumbs__list-item:before {
-    margin: 0;
-    top: 18px;
-  }
+    .govuk-breadcrumbs__link {
+      position: relative;
+    }
 
-  .govuk-breadcrumbs__link {
-    position: relative;
-  }
-
-  .govuk-breadcrumbs__link::after {
-    content: "";
-    position: absolute;
-    top: -14px;
-    right: 0;
-    left: 0;
-    bottom: -14px;
+    .govuk-breadcrumbs__link::after {
+      content: "";
+      position: absolute;
+      top: -14px;
+      right: 0;
+      left: 0;
+      bottom: -14px;
+    }
   }
 }

--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -1,15 +1,19 @@
 <%
   breadcrumbs ||= []
   inverse ||= false
-  invert_class = inverse ? "gem-c-breadcrumbs--inverse" : ""
+  collapse_on_mobile ||= false
   breadcrumb_presenter = GovukPublishingComponents::Presenters::Breadcrumbs.new(breadcrumbs)
+
+  classes = "gem-c-breadcrumbs govuk-breadcrumbs"
+  classes << " gem-c-breadcrumbs--collapse-on-mobile" if collapse_on_mobile
+  classes << " gem-c-breadcrumbs--inverse" if inverse
 %>
 
 <script type="application/ld+json">
   <%= raw breadcrumb_presenter.structured_data.to_json %>
 </script>
 
-<div class="gem-c-breadcrumbs govuk-breadcrumbs <%= invert_class %>" data-module="track-click">
+<div class="<%= classes %>" data-module="track-click">
   <ol class="govuk-breadcrumbs__list">
     <% breadcrumbs.each_with_index do |crumb, index| %>
       <% breadcrumb = GovukPublishingComponents::Presenters::Breadcrumb.new(crumb, index) %>

--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -17,19 +17,21 @@
   <ol class="govuk-breadcrumbs__list">
     <% breadcrumbs.each_with_index do |crumb, index| %>
       <% breadcrumb = GovukPublishingComponents::Presenters::Breadcrumb.new(crumb, index) %>
+        <li class="govuk-breadcrumbs__list-item" aria-current="<%= breadcrumb.aria_current %>">
         <% if breadcrumb.is_link? %>
-          <li class="govuk-breadcrumbs__list-item" aria-current="<%= breadcrumb.aria_current %>">
-              <%= link_to(
-                breadcrumb[:title],
-                breadcrumb.path,
-                data: breadcrumb.tracking_data(breadcrumbs.length),
-                class: "govuk-breadcrumbs__link",
-                aria: {
-                  current: breadcrumb.aria_current,
-                }
-              ) %>
-          </li>
+          <%= link_to(
+            breadcrumb[:title],
+            breadcrumb.path,
+            data: breadcrumb.tracking_data(breadcrumbs.length),
+            class: "govuk-breadcrumbs__link",
+            aria: {
+              current: breadcrumb.aria_current,
+            }
+          ) %>
+        <% else %>
+          <%= breadcrumb[:title] %>
         <% end %>
+        </li>
     <% end %>
   </ol>
 </div>

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -1,6 +1,7 @@
 <% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request) %>
 <% prioritise_taxon_breadcrumbs ||= false %>
 <% inverse ||= false %>
+<% collapse_on_mobile ||= true unless local_assigns[:collapse_on_mobile].eql?(false) %>
 
 <div class='gem-c-contextual-breadcrumbs'>
   <% if navigation.content_tagged_to_current_step_by_step? %>
@@ -9,27 +10,29 @@
       navigation.step_nav_helper.header %>
   <% elsif navigation.content_tagged_to_a_finder? %>
     <%# Rendering finder breadcrumbs because the page is tagged to a finder %>
-    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs, inverse: inverse %>
+    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs, inverse: inverse, collapse_on_mobile: collapse_on_mobile %>
   <% elsif navigation.content_is_tagged_to_a_live_taxon? && prioritise_taxon_breadcrumbs %>
     <%# Rendering taxonomy breadcrumbs because the page is tagged to live taxons
           and we want to prioritise them over all other breadcrumbs %>
     <%= render 'govuk_publishing_components/components/breadcrumbs',
                breadcrumbs: navigation.taxon_breadcrumbs[:breadcrumbs],
-               inverse: inverse %>
+               inverse: inverse,
+               collapse_on_mobile: collapse_on_mobile %>
   <% elsif navigation.content_tagged_to_mainstream_browse_pages? %>
     <%# Rendering parent-based breadcrumbs because the page is tagged to mainstream browse %>
-    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs, inverse: inverse %>
+    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs, inverse: inverse, collapse_on_mobile: collapse_on_mobile %>
   <% elsif navigation.content_has_curated_related_items? %>
     <%# Rendering parent-based breadcrumbs because the page has curated related links %>
-    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs, inverse: inverse %>
+    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs, inverse: inverse, collapse_on_mobile: collapse_on_mobile %>
   <% elsif navigation.content_is_tagged_to_a_live_taxon? && !navigation.content_is_a_specialist_document? %>
     <%# Rendering taxonomy breadcrumbs because the page is tagged to live taxons %>
     <%= render 'govuk_publishing_components/components/breadcrumbs',
       breadcrumbs: navigation.taxon_breadcrumbs[:breadcrumbs],
-      inverse: inverse %>
+      inverse: inverse,
+      collapse_on_mobile: collapse_on_mobile %>
   <% elsif navigation.breadcrumbs.any? %>
     <%# Rendering parent-based breadcrumbs because no browse, no related links, no live taxons %>
-    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs, inverse: inverse %>
+    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: navigation.breadcrumbs, inverse: inverse, collapse_on_mobile: collapse_on_mobile %>
   <% else %>
     <%# Not rendering any breadcrumbs because there aren't any %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
@@ -4,7 +4,7 @@ body: |
   Accepts an array of breadcrumb objects. Each crumb must have a title and a URL.
   Links have tracking data but links to the homepage (any link with a url of "/") will be tracked separately as `homeLinkClicked`
 
-  Note: Only the first and last (or parent) item in the breadcrumb will be displayed when the page width is less than the "tablet" govuk-breakpoint.
+   We recommend that if using the breadcrumbs for navigation purposes, you set collapse_on_mobile to true to make things more readable for mobile users. However, you can specify `collapse_on_mobile`:`false` or remove the flag completely to stop this behaviour.
 shared_accessibility_criteria:
   - link
 accessibility_criteria:
@@ -16,6 +16,7 @@ display_html: true
 examples:
   default:
     data:
+      collapse_on_mobile: true
       breadcrumbs:
       - title: 'Section'
         url: '/section'
@@ -24,6 +25,7 @@ examples:
   inverse:
     description: On a dark background, such as the header of topic pages
     data:
+      collapse_on_mobile: true
       breadcrumbs:
       - title: 'Section'
         url: '/section'
@@ -35,14 +37,17 @@ examples:
       dark_background: true
   no_breadcrumbs:
     data:
+      collapse_on_mobile: true
       breadcrumbs: []
   single_section:
     data:
+      collapse_on_mobile: true
       breadcrumbs:
       - title: 'Section'
         url: '/section'
   many_breadcrumbs:
     data:
+      collapse_on_mobile: true
       breadcrumbs:
       - title: 'Home'
         url: '/'
@@ -54,6 +59,7 @@ examples:
         url: '/section/sub-section/sub-sub-section'
   no_home:
     data:
+      collapse_on_mobile: true
       breadcrumbs:
       - title: 'Service Manual'
         url: '/service-manual'
@@ -61,6 +67,7 @@ examples:
         url: '/service-manual/agile-delivery'
   real:
     data:
+      collapse_on_mobile: true
       breadcrumbs:
       - title: 'Home'
         url: '/'
@@ -68,9 +75,10 @@ examples:
         url: '/browse/abroad'
       - title: 'Travel abroad'
         url: '/browse/abroad/travel-abroad'
-  long_taxon_on_mobile:
-    description: This is an example of a breadcrumb (specifically for mobile) with long taxons on the the parent item and a greater touch target area
+  long_taxon:
+    description: This is an example of a breadcrumb with long taxons to demonstrate the wrapping behaviour and touch target area on mobile
     data:
+      collapse_on_mobile: true
       breadcrumbs:
       - title: 'Home'
         url: '/'
@@ -78,3 +86,14 @@ examples:
         url: '/education'
       - title: 'Education of disadvantaged children appended with some extra long content to make this a very very very very long taxon'
         url: '/education'
+  stop_collapsing_on_mobile:
+    description: We recommend that if using the breadcrumbs for navigation purposes, you set collapse_on_mobile to true to make things more readable for mobile users. However, you can specify `collapse_on_mobile`:`false` or remove the flag completely to stop this behaviour.
+    data:
+      collapse_on_mobile: false
+      breadcrumbs:
+      - title: 'Home'
+        url: '/'
+      - title: 'Passports, travel and living abroad'
+        url: '/browse/abroad'
+      - title: 'Travel abroad'
+        url: '/browse/abroad/travel-abroad'

--- a/spec/components/breadcrumbs_spec.rb
+++ b/spec/components/breadcrumbs_spec.rb
@@ -128,14 +128,17 @@ describe "Breadcrumbs", type: :view do
     assert_select ".gem-c-breadcrumbs--inverse"
   end
 
-  it "ignore breadcrumb items without url" do
+  it "renders breadcrumb items without link as text" do
     render_component(
       breadcrumbs: [
         { title: 'Topic', url: '/topic' },
         { title: 'Current Page' },
       ]
     )
-    assert_select('.govuk-breadcrumbs__list-item:last-child', 'Topic')
+
+    assert_link_with_text_in('.govuk-breadcrumbs__list-item:first-child', '/topic', 'Topic')
+    assert_select('.govuk-breadcrumbs__list-item:last-child', 'Current Page')
+    assert_select('.govuk-breadcrumbs__list-item:last-child a', false)
   end
 
   it "collapses on mobile if passed a flag" do

--- a/spec/components/breadcrumbs_spec.rb
+++ b/spec/components/breadcrumbs_spec.rb
@@ -137,4 +137,14 @@ describe "Breadcrumbs", type: :view do
     )
     assert_select('.govuk-breadcrumbs__list-item:last-child', 'Topic')
   end
+
+  it "collapses on mobile if passed a flag" do
+    render_component(collapse_on_mobile: true, breadcrumbs: [
+        { title: 'Home', url: '/' },
+        { title: 'Section', url: '/section' },
+        { title: 'Sub-section', url: '/sub-section' },
+      ])
+
+    assert_select('.gem-c-breadcrumbs.govuk-breadcrumbs.gem-c-breadcrumbs--collapse-on-mobile')
+  end
 end

--- a/spec/components/contextual_breadcrumbs_spec.rb
+++ b/spec/components/contextual_breadcrumbs_spec.rb
@@ -31,6 +31,24 @@ describe "ContextualBreadcrumbs", type: :view do
     content_item
   end
 
+  it "renders breadcrumbs that collapse on mobile by default" do
+    content_item = example_document_for("guide", "guide")
+    content_item = remove_mainstream_browse(content_item)
+    content_item = remove_curated_related_item(content_item)
+    content_item = set_live_taxons(content_item)
+    render_component(content_item: content_item)
+    assert_select ".gem-c-breadcrumbs.gem-c-breadcrumbs--collapse-on-mobile"
+  end
+
+  it "renders breadcrumbs that don't collapse on mobile if flag is passed" do
+    content_item = example_document_for("guide", "guide")
+    content_item = remove_mainstream_browse(content_item)
+    content_item = remove_curated_related_item(content_item)
+    content_item = set_live_taxons(content_item)
+    render_component(content_item: content_item, collapse_on_mobile: false)
+    assert_select ".gem-c-breadcrumbs.gem-c-breadcrumbs--collapse-on-mobile", false
+  end
+
   it "renders step by step breadcrumbs and step by step header if the content item is tagged to step by step" do
     render_component(content_item: example_document_for("guide", "guide-with-step-navs"))
     assert_select(".gem-c-step-nav-header")


### PR DESCRIPTION
## What

- Revert default breadcrumb behaviour back to non-collapsing on mobile
- Adds a `collapse_on_mobile` flag. This defaults to false, but it is recommended that anyone using the breadcrumbs for navigation sets this to true.
- Set collapse_on_mobile to true in the contextual breadcrumbs component
- Reverts [#1324](https://github.com/alphagov/govuk_publishing_components/pull/1324) to allow breadcrumb items without URLs.
- Mobile touch targets only apply if `collapse_on_mobile` is set to true. We can look at fixing this in the future, but I think it will need some design work.

<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
As discussed in https://github.com/alphagov/govuk_publishing_components/pull/1324 , we had missed some use cases for this component and our changes essentially broke this component for them.

My original approach was to introduce a `collapse_on_mobile` flag defaulting to true (opt-out approach). However, this may have caused problems if contributing the change to the design system which would probably have to be an opt-in approach.

Final approach is reverting default behaviour back to non-collapsing behaviour on mobile. This can be switched on with the `collapse_on_mobile` flag. This is a little bit more work as we will need to identify all breadcrumb uses and update the apps to use this flag, but means this is not a breaking change and should make contributing the change to the design system easier.

## Visual Changes
## collapse_on_mobile set to true
<img width="181" alt="Screenshot 2020-02-27 at 19 50 32" src="https://user-images.githubusercontent.com/29889908/75481122-74f0df80-599a-11ea-8717-074a80db1ac1.png">

## collapse_on_mobile set to false (or removed)
<img width="296" alt="Screenshot 2020-02-27 at 19 50 43" src="https://user-images.githubusercontent.com/29889908/75481145-7c17ed80-599a-11ea-90b4-1a585ae1a4a6.png">

https://govuk-publis-provide-br-aju5m4.herokuapp.com/component-guide/breadcrumbs