### PR TITLE
Add prefix option to input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
   To import individual components refer to ['Include the assets section in docs'](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md) and the 'Suggested imports for this application' section available on `/component-guide` in your application.
 
+* Add prefix option to input component ([PR #1509](https://github.com/alphagov/govuk_publishing_components/pull/1509))
+
 ## 21.50.1
 
 * Tweak action link ([PR #1518](https://github.com/alphagov/govuk_publishing_components/pull/1518))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -31,7 +31,7 @@
   }
 }
 
-.gem-c-input__suffix {
+.gem-c-input__prefix, .gem-c-input__suffix {
   @include govuk-font($size: 19);
 
   background-color: govuk-colour("light-grey", $legacy: "grey-3");
@@ -40,13 +40,22 @@
   box-sizing: border-box;
   cursor: default; // emphasise non-editable status of prefixes and suffixes
   display: inline-block;
-  flex: 0 0 0;
-  padding: govuk-spacing(1);
   white-space: nowrap;
   width: auto;
+  text-align: center;
   height: 40px;
+  padding: govuk-spacing(1);
+  min-width: 40px;
   @if $govuk-typography-use-rem {
-    height: govuk-px-to-rem(40px);
+      min-width: govuk-px-to-rem(40px);
   }
   margin-top: 0;
+}
+
+.gem-c-input__prefix {
+  border-right: 0;
+}
+
+.gem-c-input__suffix {
+  border-left: 0;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -31,12 +31,12 @@
   }
 }
 
-.gem-c-input__prefix, .gem-c-input__suffix {
+.gem-c-input__prefix,
+.gem-c-input__suffix {
   @include govuk-font($size: 19);
 
   background-color: govuk-colour("light-grey", $legacy: "grey-3");
   border: $govuk-border-width-form-element solid $govuk-input-border-colour;
-  border-left: 0;
   box-sizing: border-box;
   cursor: default; // emphasise non-editable status of prefixes and suffixes
   display: inline-block;
@@ -47,7 +47,7 @@
   padding: govuk-spacing(1);
   min-width: 40px;
   @if $govuk-typography-use-rem {
-      min-width: govuk-px-to-rem(40px);
+    min-width: govuk-px-to-rem(40px);
   }
   margin-top: 0;
 }

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -22,6 +22,7 @@
   error_id = "error-#{SecureRandom.hex(4)}"
   search_icon ||= nil
   heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
+  prefix ||= nil
   suffix ||= nil
 
   css_classes = %w(gem-c-input govuk-input)
@@ -92,7 +93,13 @@
     }
   %>
 
-  <% if prefix %>
+  <% if prefix && suffix %>
+    <%= tag.div class: "gem-c-input__wrapper" do %>
+      <%= tag.span prefix, class: "gem-c-input__prefix", aria: { hidden: true } %>
+      <%= input_tag %>
+      <%= tag.span suffix, class: "gem-c-input__suffix", aria: { hidden: true } %>
+    <% end %>
+  <% elsif prefix %>
     <%= tag.div class: "gem-c-input__wrapper" do %>
       <%= tag.span prefix, class: "gem-c-input__prefix", aria: { hidden: true } %><%= input_tag %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -92,7 +92,11 @@
     }
   %>
 
-  <% if suffix %>
+  <% if prefix %>
+    <%= tag.div class: "gem-c-input__wrapper" do %>
+      <%= tag.span prefix, class: "gem-c-input__prefix", aria: { hidden: true } %><%= input_tag %>
+    <% end %>
+  <% elsif suffix %> 
     <%= tag.div class: "gem-c-input__wrapper" do %>
       <%= input_tag %><%= tag.span suffix, class: "gem-c-input__suffix", aria: { hidden: true } %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -140,6 +140,15 @@ examples:
       name: "lead-times"
       width: 10
       suffix: "days"
+  with_prefix_and_suffix:
+    description: To help users understand how the input should look like. Often used for units of measurement.
+    data:
+      label:
+        text: "Cost per item, in pounds"
+      name: "Cost-per-item"
+      width: 10
+      prefix: "£"
+      suffix: "per item"
   with_suffix_and_error:
     description: To help users understand how the input should look like. Often used for units of measurement.
     data:

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -215,6 +215,16 @@ describe "Input", type: :view do
     assert_select ".govuk-label.govuk-label--xl"
   end
 
+  it "renders text input with prefix" do
+    render_component(
+      label: { text: "Cost per item, in pounds" },
+      name: "cost-per-item",
+      prefix: "£",
+    )
+    assert_select ".gem-c-input__wrapper .gem-c-input[name=cost-per-item]"
+    assert_select ".gem-c-input__wrapper .gem-c-input__prefix[aria-hidden=true]", text: "£"
+  end
+
   it "renders text input with suffix" do
     render_component(
       label: { text: "Approximate lead times, in days" },


### PR DESCRIPTION
## What

Add a prefix option to the input component

## Why

Users were entering data which was unusable, i.e entering text when we desired numbers. This change will help us indicate to users how we would like them to input data.

## Visual Changes

**BEFORE**

<img width="529" alt="Screenshot 2020-05-19 at 08 26 24" src="https://user-images.githubusercontent.com/41922771/82297360-75ea4980-99aa-11ea-9d64-1bed6c68a292.png">




**AFTER**
<img width="277" alt="Screenshot 2020-05-19 at 16 47 55" src="https://user-images.githubusercontent.com/41922771/82348269-86bdae00-99f0-11ea-8d88-e29b6f215ee8.png">


[Trello](https://trello.com/c/GCGNaCSH/367-add-prefix-to-input-fields-on-product-details-question)