### PR TITLE
Version 21.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.53.0
 
 * Add breadcrumbs from parent for html documents ([PR #1526] (https://github.com/alphagov/govuk_publishing_components/pull/1526)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.52.1)
+    govuk_publishing_components (21.53.0)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.52.1".freeze
+  VERSION = "21.53.0".freeze
 end


### PR DESCRIPTION
Add breadcrumbs from parent for html documents ([PR #1526] (https://github.com/alphagov/govuk_publishing_components/pull/1526)