### PR TITLE
Update summary list component to allow delete action at the group level and custom heading levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update summary list component to allow delete action at the group level and custom heading levels ([PR #1574](https://github.com/alphagov/govuk_publishing_components/pull/1574))
+
 ## 21.55.4
 
 * Rework suggested imports functionality ([PR #1571](https://github.com/alphagov/govuk_publishing_components/pull/1571))

--- a/app/assets/stylesheets/govuk_publishing_components/component_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/component_support.scss
@@ -8,6 +8,7 @@
 
 @import "govuk_publishing_components/components/helpers/variables";
 @import "govuk_publishing_components/components/helpers/brand-colours";
+@import "govuk_publishing_components/components/helpers/link";
 @import "govuk_publishing_components/components/mixins/govuk-template-link-focus-override";
 @import "govuk_publishing_components/components/mixins/media-down";
 @import "govuk_publishing_components/components/mixins/margins";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_summary-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_summary-list.scss
@@ -1,7 +1,6 @@
 @import "govuk/components/summary-list/summary-list";
 
 .gem-c-summary-list {
-  position: relative;
   border-bottom: 1px solid $govuk-border-colour;
 
   @include govuk-font(19);
@@ -14,12 +13,26 @@
   &:nth-last-of-type(1) {
     border-bottom: 0;
   }
+
+  .govuk-summary-list {
+    clear: both;
+  }
 }
 
-.gem-c-summary-list__edit-section-link {
-  position: absolute;
-  top: 0;
-  right: 0;
+.gem-c-summary-list__group-title {
+  @include govuk-media-query($from: tablet) {
+    display: inline-block;
+    margin-right: govuk-spacing(3);
+  }
+}
+
+.gem-c-summary-list__group-actions-list {
+  margin-bottom: govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    float: right;
+    width: auto;
+  }
 }
 
 .gem-c-summary__block {

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_link.scss
@@ -1,0 +1,17 @@
+.gem-link--destructive {
+  @include govuk-font(19);
+
+  &:link {
+    color: $govuk-error-colour;
+  }
+
+  &:visited,
+  &:hover,
+  &:active {
+    color: darken($govuk-error-colour, 5%);
+  }
+
+  &:focus {
+    color: $govuk-focus-text-colour;
+  }
+}

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -3,21 +3,36 @@
   title ||= nil
   borderless ||= false
   edit ||= {}
+  delete ||= {}
   items ||= []
   block ||= yield
 %>
 <% if title || items.any? %>
   <%= tag.div class: "gem-c-summary-list #{"govuk-summary-list--no-border" if borderless}", id: id do %>
     <% if title %>
-      <%= tag.h3 title, class: "govuk-heading-m" %>
-      <% if edit.any? %>
-        <%= tag.ul class: "govuk-summary-list__actions-list" do %>
-          <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
-            <%= link_to edit.fetch(:href),
-                      class: "govuk-link gem-c-summary-list__edit-section-link",
-                      title: "#{edit.fetch(:link_text, "Change")} #{title}",
-                      data: edit.fetch(:data_attributes, {}) do %>
-               <%= edit.fetch(:link_text, "Change") %> <%= tag.span title, class: "govuk-visually-hidden" %>
+      <%= tag.h3 title, class: "govuk-heading-m gem-c-summary-list__group-title" %>
+      <% if edit.any? || delete.any? %>
+        <%= tag.ul class: "govuk-summary-list__actions-list gem-c-summary-list__group-actions-list" do %>
+          <%- if edit.any? %>
+            <% edit_section_link_text = edit[:link_text] || "Change" %>
+            <%= tag.li class: "govuk-summary-list__actions-list-item" do -%>
+              <%= link_to edit.fetch(:href),
+                        class: "govuk-link",
+                        title: "#{edit_section_link_text} #{title}",
+                        data: edit.fetch(:data_attributes, {}) do %>
+                <%= edit_section_link_text %><%= tag.span " #{title}", class: "govuk-visually-hidden" -%>
+              <% end %>
+            <% end %>
+          <% end %>
+          <% if delete.any? %>
+            <% delete_section_link_text = delete[:link_text] || "Delete" %>
+            <%= tag.li class: "govuk-summary-list__actions-list-item" do -%>
+              <%= link_to delete.fetch(:href),
+                        class: "govuk-link",
+                        title: "#{delete_section_link_text} #{title}",
+                        data: delete.fetch(:data_attributes, {}) do %>
+                <%= delete_section_link_text %><%= tag.span " #{title}", class: "govuk-visually-hidden" -%>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>
@@ -42,7 +57,8 @@
                                   class: "govuk-link",
                                   title: "#{edit_link_text} #{item[:field]}",
                                   data: item[:edit].fetch(:data_attributes, {}) do %>
-                        <%= edit_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" %><% end %>
+                        <%= edit_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" -%>
+                      <% end %>
                     <% end %>
                   <% end %>
                   <% if item.fetch(:delete, {}).any? %>
@@ -52,7 +68,7 @@
                                   class: "govuk-link",
                                   title: "#{delete_link_text} #{item[:field]}",
                                   data: item[:delete].fetch(:data_attributes, {}) do %>
-                        <%= delete_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" %>
+                        <%= delete_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" -%>
                       <% end %>
                     <% end %>
                   <% end %>

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -18,7 +18,7 @@
       <% if edit.any? || delete.any? %>
         <%= tag.ul class: "govuk-summary-list__actions-list gem-c-summary-list__group-actions-list" do %>
           <%- if edit.any? %>
-            <% edit_section_link_text = edit[:link_text] || "Change" %>
+            <% edit_section_link_text = edit[:link_text] || t("components.summary_list.edit") %>
             <%= tag.li class: "govuk-summary-list__actions-list-item" do -%>
               <%= link_to edit.fetch(:href),
                         class: "govuk-link",
@@ -29,7 +29,7 @@
             <% end %>
           <% end %>
           <% if delete.any? %>
-            <% delete_section_link_text = delete[:link_text] || "Delete" %>
+            <% delete_section_link_text = delete[:link_text] || t("components.summary_list.delete") %>
             <%= tag.li class: "govuk-summary-list__actions-list-item" do -%>
               <%= link_to delete.fetch(:href),
                         class: "govuk-link gem-link--destructive",
@@ -56,7 +56,7 @@
                 <%= tag.ul class: "govuk-summary-list__actions-list" do %>
                   <% if item.fetch(:edit, {}).any? %>
                     <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
-                      <% edit_link_text = item[:edit][:link_text] || "Change" %>
+                      <% edit_link_text = item[:edit][:link_text] || t("components.summary_list.edit") %>
                       <%= link_to item[:edit].fetch(:href),
                                   class: "govuk-link",
                                   title: "#{edit_link_text} #{item[:field]}",
@@ -67,7 +67,7 @@
                   <% end %>
                   <% if item.fetch(:delete, {}).any? %>
                     <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
-                      <% delete_link_text = item[:delete][:link_text] || "Delete" %>
+                      <% delete_link_text = item[:delete][:link_text] || t("components.summary_list.delete") %>
                       <%= link_to item[:delete].fetch(:href),
                                   class: "govuk-link gem-link--destructive",
                                   title: "#{delete_link_text} #{item[:field]}",

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -28,7 +28,7 @@
             <% delete_section_link_text = delete[:link_text] || "Delete" %>
             <%= tag.li class: "govuk-summary-list__actions-list-item" do -%>
               <%= link_to delete.fetch(:href),
-                        class: "govuk-link",
+                        class: "govuk-link gem-link--destructive",
                         title: "#{delete_section_link_text} #{title}",
                         data: delete.fetch(:data_attributes, {}) do %>
                 <%= delete_section_link_text %><%= tag.span " #{title}", class: "govuk-visually-hidden" -%>
@@ -65,7 +65,7 @@
                     <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
                       <% delete_link_text = item[:delete][:link_text] || "Delete" %>
                       <%= link_to item[:delete].fetch(:href),
-                                  class: "govuk-link",
+                                  class: "govuk-link gem-link--destructive",
                                   title: "#{delete_link_text} #{item[:field]}",
                                   data: item[:delete].fetch(:data_attributes, {}) do %>
                         <%= delete_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" -%>

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -1,4 +1,8 @@
 <%
+  local_assigns[:heading_level] ||= 3
+  heading_size = 'm' unless ['s', 'm', 'l', 'xl'].include?(heading_size)
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+
   id ||= nil
   title ||= nil
   borderless ||= false
@@ -10,7 +14,7 @@
 <% if title || items.any? %>
   <%= tag.div class: "gem-c-summary-list #{"govuk-summary-list--no-border" if borderless}", id: id do %>
     <% if title %>
-      <%= tag.h3 title, class: "govuk-heading-m gem-c-summary-list__group-title" %>
+      <%= content_tag(shared_helper.get_heading_level, title, class: "govuk-heading-#{heading_size} gem-c-summary-list__group-title") %>
       <% if edit.any? || delete.any? %>
         <%= tag.ul class: "govuk-summary-list__actions-list gem-c-summary-list__group-actions-list" do %>
           <%- if edit.any? %>

--- a/app/views/govuk_publishing_components/components/docs/summary_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/summary_list.yml
@@ -62,6 +62,12 @@ examples:
         data_attributes:
           gtm: "delete-title-summary-body"
 
+  with_custom_section_heading:
+    data:
+      <<: *default-example-data
+      heading_level: 2
+      heading_size: l
+
   with_custom_link_on_section:
     description: |
       Take care that the provided `link_text` still makes sense to screen readers when combined with the title.

--- a/app/views/govuk_publishing_components/components/docs/summary_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/summary_list.yml
@@ -1,5 +1,6 @@
 name: Summary list
 description: Use the summary list to summarise information, for example, a user’s responses at the end of a form.
+body:  This component extends the [Summary list component in the Design System](https://design-system.service.gov.uk/components/summary-list/) allowing the rendering of multiple groups of lists, and actions at the group level.
 accessibility_criteria: |
   Action links in the component must:
 
@@ -40,6 +41,26 @@ examples:
         href: "edit-title-summary-body"
         data_attributes:
           gtm: "edit-title-summary-body"
+
+  with_delete_on_section:
+    data:
+      <<: *default-example-data
+      delete:
+        href: "delete-title-summary-body"
+        data_attributes:
+          gtm: "delete-title-summary-body"
+
+  with_edit_and_delete_on_section:
+    data:
+      <<: *default-example-data
+      edit:
+        href: "edit-title-summary-body"
+        data_attributes:
+          gtm: "edit-title-summary-body"
+      delete:
+        href: "delete-title-summary-body"
+        data_attributes:
+          gtm: "delete-title-summary-body"
 
   with_custom_link_on_section:
     description: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,3 +71,6 @@ en:
       email_signup_link_text: "Get email alerts"
       feed_link_text: "Subscribe to feed"
       subscriptions: "Subscriptions"
+    summary_list:
+      edit: "Change"
+      delete: "Delete"

--- a/spec/components/summary_list_spec.rb
+++ b/spec/components/summary_list_spec.rb
@@ -36,15 +36,17 @@ describe "Summary list", type: :view do
     assert_select '.gem-c-summary-list__group-actions-list .govuk-link.gem-link--destructive[title="Delete Title, summary and body"][href="#delete-title-summary-body"][data-gtm="delete-title-summary-body"]', text: "Delete Title, summary and body"
   end
 
-  it "renders section title with custom link text" do
+  it "renders section title with custom link text and heading level" do
     render_component(
       title: "Items",
+      heading_level: 2,
+      heading_size: "l",
       edit: {
         href: "#custom-action",
         link_text: "Reorder",
       },
     )
-    assert_select ".gem-c-summary-list .govuk-heading-m", text: "Items"
+    assert_select ".gem-c-summary-list h2.govuk-heading-l", text: "Items"
     assert_select '.gem-c-summary-list__group-actions-list .govuk-link[title="Reorder Items"][href="#custom-action"]', text: "Reorder Items"
   end
 

--- a/spec/components/summary_list_spec.rb
+++ b/spec/components/summary_list_spec.rb
@@ -33,7 +33,7 @@ describe "Summary list", type: :view do
     )
     assert_select ".gem-c-summary-list h3.govuk-heading-m.gem-c-summary-list__group-title", text: "Title, summary and body"
     assert_select '.gem-c-summary-list__group-actions-list .govuk-link[title="Change Title, summary and body"][href="#edit-title-summary-body"][data-gtm="edit-title-summary-body"]', text: "Change Title, summary and body"
-    assert_select '.gem-c-summary-list__group-actions-list .govuk-link[title="Delete Title, summary and body"][href="#delete-title-summary-body"][data-gtm="delete-title-summary-body"]', text: "Delete Title, summary and body"
+    assert_select '.gem-c-summary-list__group-actions-list .govuk-link.gem-link--destructive[title="Delete Title, summary and body"][href="#delete-title-summary-body"][data-gtm="delete-title-summary-body"]', text: "Delete Title, summary and body"
   end
 
   it "renders section title with custom link text" do
@@ -120,7 +120,7 @@ describe "Summary list", type: :view do
     )
     assert_select ".govuk-summary-list__key", text: "Title"
     assert_select ".govuk-summary-list__value", text: "Ethical standards for public service providers"
-    assert_select '.govuk-summary-list__actions-list-item .govuk-link[title="Delete Title"][href="#delete-title"][data-gtm="delete-title"]', text: "Delete Title"
+    assert_select '.govuk-summary-list__actions-list-item .govuk-link.gem-link--destructive[title="Delete Title"][href="#delete-title"][data-gtm="delete-title"]', text: "Delete Title"
   end
 
   it "renders items with custom text for edit and delete action" do
@@ -141,6 +141,6 @@ describe "Summary list", type: :view do
       ],
     )
     assert_select '.govuk-summary-list__actions-list-item .govuk-link[title="Edit Title"][href="#edit-title"]', text: "Edit Title"
-    assert_select '.govuk-summary-list__actions-list-item .govuk-link[title="Remove Title"][href="#delete-title"]', text: "Remove Title"
+    assert_select '.govuk-summary-list__actions-list-item .govuk-link.gem-link--destructive[title="Remove Title"][href="#delete-title"]', text: "Remove Title"
   end
 end

--- a/spec/components/summary_list_spec.rb
+++ b/spec/components/summary_list_spec.rb
@@ -15,7 +15,7 @@ describe "Summary list", type: :view do
     assert_select ".gem-c-summary-list .govuk-heading-m", text: "Title, summary and body"
   end
 
-  it "renders section title with edit action" do
+  it "renders section title with edit and delete actions" do
     render_component(
       title: "Title, summary and body",
       edit: {
@@ -24,9 +24,16 @@ describe "Summary list", type: :view do
           gtm: "edit-title-summary-body",
         },
       },
+      delete: {
+        href: "#delete-title-summary-body",
+        data_attributes: {
+          gtm: "delete-title-summary-body",
+        },
+      },
     )
-    assert_select ".gem-c-summary-list .govuk-heading-m", text: "Title, summary and body"
-    assert_select '.gem-c-summary-list__edit-section-link[title="Change Title, summary and body"][href="#edit-title-summary-body"][data-gtm="edit-title-summary-body"]', text: "Change Title, summary and body"
+    assert_select ".gem-c-summary-list h3.govuk-heading-m.gem-c-summary-list__group-title", text: "Title, summary and body"
+    assert_select '.gem-c-summary-list__group-actions-list .govuk-link[title="Change Title, summary and body"][href="#edit-title-summary-body"][data-gtm="edit-title-summary-body"]', text: "Change Title, summary and body"
+    assert_select '.gem-c-summary-list__group-actions-list .govuk-link[title="Delete Title, summary and body"][href="#delete-title-summary-body"][data-gtm="delete-title-summary-body"]', text: "Delete Title, summary and body"
   end
 
   it "renders section title with custom link text" do
@@ -38,7 +45,7 @@ describe "Summary list", type: :view do
       },
     )
     assert_select ".gem-c-summary-list .govuk-heading-m", text: "Items"
-    assert_select '.gem-c-summary-list__edit-section-link[title="Reorder Items"][href="#custom-action"]', text: "Reorder Items"
+    assert_select '.gem-c-summary-list__group-actions-list .govuk-link[title="Reorder Items"][href="#custom-action"]', text: "Reorder Items"
   end
 
   it "renders section title with block" do


### PR DESCRIPTION
## What
Update the summary-list component with the following to support the following features:
 - allow delete action at group level
 - render delete actions as destructive links (in red)
 - allow custom heading level and size on section titles

## Why
Required by design for the [business-volunteer-form](https://github.com/alphagov/govuk-coronavirus-business-volunteer-form)

## Visual Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="960" alt="Screenshot 2020-06-15 at 16 55 47" src="https://user-images.githubusercontent.com/788096/84679384-26efef80-af29-11ea-8db8-bd9422363538.png">

</td><td valign="top">

<img width="960" alt="Screenshot 2020-06-15 at 16 55 35" src="https://user-images.githubusercontent.com/788096/84679413-2bb4a380-af29-11ea-88bc-e68557502fca.png">


</td></tr>
<tr><td valign="top">

<img width="960" alt="Screenshot 2020-06-15 at 16 55 16" src="https://user-images.githubusercontent.com/788096/84679423-2f482a80-af29-11ea-83e4-2a1778dbb855.png">


</td><td valign="top">

<img width="960" alt="Screenshot 2020-06-15 at 16 55 06" src="https://user-images.githubusercontent.com/788096/84679437-340cde80-af29-11ea-9c09-73692b83479f.png">


</td></tr>
</table>

[Trello card](https://trello.com/c/Bszitcav/601-update-summary-list-component-to-allow-delete-action-at-the-group-level)