### PR TITLE
Find components within components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Find components within components ([PR #1541](https://github.com/alphagov/govuk_publishing_components/pull/1541))
+
 ## 21.55.0
 
 * Add new options to action link component ([PR #1551](https://github.com/alphagov/govuk_publishing_components/pull/1551))

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -47,22 +47,7 @@ module GovukPublishingComponents
       additional_files = "@import 'govuk_publishing_components/govuk_frontend_support';\n"
       additional_files << "@import 'govuk_publishing_components/component_support';\n" unless print_styles
 
-      components = components_in_use
-      components_to_search = components
-      loop = true
-
-      while loop
-        extra_components = find_partials_in(components_to_search)
-
-        if extra_components.any?
-          components << extra_components
-          components_to_search = extra_components
-        else
-          loop = false
-        end
-      end
-
-      components = components.flatten.uniq.sort
+      components = find_all_partials_in(components_in_use)
 
       components.map { |component|
         "@import 'govuk_publishing_components/components/#{print_path}#{component.gsub('_', '-')}';" if component_has_sass_file(component.gsub("_", "-"), print_styles)
@@ -72,16 +57,7 @@ module GovukPublishingComponents
     def components_in_use_js
       additional_files = "//= require govuk_publishing_components/lib\n"
 
-      components = components_in_use
-      extra_components = []
-
-      components.each do |component|
-        components_in_component = components_within_component(component)
-        extra_components << components_in_component
-      end
-
-      components << extra_components.compact
-      components = components.flatten.uniq.sort
+      components = find_all_partials_in(components_in_use)
 
       components.map { |component|
         "//= require govuk_publishing_components/components/#{component.gsub('_', '-')}" if component_has_js_file(component.gsub("_", "-"))
@@ -114,6 +90,24 @@ module GovukPublishingComponents
       end
 
       matches.flatten.uniq.map(&:to_s).sort.map { |m| m.gsub("govuk_publishing_components/components/", "") }
+    end
+
+    def find_all_partials_in(components)
+      components_to_search = components
+      partials_found = true
+
+      while partials_found
+        extra_components = find_partials_in(components_to_search)
+
+        if extra_components.any?
+          components << extra_components
+          components_to_search = extra_components
+        else
+          partials_found = false
+        end
+      end
+
+      components.flatten.uniq.sort
     end
 
     def find_partials_in(components)

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -48,9 +48,11 @@ describe "Component guide index" do
     expected_main_sass = "@import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';
 @import 'govuk_publishing_components/components/breadcrumbs';
+@import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/contextual-sidebar';
 @import 'govuk_publishing_components/components/error-message';
 @import 'govuk_publishing_components/components/error-summary';
+@import 'govuk_publishing_components/components/feedback';
 @import 'govuk_publishing_components/components/govspeak';
 @import 'govuk_publishing_components/components/hint';
 @import 'govuk_publishing_components/components/input';
@@ -66,7 +68,7 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/tabs';
 @import 'govuk_publishing_components/components/title';"
 
-    expect(page).to have_selector(".component-doc-h2", text: "Gem components used by this app (12)")
+    expect(page).to have_selector(".component-doc-h2", text: "Gem components used by this app (13)")
     expect(page).to have_selector(".govuk-details__summary-text", text: "Suggested imports for this application")
 
     expect(page.find(:css, 'textarea[name="main-sass"]', visible: false).value).to eq(expected_main_sass)
@@ -75,6 +77,8 @@ describe "Component guide index" do
   it "includes suggested print sass for the application" do
     visit "/component-guide"
     expected_print_sass = "@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/components/print/button';
+@import 'govuk_publishing_components/components/print/feedback';
 @import 'govuk_publishing_components/components/print/govspeak';
 @import 'govuk_publishing_components/components/print/layout-footer';
 @import 'govuk_publishing_components/components/print/layout-header';
@@ -90,6 +94,7 @@ describe "Component guide index" do
     visit "/component-guide"
     expected_main_js = "//= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/tabs"

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -93,6 +93,7 @@ describe "Component guide index" do
   it "includes suggested js for the application" do
     visit "/component-guide"
     expected_main_js = "//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -13,5 +13,6 @@
     <div id='wrapper'>
       <%= yield %>
     </div>
+    <%= render "govuk_publishing_components/components/feedback" %>
   </body>
 </html>


### PR DESCRIPTION
## What
- the suggested sass code was looking to see if any components contained other components, but stopped at that first level
- the feedback component contains several partials (identified and correctly ignored by the original code) but they include other components
- this change keeps burrowing down through partials/subcomponents until it can't find anything else
- updated the dummy app to include the feedback component so that this can be tested, which works because the dummy app doesn't include button but feedback does
- however I'm not sure how to do a concrete test for this i.e. if button was already in the dummy app and this code didn't work properly, the test would still pass

## Why
Noticed in the upgrade to individual components in `service-manual-frontend` that it hadn't included the input component, because it was 'hidden' in the feedback components partials

## Visual Changes
None.