### PR TITLE
369 Show breadcrumbs alongside superbreadcrumbs everywhere they appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove unnecessary margin around expanded feedback component ([PR #1547](https://github.com/alphagov/govuk_publishing_components/pull/1547))
+* Show breadcrumbs alongside superbreadcrumbs everywhere they appear ([PR #1572](https://github.com/alphagov/govuk_publishing_components/pull/1572))
 
 ## 21.55.3
 

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -1,16 +1,20 @@
 <% prioritise_taxon_breadcrumbs ||= false %>
-<% breadcrumb_selector = GovukPublishingComponents::Presenters::BreadcrumbSelector.call(content_item, request, prioritise_taxon_breadcrumbs) %>
+<% breadcrumb_selector = GovukPublishingComponents::Presenters::BreadcrumbSelector.new(content_item, request, prioritise_taxon_breadcrumbs) %>
 <% inverse ||= false %>
 <% collapse_on_mobile ||= true unless local_assigns[:collapse_on_mobile].eql?(false) %>
 
-<div class='gem-c-contextual-breadcrumbs'>
-  <% if breadcrumb_selector[:step_by_step] %>
-    <%= render 'govuk_publishing_components/components/step_by_step_nav_header',
-               breadcrumb_selector[:breadcrumbs] %>
-  <% elsif breadcrumb_selector[:breadcrumbs] %>
+<div class="gem-c-contextual-breadcrumbs">
+  <% if breadcrumb_selector.step_by_step %>
+    <%= render 'govuk_publishing_components/components/step_by_step_nav_header', breadcrumb_selector.breadcrumbs %>
+  <% elsif breadcrumb_selector.breadcrumbs %>
     <%= render 'govuk_publishing_components/components/breadcrumbs',
-               breadcrumbs: breadcrumb_selector[:breadcrumbs],
+               breadcrumbs: breadcrumb_selector.breadcrumbs,
                inverse: inverse,
                collapse_on_mobile: collapse_on_mobile %>
   <% end %>
+
+  <%= render(
+        'govuk_publishing_components/components/step_by_step_nav_header', breadcrumb_selector.priority_breadcrumbs
+      ) if breadcrumb_selector.priority_breadcrumbs
+  %>
 </div>

--- a/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
+++ b/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
@@ -1,10 +1,6 @@
 module GovukPublishingComponents
   module Presenters
     class BreadcrumbSelector
-      def self.call(*args)
-        new(*args).output
-      end
-
       attr_reader :content_item, :request, :prioritise_taxon_breadcrumbs
 
       def initialize(content_item, request, prioritise_taxon_breadcrumbs)
@@ -12,6 +8,22 @@ module GovukPublishingComponents
         @request = request
         @prioritise_taxon_breadcrumbs = prioritise_taxon_breadcrumbs
       end
+
+      def breadcrumbs
+        best_match_option[:breadcrumbs]
+      end
+
+      def step_by_step
+        best_match_option[:step_by_step]
+      end
+
+      def priority_breadcrumbs
+        return parent_item_navigation.priority_breadcrumbs if content_item_navigation.html_publication_with_parent?
+
+        content_item_navigation.priority_breadcrumbs
+      end
+
+    private
 
       def content_item_navigation
         @content_item_navigation ||= ContextualNavigation.new(content_item, request)
@@ -45,9 +57,8 @@ module GovukPublishingComponents
         }
       end
 
-      def output
+      def best_match_option
         return content_item_options unless content_item_navigation.html_publication_with_parent?
-        return parent_item_options if parent_item_navigation.priority_breadcrumbs
 
         step_by_step_header = parent_item_options[:step_by_step]
 
@@ -67,11 +78,6 @@ module GovukPublishingComponents
           {
             step_by_step: true,
             breadcrumbs: navigation.step_nav_helper.header,
-          }
-        elsif navigation.priority_breadcrumbs
-          {
-            step_by_step: true,
-            breadcrumbs: navigation.priority_breadcrumbs,
           }
         elsif navigation.content_is_tagged_to_a_live_taxon? && prioritise_taxon_breadcrumbs
           {

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -4,8 +4,9 @@ describe "Contextual navigation" do
   scenario "There is a coronavirus taxon" do
     given_theres_a_page_with_coronavirus_taxon
     and_i_visit_that_page
-    then_i_do_not_see_home_and_parent_breadcrumbs
-    then_i_see_the_coronavirus_contextual_breadcrumbs
+    then_i_see_the_step_by_step
+    and_the_step_by_step_header
+    and_i_see_the_coronavirus_contextual_breadcrumbs
   end
 
   scenario "There's a step by step list" do
@@ -54,15 +55,15 @@ describe "Contextual navigation" do
     given_there_is_a_parent_page
     and_the_page_is_an_html_publication_with_that_parent
     and_i_visit_that_page
-    then_i_see_home_and_parent_breadcrumbs
+    then_i_see_home_and_parent_links
   end
 
   scenario "It's a HTML Publication with a parent with coronavirus taxon" do
     given_there_is_a_parent_page_with_coronavirus_taxon
     and_the_page_is_an_html_publication_with_that_parent
     and_i_visit_that_page
-    then_i_do_not_see_home_and_parent_breadcrumbs
-    then_i_see_the_coronavirus_contextual_breadcrumbs
+    then_i_see_home_and_parent_links
+    and_i_see_the_coronavirus_contextual_breadcrumbs
   end
 
   scenario "It's a HTML Publication with a parent with breadcrumbs" do
@@ -118,7 +119,6 @@ describe "Contextual navigation" do
     given_there_are_one_primary_step_by_steps_and_one_secondary_to_step_navs
     and_i_visit_that_page
     then_i_see_the_step_by_step
-    and_the_step_by_step_header
     then_i_see_the_primary_step_by_step
   end
 
@@ -284,7 +284,12 @@ describe "Contextual navigation" do
     live_taxon = example_item("taxon", "taxon")
     live_taxon["links"]["parent_taxons"] = [coronavirus_taxon]
 
-    content_store_has_random_item links: { "taxons" => [live_taxon] }
+    content_store_has_random_item(
+      links: {
+        "taxons" => [live_taxon],
+        part_of_step_navs: [random_step_nav_item("step_by_step_nav")],
+      },
+    )
   end
 
   def given_there_is_a_parent_page
@@ -426,7 +431,7 @@ describe "Contextual navigation" do
     end
   end
 
-  def then_i_see_the_coronavirus_contextual_breadcrumbs
+  def and_i_see_the_coronavirus_contextual_breadcrumbs
     within ".gem-c-contextual-breadcrumbs" do
       expect(page).to have_link(coronavirus_taxon["title"])
     end
@@ -447,6 +452,14 @@ describe "Contextual navigation" do
   def then_i_see_the_legacy_topic_in_the_related_navigation_footer
     within ".gem-c-contextual-footer" do
       expect(page).to have_css(".gem-c-related-navigation__link", text: "Oil and gas")
+    end
+  end
+
+  # Use links version if output could be either step by step or breadcrumbs
+  def then_i_see_home_and_parent_links
+    within ".gem-c-contextual-breadcrumbs" do
+      expect(page).to have_link("Home")
+      expect(page).to have_link(@parent["title"])
     end
   end
 

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -52,7 +52,7 @@ describe "Contextual navigation" do
   end
 
   scenario "It's a HTML Publication document" do
-    given_there_is_a_parent_page
+    given_there_is_a_non_step_by_step_parent_page
     and_the_page_is_an_html_publication_with_that_parent
     and_i_visit_that_page
     then_i_see_home_and_parent_links
@@ -292,17 +292,24 @@ describe "Contextual navigation" do
     )
   end
 
-  def given_there_is_a_parent_page
-    @parent = random_item("placeholder")
+  def given_there_is_a_non_step_by_step_parent_page
+    @parent = not_step_by_step_content
   end
 
   def given_there_is_a_parent_page_with_coronavirus_taxon
     taxon = example_item("taxon", "taxon")
     taxon["links"]["parent_taxons"] = [coronavirus_taxon]
 
-    @parent = random_item("placeholder")
+    @parent = not_step_by_step_content
     @parent["links"]["taxons"] = [taxon]
     @parent["links"].delete("finder")
+  end
+
+  def not_step_by_step_content
+    not_step_by_step_content = random_item("placeholder")
+    not_step_by_step_content["links"].delete("part_of_step_navs")
+    not_step_by_step_content["links"].delete("secondary_to_step_navs")
+    not_step_by_step_content
   end
 
   def given_there_is_a_parent_page_with_two_taxon


### PR DESCRIPTION
## What
We want to show breadcrumbs alongside superbreadcrumbs where we're using them. Superbreadcrumbs should appear below breadcrumbs. This is how they worked when originally implemented on step by steps.

Also refactor of `BreadcrumbSelector` to return an instance with public methods rather than a hash.

## Why
We want breadcrumbs to be a consistent pattern on every page of the site. But keep the benefits of the superbreadcrumbs on coronavirus content and step by steps.

## Visual Changes

### Before change

![breadcrumbs_and_superbreadcrumb_before_change](https://user-images.githubusercontent.com/213040/84516578-e5133f00-acc5-11ea-9cb4-b053a73b6a8f.png)

### After change

![breadcrumbs_and_superbreadcrumb_version_2](https://user-images.githubusercontent.com/213040/84516602-ee9ca700-acc5-11ea-9053-f918141ae681.png)

### Same in mobile view

![breadcrumbs_and_superbreadcrumb_version_2_mobile](https://user-images.githubusercontent.com/213040/84516625-f6f4e200-acc5-11ea-9c54-c6eb9a1661f5.png)

