### PR TITLE
Version 21.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.42.0
 
 * Add custom margin option to accordion component ([PR #1470](https://github.com/alphagov/govuk_publishing_components/pull/1470))
 * Explicitly set accordion heading line height ([PR #1386](https://github.com/alphagov/govuk_publishing_components/pull/1386))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.41.4)
+    govuk_publishing_components (21.42.0)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.41.4".freeze
+  VERSION = "21.42.0".freeze
 end


### PR DESCRIPTION
## 21.42.0

* Add custom margin option to accordion component ([PR #1470](https://github.com/alphagov/govuk_publishing_components/pull/1470))
* Explicitly set accordion heading line height ([PR #1386](https://github.com/alphagov/govuk_publishing_components/pull/1386))
