### PR TITLE
Add PHE branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add PHE branding ([PR #1396](https://github.com/alphagov/govuk_publishing_components/pull/1396))
+
 ## 21.32.0
 
 * Enable label as page heading ([PR #1389](https://github.com/alphagov/govuk_publishing_components/pull/1389))

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -90,3 +90,16 @@
     border-color: govuk-colour("black");
   }
 }
+
+// new brand colour to match Public Health England
+// used on the coronavirus page
+// note that PHE already has a different brand colour, the brand
+// department-for-health is used on the PHE org page
+$covid-green: #7eff8e;
+
+.brand--public-health-england {
+  &.brand__border-color,
+  .brand__border-color {
+    border-color: $covid-green;
+  }
+}


### PR DESCRIPTION
## What
Add a brand colour for Public Health England, to be used on the coronavirus landing page.

## Why
We don't have this as a brand colour yet and we now need to use it in components.

## Visual Changes
No visual changes, but here's an example of the colour in use.

<img width="901" alt="Screenshot 2020-03-23 at 09 19 29" src="https://user-images.githubusercontent.com/861310/77301401-856d4f00-6ce7-11ea-8159-b6d8b339697a.png">

