### PR TITLE
Update link accessibility criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update link accessibility criteria ([PR #1407](https://github.com/alphagov/govuk_publishing_components/pull/1407))
+
 ## 21.35.0
 
 * Set global_bar_cookie immediately when cookie consent given ([PR #1405](https://github.com/alphagov/govuk_publishing_components/pull/1405))

--- a/app/models/govuk_publishing_components/shared_accessibility_criteria.rb
+++ b/app/models/govuk_publishing_components/shared_accessibility_criteria.rb
@@ -13,6 +13,7 @@ Links in the component must:
 - be usable with touch
 - be usable with [voice commands](https://www.w3.org/WAI/perspectives/voice.html)
 - have visible text
+- have meaningful text
       "
     end
   end

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -6,12 +6,8 @@ body: |
   If the examples below are not showing the banner, make sure the `cookies_preferences_set` cookie is not present or is set to false.
 accessibility_criteria: |
   Text in the cookie banner must be clear and unambiguous and should provide a way to dismiss the message.
-
-  Links in the component must:
-
-  - accept focus
-  - be focusable with a keyboard
-  - indicate when they have focus
+shared_accessibility_criteria:
+  - link
 accessibility_excluded_rules:
   - 'duplicate-id' # a banner should have a unique id for a given page. However, this page contains multiple examples of the banner with the same id.
 examples:

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -7,16 +7,6 @@ accessibility_criteria: |
 
   - have a text contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
 
-  Links in the Footer must:
-
-  - accept focus
-  - be focusable with a keyboard
-  - be usable with a keyboard
-  - indicate when they have focus
-  - change in appearance when touched (in the touch-down state)
-  - change in appearance when hovered
-  - have visible text
-
   Images in the Footer must:
 
   - be presentational when linked to from accompanying text "Open Government Licence (OGL) icon".
@@ -36,6 +26,8 @@ accessibility_criteria: |
     Assumption made is that is most predictable for users of assistive technologies.
     The spec indicates that `contentinfo` is useful for "Examples of information included in this region of the page are copyrights and links to privacy statements.", which may indicate that it might be better placed around the 'meta' section of this component.
     Should be challenged if user research indicates this is an issue.
+shared_accessibility_criteria:
+  - link
 accessibility_excluded_rules:
   - landmark-contentinfo-is-top-level # The footer element can not be top level in the examples
 examples:

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -48,16 +48,6 @@ accessibility_criteria: |
 
   - have a text contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
 
-  Links in the Header must:
-
-  - accept focus
-  - be focusable with a keyboard
-  - be usable with a keyboard
-  - indicate when they have focus
-  - change in appearance when touched (in the touch-down state)
-  - change in appearance when hovered
-  - have visible text
-
   Images in the Header must:
 
   - be presentational when linked to from accompanying text (crown icon).
@@ -65,3 +55,5 @@ accessibility_criteria: |
   Landmarks and Roles in the Header should:
 
   - have a role of `banner` at the root of the component (<header>) ([ARIA 1.1](https://www.w3.org/TR/wai-aria-1.1/#banner))
+shared_accessibility_criteria:
+  - link


### PR DESCRIPTION
## What / why
Adds 'have meaningful text' into the shared accessibility criteria for links, and changes some of the documentation files to use the shared accessibility criteria for links, rather than writing out their own, which were largely the same.

## Visual Changes
None.
