### PR TITLE
Remove jQuery from modules system

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/modules.js
+++ b/app/assets/javascripts/govuk_publishing_components/modules.js
@@ -1,22 +1,23 @@
 ;(function (global) {
   'use strict'
 
-  var $ = global.jQuery
   var GOVUK = global.GOVUK || {}
   GOVUK.Modules = GOVUK.Modules || {}
 
   GOVUK.modules = {
     find: function (container) {
-      container = container || $('body')
+      container = container || document.querySelector('body')
+
+      if (container.jquery) container = container[0]
 
       var modules
       var moduleSelector = '[data-module]'
 
-      modules = container.find(moduleSelector)
+      modules = Array.prototype.slice.call(container.querySelectorAll(moduleSelector))
 
       // Container could be a module too
-      if (container.is(moduleSelector)) {
-        modules = modules.add(container)
+      if (container.getAttribute('data-module')) {
+        modules.push(container)
       }
 
       return modules
@@ -27,9 +28,9 @@
 
       for (var i = 0, l = modules.length; i < l; i++) {
         var module
-        var element = $(modules[i])
-        var moduleName = camelCaseAndCapitalise(element.data('module'))
-        var started = element.data('module-started')
+        var element = modules[i]
+        var moduleName = camelCaseAndCapitalise(element.getAttribute('data-module'))
+        var started = element.getAttribute('data-module-started')
         var frontendModuleName = moduleName.replace('Govuk', '')
 
         if ( // GOV.UK Publishing & Legacy Modules
@@ -39,14 +40,14 @@
         ) {
           module = new GOVUK.Modules[moduleName]()
           module.start(element)
-          element.data('module-started', true)
+          element.setAttribute('data-module-started', true)
         } else if ( // GOV.UK Frontend Modules
           typeof GOVUK.Modules[frontendModuleName] === 'function' &&
           GOVUK.Modules[frontendModuleName].prototype.init &&
           !started
         ) {
-          module = new GOVUK.Modules[frontendModuleName](element[0]).init()
-          element.data('module-started', true)
+          module = new GOVUK.Modules[frontendModuleName](element).init()
+          element.setAttribute('data-module-started', true)
         }
       }
 

--- a/spec/javascripts/govuk_publishing_components/modules.spec.js
+++ b/spec/javascripts/govuk_publishing_components/modules.spec.js
@@ -11,7 +11,7 @@ describe('GOVUK Modules', function () {
     $('body').append(module)
 
     expect(GOVUK.modules.find().length).toBe(1)
-    expect(GOVUK.modules.find().eq(0).is('[data-module="a-module"]')).toBe(true)
+    expect(GOVUK.modules.find()[0].getAttribute('data-module')).toBe('a-module')
     module.remove()
   })
 
@@ -20,7 +20,7 @@ describe('GOVUK Modules', function () {
     var container = $('<div></div>').append(module)
 
     expect(GOVUK.modules.find(container).length).toBe(1)
-    expect(GOVUK.modules.find(container).eq(0).data('module')).toBe('a-module')
+    expect(GOVUK.modules.find(container)[0].getAttribute('data-module')).toBe('a-module')
     container.remove()
   })
 
@@ -29,8 +29,8 @@ describe('GOVUK Modules', function () {
     var container = $('<div data-module="container-module"></div>').append(module)
 
     expect(GOVUK.modules.find(container).length).toBe(2)
-    expect(GOVUK.modules.find(container).eq(0).data('module')).toBe('container-module')
-    expect(GOVUK.modules.find(container).eq(1).data('module')).toBe('a-module')
+    expect(GOVUK.modules.find(container)[1].getAttribute('data-module')).toBe('container-module')
+    expect(GOVUK.modules.find(container)[0].getAttribute('data-module')).toBe('a-module')
     container.remove()
   })
 
@@ -108,7 +108,7 @@ describe('GOVUK Modules', function () {
       GOVUK.modules.start(container)
 
       var args = callbackLegacyModule.calls.argsFor(0)
-      expect(args[0].is('div[data-module="legacy-test-alert-module"]')).toBe(true)
+      expect(args[0].getAttribute('data-module')).toBe('legacy-test-alert-module')
     })
 
     it('starts all modules that are on the page', function () {


### PR DESCRIPTION
## What
Remove jQuery from the modules system

## Why
- there are projects that require jQuery only because the module system is based on it (such as Content Publisher)
- this will allow us to start removing jQuery gradually from GOV.UK

## Notes
This is a breaking change because all scripts using the GOV.UK Publishing and the legacy GOV.UK Frontend Toolkit pattern have an initialisation pattern that expects the argument to be a jQuery object. This includes scripts in `collections`, `finder-frontend`, `frontend`, `service-manual-frontend`, `whitehall`, `static` for the public-facing applications and most of the admin applications.

The upgrade process is fairly simple:
```
GOVUK.Modules.TestModule = function () {
  this.start = function ($element) {
    console.log($element)
  }
}
```
will become
```diff
GOVUK.Modules.TestModule = function () {
  this.start = function (element) {
+   $element = $(element)
    console.log($element)
  }
}
```

## Visual Changes
No visual changes

[Trello card](https://trello.com/c/sghHecNi/91-remove-jquery-dependency)