### PR TITLE
Do not show coronavirus taxons in contextual breadcrumbs and footer

### DIFF
--- a/app/helpers/govuk_publishing_components/application_helper.rb
+++ b/app/helpers/govuk_publishing_components/application_helper.rb
@@ -1,4 +1,6 @@
 module GovukPublishingComponents
+  CORONAVIRUS_TAXON_BASE_PATH = "/coronavirus-taxons".freeze
+
   module ApplicationHelper
   end
 end

--- a/lib/govuk_publishing_components/presenters/content_item.rb
+++ b/lib/govuk_publishing_components/presenters/content_item.rb
@@ -28,7 +28,7 @@ module GovukPublishingComponents
       def parent_taxons
         @parent_taxons ||= begin
           taxon_links
-            .select { |t| phase_is_live?(t) }
+            .select { |t| phase_is_live?(t) && is_not_a_coronavirus_taxon?(t) }
             .map { |taxon| ContentItem.new(taxon) }.sort_by(&:title)
         end
       end
@@ -147,6 +147,18 @@ module GovukPublishingComponents
         links.select do |link|
           link["document_type"] == type
         end
+      end
+
+      def is_not_a_coronavirus_taxon?(taxon)
+        return false if taxon["base_path"] == CORONAVIRUS_TAXON_BASE_PATH
+
+        parent_taxons = recursive_parents_of_taxon(taxon).flatten.compact
+        parent_taxons.all? { |child_taxon| child_taxon["base_path"] != CORONAVIRUS_TAXON_BASE_PATH }
+      end
+
+      def recursive_parents_of_taxon(taxon)
+        taxon.dig("links", "parent_taxons") || [].
+            map { |parent_taxon| recursive_parents_of_taxon(parent_taxon) }.flatten.compact
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -53,7 +53,7 @@ module GovukPublishingComponents
       end
 
       def content_is_tagged_to_a_live_taxon?
-        content_item.dig("links", "taxons").to_a.any? { |taxon| taxon["phase"] == "live" }
+        ContentItem.new(content_item).parent_taxons.any?
       end
 
       def content_is_a_specialist_document?

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -225,7 +225,7 @@ module GovukPublishingComponents
         links = Array(@content_item.dig("links", key))
 
         if key == "taxons"
-          links = links.find_all { |link| link["phase"] == "live" }
+          links = links.find_all { |link| link["phase"] == "live" && is_not_a_coronavirus_taxon?(link) }
         end
 
         if only.present?
@@ -239,6 +239,18 @@ module GovukPublishingComponents
             locale: link["locale"],
           }
         }
+      end
+
+      def is_not_a_coronavirus_taxon?(taxon)
+        return false if taxon["base_path"] == CORONAVIRUS_TAXON_BASE_PATH
+
+        parent_taxons = recursive_parents_of_taxon(taxon).flatten.compact
+        parent_taxons.all? { |child_taxon| child_taxon["base_path"] != CORONAVIRUS_TAXON_BASE_PATH }
+      end
+
+      def recursive_parents_of_taxon(taxon)
+        taxon.dig("links", "parent_taxons") || [].
+            map { |parent_taxon| recursive_parents_of_taxon(parent_taxon) }.flatten.compact
       end
     end
   end

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -50,6 +50,20 @@ describe "Contextual navigation" do
     and_the_taxonomy_breadcrumbs
   end
 
+  scenario "There's a child of coronavirus taxon and another taxon tagged" do
+    given_theres_a_guide_tagged_to_a_child_of_the_coronavirus_taxon_and_a_live_taxon
+    and_i_visit_that_page
+    then_i_see_the_taxon_in_the_related_navigation_footer
+    and_the_taxonomy_breadcrumbs
+  end
+
+  scenario "There's a coronavirus taxon and another taxon tagged" do
+    given_theres_a_guide_tagged_to_the_coronavirus_taxon_and_a_live_taxon
+    and_i_visit_that_page
+    then_i_see_the_taxon_in_the_related_navigation_footer
+    and_the_taxonomy_breadcrumbs
+  end
+
   scenario "There's legacy things tagged" do
     given_theres_a_page_with_just_legacy_taxonomy
     and_i_visit_that_page
@@ -236,6 +250,42 @@ describe "Contextual navigation" do
     )
   end
 
+  def given_theres_a_guide_tagged_to_a_child_of_the_coronavirus_taxon_and_a_live_taxon
+    coronavirus_taxon = example_item("taxon", "taxon").tap do |taxon|
+      taxon["title"] = "Coronavirus taxon"
+      taxon["base_path"] = "/coronavirus-taxons"
+    end
+
+    child_of_coronavirus_taxon = example_item("taxon", "taxon").tap do |taxon|
+      taxon["title"] = "Child of Coronavirus taxon"
+      taxon["links"]["parent_taxons"] = [coronavirus_taxon]
+    end
+
+    live_taxon = example_item("taxon", "taxon")
+
+    content_store_has_random_item(
+      schema: "guide",
+      links: {
+        "taxons" => [child_of_coronavirus_taxon, live_taxon],
+      },
+    )
+  end
+
+  def given_theres_a_guide_tagged_to_the_coronavirus_taxon_and_a_live_taxon
+    coronavirus_taxon = example_item("taxon", "taxon").tap do |taxon|
+      taxon["title"] = "Coronavirus taxon"
+      taxon["base_path"] = "/coronavirus-taxons"
+    end
+    live_taxon = example_item("taxon", "taxon")
+
+    content_store_has_random_item(
+      schema: "guide",
+      links: {
+        "taxons" => [coronavirus_taxon, live_taxon],
+      },
+    )
+  end
+
   def given_theres_a_page_with_just_legacy_taxonomy
     content_store_has_random_item(links: {
       "topics" => [example_item("topic", "topic")],
@@ -342,12 +392,14 @@ describe "Contextual navigation" do
     within ".gem-c-breadcrumbs" do
       expect(page).to have_link("Home")
       expect(page).to have_link("A level")
+      expect(page).to_not have_css(".gem-c-related-navigation__link", text: "Child of Coronavirus taxon")
     end
   end
 
   def then_i_see_the_taxon_in_the_related_navigation_footer
     within ".gem-c-contextual-footer" do
       expect(page).to have_css(".gem-c-related-navigation__link", text: "A level")
+      expect(page).to_not have_css(".gem-c-related-navigation__link", text: "Child of Coronavirus taxon")
     end
   end
 

--- a/spec/lib/govuk_publishing_components/presenters/content_item_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_item_spec.rb
@@ -67,6 +67,39 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentItem do
           expect(described_class.new(content_item_response).parent_taxons).to eq([])
         end
       end
+
+      context "with a taxon whose parent is the coronavirus taxon" do
+        let(:taxon) do
+          {
+              "content_id" => "cccc-dddd",
+              "title" => "Taxon",
+              "phase" => "live",
+              "links" => {
+                  "parent_taxons" => [
+                      {
+                          "base_path" => "/coronavirus-taxons",
+                          "content_id" => "xxxx-xxxx",
+                          "title" => "Non Whitelisted Taxon",
+                      },
+                  ],
+              },
+          }
+        end
+
+        let(:content_item_response) do
+          {
+              "title" => "Some Answer Content Item",
+              "document_type" => "answer",
+              "links" => {
+                  "taxons" => [taxon],
+              },
+          }
+        end
+
+        it "returns an empty array" do
+          expect(described_class.new(content_item_response).parent_taxons).to eq([])
+        end
+      end
     end
 
     context "for a content item with no taxons links" do


### PR DESCRIPTION
## What
Do not show links to coronavirus taxa in contextual breadcrumbs and footers

## Why
We don't want to link to those pages

### Nota Bene

There is some repetition here, I got into a deep rabbit hole trying to DRY it out but couldn't figure out an elegant way of doing it