### PR TITLE
Bump to 21.55.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 21.55.3
+
+* Use video title as eventLabel for YT video event tracking ([PR #1562](https://github.com/alphagov/govuk_publishing_components/pull/1562))
+
 ## 21.55.2
 
 * Reorder the breadcrumb so superbreadcrumb not top option ([PR #1556](https://github.com/alphagov/govuk_publishing_components/pull/1556))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.55.2)
+    govuk_publishing_components (21.55.3)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.55.2".freeze
+  VERSION = "21.55.3".freeze
 end


### PR DESCRIPTION
## 21.55.3

* Use video title as eventLabel for YT video event tracking ([PR #1562](https://github.com/alphagov/govuk_publishing_components/pull/1562))