### PR TITLE
Rename colour variable

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -95,11 +95,11 @@
 // used on the coronavirus page
 // note that PHE already has a different brand colour, the brand
 // department-for-health is used on the PHE org page
-$covid-green: #7eff8e;
+$gem-c-covid-green: #7eff8e;
 
 .brand--public-health-england {
   &.brand__border-color,
   .brand__border-color {
-    border-color: $covid-green;
+    border-color: $gem-c-covid-green;
   }
 }


### PR DESCRIPTION
## What
Rename recently added colour variable to have a `gem-c` prefix.

## Why
Because it's already used elsewhere and might cause a conflict. Also this is good practice.

## Visual Changes
None.
