### PR TITLE
Remove excess newlines for attachment link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@
 ## Unreleased changes
 
 * Adds tracking for youtube ([PR #1440](https://github.com/alphagov/govuk_publishing_components/pull/1438))
+* Fix excess newlines for the Attachment Link component ([PR #1442](https://github.com/alphagov/govuk_publishing_components/pull/1442))
 
 ## 21.39.0
+
 * Add cookie banner variation for services ([PR #1438](https://github.com/alphagov/govuk_publishing_components/pull/1438))
 
 ## 21.38.5

--- a/app/views/govuk_publishing_components/components/_attachment_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment_link.html.erb
@@ -33,7 +33,6 @@
   <%= link_to(attachment.title, attachment.url,
               class: "govuk-link",
               target: target,
-              data: data_attributes) %>
-
-  <%= raw("(#{attributes.join(', ')})") if attributes.any? %>
+              data: data_attributes) -%>
+  <%= raw("(#{attributes.join(', ')})") if attributes.any? -%>
 <% end %>

--- a/spec/components/attachment_link_spec.rb
+++ b/spec/components/attachment_link_spec.rb
@@ -62,4 +62,27 @@ describe "Attachment Link", type: :view do
     )
     assert_select "a.govuk-link[data-gtm='attachment-preview']"
   end
+
+  it "does not have a newline character after the last metadata attribute's closing span tag" do
+    render_component(
+      attachment: {
+        title: "Attachment",
+        url: "attachment",
+        content_type: "text/plain",
+      },
+    )
+
+    expect(rendered).to end_with("</span>)</span>")
+  end
+
+  it "does not have any newline characters after the link element" do
+    render_component(
+      attachment: {
+        title: "Attachment",
+        url: "attachment",
+      },
+    )
+
+    expect(rendered).not_to match(/<\/a>\n/)
+  end
 end


### PR DESCRIPTION
## What
We discovered a small bug in Content Publisher content where attachment links
that are rendered in Govspeak have a couple of instances of excess newline
characters being generated.

1. Newline between the last metadata attribute's (`.gem-c-attachment-link__attribute`) closing span tag, and the `gem-c-attachment-link` closing span tag.
   e.g. `<span class=\"gem-c-attachment-link__attribute\">2 pages</span>)\n</span>`

2. Two newline characters after the attachment link text.
   e.g. `<a class=\"govuk-link\" href=\"attachment\">Attachment</a>\n\n`

This fixes the ERB tags so that the extra newlines aren't generated for these
elements.

## Why

When importing documents in to Content Publisher from Whitehall, our integrity checks threw an error as there was a mismatch between the HTML generated by Govspeak in Content Publisher and the HTML present in Publishing API (note Whitehall doesn't use this component to render inline attachments).

**Example of newline between span tags**
- Content Publisher HTML
`<span class="gem-c-attachment-link__attribute">2 pages</span>)\n</span>`

- Publishing API HTML
`<span class="gem-c-attachment-link__attribute">2 pages</span>)</span>`

**Example of extra newlines after link**

- Content Publisher HTML
`<a class="govuk-link" href="http://static.dev.gov.uk/...">market investigation note</a>\n\n`

- Publishing API HTML
`<a class="govuk-link" href="http://static.dev.gov.uk/...">market investigation note</a>\n`

## Visual Changes

The added newline between span tags also had a visual impact when previewing an inline attachment in Content Publisher.

**Before**
<img width="644" alt="Screenshot 2020-04-09 at 13 55 36" src="https://user-images.githubusercontent.com/13434452/78897449-18d5ac80-7a6a-11ea-90fb-e7fd049a7fa9.png">

**After**
<img width="646" alt="Screenshot 2020-04-09 at 13 55 53" src="https://user-images.githubusercontent.com/13434452/78897470-20955100-7a6a-11ea-94e2-025b36599f7b.png">
