### PR TITLE
Release 21.56.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## unreleased
+## 21.56.1
 
 * Replace bodged parent breadcrumbs with specialist topic breadcrumbs ([PR #1565](https://github.com/alphagov/govuk_publishing_components/pull/1565))
 * Add worker support hub page to the priority breadcrumb list ([PR #1579](https://github.com/alphagov/govuk_publishing_components/pull/1579))
 
-## 21.26.0
+## 21.56.0
 
 * Update summary list component to allow delete action at the group level and custom heading levels ([PR #1574](https://github.com/alphagov/govuk_publishing_components/pull/1574))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.56.0)
+    govuk_publishing_components (21.56.1)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.56.0".freeze
+  VERSION = "21.56.1".freeze
 end


### PR DESCRIPTION
* Replace bodged parent breadcrumbs with specialist topic breadcrumbs ([PR #1565](https://github.com/alphagov/govuk_publishing_components/pull/1565))
* Add worker support hub page to the priority breadcrumb list ([PR #1579](https://github.com/alphagov/govuk_publishing_components/pull/1579))
