### PR TITLE
Tweak action link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Tweak action link ([PR #1518](https://github.com/alphagov/govuk_publishing_components/pull/1518))
+
 ## 21.50.0
 
 * Add is_page_heading to select ([PR #1516](https://github.com/alphagov/govuk_publishing_components/pull/1516))
 
 ## 21.49.0
 
-* Add priority breadcrumb ([PR #1501] (https://github.com/alphagov/govuk_publishing_components/pull/1501))
+* Add priority breadcrumb ([PR #1501](https://github.com/alphagov/govuk_publishing_components/pull/1501))
 
 ## 21.48.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -94,7 +94,7 @@
     background-image: image-url("govuk_publishing_components/action-link-arrow--simple.svg");
     // sass-lint:enable no-duplicate-properties
     background-size: 25px auto;
-    background-position: 0 0;
+    background-position: 0 2px;
   }
 
   .gem-c-action-link__link {
@@ -117,7 +117,7 @@
     background-image: image-url("govuk_publishing_components/action-link-arrow--dark.svg");
     // sass-lint:enable no-duplicate-properties
     background-size: 25px auto;
-    background-position: 0 0;
+    background-position: 0 2px;
   }
 
   .gem-c-action-link__link {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -20,6 +20,11 @@
   }
 }
 
+.gem-c-action-link__contents-wrapper {
+  display: table-cell;
+  vertical-align: middle;
+}
+
 .gem-c-action-link__link-wrapper {
   @include govuk-font(19, $weight: bold, $line-height: 1.3);
   display: table-cell;

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -24,16 +24,24 @@
 %>
 <% if href.present? && text.present? %>
   <div class="<%= css_classes.join(' ') %>">
-    <span class="gem-c-action-link__link-wrapper">
-      <%= link_to  href, :class => link_classes, :data => data do %>
-        <%= text %>
-        <%= content_tag(:span, nowrap_text, class: "gem-c-action-link__nowrap-text") if nowrap_text %>
-      <% end %>
-    </span>
-    <% if subtext %>
-      <span class="gem-c-action-link__subtext-wrapper">
-        <%= content_tag(:span, subtext, class: "gem-c-action-link__subtext") %>
+    <% contents = capture do %>
+      <span class="gem-c-action-link__link-wrapper">
+        <%= link_to  href, :class => link_classes, :data => data do %>
+          <%= text %>
+          <%= content_tag(:span, nowrap_text, class: "gem-c-action-link__nowrap-text") if nowrap_text %>
+        <% end %>
       </span>
+      <% if subtext %>
+        <span class="gem-c-action-link__subtext-wrapper">
+          <%= content_tag(:span, subtext, class: "gem-c-action-link__subtext") %>
+        </span>
+      <% end %>
+    <% end %>
+
+    <% if subtext %>
+      <%= content_tag(:span, contents, class: "gem-c-action-link__contents-wrapper") %>
+    <% else %>
+      <%= contents %>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
## What
Make some slight visual fixes to the action link component, specifically:

- fix vertical centering for action links with subtext on mobile
- adjust position of arrow for simple and dark options

## Why
Because:

- vertical centering was broken. The fix does involve adding yet another element (but only if subtext is present) but I think it's the only way (happy to be corrected though)
- the arrows for simple and dark weren't quite lined up right with the text. This is actually a tricky one, for some reason these arrows (unlike all the other arrows) are aligned to the top of the component, rather than centrally. So they still don't look great if the link text wraps onto two lines. But at least it looks slightly better now in one situation.

## Visual Changes

Vertical centering on mobile with subtext before (I've artificially increased the height of the component to emphasise the problem):

<img width="401" alt="Screenshot 2020-05-21 at 09 46 09" src="https://user-images.githubusercontent.com/861310/82542165-6d7c4500-9b49-11ea-92f0-f725d355b91f.png">

After:

<img width="401" alt="Screenshot 2020-05-21 at 09 45 24" src="https://user-images.githubusercontent.com/861310/82542213-85ec5f80-9b49-11ea-894d-a42d9f3b44c5.png">

Simple and dark arrows before:

<img width="506" alt="Screenshot 2020-05-21 at 09 50 39" src="https://user-images.githubusercontent.com/861310/82542254-956ba880-9b49-11ea-94c2-004fe7ef8494.png">

After:

<img width="515" alt="Screenshot 2020-05-21 at 09 51 35" src="https://user-images.githubusercontent.com/861310/82542276-9d2b4d00-9b49-11ea-9859-fdc3b2be665b.png">

Trello card: https://trello.com/c/l9xuuuTB/279-update-emergency-banner-design