### PR TITLE
Update colour from lime to lemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Switch Public Health England branding colour from green to yellow ([PR #1425](https://github.com/alphagov/govuk_publishing_components/pull/1425))
+
 ## 21.38.1
 
 * Correct CreativeWork to use name and text fields instead of headLine and description ([PR #1423](https://github.com/alphagov/govuk_publishing_components/pull/1423))

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -95,11 +95,11 @@
 // used on the coronavirus page
 // note that PHE already has a different brand colour, the brand
 // department-for-health is used on the PHE org page
-$gem-c-covid-green: #7eff8e;
+$gem-c-covid-yellow: #ffe817;
 
 .brand--public-health-england {
   &.brand__border-color,
   .brand__border-color {
-    border-color: $gem-c-covid-green;
+    border-color: $gem-c-covid-yellow;
   }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/YT0f0FDN/133-update-theme-from-lime-to-yellow

## What
Switch covid-green to covid-yellow
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
Update the branding colour for Public Health England to match the latest colours being used

## Visual Changes
<img width="918" alt="Screenshot 2020-04-03 at 10 20 45" src="https://user-images.githubusercontent.com/29889908/78344990-18827080-7595-11ea-94b3-412f86945fa7.png">
<img width="916" alt="Screenshot 2020-04-03 at 10 19 40" src="https://user-images.githubusercontent.com/29889908/78344996-191b0700-7595-11ea-9d1d-53a3e2333772.png">