### PR TITLE
Undo recursive FAQPage presenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add prefix option to input component ([PR #1509](https://github.com/alphagov/govuk_publishing_components/pull/1509))
+* Undo recursive FAQPage presenter ([PR #1527](https://github.com/alphagov/govuk_publishing_components/pull/1527))
 
 ## 21.51.0
 

--- a/lib/govuk_publishing_components/presenters/machine_readable/faq_page_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/faq_page_schema.rb
@@ -57,42 +57,22 @@ module GovukPublishingComponents
 
         question = page.title
 
+        # rubocop:disable Style/IfInsideElse
         doc.xpath("html/body").children.each_with_object({}) do |element, q_and_as|
-          _q_and_as, question = recursive_question_and_answers(element, question, q_and_as)
-        end
-      end
-
-      def recursive_question_and_answers(element, question, q_and_as)
-        if is_a_question?(element)
-          question = element.text
-          q_and_as[question] = { anchor: element["id"] }
-        else
-          q_and_as = add_answer_to_question(q_and_as, element, question)
-          element.children.each do |child_element|
-            if child_element.element?
-              q_and_as, question = recursive_question_and_answers(child_element, question, q_and_as)
+          if question_element?(element)
+            question = element.text
+            q_and_as[question] = { anchor: element["id"] }
+          else
+            if question_hash_is_unset?(q_and_as, question)
+              q_and_as[question] = { answer: element.to_s }
+            elsif answer_is_unset?(q_and_as, question)
+              q_and_as[question][:answer] = element.to_s
+            else
+              q_and_as[question][:answer] << element.to_s
             end
           end
         end
-
-        [q_and_as, question]
-      end
-
-      def add_answer_to_question(q_and_as, element, question)
-        if no_questions_in_subtree?(element)
-          if question_hash_is_unset?(q_and_as, question)
-            q_and_as[question] = { answer: element.to_s }
-          elsif answer_is_unset?(q_and_as, question)
-            q_and_as[question][:answer] = element.to_s
-          else
-            q_and_as[question][:answer] << element.to_s
-          end
-        end
-        q_and_as
-      end
-
-      def no_questions_in_subtree?(element)
-        element.search(QUESTION_TAG).none?
+        # rubocop:enable Style/IfInsideElse
       end
 
       def question_hash_is_unset?(q_and_as, question)
@@ -106,7 +86,7 @@ module GovukPublishingComponents
       # we use H2 tags as the "question" and the html between them as the "answer"
       QUESTION_TAG = "h2".freeze
 
-      def is_a_question?(element)
+      def question_element?(element)
         element.name == QUESTION_TAG
       end
 

--- a/lib/govuk_publishing_components/presenters/machine_readable/faq_page_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/faq_page_schema.rb
@@ -57,22 +57,18 @@ module GovukPublishingComponents
 
         question = page.title
 
-        # rubocop:disable Style/IfInsideElse
         doc.xpath("html/body").children.each_with_object({}) do |element, q_and_as|
           if question_element?(element)
             question = element.text
             q_and_as[question] = { anchor: element["id"] }
+          elsif question_hash_is_unset?(q_and_as, question)
+            q_and_as[question] = { answer: element.to_s }
+          elsif answer_is_unset?(q_and_as, question)
+            q_and_as[question][:answer] = element.to_s
           else
-            if question_hash_is_unset?(q_and_as, question)
-              q_and_as[question] = { answer: element.to_s }
-            elsif answer_is_unset?(q_and_as, question)
-              q_and_as[question][:answer] = element.to_s
-            else
-              q_and_as[question][:answer] << element.to_s
-            end
+            q_and_as[question][:answer] << element.to_s
           end
         end
-        # rubocop:enable Style/IfInsideElse
       end
 
       def question_hash_is_unset?(q_and_as, question)

--- a/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/schema_org_spec.rb
@@ -309,42 +309,6 @@ RSpec.describe GovukPublishingComponents::Presenters::SchemaOrg do
         expect(q_and_a.map { |faq| faq["name"] }).to_not include("Step two")
       end
 
-      it "parses nested questions" do
-        part_body = "<div>
-                     <main>
-                     <h2 id='step-one'>Step one</h2>
-                     <p>First catch your dragon</p>
-                     <h2 id='step-two'>Step two</h2>
-                     <p>Give it a treat</p>
-                     <h2 id='step-three'>Step three</h2>
-                     <p>Give it a pat (wear gloves)</p>
-                     </main>
-                     </div>
-                    "
-
-        content_item = dragon_guide
-
-        q_and_a = generate_structured_data(
-          content_item: content_item,
-          schema: :faq,
-          body: part_body,
-        ).structured_data["mainEntity"]
-
-        expect(q_and_a.count).to eq(3)
-
-        expect(q_and_a.first["url"]).to eq("http://www.dev.gov.uk/how-to-train-your-dragon#step-one")
-        expect(q_and_a.second["url"]).to eq("http://www.dev.gov.uk/how-to-train-your-dragon#step-two")
-
-        expect(q_and_a.first["name"]).to eq("Step one")
-        expect(q_and_a.first["acceptedAnswer"]["text"].strip).to eq("<p>First catch your dragon</p>")
-
-        expect(q_and_a.second["name"]).to eq("Step two")
-        expect(q_and_a.second["acceptedAnswer"]["text"].strip).to eq("<p>Give it a treat</p>")
-
-        expect(q_and_a.third["name"]).to eq("Step three")
-        expect(q_and_a.third["acceptedAnswer"]["text"].strip).to eq("<p>Give it a pat (wear gloves)</p>")
-      end
-
       it "handles an empty body to ensure that preview works OK" do
         empty_part_body = ""
         content_item = dragon_guide


### PR DESCRIPTION
## What

Removes the recursive bit of the FAQSchema presenter which is used to extract questions and answers from the HTML publication format.

## Why

I'm intending to do this more simply and specifically for HTML publications within government-frontend. This code is quite hard to debug without context, and it's not working quite right at the moment.

Note that this is not a breaking change - it still resolves a valid schema on HTML publications, but they are a bit less useful.

This reverts commit f0e470a27660e1d0bcfbd318e4957ba983191095.
