### PR TITLE
Fix html publications tagged to step by steps

### DIFF
--- a/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
+++ b/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
@@ -49,9 +49,11 @@ module GovukPublishingComponents
         return content_item_options unless content_item_navigation.html_document_with_parent?
         return parent_item_options if parent_item_navigation.priority_breadcrumbs
 
+        step_by_step_header = parent_item_options[:step_by_step]
+
         {
-          step_by_step: parent_item_options[:step_by_step],
-          breadcrumbs: parent_breadcrumbs,
+          step_by_step: step_by_step_header,
+          breadcrumbs: step_by_step_header ? parent_breadcrumbs.first : parent_breadcrumbs,
         }
       end
 

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -73,6 +73,13 @@ describe "Contextual navigation" do
     then_i_see_four_breadcrumb_links # home, 2 x taxon, parent
   end
 
+  scenario "It's a HTML Publication with a parent tagged to a step by step" do
+    given_there_is_a_parent_page_with_a_step_by_step
+    and_the_page_is_an_html_publication_with_that_parent
+    and_i_visit_that_page
+    then_i_see_the_step_by_step_breadcrumbs
+  end
+
   scenario "There's a taxon tagged" do
     given_theres_a_guide_with_a_live_taxon_tagged_to_it
     and_i_visit_that_page
@@ -299,6 +306,13 @@ describe "Contextual navigation" do
     @parent["links"] = { "taxons" => [taxon, taxon_two] }
   end
 
+  def given_there_is_a_parent_page_with_a_step_by_step
+    step_by_step = random_step_nav_item("step_by_step_nav").merge("title" => "A step by step page")
+
+    @parent = random_item("placeholder")
+    @parent["links"]["part_of_step_navs"] = [step_by_step]
+  end
+
   def and_the_page_is_an_html_publication_with_that_parent
     content_item = example_item("html_publication", "published")
     content_item["base_path"] = "/page-with-contextual-navigation"
@@ -413,6 +427,12 @@ describe "Contextual navigation" do
   def then_i_see_the_coronavirus_contextual_breadcrumbs
     within ".gem-c-contextual-breadcrumbs" do
       expect(page).to have_link(coronavirus_taxon["title"])
+    end
+  end
+
+  def then_i_see_the_step_by_step_breadcrumbs
+    within ".gem-c-contextual-breadcrumbs" do
+      expect(page).to have_link("A step by step page")
     end
   end
 


### PR DESCRIPTION
The step by step header expects a hash, whereas the other breadcrumb component expects an array of items.

Resolves: https://sentry.io/organizations/govuk/issues/1697331489/?project=202226&query=is%3Aunresolved

https://trello.com/c/dY8wHgpu/280-adding-breadcrumbs-and-superbreadcrumbs-to-all-html-publications
