### PR TITLE
Remove PHE brand colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove PHE brand colour ([PR #1489](https://github.com/alphagov/govuk_publishing_components/pull/1489))
 * Fix legacy colour on input component ([PR #1487](https://github.com/alphagov/govuk_publishing_components/pull/1487))
 * Add `exclusive` option to checkboxes component ([PR #1478](https://github.com/alphagov/govuk_publishing_components/pull/1478))
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -90,16 +90,3 @@
     border-color: govuk-colour("black");
   }
 }
-
-// new brand colour to match Public Health England
-// used on the coronavirus page
-// note that PHE already has a different brand colour, the brand
-// department-for-health is used on the PHE org page
-$gem-c-covid-yellow: #ffe114;
-
-.brand--public-health-england {
-  &.brand__border-color,
-  .brand__border-color {
-    border-color: $gem-c-covid-yellow;
-  }
-}


### PR DESCRIPTION
## What
Remove the PHE brand colour from our brand colours sass, originally added in https://github.com/alphagov/govuk_publishing_components/pull/1396

## Why
- not being used, was originally used with the heading component on the coronavirus landing page, but we're not using it that way anymore
- colour is going to change again anyway

## Visual Changes
None.
