### PR TITLE
Make feedback component more responsive and usable on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Make feedback component more responsive and usable on mobile ([PR #1346](https://github.com/alphagov/govuk_publishing_components/pull/1346))
+
 ## 21.28.1
 
 * Fix overflowing text in attachments ([PR #1352](https://github.com/alphagov/govuk_publishing_components/pull/1352))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -1,23 +1,16 @@
 .gem-c-feedback {
   background: govuk-colour("white");
-  margin: 0 auto;
+  margin: govuk-spacing(6) auto 0 auto;
   max-width: $govuk-page-width;
   position: relative;
 
   @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(9);
     border-bottom: 1px solid govuk-colour("white");
   }
 
   .visually-hidden {
     @include govuk-visually-hidden;
-  }
-}
-
-.gem-c-feedback--top-margin {
-  margin-top: govuk-spacing(6);
-
-  @include govuk-media-query($from: tablet) {
-    margin-top: govuk-spacing(9);
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -117,6 +117,29 @@
   }
 }
 
+.gem-c-feedback__option-list {
+  display: inline-block;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  margin-right: govuk-spacing(2);
+  margin-top: govuk-spacing(2);
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: 0;
+  }
+}
+
+.gem-c-feedback__option-list-item {
+  display: inline-block;
+}
+
+.gem-c-feedback__option-list-item:first-child {
+  margin-right: govuk-spacing(7);
+}
+
+
+// Feedback form styles
 .gem-c-feedback__error-summary {
   margin-bottom: govuk-spacing(3);
   padding: govuk-spacing(3);
@@ -219,28 +242,5 @@
 
   &:focus {
     outline: $govuk-focus-width solid $govuk-focus-colour;
-  }
-}
-
-.js-enabled {
-  .gem-c-feedback__option-list {
-    display: inline-block;
-    list-style-type: none;
-    margin: 0;
-    padding: 0;
-    margin-right: govuk-spacing(2);
-    margin-top: govuk-spacing(2);
-
-    @include govuk-media-query($from: tablet) {
-      margin-top: 0;
-    }
-  }
-
-  .gem-c-feedback__option-list-item {
-    display: inline-block;
-  }
-
-  .gem-c-feedback__option-list-item:first-child {
-    margin-right: govuk-spacing(7);
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -248,16 +248,7 @@
     display: inline-block;
   }
 
-  .gem-c-feedback__option-list-item--useful {
+  .gem-c-feedback__option-list-item:first-child {
     margin-right: govuk-spacing(7);
-    @include govuk-media-query($until: tablet) {
-      display: inline-block;
-    }
-  }
-
-  .gem-c-feedback__option-list-item--not-useful {
-    @include govuk-media-query($until: tablet) {
-      display: inline-block;
-    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -3,10 +3,9 @@
   margin: 0 auto;
   max-width: $govuk-page-width;
   position: relative;
-  border-bottom: 1px solid govuk-colour("white");
 
-  @include govuk-media-query($until: tablet) {
-    border-bottom: 0;
+  @include govuk-media-query($from: tablet) {
+    border-bottom: 1px solid govuk-colour("white");
   }
 
   .visually-hidden {
@@ -41,24 +40,24 @@
 }
 
 .gem-c-feedback__prompt-questions {
+  text-align: center;
+  border-bottom: 1px solid govuk-colour("white");
   padding: govuk-spacing(5) govuk-spacing(5) govuk-spacing(5) govuk-spacing(5);
-  width: 50%;
-  float: left;
   box-sizing: border-box;
 
-  @include govuk-media-query($until: tablet) {
-    text-align: center;
-    border-bottom: 1px solid govuk-colour("white");
-    width: 100%;
-    float: none;
+  @include govuk-media-query($from: tablet) {
+    width: 50%;
+    float: left;
+    text-align: left;
+    border-bottom: 0;
   }
 }
 
 .gem-c-feedback__prompt-questions--something-is-wrong {
-  text-align: right;
+  text-align: center;
 
-  @include govuk-media-query($until: tablet) {
-    text-align: center;
+  @include govuk-media-query($from: tablet) {
+    text-align: right;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -87,8 +87,16 @@
 .gem-c-feedback__prompt-link {
   @include govuk-link-common;
   @include govuk-font(19);
-  position: relative;
   display: inline-block;
+
+  @include govuk-media-query($from: tablet) {
+    @include govuk-font(16);
+  }
+}
+
+.gem-c-feedback__email-link,
+.gem-c-feedback__prompt-link {
+  position: relative;
 
   &:after {
     content: "";
@@ -97,10 +105,6 @@
     right: -14px;
     left: -14px;
     bottom: -14px;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    @include govuk-font(16);
   }
 }
 
@@ -219,7 +223,7 @@
 
 .gem-c-feedback__email-link {
   display: block;
-  margin-top: govuk-spacing(3);
+  margin-top: govuk-spacing(4);
 
   @include govuk-media-query($from: desktop) {
     display: inline-block;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -8,10 +8,6 @@
     margin-top: govuk-spacing(9);
     border-bottom: 1px solid govuk-colour("white");
   }
-
-  .visually-hidden {
-    @include govuk-visually-hidden;
-  }
 }
 
 // hide without js

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -3,6 +3,11 @@
   margin: 0 auto;
   max-width: $govuk-page-width;
   position: relative;
+  border-bottom: 1px solid govuk-colour("white");
+
+  @include govuk-media-query($until: tablet) {
+    border-bottom: 0;
+  }
 
   .visually-hidden {
     @include govuk-visually-hidden;
@@ -35,39 +40,80 @@
   }
 }
 
+.gem-c-feedback__js-prompt-questions  {
+  border-bottom: 1px solid govuk-colour("white");
+  padding: govuk-spacing(5) govuk-spacing(5) govuk-spacing(5) govuk-spacing(5);
+  width: 50%;
+  float: left;
+  box-sizing: border-box;
+
+  @include govuk-media-query($until: tablet) {
+    text-align: center;
+    border-bottom: 1px solid govuk-colour("white");
+    width: 100%;
+    float: none;
+  }
+}
+
+.gem-c-feedback__js-prompt-questions--something-is-wrong {
+  text-align: right;
+
+  @include govuk-media-query($until: tablet) {
+    text-align: center;
+  }
+}
+
 .gem-c-feedback__prompt {
   @include govuk-clearfix;
   background-color: govuk-colour("blue");
   color: govuk-colour("white");
-  padding: govuk-spacing(2) govuk-spacing(3) 0;
   outline: 0;
 }
 
 .gem-c-feedback__prompt-question,
 .gem-c-feedback__prompt-success {
   @include govuk-font(19, $weight: bold);
+
+  @include govuk-media-query($from: tablet) {
+    @include govuk-font(16, $weight: bold);
+  }
+}
+
+.gem-c-feedback__prompt-question {
   display: inline-block;
 
   // There's a global h3 rule in some layouts that interferes with this component
   margin: 0;
+
+  margin-left: govuk-spacing(4);
+  margin-right: govuk-spacing(4);
 
   &:focus {
     outline: 0;
   }
 
   @include govuk-media-query($from: tablet) {
-    @include govuk-font(16, $weight: bold);
-    float: left;
+    margin-left: 0;
   }
 }
 
 .gem-c-feedback__prompt-link {
   @include govuk-link-common;
   @include govuk-font(19);
+  position: relative;
+  display: inline-block;
+
+  &:after {
+    content: "";
+    position: absolute;
+    top: -14px;
+    right: -14px;
+    left: -14px;
+    bottom: -14px;
+  }
 
   @include govuk-media-query($from: tablet) {
     @include govuk-font(16);
-    margin-left: govuk-spacing(2);
   }
 }
 
@@ -185,80 +231,34 @@
   }
 }
 
-.gem-c-feedback__option-list {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-
 .js-enabled {
-  .gem-c-feedback__js-prompt-questions {
-    @include govuk-media-query($until: tablet) {
-      display: grid;
-    }
-  }
-
-  .gem-c-feedback__prompt-question {
-    @include govuk-media-query($until: tablet) {
-      grid-area: 1 / 1;
-    }
-  }
-
   .gem-c-feedback__option-list {
+    display: inline-block;
     list-style-type: none;
     margin: 0;
     padding: 0;
+    margin-right: govuk-spacing(2);
+    margin-top: govuk-spacing(2);
 
-    @include govuk-media-query($until: tablet) {
-      grid-area: 1 / 1 / 2 / 2;
-      display: grid;
-      grid-template-columns: 140px 1fr;
-      // older grid spec
-      grid-row-gap: govuk-spacing(3);
-      // newer grid spec
-      row-gap: govuk-spacing(3); // sass-lint:disable-line no-misspelled-properties
+    @include govuk-media-query($from: tablet) {
+      margin-top: 0;
     }
   }
 
   .gem-c-feedback__option-list-item {
-    @include govuk-media-query($from: tablet) {
-      float: left;
-    }
+    display: inline-block;
   }
 
   .gem-c-feedback__option-list-item--useful {
+    margin-right: govuk-spacing(7);
     @include govuk-media-query($until: tablet) {
       display: inline-block;
-      @supports (display: grid) {
-        grid-area: 1 / 2;
-        padding-left: govuk-spacing(3);
-      }
     }
   }
 
   .gem-c-feedback__option-list-item--not-useful {
     @include govuk-media-query($until: tablet) {
       display: inline-block;
-      @supports (display: grid) {
-        grid-area: 1 / 2;
-        padding-left: 50px;
-      }
-    }
-  }
-
-  .gem-c-feedback__option-list-item--wrong {
-    @include govuk-media-query($until: tablet) {
-      display: block;
-      margin-top: govuk-spacing(3);
-      @supports (display: grid) {
-        margin-top: 0;
-        grid-area: 2 / 1 / 2 / 3;
-      }
-    }
-
-    @include govuk-media-query($from: tablet) {
-      float: right;
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -27,7 +27,7 @@
 .gem-c-feedback__js-show,
 .gem-c-feedback__form,
 .gem-c-feedback__prompt-success,
-.gem-c-feedback__js-prompt-questions,
+.gem-c-feedback__prompt-questions,
 .gem-c-feedback__error-summary {
   display: none;
 
@@ -40,8 +40,7 @@
   }
 }
 
-.gem-c-feedback__js-prompt-questions  {
-  border-bottom: 1px solid govuk-colour("white");
+.gem-c-feedback__prompt-questions {
   padding: govuk-spacing(5) govuk-spacing(5) govuk-spacing(5) govuk-spacing(5);
   width: 50%;
   float: left;
@@ -55,7 +54,7 @@
   }
 }
 
-.gem-c-feedback__js-prompt-questions--something-is-wrong {
+.gem-c-feedback__prompt-questions--something-is-wrong {
   text-align: right;
 
   @include govuk-media-query($until: tablet) {

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -1,7 +1,4 @@
 <%
-  margin_top ||= 1
-  margin_top_class = "gem-c-feedback--top-margin" if margin_top == 1
-
   def utf_encode(element)
     element.is_a?(String) ? element.encode : element
   end
@@ -11,7 +8,7 @@
   path_without_pii = utf_encode(request.fullpath.gsub(email_regex, '[email]'))
 %>
 
-<div class="gem-c-feedback <%= margin_top_class %>" data-module="feedback">
+<div class="gem-c-feedback" data-module="feedback">
   <%= render "govuk_publishing_components/components/feedback/yes_no_banner" %>
   <%= render "govuk_publishing_components/components/feedback/problem_form", url_without_pii: url_without_pii %>
   <%= render "govuk_publishing_components/components/feedback/survey_signup_form", path_without_pii: path_without_pii %>

--- a/app/views/govuk_publishing_components/components/docs/feedback.yml
+++ b/app/views/govuk_publishing_components/components/docs/feedback.yml
@@ -1,9 +1,7 @@
 name: Feedback
 description: Invites user feedback on the current page.
 body: |
-  This component is designed to sit at the bottom of pages on GOV.UK to allow users to submit feedback on that page. It is based on the 'improve this page' component from the Service manual, but changes have been made.
-
-  This component includes imported button styles, which is not ideal (styles are duplicated). Once the [button component](/component-guide/button) has been moved to the gem, this should be used instead.
+  This component is designed to sit at the bottom of pages on GOV.UK to allow users to submit feedback on that page.
 accessibility_criteria: |
   Form elements in the component must:
 

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -3,7 +3,7 @@
 %>
 
 <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
-  <div class="gem-c-feedback__js-prompt-questions js-prompt-questions">
+  <div class="gem-c-feedback__prompt-questions js-prompt-questions">
     <h2 class="gem-c-feedback__prompt-question">Is this page useful?</h2>
     <!-- Maybe button exists only to try and capture clicks by bots -->
     <%= link_to contact_govuk_path, {
@@ -50,10 +50,10 @@
       </li>
     </ul>
   </div>
-  <div class="gem-c-feedback__js-prompt-questions gem-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">
+  <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">
     Thank you for your feedback
   </div>
-  <div class="gem-c-feedback__js-prompt-questions gem-c-feedback__js-prompt-questions--something-is-wrong js-prompt-questions">
+  <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions">
     <%= link_to contact_govuk_path, {
       class: 'gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong',
       data: {

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -5,6 +5,7 @@
 <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
   <div class="gem-c-feedback__js-prompt-questions js-prompt-questions">
     <h2 class="gem-c-feedback__prompt-question">Is this page useful?</h2>
+    <!-- Maybe button exists only to try and capture clicks by bots -->
     <%= link_to contact_govuk_path, {
         class: 'gem-c-feedback__prompt-link',
         data: {

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -31,7 +31,7 @@
           'aria-expanded': false,
           role: 'button',
         } do %>
-          Yes <span class="visually-hidden">this page is useful</span>
+          Yes <span class="govuk-visually-hidden">this page is useful</span>
         <% end %>
       </li>
       <li class="gem-c-feedback__option-list-item">
@@ -45,7 +45,7 @@
           'aria-expanded': false,
           role: 'button',
         } do %>
-          No <span class="visually-hidden">this page is not useful</span>
+          No <span class="govuk-visually-hidden">this page is not useful</span>
         <% end %>
       </li>
     </ul>

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -47,24 +47,23 @@
           No <span class="visually-hidden">this page is not useful</span>
         <% end %>
       </li>
-      <li class="gem-c-feedback__option-list-item gem-c-feedback__option-list-item--wrong">
-        <%= link_to contact_govuk_path, {
-          class: 'gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong',
-          data: {
-            'track-category' => 'Onsite Feedback',
-            'track-action' => 'GOV.UK Open Form'
-          },
-          'aria-controls': 'something-is-wrong',
-          'aria-expanded': false,
-          role: 'button',
-        } do %>
-          Is there anything wrong with this page?
-        <% end %>
-      </li>
     </ul>
   </div>
-
-  <div class="gem-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">
+  <div class="gem-c-feedback__js-prompt-questions gem-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">
     Thank you for your feedback
+  </div>
+  <div class="gem-c-feedback__js-prompt-questions gem-c-feedback__js-prompt-questions--something-is-wrong js-prompt-questions">
+    <%= link_to contact_govuk_path, {
+      class: 'gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong',
+      data: {
+        'track-category' => 'Onsite Feedback',
+        'track-action' => 'GOV.UK Open Form'
+      },
+      'aria-controls': 'something-is-wrong',
+      'aria-expanded': false,
+      role: 'button',
+    } do %>
+      Is there anything wrong with this page?
+    <% end %>
   </div>
 </div>

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -21,7 +21,7 @@
         Maybe
     <% end %>
     <ul class="gem-c-feedback__option-list">
-      <li class="gem-c-feedback__option-list-item gem-c-feedback__option-list-item--useful">
+      <li class="gem-c-feedback__option-list-item">
         <%= link_to contact_govuk_path, {
           class: 'gem-c-feedback__prompt-link js-page-is-useful',
           data: {
@@ -34,7 +34,7 @@
           Yes <span class="visually-hidden">this page is useful</span>
         <% end %>
       </li>
-      <li class="gem-c-feedback__option-list-item gem-c-feedback__option-list-item--not-useful">
+      <li class="gem-c-feedback__option-list-item">
         <%= link_to contact_govuk_path, {
           class: 'gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful',
           data: {

--- a/spec/components/feedback_spec.rb
+++ b/spec/components/feedback_spec.rb
@@ -18,12 +18,6 @@ describe "Feedback", type: :view do
     assert_select ".gem-c-feedback .gem-c-feedback__prompt-link.js-something-is-wrong[href='/contact/govuk']", text: "Is there anything wrong with this page?"
   end
 
-  it "removes top margin when margin_top flag is set" do
-    render_component(margin_top: 0)
-
-    assert_select ".gem-c-feedback.gem-c-feedback--margin-top", false
-  end
-
   it "has required email survey signup form fields" do
     render_component({})
 

--- a/spec/components/feedback_spec.rb
+++ b/spec/components/feedback_spec.rb
@@ -8,14 +8,14 @@ describe "Feedback", type: :view do
   it "asks the user if the page is useful without javascript enabled" do
     render_component({})
 
-    assert_select ".gem-c-feedback .gem-c-feedback__option-list-item--useful a[href='/contact/govuk']", text: "Yes this page is useful"
-    assert_select ".gem-c-feedback .gem-c-feedback__prompt-link.js-page-is-not-useful[href='/contact/govuk']", text: "No this page is not useful"
+    assert_select ".gem-c-feedback .gem-c-feedback__option-list-item .js-page-is-useful[href='/contact/govuk']", text: "Yes this page is useful"
+    assert_select ".gem-c-feedback .gem-c-feedback__option-list-item .js-page-is-not-useful[href='/contact/govuk']", text: "No this page is not useful"
   end
 
   it "asks the user if there is anything wrong with the page without javascript enabled" do
     render_component({})
 
-    assert_select ".gem-c-feedback .gem-c-feedback__option-list-item--wrong a[href='/contact/govuk']", text: "Is there anything wrong with this page?"
+    assert_select ".gem-c-feedback .gem-c-feedback__prompt-link.js-something-is-wrong[href='/contact/govuk']", text: "Is there anything wrong with this page?"
   end
 
   it "removes top margin when margin_top flag is set" do


### PR DESCRIPTION
## What
- Implement new design for feedback component, with larger touch targets and more responsive layout.
- Tidy up unused feedback component code
- Remove outdated sections of feedback component documentation

<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
Small touch targets and small spacing between items makes it visually frustrating, but for mobile users this might make it harder to click on the intended link.
The previous design also failed when a user zoomed, as the links started to overflow the container.

## Before and After (desktop)
<img width="983" alt="Screenshot 2020-03-09 at 10 42 08" src="https://user-images.githubusercontent.com/29889908/76205763-cdbe4480-61f2-11ea-9649-525eb982eb6b.png">

<img width="990" alt="Screenshot 2020-03-09 at 10 41 59" src="https://user-images.githubusercontent.com/29889908/76205934-137b0d00-61f3-11ea-8cba-23cbd1beac0d.png">

## Before and After (mobile)
<img width="317" alt="Screenshot 2020-03-09 at 10 42 35" src="https://user-images.githubusercontent.com/29889908/76205952-1ece3880-61f3-11ea-9966-3c2eb49e8a08.png">
<img width="435" alt="Screenshot 2020-03-09 at 10 42 50" src="https://user-images.githubusercontent.com/29889908/76205953-1f66cf00-61f3-11ea-9c68-02a6e02c69d7.png">

