### PR TITLE
Initialise global bar on approving all cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Set global_bar_cookie immediately when cookie consent given ([PR #1405](https://github.com/alphagov/govuk_publishing_components/pull/1405))
+
 ## 21.34.1
 
 * Fix conditional reveal on checkboxes #1402 ([PR #1402](https://github.com/alphagov/govuk_publishing_components/pull/1402))

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -71,6 +71,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (window.GOVUK.analyticsInit) {
       window.GOVUK.analyticsInit()
     }
+    if (window.GOVUK.globalBarInit) {
+      window.GOVUK.globalBarInit.init()
+    }
   }
 
   CookieBanner.prototype.showConfirmationMessage = function () {

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -120,6 +120,29 @@ describe('Cookie banner', function () {
     expect(GOVUK.analyticsInit).toHaveBeenCalled()
   })
 
+  it('sets global_bar_seen cookie when accepting cookies', function () {
+    GOVUK.globalBarInit = {
+      init: function () {}
+    }
+    spyOn(GOVUK.globalBarInit, 'init')
+    spyOn(GOVUK, 'setCookie').and.callThrough()
+
+    var element = document.querySelector('[data-module="cookie-banner"]')
+    new GOVUK.Modules.CookieBanner().start($(element))
+
+    // Manually reset the consent cookie so we can check the accept button works as intended
+    expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
+    GOVUK.cookie('cookies_policy', null)
+
+    var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
+    acceptCookiesButton.click()
+
+    expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', 'true', { days: 365 })
+    expect(GOVUK.getCookie('cookies_preferences_set')).toEqual('true')
+    expect(GOVUK.getCookie('cookies_policy')).toEqual(ALL_COOKIE_CONSENT)
+    expect(GOVUK.globalBarInit.init).toHaveBeenCalled()
+  })
+
   it('shows a confirmation message when cookies have been accepted', function () {
     var element = document.querySelector('[data-module="cookie-banner"]')
     new GOVUK.Modules.CookieBanner().start($(element))


### PR DESCRIPTION
Currently, if a user accepts cookies and then immediately clicks to hide the global banner, this setting isn't saved and they will see the banner the next time they refresh.
This is because the global_bar_seen cookie isn't set when giving consent to cookies, it is only set on the next page view.

This commit runs the initialise code for the global bar when cookies are approved, to set the cookie without the need for page refresh.
