### PR TITLE
Increase limit for steps bullet point images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Increase limit for steps bullet point images ([PR #1534](https://github.com/alphagov/govuk_publishing_components/pull/1534))
+
 ## 21.52.0
 
 * Add prefix option to input component ([PR #1509](https://github.com/alphagov/govuk_publishing_components/pull/1509))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_steps.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_steps.scss
@@ -10,7 +10,7 @@
     margin-left: 0;
     padding: .75em 0 .75em 2.5em;
 
-    @for $i from 1 through 14 {
+    @for $i from 1 through 30 {
       &:nth-child(#{$i}) {
         background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='250' height='250'%3E%3Ccircle cx='125' cy='125' r='100' fill='black' /%3E%3Ctext x='50%25' y='50%25' text-anchor='middle' alignment-baseline='middle' font-family='sans-serif' font-size='100px' fill='white'%3E#{$i}%3C/text%3E%3C/svg%3E");
         background-repeat: no-repeat;


### PR DESCRIPTION
## What
Previously these sequential bullet images stopped displaying after point
14. This ups the limit to 30 as it seems a reasonable limit.

## Why
Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4089053

## Visual Changes

### Previous
<img width="618" alt="Screenshot 2020-05-26 at 16 08 43" src="https://user-images.githubusercontent.com/24479188/82925544-bd0da700-9f75-11ea-94d8-2d9332ed740e.png">

### Now
<img width="565" alt="Screenshot 2020-05-26 at 17 30 52" src="https://user-images.githubusercontent.com/24479188/82926128-a6b41b00-9f76-11ea-8d4e-e5579f90367c.png">
