### PR TITLE
Rework suggested imports functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Rework suggested imports functionality ([PR #1571](https://github.com/alphagov/govuk_publishing_components/pull/1571))
 * Remove unnecessary margin around expanded feedback component ([PR #1547](https://github.com/alphagov/govuk_publishing_components/pull/1547))
 
 ## 21.55.3

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -2,6 +2,8 @@ module GovukPublishingComponents
   class ComponentGuideController < GovukPublishingComponents::ApplicationController
     append_view_path File.join(Rails.root, "app", "views", GovukPublishingComponents::Config.component_directory_name)
 
+    MATCH_COMPONENTS = /(?<=govuk_publishing_components\/components\/)[\/a-zA-Z_-]+(?=['"])/.freeze
+
     def index
       @application_path = Rails.root
       @component_gem_path = Gem.loaded_specs["govuk_publishing_components"].full_gem_path
@@ -86,24 +88,30 @@ module GovukPublishingComponents
 
       files.each do |file|
         data = File.read(file)
-        matches << data.scan(/(govuk_publishing_components\/components\/[a-z_-]+)/)
+        matches << data.scan(MATCH_COMPONENTS)
       end
 
-      matches.flatten.uniq.map(&:to_s).sort.map { |m| m.gsub("govuk_publishing_components/components/", "") }
+      matches.flatten.uniq.map(&:to_s).sort
     end
 
-    def find_all_partials_in(components)
-      components_to_search = components
-      partials_found = true
+    def find_all_partials_in(templates)
+      components = [templates]
 
-      while partials_found
-        extra_components = find_partials_in(components_to_search)
+      templates.each do |template|
+        partials_found = true
+        components_to_search = [template]
+        components_found = []
 
-        if extra_components.any?
-          components << extra_components
-          components_to_search = extra_components
-        else
-          partials_found = false
+        while partials_found
+          extra_components = find_partials_in(components_to_search)
+
+          if extra_components.any?
+            components_found << extra_components
+            components_to_search = extra_components
+          else
+            partials_found = false
+            components << components_found.uniq.sort if components_found.any?
+          end
         end
       end
 
@@ -113,8 +121,7 @@ module GovukPublishingComponents
     def find_partials_in(components)
       extra_components = []
       components.each do |component|
-        components_in_component = components_within_component(component)
-        extra_components << components_in_component
+        extra_components << components_within_component(component)
       end
 
       extra_components.flatten.uniq.sort
@@ -132,9 +139,12 @@ module GovukPublishingComponents
     def components_within_component(component)
       filename = @component_gem_path + "/app/views/govuk_publishing_components/components/#{component}.html.erb"
       filename = filename.sub(/.*\K\//, "/_") # files begin with _ but the method may have been passed 'filename' or 'dir/partial'
+
+      return [] unless File.file?(filename)
+
       data = File.read(filename)
-      match = data.scan(/(govuk_publishing_components\/components\/[\/a-z_-]+)/)
-      match.flatten.uniq.map(&:to_s).sort.map { |m| m.gsub("govuk_publishing_components/components/", "") }
+      match = data.scan(MATCH_COMPONENTS)
+      match.flatten.uniq.map(&:to_s).sort
     end
 
     def index_breadcrumb

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
     <div id='wrapper'>
       <%= yield %>
     </div>
+    <%= render "govuk_publishing_components/components/attachment/thumbnail_spreadsheet.svg" %>
     <%= render "govuk_publishing_components/components/feedback" %>
   </body>
 </html>


### PR DESCRIPTION
## What
Modifies the logic behind the suggested imports functionality of the component guide to be more specific when dealing with includes that look like components, but aren't.

## Why
This is causing a 500 error in content-publisher, see https://github.com/alphagov/govuk_publishing_components/issues/1570

## Visual Changes
None.
