### PR TITLE
Expand scope of suggested sass functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Expand scope of suggested sass functionality ([PR #1461](https://github.com/alphagov/govuk_publishing_components/pull/1461))
+
 ## 21.41.2
 
 * Make FAQs look deeper in the page for questions ([PR #1437](https://github.com/alphagov/govuk_publishing_components/pull/1437))

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -80,6 +80,8 @@ module GovukPublishingComponents
       matches = []
 
       files = Dir["#{@application_path}/app/views/**/*.html.erb"]
+      files.concat Dir["#{@application_path}/app/**/*.rb"]
+
       files.each do |file|
         data = File.read(file)
         matches << data.scan(/(govuk_publishing_components\/components\/[a-z_-]+)/)


### PR DESCRIPTION
## What / why
- was previously looking for instances of component use only in the view, but government-frontend had one component call in a ruby helper, which was overlooked, resulting in an unstyled component
- now includes all ruby files in /app/ when looking for components

## Visual Changes
None

