### PR TITLE
Adapt phase banner to allow embedding govspeak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow small and unspaced modifiers for govspeak component ([PR #1473](https://github.com/alphagov/govuk_publishing_components/pull/1473))
+* Allow govspeak as input for phase component ([PR #1473](https://github.com/alphagov/govuk_publishing_components/pull/1473))
+
 ## 21.42.0
 
 * Add custom margin option to accordion component ([PR #1470](https://github.com/alphagov/govuk_publishing_components/pull/1470))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -92,3 +92,32 @@
     font-weight: inherit;
   }
 }
+
+.gem-c-govspeak--small {
+  ol,
+  ul,
+  p {
+    @include govuk-font($size: 16)
+  }
+}
+
+.gem-c-govspeak--unspaced {
+  p,
+  ol,
+  ul,
+  li,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin-top: 0;
+    margin-bottom: 0;
+
+    @include govuk-media-query($from: tablet) {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+}

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -5,6 +5,8 @@
   classes = []
   classes << direction_class if direction_class
   classes << "disable-youtube" if disable_youtube_expansions
+  classes << "gem-c-govspeak--small" if local_assigns[:small]
+  classes << "gem-c-govspeak--unspaced" if local_assigns[:unspaced]
 %>
 
 <div class="gem-c-govspeak govuk-govspeak <%= classes.join(" ") %>" data-module="govspeak">

--- a/app/views/govuk_publishing_components/components/_phase_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_phase_banner.html.erb
@@ -10,9 +10,9 @@ end
 
 unless message.present?
   if phase == "beta"
-    message = raw("This part of GOV.UK is being rebuilt &ndash; <a class=\"govuk-link\" href=\"/help/beta\">find out what beta means</a>")
+    message = raw("<p>This part of GOV.UK is being rebuilt &ndash; <a class=\"govuk-link\" href=\"/help/beta\">find out what beta means</a></p>")
   elsif phase == "alpha"
-    message = raw("This part of GOV.UK is being built &ndash; <a class=\"govuk-link\" href=\"/service-manual/phases/ideal-alphas\">find out what alpha means</a>")
+    message = raw("<p>This part of GOV.UK is being built &ndash; <a class=\"govuk-link\" href=\"/service-manual/phases/ideal-alphas\">find out what alpha means</a></p>")
   end
 end
 
@@ -21,9 +21,9 @@ container_css_classes << "gem-c-phase-banner--inverse" if inverse
 %>
 
 <%= tag.div class: container_css_classes do %>
-  <%= tag.p class: "govuk-phase-banner__content" do %>
+  <%= tag.div class: "govuk-phase-banner__content" do %>
     <%= tag.strong app_name, class: "govuk-phase-banner__content__app-name" if app_name %>
     <%= tag.strong phase, class: "govuk-tag govuk-phase-banner__content__tag" %>
-    <%= tag.span message, class: "govuk-phase-banner__text" if message %>
+    <%= tag.div message, class: "govuk-phase-banner__text" if message %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -30,6 +30,27 @@ examples:
       content: |
         <h2>This is a title</h2>
         <p>This is some body text with <a href=#>a link</a></p>
+  small:
+    description: |
+      Applying this option reduces the size of typography to be consistent with
+      the body-small option provided by govuk-frontend.
+      This isn't recommended for large blocks of govspeak as it won't be
+      applied uniformly to all elements.
+    data:
+      small: true
+      content: |
+        <p>Copy is rendered at a smaller size <a href=#>with the small option</a></p>
+  unspaced:
+    description: |
+      Applying this option removes the margins from typograph elements with the
+      expectation that these will be used in situations where they are embedded
+      into elements already providing margins. This is only intended for small
+      snippets of govspeak and only affects basic typography.
+    data:
+      unspaced: true
+      content: |
+        <h2>This is a h2 title</h2>
+        <p>Elements have the margin spacing removed</p>
   heading_levels:
     data:
       block: |

--- a/app/views/govuk_publishing_components/components/docs/phase_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/phase_banner.yml
@@ -32,3 +32,10 @@ examples:
       app_name: Skittles Maker
       phase: beta
       inverse: true
+  with_govspeak_embedded:
+    data:
+      phase: beta
+      message: |
+        <div class="gem-c-govspeak gem-c-govspeak--small gem-c-govspeak--unspaced govuk-govspeak" data-module="govspeak">
+          <p>This is a description - <a href="https://www.gov.uk/help/beta">provide us with feedback</a></p>
+        </div>


### PR DESCRIPTION
This changes the phase banner to allow a govspeak component to be
embedded and still render ok. The reason for this is so that content
designers can be provided with the means to specify the phase banner
text which may require links embedded into the text.

To do this I've made changes to the HTML structure of the phase
component so that it no longer is only inline elements in a p element.
This allows the govspeak component to be inserted without the HTML
becoming invalid.

To allow the govspeak to be rendered in a style appropriate for this
component I've created two new modifiers for the component: small
and unspaced. These allow using the equivalent of govuk-frontends
body-small size and removing typography margins.

Example:

![Screenshot 2020-04-27 at 18 50 16](https://user-images.githubusercontent.com/282717/80403712-f5a75b80-88b7-11ea-9271-732114c8a310.png)
