### PR TITLE
366 Add worker support hub page to the priority breadcrumb list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## unreleased
 
 * Replace bodged parent breadcrumbs with specialist topic breadcrumbs ([PR #1565](https://github.com/alphagov/govuk_publishing_components/pull/1565))
+* Add worker support hub page to the priority breadcrumb list ([PR #1579](https://github.com/alphagov/govuk_publishing_components/pull/1579))
 
 ## 21.26.0
 

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -6,6 +6,7 @@ module GovukPublishingComponents
       #   and the bottom one the lowest priority
       PRIORITY_TAXONS = {
         education_coronavirus: "272308f4-05c8-4d0d-abc7-b7c2e3ccd249",
+        worker_coronavirus: "b7f57213-4b16-446d-8ded-81955d782680",
         business_coronavirus: "65666cdf-b177-4d79-9687-b9c32805e450",
       }.freeze
 

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
     }
   end
 
+  let(:worker_taxon) do
+    {
+      "content_id" => "b7f57213-4b16-446d-8ded-81955d782680",
+      "base_path" => "/coronavirus-taxon/work-and-financial-support",
+      "title" => "Work and financial support during coronavirus",
+    }
+  end
+
   let(:other_taxon) do
     {
       "content_id" => SecureRandom.uuid,
@@ -41,6 +49,14 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
 
           it "returns the business taxon" do
             expect(subject.taxon).to eq(business_taxon)
+          end
+        end
+
+        context "with worker taxon" do
+          let(:payload) { [worker_taxon] }
+
+          it "returns the worker taxon" do
+            expect(subject.taxon).to eq(worker_taxon)
           end
         end
 


### PR DESCRIPTION
Adds the worker support hub page to the priority breadcrumb list
