### PR TITLE
Add missing legacy colour for dark-grey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Patch: add missing legacy colour for dark-grey ([PR #1358](https://github.com/alphagov/govuk_publishing_components/pull/1358))
+
 ## 21.29.0
 
 * Make feedback component more responsive and usable on mobile ([PR #1346](https://github.com/alphagov/govuk_publishing_components/pull/1346))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
@@ -68,7 +68,7 @@
   margin-bottom: 1px;
   height: .482em;
   width: .63em;
-  fill: govuk-colour("dark-grey");
+  fill: govuk-colour("dark-grey", $legacy: "grey-1");
 }
 
 .gem-c-pagination__link-label {


### PR DESCRIPTION
## What
Adds the legacy alternative for dark-grey in the previous and next navigation component.
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
I missed off the `legacy` value for dark-grey when making changes to the previous and next navigation component, and this was leading to some failing builds for some apps.
