### PR TITLE
Version 21.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.27.0
 
 * Remove font_size option on contents list ([PR #1325](https://github.com/alphagov/govuk_publishing_components/pull/1325))
 * Fix feedback component tests ([PR #1329](https://github.com/alphagov/govuk_publishing_components/pull/1329))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.26.2)
+    govuk_publishing_components (21.27.0)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = '21.26.2'.freeze
+  VERSION = '21.27.0'.freeze
 end


### PR DESCRIPTION
Includes:

* Remove font_size option on contents list ([PR #1325](https://github.com/alphagov/govuk_publishing_components/pull/1325))
* Fix feedback component tests ([PR #1329](https://github.com/alphagov/govuk_publishing_components/pull/1329))
* Revert 'Dont show breadcrumb item with no url' ([PR #1330](https://github.com/alphagov/govuk_publishing_components/pull/1330))
* Make breadcrumb collapsing behaviour opt-in and provide `collapse_on_mobile` flag ([PR #1330](https://github.com/alphagov/govuk_publishing_components/pull/1330))