### PR TITLE
Fix app-level component preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix app-level component preview ([PR #1435](https://github.com/alphagov/govuk_publishing_components/pull/1435))
+
 ## 21.38.4
 
 * Add 'hide_order_copy_link' parameter to hide 'Order a copy' ([PR #1430](https://github.com/alphagov/govuk_publishing_components/pull/1430))

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -16,7 +16,12 @@
     <%= csrf_meta_tags %>
     <%= favicon_link_tag "govuk_publishing_components/favicon-production.png" %>
 
+    <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_stylesheet}" %>
     <%= stylesheet_link_tag "component_guide/application", media: "screen" %>
+
+    <% if GovukPublishingComponents::Config.application_print_stylesheet %>
+      <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_print_stylesheet}", media: "print" %>
+    <% end %>
     <%= stylesheet_link_tag "component_guide/print", media: "print" %>
 
     <%= javascript_include_tag "govuk_publishing_components/vendor/modernizr" %>


### PR DESCRIPTION
## What
Add application stylesheets to the component guide

## Why
To preview app-level components in the component guide.

Follow up on #1409