### PR TITLE
Add the "distribution" property to the dataset metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## Unreleased
 
 * Add heading option to warning component ([PR #1415](https://github.com/alphagov/govuk_publishing_components/pull/1415))
+* Add the "distribution" property to the dataset machine readable metadata ([PR #1416](https://github.com/alphagov/govuk_publishing_components/pull/1416))
+* Fix the dataset machine readable metadata erroring if there is no description set ([PR #1416](https://github.com/alphagov/govuk_publishing_components/pull/1416))
 
 ## 21.36.1
 

--- a/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/machine_readable_metadata.yml
@@ -134,3 +134,24 @@ examples:
         base_path: "government/statistical-data-sets/hogwarts-data"
         details: {}
       schema: :dataset
+  dataset_schema_with_attachments:
+    data:
+      content_item:
+        title: "All the data about Hogwarts"
+        base_path: "government/statistical-data-sets/hogwarts-data"
+        details:
+          attachments:
+            - attachment_type: "file"
+              url: "https://assets.publishing.service.gov.uk/hogwarts-data/headmasters.csv"
+              title: "List of headmasters"
+              content_type: "text/csv"
+              id: "headmasters.csv"
+            - attachment_type: "html"
+              url: "https://www.gov.uk/government/statistical-data-sets/hogwarts-data/houses"
+              title: "Houses of Hogwarts"
+              id: "houses"
+            - attachment_type: "external"
+              url: "https://hogwarts.gov.uk/datasets/dungeon-cleaning-schedule"
+              title: "Dungeon cleaning shedule"
+              id: "dungeon-cleaning-schedule"
+      schema: :dataset

--- a/lib/govuk_publishing_components/presenters/machine_readable/dataset_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/dataset_schema.rb
@@ -10,6 +10,7 @@ module GovukPublishingComponents
       def structured_data
         # http://schema.org/Dataset
         data = CreativeWorkSchema.new(@page).structured_data
+          .merge(distribution)
           .merge(description)
           .merge(name)
         data["@type"] = "Dataset"
@@ -17,6 +18,14 @@ module GovukPublishingComponents
       end
 
     private
+
+      def distribution
+        return {} unless page.attachments
+
+        {
+          "distribution" => page.attachments.map { |a| present_attachment(a.with_indifferent_access) }.compact,
+        }
+      end
 
       def description
         {
@@ -28,6 +37,27 @@ module GovukPublishingComponents
         {
           "name" => page.title,
         }
+      end
+
+      def present_attachment(attachment)
+        title = attachment[:title]
+        url = attachment[:url]
+        return unless title
+        return unless url
+
+        case attachment[:attachment_type]
+        when "external", "html"
+          {
+            "name" => title,
+            "url" => url,
+          }
+        when "file"
+          {
+            "name" => title,
+            "contentUrl" => url,
+            "encodingFormat" => attachment[:content_type],
+          }.compact
+        end
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/machine_readable/dataset_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/dataset_schema.rb
@@ -28,8 +28,11 @@ module GovukPublishingComponents
       end
 
       def description
+        descr = page.body || page.description
+        return {} unless descr
+
         {
-          "description" => (page.body || page.description).slice(0..4999),
+          "description" => descr.slice(0..4999),
         }
       end
 

--- a/lib/govuk_publishing_components/presenters/machine_readable/page.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/page.rb
@@ -51,6 +51,10 @@ module GovukPublishingComponents
         content_item["base_path"]
       end
 
+      def attachments
+        content_item.dig("details", "attachments")
+      end
+
       def content_item
         local_assigns[:content_item]
       end

--- a/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
@@ -62,6 +62,11 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
               "slug": "government-title",
               "current": false,
             },
+            "attachments" => [
+              { "id" => "1", "attachment_type" => "file", "url" => "https://www.gov.uk/a-cat.jpg", "title" => "A picture of a cat", "content_type" => "image/jpeg" },
+              { "id" => "2", "attachment_type" => "html", "url" => "https://www.gov.uk/dogs", "title" => "Some good boys" },
+              { "id" => "3", "attachment_type" => "external", "url" => "https://micropig-register.service.gov.uk", "title" => "Register of government micropigs" },
+            ],
           },
           "description" => "Dataset description",
           "title" => "Dataset Title",
@@ -76,6 +81,11 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
       expect(structured_data["@type"]).to eql("Dataset")
       expect(structured_data["name"]).to eql("Dataset Title")
       expect(structured_data["description"].length).to eql(5000)
+      expect(structured_data["distribution"]).to eql([
+        { "name" => "A picture of a cat", "contentUrl" => "https://www.gov.uk/a-cat.jpg", "encodingFormat" => "image/jpeg" },
+        { "name" => "Some good boys", "url" => "https://www.gov.uk/dogs" },
+        { "name" => "Register of government micropigs", "url" => "https://micropig-register.service.gov.uk" },
+      ])
     end
 
     context "schema.org GovernmentService" do


### PR DESCRIPTION
## What
Add the "distribution" property to the machine readable metadata for datasets.  You can try it out by putting something like this snippet in the Google metadata verification tool:

```
{
  "@context": "http://schema.org",
  "@type": "Dataset",
  "mainEntityOfPage": {
    "@type": "WebPage",
    "@id": "https://www.gov.uk/government/statistics/e-coli-bacteraemia-monthly-data-by-location-of-onset"
  },
  "headline": "E. coli bacteraemia: monthly data by location of onset",
  "distribution": [
    {
    	"name": "E. coli bacteraemia: monthly counts by location of onset by NHS organisation, from February 2019 to February 2020",
        "encodingFormat": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
      	"contentUrl": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/875805/Table_3_ecoli_Feb_2020.xlsx" },
    {
    	"name": "E. coli bacteraemia: monthly counts by location of onset by NHS organisation, from February 2019 to February 2020",
    	"encodingFormat": "application/vnd.oasis.opendocument.spreadsheet",
    	"contentUrl": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/875807/Table_3_ecoli_Feb_2020.ods"},
    {
    	"name": "E. coli bacteraemia: monthly counts by location of onset by NHS organisation, from January 2019 to January 2020",
    	"url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/869545/Table_3_ecoli_Jan_2020.xlsx"}
  ],
  "name": "E. coli bacteraemia: monthly data by location of onset"
}
```

## Why
So that tools reading the metadata know what a dataset refers to.

## Visual Changes
None.

---

[Trello card](https://trello.com/c/L2BEtv8m/1469-link-to-statistical-dataset-files-from-schemaorg-metadata)