### PR TITLE
Update step by step header component style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix margin on buttons with info text ([PR #1474](https://github.com/alphagov/govuk_publishing_components/pull/1474))
+* Update step by step header component style ([PR #1476](https://github.com/alphagov/govuk_publishing_components/pull/1476))
 
 ## 21.42.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
@@ -3,26 +3,24 @@
   position: relative;
   padding: 10px;
   background: govuk-colour("light-grey", $legacy: "grey-4");
-  border-top: solid 1px govuk-colour("mid-grey", $legacy: "grey-2");
-  border-bottom: solid 1px govuk-colour("mid-grey", $legacy: "grey-2");
+  border-bottom: solid 1px govuk-colour("blue");
+  margin-top: govuk-spacing(3);
 
   @include govuk-media-query($from: tablet) {
-    padding: govuk-spacing(3);
+    padding: govuk-spacing(5);
   }
 }
 
 // scss-lint:disable SelectorFormat
 
 .gem-c-step-nav-header__part-of {
-  @include govuk-font(16, $weight: bold);
-
+  @include govuk-font(19, $weight: bold);
   display: block;
-  padding-bottom: .2em;
 }
 
 .gem-c-step-nav-header__title {
   @extend %govuk-link;
-  @include govuk-font(24, $weight: bold);
+  @include govuk-font(24, $weight: bold, $line-height: 1);
 }
 
 // scss-lint:enable SelectorFormat

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav_header.yml
@@ -16,6 +16,10 @@ examples:
     data:
       title: 'Having children: step by step'
       path: /childcare-parenting/pregnancy-and-birth
+  with_a_long_text:
+    data:
+      title: 'Coronavirus: businesses and self-employed people'
+      path: /childcare-parenting/pregnancy-and-birth
   with_unique_tracking:
     description: In order to identify the step by step navigation the component is part of, we need to track a unique ID of the navigation in Google Analytics. This ID should be the same across all pages that are linked from and are part of that navigation. Its value is included in any tracking events, specifically in dimension96. It refers to the ID of the step nav that the component links to.
     data:


### PR DESCRIPTION
Removes top border
Changes border bottom colour to blue
Adds margin top of 15px

---

## Context
We know that 70% of traffic to coronavirus content is direct to content rather than via landing page. We want to provide users with a clear route to the landing page, and to useful related content. This is to help them discover support that they might not already be aware of or think to search for.

## What
We need to adapt the step by step superbreadcrumb component to be able to be used in this case.

The feature will provide users with a link to the landing page or hub that the content is tagged to using the taxonomy, using the 'superbreadcrumb'.

It will also provide users with a set of related links which will be drawn from the curated content associated with the lowest level topic that the content item is tagged to.

## Why
Providing users with clear routes to discover useful content relevant to them.

https://trello.com/c/IOjnO55X/196-update-superbreadcrumb-component-ready-for-coronavirus-tagged-content

## Visual change

## Before

<img width="1170" alt="Screenshot 2020-04-29 at 12 22 52" src="https://user-images.githubusercontent.com/4599889/80590659-34eabf00-8a14-11ea-866d-f4511b9e6c6e.png">
<img width="477" alt="Screenshot 2020-04-29 at 12 23 03" src="https://user-images.githubusercontent.com/4599889/80590664-361bec00-8a14-11ea-8241-b528576f6dfb.png">

## After

![Apr-29-2020 11-40-26](https://user-images.githubusercontent.com/4599889/80590679-3d42fa00-8a14-11ea-9765-ec460726e3e8.gif)

