### PR TITLE
Update install instructions

### DIFF
--- a/docs/install-and-use.md
+++ b/docs/install-and-use.md
@@ -19,7 +19,7 @@ Mount the component guide in your application:
 
 ```ruby
 # config/routes.rb
-mount GovukPublishingComponents::Engine, at: "/component-guide"
+mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
 ```
 
 If your application was government-frontend the component guide would be at:


### PR DESCRIPTION
This should help prevent folks inadvertently making the /component-guide available in production.

https://trello.com/c/6QWT52eB/496-prevent-production-apps-rendering-component-guide?menu=filter&filter=label:Tech