### PR TITLE
Fix handling of `on_govuk_blue` parameter value in the search component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix handling of `on_govuk_blue` parameter value in the search component ([PR #1334](https://github.com/alphagov/govuk_publishing_components/pull/1334))
+
 ## 21.27.0
 
 * Remove font_size option on contents list ([PR #1325](https://github.com/alphagov/govuk_publishing_components/pull/1325))

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -1,6 +1,6 @@
 <%
   class_name = "gem-c-search--on-white"
-  class_name = "gem-c-search--on-govuk-blue" if local_assigns.include?(:on_govuk_blue)
+  class_name = "gem-c-search--on-govuk-blue" if local_assigns[:on_govuk_blue].eql?(true)
   size ||= ""
   class_name = "#{class_name} gem-c-search--large" if size == 'large'
   class_name = "#{class_name} gem-c-search--separate-label" if local_assigns.include?(:inline_label)

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -15,6 +15,11 @@ describe "Search", type: :view do
     assert_select ".gem-c-search.gem-c-search--on-govuk-blue"
   end
 
+  it "doesn't render a search box for a dark background if the parameter is invalid" do
+    render_component(on_govuk_blue: 'dummy')
+    assert_select ".gem-c-search.gem-c-search--on-govuk-blue", false
+  end
+
   it "renders a search box with a custom label text" do
     render_component(label_text: "This is my new label")
     assert_select ".gem-c-search .gem-c-search__label", text: "This is my new label"


### PR DESCRIPTION
## What

Check for `true` (boolean) value for `on_govuk_blue` parameter.

We used to check only if the parameter exist, not its value.
This made it difficult to conditionally toggle classes.

Now we check it the local_assign value is `true` before we add `gem-c-search--on-govuk-blue` CSS class to the component.


## Why
In finder-frontend we're looking to unify the page templates and we have scenarios where the search box will appear on either a white or blue background. At the moment the search component renders will appropriate classes as soon as `on_govuk_blue` local parameter is present without checking for `true`, which means we cannot alternate the appearance

## Visual Changes
No visual changes
