### PR TITLE
Fix conditional reveal on checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix conditional reveal on checkboxes #1402 ([PR #1402](https://github.com/alphagov/govuk_publishing_components/pull/1402))
+
 ## 21.34.0
 
 * Add custom multivariate test as essential cookie ([PR #1400](https://github.com/alphagov/govuk_publishing_components/pull/1400))

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -285,9 +285,26 @@ examples:
         - label: "Phone"
           value: "phone"
           conditional: <div class="govuk-form-group"><label class="govuk-label" for="contact-by-phone">Phone number</label><input class="govuk-input govuk-!-width-one-third" id="contact-by-phone" name="contactingme" type="tel"></div>
-        - label: "Other"
-          value: "other"
-          conditional: "See no styling."
+        - label: "Text message"
+          value: "text"
+          conditional: <div class="govuk-form-group"><label class="govuk-label" for="contact-by-text">Mobile phone number</label><input class="govuk-input govuk-!-width-one-third" id="contact-by-text" name="contactingme" type="tel"></div>
+  checkbox_items_with_conditional_reveal_checked:
+    data:
+      name: "contacting-checked"
+      id: "contacting-checked"
+      heading: "How would you like to be contacted?"
+      hint_text: "Please select all options that are relevant to you."
+      items:
+        - label: "Email"
+          value: "email"
+          conditional: <div class="govuk-form-group"><label class="govuk-label" for="contact-by-email">Email address</label><input class="govuk-input govuk-!-width-one-third" id="contact-by-email" name="contactingme" type="email"></div>
+          checked: true
+        - label: "Phone"
+          value: "phone"
+          conditional: <div class="govuk-form-group"><label class="govuk-label" for="contact-by-phone">Phone number</label><input class="govuk-input govuk-!-width-one-third" id="contact-by-phone" name="contactingme" type="tel"></div>
+        - label: "Text message"
+          value: "text"
+          conditional: <div class="govuk-form-group"><label class="govuk-label" for="contact-by-text">Mobile phone number</label><input class="govuk-input govuk-!-width-one-third" id="contact-by-text" name="contactingme" type="tel"></div>
   checkbox_items_with_checked_items:
     data:
       name: "nationality"

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -313,6 +313,18 @@ examples:
       - value: "govuk-verify"
         text: "Use GOV.UK Verify"
         conditional: "You’ll need to prove your identity using GOV.UK Verify"
+  conditional_checked:
+    data:
+      name: "radio-group-conditional"
+      id_prefix: "conditional-checked"
+      items:
+      - value: "government-gateway"
+        text: "Use Government Gateway"
+        conditional: "You’ll need to prove your identity using Government Gateway"
+        checked: true
+      - value: "govuk-verify"
+        text: "Use GOV.UK Verify"
+        conditional: "You’ll need to prove your identity using GOV.UK Verify"
   tracking-url:
     data:
       name: "radio-group-tracking-url"

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -70,11 +70,13 @@ module GovukPublishingComponents
 
       def checkbox_markup(checkbox, index)
         checkbox_id = checkbox[:id] || "#{@id}-#{index}"
-        controls = checkbox[:conditional].present? ? "#{checkbox_id}-conditional-#{index || rand(1..100)}" : checkbox[:controls]
+        controls = checkbox[:controls]
+        aria_controls = "#{checkbox_id}-conditional-#{index || rand(1..100)}" if checkbox[:conditional].present?
         checkbox_name = checkbox[:name].present? ? checkbox[:name] : @name
         checked = true if checkbox[:checked].present?
         data = checkbox[:data_attributes] || {}
         data[:controls] = controls
+        data["aria-controls"] = aria_controls
 
         capture do
           concat check_box_tag checkbox_name, checkbox[:value], checked, class: "govuk-checkboxes__input", id: checkbox_id, data: data


### PR DESCRIPTION
## What
Fix conditional reveal on checkboxes
Add examples for pre-checked items with conditonal reveal

## Why
GOV.UK Frontend script for conditional reveal (`checkboxes.js`) requires a `data-aria-controls` not a `data-controls` attribute as currently implemented. This being misconfigured means the script doesn't show the conditional content when pre-checked. This is a major problem when presenting errors to a field within the conditionally revealed block.

## Visual Changes
No visual changes, only functional changes: [Preview checkboxes with conditional revealed content in a pre-checked state](https://govuk-publis-fix-condit-svxz7n.herokuapp.com/component-guide/checkboxes/checkbox_items_with_conditional_reveal_checked) – you'll also see a bunch of axe errors which are not introduced by this change and shall be addressed, but I'll raise a separate issue for this.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="960" alt="Screenshot 2020-03-24 at 19 04 34" src="https://user-images.githubusercontent.com/788096/77466547-58fa2580-6e02-11ea-8847-137b0b34cf9f.png">


</td><td valign="top">

<img width="960" alt="Screenshot 2020-03-24 at 19 04 12" src="https://user-images.githubusercontent.com/788096/77466563-5e577000-6e02-11ea-8cbe-33589adb69a0.png">


</td></tr>
</table>
