### PR TITLE
Allow individual script imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow individual JavaScript imports ([PR #1472](https://github.com/alphagov/govuk_publishing_components/pull/1472))
+
+  To import individual components refer to ['Include the assets section in docs'](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md) and the 'Suggested imports for this application' section available on `/component-guide` in your application.
+
 ## 21.50.1
 
 * Tweak action link ([PR #1518](https://github.com/alphagov/govuk_publishing_components/pull/1518))
@@ -202,7 +208,7 @@
 
 ## 21.26.0
 
-* Allow individual components to be imported into apps ([PR #1159](https://github.com/alphagov/govuk_publishing_components/pull/1159))
+* Allow individual Sass imports ([PR #1159](https://github.com/alphagov/govuk_publishing_components/pull/1159))
 
 ## 21.25.0
 

--- a/app/assets/javascripts/govuk_publishing_components/all_components.js
+++ b/app/assets/javascripts/govuk_publishing_components/all_components.js
@@ -1,5 +1,4 @@
 // = require_tree ./lib
 // = require_tree ./components
-// = require govuk/all.js
 
 window.GOVUKFrontend.initAll = function () {}

--- a/app/assets/javascripts/govuk_publishing_components/all_components.js
+++ b/app/assets/javascripts/govuk_publishing_components/all_components.js
@@ -2,5 +2,4 @@
 // = require_tree ./components
 // = require govuk/all.js
 
-// Initialise all GOVUKFrontend components
-window.GOVUKFrontend.initAll()
+window.GOVUKFrontend.initAll = function () {}

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -1,2 +1,5 @@
 // This component relies on JavaScript from GOV.UK Frontend
 // = require govuk/components/accordion/accordion.js
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+window.GOVUK.Modules.Accordion = window.GOVUKFrontend

--- a/app/assets/javascripts/govuk_publishing_components/components/button.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/button.js
@@ -1,5 +1,5 @@
 // This component relies on JavaScript from GOV.UK Frontend
-// = require govuk/components/error-summary/error-summary.js
+// = require govuk/components/button/button.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
-window.GOVUK.Modules.ErrorSummary = window.GOVUKFrontend
+window.GOVUK.Modules.Button = window.GOVUKFrontend

--- a/app/assets/javascripts/govuk_publishing_components/components/character-count.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/character-count.js
@@ -1,2 +1,5 @@
 // This component relies on JavaScript from GOV.UK Frontend
 // = require govuk/components/character-count/character-count.js
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+window.GOVUK.Modules.CharacterCount = window.GOVUKFrontend

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -1,7 +1,8 @@
 /* eslint-env jquery */
 // = require govuk/components/checkboxes/checkboxes.js
 window.GOVUK = window.GOVUK || {}
-window.GOVUK.Modules = window.GOVUK.Modules || {};
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+window.GOVUK.Modules.Checkboxes = window.GOVUKFrontend;
 
 (function (Modules) {
   'use strict'

--- a/app/assets/javascripts/govuk_publishing_components/components/header.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/header.js
@@ -1,5 +1,5 @@
 // This component relies on JavaScript from GOV.UK Frontend
-// = require govuk/components/error-summary/error-summary.js
+// = require govuk/components/header/header.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
-window.GOVUK.Modules.ErrorSummary = window.GOVUKFrontend
+window.GOVUK.Modules.Header = window.GOVUKFrontend

--- a/app/assets/javascripts/govuk_publishing_components/components/radio.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/radio.js
@@ -1,2 +1,5 @@
 // This component relies on JavaScript from GOV.UK Frontend
 // = require govuk/components/radios/radios.js
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+window.GOVUK.Modules.Radios = window.GOVUKFrontend

--- a/app/assets/javascripts/govuk_publishing_components/components/tabs.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/tabs.js
@@ -1,5 +1,5 @@
 // This component relies on JavaScript from GOV.UK Frontend
-// = require govuk/components/error-summary/error-summary.js
+// = require govuk/components/tabs/tabs.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
-window.GOVUK.Modules.ErrorSummary = window.GOVUKFrontend
+window.GOVUK.Modules.Tabs = window.GOVUKFrontend

--- a/app/assets/javascripts/govuk_publishing_components/lib.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib.js
@@ -1,0 +1,1 @@
+// = require_tree ./lib

--- a/app/assets/javascripts/govuk_publishing_components/modules.js
+++ b/app/assets/javascripts/govuk_publishing_components/modules.js
@@ -28,12 +28,24 @@
       for (var i = 0, l = modules.length; i < l; i++) {
         var module
         var element = $(modules[i])
-        var type = camelCaseAndCapitalise(element.data('module'))
+        var moduleName = camelCaseAndCapitalise(element.data('module'))
         var started = element.data('module-started')
+        var frontendModuleName = moduleName.replace('Govuk', '')
 
-        if (typeof GOVUK.Modules[type] === 'function' && !started) {
-          module = new GOVUK.Modules[type]()
+        if ( // GOV.UK Publishing & Legacy Modules
+          typeof GOVUK.Modules[moduleName] === 'function' &&
+          !GOVUK.Modules[moduleName].prototype.init &&
+          !started
+        ) {
+          module = new GOVUK.Modules[moduleName]()
           module.start(element)
+          element.data('module-started', true)
+        } else if ( // GOV.UK Frontend Modules
+          typeof GOVUK.Modules[frontendModuleName] === 'function' &&
+          GOVUK.Modules[frontendModuleName].prototype.init &&
+          !started
+        ) {
+          module = new GOVUK.Modules[frontendModuleName](element[0]).init()
           element.data('module-started', true)
         }
       }

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -10,6 +10,7 @@ module GovukPublishingComponents
       @components_in_use_docs = components_in_use_docs.used_in_this_app
       @components_in_use_sass = components_in_use_sass(false)
       @components_in_use_print_sass = components_in_use_sass(true)
+      @components_in_use_js = components_in_use_js
     end
 
     def show
@@ -62,6 +63,25 @@ module GovukPublishingComponents
       }.compact.uniq.sort.join("\n").squeeze("\n").prepend(additional_files)
     end
 
+    def components_in_use_js
+      additional_files = "//= require govuk_publishing_components/lib\n"
+
+      components = components_in_use
+      extra_components = []
+
+      components.each do |component|
+        components_in_component = components_within_component(component)
+        extra_components << components_in_component
+      end
+
+      components << extra_components.compact
+      components = components.flatten.uniq.sort
+
+      components.map { |component|
+        "//= require govuk_publishing_components/components/#{component.gsub('_', '-')}" if component_has_js_file(component.gsub("_", "-"))
+      }.compact.uniq.sort.join("\n").squeeze("\n").prepend(additional_files)
+    end
+
   private
 
     def component_docs
@@ -93,6 +113,10 @@ module GovukPublishingComponents
     def component_has_sass_file(component, print_styles)
       print_path = "print/" if print_styles
       Pathname.new(@component_gem_path + "/app/assets/stylesheets/govuk_publishing_components/components/#{print_path}_#{component}.scss").exist?
+    end
+
+    def component_has_js_file(component)
+      Pathname.new(@component_gem_path + "/app/assets/javascripts/govuk_publishing_components/components/#{component}.js").exist?
     end
 
     def components_within_component(component)

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -20,7 +20,7 @@
   <h2 class="component-doc-h2">Gem components used by this app (<%= @components_in_use_docs.length %>)</h2>
 
   <%= render "govuk_publishing_components/components/details", {
-    title: "Suggested Sass for this application"
+    title: "Suggested imports for this application"
   } do %>
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
@@ -35,6 +35,13 @@
       },
       name: "print-sass",
       value: @components_in_use_print_sass
+    } %>
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: "Add this to your application's main js file, before your other local imports."
+      },
+      name: "main-js",
+      value: @components_in_use_js
     } %>
   <% end %>
 <pre>

--- a/docs/install-and-use.md
+++ b/docs/install-and-use.md
@@ -67,7 +67,7 @@ For example:
 @import 'govuk_publishing_components/components/_back-link';
 ```
 
-If you load the component guide in the application the suggested Sass for it has been generated for you. Click the 'Suggested Sass for this application' link, then copy and paste the output into your `application.scss` file. Remember to also copy the suggested print Sass into your application's `print.scss` file.
+If you load the component guide in the application the suggested Sass for it has been generated for you. Click the 'Suggested imports for this application' link, then copy and paste the output into your `application.scss` file. Remember to also copy the suggested print Sass into your application's `print.scss` file.
 
 ### Import all Sass (deprecated, will be removed in a later version)
 
@@ -83,9 +83,28 @@ And for print styles
 @import "govuk_publishing_components/all_components_print";
 ```
 
-### Javascript
+### Import JavaScript for individual components
 
-If your application doesn't use Slimmer/Static (newer admin applications):
+If your application doesn't use Slimmer/Static:
+
+```js
+# application.js
+//= require govuk_publishing_components/dependencies
+//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/button
+```
+
+If your application does use Slimmer/Static:
+
+```js
+# application.js
+//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/button
+```
+
+### Import all Javascript (deprecated, will be removed in a later version)
+
+If your application doesn't use Slimmer/Static:
 
 ```js
 # application.js

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -67,7 +67,7 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/title';"
 
     expect(page).to have_selector(".component-doc-h2", text: "Gem components used by this app (12)")
-    expect(page).to have_selector(".govuk-details__summary-text", text: "Suggested Sass for this application")
+    expect(page).to have_selector(".govuk-details__summary-text", text: "Suggested imports for this application")
 
     expect(page.find(:css, 'textarea[name="main-sass"]', visible: false).value).to eq(expected_main_sass)
   end
@@ -84,6 +84,17 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/print/title';"
 
     expect(page.find(:css, 'textarea[name="print-sass"]', visible: false).value).to eq(expected_print_sass)
+  end
+
+  it "includes suggested js for the application" do
+    visit "/component-guide"
+    expected_main_js = "//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/step-by-step-nav
+//= require govuk_publishing_components/components/tabs"
+
+    expect(page.find(:css, 'textarea[name="main-js"]', visible: false).value).to eq(expected_main_js)
   end
 
   it "creates a page for the component" do


### PR DESCRIPTION
## What
Allow individual, component-based, JavaScript imports.

## Why
Follow up on #1159 to complete [RFC 108](https://github.com/alphagov/govuk-rfcs/pull/110)
To avoid excessive code from being imported in the application.

## Notes
~~This PR will remain draft until tested with applications consuming the gem but comments/reviews are welcome.~~

Tested with:
 - [x] [`content-publisher`](https://github.com/alphagov/content-publisher/tree/test-individual-script-imports)
 - [x] [`finder-frontend`](https://github.com/alphagov/finder-frontend/tree/test-individual-script-imports)
 - [x] [`frontend`](https://github.com/alphagov/frontend/tree/test-individual-script-imports)

For applications dependent on `static`/`slimmer`, `static` requires to be updated first to use the modules system from this gem instead of `govuk_frontend_toolkit`.

### Modules in GOV.UK
JavaScript modules in GOV.UK are actually design patterns for keeping pieces of code independent of other components. We currently have 3 design patterns for writing JavaScript in GOV.UK applications.

#### GOV.UK Frontend Toolkit Modules
Mostly found in legacy scripts, either migrated from Toolkit, Elements, or written in the same era.
```
GOVUK.Modules.TestModule = function () {
  var that = this
  that.start = function (element) {
    //
  }
}
```

#### GOV.UK Publishing Modules
Found across GOV.UK applications, on relatively new scripts (2 years or younger). Similar to the `govuk-frontend` approach described below, it relies on the classic prototype pattern but with a `start` function that takes the element that initialises on. This `start` function was preserved so that the module initialisation script (`modules.js`) would work for both legacy and new scripts without any alteration required.
```
function TestModule () { }
TestModule.prototype.start = function (element) {
  //
}
```

#### GOV.UK Frontend Modules
Used in `govuk-frontend` scripts. Relies on the classic prototype pattern with an  `init` function. The element is passed to the constructor function.
```
function TestModule (element) {
  this.element = element
}
TestModule.prototype.init = function () {
  //
}
```

## Visual Changes
No visual changes.
