### PR TITLE
Fix hide link on cookie banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Adds tracking for youtube ([PR #1440](https://github.com/alphagov/govuk_publishing_components/pull/1438))
 * Fix excess newlines for the Attachment Link component ([PR #1442](https://github.com/alphagov/govuk_publishing_components/pull/1442))
+* Bugfix: Ensure cookie banner hide button always hides the cookie banner ([PR #1443](https://github.com/alphagov/govuk_publishing_components/pull/1443)).
 
 ## 21.39.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -17,9 +17,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   CookieBanner.prototype.setupCookieMessage = function () {
-    this.$hideLink = this.$module.querySelector('button[data-hide-cookie-banner]')
-    if (this.$hideLink) {
-      this.$hideLink.addEventListener('click', this.$module.hideCookieMessage)
+    this.$hideLinks = this.$module.querySelectorAll('button[data-hide-cookie-banner]')
+    if (this.$hideLinks && this.$hideLinks.length) {
+      for (var i = 0; i < this.$hideLinks.length; i++) {
+        this.$hideLinks[i].addEventListener('click', this.$module.hideCookieMessage)
+      }
     }
 
     this.$acceptCookiesLink = this.$module.querySelector('button[data-accept-cookies]')


### PR DESCRIPTION
## What

This adds an event listener to all cookie banner hide buttons. Previously only the first hide button would hide the banner.

querySelectorAll returns a list of elements, whereas querySelector returns only the first element found. Since there are two hide links now we want to add an event listener to all of them.

## Visual Changes

https://govuk-publis-bilbof-fix-dk83zo.herokuapp.com/component-guide/cookie_banner/in_services_asking_for_analytics_only

https://trello.com/c/oT8l91fv/198-bugfix-hide-button-on-cookie-banner-component-should-hide-banner