### PR TITLE
Load application styles after gem styles in the component guide

### DIFF
--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -16,9 +16,9 @@
     <%= csrf_meta_tags %>
     <%= favicon_link_tag "govuk_publishing_components/favicon-production.png" %>
 
-    <%= yield :application_stylesheet %>
     <%= stylesheet_link_tag "component_guide/application", media: "screen" %>
     <%= stylesheet_link_tag "component_guide/print", media: "print" %>
+    <%= yield :application_stylesheet %>
 
     <%= javascript_include_tag "govuk_publishing_components/vendor/modernizr" %>
     <%= yield :extra_headers %>


### PR DESCRIPTION
## What
Load application styles after gem styles (same order as scripts and all assets in apps).

## Why
In frontend applications, styles/scripts from the gem are loaded first, then the application-level styles/scripts which sometimes depend or inherit from the ones in the gem. With this change, we apply the same order to the component guide so that components look and behave the same as they do when used in the application.

## Visual Changes
Some visual fixes for components presented in the guide across apps.