### PR TITLE
Allow arbitrary depth in taxonomy tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add prefix option to input component ([PR #1509](https://github.com/alphagov/govuk_publishing_components/pull/1509))
 * Undo recursive FAQPage presenter ([PR #1527](https://github.com/alphagov/govuk_publishing_components/pull/1527))
+* Allow arbitrary depth in priority taxonomy tagging([PR #1530](https://github.com/alphagov/govuk_publishing_components/pull/1530))
 
 ## 21.51.0
 

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -27,16 +27,22 @@ module GovukPublishingComponents
     private
 
       def priority_taxons
-        taxons = content_item.dig("links", "taxons")&.map do |taxon|
-          taxon.dig("links", "parent_taxons")&.select do |parent_taxon|
-            PRIORITY_TAXONS.values.include?(parent_taxon["content_id"])
+        taxons = []
+        content_item.dig("links", "taxons")&.map do |taxon|
+          taxons << taxon if priority_taxon?(taxon)
+
+          taxons << taxon.dig("links", "parent_taxons")&.select do |parent_taxon|
+            priority_taxon?(parent_taxon)
           end
         end
-        return [] unless taxons
 
         taxons.flatten!
         taxons.compact!
         taxons
+      end
+
+      def priority_taxon?(taxon)
+        PRIORITY_TAXONS.values.include?(taxon["content_id"])
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -27,18 +27,16 @@ module GovukPublishingComponents
     private
 
       def priority_taxons
-        taxons = []
-        content_item.dig("links", "taxons")&.map do |taxon|
-          taxons << taxon if priority_taxon?(taxon)
-
-          taxons << taxon.dig("links", "parent_taxons")&.select do |parent_taxon|
-            priority_taxon?(parent_taxon)
-          end
+        taxons = content_item.dig("links", "taxons")
+        taxon_tree(taxons).select do |taxon|
+          priority_taxon?(taxon)
         end
+      end
 
-        taxons.flatten!
-        taxons.compact!
-        taxons
+      def taxon_tree(taxons)
+        return [] if taxons.blank?
+
+        taxons + taxons.flat_map { |taxon| taxon_tree(taxon.dig("links", "parent_taxons")) }
       end
 
       def priority_taxon?(taxon)

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -27,47 +27,61 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
 
   let(:payload) { [education_taxon] }
 
-  subject { described_class.new(content_with(payload)) }
-
   describe "#taxon" do
-    it "returns the matching taxon" do
-      expect(subject.taxon).to eq(education_taxon)
-    end
+    %w[directly_tagged_to_taxons indirectly_tagged_to_taxons].each do |tagged_to_taxons|
+      context tagged_to_taxons do
+        subject { described_class.new(send(tagged_to_taxons, payload)) }
 
-    context "with business taxon" do
-      let(:payload) { [business_taxon] }
+        it "returns the matching taxon" do
+          expect(subject.taxon).to eq(education_taxon)
+        end
 
-      it "returns the business taxon" do
-        expect(subject.taxon).to eq(business_taxon)
+        context "with business taxon" do
+          let(:payload) { [business_taxon] }
+
+          it "returns the business taxon" do
+            expect(subject.taxon).to eq(business_taxon)
+          end
+        end
+
+        context "with education and business taxons" do
+          let(:payload) { [education_taxon, business_taxon] }
+
+          it "returns the education taxon" do
+            expect(subject.taxon).to eq(education_taxon)
+          end
+        end
+
+        context "with no matches" do
+          let(:payload) { [] }
+
+          it "returns nil" do
+            expect(subject.taxon).to be_nil
+          end
+        end
       end
-    end
 
-    context "with education and business taxons" do
-      let(:payload) { [education_taxon, business_taxon] }
+      describe ".call" do
+        let(:content) { send(tagged_to_taxons, [education_taxon]) }
 
-      it "returns the education taxon" do
-        expect(subject.taxon).to eq(education_taxon)
-      end
-    end
-
-    context "with no matches" do
-      let(:payload) { [] }
-
-      it "returns nil" do
-        expect(subject.taxon).to be_nil
+        it "returns the matching taxon" do
+          expect(described_class.call(content)).to eq(education_taxon)
+        end
       end
     end
   end
 
-  describe ".call" do
-    let(:content) { content_with([education_taxon]) }
 
-    it "returns the matching taxon" do
-      expect(described_class.call(content)).to eq(education_taxon)
-    end
+  def directly_tagged_to_taxons(taxons)
+    taxons << other_taxon
+    {
+      "links" => {
+        "taxons" => taxons.shuffle,
+      },
+    }
   end
 
-  def content_with(taxons)
+  def indirectly_tagged_to_taxons(taxons)
     taxons << other_taxon
     {
       "links" => {

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
     end
   end
 
-
   def directly_tagged_to_taxons(taxons)
     taxons << other_taxon
     {


### PR DESCRIPTION
## What
Allow arbitrary depth in taxonomy tagging

This now assembles all the taxons that content is tagged to, whether directly, or via taxonomy inheritance.  It then checks to see if any of those are priority taxons and judges from that whether to show the super-breadcrumb

## Why
At the moment, we're not checking the whole taxon tree to see whether a piece of content is tagged to a priority taxon. 
