### PR TITLE
Version 21.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.36.1
 
 * Fix back link arrow rendering in Safari ([PR #1411](https://github.com/alphagov/govuk_publishing_components/pull/1411))
 * Change component guide sass ([PR #1409](https://github.com/alphagov/govuk_publishing_components/pull/1409))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.36.0)
+    govuk_publishing_components (21.36.1)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.36.0".freeze
+  VERSION = "21.36.1".freeze
 end


### PR DESCRIPTION
## 21.36.1

* Fix back link arrow rendering in Safari ([PR #1411](https://github.com/alphagov/govuk_publishing_components/pull/1411))
* Change component guide sass ([PR #1409](https://github.com/alphagov/govuk_publishing_components/pull/1409))
