### PR TITLE
Add custom multivariate test cookie as essential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add custom multivariate test as essential cookie ([PR #1400](https://github.com/alphagov/govuk_publishing_components/pull/1400))
+
 ## 21.33.0
 
 * Add PHE branding ([PR #1396](https://github.com/alphagov/govuk_publishing_components/pull/1396))

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -19,6 +19,7 @@
     '_email-alert-frontend_session': 'essential',
     'licensing_session': 'essential',
     'govuk_contact_referrer': 'essential',
+    'multivariatetest_cohort_coronavirus_extremely_vulnerable_rate_limit': 'essential',
     'dgu_beta_banner_dismissed': 'settings',
     'global_bar_seen': 'settings',
     'govuk_browser_upgrade_dismisssed': 'settings',


### PR DESCRIPTION
Required for https://github.com/alphagov/frontend/pull/2298

The cookie name is constructed in https://github.com/alphagov/frontend/pull/2298/files#diff-6b36a1b0d15da539f564a110dc18b378R139 and https://github.com/alphagov/frontend/pull/2298/files#diff-ca00ebfded4d715e743554943f03131fR34.