### PR TITLE
Add heading option to warning component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add heading option to warning component ([PR #1415](https://github.com/alphagov/govuk_publishing_components/pull/1415))
+
 ## 21.36.1
 
 * Fix back link arrow rendering in Safari ([PR #1411](https://github.com/alphagov/govuk_publishing_components/pull/1411))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_warning-text.scss
@@ -1,5 +1,9 @@
 @import "govuk/components/warning-text/warning-text";
 
+.gem-c-warning-text .govuk-warning-text__text {
+  margin: 0;
+}
+
 .gem-c-warning-text__text--no-indent {
   padding-left: 0;
   margin-left: 0;

--- a/app/views/govuk_publishing_components/components/_warning_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_warning_text.html.erb
@@ -4,6 +4,9 @@
   text_icon ||= '!'
   large_font ||= false
   highlight_text ||= false
+  heading_level ||= 0
+
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   text_classes = %w(govuk-warning-text__text)
   text_classes << "gem-c-warning-text__text--no-indent" if text_icon.empty?
@@ -15,8 +18,17 @@
   <% unless text_icon.empty? %>
     <%= tag.span text_icon, class: "govuk-warning-text__icon", "aria-hidden": "true" %>
   <% end %>
-  <%= tag.strong class: text_classes do %>
+  <% inner_text = capture do %>
     <%= tag.span text_assistive, class: "govuk-warning-text__assistive" %>
     <%= text %>
+  <% end %>
+  <% if heading_level > 0 %>
+    <%= content_tag(shared_helper.get_heading_level, class: text_classes) do %>
+      <%= inner_text %>
+    <% end %>
+  <% else %>
+    <%= tag.strong class: text_classes do %>
+      <%= inner_text %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/warning_text.yml
+++ b/app/views/govuk_publishing_components/components/docs/warning_text.yml
@@ -29,3 +29,7 @@ examples:
     data:
       text: "This content has changed"
       highlight_text: true
+  as_a_heading:
+    data:
+      text: "This is a heading 3"
+      heading_level: 3

--- a/spec/components/warning_text_spec.rb
+++ b/spec/components/warning_text_spec.rb
@@ -42,4 +42,10 @@ describe "warning text", type: :view do
     render_component(highlight_text: true, large_font: true, text: "Because")
     assert_select(".govuk-warning-text__text.gem-c-warning-text__text--highlight.gem-c-warning-text__text--large", text: /Because/i)
   end
+
+  it "renders as a heading" do
+    render_component(text: "Because", heading_level: 1)
+    assert_select("h1.govuk-warning-text__text", text: /Because/i)
+    assert_select("h1.govuk-warning-text__text .govuk-warning-text__assistive", text: /Warning/i)
+  end
 end


### PR DESCRIPTION
## What
- allows the component to be rendered as a heading
- uses the shared helper code for headings

## Why
We're using the styles from the component on a heading element on [travel pages like this one](https://www.gov.uk/foreign-travel-advice/usa/entry-requirements) but not the component itself. This change will allow us to switch to using the component.

## Visual Changes
<img width="935" alt="Screenshot 2020-04-01 at 10 50 06" src="https://user-images.githubusercontent.com/861310/78124036-01157d00-7407-11ea-9c87-79367a28847d.png">

