### PR TITLE
Release 21.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.30.0
 
 * Update attachment component to accommodate publications ([PR #1375](https://github.com/alphagov/govuk_publishing_components/pull/1375))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.29.1)
+    govuk_publishing_components (21.30.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -97,7 +97,7 @@ GEM
       rest-client (~> 2.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk_app_config (2.1.1)
+    govuk_app_config (2.1.2)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 3.1.0)
       statsd-ruby (~> 1.4.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.29.1".freeze
+  VERSION = "21.30.0".freeze
 end


### PR DESCRIPTION
## 21.30.0

* Update attachment component to accommodate publications ([PR #1375](https://github.com/alphagov/govuk_publishing_components/pull/1375))
