### PR TITLE
Prevent govspeak links from breaking the layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Prevent govspeak links from breaking the layout ([PR #1492](https://github.com/alphagov/govuk_publishing_components/pull/1492))
 * Remove PHE brand colour ([PR #1489](https://github.com/alphagov/govuk_publishing_components/pull/1489))
 * Fix legacy colour on input component ([PR #1487](https://github.com/alphagov/govuk_publishing_components/pull/1487))
 * Add `exclusive` option to checkboxes component ([PR #1478](https://github.com/alphagov/govuk_publishing_components/pull/1478))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_footnotes.scss
@@ -15,6 +15,10 @@
     margin-top: govuk-spacing(6);
     padding-top: govuk-spacing(2);
 
+    a {
+      overflow-wrap: break-word;
+    }
+
     ol {
       margin-top: 0;
       padding-top: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_typography.scss
@@ -17,6 +17,10 @@
     margin-left: 0;
     margin-right: govuk-spacing(4);
 
+    a {
+      overflow-wrap: break-word;
+    }
+
     ul,
     ol {
       margin-top: 0;

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -257,6 +257,10 @@ examples:
             <li id="fn:1a">
               <p>And here is the definition. <a href="#fnref:1a" class="reversefootnote">&#8617;</a></p>
             </li>
+            <li id="fn:2">
+              <a href="https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/datasets/weeklyprovisionalfiguresondeathsregisteredinenglandandwales" class="govuk-link">https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/datasets/weeklyprovisionalfiguresondeathsregisteredinenglandandwales</a>
+              <a href="#fnref:2" class="govuk-link">↩</a>
+            </li>
           </ol>
         </div>
   rtl_block:


### PR DESCRIPTION
## What
Prevent govspeak links from breaking the layout.

## Why
We are not always in control of how links are being generated, and when not using dash-separated paths in the URL, links in govspeak break the layout by overflowing. This can become more problematic for users on narrow viewports/mobile devices where an accidental drag can leave them with a blank screen.

## Visual Changes

Application example using `government-frontend` and links in footnotes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1440" alt="govspeak-government-frontend-before" src="https://user-images.githubusercontent.com/788096/81683554-25289d00-944e-11ea-885d-e04b01e26904.png">

</td><td valign="top">

<img width="1440" alt="govspeak-government-frontend-after" src="https://user-images.githubusercontent.com/788096/81683601-2eb20500-944e-11ea-8bf8-749a63be4f8c.png">


</td></tr>
</table>

Mobile example using Chrome on Android and Safari on iOS
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="900" alt="chrome-android-before" src="https://user-images.githubusercontent.com/788096/81684036-881a3400-944e-11ea-9dd7-e4e5c86a46b1.png">

</td><td valign="top">

<img width="900" alt="chrome-android-after" src="https://user-images.githubusercontent.com/788096/81684062-8cdee800-944e-11ea-80b8-80cdfe88efe2.png">

</td></tr>
<tr><td valign="top">

<img width="900" alt="safari-ios-before" src="https://user-images.githubusercontent.com/788096/81684243-b39d1e80-944e-11ea-809e-ec1b41052c13.png">


</td><td valign="top">

<img width="900" alt="safari-ios-after" src="https://user-images.githubusercontent.com/788096/81684254-b5ff7880-944e-11ea-905a-c6e0e6c25a40.png">

</td></tr>

</table>

### Cross-browser examples
`overflow-wrap` is widely supported for this scenario, except for IE and Edge. Interesting implementation in Firefox which tries to break at `/` whenever possible.

Firefox
<img width="660" alt="firefox-after" src="https://user-images.githubusercontent.com/788096/81684652-0ecf1100-944f-11ea-915c-9c013f383aad.png">

Safari
<img width="660" alt="safari-after" src="https://user-images.githubusercontent.com/788096/81684677-142c5b80-944f-11ea-93ea-8101d3467a40.png">

Chrome
<img width="662" alt="chrome-after" src="https://user-images.githubusercontent.com/788096/81684695-17bfe280-944f-11ea-8451-59cc6fd2aea0.png">
