### PR TITLE
Fix layout on input with prefix/suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix layout on input with prefix/suffix ([PR #1581](https://github.com/alphagov/govuk_publishing_components/pull/1581))
+
 ## 21.56.1
 
 * Replace bodged parent breadcrumbs with specialist topic breadcrumbs ([PR #1565](https://github.com/alphagov/govuk_publishing_components/pull/1565))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -10,6 +10,7 @@
 // TODO: remove these styles once static is made less aggressive
 .gem-c-input.govuk-input {
   margin: 0;
+  min-width: 0;
   padding: govuk-spacing(1);
 
   &.gem-c-input--search-icon {
@@ -40,16 +41,19 @@
   box-sizing: border-box;
   cursor: default; // emphasise non-editable status of prefixes and suffixes
   display: inline-block;
+  flex: 0 0 auto;
+  height: 40px;
+  margin-top: 0;
+  min-width: 40px;
+  padding: govuk-spacing(1);
+  text-align: center;
   white-space: nowrap;
   width: auto;
-  text-align: center;
-  height: 40px;
-  padding: govuk-spacing(1);
-  min-width: 40px;
+
   @if $govuk-typography-use-rem {
+    height: govuk-px-to-rem(40px);
     min-width: govuk-px-to-rem(40px);
   }
-  margin-top: 0;
 }
 
 .gem-c-input__prefix {

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -95,15 +95,14 @@
 
   <% if prefix && suffix %>
     <%= tag.div class: "gem-c-input__wrapper" do %>
-      <%= tag.span prefix, class: "gem-c-input__prefix", aria: { hidden: true } %>
-      <%= input_tag %>
-      <%= tag.span suffix, class: "gem-c-input__suffix", aria: { hidden: true } %>
+      <% # The line below relies on in-line styling for legacy browsers and it's whitespace-sensitive %>
+      <%= tag.span prefix, class: "gem-c-input__prefix", aria: { hidden: true } %><%= input_tag %><%= tag.span suffix, class: "gem-c-input__suffix", aria: { hidden: true } %>
     <% end %>
   <% elsif prefix %>
     <%= tag.div class: "gem-c-input__wrapper" do %>
       <%= tag.span prefix, class: "gem-c-input__prefix", aria: { hidden: true } %><%= input_tag %>
     <% end %>
-  <% elsif suffix %> 
+  <% elsif suffix %>
     <%= tag.div class: "gem-c-input__wrapper" do %>
       <%= input_tag %><%= tag.span suffix, class: "gem-c-input__suffix", aria: { hidden: true } %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -132,6 +132,14 @@ examples:
         text: "What is your name?"
       name: "name"
       heading_size: "l"
+  with_prefix:
+    description: To help users understand how the input should look like. Often used for units of measurement.
+    data:
+      label:
+        text: "Cost, in pounds"
+      name: "cost"
+      width: 10
+      prefix: "£"
   with_suffix:
     description: To help users understand how the input should look like. Often used for units of measurement.
     data:
@@ -145,7 +153,7 @@ examples:
     data:
       label:
         text: "Cost per item, in pounds"
-      name: "Cost-per-item"
+      name: "cost-per-item"
       width: 10
       prefix: "£"
       suffix: "per item"


### PR DESCRIPTION
## What
Fix the layout issues on input with prefix/suffix after adding the [prefix feature](#1509):
 - on mobile devices or when the input was set to full-width (didn't have a specified width) the suffix content was overflowing on the majority of browsers
 - on Firefox, the component was overflowing on narrow screens and mobile devices (as Firefox requires a `min-width` to shrink to)

## Why
To ensure cross-browser and cross-device compatibility.

## Visual Changes
<table>

Chrome 83 – full-width input
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="960" alt="chrome83-before" src="https://user-images.githubusercontent.com/788096/85142708-aee33b80-b240-11ea-8325-b3c5dca0804e.png">

</td><td valign="top">

<img width="960" alt="chrome83-after" src="https://user-images.githubusercontent.com/788096/85142732-b60a4980-b240-11ea-996a-6a32023601b3.png">

</td></tr>
</table>

Firefox 77 – narrow screen
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="286" alt="firefox77-before" src="https://user-images.githubusercontent.com/788096/85143117-434d9e00-b241-11ea-991e-451623135389.png">


</td><td valign="top">

<img width="284" alt="firefox77-after" src="https://user-images.githubusercontent.com/788096/85143125-45aff800-b241-11ea-9171-7efcada8be7b.png">


</td></tr>
</table>

Chrome 83
<img width="960" alt="Chrome83" src="https://user-images.githubusercontent.com/788096/85143166-5496aa80-b241-11ea-980d-3240dfda020c.png">

Firefox 77
<img width="961" alt="Firefox77" src="https://user-images.githubusercontent.com/788096/85143189-5c564f00-b241-11ea-9691-0d59c2465cd8.png">

Edge 83
<img width="960" alt="Edge83" src="https://user-images.githubusercontent.com/788096/85143236-6aa46b00-b241-11ea-8baf-c6b0cee0ba85.png">

IE11
<img width="960" alt="IE11" src="https://user-images.githubusercontent.com/788096/85143258-709a4c00-b241-11ea-9b65-93bcbaa30c1f.png">

IE10
<img width="961" alt="IE10" src="https://user-images.githubusercontent.com/788096/85143273-75f79680-b241-11ea-9b27-d003ac153efd.png">

IE9
<img width="960" alt="IE9" src="https://user-images.githubusercontent.com/788096/85143287-7c860e00-b241-11ea-8428-27daba004b34.png">

IE8
<img width="961" alt="IE8" src="https://user-images.githubusercontent.com/788096/85143316-827bef00-b241-11ea-99d2-ab0f9120fd4d.png">

[Trello card](https://trello.com/c/uk6JEyIN), Fixes https://github.com/alphagov/govuk_publishing_components/issues/1555