### PR TITLE
Hide services cookie banner when JavaScript is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Hide services cookie banner when JavaScript is disabled ([PR #1586](https://github.com/alphagov/govuk_publishing_components/pull/1586))
+
 ## 21.56.2
 
 * Fix layout on input with prefix/suffix ([PR #1581](https://github.com/alphagov/govuk_publishing_components/pull/1581))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -12,6 +12,10 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
   background-color: $govuk-cookie-banner-background;
 }
 
+.gem-c-cookie-banner--services {
+  display: none;
+}
+
 .gem-c-cookie-banner__message {
   display: inline-block;
   padding-bottom: govuk-spacing(2);

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -5,9 +5,11 @@
   cookie_preferences_href ||= "/help/cookies"
   confirmation_message ||= raw("You’ve accepted all cookies. You can <a class='govuk-link' href='#{cookie_preferences_href}' data-module='track-click' data-track-category='cookieBanner' data-track-action='Cookie banner settings clicked from confirmation'>change your cookie settings</a> at any time.")
   services_cookies ||= nil
+  css_classes = %w(gem-c-cookie-banner govuk-clearfix)
+  css_classes << "gem-c-cookie-banner--services" if services_cookies
 %>
 
-<div id="<%= id %>" class="gem-c-cookie-banner govuk-clearfix" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet>
+<div id="<%= id %>" class="<%= css_classes.join(' ') %>" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet>
   <div class="gem-c-cookie-banner__wrapper govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -90,6 +90,7 @@ describe "Cookie banner", type: :view do
       },
     )
 
+    assert_select ".gem-c-cookie-banner.gem-c-cookie-banner--services"
     assert_select ".gem-c-cookie-banner__buttons--flex button[data-module=track-click][data-track-category=cookieBanner][data-accept-cookies=true]", text: "Yes"
     assert_select ".gem-c-cookie-banner__buttons--flex button[data-module=track-click][data-track-category=cookieBanner][data-hide-cookie-banner=true]", text: "No"
     assert_select ".gem-c-cookie-banner__buttons--flex .gem-c-cookie-banner__link[href='/cookies']", text: "How we use cookies"


### PR DESCRIPTION
## What
When JavaScript is disabled we should hide the cookie banner user in services as its sole purpose is to let the user accept/decline cookies used for analytics purposes, which are only being done if JavaScript is enabled.

## Why
To avoid confusing users when JavaScript is disabled

## Visual Changes
Changes to the cookie banner variation used in services (with `services_cookies` set, such as Covid-19 services).
No changes to the cookie banner used on GOV.UK

<table>
<tr><th>JavaScript enabled</th><th>JavaScript disabled</th></tr>
<tr><td valign="top">

<img width="960" alt="Screenshot 2020-06-23 at 17 02 51" src="https://user-images.githubusercontent.com/788096/85427303-7bbbe780-b573-11ea-8d23-8799328034a0.png">

</td><td valign="top">

<img width="960" alt="Screenshot 2020-06-23 at 17 03 10" src="https://user-images.githubusercontent.com/788096/85427340-870f1300-b573-11ea-8e68-89d6b012d2bf.png">

</td></tr>
</table>

