### PR TITLE
Add invert option to heading component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add PHE branding ([PR #1396](https://github.com/alphagov/govuk_publishing_components/pull/1396))
+* Add invert option to heading component ([PR #1397](https://github.com/alphagov/govuk_publishing_components/pull/1397))
 
 ## 21.32.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
@@ -44,3 +44,7 @@
   border-top-style: solid;
   border-top-width: 5px;
 }
+
+.gem-c-heading--inverse {
+  color: govuk-colour("white");
+}

--- a/app/views/govuk_publishing_components/components/_heading.html.erb
+++ b/app/views/govuk_publishing_components/components/_heading.html.erb
@@ -13,7 +13,7 @@
   classes << (shared_helper.get_margin_bottom) if [*0..9].include?(local_assigns[:margin_bottom])
 %>
 <%= content_tag(shared_helper.get_heading_level, text,
-    class: classes,
-    id: heading_helper.id,
-    lang: lang
+  class: classes,
+  id: heading_helper.id,
+  lang: lang
 ) %>

--- a/app/views/govuk_publishing_components/components/docs/heading.yml
+++ b/app/views/govuk_publishing_components/components/docs/heading.yml
@@ -68,6 +68,12 @@ examples:
       brand: 'department-for-environment-food-rural-affairs'
       padding: true
       border_top: 5
+  inverted:
+    data:
+      text: 'On a dark background'
+      inverse: true
+    context:
+      dark_background: true
   with_lang_attribute:
     description: |
       The component is used on translated pages that don’t have a translation for the text strings. This means that it could display the fallback English string if the translate method can’t find an appropriate translation. This makes sure that the lang can be set to ensure that browsers understand which parts of the page are in each language.

--- a/lib/govuk_publishing_components/presenters/heading_helper.rb
+++ b/lib/govuk_publishing_components/presenters/heading_helper.rb
@@ -11,6 +11,7 @@ module GovukPublishingComponents
         @classes << " gem-c-heading--mobile-top-margin" if options[:mobile_top_margin]
         @classes << " gem-c-heading--padding" if options[:padding]
         @classes << " gem-c-heading--border-top-#{options[:border_top]}" if [1, 2, 5].include? options[:border_top]
+        @classes << " gem-c-heading--inverse" if options[:inverse]
       end
     end
   end

--- a/spec/components/heading_spec.rb
+++ b/spec/components/heading_spec.rb
@@ -85,4 +85,9 @@ describe "Heading", type: :view do
     render_component(text: "Branded", lang: "cy")
     assert_select ".gem-c-heading[lang=cy]"
   end
+
+  it "inverts the heading" do
+    render_component(text: "Inverted", inverse: true)
+    assert_select ".gem-c-heading.gem-c-heading--inverse"
+  end
 end


### PR DESCRIPTION
## What
Adds an inverse option for the heading, for white text on a dark background.

## Why
Needed on the coronavirus landing page.

## Visual Changes

<img width="893" alt="Screenshot 2020-03-23 at 09 48 51" src="https://user-images.githubusercontent.com/861310/77303893-961fc400-6ceb-11ea-8196-6229338db304.png">

