### PR TITLE
Change component guide sass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix back link arrow rendering in Safari ([PR #1411](https://github.com/alphagov/govuk_publishing_components/pull/1411))
+* Change component guide sass ([PR #1409](https://github.com/alphagov/govuk_publishing_components/pull/1409))
 
 ## 21.36.0
 

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -7,6 +7,8 @@
 @import "govuk/helpers/all";
 @import "govuk/core/all";
 
+@import "govuk_publishing_components/all_components";
+
 $gem-guide-border-width: 1px;
 
 .component-list {

--- a/app/assets/stylesheets/component_guide/print.scss
+++ b/app/assets/stylesheets/component_guide/print.scss
@@ -1,0 +1,1 @@
+@import "govuk_publishing_components/all_components_print";

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -46,7 +46,7 @@ module GovukPublishingComponents
       additional_files = "@import 'govuk_publishing_components/govuk_frontend_support';\n"
       additional_files << "@import 'govuk_publishing_components/component_support';\n" unless print_styles
 
-      components = components_in_use("#{@application_path}/app/views/")
+      components = components_in_use
       extra_components = []
 
       components.each do |component|
@@ -55,7 +55,6 @@ module GovukPublishingComponents
       end
 
       components << extra_components.compact
-      components << components_used_by_component_guide.compact
       components = components.flatten.uniq.sort
 
       components.map { |component|
@@ -74,13 +73,13 @@ module GovukPublishingComponents
     end
 
     def components_in_use_docs
-      @components_in_use_docs ||= ComponentDocs.new(gem_components: true, limit_to: components_in_use("#{@application_path}/app/views/"))
+      @components_in_use_docs ||= ComponentDocs.new(gem_components: true, limit_to: components_in_use)
     end
 
-    def components_in_use(path)
+    def components_in_use
       matches = []
 
-      files = Dir[path + "**/*.html.erb"]
+      files = Dir["#{@application_path}/app/views/**/*.html.erb"]
       files.each do |file|
         data = File.read(file)
         matches << data.scan(/(govuk_publishing_components\/components\/[a-z_-]+)/)
@@ -112,11 +111,6 @@ module GovukPublishingComponents
         h[:title] = component_doc.name
         h[:url] = component_doc_path(component_doc.id) if component_example
       end
-    end
-
-    def components_used_by_component_guide
-      components = components_in_use("#{@component_gem_path}/app/views/govuk_publishing_components/component_guide/")
-      components << components_in_use("#{@component_gem_path}/app/views/layouts/")
     end
   end
 end

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -16,12 +16,8 @@
     <%= csrf_meta_tags %>
     <%= favicon_link_tag "govuk_publishing_components/favicon-production.png" %>
 
-    <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_stylesheet}" %>
     <%= stylesheet_link_tag "component_guide/application", media: "screen" %>
-
-    <% if GovukPublishingComponents::Config.application_print_stylesheet %>
-      <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_print_stylesheet}", media: "print" %>
-    <% end %>
+    <%= stylesheet_link_tag "component_guide/print", media: "print" %>
 
     <%= javascript_include_tag "govuk_publishing_components/vendor/modernizr" %>
     <%= yield :extra_headers %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -6,6 +6,7 @@ Rails.application.config.assets.precompile += %w(
   component_guide/application.js
   component_guide/filter-components.js
   component_guide/visual-regression.js
+  component_guide/print.css
   govuk_publishing_components/all_components.js
   govuk_publishing_components/modules.js
   govuk_publishing_components/vendor/modernizr.js

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -34,12 +34,12 @@ describe "Component guide index" do
   it "includes component guide styles and scripts" do
     visit "/component-guide"
     expect(page).to have_selector('link[href*="/assets/component_guide/application"]', visible: false)
+    expect(page).to have_selector('link[href*="/assets/component_guide/print"]', visible: false)
     expect(page).to have_selector('script[src*="/assets/component_guide/application"]', visible: false)
   end
 
-  it "includes the application’s styles and scripts" do
+  it "includes the application’s scripts" do
     visit "/component-guide"
-    expect(page).to have_selector('link[href*="/assets/application"]', visible: false)
     expect(page).to have_selector('script[src*="/assets/application"]', visible: false)
   end
 

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -49,7 +49,6 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/component_support';
 @import 'govuk_publishing_components/components/_breadcrumbs';
 @import 'govuk_publishing_components/components/_contextual-sidebar';
-@import 'govuk_publishing_components/components/_details';
 @import 'govuk_publishing_components/components/_error-message';
 @import 'govuk_publishing_components/components/_error-summary';
 @import 'govuk_publishing_components/components/_govspeak';
@@ -59,15 +58,12 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/_layout-footer';
 @import 'govuk_publishing_components/components/_layout-for-admin';
 @import 'govuk_publishing_components/components/_layout-header';
-@import 'govuk_publishing_components/components/_lead-paragraph';
 @import 'govuk_publishing_components/components/_related-navigation';
-@import 'govuk_publishing_components/components/_search';
 @import 'govuk_publishing_components/components/_skip-link';
 @import 'govuk_publishing_components/components/_step-by-step-nav';
 @import 'govuk_publishing_components/components/_step-by-step-nav-header';
 @import 'govuk_publishing_components/components/_step-by-step-nav-related';
 @import 'govuk_publishing_components/components/_tabs';
-@import 'govuk_publishing_components/components/_textarea';
 @import 'govuk_publishing_components/components/_title';"
 
     expect(page).to have_selector(".component-doc-h2", text: "Gem components used by this app (12)")
@@ -82,11 +78,9 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/print/_govspeak';
 @import 'govuk_publishing_components/components/print/_layout-footer';
 @import 'govuk_publishing_components/components/print/_layout-header';
-@import 'govuk_publishing_components/components/print/_search';
 @import 'govuk_publishing_components/components/print/_skip-link';
 @import 'govuk_publishing_components/components/print/_step-by-step-nav';
 @import 'govuk_publishing_components/components/print/_step-by-step-nav-header';
-@import 'govuk_publishing_components/components/print/_textarea';
 @import 'govuk_publishing_components/components/print/_title';"
 
     expect(page.find(:css, 'textarea[name="print-sass"]', visible: false).value).to eq(expected_print_sass)


### PR DESCRIPTION
## What
New strategy for the component guide sass:

- include all components
- include a new print stylesheet for all the components
- don't include the application stylesheet anymore

## Why
Oh boy this is complicated. Hold on to your hats.

Back before individual component sass inclusion, the component guide was relatively simple. It had its own styles for specific bits but also used several components (e.g. lead paragraph). It pulled in the stylesheet from the parent application (either an actual application, or the gem's own dummy app). Both the parent and the dummy included all styles for all components, so everything worked.

Then we introduced individual component sass inclusion. The guide in the gem worked fine, because the dummy app was still pulling in all component styles, but the guide in an application was broken, because it only had the styles for the components used by the application, which didn't necessarily include the ones used by the guide. The temporary fix was to include all the components in the guide stylesheet. Everything rendered fine, but some components had duplicate styles, because they were being pulled in from the guide stylesheet and the application stylesheet.

This wasn't too bad, but it meant that debugging styles (particularly when reviewing code) was difficult as they were included twice. Enter the next solution - extend the 'suggested sass for this application' feature to include not only the components in use by the application, but also any that the guide used. This was good, although it did mean that the CSS file size went up fractionally for no reason (for components used by the guide but not by the application).

Unfortunately, that didn't work! For the simple reason that the components used by the guide plus the components used by an application didn't include all of the components. So it was possible to browse through the guide in an application and find unstyled components.

Which brings us to this solution. The guide includes all the components (and component print styles) and doesn't now include the application stylesheet. The suggested sass feature no longer includes the guide components, because they're all included anyway. This means no duplication and no missing styles for components in the guide. It does, unfortunately, mean that if there are any styles in the application that conflict with the components (for example an override that changes the font size or spacing of an element in a component) this will no longer be visible in the component guide. But I think that's okay - I'm not aware of this ever being useful, and any addition of a component onto a page should include the developer giving it a visual check.

I hope that made sense. Here's a soothing picture of a cat as a reward for getting through all that explanation (he's duplicated too). Please someone tell me if I'm wrong about any of this! 

![image](https://user-images.githubusercontent.com/861310/77739865-2cb0f580-700a-11ea-8590-ca633a1b779f.png)


## Visual Changes
None.