### PR TITLE
Bump to 21.41.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.41.2
 
 * Make FAQs look deeper in the page for questions ([PR #1437](https://github.com/alphagov/govuk_publishing_components/pull/1437))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.41.1)
+    govuk_publishing_components (21.41.2)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.41.1".freeze
+  VERSION = "21.41.2".freeze
 end


### PR DESCRIPTION
Just contains a tweak to the FAQPage schema to allow it to work with deeper document structures.

Works with https://github.com/alphagov/government-frontend/pull/1726