### PR TITLE
Extract document-item component from document-list

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -33,6 +33,7 @@
 @import "components/copy-to-clipboard";
 @import "components/date-input";
 @import "components/details";
+@import "components/document-item";
 @import "components/document-list";
 @import "components/error-alert";
 @import "components/error-message";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-item.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-item.scss
@@ -1,0 +1,93 @@
+.gem-c-document-item {
+  @include govuk-font(19);
+  border-bottom: 1px solid $govuk-border-colour;
+  list-style: none;
+  margin-bottom: govuk-spacing(2);
+  overflow: hidden;
+  padding-bottom: govuk-spacing(2);
+
+  &:last-child {
+    border-bottom: 0;
+  }
+}
+
+.gem-c-document-item__title {
+  @include govuk-font($size: 19, $weight: bold);
+  display: inline-block;
+}
+
+.gem-c-document-item__link {
+  @include govuk-link-common;
+  @include govuk-link-style-default;
+}
+
+.gem-c-document-item--no-underline {
+  .gem-c-document-item__title {
+    text-decoration: none;
+  }
+}
+
+.gem-c-document-item__title--context {
+  margin-right: govuk-spacing(2);
+
+  .direction-rtl & {
+    margin-left: govuk-spacing(2);
+    margin-right: 0;
+  }
+}
+
+.gem-c-document-item__context {
+  color: govuk-colour("dark-grey", $legacy: "grey-1");
+}
+
+.gem-c-document-item__description {
+  @include govuk-text-colour;
+  margin: govuk-spacing(1) 0;
+}
+
+.gem-c-document-item__subtext {
+  margin: govuk-spacing(1) 0 0 0;
+}
+
+.gem-c-document-item__description,
+.gem-c-document-item__subtext {
+  @include govuk-font($size: 16, $line-height: 1.5);
+}
+
+.gem-c-document-item__metadata {
+  margin: 0;
+  padding: 0;
+}
+
+.gem-c-document-item__attribute {
+  @include govuk-text-colour;
+  @include govuk-font(14);
+  display: inline-block;
+  list-style: none;
+  padding-right: govuk-spacing(4);
+
+  .direction-rtl & {
+    padding-left: govuk-spacing(4);
+    padding-right: 0;
+  }
+}
+
+.gem-c-document-item--multi-list {
+  margin-right: 25px;
+  width: 100%;
+}
+
+.gem-c-document-item--highlight {
+  border: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
+  margin-bottom: govuk-spacing(6);
+  padding: govuk-spacing(6);
+
+  .gem-c-document-item__title {
+    @include govuk-font(24, bold);
+  }
+}
+
+.gem-c-document-item__highlight-text {
+  @include govuk-font(16, bold);
+  margin: 0 0 govuk-spacing(3) 0;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -5,103 +5,10 @@
   padding: 0;
 }
 
-.gem-c-document-list__item {
-  overflow: hidden;
-  margin-bottom: govuk-spacing(4);
-  padding-bottom: govuk-spacing(4);
-  border-bottom: 1px solid $govuk-border-colour;
-  list-style: none;
-
-  &:last-child {
-    border-bottom: 0;
-  }
-}
-
-.gem-c-document-list__item-title {
-  @include govuk-font($size: 19, $weight: bold);
-  display: inline-block;
-}
-
-.gem-c-document-list__item-link {
-  @include govuk-link-common;
-  @include govuk-link-style-default;
-}
-
-.gem-c-document-list--no-underline {
-  .gem-c-document-list__item-title {
-    text-decoration: none;
-  }
-}
-
-.gem-c-document-list__item-title--context {
-  margin-right: govuk-spacing(2);
-
-  .direction-rtl & {
-    margin-right: 0;
-    margin-left: govuk-spacing(2);
-  }
-}
-
-.gem-c-document-list__item-context {
-  color: govuk-colour("dark-grey", $legacy: "grey-1");
-}
-
-.gem-c-document-list__item-description {
-  @include govuk-text-colour;
-  margin: govuk-spacing(1) 0;
-}
-
-.gem-c-document-list__subtext {
-  margin: govuk-spacing(1) 0 0 0;
-}
-
-.gem-c-document-list__item-description,
-.gem-c-document-list__subtext {
-  @include govuk-font($size: 16, $line-height: 1.5);
-}
-
-.gem-c-document-list__item-metadata {
-  padding: 0;
-}
-
-.gem-c-document-list__attribute {
-  @include govuk-text-colour;
-  @include govuk-font(14);
-  display: inline-block;
-  list-style: none;
-  padding-right: govuk-spacing(4);
-
-  .direction-rtl & {
-    padding-right: 0;
-    padding-left: govuk-spacing(4);
-  }
-}
-
 .gem-c-document-list--bottom-margin {
   margin-bottom: govuk-spacing(4);
 }
 
 .gem-c-document-list--top-margin {
   margin-top: govuk-spacing(4);
-}
-
-.gem-c-document-list__multi-list {
-  width: 100%;
-  margin-right: 25px;
-}
-
-.gem-c-document-list__item--highlight {
-  border: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
-  padding: govuk-spacing(6);
-  margin-bottom: govuk-spacing(6);
-
-  .gem-c-document-list__item-title {
-    @include govuk-font(24, bold);
-  }
-}
-
-.gem-c-document-list__highlight-text {
-  @include govuk-font(16, bold);
-  margin: 0 0 govuk-spacing(3) 0;
-
 }

--- a/app/views/govuk_publishing_components/components/_document_item.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_item.html.erb
@@ -1,0 +1,77 @@
+<%
+  brand ||= false
+  brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
+  within_list ||= false
+  within_multitype_list ||= false
+
+  classes = "gem-c-document-item "
+  classes << "gem-c-document-item--multi-list" if within_multitype_list
+  classes << "gem-c-document-item--highlight" if item[:highlight]
+  classes << brand_helper.brand_class if brand
+
+  title_classes = "gem-c-document-item__title "
+  title_classes << "gem-c-document-item__title--context" if item[:link][:context]
+  title_classes << brand_helper.color_class if brand
+%>
+
+<% if within_list %>
+  <li class="<%= classes %>">
+<% else %>
+  <div class="<%= classes %>">
+<% end %>
+
+  <% if item[:highlight] && item[:highlight_text] %>
+    <p class='gem-c-document-item__highlight-text'><%= item[:highlight_text] %></p>
+  <% end %>
+
+  <%=
+    if item[:link][:path]
+      link_to(
+        item[:link][:text],
+        item[:link][:path],
+        data: item[:link][:data_attributes],
+        class: "#{title_classes} gem-c-document-item__link",
+      )
+    else
+      content_tag(
+        "span",
+        item[:link][:text],
+        data: item[:link][:data_attributes],
+        class: title_classes,
+      )
+    end
+  %>
+
+  <% if item[:link][:context] %>
+    <span class="gem-c-document-item__context"><%= item[:link][:context] %></span>
+  <% end %>
+
+  <% if item[:link][:description] %>
+    <p class="gem-c-document-item__description" ><%= item[:link][:description] %></p>
+  <% end %>
+
+  <% if item[:metadata] %>
+    <ul class="gem-c-document-item__metadata">
+      <% item[:metadata].compact.each do |item_metadata_key, item_metadata_value| %>
+        <li class="gem-c-document-item__attribute">
+          <% if item_metadata_key.to_s.eql?("public_updated_at") %>
+            <time datetime="<%= item_metadata_value.iso8601 %>">
+              <%= l(item_metadata_value, format: '%e %B %Y') %>
+            </time>
+          <% else %>
+            <%= item_metadata_value %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <% if item[:subtext] %>
+    <p class="gem-c-document-item__subtext"><%= item[:subtext] %></p>
+  <% end %>
+
+<% if within_list %>
+  </li>
+<% else %>
+  </div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -7,8 +7,6 @@
   classes << " gem-c-document-list--no-underline" if local_assigns[:remove_underline]
 
   within_multitype_list ||= false
-  within_multitype_list_class = " gem-c-document-list__multi-list" if within_multitype_list
-  title_with_context_class = " gem-c-document-list__item-title--context"
 
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
@@ -18,61 +16,7 @@
     <ol class="<%= classes %>">
   <% end %>
     <% items.each do |item| %>
-      <% highlight_class = " gem-c-document-list__item--highlight" if item[:highlight] %>
-
-      <li class="gem-c-document-list__item<%= within_multitype_list_class %> <%= brand_helper.brand_class %> <%= highlight_class %>">
-        <% if item[:highlight] && item[:highlight_text] %>
-          <p class='gem-c-document-list__highlight-text'><%= item[:highlight_text] %></p>
-        <% end %>
-
-        <%=
-          item_classes = "gem-c-document-list__item-title #{brand_helper.color_class} #{title_with_context_class if item[:link][:context]}"
-
-          if item[:link][:path]
-            link_to(
-              item[:link][:text],
-              item[:link][:path],
-              data: item[:link][:data_attributes],
-              class: "#{item_classes} gem-c-document-list__item-link",
-            )
-          else
-            content_tag(
-              "span",
-              item[:link][:text],
-              data: item[:link][:data_attributes],
-              class: item_classes,
-            )
-          end
-        %>
-
-        <% if item[:link][:context] %>
-          <span class="gem-c-document-list__item-context"><%= item[:link][:context] %></span>
-        <% end %>
-
-        <% if item[:link][:description] %>
-          <p class="gem-c-document-list__item-description" ><%= item[:link][:description] %></p>
-        <% end %>
-
-        <% if item[:metadata] %>
-          <ul class="gem-c-document-list__item-metadata">
-            <% item[:metadata].compact.each do |item_metadata_key, item_metadata_value| %>
-              <li class="gem-c-document-list__attribute">
-                <% if item_metadata_key.to_s.eql?("public_updated_at") %>
-                  <time datetime="<%= item_metadata_value.iso8601 %>">
-                    <%= l(item_metadata_value, format: '%e %B %Y') %>
-                  </time>
-                <% else %>
-                  <%= item_metadata_value %>
-                <% end %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
-
-        <% if item[:subtext] %>
-          <p class="gem-c-document-list__subtext"><%= item[:subtext] %></p>
-        <% end %>
-      </li>
+      <%= render "govuk_publishing_components/components/document_item", { item: item, brand: brand, within_list: true, within_multitype_list: within_multitype_list } %>
     <% end %>
   <% unless within_multitype_list %>
     </ol>

--- a/app/views/govuk_publishing_components/components/docs/document_item.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_item.yml
@@ -1,0 +1,142 @@
+name: Document item
+description: A document item including a link, description and metadata
+body: |
+  Outputs a document that may include:
+
+  * document title
+  * link to the document
+  * last updated date object
+  * document type
+
+  This component is used in the [document_list component](/component-guide/document_list).
+
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      item:
+        link:
+          text: 'Alternative provision'
+          path: '/government/publications/alternative-provision'
+        metadata:
+          public_updated_at: 2016-06-27 10:29:44
+          document_type: 'Statutory guidance'
+  without_links:
+    data:
+      item:
+        link:
+          text: 'Alternative provision'
+        metadata:
+          public_updated_at: 2016-06-27 10:29:44
+          document_type: 'Statutory guidance'
+  with_data_attributes_on_links:
+    data:
+      item:
+        link:
+          text: 'School behaviour and attendance: parental responsibility measures'
+          path: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+          data_attributes:
+            track_category: 'navDocumentCollectionLinkClicked'
+            track_action: 1.1
+            track_label: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+            track_options:
+              dimension28: 2
+              dimension29: 'School behaviour and attendance: parental responsibility measures'
+        metadata:
+          public_updated_at: 2017-01-05 14:50:33
+          document_type: 'Statutory guidance'
+  with_description:
+    description: Documents can be passed to the component with a description. This is for use on topic pages, to display lists of mainstream services.
+    data:
+      item:
+        link:
+          text: 'Become an apprentice'
+          path: '/become-an-apprentice'
+          description: 'Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship.'
+  with_description_and_metadata:
+    data:
+      item:
+        link:
+          text: 'School behaviour and attendance: parental responsibility measures'
+          path: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+          description: 'The responsibilities parents have relating to school behaviour and attendance.'
+        metadata:
+          public_updated_at: 2017-01-05 14:50:33
+          document_type: 'Statutory guidance'
+  with_branding:
+    description: Where this component could be used on an organisation page (such as the [Attorney General's Office](https://www.gov.uk/government/organisations/attorney-generals-office)) branding can be applied for link colours and border colours. See the [branding documentation](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) for more details.
+    data:
+      brand: 'attorney-generals-office'
+      item:
+        link:
+          text: 'School behaviour and attendance: parental responsibility measures'
+          path: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+        metadata:
+          public_updated_at: 2017-01-05 14:50:33
+          document_type: 'Statutory guidance'
+  with_only_link:
+    data:
+      item:
+        link:
+          text: 'School behaviour and attendance: parental responsibility measures'
+          path: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+  with_context:
+    description: Context can be provided to render next to the item title.
+    data:
+      item:
+        link:
+          text: 'Forestry Commission'
+          path: '/government/organisations/forestry-commission'
+          context: 'separate website'
+  with_subtext:
+    description: This is used on finders to highlight search results from past governments.
+    data:
+      item:
+        link:
+          text: 'Department for Education – Statistics at DfE'
+          path: '/government/organisations/department-for-education/about/statistics'
+          description: 'The Department for Education publishes official statistics on education and children.'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Corporate information'
+        subtext: 'First published during the 2007 Labour Government'
+  without_underline:
+    description: The current search design does not include underlines on links and has been tested without underlines. Other uses will require further user testing.
+    data:
+      remove_underline: true
+      item:
+        link:
+          text: 'Department for Education – Statistics at DfE'
+          path: '/government/organisations/department-for-education/about/statistics'
+          description: 'The Department for Education publishes official statistics on education and children.'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Corporate information'
+        subtext: 'First published during the 2007 Labour Government'
+  highlighted_result:
+    description: Highlight one or more of the item in the list. This is used on finders to provide a 'top result' for a search. The `highlight_text` parameter is optional.
+    data:
+      item:
+        link:
+          text: 'Department for Education – Statistics at DfE'
+          path: '/government/organisations/department-for-education/about/statistics'
+          description: 'The Department for Education publishes official statistics on education and children.'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Corporate information'
+        subtext: 'First published during the 2007 Labour Government'
+        highlight: true
+        highlight_text: 'Most relevant result'
+  right_to_left:
+    data:
+      item:
+        link:
+          text: 'School behaviour and attendance: parental responsibility measures'
+          path: '/government/publications/parental-responsibility-measures-for-behaviour-and-attendance'
+          description: "Statutory guidance for schools, local authorities and the police on dealing with poor attendance and behaviour in school"
+        metadata:
+          public_updated_at: 2017-01-05 14:50:33
+          document_type: 'Statutory guidance'
+      context:
+        right_to_left: true

--- a/spec/components/document_item_spec.rb
+++ b/spec/components/document_item_spec.rb
@@ -1,0 +1,290 @@
+require 'rails_helper'
+
+describe "Document list", type: :view do
+  def component_name
+    "document_list"
+  end
+
+  it "renders nothing when no data is given" do
+    assert_empty render_component({})
+  end
+
+  it "renders nothing when an empty array is passed in" do
+    assert_empty render_component(items: [])
+  end
+
+  it 'adds spacing around the document list when margin flags are set' do
+    render_component(
+      margin_bottom: true,
+      margin_top: true,
+      items: [
+        {
+          link: {
+            text: "School behaviour and attendance: parental responsibility measures",
+            path: "/government/publications/parental-responsibility-measures-for-behaviour-and-attendance",
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+            document_type: "Statutory guidance"
+          }
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list.gem-c-document-list--top-margin.gem-c-document-list--bottom-margin'
+  end
+
+  it "renders a document list correctly" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "School behaviour and attendance: parental responsibility measures",
+            path: "/government/publications/parental-responsibility-measures-for-behaviour-and-attendance",
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+            document_type: "Statutory guidance"
+          }
+        },
+        {
+          link: {
+            text: "Become an apprentice",
+            path: "/become-an-apprentice",
+            description: 'Becoming an apprentice - what to expect'
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-07-19 15:01:48 +0000"),
+            document_type: "Statutory guidance"
+          }
+        }
+      ]
+    )
+    li = ".gem-c-document-list__item-title"
+    attribute = ".gem-c-document-list__attribute"
+
+    assert_select "#{li}[href='/government/publications/parental-responsibility-measures-for-behaviour-and-attendance']", text: "School behaviour and attendance: parental responsibility measures"
+    assert_select "#{attribute} time", text: "5 January 2017"
+    assert_select "#{attribute} time[datetime='2017-01-05T14:50:33Z']"
+    assert_select ".gem-c-document-list__attribute", text: "Statutory guidance"
+
+    assert_select "#{li}[href='/become-an-apprentice']", text: "Become an apprentice"
+    assert_select ".gem-c-document-list__item-description", text: 'Becoming an apprentice - what to expect'
+    assert_select "#{attribute} time", text: "19 July 2017"
+    assert_select "#{attribute} time[datetime='2017-07-19T15:01:48Z']"
+  end
+
+  it "renders a document list item even when public_updated_at is nil" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Some news stories are timeless",
+            path: "/timeless-news",
+          },
+          metadata: {
+            document_type: "News Story",
+            public_updated_at: nil
+          }
+        }
+      ]
+    )
+
+    assert_select ".gem-c-document-list__item-title[href='/timeless-news']", text: "Some news stories are timeless"
+    assert_select ".gem-c-document-list__attribute", text: "News Story"
+  end
+
+
+  it "renders a document list with link tracking" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Link 1",
+            path: "/link1",
+            data_attributes: {
+              track_category: "navDocumentCollectionLinkClicked",
+              track_action: "1.1",
+              track_label: "/link1",
+              track_options: {
+                dimension28: "2",
+                dimension29: "Link 1"
+              }
+            }
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+            document_type: "Statutory guidance"
+          }
+        },
+        {
+          link: {
+            text: "Link 2",
+            path: "/link2",
+            data_attributes: {
+              track_category: "navDocumentCollectionLinkClicked",
+              track_action: "1.2",
+              track_label: "/link2",
+              track_options: {
+                dimension28: "2",
+                dimension29: "Link 2"
+              }
+            }
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-07-19 15:01:48 +0000"),
+            document_type: "Statutory guidance"
+          }
+        }
+      ]
+    )
+
+    li = "a.gem-c-document-list__item-title"
+
+    assert_select "#{li}[href='/link1']", text: "Link 1"
+    assert_select "#{li}[data-track-category='navDocumentCollectionLinkClicked']", text: "Link 1"
+    assert_select "#{li}[data-track-action='1.1']", text: "Link 1"
+    assert_select "#{li}[data-track-label='/link1']", text: "Link 1"
+    assert_select "#{li}[data-track-options='{\"dimension28\":\"2\",\"dimension29\":\"Link 1\"}']", text: "Link 1"
+
+    assert_select "#{li}[href='/link2']", text: "Link 2"
+    assert_select "#{li}[data-track-category='navDocumentCollectionLinkClicked']", text: "Link 2"
+    assert_select "#{li}[data-track-action='1.2']", text: "Link 2"
+    assert_select "#{li}[data-track-label='/link2']", text: "Link 2"
+    assert_select "#{li}[data-track-options='{\"dimension28\":\"2\",\"dimension29\":\"Link 2\"}']", text: "Link 2"
+  end
+
+  it "renders a document list without links" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "School behaviour and attendance: parental responsibility measures",
+          },
+        },
+        {
+          link: {
+            text: "Become an apprentice",
+          },
+        }
+      ]
+    )
+
+    span = "span.gem-c-document-list__item-title"
+
+    assert_select "#{span}:first-of-type", text: "School behaviour and attendance: parental responsibility measures"
+    assert_select "#{span}:last-of-type", text: "Become an apprentice"
+  end
+
+  it "adds branding correctly" do
+    render_component(
+      brand: 'attorney-generals-office',
+      items: [
+        {
+          link: {
+            text: "School behaviour and attendance: parental responsibility measures",
+            path: "/government/publications/parental-responsibility-measures-for-behaviour-and-attendance",
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+            document_type: "Statutory guidance"
+          }
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list__item.brand--attorney-generals-office'
+    assert_select '.gem-c-document-list .gem-c-document-list__item-title.brand__color'
+  end
+
+  it "does not wrap link in heading element if no description or metadata provided" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+          }
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list__item h3', false, 'Element should not be wrapped in heading if it is not acting as a heading for any other content'
+    assert_select '.gem-c-document-list__item a[href="/link/path"]', text: 'Link Title'
+  end
+
+  it "renders the item title with context when provided" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+            context: "some context"
+          }
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list__item-title--context[href="/link/path"]', text: 'Link Title'
+    assert_select '.gem-c-document-list__item-context', text: 'some context'
+  end
+
+  it "adds subtext" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+          },
+          subtext: "This is some subtext"
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list__subtext', text: 'This is some subtext'
+  end
+
+  it "removes underline from links" do
+    render_component(
+      remove_underline: true,
+      items: [
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+          }
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list.gem-c-document-list--no-underline'
+  end
+
+  it "highlights items" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+          },
+          highlight: true,
+          highlight_text: 'Most relevant result'
+        },
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+          },
+          highlight: true
+        }
+      ]
+    )
+
+    assert_select '.gem-c-document-list__item.gem-c-document-list__item--highlight', count: 2
+    assert_select '.gem-c-document-list__item:nth-child(1) .gem-c-document-list__highlight-text', text: 'Most relevant result'
+    assert_select '.gem-c-document-list__item:nth-child(2) .gem-c-document-list__highlight-text', false
+  end
+end


### PR DESCRIPTION
Raising this for visibility. Requires linting to pass in CI.

## What
Simplify document list markup when used in a table.

## Why
Each document is unnecessarily wrapped into an ordered list within the document list component (when presented in a table in Content Publisher). When rendering a single document with the component the ordered list should not be rendered.

## Visual Changes
TBD

[Trello card](https://trello.com/c/pJHJYOcK)