### PR TITLE
Add exclusive option to checkboxes component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix legacy colour on input component ([PR #1487](https://github.com/alphagov/govuk_publishing_components/pull/1487))
+* Add `exclusive` option to checkboxes component ([PR #1478](https://github.com/alphagov/govuk_publishing_components/pull/1478))
 
 ## 21.45.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -48,6 +48,21 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           }
         }
       })
+
+      $(scope).on('change', '[data-exclusive=true] input[type=checkbox]', function (e) {
+        var currentCheckbox = e.target
+        var checkboxes = currentCheckbox.closest('.govuk-checkboxes')
+        var exclusiveOption = $(checkboxes).find('input[type=checkbox][data-exclusive]')
+        var nonExclusiveOptions = $(checkboxes).find('input[type=checkbox]:not([data-exclusive])')
+
+        if (currentCheckbox.dataset.exclusive === 'true' && currentCheckbox.checked === true) {
+          nonExclusiveOptions.each(function () {
+            $(this).prop('checked', false)
+          })
+        } else if (currentCheckbox.dataset.exclusive !== 'true' && currentCheckbox.checked === true) {
+          exclusiveOption.prop('checked', false)
+        }
+      })
     }
 
     this.toggleNestedCheckboxes = function (scope, checkbox) {

--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -25,6 +25,7 @@
         <%= tag.ul class: cb_helper.list_classes, data: {
           module: ('checkboxes' if cb_helper.has_conditional),
           nested: ('true' if cb_helper.has_nested),
+          exclusive: ('true' if cb_helper.has_exclusive)
         } do %>
           <% cb_helper.items.each_with_index do |item, index| %>
             <%= tag.li class: "govuk-checkboxes__item" do %>

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -268,6 +268,28 @@ examples:
           value: "irish"
         - label: "Other"
           value: "other"
+  checkbox_with_exclusive_item:
+    description: |
+      Allows an option to become exclusive, as follows:
+
+        - when the exclusive item is checked, all non-exclusive items are unchecked
+        - when a non-exclusive item is checked, the exclusive item is unchecked
+
+      This behaviour should be doubled by similar checks on the backend.
+    data:
+      name: "nationality-exclusive"
+      heading: "What kind of expertise can you offer?"
+      hint_text: "Select the types of support you can offer."
+      items:
+        - label: "Medical"
+          value: "medical"
+        - label: "Engineering"
+          value: "engineering"
+        - label: "Other"
+          value: "other"
+        - label: "I cannot offer expertise"
+          value: "no-expertise"
+          exclusive: true
   checkbox_items_with_conditional_reveal:
     description: |
       Checkboxes can be configured to show additional elements when checked. This could include further components, such as text inputs as shown.

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -5,7 +5,8 @@ module GovukPublishingComponents
       include ActionView::Context
 
       attr_reader :items, :name, :css_classes, :list_classes, :error, :has_conditional,
-                  :has_nested, :id, :hint_text, :description, :heading_size, :heading_caption
+                  :has_nested, :id, :hint_text, :description, :heading_size, :heading_caption,
+                  :has_exclusive
 
       def initialize(options)
         @items = options[:items] || []
@@ -19,6 +20,7 @@ module GovukPublishingComponents
 
         # check if any item is set as being conditional
         @has_conditional = options[:items].any? { |item| item.is_a?(Hash) && item[:conditional] }
+        @has_exclusive = options[:items].any? { |item| item.is_a?(Hash) && item[:exclusive] }
         @has_nested = options[:items].any? { |item| item.is_a?(Hash) && item[:items] }
 
         @id = options[:id] || "checkboxes-#{SecureRandom.hex(4)}"
@@ -77,6 +79,7 @@ module GovukPublishingComponents
         data = checkbox[:data_attributes] || {}
         data[:controls] = controls
         data["aria-controls"] = aria_controls
+        data[:exclusive] = checkbox[:exclusive]
 
         capture do
           concat check_box_tag checkbox_name, checkbox[:value], checked, class: "govuk-checkboxes__input", id: checkbox_id, data: data

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -312,6 +312,23 @@ describe "Checkboxes", type: :view do
     assert_select("#nationality-error", text: "Select if you are British, Irish or a citizen of a different country")
   end
 
+  it "renders checkboxes with exclusive option" do
+    render_component(
+      id: "nationality",
+      name: "nationality",
+      heading: "What is your nationality?",
+      error: "Select if you are British, Irish or a citizen of a different country",
+      hint_text: "If you have dual nationality, select all options that are relevant to you.",
+      items: [
+        { label: "British", value: "british", hint: "including English, Scottish, Welsh and Northern Irish" },
+        { label: "Irish", value: "irish" },
+        { label: "Other", value: "other", exclusive: true },
+      ],
+    )
+    assert_select ".govuk-checkboxes[data-exclusive=true]"
+    assert_select ".govuk-checkboxes__input[value=other][data-exclusive=true]"
+  end
+
   it "renders checkboxes with conditional reveal" do
     render_component(
       id: "nationality",

--- a/spec/javascripts/components/checkboxes-spec.js
+++ b/spec/javascripts/components/checkboxes-spec.js
@@ -14,7 +14,7 @@ describe('Checkboxes component', function () {
            '<h1 class="govuk-fieldset__heading">What is your favourite colour?</h1>' +
         '</legend>' +
         '<span id="checkboxes-1ac8e5cf-hint" class="govuk-hint">Select all that apply.</span>' +
-        '<ul class="govuk-checkboxes gem-c-checkboxes__list" data-nested="true">' +
+        '<ul class="govuk-checkboxes gem-c-checkboxes__list" data-nested="true" data-exclusive="true">' +
            '<li class="govuk-checkboxes__item">' +
               '<input id="checkboxes-1ac8e5cf-0" name="favourite_colour" type="checkbox" value="red" class="govuk-checkboxes__input" data-track-category="choseFavouriteColour" data-track-action="favourite-color" data-track-label="red" data-track-value="1" data-track-options=\'{"dimension28": "wubbalubbadubdub","dimension29": "Pickle Rick"}\'>' +
               '<label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-0">Red</label>' +
@@ -44,7 +44,7 @@ describe('Checkboxes component', function () {
               '</ul>' +
            '</li>' +
            '<li class="govuk-checkboxes__item">' +
-              '<input id="checkboxes-1ac8e5cf-2" name="favourite_colour" type="checkbox" value="other" class="govuk-checkboxes__input">' +
+              '<input id="checkboxes-1ac8e5cf-2" name="favourite_colour" type="checkbox" value="other" class="govuk-checkboxes__input" data-exclusive="true">' +
               '<label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-2">Other</label>' +
            '</li>' +
         '</ul>' +
@@ -57,6 +57,8 @@ describe('Checkboxes component', function () {
   var $checkboxesWrapper
   var expectedRedOptions
   var expectedBlueOptions
+  var $exclusiveOption
+  var $nonExclusiveOptions
 
   beforeEach(function () {
     window.setFixtures(FIXTURE)
@@ -66,6 +68,8 @@ describe('Checkboxes component', function () {
     $parentCheckbox = $parentCheckboxWrapper.find('> .govuk-checkboxes__input')
     $nestedChildren = $parentCheckboxWrapper.find('.govuk-checkboxes--nested .govuk-checkboxes__input')
     $checkboxesWrapper = $('.gem-c-checkboxes')
+    $exclusiveOption = $checkboxesWrapper.find('input[type=checkbox][data-exclusive]')
+    $nonExclusiveOptions = $checkboxesWrapper.find('input[type=checkbox]:not([data-exclusive])')
     expectedRedOptions = { label: 'red', value: 1, dimension28: 'wubbalubbadubdub', dimension29: 'Pickle Rick' }
     expectedBlueOptions = { label: 'blue', value: 2, dimension28: 'Get schwifty', dimension29: 'Squanch' }
 
@@ -156,6 +160,20 @@ describe('Checkboxes component', function () {
       var fakeOnChangeEvent = { type: 'change', suppressAnalytics: true }
       $checkbox.trigger(fakeOnChangeEvent)
       expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('with exclusive option', function () {
+    it('unchecks non-exclusive options when exclusive option is checked', function () {
+      $nonExclusiveOptions.first().click()
+      $exclusiveOption.click()
+      expect($nonExclusiveOptions.length).toEqual($nonExclusiveOptions.filter(':not(checked)').length)
+      expect($exclusiveOption.is(':checked')).toEqual(true)
+    })
+
+    it('unchecks exclusive option when a non-exclusive option is checked', function () {
+      $nonExclusiveOptions.first().click()
+      expect($exclusiveOption.is(':checked')).toEqual(false)
     })
   })
 })


### PR DESCRIPTION
## What
Allow a checkbox option to become exclusive, as follows:
- when the exclusive item is checked all non-exclusive items are unchecked
- when a non-exclusive item is checked the exclusive item is unchecked.

This behavior should be doubled by similar checks on the backend to cover the cases when JavaScript is disabled.

## Why
- Required in [coronavirus-business-volunteer-form](https://github.com/alphagov/govuk-coronavirus-business-volunteer-form) and [coronavirus-find-support](https://github.com/alphagov/govuk-coronavirus-find-support); follow-up PRs will be raised in both repos
- Clears technical debt and fixes #1456 (by covering the [`toggleCheckboxes`](https://github.com/alphagov/smart-answers/blob/master/app/assets/javascripts/helpers.js#L29-L42) functionality in the checkboxes component; a follow-up PR will be raised in `smart-answers` to make it use this script and remove the existing one).

## Visual Changes
No visual changes. [Preview functionality](https://govuk-publis-exclusive--x77oyd.herokuapp.com/component-guide/checkboxes/checkbox_with_exclusive_item/).

[Trello card](https://trello.com/c/TUIIAq8f/271-deselecting-checkboxes-if-a-no-none-answer-is-checked)
