### PR TITLE
Modify Step nav header component to support custom tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Modify Step nav header component to support custom tracking ([PR #1533](https://github.com/alphagov/govuk_publishing_components/pull/1533))
+
+
 ## 21.53.0
 
-* Add breadcrumbs from parent for html documents ([PR #1526] (https://github.com/alphagov/govuk_publishing_components/pull/1526)
+* Add breadcrumbs from parent for html documents ([PR #1526](https://github.com/alphagov/govuk_publishing_components/pull/1526))
 
 ## 21.52.1
 

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
@@ -1,12 +1,23 @@
 <%
   title ||= false
   path ||= false
-  tracking_id ||= false
   breadcrumbs = [
     { title: "Home", url: "/" },
     { title: title, url: path }
   ]
   breadcrumb_presenter = GovukPublishingComponents::Presenters::Breadcrumbs.new(breadcrumbs)
+
+  tracking_id ||= false
+  tracking_category ||= "stepNavHeaderClicked"
+  tracking_action ||= "top"
+  tracking_label ||= path
+  tracking_dimension_enabled = tracking_dimension_enabled != false
+  tracking_dimension ||= title
+  tracking_dimension_index ||= 29
+
+  if tracking_id
+    tracking_options ||= ({ dimension96: tracking_id }).to_json
+  end
 %>
 <% if title %>
   <script type="application/ld+json">
@@ -18,12 +29,17 @@
     <% if path %>
       <a href="<%= path %>"
         class="gem-c-step-nav-header__title"
-        data-track-category="stepNavHeaderClicked"
-        data-track-action="top"
-        data-track-label="<%= path %>"
-        data-track-dimension="<%= title %>"
-        data-track-dimension-index="29"
-        data-track-options='{"dimension96" : "<%= tracking_id %>" }'>
+        data-track-category="<%= tracking_category %>"
+        data-track-action="<%= tracking_action %>"
+        data-track-label="<%= tracking_label %>"
+        <% if tracking_dimension_enabled %>
+          data-track-dimension="<%= tracking_dimension %>"
+          data-track-dimension-index="<%= tracking_dimension_index %>"
+        <% end %>
+        <% if tracking_id %>
+          data-track-options='<%= tracking_options %>'
+        <% end %>
+      >
         <%= title %>
       </a>
     <% else %>

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav_header.yml
@@ -26,3 +26,20 @@ examples:
       title: 'With a tracking id'
       path: '#'
       tracking_id: 'this-is-the-tracking-id'
+  with_custom_tracking:
+    data:
+      title: 'With a custom tracking'
+      path: '#'
+      tracking_category: "customTrackingCategoryClicked"
+      tracking_action: "customTrackingAction"
+      tracking_label: "customTrackingLabel"
+      tracking_dimension: "customTrackingDimension"
+      tracking_dimension_index: "23"
+  without_custom_dimension:
+    data:
+      title: 'Without custom dimensions'
+      path: '#'
+      tracking_category: "customTrackingCategoryClicked"
+      tracking_action: "customTrackingAction"
+      tracking_label: "customTrackingLabel"
+      tracking_dimension_enabled: false

--- a/spec/components/step_by_step_nav_header_spec.rb
+++ b/spec/components/step_by_step_nav_header_spec.rb
@@ -15,25 +15,6 @@ describe "Step by step navigation header", type: :view do
     assert_select ".gem-c-step-nav-header span.gem-c-step-nav-header__title", text: "This is my title"
   end
 
-  it "renders with a link" do
-    render_component(title: "This is my title", path: "/notalink")
-
-    link = ".gem-c-step-nav-header a.gem-c-step-nav-header__title"
-
-    assert_select link + "[href='/notalink']", text: "This is my title"
-    assert_select link + "[data-track-category='stepNavHeaderClicked']"
-    assert_select link + "[data-track-action='top']"
-    assert_select link + "[data-track-label='/notalink']"
-    assert_select link + "[data-track-dimension='This is my title']"
-    assert_select link + "[data-track-dimension-index='29']"
-  end
-
-  it "adds a tracking id" do
-    render_component(title: "This is my title", path: "/notalink", tracking_id: "brian")
-
-    assert_select ".gem-c-step-nav-header .gem-c-step-nav-header__title[data-track-options='{\"dimension96\" : \"brian\" }']"
-  end
-
   it "renders machine readable breadcrumbs" do
     render_component(title: "This is my title", path: "/notalink")
 
@@ -55,5 +36,68 @@ describe "Step by step navigation header", type: :view do
     rendered_values = breadcrumbs.map { |b| b["item"].values }
 
     assert_equal expected_breadcrumb_values, rendered_values
+  end
+
+  it "renders with a link" do
+    render_component(title: "This is my title", path: "/notalink")
+
+    link = ".gem-c-step-nav-header a.gem-c-step-nav-header__title"
+
+    assert_select link + "[href='/notalink']", text: "This is my title"
+    assert_select link + "[data-track-category='stepNavHeaderClicked']"
+    assert_select link + "[data-track-action='top']"
+    assert_select link + "[data-track-label='/notalink']"
+    assert_select link + "[data-track-dimension='This is my title']"
+    assert_select link + "[data-track-dimension-index='29']"
+  end
+
+  it "adds a tracking id" do
+    render_component(title: "This is my title", path: "/notalink", tracking_id: "brian")
+
+    assert_select ".gem-c-step-nav-header .gem-c-step-nav-header__title[data-track-options='{\"dimension96\":\"brian\"}']"
+  end
+
+  it "adds a custom tracking" do
+    render_component(
+      title: "This is my title",
+      path: "/notalink",
+      tracking_id: "tracking-id",
+      tracking_category: "customTrackingCategoryClicked",
+      tracking_action: "customTrackingAction",
+      tracking_label: "customTrackingLabel",
+      tracking_dimension: "customTrackingDimension",
+      tracking_dimension_index: "23",
+    )
+
+    link = ".gem-c-step-nav-header a.gem-c-step-nav-header__title"
+
+    assert_select link + "[href='/notalink']", text: "This is my title"
+    assert_select link + "[data-track-category='customTrackingCategoryClicked']"
+    assert_select link + "[data-track-action='customTrackingAction']"
+    assert_select link + "[data-track-label='customTrackingLabel']"
+    assert_select link + "[data-track-dimension='customTrackingDimension']"
+    assert_select link + "[data-track-dimension-index='23']"
+    assert_select link + "[data-track-options='{\"dimension96\":\"tracking-id\"}']"
+  end
+
+  it "adds a custom tracking without tracking id or custom dimensions" do
+    render_component(
+      title: "This is my title",
+      path: "/notalink",
+      tracking_category: "customTrackingCategoryClicked",
+      tracking_action: "customTrackingAction",
+      tracking_label: "customTrackingLabel",
+      tracking_dimension_enabled: false,
+    )
+
+    link = ".gem-c-step-nav-header a.gem-c-step-nav-header__title"
+
+    assert_select link + "[href='/notalink']", text: "This is my title"
+    assert_select link + "[data-track-category='customTrackingCategoryClicked']"
+    assert_select link + "[data-track-action='customTrackingAction']"
+    assert_select link + "[data-track-label='customTrackingLabel']"
+    assert_select link + "[data-track-dimension]", false
+    assert_select link + "[data-track-dimension-index]", false
+    assert_select link + "[data-track-options]", false
   end
 end


### PR DESCRIPTION
We don't currently track users who click on the superbread crumbs (on the business & education hubs). As this feature is going to be rolled out with the new taxonomy it would be good to add tracking to understand if it is helping users navigate back through the pages.

Event category: breadcrumbClicked
Event action: superBreadcrumb
Event label: page path link (to hub page)

Its done when: When a users clicks on a super bread crumb an event is triggered in GA and we can track the page they were on and the page they went to.

https://trello.com/c/G2iuimyb/283-add-analytics-tracking-to-super-breadcrumb
