### PR TITLE
Fix back link in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix back link arrow rendering in Safari ([PR #1411](https://github.com/alphagov/govuk_publishing_components/pull/1411))
+
 ## 21.36.0
 
 * Update link accessibility criteria ([PR #1407](https://github.com/alphagov/govuk_publishing_components/pull/1407))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_back-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_back-link.scss
@@ -25,6 +25,7 @@
     border: solid;
     border-width: 1px 1px 0 0;
     clip-path: inherit;
+    -webkit-clip-path: inherit;
   }
 }
 


### PR DESCRIPTION
## What

Safari only supports clip-path with the -webkit prefix, which is being being used to apply the clip-path in GOV.UK Frontend. In order to unset it, we also need to use the -webkit prefix here.

## Why

See #1387

## Visual Changes

### Before

![Screenshot 2020-03-27 at 15 58 04](https://user-images.githubusercontent.com/121939/77774981-d2348b00-7043-11ea-9171-0d85aca6ca7b.png)

### After

![Screenshot 2020-03-27 at 15 58 33](https://user-images.githubusercontent.com/121939/77774992-d365b800-7043-11ea-8872-1648c15bfb30.png)

Fixes #1387