### PR TITLE
Expand js classes code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Expand js classes code ([PR #1513](https://github.com/alphagov/govuk_publishing_components/pull/1513))
+
 ## 21.47.0
 
 * Add action link component ([PR #1497](https://github.com/alphagov/govuk_publishing_components/pull/1497))

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -10,17 +10,22 @@
   simple ||= false
   dark_icon ||= false
   data ||= nil
+  classes ||= nil
+
   css_classes = %w(gem-c-action-link)
   css_classes << "gem-c-action-link--light-text" if light_text
   css_classes << "gem-c-action-link--dark-icon" if dark_icon
   css_classes << "gem-c-action-link--simple" if simple
   css_classes << "gem-c-action-link--with-subtext" if subtext
   css_classes << (shared_helper.get_margin_bottom)
+
+  link_classes = %w(govuk-link gem-c-action-link__link)
+  link_classes << shared_helper.classes if classes
 %>
 <% if href.present? && text.present? %>
   <div class="<%= css_classes.join(' ') %>">
     <span class="gem-c-action-link__link-wrapper">
-      <%= link_to  href, :class => "govuk-link gem-c-action-link__link", :data => data do %>
+      <%= link_to  href, :class => link_classes, :data => data do %>
         <%= text %>
         <%= content_tag(:span, nowrap_text, class: "gem-c-action-link__nowrap-text") if nowrap_text %>
       <% end %>

--- a/app/views/govuk_publishing_components/components/_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_button.html.erb
@@ -1,4 +1,8 @@
-<% button = GovukPublishingComponents::Presenters::ButtonHelper.new(local_assigns) %>
+<%
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  local_assigns[:classes] = shared_helper.classes
+  button = GovukPublishingComponents::Presenters::ButtonHelper.new(local_assigns)
+%>
 
 <% start_button_text = capture do %>
   <%= button.text %>

--- a/app/views/govuk_publishing_components/components/docs/action_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/action_link.yml
@@ -18,6 +18,12 @@ examples:
       href: '/my-test-page'
       data:
         attr_test: "hasDataAttribute"
+  with_js_classes:
+    description: Use `js-` prefixed classes only as interaction hooks – to query and operate on elements via JavaScript. Classes are added to the link itself.
+    data:
+      text: "Coronavirus (COVID-19)"
+      href: '/my-test-page'
+      classes: 'js-hook'
   with_no_wrapping_text:
     data:
       text: "Coronavirus (COVID-19):"

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -44,12 +44,7 @@ module GovukPublishingComponents
         @destructive = local_assigns[:destructive]
         @name = local_assigns[:name]
         @value = local_assigns[:value]
-        if local_assigns.include?(:classes)
-          @classes = local_assigns[:classes].split(" ")
-          unless @classes.all? { |c| c.start_with?("js-") }
-            raise(ArgumentError, "The button component expects classes to be prefixed with `js-`")
-          end
-        end
+        @classes = local_assigns[:classes]
         @aria_label = local_assigns[:aria_label]
       end
 

--- a/lib/govuk_publishing_components/presenters/shared_helper.rb
+++ b/lib/govuk_publishing_components/presenters/shared_helper.rb
@@ -1,13 +1,20 @@
 module GovukPublishingComponents
   module Presenters
     class SharedHelper
-      attr_reader :options, :margin_top, :margin_bottom, :heading_level
+      attr_reader :options, :margin_top, :margin_bottom, :heading_level, :classes
 
       def initialize(local_assigns)
         @options = local_assigns
         @margin_top = @options[:margin_top] || nil
         @margin_bottom = @options[:margin_bottom] || 3
         @heading_level = @options[:heading_level] || 2
+
+        if local_assigns.include?(:classes)
+          @classes = local_assigns[:classes].split(" ")
+          unless @classes.all? { |c| c.start_with?("js-") }
+            raise(ArgumentError, "Passed classes must be prefixed with `js-`")
+          end
+        end
       end
 
       def get_margin_top

--- a/spec/components/action_link_spec.rb
+++ b/spec/components/action_link_spec.rb
@@ -30,6 +30,15 @@ describe "Action link", type: :view do
     assert_select '.gem-c-action-link.govuk-\!-margin-bottom-6'
   end
 
+  it "adds js- prefixed classes to the component" do
+    render_component(
+      text: "Get more info",
+      href: "/coronavirus",
+      classes: "js-hook",
+    )
+    assert_select ".gem-c-action-link .gem-c-action-link__link.js-hook"
+  end
+
   it "renders non wrapping text if nowrap text is passed through" do
     render_component(
       text: "Get more info",

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -188,7 +188,7 @@ describe "Button", type: :view do
   it "raises exception is CSS classes are not prefixed with `js-`" do
     expect {
       render_component(text: "Button", classes: "my-class")
-    }.to raise_error("The button component expects classes to be prefixed with `js-`")
+    }.to raise_error("Passed classes must be prefixed with `js-`")
   end
 
   it "renders with aria-label" do

--- a/spec/lib/govuk_publishing_components/components/shared_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/shared_helper_spec.rb
@@ -41,5 +41,16 @@ RSpec.describe GovukPublishingComponents::Presenters::SharedHelper do
       result = shared_helper.get_heading_level
       expect(result).to eql("span")
     end
+
+    it "accepts passed class names if prefixed with 'js-'" do
+      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(classes: "js-okay js-fine")
+      expect(shared_helper.classes).to eql(%w[js-okay js-fine])
+    end
+
+    it "rejects passed class names if not prefixed with 'js-'" do
+      expect {
+        GovukPublishingComponents::Presenters::SharedHelper.new(classes: "js-okay not-cool-man")
+      }.to raise_error(ArgumentError, "Passed classes must be prefixed with `js-`")
+    end
   end
 end


### PR DESCRIPTION
## What
Move the code for passing classes to the button component into the shared helper. This code only accepts classes passed to the component if they are prefixed with `js-`. 

Update the button component to use the shared helper for the classes option, and add the classes option into the action link component.

## Why
Moving the code for handling passed classes from the button component to the shared helper allows more than one component to use it in a consistent way, and this is now needed for the action link component.

## Visual Changes
None.