### PR TITLE
Add `id` to checkboxes component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add action link component ([PR #1497](https://github.com/alphagov/govuk_publishing_components/pull/1497))
+* Add `id` to checkboxes component ([PR #1503](https://github.com/alphagov/govuk_publishing_components/pull/1503))
 
 ## 21.46.0
 

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -1,4 +1,5 @@
 <%
+  id ||= nil
   id_prefix ||= "radio-#{SecureRandom.hex(4)}"
   items ||= []
 
@@ -34,7 +35,7 @@
   # check if any item is set as being conditional
   has_conditional = items.any? { |item| item.is_a?(Hash) && item[:conditional] }
 %>
-<%= content_tag :div, class: form_group_css_classes do %>
+<%= tag.div id: id, class: form_group_css_classes do %>
   <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": aria do %>
 
     <% if heading.present? %>

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -346,3 +346,12 @@ examples:
           text: "On"
         - value: "off"
           text: "Off"
+  with_custom_id_attribute:
+    data:
+      name: "radio-group"
+      id: "radio-group"
+      items:
+      - value: "government-gateway"
+        text: "Use Government Gateway"
+      - value: "govuk-verify"
+        text: "Use GOV.UK Verify"

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -285,6 +285,25 @@ describe "Radio", type: :view do
     assert_select ".govuk-radios__label[for=custom-1]", text: "Use GOV.UK Verify"
   end
 
+  it "renders radio-group with custom id" do
+    render_component(
+      id: "radio-group",
+      name: "radio-group-custom-id",
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway",
+        },
+        {
+          value: "govuk-verify",
+          text: "Use GOV.UK Verify",
+        },
+      ],
+    )
+
+    assert_select ".govuk-form-group[id=radio-group]"
+  end
+
   it "renders radio-group with or divider" do
     render_component(
       name: "radio-group-or-divider",


### PR DESCRIPTION
## What
Allow `id` to be specified for the outermost element generated by the checkboxes component.

## Why
To be able to refer an instance of a checkboxes component. A small step in aligning the checkboxes and radio components.

## Visual Changes
No visual changes

Required in [govuk-coronavirus-business-volunteer-form as per comment](https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/pull/292#discussion_r423794164)
