### PR TITLE
Add 'hide_order_copy_link' parameter to hide 'Order a copy'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add 'hide_order_copy_link' parameter to hide 'Order a copy' ([PR #1430](https://github.com/alphagov/govuk_publishing_components/pull/1430))
+
 ## 21.38.3
 
 * Update yellow hex code for Public Health England ([PR #1428](https://github.com/alphagov/govuk_publishing_components/pull/1428))

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -2,6 +2,7 @@
   attachment = GovukPublishingComponents::Presenters::Attachment.new(attachment)
   target ||= "_self"
   hide_opendocument_metadata ||= false
+  hide_order_copy_link ||= false
   attributes = []
   data_attributes ||= {}
 
@@ -68,7 +69,7 @@
       <%= tag.p raw(attributes.join(', ')), class: "gem-c-attachment__metadata" %>
     <% end %>
 
-    <% if attachment.is_official_document %>
+    <% if attachment.is_official_document && !hide_order_copy_link %>
       <%= tag.p link_to("Order a copy", "https://www.gov.uk/guidance/how-to-buy-printed-copies-of-official-documents", class: "govuk-link govuk-link--no-visited-state", target: "_blank"),
         class: "gem-c-attachment__metadata" %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -143,3 +143,18 @@ examples:
         isbn: "978-1-913635-01-5"
         unique_reference: "2942"
         unnumbered_hoc_paper: true
+  hide_order_a_copy:
+    description: |
+      With 'Order a copy' hidden
+    data:
+      attachment:
+        title: "Budget 2020"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/871799/Budget_2020_Web_Accessible_Complete.pdf
+        filename: Budget_2020_Web_Accessible_Complete.pdf
+        content_type: application/pdf
+        file_size: 20000
+        number_of_pages: 12
+        isbn: "978-1-913635-01-5"
+        unique_reference: "2942"
+        unnumbered_hoc_paper: true
+      hide_order_copy_link: true

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -161,4 +161,21 @@ describe "Attachment", type: :view do
       )
     assert_select ".gem-c-attachment__metadata:nth-of-type(3) .govuk-link", text: "Order a copy"
   end
+
+  it "does not show 'Order a copy' link if disabled" do
+    render_component(
+      attachment: {
+        title: "The government financial reporting review",
+        url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/791567/the_government_financial_reporting_review_web.pdf",
+        filename: "department-for-transport-information-asset-register.csv",
+        content_type: "application/pdf",
+        file_size: 20000,
+        number_of_pages: 7,
+        isbn: "978-1-5286-1173-2",
+        command_paper_number: "Cd. 67",
+      },
+      hide_order_copy_link: true,
+    )
+    assert_select ".gem-c-attachment__metadata:nth-of-type(3) .govuk-link", false
+  end
 end


### PR DESCRIPTION
## What & why
Attachment is used on admin-facing pages as well as user-facing
pages. Their requirements for a preview are somewhat different,
and having 'Order a copy' doesn't fit the design for them.

I've chosen to make this a boolean, following the style of the
'hide_opendocument_metadata' parameter, rather than inventing
some sort of 'admin context' which is open to misinterpretation.

Trello: https://trello.com/c/UET4vx6k/1439-update-attachment-component-to-accommodate-new-attachment-design

## Visual Changes
<img width="464" alt="Screenshot 2020-04-03 at 12 49 56" src="https://user-images.githubusercontent.com/5111927/78357602-a5372980-75a9-11ea-95fd-0bcfde982650.png">

See https://govuk-publis-hide-order-mpkgzj.herokuapp.com/component-guide/attachment
