### PR TITLE
Remove `display: none` rules from component print stylesheets, and use the `govuk-!-display-none-print` class instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove `display: none` rules from component print stylesheets, and use the `govuk-!-display-none-print` class instead. ([PR #1561](https://github.com/alphagov/govuk_publishing_components/pull/1561))
+
 ## 24.10.3
 
 * Remove phase banner restrictions ([PR #2057](https://github.com/alphagov/govuk_publishing_components/pull/2057))

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -74,7 +74,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Gemstepnav.prototype.addShowHideAllButton = function () {
     var showall = document.createElement('div')
-    showall.className = 'gem-c-step-nav__controls'
+    showall.className = 'gem-c-step-nav__controls govuk-!-display-none-print'
     showall.innerHTML = '<button aria-expanded="false" class="gem-c-step-nav__button gem-c-step-nav__button--controls js-step-controls-button">' +
       '<span class="gem-c-step-nav__button-text gem-c-step-nav__button-text--all js-step-controls-button-text">' + this.$module.actions.showAllText + '</span>' +
       '<span class="gem-c-step-nav__chevron js-step-controls-button-icon">' + this.$module.downChevronSvg + '</span>' +
@@ -98,7 +98,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var commaSpan = document.createElement('span')
         var thisSectionSpan = document.createElement('span')
 
-        showHideSpan.className = 'gem-c-step-nav__toggle-link js-toggle-link'
+        showHideSpan.className = 'gem-c-step-nav__toggle-link js-toggle-link govuk-!-display-none-print'
         showHideSpanText.className = 'gem-c-step-nav__button-text js-toggle-link-text'
         showHideSpanIcon.className = 'gem-c-step-nav__chevron js-toggle-link-icon'
         commaSpan.className = 'govuk-visually-hidden'

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -4,22 +4,11 @@
 @import "govuk_frontend_support";
 
 @import "components/print/accordion";
-@import "components/print/attachment";
-@import "components/print/back-link";
 @import "components/print/button";
 @import "components/print/contents-list";
-@import "components/print/feedback";
 @import "components/print/govspeak-html-publication";
 @import "components/print/govspeak";
-@import "components/print/layout-header";
-@import "components/print/layout-footer";
-@import "components/print/metadata";
-@import "components/print/search";
-@import "components/print/share-links";
-@import "components/print/skip-link";
 @import "components/print/step-by-step-nav-header";
 @import "components/print/step-by-step-nav";
-@import "components/print/subscription-links";
 @import "components/print/textarea";
 @import "components/print/title";
-@import "components/print/translation-nav";

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_attachment.scss
@@ -1,3 +1,2 @@
-.gem-c-attachment__thumbnail-image {
-  display: none;
-}
+//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
+// https://github.com/alphagov/government-frontend/blob/7a0b068a0faa1da07f58acf0b1d3a0aa3e1daf56/app/assets/stylesheets/print.scss#L2

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_back-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_back-link.scss
@@ -1,3 +1,2 @@
-.gem-c-back-link {
-  display: none;
-}
+//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
+// https://github.com/alphagov/govuk-account-manager-prototype/blob/7858b55afcddc2f855d909abd051838d95f21f13/app/assets/stylesheets/print.scss#L2

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_button.scss
@@ -6,7 +6,3 @@
   color: $govuk-text-colour;
   text-decoration: none;
 }
-
-.govuk-button__start-icon {
-  display: none;
-}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_feedback.scss
@@ -1,3 +1,2 @@
-.gem-c-feedback {
-  display: none;
-}
+//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
+// https://github.com/alphagov/government-frontend/blob/7a0b068a0faa1da07f58acf0b1d3a0aa3e1daf56/app/assets/stylesheets/print.scss#L6

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_layout-footer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_layout-footer.scss
@@ -1,6 +1,2 @@
-.gem-c-layout-footer {
-  .govuk-footer__inline-list,
-  .govuk-footer__section {
-    display: none;
-  }
-}
+//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
+// https://github.com/alphagov/govuk-account-manager-prototype/blob/7858b55afcddc2f855d909abd051838d95f21f13/app/assets/stylesheets/print.scss#L5

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_layout-header.scss
@@ -1,3 +1,2 @@
-.gem-c-header__menu-button {
-  display: none;
-}
+//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
+// https://github.com/alphagov/govuk-account-manager-prototype/blob/7858b55afcddc2f855d909abd051838d95f21f13/app/assets/stylesheets/print.scss#L6

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_metadata.scss
@@ -1,6 +1,2 @@
-.gem-c-metadata {
-  .gem-c-metadata__definition-link,
-  .gem-c-metadata__toggle-wrap {
-    display: none;
-  }
-}
+//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
+// https://github.com/alphagov/manuals-frontend/blob/466b4c7a6507a3d76818e26612f174616f5cdf94/app/assets/stylesheets/print.scss#L15

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_search.scss
@@ -1,3 +1,2 @@
-.gem-c-search {
-  display: none;
-}
+//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
+// https://github.com/alphagov/govuk-account-manager-prototype/blob/7858b55afcddc2f855d909abd051838d95f21f13/app/assets/stylesheets/print.scss#L7

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_share-links.scss
@@ -1,3 +1,2 @@
-.gem-c-share-links {
-  display: none;
-}
+//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
+// https://github.com/alphagov/collections/blob/fc9db4ef6d87ad52d0ac795d1dd05d5fa116dde1/app/assets/stylesheets/print.scss#L9

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_skip-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_skip-link.scss
@@ -1,3 +1,2 @@
-.gem-c-skip-link {
-  display: none;
-}
+//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
+// https://github.com/alphagov/govuk-account-manager-prototype/blob/7858b55afcddc2f855d909abd051838d95f21f13/app/assets/stylesheets/print.scss#L8

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_step-by-step-nav-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_step-by-step-nav-header.scss
@@ -5,7 +5,3 @@
 .gem-c-step-nav-header__title {
   @include govuk-font(24, $weight: bold);
 }
-
-.gem-c-step-nav-header__skip-link {
-  display: none;
-}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_subscription-links.scss
@@ -1,3 +1,2 @@
-.gem-c-subscription-links {
-  display: none;
-}
+//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
+// https://github.com/alphagov/frontend/blob/34e84c7d6dc22bd4b06ce4c18a3d00b29fdcee83/app/assets/stylesheets/print.scss#L12

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_translation-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_translation-nav.scss
@@ -1,3 +1,2 @@
-.gem-c-translation-nav {
-  display: none;
-}
+//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
+// https://github.com/alphagov/government-frontend/blob/7a0b068a0faa1da07f58acf0b1d3a0aa3e1daf56/app/assets/stylesheets/print.scss#L16

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -32,7 +32,7 @@
     )
   end
 %>
-<%= tag.section class: "gem-c-attachment" do %>
+<%= tag.section class: "gem-c-attachment govuk-!-display-none-print" do %>
   <%= tag.div class: "gem-c-attachment__thumbnail" do %>
     <%= link_to attachment.url,
                 class: "govuk-link",

--- a/app/views/govuk_publishing_components/components/_back_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_back_link.html.erb
@@ -5,6 +5,6 @@
 <%= link_to(
   text,
   href,
-  class: %w(gem-c-back-link govuk-back-link),
+  class: %w(gem-c-back-link govuk-back-link govuk-!-display-none-print),
   data: data_attributes
 ) %>

--- a/app/views/govuk_publishing_components/components/_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_button.html.erb
@@ -7,7 +7,7 @@
 
 <% start_button_text = capture do %>
   <%= button.text %>
-  <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+  <svg class="govuk-button__start-icon govuk-!-display-none-print" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
     <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
   </svg>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -8,7 +8,7 @@
   path_without_pii = utf_encode(request.fullpath.gsub(email_regex, '[email]'))
 %>
 
-<div class="gem-c-feedback" data-module="feedback">
+<div class="gem-c-feedback govuk-!-display-none-print" data-module="feedback">
   <%= render "govuk_publishing_components/components/feedback/yes_no_banner" %>
   <%= render "govuk_publishing_components/components/feedback/problem_form", url_without_pii: url_without_pii %>
   <%= render "govuk_publishing_components/components/feedback/survey_signup_form", path_without_pii: path_without_pii %>

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -29,7 +29,7 @@
               list_classes = %w[govuk-footer__list]
               list_classes << "govuk-footer__list--columns-#{item[:columns]}" if item[:columns] unless single_item_list
             %>
-            <div class="<%= width_class %>">
+            <div class="<%= width_class %> govuk-!-display-none-print">
               <h2 class="govuk-footer__heading govuk-heading-m"><%= item[:title] %></h2>
                 <ul class="<%= list_classes.join(' ') %>">
                   <% item[:items].each do |item| %>
@@ -58,7 +58,7 @@
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         <% if meta.any? %>
           <h2 class="govuk-visually-hidden">Support links</h2>
-          <ul class="govuk-footer__inline-list">
+          <ul class="govuk-footer__inline-list govuk-!-display-none-print">
             <% meta[:items].each do |item| %>
               <li class="govuk-footer__inline-list-item">
                 <%

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -42,7 +42,7 @@
       <dd class="gem-c-metadata__definition">
         <%= last_updated %>
         <% if local_assigns.include?(:see_updates_link) %>
-          &#8212; <a href="#history" class="gem-c-metadata__definition-link"
+          &#8212; <a href="#history" class="gem-c-metadata__definition-link govuk-!-display-none-print"
                              data-track-category="content-history"
                              data-track-action="see-all-updates-link-clicked"
                              data-track-label="history">

--- a/app/views/govuk_publishing_components/components/_print_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_print_link.html.erb
@@ -13,7 +13,7 @@
     margin_bottom: margin_bottom
   })
 
-  wrapper_classes = %w(gem-c-print-link)
+  wrapper_classes = %w(gem-c-print-link govuk-!-display-none-print)
   wrapper_classes << "gem-c-print-link--show-without-js" unless require_js
   wrapper_classes << (shared_helper.get_margin_top)
   wrapper_classes << (shared_helper.get_margin_bottom)

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -10,7 +10,7 @@
   size ||= ""
   value ||= ""
 
-  classes = %w[gem-c-search]
+  classes = %w[gem-c-search govuk-!-display-none-print]
   classes << (shared_helper.get_margin_top)
   classes << (shared_helper.get_margin_bottom) if local_assigns[:margin_bottom]
   classes << "gem-c-search--large" if size == "large"

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -8,7 +8,7 @@
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
 
-  classes = %w(gem-c-share-links)
+  classes = %w(gem-c-share-links govuk-!-display-none-print)
   classes << "gem-c-share-links--stacked" if stacked
   classes << "gem-c-share-links--columns" if columns
   classes << brand_helper.brand_class

--- a/app/views/govuk_publishing_components/components/_skip_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_skip_link.html.erb
@@ -2,4 +2,4 @@
   href ||= '#main-content'
   text ||= t('components.skip_link.text')
 %>
-<%= link_to(text, href, class: "gem-c-skip-link govuk-skip-link") %>
+<%= link_to(text, href, class: "gem-c-skip-link govuk-skip-link govuk-!-display-none-print") %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
@@ -19,7 +19,7 @@
 <% if steps %>
   <div
     data-module="gemstepnav"
-    class="gem-c-step-nav js-hidden <% unless small %>gem-c-step-nav--large<% end %>"
+    class="gem-c-step-nav js-hidden <% if small %>govuk-!-display-none-print<% end %> <% unless small %>gem-c-step-nav--large<% end %>"
     <%= "data-remember" if remember_last_step %>
     <%= "data-id=#{tracking_id}" if tracking_id %>
     data-show-text="<%= t("components.step_by_step_nav.show", default: "show") %>"
@@ -56,7 +56,7 @@
                       <%= logic %>
                     <% else %>
                       <% step_number += 1 %>
-                      <span class="gem-c-step-nav__circle-step-label visuallyhidden">Step</span> <%= step_number %><span class="gem-c-step-nav__circle-step-colon visuallyhidden" aria-hidden="true">:</span>
+                      <span class="gem-c-step-nav__circle-step-label govuk-!-display-none-print visuallyhidden">Step</span> <%= step_number %><span class="gem-c-step-nav__circle-step-colon govuk-!-display-none-print visuallyhidden" aria-hidden="true">:</span>
                     <% end %>
                   </span>
                 </span>

--- a/app/views/govuk_publishing_components/components/_subscription_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription_links.html.erb
@@ -8,7 +8,7 @@
   local_assigns[:margin_bottom] ||= 0
   local_assigns[:margin_bottom] = 0 if local_assigns[:margin_bottom] > 9
 
-  css_classes = %w( gem-c-subscription-links )
+  css_classes = %w( gem-c-subscription-links govuk-!-display-none-print )
   css_classes << (shared_helper.get_margin_bottom) unless local_assigns[:margin_bottom] == 0
   css_classes << brand_helper.brand_class
   css_classes << "gem-c-subscription-links--with-feed-box" if sl_helper.feed_link_box_value

--- a/app/views/govuk_publishing_components/components/_translation_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_translation_nav.html.erb
@@ -5,7 +5,7 @@
 %>
 <% if translation_helper.has_translations? %>
   <nav role="navigation"
-    class="gem-c-translation-nav <%= translation_helper.classes %> <%= brand_helper.brand_class %>"
+    class="gem-c-translation-nav govuk-!-display-none-print <%= translation_helper.classes %> <%= brand_helper.brand_class %>"
     aria-label="<%= t("common.translations") %>"
     <%= "data-module=\"gem-track-click\"" if translation_helper.tracking_is_present? %>
   >

--- a/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
@@ -4,7 +4,7 @@
   <button
     aria-controls="navigation"
     aria-label="Show or hide Top Level Navigation"
-    class="govuk-header__menu-button govuk-js-header-toggle gem-c-header__menu-button"
+    class="govuk-header__menu-button govuk-js-header-toggle gem-c-header__menu-button govuk-!-display-none-print"
     type="button"
   >
     <%= t("components.layout_header.menu") %>

--- a/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
+++ b/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
@@ -8,9 +8,9 @@
 %>
 <% if remaining.any? %>
   <%= items.to_sentence(last_word_connector: ', ').html_safe %>
-  <div class="gem-c-metadata__toggle-wrap">
+  <div class="gem-c-metadata__toggle-wrap govuk-!-display-none-print">
     <a href="#"
-       class="gem-c-metadata__definition-link"
+       class="gem-c-metadata__definition-link govuk-!-display-none-print"
        data-controls="toggle-<%= toggle_id %>"
        data-expanded="false"
        data-toggled-text="<%= t("components.metadata.toggle_less", default: "Show fewer") %>">


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
Where possible and practicable, remove `display: none` rules from component print stylesheets, and use the `govuk-!-display-none-print` class instead.
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->
Many components are hidden in the printable version due to being interactive or simply irrelevant to a user printing a page.
This is currently done in separate print stylesheets.

Thanks to the adoption of a dedicated `govuk-!-display-none-print` class in govuk-frontend, we can remove `display:none` from many components' print stylesheets and use the special class instead.

The next step would be to remove all references for now empty component stylesheets from the GOVUK apps.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
No visual changes should occur as a result. 

Fixes #1770
Also, closes #2063 

https://trello.com/c/EHMAHSjh