### PR TITLE
Fix button alignment on cookie-banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased changes
+
+* Fix button alignment on cookie-banner ([PR #1450](https://github.com/alphagov/govuk_publishing_components/pull/1450))
+
 ## 21.41.0
 
 * Fixes a bug with Youtube livestream introduced in #1440 ([PR #1447](https://github.com/alphagov/govuk_publishing_components/pull/1447))
 
 ## 21.40.0
 
-* Adds tracking for youtube ([PR #1440](https://github.com/alphagov/govuk_publishing_components/pull/1438))
+* Adds tracking for youtube ([PR #1440](https://github.com/alphagov/govuk_publishing_components/pull/1440))
 * Fix excess newlines for the Attachment Link component ([PR #1442](https://github.com/alphagov/govuk_publishing_components/pull/1442))
 * Bugfix: Ensure cookie banner hide button always hides the cookie banner ([PR #1443](https://github.com/alphagov/govuk_publishing_components/pull/1443)).
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -112,16 +112,12 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
   flex-wrap: wrap;
   align-items: baseline;
 
-  .govuk-button {
+  .govuk-button,
+  .gem-c-cookie-banner__link {
     flex-grow: 1;
     flex-basis: 10rem;
     margin-right: govuk-spacing(3);
     margin-bottom: govuk-spacing(3);
-  }
-
-  .gem-c-cookie-banner__link {
-    flex-grow: 1;
-    display: inline-block;
   }
 }
 


### PR DESCRIPTION
## What
Fix actions (buttons/link) alignment at various breakpoints on the 'services' variation of the cookie banner.

This variation of the component was borrowed from GovWifi which has a longer link text. This is a generic solution (not ideal) but fixes the issue regardless of the text size used on content.

## Why
No to seem like we're leading users towards one answer or another

## Visual Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_3212_component-guide_cookie_banner_in_services_asking_for_analytics_only_ (1)](https://user-images.githubusercontent.com/788096/79008489-6bd85e00-7b55-11ea-85a5-f5e2ef8b45f8.png)


</td><td valign="top">

![localhost_3212_component-guide_cookie_banner_in_services_asking_for_analytics_only_ (2)](https://user-images.githubusercontent.com/788096/79008495-6e3ab800-7b55-11ea-8ec6-8aa4cd527116.png)


</td></tr>
</table>

Fixes #1446