### PR TITLE
Adds tracking for super breadcrumbs

### DIFF
--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -25,7 +25,14 @@ module GovukPublishingComponents
       end
 
       def breadcrumbs
-        taxon && { title: taxon["title"], path: taxon["base_path"] }
+        taxon && {
+          title: taxon["title"],
+          path: taxon["base_path"],
+          tracking_category: "breadcrumbClicked",
+          tracking_action: "superBreadcrumb",
+          tracking_label: content_item["base_path"],
+          tracking_dimension_enabled: false,
+        }
       end
 
     private

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
         let(:content) { send(tagged_to_taxons, [education_taxon]) }
 
         it "returns the matching taxon" do
-          expect(described_class.call(content)).to eq(breadcrumb_for(education_taxon))
+          expect(described_class.call(content)).to eq(breadcrumb_for(content, education_taxon))
         end
       end
     end
@@ -95,10 +95,14 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
     }
   end
 
-  def breadcrumb_for(taxon)
+  def breadcrumb_for(content_item, taxon)
     {
       title: taxon["title"],
       path: taxon["base_path"],
+      tracking_category: "breadcrumbClicked",
+      tracking_action: "superBreadcrumb",
+      tracking_label: content_item["base_path"],
+      tracking_dimension_enabled: false,
     }
   end
 end


### PR DESCRIPTION
We don't currently track users who click on the superbread crumbs (on the business & education hubs). As this feature is going to be rolled out with the new taxonomy it would be good to add tracking to understand if it is helping users navigate back through the pages.

Event category: breadcrumbClicked
Event action: superBreadcrumb
Event label: page path link (to hub page)

Its done when: When a users clicks on a super bread crumb an event is triggered in GA and we can track the page they were on and the page they went to.

https://trello.com/c/G2iuimyb/283-add-analytics-tracking-to-super-breadcrumb