### PR TITLE
Explicitly set accordion heading line height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add custom margin option to accordion component ([PR #1470](https://github.com/alphagov/govuk_publishing_components/pull/1470))
+* Explicitly set accordion heading line height ([PR #1386](https://github.com/alphagov/govuk_publishing_components/pull/1386))
 
 ## 21.41.4
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
@@ -1,5 +1,15 @@
 @import "govuk/components/accordion/accordion";
 
+.gem-c-accordion {
+  .govuk-accordion__section-heading {
+    // this is a temporary addition to fix the line height when it
+    // is being overridden by styles from govuk-template in collections
+    @include govuk-media-query($until: desktop) {
+      @include govuk-font(24, $weight: bold, $line-height: 1.6);
+    }
+  }
+}
+
 .govuk-accordion--condensed {
   .govuk-accordion__section-button {
     @include govuk-media-query($from: tablet) {


### PR DESCRIPTION
## What / why

Our accordion component is unintentionally deviating from govuk-frontend, resulting in a slightly smaller touch area on mobile devices.

- govuk-frontend component does not appear to explicitly set the line height for the h2 in an accordion
- inside some applications h2 elements have some default styling which was subtly reducing the line height
- end result was on mobile, unopened accordions were 54px tall, not 60px as intended
- this fixes this by explicitly defining the h2 font on mobile

## Visual Changes

Before | After
----- | -----
<img width="309" alt="Screenshot 2020-03-20 at 14 49 56" src="https://user-images.githubusercontent.com/861310/77175222-28d91c80-6aba-11ea-9deb-2a93f885e6c5.png"> | <img width="303" alt="Screenshot 2020-03-20 at 14 50 07" src="https://user-images.githubusercontent.com/861310/77175234-2ecefd80-6aba-11ea-8b98-f009fdc7c78c.png">
