### PR TITLE
Fix duplicate CSS for components loading in component guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix duplicate CSS for components loading in component guide ([PR #1356](https://github.com/alphagov/govuk_publishing_components/pull/1356))
 * Make feedback component more responsive and usable on mobile ([PR #1346](https://github.com/alphagov/govuk_publishing_components/pull/1346))
 * Extend document-list component to show parts of a document ([PR #1326](https://github.com/alphagov/govuk_publishing_components/pull/1326))
 

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -7,8 +7,6 @@
 @import "govuk/helpers/all";
 @import "govuk/core/all";
 
-@import "govuk_publishing_components/all_components";
-
 $gem-guide-border-width: 1px;
 
 .component-list {

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -46,7 +46,7 @@ module GovukPublishingComponents
       additional_files = "@import 'govuk_publishing_components/govuk_frontend_support';\n"
       additional_files << "@import 'govuk_publishing_components/component_support';\n" unless print_styles
 
-      components = components_in_use("#{@application_path}/app/views/**/*.html.erb")
+      components = components_in_use("#{@application_path}/app/views/")
       extra_components = []
 
       components.each do |component|
@@ -74,13 +74,13 @@ module GovukPublishingComponents
     end
 
     def components_in_use_docs
-      @components_in_use_docs ||= ComponentDocs.new(gem_components: true, limit_to: components_in_use("#{@application_path}/app/views/**/*.html.erb"))
+      @components_in_use_docs ||= ComponentDocs.new(gem_components: true, limit_to: components_in_use("#{@application_path}/app/views/"))
     end
 
     def components_in_use(path)
       matches = []
 
-      files = Dir[path]
+      files = Dir[path + "**/*.html.erb"]
       files.each do |file|
         data = File.read(file)
         matches << data.scan(/(govuk_publishing_components\/components\/[a-z_-]+)/)
@@ -115,7 +115,8 @@ module GovukPublishingComponents
     end
 
     def components_used_by_component_guide
-      %w(breadcrumbs details layout-footer layout-header lead-paragraph search textarea title)
+      components = components_in_use("#{@component_gem_path}/app/views/govuk_publishing_components/component_guide/")
+      components << components_in_use("#{@component_gem_path}/app/views/layouts/")
     end
   end
 end

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -53,11 +53,12 @@ module GovukPublishingComponents
       end
 
       components << extra_components.compact
+      components << components_used_by_component_guide.compact
       components = components.flatten.uniq.sort
 
       components.map { |component|
         "@import 'govuk_publishing_components/components/#{print_path}_#{component.gsub('_', '-')}';" if component_has_sass_file(component.gsub("_", "-"), print_styles)
-      }.join("\n").squeeze("\n").prepend(additional_files)
+      }.compact.uniq.sort.join("\n").squeeze("\n").prepend(additional_files)
     end
 
   private
@@ -109,6 +110,10 @@ module GovukPublishingComponents
         h[:title] = component_doc.name
         h[:url] = component_doc_path(component_doc.id) if component_example
       end
+    end
+
+    def components_used_by_component_guide
+      %w(breadcrumbs details layout-footer layout-header lead-paragraph search textarea title)
     end
   end
 end

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -49,6 +49,7 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/component_support';
 @import 'govuk_publishing_components/components/_breadcrumbs';
 @import 'govuk_publishing_components/components/_contextual-sidebar';
+@import 'govuk_publishing_components/components/_details';
 @import 'govuk_publishing_components/components/_error-message';
 @import 'govuk_publishing_components/components/_error-summary';
 @import 'govuk_publishing_components/components/_govspeak';
@@ -58,28 +59,36 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/_layout-footer';
 @import 'govuk_publishing_components/components/_layout-for-admin';
 @import 'govuk_publishing_components/components/_layout-header';
+@import 'govuk_publishing_components/components/_lead-paragraph';
 @import 'govuk_publishing_components/components/_related-navigation';
+@import 'govuk_publishing_components/components/_search';
 @import 'govuk_publishing_components/components/_skip-link';
 @import 'govuk_publishing_components/components/_step-by-step-nav';
 @import 'govuk_publishing_components/components/_step-by-step-nav-header';
 @import 'govuk_publishing_components/components/_step-by-step-nav-related';
 @import 'govuk_publishing_components/components/_tabs';
+@import 'govuk_publishing_components/components/_textarea';
 @import 'govuk_publishing_components/components/_title';"
-
-    expected_print_sass = "@import 'govuk_publishing_components/govuk_frontend_support';
-
-@import 'govuk_publishing_components/components/print/_govspeak';
-@import 'govuk_publishing_components/components/print/_layout-footer';
-@import 'govuk_publishing_components/components/print/_layout-header';
-@import 'govuk_publishing_components/components/print/_skip-link';
-@import 'govuk_publishing_components/components/print/_step-by-step-nav';
-@import 'govuk_publishing_components/components/print/_step-by-step-nav-header';
-@import 'govuk_publishing_components/components/print/_title';"
 
     expect(page).to have_selector(".component-doc-h2", text: "Gem components used by this app (12)")
     expect(page).to have_selector(".govuk-details__summary-text", text: "Suggested Sass for this application")
 
     expect(page.find(:css, 'textarea[name="main-sass"]', visible: false).value).to eq(expected_main_sass)
+  end
+
+  it "includes suggested print sass for the application" do
+    visit "/component-guide"
+    expected_print_sass = "@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/components/print/_govspeak';
+@import 'govuk_publishing_components/components/print/_layout-footer';
+@import 'govuk_publishing_components/components/print/_layout-header';
+@import 'govuk_publishing_components/components/print/_search';
+@import 'govuk_publishing_components/components/print/_skip-link';
+@import 'govuk_publishing_components/components/print/_step-by-step-nav';
+@import 'govuk_publishing_components/components/print/_step-by-step-nav-header';
+@import 'govuk_publishing_components/components/print/_textarea';
+@import 'govuk_publishing_components/components/print/_title';"
+
     expect(page.find(:css, 'textarea[name="print-sass"]', visible: false).value).to eq(expected_print_sass)
   end
 


### PR DESCRIPTION
## What
Since the change to allow applications to only include the sass for components they need, we've had duplicate CSS for all components loading in the component guide.

This change includes the sass for components used in the guide in the suggested sass and removes the sass for components from the guide stylesheet. There are two possible configurations for an application:

- the application includes the sass for all components, as before. Both the application and the guide have no styling issues or duplication
- the application includes the sass for only the components it is using, plus the components in use within the guide (8 components, although there may be some overlap, e.g. both probably use `breadcrumbs`). Both the application and the guide have no styling issues or duplication

This change fixes the duplicate CSS problem but it introduces two other possible issues worth noting:

- applications using the new suggested sass may include CSS from a few components that are only in use in the guide (I think currently this is likely to be `layout_header` and `layout_footer`) so a small amount of CSS will be loaded unnecessarily
- for applications that have already switched to the new individual sass feature (`collections` and `finder-frontend`) this may represent a slightly breaking change, although the worst that will happen is parts of the component guide might not be styled

## Why
The component guide loads its own stylesheet plus the stylesheet for the application it is running in. If it's not running in an application it loads the stylesheet from the dummy app.

In the old world, both the dummy app and the application included the sass for all components, and the guide stylesheet didn't include any, so there was no duplication. When the individual sass feature was introduced a problem arose - there are components in use by the guide that might not be in use by the application, so parts of the guide weren't being styled. To fix this, the sass for all components was added to the guide stylesheet, but this introduced this duplication.

This change now addresses this problem.

## Visual Changes
None.

Trello card: https://trello.com/c/FpI4ntWf/234-fix-duplicate-css-in-component-guide