### PR TITLE
Release 21.54.0 (bump minor version)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.54.0
 
-* Add margin bottom option to step nav header component ([PR #1544](https://github.com/alphagov/govuk_publishing_components/pull/1544))
 * Modify Step nav header component to support custom tracking ([PR #1533](https://github.com/alphagov/govuk_publishing_components/pull/1533))
-
+* Adds tracking for super breadcrumbs ([PR #1542](https://github.com/alphagov/govuk_publishing_components/pull/1542))
+* Add margin bottom option to step nav header component ([PR #1544](https://github.com/alphagov/govuk_publishing_components/pull/1544))
+* Bugfix to Step nav header on HTML publications ([PR #1545](https://github.com/alphagov/govuk_publishing_components/pull/1545))
 
 ## 21.53.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.53.0)
+    govuk_publishing_components (21.54.0)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.53.0".freeze
+  VERSION = "21.54.0".freeze
 end


### PR DESCRIPTION
Includes:

* Modify step nav header component to support custom tracking ([PR #1533](https://github.com/alphagov/govuk_publishing_components/pull/1533))
* Adds tracking for super breadcrumbs ([PR #1542](https://github.com/alphagov/govuk_publishing_components/pull/1542))
* Add margin bottom option to step nav header component ([PR #1544](https://github.com/alphagov/govuk_publishing_components/pull/1544))
* Bugfix to step nav header on HTML publications ([PR #1545](https://github.com/alphagov/govuk_publishing_components/pull/1545))