### PR TITLE
Add more font sizes to heading component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add more font sizes to heading component ([PR #1587](https://github.com/alphagov/govuk_publishing_components/pull/1587))
+
 ## 21.59.0
 
 * Add component auditing ([PR #1589](https://github.com/alphagov/govuk_publishing_components/pull/1589))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_heading.scss
@@ -1,15 +1,10 @@
 .gem-c-heading {
-  @include govuk-text-colour;
-  @include govuk-font(27, $weight: bold);
   margin: 0;
 }
 
-.gem-c-heading--font-size-24 {
-  @include govuk-font(24, $weight: bold);
-}
-
-.gem-c-heading--font-size-19 {
-  @include govuk-font(19, $weight: bold);
+.gem-c-heading--font-size-27 {
+  @include govuk-text-colour;
+  @include govuk-font(27, $weight: bold);
 }
 
 // special case for publications and consultations pages

--- a/app/views/govuk_publishing_components/components/docs/heading.yml
+++ b/app/views/govuk_publishing_components/components/docs/heading.yml
@@ -24,10 +24,13 @@ examples:
       text: 'Original consultation'
       heading_level: 3
   different_font_sizes:
-    description: Choose a different font size. Valid options are 24 (24px) and 19 (19px), with the component defaulting to 27px, appropriate for a H1. This option is not tied to the heading_level option in order to give flexibility.
+    description: |
+      Set a different font size for the heading. Uses the [GOV.UK Frontend heading sizes](https://design-system.service.gov.uk/styles/typography/#headings) but defaults to 27px for legacy reasons. Valid options are `xl`, `l`, `m` and `s`.
+
+      This option is not tied to the heading_level option in order to give flexibility.
     data:
-      text: 'Heading 3'
-      font_size: 19
+      text: 'One big heading'
+      font_size: "xl"
   with_id_attribute:
     data:
       text: 'Detail of outcome'

--- a/lib/govuk_publishing_components/presenters/heading_helper.rb
+++ b/lib/govuk_publishing_components/presenters/heading_helper.rb
@@ -7,11 +7,31 @@ module GovukPublishingComponents
         @id = options[:id]
 
         @classes = ""
-        @classes << " gem-c-heading--font-size-#{options[:font_size]}" if [24, 19].include? options[:font_size]
+        @classes << heading_size(options[:font_size])
         @classes << " gem-c-heading--mobile-top-margin" if options[:mobile_top_margin]
         @classes << " gem-c-heading--padding" if options[:padding]
         @classes << " gem-c-heading--border-top-#{options[:border_top]}" if [1, 2, 5].include? options[:border_top]
         @classes << " gem-c-heading--inverse" if options[:inverse]
+      end
+
+    private
+
+      def heading_size(option)
+        gem_class = "gem-c-heading--font-size-"
+        govuk_class = "govuk-heading-"
+
+        case option
+        when "xl"
+          "#{govuk_class}xl"
+        when "l"
+          "#{govuk_class}l"
+        when 24, "m"
+          "#{govuk_class}m"
+        when 19, "s"
+          "#{govuk_class}s"
+        else
+          "#{gem_class}27"
+        end
       end
     end
   end

--- a/spec/components/heading_spec.rb
+++ b/spec/components/heading_spec.rb
@@ -21,14 +21,42 @@ describe "Heading", type: :view do
     assert_select "h3.gem-c-heading", text: "Original consultation"
   end
 
-  it "adds font size 2" do
-    render_component(text: "font size 24", font_size: 24)
-    assert_select ".gem-c-heading.gem-c-heading--font-size-24"
+  it "adds xl font size" do
+    render_component(text: "Extra large", font_size: "xl")
+    assert_select ".gem-c-heading.govuk-heading-xl"
   end
 
-  it "adds font size 3" do
-    render_component(text: "font size 19", font_size: 19)
-    assert_select ".gem-c-heading.gem-c-heading--font-size-19"
+  it "adds l font size" do
+    render_component(text: "Large", font_size: "l")
+    assert_select ".gem-c-heading.govuk-heading-l"
+  end
+
+  it "adds m font size" do
+    render_component(text: "Medium", font_size: "m")
+    assert_select ".gem-c-heading.govuk-heading-m"
+  end
+
+  it "supports legacy font size option of 24" do
+    render_component(text: "Medium", font_size: 24)
+    assert_select ".gem-c-heading.govuk-heading-m"
+  end
+
+  it "adds s font size" do
+    render_component(text: "Small", font_size: "s")
+    assert_select ".gem-c-heading.govuk-heading-s"
+  end
+
+  it "supports legacy font size option of 19" do
+    render_component(text: "Small", font_size: 19)
+    assert_select ".gem-c-heading.govuk-heading-s"
+  end
+
+  it "adds default font size if given no or an invalid value" do
+    render_component(text: "font size not specified")
+    assert_select ".gem-c-heading.gem-c-heading--font-size-27"
+
+    render_component(text: "font size 199", font_size: 199)
+    assert_select ".gem-c-heading.gem-c-heading--font-size-27"
   end
 
   it "has a specified id attribute" do


### PR DESCRIPTION
## What
Add more font sizes to the heading component. We had 19 and 24 (defaulting to 27), which correspond to govuk headings small and medium and this PR adds 36 (large) and 48 (extra large).

I'm not sure why we have 27 as the default as that doesn't match a govuk heading size, but I'm not going to remove it as it's in use all over the place.

## Why
We probably didn't have these font sizes as options before because we also have the Page title component, which provides the 48px size. However I've started to wonder why we need two components and whether one could be enough to provide all needed functionality. This change is an interim step towards merging these two components, plus I need headings of these sizes in one of our applications.


## Visual Changes

<img width="961" alt="Screenshot 2020-06-24 at 09 48 51" src="https://user-images.githubusercontent.com/861310/85524284-f29ec200-b5ff-11ea-86a7-ab9773764887.png">
