### PR TITLE
Bump version to 21.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.43.0
 
 * Fix margin on buttons with info text ([PR #1474](https://github.com/alphagov/govuk_publishing_components/pull/1474))
 * Update step by step header component style ([PR #1476](https://github.com/alphagov/govuk_publishing_components/pull/1476))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.42.0)
+    govuk_publishing_components (21.43.0)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.42.0".freeze
+  VERSION = "21.43.0".freeze
 end


### PR DESCRIPTION
Includes:
* Fix margin on buttons with info text ([PR #1474](https://github.com/alphagov/govuk_publishing_components/pull/1474))
* Update step by step header component style ([PR #1476](https://github.com/alphagov/govuk_publishing_components/pull/1476))