### PR TITLE
Fix margin on buttons with info text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix margin on buttons with info text ([PR #1474](https://github.com/alphagov/govuk_publishing_components/pull/1474))
+
 ## 21.42.0
 
 * Add custom margin option to accordion component ([PR #1470](https://github.com/alphagov/govuk_publishing_components/pull/1470))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_button.scss
@@ -18,7 +18,8 @@ $gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
 // this will be moved and extended into a model for general component spacing
 // once this has been decided upon and other work completed, see:
 // https://trello.com/c/KEkNsxG3/142-3-implement-customisable-spacing-for-components
-.gem-c-button--bottom-margin {
+.gem-c-button--bottom-margin,
+.gem-c-button__info-text--bottom-margin {
   @include responsive-bottom-margin;
 }
 

--- a/app/views/govuk_publishing_components/components/_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_button.html.erb
@@ -22,5 +22,5 @@
 <% end %>
 
 <% if button.info_text %>
-  <%= tag.span button.info_text, class: "gem-c-button__info-text" %>
+  <%= tag.span button.info_text, class: button.info_text_classes %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -62,6 +62,13 @@ examples:
       href: "#"
       start: true
       info_text: "Sometimes you want to explain where a user is going to."
+  start_now_button_with_info_text_and_margin_bottom:
+    data:
+      text: "Start now"
+      href: "#"
+      start: true
+      info_text: "Sometimes you want to explain where a user is going to and have a margin bottom"
+      margin_bottom: true
   with_margin_bottom:
     description: "Sometimes it's useful to break up a page, for example if a button is at the bottom of a page."
     data:

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -3,16 +3,20 @@ require "action_view"
 module GovukPublishingComponents
   module Presenters
     class ButtonHelper
-      attr_reader :href, :text, :title, :info_text, :rel, :data_attributes,
-                  :margin_bottom, :inline_layout, :target, :type, :start,
-                  :secondary, :secondary_quiet, :destructive, :name, :value,
-                  :classes, :aria_label
+      attr_reader :href, :text, :title, :info_text, :info_text_classes,
+                  :rel, :data_attributes, :margin_bottom, :inline_layout,
+                  :target, :type, :start, :secondary, :secondary_quiet,
+                  :destructive, :name, :value, :classes, :aria_label
 
       def initialize(local_assigns)
         @href = local_assigns[:href]
         @text = local_assigns[:text]
         @title = local_assigns[:title]
         @info_text = local_assigns[:info_text]
+        @info_text_classes = %w(gem-c-button__info-text)
+        if local_assigns[:margin_bottom]
+          @info_text_classes << "gem-c-button__info-text--bottom-margin"
+        end
         @rel = local_assigns[:rel]
         @data_attributes = local_assigns[:data_attributes]
         @margin_bottom = local_assigns[:margin_bottom]
@@ -64,7 +68,7 @@ module GovukPublishingComponents
         css_classes << "gem-c-button--secondary" if secondary
         css_classes << "gem-c-button--secondary-quiet" if secondary_quiet
         css_classes << "govuk-button--warning" if destructive
-        css_classes << "gem-c-button--bottom-margin" if margin_bottom
+        css_classes << "gem-c-button--bottom-margin" if margin_bottom && !info_text
         css_classes << "gem-c-button--inline" if inline_layout
         css_classes << classes if classes
         css_classes.join(" ")

--- a/spec/components/all_components_spec.rb
+++ b/spec/components/all_components_spec.rb
@@ -24,7 +24,7 @@ describe "All components" do
       end
 
       it "has the correct class in the ERB template",
-         skip: component_name.in?(%w[step_by_step_nav_related step_by_step_nav_header step_by_step_nav previous_and_next_navigation]),
+         skip: component_name.in?(%w[button step_by_step_nav_related step_by_step_nav_header step_by_step_nav previous_and_next_navigation]),
          not_applicable: component_name.in?(%w[meta_tags machine_readable_metadata google_tag_manager_script table admin_analytics]) do
         erb = File.read(filename)
 

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -76,6 +76,15 @@ describe "Button", type: :view do
     assert_select ".gem-c-button__info-text", text: "Information text"
   end
 
+  it "renders info text with margin bottom" do
+    render_component(text: "Start now", info_text: "Information text", margin_bottom: true)
+
+    assert_select ".gem-c-button--bottom-margin", count: 0
+
+    assert_select ".govuk-button", text: "Start now"
+    assert_select ".gem-c-button__info-text.gem-c-button__info-text--bottom-margin", text: "Information text"
+  end
+
   it "renders rel attribute correctly" do
     render_component(text: "Start now", rel: "nofollow")
     assert_select ".govuk-button[rel='nofollow']", text: "Start now"


### PR DESCRIPTION
## What
Apply bottom margin to the info text element instead of the button element when both `margin_bottom` and `info_text` attributes are set.

## Why
To avoid having a gap between the button and the info text.
Found while [dropping the wrapper layout in frontend](https://github.com/alphagov/frontend/pull/2154).

## Visual Changes
Before
<img width="960" alt="start-button-before" src="https://user-images.githubusercontent.com/788096/80500482-2f36a000-8966-11ea-8204-bc3780d00794.png">

After
<img width="960" alt="start-button-after" src="https://user-images.githubusercontent.com/788096/80500495-32ca2700-8966-11ea-8ba6-bf2c560f812c.png">
