### PR TITLE
Add explicit config for Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,45 @@
+# This overrides the config in the Dependabot UI.
+# We're trialling this to see if it can be used as
+# a way to reduce the number of Dependabot PRs for
+# gems where updates aren't so valuable.
+version: 1
+update_configs:
+  - package_manager: ruby:bundler
+    directory: /
+    update_schedule: daily
+    allowed_updates:
+      # Security updates - we should always do these
+      - match: { update_type: security }
+      - match: { dependency_name: brakeman }
+      # Internal gems - we should always update these
+      - match: { dependency_name: gds-api-adapters }
+      - match: { dependency_name: gds-sso }
+      - match: { dependency_name: govspeak }
+      - match: { dependency_name: govuk_app_config }
+      - match: { dependency_name: govuk_publishing_components }
+      - match: { dependency_name: govuk_schemas }
+      - match: { dependency_name: govuk_sidekiq }
+      - match: { dependency_name: govuk_test }
+      - match: { dependency_name: rubocop-govuk }
+      - match: { dependency_name: plek }
+      - match: { dependency_name: scss_lint-govuk }
+      # Framework gems - we use these to write lots of code
+      - match: { dependency_name: factory_bot_rails }
+      - match: { dependency_name: jasmine }
+      - match: { dependency_name: rails }
+      - match: { dependency_name: rspec-rails }
+      - match: { dependency_name: sass-rails }
+      - match: { dependency_name: sassc-rails }
+  - package_manager: javascript
+    directory: /
+    update_schedule: daily
+    allowed_updates:
+      # Security updates - we should always do these
+      - match: { update_type: security }
+      # Internal packages - we should always update these
+      - match: { dependency_name: accessible-autocomplete }
+      - match: { dependency_name: markdown-toolbar-element }
+      - match: { dependency_name: miller-columns-element }
+      - match: { dependency_name: paste-html-to-govspeak }
+      # Framework packages - we use these to write lots of code
+      - match: { dependency_name: govuk-frontend }


### PR DESCRIPTION
Currently Dependabot is enabled for all Gems and packages on this repo. We'd like to trial limiting the number of PRs opened by Dependabot to libraries that we care about explicitly.

See https://github.com/alphagov/content-publisher/pull/2062 for more context on this configuration file (and a similar config file for Content Publisher).

There's a few reasons I've picked this repo to try out this config (as well as the existing configuration in Content Publisher).

- It's a Gem, allowing us to learn more about if there's anything special about Gems which means going down this route would be problematic.
- It includes a framework library (`govuk-frontend`) which we'd want to have enabled for this repo, but perhaps not for any others.
- It allows us to test the idea of having a global config file containing rules for libraries not used by this repo, and check that Dependabot is okay with that.