### PR TITLE
Version 21.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.35.0
 
 * Set global_bar_cookie immediately when cookie consent given ([PR #1405](https://github.com/alphagov/govuk_publishing_components/pull/1405))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.34.1)
+    govuk_publishing_components (21.35.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -287,7 +287,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.1)
-    unicorn (5.5.3)
+    unicorn (5.5.4)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     webdrivers (4.2.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.34.1".freeze
+  VERSION = "21.35.0".freeze
 end


### PR DESCRIPTION
Includes:

* Set global_bar_cookie immediately when cookie consent given ([PR #1405](https://github.com/alphagov/govuk_publishing_components/pull/1405))
