### PR TITLE
Bump to version 21.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.37.0
 
 * Add heading option to warning component ([PR #1415](https://github.com/alphagov/govuk_publishing_components/pull/1415))
 * Add the "distribution" property to the dataset machine readable metadata ([PR #1416](https://github.com/alphagov/govuk_publishing_components/pull/1416))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.36.1)
+    govuk_publishing_components (21.37.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -83,7 +83,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.9.0)
     execjs (2.7.0)
-    faraday (1.0.0)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
     foreman (0.85.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.36.1".freeze
+  VERSION = "21.37.0".freeze
 end


### PR DESCRIPTION
* Add heading option to warning component ([PR #1415](https://github.com/alphagov/govuk_publishing_components/pull/1415))
* Add the "distribution" property to the dataset machine readable metadata ([PR #1416](https://github.com/alphagov/govuk_publishing_components/pull/1416))
* Fix the dataset machine readable metadata erroring if there is no description set ([PR #1416](https://github.com/alphagov/govuk_publishing_components/pull/1416))