### PR TITLE
Allow livestream youtube URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Expand video player to support youtube livestream URLs ([PR #1418](https://github.com/alphagov/govuk_publishing_components/pull/1418))
+
 ## 21.37.0
 
 * Add heading option to warning component ([PR #1415](https://github.com/alphagov/govuk_publishing_components/pull/1415))

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -54,6 +54,8 @@
     youtubeVideoContainer.className += 'gem-c-govspeak__youtube-video'
     youtubeVideoContainer.innerHTML = '<span id="' + elementId + '" data-video-id="' + id + '"></span>'
 
+    options['title'] = $link.textContent
+
     parentContainer.replaceChild(youtubeVideoContainer, parentPara)
     this.insertVideo(elementId, options)
   }
@@ -90,7 +92,8 @@
         events: {
           onReady: function (event) {
             // update iframe title attribute once video is ready
-            event.target.a.setAttribute('title', title + ' (video)')
+            var videoTitle = options.title
+            event.target.f.title = videoTitle + ' (video)'
           }
         }
       })

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -20,11 +20,19 @@
 
     for (var i = 0; i < $youtubeLinks.length; ++i) {
       var $link = $youtubeLinks[i]
+      var href = $link.getAttribute('href')
 
-      var videoId = YoutubeLinkEnhancement.parseVideoId($link.getAttribute('href'))
+      if (href.includes("/live_stream")) {
+        var channelId = YoutubeLinkEnhancement.parseLivestream(href)
 
-      if (!this.hasDisabledEmbed($link) && videoId) {
-        this.setupVideo($link, videoId)
+        if (!this.hasDisabledEmbed($link) && channelId) {
+          this.setupVideo({link: $link, channel: channelId})
+        }
+      } else {
+        var videoId = YoutubeLinkEnhancement.parseVideoId(href)
+        if (!this.hasDisabledEmbed($link) && videoId) {
+          this.setupVideo({link: $link, videoId: videoId})
+        }
       }
     }
   }
@@ -33,21 +41,34 @@
     return $link.getAttribute('data-youtube-player') === 'off'
   }
 
-  YoutubeLinkEnhancement.prototype.setupVideo = function ($link, videoId) {
+  YoutubeLinkEnhancement.prototype.setupVideo = function (options) {
     var elementId = YoutubeLinkEnhancement.nextId()
+    var $link = options.link
+
+    var id = options.videoId ? options.videoId : options.channel
 
     var parentPara = $link.parentNode
     var parentContainer = parentPara.parentNode
 
     var youtubeVideoContainer = document.createElement('div')
     youtubeVideoContainer.className += 'gem-c-govspeak__youtube-video'
-    youtubeVideoContainer.innerHTML = '<span id="' + elementId + '" data-video-id="' + videoId + '"></span>'
+    youtubeVideoContainer.innerHTML = '<span id="' + elementId + '" data-video-id="' + id + '"></span>'
 
     parentContainer.replaceChild(youtubeVideoContainer, parentPara)
-    this.insertVideo(elementId, videoId, $link.textContent)
+    this.insertVideo(elementId, options)
   }
 
-  YoutubeLinkEnhancement.prototype.insertVideo = function (elementId, videoId, title) {
+  YoutubeLinkEnhancement.prototype.insertVideo = function (elementId, options) {
+    var channelId = ""
+    var videoId = ""
+
+    if (options.channel) {
+      channelId = options.channel
+      videoId = "live_stream"
+    } else {
+      videoId = options.videoId
+    }
+
     var videoInsert = function () {
       new window.YT.Player(elementId, { // eslint-disable-line no-new
         videoId: videoId,
@@ -62,7 +83,9 @@
           // https://www.w3.org/WAI/WCAG21/quickref/#character-key-shortcuts
           disablekb: 1,
           // prevent the YouTube logo from displaying in the control bar
-          modestbranding: 1
+          modestbranding: 1,
+          // To support live_stream videos
+          channel: channelId
         },
         events: {
           onReady: function (event) {
@@ -105,6 +128,14 @@
     this.apiScriptInserted = true
   }
 
+  YoutubeLinkEnhancement.parseLivestream = function (url) {
+    var matches = url.match(/channel=([^&]*)/)
+
+    if (matches) {
+      return matches[1]
+    }
+  }
+
   // This is a public class method so it can be used outside of this embed to
   // check that user input for videos will be supported in govspeak
   YoutubeLinkEnhancement.parseVideoId = function (url) {
@@ -123,8 +154,7 @@
       }
       return params.v
     }
-
-    if (url.indexOf('youtu.be') > -1) {
+    else if (url.indexOf('youtu.be') > -1) {
       parts = url.split('/')
       return parts.pop()
     }

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -285,6 +285,11 @@ examples:
       block: |
         <p>This content has a YouTube video link, converted to an accessible embedded player by component JavaScript.</p>
         <p><a href="https://www.youtube.com/watch?v=y6hbrS3DheU">Operations: a developer's guide, by Anna Shipman</a></p>
+  with_youtube_livestream:
+    data:
+      block: |
+        <p>This content has a YouTube livestream link, converted to an accessible embedded player by component JavaScript.</p>
+        <p><a href="https://www.youtube.com/embed/live_stream?channel=UCoMdktPbSTixAyNGwb-UYkQ">Livestream video</a></p>
   with_youtube_embed_disabled:
     data:
       disable_youtube_expansions: true

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
@@ -102,4 +102,86 @@ describe('Youtube link enhancement', function () {
       expect(id).not.toBeDefined()
     })
   })
+
+  describe('livestream behaviour', function () {
+    var container
+
+    beforeEach(function () {
+      container = document.createElement('div')
+    })
+
+    afterEach(function() {
+      document.body.removeChild(container)
+    })
+
+    it('replaces a livestream link and it\'s container with a media-player embed', function () {
+      container.innerHTML =
+        '<div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">' +
+          '<p><a href="https://www.youtube.com/embed/live_stream?channel=UCoMdktPbSTixAyNGwb-UYkQ">Livestream</a></p>' +
+        '<div>'
+      document.body.appendChild(container)
+
+      var element = document.querySelector('.gem-c-govspeak')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement(element)
+      enhancement.init()
+
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-video').length).toBe(1)
+      expect(document.querySelectorAll('.gem-c-govspeak p, .gem-c-govspeak a').length).toBe(0)
+    })
+
+    it('doesn\'t replace livestream links marked not to embed', function () {
+      container.innerHTML =
+        '<div class="gem-c-govspeak">' +
+          '<p><a href="https://www.youtube.com/embed/live_stream?channel=UCoMdktPbSTixAyNGwb-UYkQ" data-youtube-player="off">Agile at GDS</a></p>' +
+        '</div>'
+      document.body.appendChild(container)
+
+      var element = document.querySelector('.gem-c-govspeak')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement(element)
+      enhancement.init()
+
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-video').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak p, .gem-c-govspeak a').length).toBe(2)
+    })
+
+    it('doesn\'t replace livestream links when a user has revoked campaign cookie consent', function () {
+      window.GOVUK.cookie('cookies_policy', JSON.stringify({ campaigns: false }))
+
+      container.innerHTML =
+        '<div class="gem-c-govspeak">' +
+          '<p><a href="https://www.youtube.com/embed/live_stream?channel=UCoMdktPbSTixAyNGwb-UYkQ">Agile at GDS</a></p>' +
+        '</div>'
+      document.body.appendChild(container)
+
+      var element = document.querySelector('.gem-c-govspeak')
+      var enhancement = new GOVUK.GovspeakYoutubeLinkEnhancement(element)
+      enhancement.init()
+
+      expect(document.querySelectorAll('.gem-c-govspeak__youtube-video').length).toBe(0)
+      expect(document.querySelectorAll('.gem-c-govspeak p, .gem-c-govspeak a').length).toBe(2)
+    })
+  })
+
+  describe('parseLivestream', function () {
+    it('returns a channel id for a youtube.com video URL', function () {
+      var url = 'https://www.youtube.com/embed/live_stream?channel=UCoMdktPbSTixAyNGwb-UYkQ'
+      var id = GOVUK.GovspeakYoutubeLinkEnhancement.parseLivestream(url)
+
+      expect(id).toEqual('UCoMdktPbSTixAyNGwb-UYkQ')
+    })
+
+    it('doesn\'t return an id for a Youtube non video', function () {
+      var url = 'https://www.youtube.com/channel/UCSNK6abAoM6Kj0SkHOStNLg'
+      var id = GOVUK.GovspeakYoutubeLinkEnhancement.parseLivestream(url)
+
+      expect(id).not.toBeDefined()
+    })
+
+    it('doesn\'t return an id for a non youtube link', function () {
+      var url = 'https://www.gov.uk'
+      var id = GOVUK.GovspeakYoutubeLinkEnhancement.parseLivestream(url)
+
+      expect(id).not.toBeDefined()
+    })
+  })
 })


### PR DESCRIPTION
## What
Expand our video player code to handle livestream links.
This PR also fixes a Javascript error that was happening because the video title property couldn't be reached.

## Why
Our video player code expected a video URL that looks like this: 
`https://www.youtube.com/watch?v=y6hbrS3DheU` - essentially a youtube URL with a videoId (v) query param.

This means that it didn't support livestream URLs which look like this: 
`https://www.youtube.com/embed/live_stream?channel=UCoMdktPbSTixAyNGwb-UYkQ`
These URLs are structured slightly differently with 'live_stream' and a channel ID instead of videoId.

## Visual Changes
<img width="924" alt="Screenshot 2020-04-02 at 10 19 10" src="https://user-images.githubusercontent.com/29889908/78231911-6c288780-74cb-11ea-9e3d-b114a4ec1a09.png">

Preview URLs:

- [Standard Youtube Embed](https://govuk-publis-spike-live-ftkn8m.herokuapp.com/component-guide/govspeak/with_youtube_embed)
- [Livestream Youtube Embed](https://govuk-publis-spike-live-ftkn8m.herokuapp.com/component-guide/govspeak/with_youtube_livestream)