### PR TITLE
Update attachment component to accommodate publications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update attachment component to accommodate publications ([PR #1375](https://github.com/alphagov/govuk_publishing_components/pull/1375))
+
 ## 21.29.1
 
 * Patch: add missing legacy colour for dark-grey ([PR #1358](https://github.com/alphagov/govuk_publishing_components/pull/1358))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -66,6 +66,10 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey", $legacy: "grey-3");
   }
 }
 
+.gem-c-attachment__metadata--compact {
+  margin-bottom: 0;
+}
+
 .gem-c-attachment__abbr {
   text-decoration: none;
   cursor: help;

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -68,6 +68,11 @@
       <%= tag.p raw(attributes.join(', ')), class: "gem-c-attachment__metadata" %>
     <% end %>
 
+    <% if attachment.is_official_document %>
+      <%= tag.p link_to("Order a copy", "https://www.gov.uk/guidance/how-to-buy-printed-copies-of-official-documents", class: "govuk-link", target: "_blank"),
+        class: "gem-c-attachment__metadata" %>
+    <% end %>
+
     <% unless hide_opendocument_metadata %>
       <% if attachment.opendocument? %>
         <%= tag.p class: "gem-c-attachment__metadata" do %>

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -60,6 +60,10 @@
       <%= tag.p "Ref: #{attachment.reference}", class: "gem-c-attachment__metadata gem-c-attachment__metadata--compact" %>
     <% end %>
 
+    <% if attachment.unnumbered_reference.present? %>
+      <%= tag.p attachment.unnumbered_reference, class: "gem-c-attachment__metadata gem-c-attachment__metadata--compact" %>
+    <% end %>
+
     <% if attributes.any? %>
       <%= tag.p raw(attributes.join(', ')), class: "gem-c-attachment__metadata" %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -56,6 +56,10 @@
             data: data_attributes %>
     <% end %>
 
+    <% if attachment.reference.present? %>
+      <%= tag.p "Ref: #{attachment.reference}", class: "gem-c-attachment__metadata gem-c-attachment__metadata--compact" %>
+    <% end %>
+
     <% if attributes.any? %>
       <%= tag.p raw(attributes.join(', ')), class: "gem-c-attachment__metadata" %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -100,6 +100,20 @@ examples:
         isbn: "978-1-5286-1173-2"
         unique_reference: "2259"
         command_paper_number: "67"
+  command_paper_unnumbered:
+    description: |
+      Command paper, unnumbered
+    data:
+      attachment:
+        title: "The government financial reporting review"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/791567/the_government_financial_reporting_review_web.pdf
+        filename: the_government_financial_reporting_review_web.pdf
+        content_type: application/pdf
+        file_size: 20000
+        number_of_pages: 7
+        isbn: "978-1-5286-1173-2"
+        unique_reference: "2259"
+        unnumbered_command_paper: true
   act_paper_numbered:
     description: |
       Act paper (House of Commons paper), numbered
@@ -115,3 +129,17 @@ examples:
         unique_reference: "2942"
         hoc_paper_number: "121"
         parliamentary_session: "2019-20"
+  act_paper_unnumbered:
+    description: |
+      Act paper (House of Commons paper), unnumbered
+    data:
+      attachment:
+        title: "Budget 2020"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/871799/Budget_2020_Web_Accessible_Complete.pdf
+        filename: Budget_2020_Web_Accessible_Complete.pdf
+        content_type: application/pdf
+        file_size: 20000
+        number_of_pages: 12
+        isbn: "978-1-913635-01-5"
+        unique_reference: "2942"
+        unnumbered_hoc_paper: true

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -86,3 +86,32 @@ examples:
         file_size: 20000
       data_attributes:
         gtm: "attachment-preview"
+  command_paper_numbered:
+    description: |
+      Command paper, numbered
+    data:
+      attachment:
+        title: "The government financial reporting review"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/791567/the_government_financial_reporting_review_web.pdf
+        filename: department-for-transport-information-asset-register.csv
+        content_type: application/pdf
+        file_size: 20000
+        number_of_pages: 7
+        isbn: "978-1-5286-1173-2"
+        unique_reference: "2259"
+        command_paper_number: "67"
+  act_paper_numbered:
+    description: |
+      Act paper (House of Commons paper), numbered
+    data:
+      attachment:
+        title: "Budget 2020"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/871799/Budget_2020_Web_Accessible_Complete.pdf
+        filename: Budget_2020_Web_Accessible_Complete.pdf
+        content_type: application/pdf
+        file_size: 20000
+        number_of_pages: 12
+        isbn: "978-1-913635-01-5"
+        unique_reference: "2942"
+        hoc_paper_number: "121"
+        parliamentary_session: "2019-20"

--- a/lib/govuk_publishing_components/presenters/attachment.rb
+++ b/lib/govuk_publishing_components/presenters/attachment.rb
@@ -61,6 +61,12 @@ module GovukPublishingComponents
         reference.join(", ")
       end
 
+      def unnumbered_reference
+        unnumbered_reference = "Unnumbered command paper" if attachment_data[:unnumbered_command_paper].eql?(true) && !attachment_data[:command_paper_number]
+        unnumbered_reference = "Unnumbered act paper" if attachment_data[:unnumbered_hoc_paper].eql?(true) && !attachment_data[:hoc_paper_number]
+        unnumbered_reference
+      end
+
       class SupportedContentType
         attr_reader :content_type_data
 

--- a/lib/govuk_publishing_components/presenters/attachment.rb
+++ b/lib/govuk_publishing_components/presenters/attachment.rb
@@ -67,6 +67,10 @@ module GovukPublishingComponents
         unnumbered_reference
       end
 
+      def is_official_document
+        attachment_data[:command_paper_number].present? || attachment_data[:hoc_paper_number].present? || attachment_data[:unnumbered_command_paper].eql?(true) || attachment_data[:unnumbered_hoc_paper].eql?(true)
+      end
+
       class SupportedContentType
         attr_reader :content_type_data
 

--- a/lib/govuk_publishing_components/presenters/attachment.rb
+++ b/lib/govuk_publishing_components/presenters/attachment.rb
@@ -47,6 +47,20 @@ module GovukPublishingComponents
         attachment_data[:alternative_format_contact_email]
       end
 
+      def reference
+        reference = []
+        reference << "ISBN #{attachment_data[:isbn]}" if attachment_data[:isbn].present?
+        reference << attachment_data[:unique_reference] if attachment_data[:unique_reference].present?
+        reference << attachment_data[:command_paper_number] if attachment_data[:command_paper_number].present?
+        if attachment_data[:hoc_paper_number].present?
+          hoc_reference = "HC #{attachment_data[:hoc_paper_number]}"
+          hoc_reference += " #{attachment_data[:parliamentary_session]}" if attachment_data[:parliamentary_session].present?
+          reference << hoc_reference
+        end
+
+        reference.join(", ")
+      end
+
       class SupportedContentType
         attr_reader :content_type_data
 

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -128,4 +128,21 @@ describe "Attachment", type: :view do
       )
     assert_select ".gem-c-attachment__metadata:nth-of-type(1)", text: "Ref: ISBN 978-1-5286-1173-2, 2259, Cd. 67"
   end
+
+  it "shows unnumbered details on the second metadata line if marked so" do
+    render_component(
+      attachment: {
+          title: "The government financial reporting review",
+          url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/791567/the_government_financial_reporting_review_web.pdf",
+          filename: "department-for-transport-information-asset-register.csv",
+          content_type: "application/pdf",
+          file_size: 20000,
+          number_of_pages: 7,
+          isbn: "978-1-5286-1173-2",
+          unique_reference: "2259",
+          unnumbered_command_paper: true,
+        },
+      )
+    assert_select ".gem-c-attachment__metadata:nth-of-type(2)", text: "Unnumbered command paper"
+  end
 end

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -105,10 +105,27 @@ describe "Attachment", type: :view do
         url: "attachment",
         content_type: "application/vnd.oasis.opendocument.spreadsheet",
       },
-        data_attributes: { gtm: "attachment-preview" },
+      data_attributes: { gtm: "attachment-preview" },
     )
 
     assert_select ".gem-c-attachment__thumbnail a.govuk-link[data-gtm='attachment-preview']"
     assert_select ".gem-c-attachment__title a.govuk-link[data-gtm='attachment-preview']"
+  end
+
+  it "shows reference details on the first metadata line if provided" do
+    render_component(
+      attachment: {
+          title: "The government financial reporting review",
+          url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/791567/the_government_financial_reporting_review_web.pdf",
+          filename: "department-for-transport-information-asset-register.csv",
+          content_type: "application/pdf",
+          file_size: 20000,
+          number_of_pages: 7,
+          isbn: "978-1-5286-1173-2",
+          unique_reference: "2259",
+          command_paper_number: "Cd. 67",
+        },
+      )
+    assert_select ".gem-c-attachment__metadata:nth-of-type(1)", text: "Ref: ISBN 978-1-5286-1173-2, 2259, Cd. 67"
   end
 end

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -145,4 +145,20 @@ describe "Attachment", type: :view do
       )
     assert_select ".gem-c-attachment__metadata:nth-of-type(2)", text: "Unnumbered command paper"
   end
+
+  it "shows 'Order a copy' link on the third metadata line if it's an official document" do
+    render_component(
+      attachment: {
+          title: "The government financial reporting review",
+          url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/791567/the_government_financial_reporting_review_web.pdf",
+          filename: "department-for-transport-information-asset-register.csv",
+          content_type: "application/pdf",
+          file_size: 20000,
+          number_of_pages: 7,
+          isbn: "978-1-5286-1173-2",
+          command_paper_number: "Cd. 67",
+        },
+      )
+    assert_select ".gem-c-attachment__metadata:nth-of-type(3) .govuk-link", text: "Order a copy"
+  end
 end

--- a/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
@@ -168,4 +168,29 @@ RSpec.describe GovukPublishingComponents::Presenters::Attachment do
       expect(attachment.unnumbered_reference).to be nil
     end
   end
+
+  describe "#is_official_document" do
+    it "returns true if command_paper_number is set" do
+      attachment = described_class.new(title: "test",
+                                       url: "test",
+                                       content_type: "text/csv",
+                                       command_paper_number: "333")
+      expect(attachment.is_official_document).to be true
+    end
+
+    it "returns true if hoc_paper_number is set" do
+      attachment = described_class.new(title: "test",
+                                       url: "test",
+                                       content_type: "text/csv",
+                                       hoc_paper_number: "444")
+      expect(attachment.is_official_document).to be true
+    end
+
+    it "returns false if no command_paper_number or hoc_paper_number are set" do
+      attachment = described_class.new(title: "test",
+                                       url: "test",
+                                       content_type: "text/csv")
+      expect(attachment.is_official_document).to be false
+    end
+  end
 end

--- a/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
@@ -109,4 +109,27 @@ RSpec.describe GovukPublishingComponents::Presenters::Attachment do
       expect(attachment.spreadsheet?).to be false
     end
   end
+
+  describe "#reference" do
+    context "when reference details are provided" do
+      it "returns a well formatted reference string" do
+        attachment = described_class.new(title: "test",
+                                         url: "test",
+                                         content_type: "text/csv",
+                                         isbn: "111",
+                                         unique_reference: "222",
+                                         command_paper_number: "333",
+                                         hoc_paper_number: "444",
+                                         parliamentary_session: "555")
+        expect(attachment.reference).to eq("ISBN 111, 222, 333, HC 444 555")
+      end
+
+      it "returns an empty string is no reference details are provided" do
+        attachment = described_class.new(title: "test",
+                                         url: "test",
+                                         content_type: "text/csv")
+        expect(attachment.reference).to eq("")
+      end
+    end
+  end
 end

--- a/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
@@ -132,4 +132,40 @@ RSpec.describe GovukPublishingComponents::Presenters::Attachment do
       end
     end
   end
+
+  describe "#unnumbered_reference" do
+    it "returns 'Unnumbered command paper' if unnumbered_command_paper is true" do
+      attachment = described_class.new(title: "test",
+                                       url: "test",
+                                       content_type: "text/csv",
+                                       unnumbered_command_paper: true)
+      expect(attachment.unnumbered_reference).to eq("Unnumbered command paper")
+    end
+
+    it "returns 'Unnumbered act paper' if unnumbered_hoc_paper is true" do
+      attachment = described_class.new(title: "test",
+                                       url: "test",
+                                       content_type: "text/csv",
+                                       unnumbered_hoc_paper: true)
+      expect(attachment.unnumbered_reference).to eq("Unnumbered act paper")
+    end
+
+    it "returns nil if unnumbered_command_paper is true and command_paper_number is set" do
+      attachment = described_class.new(title: "test",
+                                       url: "test",
+                                       content_type: "text/csv",
+                                       command_paper_number: "333",
+                                       unnumbered_command_paper: true)
+      expect(attachment.unnumbered_reference).to be nil
+    end
+
+    it "returns nil if unnumbered_hoc_paper is true and hoc_paper_number is set" do
+      attachment = described_class.new(title: "test",
+                                       url: "test",
+                                       content_type: "text/csv",
+                                       hoc_paper_number: "444",
+                                       unnumbered_hoc_paper: true)
+      expect(attachment.unnumbered_reference).to be nil
+    end
+  end
 end


### PR DESCRIPTION
## What
Add reference details to attachments

## Why
To accommodate publications attachments and bring them close to how they are now rendered by Whitehall (in terms of presented data)

## Visual Changes
[Preview attachment component](https://govuk-publis-publicatio-e3wxt3.herokuapp.com/component-guide/attachment)


[Trello card](https://trello.com/c/UET4vx6k/1439-update-attachment-component-to-accommodate-new-attachment-design)