### PR TITLE
Enable label as page heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Enable label as page heading ([PR #1389](https://github.com/alphagov/govuk_publishing_components/pull/1389))
+
 ## 21.31.0
 
 * Prepare header component for public-facing usage ([PR #1384](https://github.com/alphagov/govuk_publishing_components/pull/1384))

--- a/app/views/govuk_publishing_components/components/_label.html.erb
+++ b/app/views/govuk_publishing_components/components/_label.html.erb
@@ -3,6 +3,7 @@
   is_radio_label ||= false
   bold ||= false
   heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
+  is_page_heading ||= false
 
   css_classes = %w( gem-c-label govuk-label )
   css_classes << "govuk-label--s" if bold
@@ -13,8 +14,12 @@
   hint_text_css_classes << "govuk-radios__hint" if is_radio_label
 %>
 
-<%= tag.label for: html_for, class: css_classes do %>
-  <%= text %>
+<% if is_page_heading %>
+  <%= tag.h1 text, class: "govuk-label-wrapper" do %>
+    <%= tag.label text, for: html_for, class: css_classes %>
+  <% end %>
+<% else %>
+  <%= tag.label text, for: html_for, class: css_classes %>
 <% end %>
 
 <% if hint_text.present? %>

--- a/app/views/govuk_publishing_components/components/docs/label.yml
+++ b/app/views/govuk_publishing_components/components/docs/label.yml
@@ -24,22 +24,29 @@ examples:
   with_hint:
     data:
       text: "National Insurance number"
-      html_for: "id-that-matches-input"
+      html_for: "id-that-matches-input-1"
       hint_id: "should-match-aria-describedby-input"
       hint_text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
   with_custom_label_size:
     description: Make the label different sizes. Valid options are 's', 'm', 'l' and 'xl'.
     data:
       text: "Surname"
-      html_for: "id-that-matches-input"
+      html_for: "id-that-matches-input-2"
       heading_size: "xl"
   bold_with_hint:
     data:
       bold: true
       text: "National Insurance number"
-      html_for: "id-that-matches-input"
+      html_for: "id-that-matches-input-3"
       hint_id: "should-match-aria-describedby-input-bold"
       hint_text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+  as_page_heading:
+    data:
+      is_page_heading: true
+      heading_size: "xl" 
+      text: "National Insurance number"
+      html_for: "id-that-matches-input-4"
+      hint_id: "should-match-aria-describedby-input-bold"
   inside_a_radio_component:
     description: |
       When the label is used inside the [radio component](/component-guide/radio) additional classes are required on the radio, which are added by this option. This is already handled by the radio component and is a specific use case, but is worth documenting.
@@ -47,7 +54,7 @@ examples:
       Note that this example will not render correctly - do not be alarmed. It only works properly when inside the radio component.
     data:
       text: "National Insurance number"
-      html_for: "id-that-matches-input"
+      html_for: "id-that-matches-input-5"
       is_radio_label: true
       html_for: "id-radio"
       hint_id: "id-radio"

--- a/app/views/govuk_publishing_components/components/docs/textarea.yml
+++ b/app/views/govuk_publishing_components/components/docs/textarea.yml
@@ -56,6 +56,14 @@ examples:
         href: '#example-error-1'
       - text: Descriptive link to the question with an error 2
         href: '#example-error-2'
+  with_label_as_page_heading:
+    data:
+      label:
+        is_page_heading: true
+        heading_size: "xl"
+        text: "Can you provide more detail?"
+      hint: "Please include as much information as possible."
+      name: "more-detail-error"
   with_value:
     data:
       label:

--- a/spec/components/label_spec.rb
+++ b/spec/components/label_spec.rb
@@ -63,6 +63,19 @@ describe "Label", type: :view do
     assert_select ".govuk-label--s"
   end
 
+  it "renders label as page heading" do
+    render_component(
+      text: "National Insurance number",
+      html_for: "id-that-matches-input",
+      is_page_heading: true,
+    )
+
+    assert_select(
+      "h1.govuk-label-wrapper .govuk-label[for='id-that-matches-input']",
+      text: "National Insurance number",
+    )
+  end
+
   it "renders label when required to be inside the radio component" do
     render_component(
       is_radio_label: true,


### PR DESCRIPTION
## What
Enable label as page heading

## Why
Rationale: https://design-system.service.gov.uk/get-started/labels-legends-headings/#labels-as-page-headings.

This PR mirrors the Design System component code in [govuk-frontend](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/label/template.njk)

## Visual Changes
Example on textarea
<img width="960" alt="Screenshot 2020-03-21 at 14 29 25" src="https://user-images.githubusercontent.com/788096/77228673-cf87f080-6b80-11ea-903a-56a4c82c0b70.png">

[Trello card](https://trello.com/c/nx25TT4p/60-allow-textarea-component-to-be-used-in-a-one-question-per-page-scenario)

Fixes #1388. Raised to help https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/pull/36