### PR TITLE
Add application stylesheet where needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add application stylesheet where needed ([PR #1436](https://github.com/alphagov/govuk_publishing_components/pull/1436))
+
 ## 21.38.4
 
 * Add 'hide_order_copy_link' parameter to hide 'Order a copy' ([PR #1430](https://github.com/alphagov/govuk_publishing_components/pull/1430))

--- a/app/views/govuk_publishing_components/component_guide/_application_stylesheet.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/_application_stylesheet.html.erb
@@ -1,0 +1,4 @@
+<%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_stylesheet}" %>
+<% if GovukPublishingComponents::Config.application_print_stylesheet %>
+  <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_print_stylesheet}", media: "print" %>
+<% end %>

--- a/app/views/govuk_publishing_components/component_guide/example.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/example.html.erb
@@ -1,4 +1,10 @@
 <% content_for :title, "#{@component_example.name} example - #{@component_doc.name} component" %>
+<% content_for :application_stylesheet do %>
+  <% if @component_doc.source == "application" %>
+    <%= render 'application_stylesheet' %>
+  <% end %>
+<% end %>
+
 <%= render 'govuk_publishing_components/components/title', title: @component_example.name, context: "#{@component_doc.name} example", margin_top: 0 %>
 
 <div class="component-show">

--- a/app/views/govuk_publishing_components/component_guide/preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/preview.html.erb
@@ -1,3 +1,9 @@
+<% content_for :application_stylesheet do %>
+  <% if @component_doc.source == "application" %>
+    <%= render 'application_stylesheet' %>
+  <% end %>
+<% end %>
+
 <% @component_examples.each do |example| %>
   <div class="component-guide-preview-page">
     <% if @component_examples.length > 1 %>

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -1,4 +1,13 @@
 <% content_for :title, "#{@component_doc.name} component" %>
+<% content_for :application_stylesheet do %>
+  <% if @component_doc.source == "application" %>
+    <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_stylesheet}" %>
+    <% if GovukPublishingComponents::Config.application_print_stylesheet %>
+      <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_print_stylesheet}", media: "print" %>
+    <% end %>
+  <% end %>
+<% end %>
+
 <%= render 'govuk_publishing_components/components/title', title: @component_doc.name, context: "Component", margin_top: 0; %>
 
 <div class="component-show">

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -1,10 +1,7 @@
 <% content_for :title, "#{@component_doc.name} component" %>
 <% content_for :application_stylesheet do %>
   <% if @component_doc.source == "application" %>
-    <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_stylesheet}" %>
-    <% if GovukPublishingComponents::Config.application_print_stylesheet %>
-      <%= stylesheet_link_tag "#{GovukPublishingComponents::Config.application_print_stylesheet}", media: "print" %>
-    <% end %>
+    <%= render 'application_stylesheet' %>
   <% end %>
 <% end %>
 

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -16,6 +16,7 @@
     <%= csrf_meta_tags %>
     <%= favicon_link_tag "govuk_publishing_components/favicon-production.png" %>
 
+    <%= yield :application_stylesheet %>
     <%= stylesheet_link_tag "component_guide/application", media: "screen" %>
     <%= stylesheet_link_tag "component_guide/print", media: "print" %>
 

--- a/spec/component_guide/component_example_spec.rb
+++ b/spec/component_guide/component_example_spec.rb
@@ -18,6 +18,20 @@ describe "Component example" do
     end
   end
 
+  it "includes the application stylesheet for an application component" do
+    visit "/component-guide/test-component"
+
+    expect(page).to have_selector('link[href*="/assets/application.css"]', visible: false)
+    expect(page).to have_selector('link[href*="/assets/print.css"]', visible: false)
+  end
+
+  it "doesn't include the application stylesheet for a gem component" do
+    visit "/component-guide/button"
+
+    expect(page).not_to have_selector('link[href*="/assets/application.css"]', visible: false)
+    expect(page).not_to have_selector('link[href*="/assets/print.css"]', visible: false)
+  end
+
   it "lists examples in a human readable way" do
     visit "/component-guide/test-component-with-params"
     expect(page).to have_selector("h2", text: "Other examples")


### PR DESCRIPTION
## What
Add the application stylesheet into the component guide if that component is from the application, not from the gem.

## Why
Work [previously done](https://github.com/alphagov/govuk_publishing_components/pull/1409) on the stylesheets used in the component guide is still not right, because excluding the application stylesheet from the component guide means that components from that application will appear unstyled.

## Visual Changes
None.
