### PR TITLE
Update links to real world examples of share links

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/share_links.yml
+++ b/app/views/govuk_publishing_components/components/docs/share_links.yml
@@ -5,9 +5,9 @@ body: |
 
   Real world examples:
 
-    - [News article](/government/news/fast-tracking-uk-innovation-apply-for-business-funding)
-    - [Consultation](/government/consultations/soft-drinks-industry-levy)
-    - [Right to left](/government/news/uk-sets-out-long-term-support-for-stable-secure-and-prosperous-afghanistan-to-2020.ur)
+    - [News article](https://www.gov.uk/government/news/fast-tracking-uk-innovation-apply-for-business-funding)
+    - [Consultation](https://www.gov.uk/government/consultations/soft-drinks-industry-levy)
+    - [Right to left](https://www.gov.uk/government/news/uk-sets-out-long-term-support-for-stable-secure-and-prosperous-afghanistan-to-2020.ur)
 
 accessibility_criteria: |
   The share link icons must be presentational and ignored by screen readers.


### PR DESCRIPTION
## What

Fix the broken 'Real world example' links in the share links component, by prefixing them with the https://www.gov.uk URL.

## Why

The real world example links are broken on https://components.publishing.service.gov.uk/component-guide/share_links.