### PR TITLE
Release 21.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.28.1
 
 * Fix overflowing text in attachments ([PR #1352](https://github.com/alphagov/govuk_publishing_components/pull/1352))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.28.0)
+    govuk_publishing_components (21.28.1)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -209,7 +209,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.4)
-    rouge (3.16.0)
+    rouge (3.17.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.6)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.28.0".freeze
+  VERSION = "21.28.1".freeze
 end


### PR DESCRIPTION
## Version 21.28.1

* Fix overflowing text in attachments ([PR #1352](https://github.com/alphagov/govuk_publishing_components/pull/1352))
