### PR TITLE
Add is_page_heading to select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add is_page_heading to select ([PR #1516](https://github.com/alphagov/govuk_publishing_components/pull/1516))
+
 ## 21.49.0
 
 * Add priority breadcrumb ([PR #1501] (https://github.com/alphagov/govuk_publishing_components/pull/1501))

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -4,6 +4,7 @@
   label ||= false
   full_width ||= false
   name ||= id
+  is_page_heading ||= false
   heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
   error_message ||= nil
   error_id ||= nil
@@ -28,7 +29,11 @@
 %>
 <% if options.any? && id && label %>
   <%= content_tag :div, class: css_classes do %>
-    <%= label_tag(id, label, class: label_classes) %>
+    <% if is_page_heading %>
+      <%= tag.h1 label_tag(id, label, class: label_classes), class: "gem-c-title__text" %>
+    <% else %>
+      <%= label_tag(id, label, class: label_classes) %>
+    <% end %>
 
     <% if error_message %>
       <%= render "govuk_publishing_components/components/error_message", {

--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -143,3 +143,15 @@ examples:
         value: 'option2'
       - text: 'Option three'
         value: 'option3'
+  with_page_heading:
+    description: This adds a H1 element with a label element inside containing the text supplied.
+    data:
+      id: 'select-with-heading'
+      label: 'This is a page heading'
+      heading_size: 'xl'
+      is_page_heading: true
+      options:
+      - text: 'Option one'
+        value: 'option1'
+      - text: 'Option two'
+        value: 'option2'

--- a/spec/components/select_spec.rb
+++ b/spec/components/select_spec.rb
@@ -254,4 +254,19 @@ describe "Select", type: :view do
 
     assert_select ".govuk-label.govuk-label--s"
   end
+
+  it "renders select with a label inside a heading" do
+    render_component(
+      id: "colour",
+      label: "What is you favourite colour?",
+      is_page_heading: true,
+      options: [
+        { text: "Red", value: "red" },
+        { text: "Blue", value: "blue" },
+      ],
+    )
+
+    assert_select "select[name=colour]"
+    assert_select ".gem-c-select h1.gem-c-title__text label.govuk-label"
+  end
 end


### PR DESCRIPTION
## What
Add `is_page_heading` and H1 tag as appropriate to select component.  Similar in approach to that taken with the `radio` element.

## Why
Allows pages who dominant feature is a select element not to have repetition the page title and the select element label.

## Visual Changes
No visual changes between this and a `select` that has an `xl` heading.  

## View Changes
https://govuk-publis-add-h1-to--ywnvox.herokuapp.com/component-guide/select/with_page_heading

Co-Authored by Jonathan Hallam <jonathan.hallam@digital.cabinet-office.gov.uk>