### PR TITLE
Provide more guidance for developers

### DIFF
--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -2,12 +2,7 @@
 
 <div class="component-markdown">
   <p>Components are packages of template, style, behaviour and documentation that live in your application.</p>
-  <p>A component must:</p>
-  <ul>
-    <li><a href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_principles.md">meet the component principles</a></li>
-    <li><a href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_conventions.md">follow component conventions</a></li>
-  </ul>
-  <p>See the <a href="https://github.com/alphagov/govuk_publishing_components">govuk_publishing_components gem</a> for further details, or <a href="https://docs.publishing.service.gov.uk/manual/components.html#component-guides">a list of all component guides</a>.</p>
+  <p>See the <a href="https://github.com/alphagov/govuk_publishing_components">govuk_publishing_components gem</a> for further details, or <a href="https://docs.publishing.service.gov.uk/manual/components.html#component-guides">a list of all component guides</a>. Read about how to <a href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/publishing-to-rubygems.md">release a new version of the gem</a>.</p>
 </div>
 
 <form role="search" data-module="filter-components" class="component-search">
@@ -86,3 +81,7 @@
     </li>
   <% end %>
 </ul>
+
+<div class="component-markdown">
+  <p class="govuk-body">If you cannot find a suitable component consider extending an existing component or <a href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/develop-component.md">creating a new one</a>.</p>
+</div>


### PR DESCRIPTION
## What
Update the links in the component guide main page to provide clearer guidance for developers. Specifically:

1. Remove most of the existing text/links to make the remaining stuff stand out more.
1. Add link to how to release a new version of the gem.
1. Keep the link to all component documentation.
1. Add a section at the bottom to act as a 'what now?' if developers can't find a component they need.

## Why

1. The existing guidance is too long and isn't answering the questions developers have.
1. We have guidance for versioning the gem but developers aren't finding it. I've seen multiple PRs in the last few weeks where versioning has been done incorrectly. I've also been recently asked by several developers how to version the gem.
1. We should still link to _some_ documentation.
1. I also keep getting questions like 'what do I do if there's no component for this?' The section at the bottom should clarify this.

## Visual changes

I've updated the main guidance at the top of the page to link to the things I think are most relevant. It now looks like this:

<img width="1064" alt="Screenshot 2020-07-03 at 09 45 32" src="https://user-images.githubusercontent.com/861310/86451081-4c933c00-bd12-11ea-90f3-33edc044c8e4.png">

I've also added a new section at the very bottom to provide specific guidance if no suitable component is found. I was originally thinking of doing something clever with the search/filter JS to only show this if no results are found, but just putting it at the bottom is a lot simpler and means it is always visible (so if your search only finds one result, or two, this information is still shown). It looks like this at the bottom:

<img width="1059" alt="Screenshot 2020-07-03 at 09 48 48" src="https://user-images.githubusercontent.com/861310/86451202-7a788080-bd12-11ea-8dcc-ddf337122a6f.png">

and like this after doing a search:

<img width="1032" alt="Screenshot 2020-07-03 at 09 49 09" src="https://user-images.githubusercontent.com/861310/86451220-806e6180-bd12-11ea-8fb8-6c0da5f48270.png">
