### PR TITLE
Fix legacy colour on input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix legacy colour on input component ([PR #1487](https://github.com/alphagov/govuk_publishing_components/pull/1487))
+
 ## 21.45.0
 
 * Add suffix option to input component ([PR #1481](https://github.com/alphagov/govuk_publishing_components/pull/1481))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -34,7 +34,7 @@
 .gem-c-input__suffix {
   @include govuk-font($size: 19);
 
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("light-grey", $legacy: "grey-3");
   border: $govuk-border-width-form-element solid $govuk-input-border-colour;
   border-left: 0;
   box-sizing: border-box;


### PR DESCRIPTION
## What
Add missing legacy colour for `light-grey` – missed in [#1481](https://github.com/alphagov/govuk_publishing_components/pull/1481/files#diff-57a28dc54e1ce322564d3c1e15811c5fR37).

## Why
It crashes apps in compatibility mode: _jenkins builds for the latest components gem are currently failing (at least for smart answers)_ as reported by @andysellick

## Visual Changes
No visual changes
