### PR TITLE
Add Youtube Embed Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased changes
+
+* Adds tracking for youtube ([PR #1440](https://github.com/alphagov/govuk_publishing_components/pull/1438))
+
 ## 21.39.0
 * Add cookie banner variation for services ([PR #1438](https://github.com/alphagov/govuk_publishing_components/pull/1438))
 

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -290,6 +290,17 @@ examples:
       block: |
         <p>This content has a YouTube livestream link, converted to an accessible embedded player by component JavaScript.</p>
         <p><a href="https://www.youtube.com/embed/live_stream?channel=UCoMdktPbSTixAyNGwb-UYkQ">Livestream video</a></p>
+  with_youtube_analytics:
+    data:
+      block: |
+        <p>This content has a YouTube link with analytics, converted to an accessible embedded player by component JavaScript.</p>
+        <p>
+          <a href="https://www.youtube.com/watch?v=ucjmWjJ25Ho"
+            data-youtube-player-analytics="true"
+            data-youtube-player-analytics-category="demo-for-components">
+            Youtube video with tracking
+          </a>
+        </p>
   with_youtube_embed_disabled:
     data:
       disable_youtube_expansions: true


### PR DESCRIPTION
## What
We need to be able to track when users are viewing the Livestream on GOV.UK.

We should use the YouTube API to send data to GA.

https://developers.google.com/youtube/iframe_api_reference#Retrieving_playlist_information

## Why
It will help us determine if it is a useful feature to include on GOV.UK.

Most commonly people use GTM to track videos on sites but we have security concerns about this.

Using the Youtube API we should be able to get around this but it is more complicated. It will give us more accurate information about viewing numbers and how users interact with the video, E.g do users pause it, start watching late and watch at increased speed? Currently, we are unable to do so and at best we can estimate the number of users but it is not accurate. For us to work this out we'd need this data to be passed to GA or equivalent as events.

## Done when
It's done when we can accurately record how many users viewed the live stream at any point.

It would be nice to be able to record how users are interacting with the video with events to trigger during the course of the stream.

https://trello.com/c/zAQSVUqi/124-add-livestream-tracking

## Demo

https://govuk-publis-youtube-an-h7le99.herokuapp.com/component-guide/govspeak/with_youtube_analytics