### PR TITLE
Change title component context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Change title component context ([PR #1464](https://github.com/alphagov/govuk_publishing_components/pull/1464))
 * Expand scope of suggested sass functionality ([PR #1461](https://github.com/alphagov/govuk_publishing_components/pull/1461))
 
 ## 21.41.2

--- a/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
@@ -7,12 +7,6 @@
   }
 }
 
-.gem-c-title__context {
-  @include govuk-font(24);
-  color: $govuk-secondary-text-colour;
-  margin: 0;
-}
-
 .gem-c-title__context-link {
   text-decoration: none;
 

--- a/app/views/govuk_publishing_components/components/_title.html.erb
+++ b/app/views/govuk_publishing_components/components/_title.html.erb
@@ -19,9 +19,9 @@
 %>
 <%= content_tag(:div, class: classes) do %>
   <% if context %>
-    <p class="gem-c-title__context" <%= "lang=#{context_locale}" if context_locale.present? %>>
+    <span class="govuk-caption-xl" <%= "lang=#{context_locale}" if context_locale.present? %>>
       <%= context_href ? link_to(context_text, context_href, class: 'gem-c-title__context-link govuk-link', data: context_data) : context_text %>
-    </p>
+    </span>
   <% end %>
   <h1 class="gem-c-title__text <% if average_title_length %>gem-c-title__text--<%= average_title_length %><% end %>">
     <%= title %>

--- a/spec/components/title_spec.rb
+++ b/spec/components/title_spec.rb
@@ -18,7 +18,7 @@ describe "Title", type: :view do
 
   it "title context appears" do
     render_component(title: "Hello World", context: "Format")
-    assert_select ".gem-c-title__context", text: "Format"
+    assert_select ".govuk-caption-xl", text: "Format"
   end
 
   it "title context link appears" do
@@ -28,7 +28,7 @@ describe "Title", type: :view do
 
   it "applies context language if supplied to a context string" do
     render_component(title: "Bonjour Monde", context: "hello", context_locale: "en")
-    assert_select ".gem-c-title__context[lang='en']"
+    assert_select ".govuk-caption-xl[lang='en']"
   end
 
   it "applies title length if supplied" do
@@ -83,6 +83,6 @@ describe "Title", type: :view do
 
   it "applies context language if supplied to a context link" do
     render_component(title: "Bonjour", context: { text: "Format", href: "/format" }, context_locale: "en")
-    assert_select ".gem-c-title__context[lang='en']"
+    assert_select ".govuk-caption-xl[lang='en']"
   end
 end


### PR DESCRIPTION
## What
- use span instead of p
- use govuk-caption-xl from govuk-frontend instead of custom style that did the same thing

## Why
- change brings this more in line with govuk-frontend and restores 5px of spacing between context and title

## Visual Changes

Before:

<img width="563" alt="Screenshot 2020-04-22 at 14 29 28" src="https://user-images.githubusercontent.com/861310/79987795-c357c180-84a5-11ea-8034-bc032ff59d98.png">

After:

<img width="630" alt="Screenshot 2020-04-22 at 14 29 15" src="https://user-images.githubusercontent.com/861310/79987820-c94da280-84a5-11ea-921e-b866ad1945a5.png">

Design system doc: https://design-system.service.gov.uk/styles/typography/#headings

Trello card: https://trello.com/c/z4DVsyk0/200-make-hub-page-breadcrumbs-more-explicit
