### PR TITLE
Document ID option for character count

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/character_count.yml
+++ b/app/views/govuk_publishing_components/components/docs/character_count.yml
@@ -32,6 +32,14 @@ examples:
         name: "with-hint"
         hint: "Please include as much information as possible."
       maxlength: 10
+  with_id_for_textarea:
+    data:
+      textarea:
+        label:
+          text: "What is your quest?"
+        name: "with-an-id"
+      id: "custom-id"
+      maxlength: 10
   with_error:
     data:
       textarea:


### PR DESCRIPTION
## What
Add documentation for how to add an ID to the textarea in the character count component documentation.

## Why
Because I spent at least an hour this morning investigating why this apparently wasn't working and possibly causing a bug, only to discover that I'd not indented the option properly 🤕 

<img width="915" alt="Screenshot 2020-04-22 at 14 12 52" src="https://user-images.githubusercontent.com/861310/79986054-61965800-84a3-11ea-850c-c77f3723c8c4.png">

## Visual Changes
None.
