### PR TITLE
Fix overflowing text in attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix overflowing text in attachments ([PR #1352](https://github.com/alphagov/govuk_publishing_components/pull/1352))
+
 ## 21.28.0
 
 * Improve numeric inputs ([PR #1345](https://github.com/alphagov/govuk_publishing_components/pull/1345))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -41,6 +41,11 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey", $legacy: "grey-3");
 
 .gem-c-attachment__details {
   padding-left: $thumbnail-width + $thumbnail-border-width * 2 + govuk-spacing(5);
+
+  .gem-c-details {
+    word-break: break-word;
+    word-wrap: break-word;
+  }
 }
 
 .gem-c-attachment__title {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -70,6 +70,11 @@
         @include govuk-font($size: 14);
       }
 
+      .url {
+        word-break: break-word;
+        word-wrap: break-word;
+      }
+
       .changed,
       .references,
       .unnumbered-paper {
@@ -98,6 +103,8 @@
           @include govuk-font($size: 14);
           margin: 0;
         }
+        word-break: break-word;
+        word-wrap: break-word;
       }
 
       .js-hidden {

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -489,7 +489,7 @@ examples:
             </p>
             <div data-module="toggle" class="accessibility-warning" id="attachment-1243761-accessibility-help">
               <h2>This file may not be suitable for users of assistive technology.
-                <a class="toggler" href="#attachment-1243761-accessibility-request" data-controls="attachment-1243761-accessibility-request" data-expanded="false">Request a different format.</a>
+                <a class="toggler" href="#attachment-1243761-accessibility-request" data-controls="attachment-1243761-accessibility-request" data-expanded="false">Request an accessible format.</a>
               </h2>
               <p id="attachment-1243761-accessibility-request" class="help-block js-hidden"><span class="arrow"></span>
                 If you use assistive technology and need a version of this document
@@ -516,9 +516,9 @@ examples:
             <a aria-hidden="true" class="thumbnail" href="http://example.com"><img alt="" src="//www.gov.uk/government/assets/pub-cover-a380604bb953dc22ac9dcfbf3cc65598327f493c37b09ac497c45148cbaa21b1.png"></a>
           </div>
           <div class="attachment-details">
-            <h2 class="title"><a rel="external" href="http://example.com">An external link</a></h2>
+            <h2 class="title"><a rel="external" href="https://www.arcgis.com/apps/opsdashboard/index.html#/f94c3c90da5b4e9f9a0b19484dd4bb14">Track coronavirus cases</a></h2>
             <p class="metadata">
-              <span class="url">http://example.com</span>
+              <span class="url">https://www.arcgis.com/apps/opsdashboard/index.html#/f94c3c90da5b4e9f9a0b19484dd4bb14</span>
             </p>
           </div>
         </section>


### PR DESCRIPTION
## What
Fix overflowing URLs and email addresses in govspeak-rendered attachments and the attachment component.

## Why
To make sure the page layout doesn't break

## Visual Changes
### govspeak attachments
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

![Screenshot 2020-03-11 at 10 41 45](https://user-images.githubusercontent.com/788096/76413505-74d6e380-638d-11ea-8099-1791eb1f1df8.png)


</td><td>

![Screenshot 2020-03-11 at 10 39 32](https://user-images.githubusercontent.com/788096/76413650-b7002500-638d-11ea-8764-9e99a0ec2714.png)


</td></tr>
</table>

Reference: [the `url` class generated by govspeak](https://github.com/alphagov/govspeak/blob/f8131efa42c2838a6c94288bd0404e13b0f17ad2/lib/govspeak/presenters/attachment_presenter.rb#L39)

### attachment component

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="357" alt="Screenshot 2020-03-11 at 10 58 49" src="https://user-images.githubusercontent.com/788096/76413771-f0d12b80-638d-11ea-94b7-a670f71c0fa6.png">

</td><td>

<img width="344" alt="Screenshot 2020-03-11 at 10 58 07" src="https://user-images.githubusercontent.com/788096/76413784-f890d000-638d-11ea-8070-75cc0e709a83.png">


</td></tr>
</table>


govspeak attachments problem on the live website: https://www.gov.uk/government/publications/covid-19-track-coronavirus-cases reported by @timpaul.

[attachments component problem tracked in Content Publisher](https://trello.com/c/IGI9Hf16).