### PR TITLE
Fix changelog heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## 21.26.0
+## 21.56.0
 
 * Update summary list component to allow delete action at the group level and custom heading levels ([PR #1574](https://github.com/alphagov/govuk_publishing_components/pull/1574))
 


### PR DESCRIPTION
## What
Fix typo in [#1577](https://github.com/alphagov/govuk_publishing_components/pull/1577/files#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR10)

## Why
🤦 

## Visual Changes
No visual changes.
