### PR TITLE
Remove ':visited' styling from 'Order a copy' link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update yellow hex code for Public Health England ([PR #1428](https://github.com/alphagov/govuk_publishing_components/pull/1428))
+* Remove ':visited' styling from 'Order a copy' link ([PR #1427](https://github.com/alphagov/govuk_publishing_components/pull/1427))
 
 ## 21.38.2
 

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -69,7 +69,7 @@
     <% end %>
 
     <% if attachment.is_official_document %>
-      <%= tag.p link_to("Order a copy", "https://www.gov.uk/guidance/how-to-buy-printed-copies-of-official-documents", class: "govuk-link", target: "_blank"),
+      <%= tag.p link_to("Order a copy", "https://www.gov.uk/guidance/how-to-buy-printed-copies-of-official-documents", class: "govuk-link govuk-link--no-visited-state", target: "_blank"),
         class: "gem-c-attachment__metadata" %>
     <% end %>
 


### PR DESCRIPTION
It could otherwise be confusing that if you've ever visited one of
these it looks like you've ordered a copy of every attachment.
This addresses https://github.com/alphagov/govuk_publishing_components/pull/1375#discussion_r395325402, part of https://trello.com/c/UET4vx6k/1439-update-attachment-component-to-accommodate-new-attachment-design.

## What
Remove ':visited' styling from 'Order a copy' link

## Why
It could otherwise be confusing that if you've ever visited one of
these it looks like you've ordered a copy of every attachment.

## Visual Changes

| Before | After |
|--------|-----|
|<img width="685" alt="Screenshot 2020-04-03 at 11 21 10" src="https://user-images.githubusercontent.com/5111927/78350562-51264800-759d-11ea-843e-7246fd6263d3.png">|<img width="680" alt="Screenshot 2020-04-03 at 11 21 29" src="https://user-images.githubusercontent.com/5111927/78350577-55eafc00-759d-11ea-8344-2ebae9c904b1.png">|


