### PR TITLE
Update govspeak button styles again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Make feedback component more responsive and usable on mobile ([PR #1346](https://github.com/alphagov/govuk_publishing_components/pull/1346))
 * Extend document-list component to show parts of a document ([PR #1326](https://github.com/alphagov/govuk_publishing_components/pull/1326))
+* Update govspeak button styles again ([PR #1342](https://github.com/alphagov/govuk_publishing_components/pull/1342))
 
 ## 21.28.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
@@ -3,13 +3,10 @@
 // scss-lint:disable PlaceholderInExtend
 // sass-lint:disable placeholder-in-extend
 .gem-c-govspeak {
-  .button,
-  .govuk-button,
   .gem-c-button {
     @extend .govuk-button;
   }
 
-  .button-start,
   .govuk-button--start {
     @extend .govuk-button--start;
   }

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -673,21 +673,9 @@ examples:
           <p>This is a summary</p>
         </div>
   buttons:
-    description: |
-      We're in process of migrating govspeak from using the old (toolkit) button styles to using the (govuk-frontend) button component from this gem. The example below demonstrates both kinds of buttons.
-
-      This documentation will be updated once that work is complete.
     data:
       block: |
         <p>
-          <a href="#" class="button" role="button">
-            Old button
-          </a>
-          <a href="#" class="button button-start" role="button">
-            Old start button
-          </a>
-        </p>
-        <p>
-          <a role="button" class="gem-c-button govuk-button" href="https://gov.uk/random">New button</a>
-          <a class="gem-c-button govuk-button govuk-button--start" role="button" href="https://gov.uk/random"> New start button <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path></svg></a>
+          <a role="button" class="gem-c-button govuk-button" href="https://gov.uk/random">Button</a>
+          <a class="gem-c-button govuk-button govuk-button--start" role="button" href="https://gov.uk/random"> Start button <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path></svg></a>
         </p>


### PR DESCRIPTION
## What
- remove 'button' class from extend for buttons in govspeak
- this change relates to an update of govspeak that switches from the toolkit buttons to the new component guide buttons
- after consideration I don't believe we need to extend both the gem-c-button class and the govuk-button class, just the gem-c-button class seems to work fine, adding both adding unnecessary CSS weight
- this change follows on from PR #1282 

## Why
This all ties in to the removal of the `.button` class from static: https://github.com/alphagov/static/pull/2035

Trello card: https://trello.com/c/d8D7JTJE/203-%F0%9F%8F%B4%E2%98%A0%EF%B8%8F-remove-design-patterns-buttons-from-static

## Visual Changes
None.