### PR TITLE
Document textarea ID option

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/textarea.yml
+++ b/app/views/govuk_publishing_components/components/docs/textarea.yml
@@ -20,6 +20,13 @@ examples:
       label:
         text: "Can you provide more detail?"
       name: "more-detail"
+  with_id_attribute:
+    description: An id can be passed for the textarea. By default one is randomly generated.
+    data:
+      label:
+        text: "What is the nature of your medical emergency?"
+      name: "emergency-name"
+      id: "emergency-id"
   with_margin_bottom:
     description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to a margin bottom of 6 (30px).
     data:

--- a/spec/components/textarea_spec.rb
+++ b/spec/components/textarea_spec.rb
@@ -23,6 +23,16 @@ describe "Textarea", type: :view do
     assert_select ".govuk-label", text: "Can you provide more detail?"
   end
 
+  it "renders textarea with a custom id" do
+    render_component(
+      label: { text: "Can you provide more detail?" },
+      name: "more-details",
+      id: "this-id",
+    )
+
+    assert_select "#this-id.govuk-textarea"
+  end
+
   it "renders textarea with a custom number of rows" do
     render_component(
       name: "custom-rows",


### PR DESCRIPTION
## What
Add documentation and a test for the ability to give the textarea component a custom ID.

## Why
I wanted to do this recently and found it wasn't documented.

## Visual Changes
<img width="937" alt="Screenshot 2020-03-27 at 10 19 02" src="https://user-images.githubusercontent.com/861310/77746157-68e95380-7014-11ea-9664-d094f42e66bd.png">

