### PR TITLE
Add margin bottom option to step nav header component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add margin bottom option to step nav header component ([PR #1544](https://github.com/alphagov/govuk_publishing_components/pull/1544))
 * Modify Step nav header component to support custom tracking ([PR #1533](https://github.com/alphagov/govuk_publishing_components/pull/1533))
 
 

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
@@ -18,13 +18,17 @@
   if tracking_id
     tracking_options ||= ({ dimension96: tracking_id }).to_json
   end
+
+  local_assigns[:margin_bottom] ||= 0
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  classes = "gem-c-step-nav-header #{shared_helper.get_margin_bottom}"
 %>
 <% if title %>
   <script type="application/ld+json">
     <%= raw breadcrumb_presenter.structured_data.to_json %>
   </script>
 
-  <div class="gem-c-step-nav-header" data-module="track-click">
+  <div class="<%= classes %>" data-module="track-click">
     <span class="gem-c-step-nav-header__part-of">Part of</span>
     <% if path %>
       <a href="<%= path %>"

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav_header.yml
@@ -20,6 +20,12 @@ examples:
     data:
       title: 'Coronavirus: businesses and self-employed people'
       path: /childcare-parenting/pregnancy-and-birth
+  with_margin_bottom:
+    description: |
+      The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a margin bottom of 30px.
+    data:
+      title: 'Learn to practice flexible spacing: step by step'
+      margin_bottom: 9
   with_unique_tracking:
     description: In order to identify the step by step navigation the component is part of, we need to track a unique ID of the navigation in Google Analytics. This ID should be the same across all pages that are linked from and are part of that navigation. Its value is included in any tracking events, specifically in dimension96. It refers to the ID of the step nav that the component links to.
     data:

--- a/spec/components/step_by_step_nav_header_spec.rb
+++ b/spec/components/step_by_step_nav_header_spec.rb
@@ -51,6 +51,18 @@ describe "Step by step navigation header", type: :view do
     assert_select link + "[data-track-dimension-index='29']"
   end
 
+  it "defaults to no margin bottom" do
+    render_component(title: "This is my title")
+
+    assert_select '.gem-c-step-nav-header.govuk-\!-margin-bottom-0'
+  end
+
+  it "adds a margin bottom" do
+    render_component(title: "This is my title", margin_bottom: 9)
+
+    assert_select '.gem-c-step-nav-header.govuk-\!-margin-bottom-9'
+  end
+
   it "adds a tracking id" do
     render_component(title: "This is my title", path: "/notalink", tracking_id: "brian")
 


### PR DESCRIPTION
## What
Uses the shared helper to add a `margin_bottom` option to the step by step navigation header component.

## Why
We need it for [this page](https://www.gov.uk/government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do) where it's colliding with the organisation logo.

Trello card: https://trello.com/c/dY8wHgpu/280-adding-breadcrumbs-and-superbreadcrumbs-to-all-html-publications