### PR TITLE
339 - Reorder the breadcrumb so superbreadcrumb not top option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Reorder the breadcrumb so superbreadcrumb not top option ([PR #1556](https://github.com/alphagov/govuk_publishing_components/pull/1556))
+
 ## 21.55.1
 
 * Find components within components ([PR #1541](https://github.com/alphagov/govuk_publishing_components/pull/1541))

--- a/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
+++ b/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
@@ -58,20 +58,20 @@ module GovukPublishingComponents
       end
 
       def options(navigation)
-        if navigation.priority_breadcrumbs
+        if navigation.content_tagged_to_a_finder?
           {
-            step_by_step: true,
-            breadcrumbs: navigation.priority_breadcrumbs,
+            step_by_step: false,
+            breadcrumbs: navigation.breadcrumbs,
           }
         elsif navigation.content_tagged_to_current_step_by_step?
           {
             step_by_step: true,
             breadcrumbs: navigation.step_nav_helper.header,
           }
-        elsif navigation.content_tagged_to_a_finder?
+        elsif navigation.priority_breadcrumbs
           {
-            step_by_step: false,
-            breadcrumbs: navigation.breadcrumbs,
+            step_by_step: true,
+            breadcrumbs: navigation.priority_breadcrumbs,
           }
         elsif navigation.content_is_tagged_to_a_live_taxon? && prioritise_taxon_breadcrumbs
           {

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -282,7 +282,7 @@ describe "Contextual navigation" do
 
   def given_theres_a_page_with_coronavirus_taxon
     live_taxon = example_item("taxon", "taxon")
-    live_taxon["links"]["parent_taxons"] << coronavirus_taxon
+    live_taxon["links"]["parent_taxons"] = [coronavirus_taxon]
 
     content_store_has_random_item links: { "taxons" => [live_taxon] }
   end
@@ -293,10 +293,11 @@ describe "Contextual navigation" do
 
   def given_there_is_a_parent_page_with_coronavirus_taxon
     taxon = example_item("taxon", "taxon")
-    taxon["links"]["parent_taxons"] << coronavirus_taxon
+    taxon["links"]["parent_taxons"] = [coronavirus_taxon]
 
     @parent = random_item("placeholder")
     @parent["links"]["taxons"] = [taxon]
+    @parent["links"].delete("finder")
   end
 
   def given_there_is_a_parent_page_with_two_taxon
@@ -311,6 +312,7 @@ describe "Contextual navigation" do
 
     @parent = random_item("placeholder")
     @parent["links"]["part_of_step_navs"] = [step_by_step]
+    @parent["links"].delete("finder")
   end
 
   def and_the_page_is_an_html_publication_with_that_parent


### PR DESCRIPTION
## What
Reverse order of top three options in breadcrumb selector, so that content_tagged_to_a_finder comes first, step by step second, priority 3rd

## Why
Superbreadcrumb (priority option) is not always the correct option. 

https://trello.com/c/hxOu0Mc9/339-reorder-the-breadcrumb-so-superbreadcrumb-not-top-option
