### PR TITLE
Add cookie banner variation for services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add application stylesheet where needed ([PR #1436](https://github.com/alphagov/govuk_publishing_components/pull/1436))
+* Add cookie banner variation for services ([PR #1438](https://github.com/alphagov/govuk_publishing_components/pull/1438))
 
 ## 21.38.4
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -77,6 +77,7 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
 
   @include govuk-media-query($from: desktop) {
     max-width: 90%;
+    margin-bottom: 0;
   }
 }
 
@@ -106,6 +107,24 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
   }
 }
 
+.gem-c-cookie-banner__buttons--flex {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+
+  .govuk-button {
+    flex-grow: 1;
+    flex-basis: 10rem;
+    margin-right: govuk-spacing(3);
+    margin-bottom: govuk-spacing(3);
+  }
+
+  .gem-c-cookie-banner__link {
+    flex-grow: 1;
+    display: inline-block;
+  }
+}
+
 // Override the styles from govuk_template
 // scss-lint:disable IdSelector
 // sass-lint:disable no-ids
@@ -130,6 +149,11 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
     margin: 0 0 govuk-spacing(2) 0;
   }
 
+  .gem-c-cookie-banner__confirmation-message {
+    @include govuk-media-query($from: desktop) {
+      margin-bottom: 0;
+    }
+  }
 }
 // sass-lint:enable no-ids
 // scss-lint:enable IdSelector

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -1,51 +1,70 @@
 <%
   id ||= 'global-cookie-message'
+  title ||= "Tell us whether you accept cookies"
   text ||= raw("We use <a class='govuk-link' href='/help/cookies'>cookies to collect information</a> about how you use GOV.UK. We use this information to make the website work as well as possible and improve government services.")
   cookie_preferences_href ||= "/help/cookies"
+  confirmation_message ||= raw("You’ve accepted all cookies. You can <a class='govuk-link' href='#{cookie_preferences_href}' data-module='track-click' data-track-category='cookieBanner' data-track-action='Cookie banner settings clicked from confirmation'>change your cookie settings</a> at any time.")
+  services_cookies ||= nil
 %>
 
 <div id="<%= id %>" class="gem-c-cookie-banner govuk-clearfix" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet>
   <div class="gem-c-cookie-banner__wrapper govuk-width-container">
     <div class="govuk-grid-row">
-      <div class=" govuk-grid-column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <div class="gem-c-cookie-banner__message">
-          <span class="govuk-heading-m">Tell us whether you accept cookies</span>
+          <h2 class="govuk-heading-m"><%= title %></h2>
           <p class="govuk-body"><%= text %></p>
         </div>
-        <div class="gem-c-cookie-banner__buttons">
-          <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
+        <% if services_cookies %>
+          <div class="gem-c-cookie-banner__buttons gem-c-cookie-banner__buttons--flex">
             <%= render "govuk_publishing_components/components/button", {
-              text: "Accept all cookies",
+              text: services_cookies.dig(:yes, :text) || "Yes",
               inline_layout: true,
-              data_attributes: {
-                module: "track-click",
-                "accept-cookies": "true",
-                "track-category": "cookieBanner",
-                "track-action": "Cookie banner accepted"
-              }
+              data_attributes: { module: "track-click", "accept-cookies": "true", }.merge(services_cookies.dig(:yes, :data_attributes) || {})
             } %>
-          </div>
-          <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
             <%= render "govuk_publishing_components/components/button", {
-              text: "Set cookie preferences",
-              href: cookie_preferences_href,
+              text: services_cookies.dig(:no, :text) || "No",
               inline_layout: true,
-              data_attributes: {
-                module: "track-click",
-                "track-category": "cookieBanner",
-                "track-action": "Cookie banner settings clicked"
-              }
+              data_attributes: { module: "track-click", "hide-cookie-banner": "true", }.merge(services_cookies.dig(:no, :data_attributes) || {})
             } %>
+            <% if services_cookies[:cookie_preferences] %>
+              <%= link_to services_cookies.dig(:cookie_preferences, :text), services_cookies.dig(:cookie_preferences, :href), class: "gem-c-cookie-banner__link govuk-link" %>
+            <% end %>
           </div>
-        </div>
+        <% else %>
+          <div class="gem-c-cookie-banner__buttons">
+            <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
+              <%= render "govuk_publishing_components/components/button", {
+                text: "Accept all cookies",
+                inline_layout: true,
+                data_attributes: {
+                  module: "track-click",
+                  "accept-cookies": "true",
+                  "track-category": "cookieBanner",
+                  "track-action": "Cookie banner accepted"
+                }
+              } %>
+            </div>
+            <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
+              <%= render "govuk_publishing_components/components/button", {
+                text: "Set cookie preferences",
+                href: cookie_preferences_href,
+                inline_layout: true,
+                data_attributes: {
+                  module: "track-click",
+                  "track-category": "cookieBanner",
+                  "track-action": "Cookie banner settings clicked"
+                }
+              } %>
+            </div>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>
 
   <div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1">
-    <p class="gem-c-cookie-banner__confirmation-message">
-      You&#8217;ve accepted all cookies. You can <a class="govuk-link" href="<%= cookie_preferences_href %>" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.
-    </p>
+    <p class="gem-c-cookie-banner__confirmation-message"><%= confirmation_message %></p>
     <button class="gem-c-cookie-banner__hide-button" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide</button>
   </div>
 </div>

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -13,9 +13,29 @@ accessibility_excluded_rules:
 examples:
   default:
     data: {}
-  with_custom_text:
+  with_custom_content:
     data:
+      title: "Can we store analytics cookies on your device?"
       text: "This is some custom text in my cookie banner which lets users know what we're using cookies for. I can also include a link to the <a class='govuk-link' href='/cookies'>cookies page</a>"
+      confirmation_message: "You’ve accepted all cookies."
   with_custom_cookie_preferences_href:
     data:
       cookie_preferences_href: "/cookies"
+  in_services_asking_for_analytics_only:
+    description: Use this type of banner in your service if it only uses cookies for analytics.
+    data:
+      title: Can we store analytics cookies on your device?
+      text: Analytics cookies help us understand how our website is being used.
+      confirmation_message: You’ve accepted all cookies. You can <a class='govuk-link' href='/cookies'>change your cookie settings</a> at any time.
+      services_cookies:
+        "yes":
+          text: "Yes"
+          data_attributes:
+            "track-category": "cookieBanner"
+        "no":
+          text: "No"
+          data_attributes:
+            "track-category": "cookieBanner"
+        cookie_preferences:
+          text: How we use cookies
+          href: "/cookies"

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -43,10 +43,16 @@ describe "Cookie banner", type: :view do
     assert_select '.gem-c-cookie-banner__hide-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Hide cookie banner"]'
   end
 
-  it "renders with custom text" do
-    render_component(text: sanitize("This is some custom text with a link to the <a href='/cookies' class='govuk-link'>cookies page</a>"))
+  it "renders with custom content" do
+    render_component(
+      title: "Can we store analytics cookies on your device?",
+      text: sanitize("This is some custom text with a link to the <a href='/cookies' class='govuk-link'>cookies page</a>"),
+      confirmation_message: "You’ve accepted all cookies.",
+    )
+    assert_select ".gem-c-cookie-banner__message .govuk-heading-m", text: "Can we store analytics cookies on your device?"
     assert_select ".gem-c-cookie-banner__message .govuk-body", text: "This is some custom text with a link to the cookies page"
     assert_select ".govuk-link[href='/cookies']", text: "cookies page"
+    assert_select ".gem-c-cookie-banner__confirmation-message", text: "You’ve accepted all cookies."
   end
 
   it "renders with a custom preferences page link" do
@@ -57,5 +63,34 @@ describe "Cookie banner", type: :view do
     # Check that the confirmation message also includes the custom URL
     assert_select ".gem-c-cookie-banner__confirmation-message a[href='/cookies']", text: "change your cookie settings"
     assert_select '.gem-c-cookie-banner__confirmation-message a[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner settings clicked from confirmation"]'
+  end
+
+  it "renders the 'analytics only' version" do
+    render_component(
+      title: "Can we store analytics cookies on your device?",
+      text: "Analytics cookies help us understand how our website is being used.",
+      services_cookies: {
+        yes: {
+          text: "Yes",
+          data_attributes: {
+            "track-category": "cookieBanner",
+          },
+        },
+        no: {
+          text: "No",
+          data_attributes: {
+            "track-category": "cookieBanner",
+          },
+        },
+        cookie_preferences: {
+          text: "How we use cookies",
+          href: "/cookies",
+        },
+      },
+    )
+
+    assert_select ".gem-c-cookie-banner__buttons--flex button[data-module=track-click][data-track-category=cookieBanner][data-accept-cookies=true]", text: "Yes"
+    assert_select ".gem-c-cookie-banner__buttons--flex button[data-module=track-click][data-track-category=cookieBanner][data-hide-cookie-banner=true]", text: "No"
+    assert_select ".gem-c-cookie-banner__buttons--flex .gem-c-cookie-banner__link[href='/cookies']", text: "How we use cookies"
   end
 end


### PR DESCRIPTION
## What
Add cookie banner variation for services.
With this addition, we also enable custom title and confirmation messages for the cookie banner.

## Why
For services asking for cookies used for analytics only, we have a simpler approach (similarly with other GDS services, such as Notify, Wifi). We introduce this variation to be used across C19-related services.

## Visual Changes
[Preview example](https://govuk-publis-update-coo-zbw2lb.herokuapp.com/component-guide/cookie_banner/in_services_asking_for_analytics_only)

Co-Authored-By: @bilbof

[Trello card](https://trello.com/c/TObzdyej)