### PR TITLE
Allow summary list custom link text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow summary list custom link text ([PR #1483](https://github.com/alphagov/govuk_publishing_components/pull/1483))
+
 ## 21.43.0
 
 * Fix margin on buttons with info text ([PR #1474](https://github.com/alphagov/govuk_publishing_components/pull/1474))

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -37,20 +37,22 @@
                 <%= tag.ul class: "govuk-summary-list__actions-list" do %>
                   <% if item.fetch(:edit, {}).any? %>
                     <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
+                      <% edit_link_text = item[:edit][:link_text] || "Change" %>
                       <%= link_to item[:edit].fetch(:href),
                                   class: "govuk-link",
-                                  title: "Change #{item[:field]}",
+                                  title: "#{edit_link_text} #{item[:field]}",
                                   data: item[:edit].fetch(:data_attributes, {}) do %>
-                        Change<%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" %><% end %>
+                        <%= edit_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" %><% end %>
                     <% end %>
                   <% end %>
                   <% if item.fetch(:delete, {}).any? %>
                     <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
+                      <% delete_link_text = item[:delete][:link_text] || "Delete" %>
                       <%= link_to item[:delete].fetch(:href),
                                   class: "govuk-link",
-                                  title: "Delete #{item[:field]}",
+                                  title: "#{delete_link_text} #{item[:field]}",
                                   data: item[:delete].fetch(:data_attributes, {}) do %>
-                        Delete<%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" %>
+                        <%= delete_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" %>
                       <% end %>
                     <% end %>
                   <% end %>

--- a/app/views/govuk_publishing_components/components/docs/summary_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/summary_list.yml
@@ -42,6 +42,10 @@ examples:
           gtm: "edit-title-summary-body"
 
   with_custom_link_on_section:
+    description: |
+      Take care that the provided `link_text` still makes sense to screen readers when combined with the title.
+      For instance, `Reorder` link text and `Items` title becomes `Reorder Items`, which reads fine, but link text
+      of `Summary` would read as `Summary Items`, which does not make sense.
     data:
       edit:
         href: "custom-link"
@@ -54,12 +58,9 @@ examples:
         value: "Value 2"
       - field: "Item 3"
         value: "Value 3"
-    accessibility_criteria: |
-      Take care that the provided `link_text` still makes sense to screen readers when combined with the title.
-      For instance, `Reorder` link text and `Items` title becomes `Reorder Items`, which reads fine, but link text
-      of `Summary` would read as `Summary Items`, which does not make sense.
 
   with_edit_on_individual_items:
+    description: The link text can be optionally modified using the 'link_text' parameter, as for the edit link in previous examples.
     data:
       title: "Title, summary and body"
       items:
@@ -67,6 +68,7 @@ examples:
         value: "Ethical standards for public service providers"
         edit:
           href: "edit-title"
+          text: "Edit"
           data_attributes:
             gtm: "edit-title"
       - field: "Summary"
@@ -79,8 +81,10 @@ examples:
         value: "After the government decided in 2013 to expand the remit of the Committee to include public service providers, the Committee on Standards in Public Life produced our first report on the issue: Ethical Standards for Providers of Public Services in 2014."
         edit:
           href: "edit-body"
+          link_text: "Edit"
         delete:
           href: "delete-body"
+          link_text: "Remove"
 
   with_block:
     description: Use the summary list with a block when you need to show an empty state message or load another component.

--- a/spec/components/summary_list_spec.rb
+++ b/spec/components/summary_list_spec.rb
@@ -115,4 +115,25 @@ describe "Summary list", type: :view do
     assert_select ".govuk-summary-list__value", text: "Ethical standards for public service providers"
     assert_select '.govuk-summary-list__actions-list-item .govuk-link[title="Delete Title"][href="#delete-title"][data-gtm="delete-title"]', text: "Delete Title"
   end
+
+  it "renders items with custom text for edit and delete action" do
+    render_component(
+      items: [
+        {
+          field: "Title",
+          value: "Ethical standards for public service providers",
+          edit: {
+            href: "#edit-title",
+            link_text: "Edit",
+          },
+          delete: {
+            href: "#delete-title",
+            link_text: "Remove",
+          },
+        },
+      ],
+    )
+    assert_select '.govuk-summary-list__actions-list-item .govuk-link[title="Edit Title"][href="#edit-title"]', text: "Edit Title"
+    assert_select '.govuk-summary-list__actions-list-item .govuk-link[title="Remove Title"][href="#delete-title"]', text: "Remove Title"
+  end
 end


### PR DESCRIPTION
## What
- allows 'change' and 'delete' links in the component to be passed custom text, need to be able to do this to handle translations
- already an option to set the text for the main edit link, so this is a natural extension

## Why
We're using the component in simple smart answers and need to be able to change the link text to Welsh.

## Visual Changes
None.
