### PR TITLE
Tweak pagination component spacing and add border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## ## 21.27.1
+## Unreleased
+
+* Tweak pagination component spacing and add border ([PR #1337](https://github.com/alphagov/govuk_publishing_components/pull/1337))
+
+## 21.27.1
 
 * Fix handling of `on_govuk_blue` parameter value in the search component ([PR #1334](https://github.com/alphagov/govuk_publishing_components/pull/1334))
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
@@ -1,6 +1,6 @@
 .gem-c-pagination {
   display: block;
-  margin: govuk-spacing(6) (- govuk-spacing(3) );
+  margin: govuk-spacing(8) 0;
 }
 
 .gem-c-pagination__list {
@@ -11,13 +11,17 @@
 .gem-c-pagination__item {
   @include govuk-font($size: 16, $line-height: (20 / 16));
   list-style: none;
+
+  &:first-child {
+    margin-bottom: govuk-spacing(4);
+  }
 }
 
 .gem-c-pagination__link {
   @extend %govuk-link;
   display: block;
-  padding: govuk-spacing(3);
   text-decoration: none;
+  padding-bottom: govuk-spacing(4);
 
   &:hover,
   &:active,
@@ -37,6 +41,7 @@
 
 .gem-c-pagination__link-title {
   display: block;
+  padding-top: govuk-spacing(3);
 }
 
 .gem-c-pagination__link-divider {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
@@ -36,11 +36,16 @@
 
   &:focus {
     @include govuk-focused-text;
+
+    .gem-c-pagination__link-title {
+      border-top-color: transparent;
+    }
   }
 }
 
 .gem-c-pagination__link-title {
   display: block;
+  border-top: 1px solid $govuk-border-colour;
   padding-top: govuk-spacing(3);
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
@@ -40,6 +40,10 @@
     .gem-c-pagination__link-title {
       border-top-color: transparent;
     }
+
+    .gem-c-pagination__link-icon {
+      fill: $govuk-text-colour;
+    }
   }
 }
 
@@ -64,6 +68,7 @@
   margin-bottom: 1px;
   height: .482em;
   width: .63em;
+  fill: govuk-colour("dark-grey");
 }
 
 .gem-c-pagination__link-label {

--- a/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
@@ -18,7 +18,7 @@
         >
           <span class="gem-c-pagination__link-title">
             <svg class="gem-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-              <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"/>
+              <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"/>
             </svg>
             <span class="gem-c-pagination__link-text">
               <%= previous_page[:title] %>
@@ -44,7 +44,7 @@
         >
           <span class="gem-c-pagination__link-title">
             <svg class="gem-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-              <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"/>
+              <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"/>
             </svg>
             <span class="gem-c-pagination__link-text">
               <%= next_page[:title] %>


### PR DESCRIPTION
Trello: https://trello.com/c/4ZsqNg3r/11-layout-improve-previous-and-next-navigation-component-on-mobile

## What
This PR makes the following changes to the pagination (previous and next) component:

- Increase spacing above and below the component
- Increase spacing between previous and next links
- Add border-top to links

Changes made as per the [design doc](https://docs.google.com/document/d/1ryu7LdOiJdKGqG_lUZOwDPOpLpSNw0MVAGaWx6ocmuw/edit#)

<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
The pagination component needs to be a separate and distinct section of the page. These changes help separate the component from the rest of the page content. The spacing and border changes also add clearer separation between the previous and next links themselves.

## Before
<img width="936" alt="Screenshot 2020-03-03 at 11 00 56" src="https://user-images.githubusercontent.com/29889908/75769573-509c5680-5d3e-11ea-92f1-dcd9672f2828.png">
<img width="948" alt="Screenshot 2020-03-03 at 11 01 30" src="https://user-images.githubusercontent.com/29889908/75769602-601b9f80-5d3e-11ea-8ebe-015c7e717541.png">

## After
<img width="929" alt="Screenshot 2020-03-03 at 11 00 52" src="https://user-images.githubusercontent.com/29889908/75769550-47ab8500-5d3e-11ea-97e0-34b21241ad88.png">
<img width="933" alt="Screenshot 2020-03-03 at 11 01 36" src="https://user-images.githubusercontent.com/29889908/75769608-63af2680-5d3e-11ea-97bb-b9003768f2eb.png">

## In context on a page (before vs after)
### Without label
<img width="658" alt="Screenshot 2020-03-03 at 11 11 55" src="https://user-images.githubusercontent.com/29889908/75770562-116f0500-5d40-11ea-81eb-11d1ad85658c.png">
<img width="653" alt="Screenshot 2020-03-03 at 11 10 46" src="https://user-images.githubusercontent.com/29889908/75770564-12079b80-5d40-11ea-98a8-c64d4df5e1fe.png">

### With label
<img width="574" alt="Screenshot 2020-03-03 at 11 21 31" src="https://user-images.githubusercontent.com/29889908/75771094-28fabd80-5d41-11ea-88c8-6a0ef81fe4fd.png">
<img width="648" alt="Screenshot 2020-03-03 at 11 20 54" src="https://user-images.githubusercontent.com/29889908/75771097-29935400-5d41-11ea-9f88-da6969b757f6.png">
