### PR TITLE
Linting where rebased-add-layout has diverged from master

### DIFF
--- a/app/models/govuk_publishing_components/component_example.rb
+++ b/app/models/govuk_publishing_components/component_example.rb
@@ -79,7 +79,7 @@ module GovukPublishingComponents
     end
 
     def black_background?
-      !!context['black_background']
+      !!context["black_background"]
     end
 
     def html_description

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -16,8 +16,8 @@
 
     <%= csrf_meta_tags %>
 
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= stylesheet_link_tag 'print', media: 'print' %>
+    <%= stylesheet_link_tag "application", media: "all", 'data-turbolinks-track': "reload" %>
+    <%= stylesheet_link_tag "print", media: "print" %>
 
     <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
     <link rel="mask-icon" href="<%= asset_path 'govuk-mask-icon.svg' %>" color="#0b0c0c">

--- a/spec/components/layout_footer_spec.rb
+++ b/spec/components/layout_footer_spec.rb
@@ -120,7 +120,7 @@ describe "Layout footer", type: :view do
   end
 
 
-  it 'renders the footer with a top border' do
+  it "renders the footer with a top border" do
     render_component(
       with_border: true,
       navigation: [
@@ -131,14 +131,14 @@ describe "Layout footer", type: :view do
             {
               href: "/browse/benefits",
               text: "Benefits",
-              attributes: { target: "_blank" }
-            }
-          ]
-        }
-      ]
+              attributes: { target: "_blank" },
+            },
+          ],
+        },
+      ],
     )
 
-    assert_select '.gem-c-layout-footer--border'
+    assert_select ".gem-c-layout-footer--border"
   end
 
   it "renders the footer meta link with attributes but will set the rel attribute if target is blank" do

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe "Layout for public", type: :view do
   def component_name
@@ -20,30 +20,30 @@ describe "Layout for public", type: :view do
   it "can support full width layouts" do
     render_component(full_width: true)
 
-    assert_select '#content.govuk-width-container', false, 'Should not apply govuk-width-container class when full width'
+    assert_select "#content.govuk-width-container", false, "Should not apply govuk-width-container class when full width"
   end
 
   it "adds additional main classes if provided" do
     render_component(main_classes: "homepage test-new-main-class")
 
-    assert_select 'main.homepage, main.test-new-main-class'
+    assert_select "main.homepage, main.test-new-main-class"
   end
 
   it "adds additional body classes if provided" do
     render_component(body_classes: "homepage test-new-body-class")
 
-    assert_select 'body.homepage, main.test-new-body-class'
+    assert_select "body.homepage, main.test-new-body-class"
   end
 
   it "can display without search bar" do
     render_component(without_search: true)
 
-    assert_select '.gem-c-layout-for-public .gem-c-search', false
+    assert_select ".gem-c-layout-for-public .gem-c-search", false
   end
 
   it "can omit the header" do
     render_component(omit_header: true)
 
-    assert_select '.gem-c-layout-for-public .gem-c-layout-header', false
+    assert_select ".gem-c-layout-for-public .gem-c-layout-header", false
   end
 end

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -50,19 +50,19 @@ describe "Layout header", type: :view do
   end
 
   it "renders the header without the bottom border" do
-    render_component(remove_bottom_border: true, environment: 'public')
+    render_component(remove_bottom_border: true, environment: "public")
 
     assert_select ".gem-c-layout-header--no-bottom-border"
   end
 
   it "renders a search bar" do
-    render_component(environment: 'public', search: true)
+    render_component(environment: "public", search: true)
 
     assert_select ".gem-c-layout-header .gem-c-search"
   end
 
   it "renders the search bar on the left when requested" do
-    render_component(environment: 'public', search: true, search_left: true)
+    render_component(environment: "public", search: true, search_left: true)
 
     assert_select ".gem-c-layout-header--search-left"
   end

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -65,11 +65,11 @@ describe "Search", type: :view do
 
   it "renders a search box with no margin" do
     render_component(no_margin: true)
-    assert_select '.gem-c-search--no-margin'
+    assert_select ".gem-c-search--no-margin"
   end
 
   it "renders a search box with no border" do
     render_component(no_border: true)
-    assert_select '.gem-c-search--no-border'
+    assert_select ".gem-c-search--no-border"
   end
 end

--- a/spec/dummy/app/controllers/welcome_controller.rb
+++ b/spec/dummy/app/controllers/welcome_controller.rb
@@ -21,7 +21,7 @@ class WelcomeController < ApplicationController
   end
 
   def public
-    render 'public_example', layout: 'dummy_public_layout'
+    render "public_example", layout: "dummy_public_layout"
   end
 
   def tabsexample

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   get "contextual-navigation", to: "welcome#contextual_navigation"
   get "contextual-navigation/*base_path", to: "welcome#contextual_navigation"
   get "admin", to: "welcome#admin"
-  get 'public', to: 'welcome#public'
+  get "public", to: "welcome#public"
   get "error-summary", to: "welcome#errorsummary"
   get "tabsexample", to: "welcome#tabsexample"
   get "table", to: "welcome#table"


### PR DESCRIPTION
Changes some quotes and adds some commas. This was necessary on parts of the codebase where we diverged from master which has been re-linted to current standards. This is a PR against rebased-add-layout rather than master.