### PR TITLE
Add custom margin option to accordion component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add custom margin option to accordion component ([PR #1470](https://github.com/alphagov/govuk_publishing_components/pull/1470))
+
 ## 21.41.4
 
 * Fix inverse option for title component context ([PR #1466](https://github.com/alphagov/govuk_publishing_components/pull/1466))

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -1,11 +1,14 @@
 <%
+  local_assigns[:margin_bottom] ||= 6
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   id ||= "default-id-#{SecureRandom.hex(4)}"
   items ||= []
   condensed ||= false
+
   accordion_classes = %w(gem-c-accordion govuk-accordion)
   accordion_classes << 'govuk-accordion--condensed' if condensed
+  accordion_classes << (shared_helper.get_margin_bottom)
 
   data_attributes ||= {}
   data_attributes[:module] = 'govuk-accordion'

--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -233,6 +233,20 @@ examples:
             text: "How people read"
           content:
             html: "<p class='govuk-body'>This is the content for How people read.</p>"
+  with_margin_bottom:
+    description: |
+      The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a margin bottom of 30px.
+    data:
+      margin_bottom: 0
+      items:
+        - heading:
+            text: "Writing well for the web"
+          content:
+            html: "<p class='govuk-body'>This is the content for Writing well for the web.</p>"
+        - heading:
+            text: "Writing well for specialists"
+          content:
+            html: "<p class='govuk-body'>This is the content for Writing well for specialists.</p>"
   with_section_open:
     description: |
       Adding `expanded: true` to the item will mean the section will default to being open, rather than closed. Once a user has opened or closed a section, the state of each section will be remembered - this can override a section's default.

--- a/spec/components/accordion_spec.rb
+++ b/spec/components/accordion_spec.rb
@@ -96,6 +96,33 @@ describe "Accordion", type: :view do
     assert_select "h5", count: 1
   end
 
+  it "sets a default margin bottom" do
+    test_data = {
+      items: [{
+                heading: { text: "Heading 1" },
+                summary: { text: "Summary 1." },
+                content: { html: "<p>Content 1.</p>" },
+              }],
+    }
+
+    render_component(test_data)
+    assert_select '.gem-c-accordion.govuk-\!-margin-bottom-6'
+  end
+
+  it "sets a custom margin bottom" do
+    test_data = {
+      margin_bottom: 0,
+      items: [{
+                heading: { text: "Heading 1" },
+                summary: { text: "Summary 1." },
+                content: { html: "<p>Content 1.</p>" },
+              }],
+    }
+
+    render_component(test_data)
+    assert_select '.gem-c-accordion.govuk-\!-margin-bottom-0'
+  end
+
   it "default heading level is used when heading_level is not set" do
     test_data = {
       id: "heading-level-default",


### PR DESCRIPTION
## What
Adds an option to set the margin bottom for the accordion component. Defaults to 30px as previous behaviour.

## Why
We need to change the bottom margin of the component in collections.

## Visual Changes
<img width="934" alt="Screenshot 2020-04-24 at 11 37 23" src="https://user-images.githubusercontent.com/861310/80204004-fe7e0000-861f-11ea-8831-d84b63f058ed.png">

