### PR TITLE
Version 21.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.55.0
 
 * Add new options to action link component ([PR #1551](https://github.com/alphagov/govuk_publishing_components/pull/1551))
+* Bump govuk-frontend from 3.6.0 to 3.7.0 ([PR #1549](https://github.com/alphagov/govuk_publishing_components/pull/1549))
 * Fix FAQ Schemas for html publications ([PR #1543](https://github.com/alphagov/govuk_publishing_components/pull/1543)
 
 ## 21.54.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.54.0)
+    govuk_publishing_components (21.55.0)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.54.0".freeze
+  VERSION = "21.55.0".freeze
 end


### PR DESCRIPTION
## 21.55.0

* Add new options to action link component ([PR #1551](https://github.com/alphagov/govuk_publishing_components/pull/1551))
* Bump govuk-frontend from 3.6.0 to 3.7.0 ([PR #1549](https://github.com/alphagov/govuk_publishing_components/pull/1549))
* Fix FAQ Schemas for html publications ([PR #1543](https://github.com/alphagov/govuk_publishing_components/pull/1543)
