### PR TITLE
Reduce re-importing of SCSS files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Change `_all_components.scss` to use dependencies from support stylesheets  ([PR #1502](https://github.com/alphagov/govuk_publishing_components/pull/1502))
 * Allow individual JavaScript imports ([PR #1472](https://github.com/alphagov/govuk_publishing_components/pull/1472))
 
   To import individual components refer to ['Include the assets section in docs'](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md) and the 'Suggested imports for this application' section available on `/component-guide` in your application.

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -1,12 +1,5 @@
 // This file contains the styles for the Component Guide.
 
-@import "govuk_publishing_components/components/helpers/govuk-frontend-settings";
-@import "govuk_publishing_components/components/helpers/markdown-typography";
-@import "govuk/settings/all";
-@import "govuk/tools/all";
-@import "govuk/helpers/all";
-@import "govuk/core/all";
-
 @import "govuk_publishing_components/all_components";
 
 $gem-guide-border-width: 1px;

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -1,20 +1,11 @@
 // This is the file that the application needs to include in order to use
 // the components.
 
-// Include all of the GOV.UK Frontend styles. This includes fonts, and individual components.
+@import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/component_support";
 
-@import "components/helpers/govuk-frontend-settings";
-
-// Include common imports used by many components
-@import "govuk/all";
-
-@import "components/helpers/variables";
-@import "components/helpers/brand-colours";
-@import "components/mixins/govuk-template-link-focus-override";
-@import "components/mixins/media-down";
-@import "components/mixins/margins";
-@import "components/mixins/clearfix";
-@import "components/mixins/css3";
+// Include all govuk frontend components
+@import "govuk/components/all";
 
 // components
 @import "components/accordion";

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -1,6 +1,3 @@
-@import "govuk/settings/colours-organisations";
-@import "govuk/helpers/colour";
-
 @mixin organisation-brand-colour {
   @each $organisation in map-keys($govuk-colours-organisations) {
     .brand--#{$organisation} {


### PR DESCRIPTION
## What

Primarily this changes the _all_components helper file to use the same support scripts as we recommend users use to import individual components.

Aside from that I then removed a number of @import calls that were superfluous

## Why

Primarily I went in looking to see if there was much low hanging fruit available where we were making unnecessary @import calls, there wasn't actually too much of that now that we support both individual components and all component importing. However I did find a few of those and, given they can add up to steep performance penalties, felt they were best removed.

I also felt it was more prudent to do the same support set-up in the _all_components file as we recommend users take in individual components. This seemed to reduce the risk that these differ in configuration.

## Visual Changes

I very much hope there are none

@andysellick and @alex-ju: I felt you two might be best suited to know if this seems a good addition and whether I was accidentally breaking any patterns/consistencies we were aiming for.