### PR TITLE
Prepare header component for public-facing usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Prepare header component for public-facing usage ([PR #1384](https://github.com/alphagov/govuk_publishing_components/pull/1384))
+
 ## 21.30.0
 
 * Update attachment component to accommodate publications ([PR #1375](https://github.com/alphagov/govuk_publishing_components/pull/1375))

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -1,6 +1,7 @@
 <%
   full_width ||= false
   product_name ||= "Publishing"
+  public_environment = environment.eql?("public")
   navigation_items ||= []
   if full_width
     width_class = "govuk-header__container--full-width"
@@ -24,13 +25,15 @@
           </span>
         </span>
 
-        <span class="govuk-header__product-name gem-c-header__product-name">
-          <%= product_name %>
-        </span>
+        <% unless public_environment %>
+          <span class="govuk-header__product-name gem-c-header__product-name">
+            <%= product_name %>
+          </span>
 
-        <span class="gem-c-environment-tag govuk-tag gem-c-environment-tag--<%= environment %>">
-          <%= environment %>
-        </span>
+          <span class="gem-c-environment-tag govuk-tag gem-c-environment-tag--<%= environment %>">
+            <%= environment %>
+          </span>
+        <% end %>
       </a>
 
     </div><div class="govuk-header__content gem-c-header__content">

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -35,7 +35,12 @@ describe "Layout header", type: :view do
     assert_select ".govuk-header__container--full-width"
   end
 
+  it "does not render the product name and environment tag if environment is 'public'" do
+    render_component(environment: "public", product_name: "Product name")
 
+    assert_select ".gem-c-header__product-name", 0
+    assert_select ".gem-c-environment-tag", 0
+  end
 
   it "renders the header with navigation items" do
     navigation_items = [


### PR DESCRIPTION
## What
Hide product name and environment tag if the environment is set to "public". In line with the approach in #1265 – which will bring a new and shiny public-facing layout ✨ , but until that's ready we can already use the header in public-facing apps such as https://github.com/alphagov/govuk-coronavirus-business-volunteer-form.

## Why
To prepare the header component for public-facing usage

[Trello card](https://trello.com/c/S8Ht5CJq/10-setup-application-page-layout)