### PR TITLE
Allow input component to accept an error id

### DIFF
--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -19,7 +19,7 @@
   width ||= nil
   has_error ||= error_message || error_items.any?
   hint_id = "hint-#{SecureRandom.hex(4)}"
-  error_id = "error-#{SecureRandom.hex(4)}"
+  error_id ||= "error-#{SecureRandom.hex(4)}"
   search_icon ||= nil
   heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
 

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -64,11 +64,13 @@ examples:
       name: "name"
       hint: "Please provide your first and last name"
   with_error:
+    description: An id for the error message is automatically generated, but can also be passed if required.
     data:
       label:
         text: "What is your name?"
       name: "name"
       error_message: "Please could you provide your name"
+      error_id: "optional"
   with_error_items:
     data:
       label:

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -165,11 +165,16 @@ describe "Input", type: :view do
       render_component(
         name: "email-address",
         error_message: "Please enter a valid email address",
+        error_id: "optional"
       )
     end
 
     it "renders the error message" do
       assert_select ".govuk-error-message", text: "Error: Please enter a valid email address"
+    end
+
+    it "accepts a passed error id" do
+      assert_select "#optional.govuk-error-message"
     end
 
     it "has 'aria-describedby' the error message id" do


### PR DESCRIPTION
## What
- allows an id for the error message to be passed if the component is in an error state
- normally auto generates one but there are situations where we want to define the error id e.g. if using the error summary that links to the errors highlighted

<img width="785" alt="Screenshot 2020-04-21 at 09 04 49" src="https://user-images.githubusercontent.com/861310/79841342-2f0b3300-83af-11ea-8c34-26fa249cb4ed.png">


## Why
Needed for the feedback application.

## Visual Changes
None.
