### PR TITLE
Enable custom classes and aria-label on button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Improve numeric inputs ([PR #1345](https://github.com/alphagov/govuk_publishing_components/pull/1345))
+* Enable custom classes and `aria-label` on button component ([PR #1344](https://github.com/alphagov/govuk_publishing_components/pull/1344))
 * Tweak pagination component spacing and add border ([PR #1337](https://github.com/alphagov/govuk_publishing_components/pull/1337))
 
 ## 21.27.1

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -107,4 +107,12 @@ examples:
       text: "This is the button text"
       value: "this_is_the_value"
       name: "this_is_the_name"
-
+  with_js_classes:
+    description: Use `js-` prefixed classes only as interaction hooks – to query and operate on elements via JavaScript
+    data:
+      text: "Button"
+      classes: "js-selector-1 js-selector-2"
+  with_aria_label:
+    data:
+      text: "Button"
+      aria_label: "Button with custom label"

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -6,7 +6,7 @@ module GovukPublishingComponents
       attr_reader :href, :text, :title, :info_text, :rel, :data_attributes,
                   :margin_bottom, :inline_layout, :target, :type, :start,
                   :secondary, :secondary_quiet, :destructive, :name, :value,
-                  :classes
+                  :classes, :aria_label
 
       def initialize(local_assigns)
         @href = local_assigns[:href]
@@ -26,6 +26,7 @@ module GovukPublishingComponents
         @name = local_assigns[:name]
         @value = local_assigns[:value]
         @classes = local_assigns[:classes]
+        @aria_label = local_assigns[:aria_label]
       end
 
       def link?
@@ -42,6 +43,7 @@ module GovukPublishingComponents
         options[:target] = target if target
         options[:name] = name if name.present? && value.present?
         options[:value] = value if name.present? && value.present?
+        options[:aria] = { label: aria_label } if aria_label
         options
       end
 

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -25,7 +25,12 @@ module GovukPublishingComponents
         @destructive = local_assigns[:destructive]
         @name = local_assigns[:name]
         @value = local_assigns[:value]
-        @classes = local_assigns[:classes]
+        if local_assigns.include?(:classes)
+          @classes = local_assigns[:classes].split(" ")
+          unless @classes.all? { |c| c.start_with?("js-") }
+            raise(ArgumentError, "The button component expects classes to be prefixed with `js-`")
+          end
+        end
         @aria_label = local_assigns[:aria_label]
       end
 

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -5,7 +5,8 @@ module GovukPublishingComponents
     class ButtonHelper
       attr_reader :href, :text, :title, :info_text, :rel, :data_attributes,
                   :margin_bottom, :inline_layout, :target, :type, :start,
-                  :secondary, :secondary_quiet, :destructive, :name, :value
+                  :secondary, :secondary_quiet, :destructive, :name, :value,
+                  :classes
 
       def initialize(local_assigns)
         @href = local_assigns[:href]
@@ -24,6 +25,7 @@ module GovukPublishingComponents
         @destructive = local_assigns[:destructive]
         @name = local_assigns[:name]
         @value = local_assigns[:value]
+        @classes = local_assigns[:classes]
       end
 
       def link?
@@ -50,14 +52,15 @@ module GovukPublishingComponents
     private
 
       def css_classes
-        classes = %w(gem-c-button govuk-button)
-        classes << "govuk-button--start" if start
-        classes << "gem-c-button--secondary" if secondary
-        classes << "gem-c-button--secondary-quiet" if secondary_quiet
-        classes << "govuk-button--warning" if destructive
-        classes << "gem-c-button--bottom-margin" if margin_bottom
-        classes << "gem-c-button--inline" if inline_layout
-        classes.join(" ")
+        css_classes = %w(gem-c-button govuk-button)
+        css_classes << "govuk-button--start" if start
+        css_classes << "gem-c-button--secondary" if secondary
+        css_classes << "gem-c-button--secondary-quiet" if secondary_quiet
+        css_classes << "govuk-button--warning" if destructive
+        css_classes << "gem-c-button--bottom-margin" if margin_bottom
+        css_classes << "gem-c-button--inline" if inline_layout
+        css_classes << classes if classes
+        css_classes.join(" ")
       end
     end
   end

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -169,4 +169,10 @@ describe "Button", type: :view do
     assert_select ".gem-c-button[name]", 0
     assert_select ".gem-c-button[value]", 0
   end
+
+  it "renders with custom CSS classes" do
+    render_component(text: "Button", classes: "js-selector-1 js-selector-2")
+
+    assert_select ".gem-c-button.js-selector-1.js-selector-2"
+  end
 end

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -170,10 +170,16 @@ describe "Button", type: :view do
     assert_select ".gem-c-button[value]", 0
   end
 
-  it "renders with custom CSS classes" do
+  it "renders with `js-` prefixed classes for interactive hooks" do
     render_component(text: "Button", classes: "js-selector-1 js-selector-2")
 
     assert_select ".gem-c-button.js-selector-1.js-selector-2"
+  end
+
+  it "raises exception is CSS classes are not prefixed with `js-`" do
+    expect {
+      render_component(text: "Button", classes: "my-class")
+    }.to raise_error("The button component expects classes to be prefixed with `js-`")
   end
 
   it "renders with aria-label" do

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -175,4 +175,10 @@ describe "Button", type: :view do
 
     assert_select ".gem-c-button.js-selector-1.js-selector-2"
   end
+
+  it "renders with aria-label" do
+    render_component(text: "Button", aria_label: "Button with custom label")
+
+    assert_select '.gem-c-button[aria-label="Button with custom label"]'
+  end
 end


### PR DESCRIPTION
## What
Add support for custom `class` and `aria-label` to the button component.

## Why
Currently need for the [reorderable list component](https://github.com/alphagov/content-publisher/pull/1819) in Content Publisher as follows:
- custom `class` is required to be able to query buttons from JavaScript using `js-` prefixed class (e.g. `.js-app-button-up` to identify a button that moves items upwards) without adding excessive wrapper elements.
- `aria-label` is required to give screen reader users context on what button acts on (e.g. "Up" button would have a "Move Budget 2019 up" as `aria-label`).

## Visual Changes
No visual changes.

[Trello card](https://trello.com/c/H3T7JWtS)
