### PR TITLE
Release 21.38.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.38.1
 
 * Correct CreativeWork to use name and text fields instead of headLine and description ([PR #1423](https://github.com/alphagov/govuk_publishing_components/pull/1423))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.38.0)
+    govuk_publishing_components (21.38.1)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.38.0".freeze
+  VERSION = "21.38.1".freeze
 end


### PR DESCRIPTION
## 21.38.1

* Correct CreativeWork to use name and text fields instead of headLine and description ([PR #1423](https://github.com/alphagov/govuk_publishing_components/pull/1423))