### PR TITLE
Resolve stub deprecation warnings

### DIFF
--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -227,7 +227,7 @@ describe "Contextual navigation" do
       },
     )
 
-    content_store_has_item(content_item["base_path"], content_item)
+    stub_content_store_has_item(content_item["base_path"], content_item)
   end
 
   def given_theres_a_guide_with_a_live_taxon_tagged_to_it
@@ -383,7 +383,7 @@ describe "Contextual navigation" do
       "links" => links,
     )
 
-    content_store_has_item(content_item["base_path"], content_item)
+    stub_content_store_has_item(content_item["base_path"], content_item)
   end
 
   def random_step_nav_item(schema_name)

--- a/spec/features/step_nav_helper_spec.rb
+++ b/spec/features/step_nav_helper_spec.rb
@@ -127,7 +127,7 @@ describe "Specimen usage of step by step navigation helpers" do
         "links" => links,
       )
     end
-    content_store_has_item(content_item["base_path"], content_item)
+    stub_content_store_has_item(content_item["base_path"], content_item)
     content_item
   end
 


### PR DESCRIPTION
gds-api-adapters renamed the stubs from `content_store_has_item` to `stub_content_store_has_item`
