### PR TITLE
Fix inverse option for title component context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix inverse option for title component context ([PR #1466](https://github.com/alphagov/govuk_publishing_components/pull/1466))
+
 ## 21.41.3
 
 * Change title component context ([PR #1464](https://github.com/alphagov/govuk_publishing_components/pull/1464))

--- a/app/views/govuk_publishing_components/components/_title.html.erb
+++ b/app/views/govuk_publishing_components/components/_title.html.erb
@@ -19,7 +19,7 @@
 %>
 <%= content_tag(:div, class: classes) do %>
   <% if context %>
-    <span class="govuk-caption-xl" <%= "lang=#{context_locale}" if context_locale.present? %>>
+    <span class="govuk-caption-xl gem-c-title__context" <%= "lang=#{context_locale}" if context_locale.present? %>>
       <%= context_href ? link_to(context_text, context_href, class: 'gem-c-title__context-link govuk-link', data: context_data) : context_text %>
     </span>
   <% end %>


### PR DESCRIPTION
## What / why
Inverse option for title component was broken by (cough my) recent change. This fixes it, by restoring the gem specific class that was already styled to inherit the font colour.

## Visual Changes

Before:

![image](https://user-images.githubusercontent.com/861310/80102595-e4361a80-856a-11ea-9766-d1e9536dfaf0.png)

After: 

<img width="710" alt="Screenshot 2020-04-23 at 14 00 57" src="https://user-images.githubusercontent.com/861310/80102592-e26c5700-856a-11ea-805a-14bcf5a451b6.png">
