### PR TITLE
Remove unnecessary margin around expanded feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove unnecessary margin around expanded feedback component ([PR #1547](https://github.com/alphagov/govuk_publishing_components/pull/1547))
+
 ## 21.55.3
 
 * Use video title as eventLabel for YT video event tracking ([PR #1562](https://github.com/alphagov/govuk_publishing_components/pull/1562))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -182,7 +182,6 @@
 }
 
 .gem-c-feedback__form {
-  margin: govuk-spacing(3) govuk-spacing(2) 0 govuk-spacing(2);
   padding: govuk-spacing(3) 0;
   border-top: govuk-spacing(2) solid govuk-colour("blue");
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -1,8 +1,6 @@
 .gem-c-feedback {
   background: govuk-colour("white");
-  margin: govuk-spacing(6) auto 0 auto;
-  max-width: $govuk-page-width;
-  position: relative;
+  margin-top: govuk-spacing(6);
 
   @include govuk-media-query($from: tablet) {
     margin-top: govuk-spacing(9);


### PR DESCRIPTION
**Don't merge this until https://github.com/alphagov/frontend/pull/2387 is merged**

## What
Remove the spacing around the form in the feedback component when the component is expanded.

## Why
The spacing is largely unnecessary and appears to be in place for one edge case only, the homepage, which has been [fixed in a separate PR](https://github.com/alphagov/frontend/pull/2387).

## Visual Changes

Here's the homepage at the moment when feedback is expanded:

<img width="599" alt="Screenshot 2020-06-01 at 12 13 58" src="https://user-images.githubusercontent.com/861310/83406159-f32fa880-a405-11ea-8bd3-d6249c68b225.png">

Here's the fix:

<img width="591" alt="Screenshot 2020-06-01 at 12 44 02" src="https://user-images.githubusercontent.com/861310/83406169-faef4d00-a405-11ea-954a-58f5a8caaf8f.png">

