### PR TITLE
Remove redundant components import

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/component_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/component_support.scss
@@ -3,7 +3,6 @@
 // and everything else from govuk-frontend not included in govuk_frontend_support
 @import "govuk/core/all";
 @import "govuk/objects/all";
-@import "govuk/components/all";
 @import "govuk/utilities/all";
 @import "govuk/overrides/all";
 


### PR DESCRIPTION
## What
Remove `govuk/components/all` from `component_support`.

## Why
We already import styles for components [in each individual file](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss#L1) so adding them in the `component_support` again inflates the scss and increased the compilation time unnecessarily.

## Visual Changes
TBD
