### PR TITLE
Add component auditing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add component auditing ([PR #1589](https://github.com/alphagov/govuk_publishing_components/pull/1589))
+
 ## 21.58.0
 
 * Fix search component label accessibility ([PR #1594](https://github.com/alphagov/govuk_publishing_components/pull/1594))

--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -1,0 +1,140 @@
+module GovukPublishingComponents
+  class AuditController < GovukPublishingComponents::ApplicationController
+    def show
+      path = Gem.loaded_specs["govuk_publishing_components"].full_gem_path
+
+      templates_path = "app/views/govuk_publishing_components/components"
+      stylesheets_path = "app/assets/stylesheets/govuk_publishing_components/components"
+      print_stylesheets_path = "app/assets/stylesheets/govuk_publishing_components/components/print"
+      javascripts_path = "app/assets/javascripts/govuk_publishing_components/components"
+      tests_path = "spec/components"
+      js_tests_path = "spec/javascripts/components"
+
+      templates = Dir["#{path}/#{templates_path}/*.html.erb"]
+      stylesheets = Dir["#{path}/#{stylesheets_path}/*.scss"]
+      print_stylesheets = Dir["#{path}/#{print_stylesheets_path}/*.scss"]
+      javascripts = Dir["#{path}/#{javascripts_path}/*.js"]
+      tests = Dir["#{path}/#{tests_path}/*.rb"]
+      js_tests = Dir["#{path}/#{js_tests_path}/*.js"]
+
+      @templates_full_path = "#{path}/#{templates_path}/"
+
+      @components = find_files(templates, [path, templates_path].join("/"))
+      @component_stylesheets = find_files(stylesheets, [path, stylesheets_path].join("/"))
+      @component_print_stylesheets = find_files(print_stylesheets, [path, print_stylesheets_path].join("/"))
+      @component_javascripts = find_files(javascripts, [path, javascripts_path].join("/"))
+      @component_tests = find_files(tests, [path, tests_path].join("/"))
+      @component_js_tests = find_files(js_tests, [path, js_tests_path].join("/"))
+
+      @data = {
+        # name: 'govuk_publishing_components',
+        # components: @components,
+        # component_stylesheets: @component_stylesheets,
+        # component_print_stylesheets: @component_print_stylesheets,
+        # component_javascripts: @component_javascripts,
+        # component_tests: @component_tests,
+        # component_js_tests: @component_js_tests,
+        components_containing_components: find_all_partials_in(templates),
+        component_listing: list_all_component_details,
+      }
+    end
+
+  private
+
+    def find_files(files, replace)
+      files.map { |file| clean_file_name(file.gsub(replace, "")) }.sort
+    end
+
+    def clean_file_name(name)
+      name.tr("/_-", " ").gsub(".html.erb", "").gsub(".scss", "").gsub(".js", "").gsub("spec", "").gsub(".rb", "").strip
+    end
+
+    def get_component_name_from_full_path(path)
+      path.gsub("/_", "/").gsub(@templates_full_path, "").gsub(".html.erb", "").tr('\"\'', "")
+    end
+
+    def get_component_link(component)
+      "/component-guide/#{component.gsub(' ', '_')}"
+    end
+
+    def find_all_partials_in(templates)
+      components = []
+
+      templates.each do |template|
+        partials_found = true
+        components_to_search = [template]
+        components_found = []
+
+        while partials_found
+          extra_components = find_partials_in(components_to_search)
+
+          if extra_components.any?
+            components_found << extra_components
+            components_to_search = extra_components
+          else
+            partials_found = false
+            components_found = components_found.flatten.reject { |c| c.include?("/") }
+
+            if components_found.any?
+              component_name = clean_file_name(get_component_name_from_full_path(template))
+              components << {
+                component: component_name,
+                link: get_component_link(component_name),
+                sub_components: components_found.uniq.sort.map { |name| clean_file_name(name) },
+              }
+            end
+          end
+        end
+      end
+
+      components.sort_by { |c| c[:component] }
+    end
+
+    def find_partials_in(components)
+      extra_components = []
+      components.each do |component|
+        extra_components << components_within_component(component)
+      end
+
+      extra_components.flatten.uniq.sort
+    end
+
+    def components_within_component(file)
+      file = get_component_name_from_full_path(file)
+      file = "#{@templates_full_path}#{file}.html.erb".sub(/.*\K\//, "/_")
+      data = File.read(file)
+      match = data.scan(/["']{1}(govuk_publishing_components\/components\/[\/a-z_-]+["']{1})/)
+      match.flatten.uniq.map(&:to_s).sort.map do |m|
+        m.gsub("govuk_publishing_components/components/", "").tr('\"\'', "")
+      end
+    end
+
+    def list_all_component_details
+      all_component_information = []
+
+      @components.each do |component|
+        all_component_information << {
+          name: component,
+          link: get_component_link(component),
+          stylesheet: check_component_has("stylesheet", component),
+          print_stylesheet: check_component_has("print_stylesheet", component),
+          javascript: check_component_has("javascript", component),
+          tests: check_component_has("test", component),
+          js_tests: check_component_has("js_test", component),
+        }
+      end
+
+      all_component_information
+    end
+
+    def check_component_has(a_thing, component)
+      look_in = @component_stylesheets if a_thing == "stylesheet"
+      look_in = @component_print_stylesheets if a_thing == "print_stylesheet"
+      look_in = @component_javascripts if a_thing == "javascript"
+      look_in = @component_tests if a_thing == "test"
+      look_in = @component_js_tests if a_thing == "js_test"
+
+      true if look_in.include?(component)
+    end
+  end
+end

--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -3,45 +3,12 @@ module GovukPublishingComponents
     def show
       path = Dir.pwd
 
-      templates_path = "app/views/govuk_publishing_components/components"
-      stylesheets_path = "app/assets/stylesheets/govuk_publishing_components/components"
-      print_stylesheets_path = "app/assets/stylesheets/govuk_publishing_components/components/print"
-      javascripts_path = "app/assets/javascripts/govuk_publishing_components/components"
-      tests_path = "spec/components"
-      js_tests_path = "spec/javascripts/components"
-
-      templates = Dir["#{path}/#{templates_path}/*.html.erb"]
-      stylesheets = Dir["#{path}/#{stylesheets_path}/*.scss"]
-      print_stylesheets = Dir["#{path}/#{print_stylesheets_path}/*.scss"]
-      javascripts = Dir["#{path}/#{javascripts_path}/*.js"]
-      tests = Dir["#{path}/#{tests_path}/*.rb"]
-      js_tests = Dir["#{path}/#{js_tests_path}/*.js"]
-
-      @templates_full_path = "#{path}/#{templates_path}/"
-
-      @components = find_files(templates, [path, templates_path].join("/"))
-      @component_stylesheets = find_files(stylesheets, [path, stylesheets_path].join("/"))
-      @component_print_stylesheets = find_files(print_stylesheets, [path, print_stylesheets_path].join("/"))
-      @component_javascripts = find_files(javascripts, [path, javascripts_path].join("/"))
-      @component_tests = find_files(tests, [path, tests_path].join("/"))
-      @component_js_tests = find_files(js_tests, [path, js_tests_path].join("/"))
-
-      data = {
-        components: @components,
-        component_stylesheets: @component_stylesheets,
-        component_print_stylesheets: @component_print_stylesheets,
-        component_javascripts: @component_javascripts,
-        component_tests: @component_tests,
-        component_js_tests: @component_js_tests,
-        components_containing_components: find_all_partials_in(templates),
-        component_listing: list_all_component_details,
-      }
-
-      application_data = analyse_applications(File.expand_path("..", path))
-      compared_data = AuditComparer.new(data, application_data)
+      components = AuditComponents.new(path)
+      applications = analyse_applications(File.expand_path("..", path))
+      compared_data = AuditComparer.new(components.data, applications)
 
       @applications = compared_data.data
-      @gem = compared_data.gem_data
+      @components = compared_data.gem_data
     end
 
   private
@@ -80,102 +47,6 @@ module GovukPublishingComponents
       end
 
       results
-    end
-
-    def find_files(files, replace)
-      files.map { |file| clean_file_name(file.gsub(replace, "")) }.sort
-    end
-
-    def clean_file_name(name)
-      name.tr("/_-", " ").gsub(".html.erb", "").gsub(".scss", "").gsub(".js", "").gsub("spec", "").gsub(".rb", "").strip
-    end
-
-    def get_component_name_from_full_path(path)
-      path.gsub("/_", "/").gsub(@templates_full_path, "").gsub(".html.erb", "").tr('\"\'', "")
-    end
-
-    def get_component_link(component)
-      "/component-guide/#{component.gsub(' ', '_')}"
-    end
-
-    def find_all_partials_in(templates)
-      components = []
-
-      templates.each do |template|
-        partials_found = true
-        components_to_search = [template]
-        components_found = []
-
-        while partials_found
-          extra_components = find_partials_in(components_to_search)
-
-          if extra_components.any?
-            components_found << extra_components
-            components_to_search = extra_components
-          else
-            partials_found = false
-            components_found = components_found.flatten.reject { |c| c.include?("/") }
-
-            if components_found.any?
-              component_name = clean_file_name(get_component_name_from_full_path(template))
-              components << {
-                component: component_name,
-                link: get_component_link(component_name),
-                sub_components: components_found.uniq.sort.map { |name| clean_file_name(name) },
-              }
-            end
-          end
-        end
-      end
-
-      components.sort_by { |c| c[:component] }
-    end
-
-    def find_partials_in(components)
-      extra_components = []
-      components.each do |component|
-        extra_components << components_within_component(component)
-      end
-
-      extra_components.flatten.uniq.sort
-    end
-
-    def components_within_component(file)
-      file = get_component_name_from_full_path(file)
-      file = "#{@templates_full_path}#{file}.html.erb".sub(/.*\K\//, "/_")
-      data = File.read(file)
-      match = data.scan(/["']{1}(govuk_publishing_components\/components\/[\/a-z_-]+["']{1})/)
-      match.flatten.uniq.map(&:to_s).sort.map do |m|
-        m.gsub("govuk_publishing_components/components/", "").tr('\"\'', "")
-      end
-    end
-
-    def list_all_component_details
-      all_component_information = []
-
-      @components.each do |component|
-        all_component_information << {
-          name: component,
-          link: get_component_link(component),
-          stylesheet: check_component_has("stylesheet", component),
-          print_stylesheet: check_component_has("print_stylesheet", component),
-          javascript: check_component_has("javascript", component),
-          tests: check_component_has("test", component),
-          js_tests: check_component_has("js_test", component),
-        }
-      end
-
-      all_component_information
-    end
-
-    def check_component_has(a_thing, component)
-      look_in = @component_stylesheets if a_thing == "stylesheet"
-      look_in = @component_print_stylesheets if a_thing == "print_stylesheet"
-      look_in = @component_javascripts if a_thing == "javascript"
-      look_in = @component_tests if a_thing == "test"
-      look_in = @component_js_tests if a_thing == "js_test"
-
-      true if look_in.include?(component)
     end
   end
 end

--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -15,7 +15,7 @@ module GovukPublishingComponents
 
     def analyse_applications(path)
       results = []
-      applications = %w(
+      applications = %w[
         calculators
         collections
         collections-publisher
@@ -38,10 +38,10 @@ module GovukPublishingComponents
         static
         travel-advice-publisher
         whitehall
-      ).sort
+      ].sort
 
       applications.each do |application|
-        application_path = [path, application].join('/')
+        application_path = [path, application].join("/")
         app = AuditApplications.new(application_path, application)
         results << app.data
       end

--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -61,21 +61,22 @@ module GovukPublishingComponents
 
       files.each do |file|
         src = File.read(file)
-        components_found << find_match(find, replace, src, file)
+        components_found << find_match(find, replace, src)
       end
 
       found = components_found.flatten.uniq.sort
-      return ["none"] if found.empty?
+      return %w[none] if found.empty?
+
       found
     end
 
-    def find_match(find, replace, src, file)
-      return ["all"] if src.match(@find_all_stylesheets) || src.match(@find_all_print_stylesheets) || src.match(@find_all_javascripts)
+    def find_match(find, replace, src)
+      return %w[all] if src.match(@find_all_stylesheets) || src.match(@find_all_print_stylesheets) || src.match(@find_all_javascripts)
 
       matches = src.scan(find)
       all_matches = []
       matches.each do |match|
-        match.to_s.gsub!(replace, '')
+        match.to_s.gsub!(replace, "")
         all_matches << clean_file_name(match.tr('[])\'"', ""))
       end
 

--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -22,13 +22,13 @@ module GovukPublishingComponents
 
       find_ruby = /(?<=render\(["']{1}govuk_publishing_components\/components\/)[a-zA-Z_-]+['"]{1}(?=['"])/
 
-      components_in_templates = find_components(templates, find_templates) || []
-      components_in_stylesheets = find_components(stylesheets, find_stylesheets) || []
-      components_in_print_stylesheets = find_components(stylesheets, find_print_stylesheets) || []
-      components_in_javascripts = find_components(javascripts, find_javascripts) || []
+      components_in_templates = find_components(templates, find_templates, "templates") || []
+      components_in_stylesheets = find_components(stylesheets, find_stylesheets, "stylesheets") || []
+      components_in_print_stylesheets = find_components(stylesheets, find_print_stylesheets, "print_stylesheets") || []
+      components_in_javascripts = find_components(javascripts, find_javascripts, "javascripts") || []
 
-      components_in_helpers = find_components(helpers, find_ruby) || []
-      components_in_presenters = find_components(presenters, find_ruby) || []
+      components_in_helpers = find_components(helpers, find_ruby, "ruby") || []
+      components_in_presenters = find_components(presenters, find_ruby, "ruby") || []
       components_in_ruby = [components_in_helpers, components_in_presenters].flatten.uniq
 
       @data = {
@@ -61,21 +61,23 @@ module GovukPublishingComponents
 
   private
 
-    def find_components(files, find)
+    def find_components(files, find, type)
       components_found = []
 
       files.each do |file|
         src = File.read(file)
-        components_found << find_match(find, src)
+        components_found << find_match(find, src, type)
       end
 
-      found = components_found.flatten.uniq.sort
-
-      found
+      # found = components_found.flatten.uniq.sort
+      # found
+      components_found.flatten.uniq.sort
     end
 
-    def find_match(find, src)
-      return %w[all] if src.match(@find_all_stylesheets) || src.match(@find_all_print_stylesheets) || src.match(@find_all_javascripts)
+    def find_match(find, src, type)
+      return %w[all] if src.match(@find_all_stylesheets) && type == "stylesheets"
+      return %w[all] if src.match(@find_all_print_stylesheets) && type == "print_stylesheets"
+      return %w[all] if src.match(@find_all_javascripts) && type == "javascripts"
 
       matches = src.scan(find)
       all_matches = []

--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -3,80 +3,83 @@ module GovukPublishingComponents
     attr_reader :data
 
     def initialize(path, name)
-      templates_path = "app/views"
-      stylesheets_path = "app/assets/stylesheets"
-      javascripts_path = "app/assets/javascripts"
-      helpers_path = "app/helpers"
-      presenters_path = "app/presenters"
+      templates = Dir["#{path}/app/views/**/*.html.erb"]
+      stylesheets = Dir["#{path}/app/assets/stylesheets/**/*.scss"]
+      javascripts = Dir["#{path}/app/assets/javascripts/**/*.js"]
+      helpers = Dir["#{path}/app/helpers/**/*.rb"]
+      presenters = Dir["#{path}/app/presenters/**/*.rb"]
 
-      templates = Dir["#{path}/#{templates_path}/**/*.html.erb"]
-      stylesheets = Dir["#{path}/#{stylesheets_path}/**/*.scss"]
-      javascripts = Dir["#{path}/#{javascripts_path}/**/*.js"]
-      helpers = Dir["#{path}/#{helpers_path}/**/*.rb"]
-      presenters = Dir["#{path}/#{presenters_path}/**/*.rb"]
-
-      find_templates = /<%=[ ]*render ['"]{1}govuk_publishing_components\/components\/[a-zA-Z_-]+/
-      replace_templates = /<%=[ ]*render ['"]{1}govuk_publishing_components\/components\//
+      find_templates = /(?<=govuk_publishing_components\/components\/)[\/a-zA-Z_-]+(?=['"])/
 
       @find_all_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components/
-      find_stylesheets = /@import ["']{1}govuk_publishing_components\/components\/(?!print)+[a-zA-Z_-]+/
-      replace_stylesheets = /@import ["']{1}govuk_publishing_components\/components\//
+      find_stylesheets = /(?<=@import ["']{1}govuk_publishing_components\/components\/)(?!print)+[a-zA-Z_-]+(?=['"])/
 
       @find_all_print_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components_print/
-      find_print_stylesheets = /@import ["']{1}govuk_publishing_components\/components\/print\/[a-zA-Z_-]+/
-      replace_print_stylesheets = /@import ["']{1}govuk_publishing_components\/components\/print\//
+      find_print_stylesheets = /(?<=@import ["']{1}govuk_publishing_components\/components\/print\/)[a-zA-Z_-]+(?=['"])/
 
       @find_all_javascripts = /\/\/[ ]*= require govuk_publishing_components\/all_components/
-      find_javascripts = /[\/]{2}[ ]*=[ ]*require govuk_publishing_components\/components\/[a-zA-Z_-]+/
-      replace_javascripts = /[\/]{2}[ ]*=[ ]*require govuk_publishing_components\/components\//
+      find_javascripts = /(?<=require govuk_publishing_components\/components\/)[a-zA-Z_-]+/
 
-      find_ruby = /render\(["']{1}govuk_publishing_components\/components\/[a-zA-Z_-]+['"]{1}/
-      replace_ruby = /render\(["']{1}govuk_publishing_components\/components\//
+      find_ruby = /(?<=render\(["']{1}govuk_publishing_components\/components\/)[a-zA-Z_-]+['"]{1}(?=['"])/
 
-      components_in_templates = find_components(templates, find_templates, replace_templates) || []
-      components_in_stylesheets = find_components(stylesheets, find_stylesheets, replace_stylesheets) || []
-      components_in_print_stylesheets = find_components(stylesheets, find_print_stylesheets, replace_print_stylesheets) || []
-      components_in_javascripts = find_components(javascripts, find_javascripts, replace_javascripts) || []
+      components_in_templates = find_components(templates, find_templates) || []
+      components_in_stylesheets = find_components(stylesheets, find_stylesheets) || []
+      components_in_print_stylesheets = find_components(stylesheets, find_print_stylesheets) || []
+      components_in_javascripts = find_components(javascripts, find_javascripts) || []
 
-      components_in_helpers = find_components(helpers, find_ruby, replace_ruby) || []
-      components_in_presenters = find_components(presenters, find_ruby, replace_ruby) || []
+      components_in_helpers = find_components(helpers, find_ruby) || []
+      components_in_presenters = find_components(presenters, find_ruby) || []
       components_in_ruby = [components_in_helpers, components_in_presenters].flatten.uniq
-      components_in_ruby.delete("none") if components_in_ruby.length > 1
 
       @data = {
         name: name,
         application_found: application_exists(path),
-        components_in_templates: components_in_templates,
-        components_in_stylesheets: components_in_stylesheets,
-        components_in_print_stylesheets: components_in_print_stylesheets,
-        components_in_javascripts: components_in_javascripts,
-        components_in_ruby: components_in_ruby,
+        components_found: [
+          {
+            location: "templates",
+            components: components_in_templates,
+          },
+          {
+            location: "stylesheets",
+            components: components_in_stylesheets,
+          },
+          {
+            location: "print_stylesheets",
+            components: components_in_print_stylesheets,
+          },
+          {
+            location: "javascripts",
+            components: components_in_javascripts,
+          },
+          {
+            location: "ruby",
+            components: components_in_ruby,
+          },
+        ],
       }
     end
 
   private
 
-    def find_components(files, find, replace)
+    def find_components(files, find)
       components_found = []
 
       files.each do |file|
         src = File.read(file)
-        components_found << find_match(find, replace, src)
+        components_found << find_match(find, src)
       end
 
       found = components_found.flatten.uniq.sort
-      return %w[none] if found.empty?
 
       found
     end
 
-    def find_match(find, replace, src)
+    def find_match(find, src)
       return %w[all] if src.match(@find_all_stylesheets) || src.match(@find_all_print_stylesheets) || src.match(@find_all_javascripts)
 
       matches = src.scan(find)
       all_matches = []
       matches.each do |match|
-        match.to_s.gsub!(replace, "")
         all_matches << clean_file_name(match.tr('[])\'"', ""))
       end
 

--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -1,0 +1,93 @@
+module GovukPublishingComponents
+  class AuditApplications
+    attr_reader :data
+
+    def initialize(path, name)
+      templates_path = "app/views"
+      stylesheets_path = "app/assets/stylesheets"
+      javascripts_path = "app/assets/javascripts"
+      helpers_path = "app/helpers"
+      presenters_path = "app/presenters"
+
+      templates = Dir["#{path}/#{templates_path}/**/*.html.erb"]
+      stylesheets = Dir["#{path}/#{stylesheets_path}/**/*.scss"]
+      javascripts = Dir["#{path}/#{javascripts_path}/**/*.js"]
+      helpers = Dir["#{path}/#{helpers_path}/**/*.rb"]
+      presenters = Dir["#{path}/#{presenters_path}/**/*.rb"]
+
+      find_templates = /<%=[ ]*render ['"]{1}govuk_publishing_components\/components\/[a-zA-Z_-]+/
+      replace_templates = /<%=[ ]*render ['"]{1}govuk_publishing_components\/components\//
+
+      @find_all_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components/
+      find_stylesheets = /@import ["']{1}govuk_publishing_components\/components\/(?!print)+[a-zA-Z_-]+/
+      replace_stylesheets = /@import ["']{1}govuk_publishing_components\/components\//
+
+      @find_all_print_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components_print/
+      find_print_stylesheets = /@import ["']{1}govuk_publishing_components\/components\/print\/[a-zA-Z_-]+/
+      replace_print_stylesheets = /@import ["']{1}govuk_publishing_components\/components\/print\//
+
+      @find_all_javascripts = /\/\/[ ]*= require govuk_publishing_components\/all_components/
+      find_javascripts = /[\/]{2}[ ]*=[ ]*require govuk_publishing_components\/components\/[a-zA-Z_-]+/
+      replace_javascripts = /[\/]{2}[ ]*=[ ]*require govuk_publishing_components\/components\//
+
+      find_ruby = /render\(["']{1}govuk_publishing_components\/components\/[a-zA-Z_-]+['"]{1}/
+      replace_ruby = /render\(["']{1}govuk_publishing_components\/components\//
+
+      components_in_templates = find_components(templates, find_templates, replace_templates) || []
+      components_in_stylesheets = find_components(stylesheets, find_stylesheets, replace_stylesheets) || []
+      components_in_print_stylesheets = find_components(stylesheets, find_print_stylesheets, replace_print_stylesheets) || []
+      components_in_javascripts = find_components(javascripts, find_javascripts, replace_javascripts) || []
+
+      components_in_helpers = find_components(helpers, find_ruby, replace_ruby) || []
+      components_in_presenters = find_components(presenters, find_ruby, replace_ruby) || []
+      components_in_ruby = [components_in_helpers, components_in_presenters].flatten.uniq
+      components_in_ruby.delete("none") if components_in_ruby.length > 1
+
+      @data = {
+        name: name,
+        application_found: application_exists(path),
+        components_in_templates: components_in_templates,
+        components_in_stylesheets: components_in_stylesheets,
+        components_in_print_stylesheets: components_in_print_stylesheets,
+        components_in_javascripts: components_in_javascripts,
+        components_in_ruby: components_in_ruby,
+      }
+    end
+
+  private
+
+    def find_components(files, find, replace)
+      components_found = []
+
+      files.each do |file|
+        src = File.read(file)
+        components_found << find_match(find, replace, src, file)
+      end
+
+      found = components_found.flatten.uniq.sort
+      return ["none"] if found.empty?
+      found
+    end
+
+    def find_match(find, replace, src, file)
+      return ["all"] if src.match(@find_all_stylesheets) || src.match(@find_all_print_stylesheets) || src.match(@find_all_javascripts)
+
+      matches = src.scan(find)
+      all_matches = []
+      matches.each do |match|
+        match.to_s.gsub!(replace, '')
+        all_matches << clean_file_name(match.tr('[])\'"', ""))
+      end
+
+      all_matches
+    end
+
+    def clean_file_name(name)
+      name.tr("_-", " ").strip
+    end
+
+    def application_exists(directory)
+      File.directory?(directory)
+    end
+  end
+end

--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -6,8 +6,6 @@ module GovukPublishingComponents
       templates = Dir["#{path}/app/views/**/*.html.erb"]
       stylesheets = Dir["#{path}/app/assets/stylesheets/**/*.scss"]
       javascripts = Dir["#{path}/app/assets/javascripts/**/*.js"]
-      helpers = Dir["#{path}/app/helpers/**/*.rb"]
-      presenters = Dir["#{path}/app/presenters/**/*.rb"]
 
       find_templates = /(?<=govuk_publishing_components\/components\/)[\/a-zA-Z_-]+(?=['"])/
 
@@ -20,16 +18,20 @@ module GovukPublishingComponents
       @find_all_javascripts = /\/\/[ ]*= require govuk_publishing_components\/all_components/
       find_javascripts = /(?<=require govuk_publishing_components\/components\/)[a-zA-Z_-]+/
 
-      find_ruby = /(?<=render\(["']{1}govuk_publishing_components\/components\/)[a-zA-Z_-]+['"]{1}(?=['"])/
-
       components_in_templates = find_components(templates, find_templates, "templates") || []
       components_in_stylesheets = find_components(stylesheets, find_stylesheets, "stylesheets") || []
       components_in_print_stylesheets = find_components(stylesheets, find_print_stylesheets, "print_stylesheets") || []
       components_in_javascripts = find_components(javascripts, find_javascripts, "javascripts") || []
 
-      components_in_helpers = find_components(helpers, find_ruby, "ruby") || []
-      components_in_presenters = find_components(presenters, find_ruby, "ruby") || []
-      components_in_ruby = [components_in_helpers, components_in_presenters].flatten.uniq
+      find_ruby = /(?<=render\(["']{1}govuk_publishing_components\/components\/)[a-zA-Z_-]+/
+      ruby_paths = %w[/app/helpers/ /app/presenters/ /lib/]
+
+      components_in_ruby = []
+      ruby_paths.each do |ruby_path|
+        components_in_ruby << find_components(Dir["#{path}#{ruby_path}**/*.rb"], find_ruby, "ruby") || []
+      end
+
+      components_in_ruby = components_in_ruby.flatten.uniq
 
       @data = {
         name: name,
@@ -69,8 +71,6 @@ module GovukPublishingComponents
         components_found << find_match(find, src, type)
       end
 
-      # found = components_found.flatten.uniq.sort
-      # found
       components_found.flatten.uniq.sort
     end
 

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -91,6 +91,7 @@ module GovukPublishingComponents
 
         second_group.each do |second|
           second_location = second[:location]
+          second_location = "code" if %w[templates ruby].include?(second_location)
           in_current = find_missing(second[:components].clone, first[:components].clone)
 
           next if second[:components].include?("all")
@@ -110,6 +111,12 @@ module GovukPublishingComponents
       warnings = []
 
       code = components.select { |c| c[:location] == "templates" || c[:location] == "ruby" }
+      code = [
+        {
+          location: "code",
+          components: code.map { |c| c[:components] }.flatten.uniq.sort,
+        },
+      ]
       assets = components.select { |c| c[:location] == "stylesheets" || c[:location] == "print_stylesheets" || c[:location] == "javascripts" }
 
       warnings << find_missing_items(code, assets)
@@ -131,7 +138,7 @@ module GovukPublishingComponents
     end
 
     def component_does_not_exist(component)
-      !@gem_data[:component_templates].include?(component) unless component == "all"
+      !@gem_data[:component_code].include?(component) unless component == "all"
     end
 
     def find_missing(needle, haystack)

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -1,0 +1,168 @@
+module GovukPublishingComponents
+  class AuditComparer
+    attr_reader :data, :gem_data
+
+    def initialize(gem_data, results)
+      @gem_data = gem_data
+      @data = sort_results(results)
+      @gem_data[:components_by_application] = get_components_by_application
+    end
+
+  private
+
+    def prettify_key(key)
+      key.to_s.gsub("_", " ").capitalize
+    end
+
+    def sort_results(results)
+      data = []
+
+      results.each do |result|
+        @all_stylesheets = true if result[:components_in_stylesheets].include?("all")
+        @all_print_stylesheets = true if result[:components_in_print_stylesheets].include?("all")
+        @all_javascripts = true if result[:components_in_javascripts].include?("all")
+
+        components_in_templates = include_any_components_within_components(result[:components_in_templates])
+        components_in_stylesheets = result[:components_in_stylesheets]
+        components_in_print_stylesheets = result[:components_in_print_stylesheets]
+        components_in_javascripts = result[:components_in_javascripts]
+        components_in_ruby = result[:components_in_ruby]
+        missing_includes = missing_includes(components_in_templates, components_in_stylesheets, components_in_print_stylesheets, components_in_javascripts, components_in_ruby)
+
+        missing_includes = highlight_missing_issues(missing_includes)
+
+        data << {
+          name: result[:name],
+          application_found: result[:application_found],
+          summary: [
+            {
+              name: "Components in templates",
+              value: components_in_templates.flatten.uniq.sort.join(', '),
+            },
+            {
+              name: "Components in stylesheets",
+              value: components_in_stylesheets.join(', '),
+            },
+            {
+              name: "Components in print stylesheets",
+              value: components_in_print_stylesheets.join(', '),
+            },
+            {
+              name: "Components in javascripts",
+              value: components_in_javascripts.join(', '),
+            },
+            {
+              name: "Components in ruby",
+              value: components_in_ruby.join(', '),
+            },
+          ],
+          missing_includes: missing_includes,
+          warning_count: count_warnings(missing_includes)
+        }
+      end
+
+      data
+    end
+
+    def include_any_components_within_components(components)
+      @gem_data[:components_containing_components].each do |component|
+        components << component[:sub_components] if components.include?(component[:component])
+      end
+
+      components.flatten.uniq.sort
+    end
+
+    def highlight_missing_issues(results)
+      results.map do |key, value|
+        {
+          name: prettify_key(key),
+          values: check_if_component_item_exists(value, key.to_s),
+        }
+      end
+    end
+
+    def check_if_component_item_exists(components, filetype)
+      key = "components" if filetype == "not_in_templates"
+
+      if filetype == "not_in_stylesheets"
+        key = "component_stylesheets"
+        override_warning = true if @all_stylesheets
+      end
+
+      if filetype == "not_in_print_stylesheets"
+        key = "component_print_stylesheets"
+        override_warning = true if @all_print_stylesheets
+      end
+
+      if filetype == "not_in_javascripts"
+        key = "component_javascripts"
+        override_warning = true if @all_javascripts
+      end
+
+      results = []
+      if key # we don't check for ruby files
+        components.each do |component|
+          warning = false
+          warning = true if @gem_data[key.to_sym].include? component unless override_warning
+          results << {
+            warning: warning,
+            component: component,
+          }
+        end
+      end
+
+      results
+    end
+
+    def missing_includes(templates, stylesheets, print_stylesheets, javascripts, ruby)
+      all = (templates.clone << stylesheets.clone << print_stylesheets.clone << javascripts.clone << ruby.clone).flatten.uniq
+      all = all - ["all"]
+
+      {
+        not_in_templates: find_missing(templates, all),
+        not_in_stylesheets: find_missing(stylesheets, all),
+        not_in_print_stylesheets: find_missing(print_stylesheets, all),
+        not_in_javascripts: find_missing(javascripts, all),
+      }
+    end
+
+    def find_missing(needle, haystack)
+      (haystack - needle).flatten.sort
+    end
+
+    def count_warnings(missing_includes)
+      count = 0
+      missing_includes.each do |include|
+        include[:values].each do |value|
+          count += 1 if value[:warning]
+        end
+      end
+
+      count
+    end
+
+    def get_components_by_application
+      results = []
+
+      @gem_data[:component_listing].each do |component|
+        found_in_applications = []
+
+        @data.each do |application|
+          name = application[:name]
+
+          application[:summary].each do |item|
+            found_in_applications << name if item[:value].include?(component[:name])
+          end
+        end
+
+        results << {
+          component: component[:name],
+          count: found_in_applications.uniq.length,
+          list: found_in_applications.uniq.join(', '),
+        }
+      end
+
+      results
+    end
+  end
+end

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -37,27 +37,27 @@ module GovukPublishingComponents
           summary: [
             {
               name: "Components in templates",
-              value: components_in_templates.flatten.uniq.sort.join(', '),
+              value: components_in_templates.flatten.uniq.sort.join(", "),
             },
             {
               name: "Components in stylesheets",
-              value: components_in_stylesheets.join(', '),
+              value: components_in_stylesheets.join(", "),
             },
             {
               name: "Components in print stylesheets",
-              value: components_in_print_stylesheets.join(', '),
+              value: components_in_print_stylesheets.join(", "),
             },
             {
               name: "Components in javascripts",
-              value: components_in_javascripts.join(', '),
+              value: components_in_javascripts.join(", "),
             },
             {
               name: "Components in ruby",
-              value: components_in_ruby.join(', '),
+              value: components_in_ruby.join(", "),
             },
           ],
           missing_includes: missing_includes,
-          warning_count: count_warnings(missing_includes)
+          warning_count: count_warnings(missing_includes),
         }
       end
 
@@ -103,7 +103,7 @@ module GovukPublishingComponents
       if key # we don't check for ruby files
         components.each do |component|
           warning = false
-          warning = true if @gem_data[key.to_sym].include? component unless override_warning
+          warning = true if @gem_data[key.to_sym].include?(component) && !override_warning
           results << {
             warning: warning,
             component: component,
@@ -116,7 +116,7 @@ module GovukPublishingComponents
 
     def missing_includes(templates, stylesheets, print_stylesheets, javascripts, ruby)
       all = (templates.clone << stylesheets.clone << print_stylesheets.clone << javascripts.clone << ruby.clone).flatten.uniq
-      all = all - ["all"]
+      all = all - %w[all] - %w[none]
 
       {
         not_in_templates: find_missing(templates, all),
@@ -158,7 +158,7 @@ module GovukPublishingComponents
         results << {
           component: component[:name],
           count: found_in_applications.uniq.length,
-          list: found_in_applications.uniq.join(', '),
+          list: found_in_applications.uniq.join(", "),
         }
       end
 

--- a/app/models/govuk_publishing_components/audit_components.rb
+++ b/app/models/govuk_publishing_components/audit_components.rb
@@ -27,7 +27,7 @@ module GovukPublishingComponents
       @component_js_tests = find_files(js_tests, [path, js_tests_path].join("/"))
 
       @data = {
-        component_templates: @components,
+        component_code: @components,
         component_stylesheets: @component_stylesheets,
         component_print_stylesheets: @component_print_stylesheets,
         component_javascripts: @component_javascripts,

--- a/app/models/govuk_publishing_components/audit_components.rb
+++ b/app/models/govuk_publishing_components/audit_components.rb
@@ -27,7 +27,7 @@ module GovukPublishingComponents
       @component_js_tests = find_files(js_tests, [path, js_tests_path].join("/"))
 
       @data = {
-        components: @components,
+        component_templates: @components,
         component_stylesheets: @component_stylesheets,
         component_print_stylesheets: @component_print_stylesheets,
         component_javascripts: @component_javascripts,

--- a/app/models/govuk_publishing_components/audit_components.rb
+++ b/app/models/govuk_publishing_components/audit_components.rb
@@ -1,0 +1,139 @@
+module GovukPublishingComponents
+  class AuditComponents
+    attr_reader :data
+
+    def initialize(path)
+      templates_path = "app/views/govuk_publishing_components/components"
+      stylesheets_path = "app/assets/stylesheets/govuk_publishing_components/components"
+      print_stylesheets_path = "app/assets/stylesheets/govuk_publishing_components/components/print"
+      javascripts_path = "app/assets/javascripts/govuk_publishing_components/components"
+      tests_path = "spec/components"
+      js_tests_path = "spec/javascripts/components"
+
+      templates = Dir["#{path}/#{templates_path}/*.html.erb"]
+      stylesheets = Dir["#{path}/#{stylesheets_path}/*.scss"]
+      print_stylesheets = Dir["#{path}/#{print_stylesheets_path}/*.scss"]
+      javascripts = Dir["#{path}/#{javascripts_path}/*.js"]
+      tests = Dir["#{path}/#{tests_path}/*.rb"]
+      js_tests = Dir["#{path}/#{js_tests_path}/*.js"]
+
+      @templates_full_path = "#{path}/#{templates_path}/"
+
+      @components = find_files(templates, [path, templates_path].join("/"))
+      @component_stylesheets = find_files(stylesheets, [path, stylesheets_path].join("/"))
+      @component_print_stylesheets = find_files(print_stylesheets, [path, print_stylesheets_path].join("/"))
+      @component_javascripts = find_files(javascripts, [path, javascripts_path].join("/"))
+      @component_tests = find_files(tests, [path, tests_path].join("/"))
+      @component_js_tests = find_files(js_tests, [path, js_tests_path].join("/"))
+
+      @data = {
+        components: @components,
+        component_stylesheets: @component_stylesheets,
+        component_print_stylesheets: @component_print_stylesheets,
+        component_javascripts: @component_javascripts,
+        component_tests: @component_tests,
+        component_js_tests: @component_js_tests,
+        components_containing_components: find_all_partials_in(templates),
+        component_listing: list_all_component_details,
+      }
+    end
+
+  private
+
+    def find_files(files, replace)
+      files.map { |file| clean_file_name(file.gsub(replace, "")) }.sort
+    end
+
+    def clean_file_name(name)
+      name.tr("/_-", " ").gsub(".html.erb", "").gsub(".scss", "").gsub(".js", "").gsub("spec", "").gsub(".rb", "").strip
+    end
+
+    def get_component_name_from_full_path(path)
+      path.gsub("/_", "/").gsub(@templates_full_path, "").gsub(".html.erb", "").tr('\"\'', "")
+    end
+
+    def get_component_link(component)
+      "/component-guide/#{component.gsub(' ', '_')}"
+    end
+
+    def find_all_partials_in(templates)
+      components = []
+
+      templates.each do |template|
+        partials_found = true
+        components_to_search = [template]
+        components_found = []
+
+        while partials_found
+          extra_components = find_partials_in(components_to_search)
+
+          if extra_components.any?
+            components_found << extra_components
+            components_to_search = extra_components
+          else
+            partials_found = false
+            components_found = components_found.flatten.reject { |c| c.include?("/") }
+
+            if components_found.any?
+              component_name = clean_file_name(get_component_name_from_full_path(template))
+              components << {
+                component: component_name,
+                link: get_component_link(component_name),
+                sub_components: components_found.uniq.sort.map { |name| clean_file_name(name) },
+              }
+            end
+          end
+        end
+      end
+
+      components.sort_by { |c| c[:component] }
+    end
+
+    def find_partials_in(components)
+      extra_components = []
+      components.each do |component|
+        extra_components << components_within_component(component)
+      end
+
+      extra_components.flatten.uniq.sort
+    end
+
+    def components_within_component(file)
+      file = get_component_name_from_full_path(file)
+      file = "#{@templates_full_path}#{file}.html.erb".sub(/.*\K\//, "/_")
+      data = File.read(file)
+      match = data.scan(/["']{1}(govuk_publishing_components\/components\/[\/a-z_-]+["']{1})/)
+      match.flatten.uniq.map(&:to_s).sort.map do |m|
+        m.gsub("govuk_publishing_components/components/", "").tr('\"\'', "")
+      end
+    end
+
+    def list_all_component_details
+      all_component_information = []
+
+      @components.each do |component|
+        all_component_information << {
+          name: component,
+          link: get_component_link(component),
+          stylesheet: check_component_has("stylesheet", component),
+          print_stylesheet: check_component_has("print_stylesheet", component),
+          javascript: check_component_has("javascript", component),
+          tests: check_component_has("test", component),
+          js_tests: check_component_has("js_test", component),
+        }
+      end
+
+      all_component_information
+    end
+
+    def check_component_has(a_thing, component)
+      look_in = @component_stylesheets if a_thing == "stylesheet"
+      look_in = @component_print_stylesheets if a_thing == "print_stylesheet"
+      look_in = @component_javascripts if a_thing == "javascript"
+      look_in = @component_tests if a_thing == "test"
+      look_in = @component_js_tests if a_thing == "js_test"
+
+      true if look_in.include?(component)
+    end
+  end
+end

--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -30,7 +30,7 @@
         </summary>
         <div class="govuk-details__text">
           <p class="govuk-body">This page shows information about component use on GOV.UK. This information has been cross referenced with the components in the gem to produce warnings where e.g. a print stylesheet for a component exists but has not been included in an application.</p>
-          <p class="govuk-body">Warnings should be investigated, although there may be a reason why the application has been configured as it is.</p>
+          <p class="govuk-body">Warnings should be investigated, although there may be a reason why the application has been configured as it is. Note that 'code' can refer to templates or ruby code.</p>
         </div>
       </details>
 

--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -21,208 +21,217 @@
   <div class="govuk-tabs__panel" id="applications">
     <h2 class="govuk-heading-l">Applications</h2>
 
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          How to use this information
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        <p class="govuk-body">This page shows the components included by applications on GOV.UK, including component references in templates, stylesheets and javascripts. It also shows where a component is referenced in one of these but not others.</p>
-        <p class="govuk-body">There may be a good reason for this. For example, a component may be referenced in a stylesheet and not a print stylesheet, because the component has no print stylesheet. The following labelling is used:</p>
-        <ul class="govuk-list govuk-list--number">
-          <li><strong class="govuk-tag govuk-tag--grey">Okay</strong> means that the component is referenced elsewhere but not included in this category because it is not needed (e.g. there is no print stylesheet)</li>
-          <li><strong class="govuk-tag">Warn</strong> means that the component is not included in this category but a corresponding file for the component exists</li>
-        </ul>
-        <p class="govuk-body">For entries labelled as 'warn' further investigation may be needed, although there still may be a good reason why the component is not included in this category.</p>
-      </div>
-    </details>
+    <% if @applications.any? %>
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            How to use this information
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p class="govuk-body">This page shows components included by applications on GOV.UK and component references in templates, stylesheets and javascripts. This includes where a component is referenced in one of these places but not others.</p>
+          <p class="govuk-body">There may be a reason for this. For example, an application may include a component stylesheet but no print stylesheet, because that component has no print stylesheet. The following labelling is used:</p>
+          <ul class="govuk-list govuk-list--number">
+            <li><strong class="govuk-tag govuk-tag--grey">Okay</strong> - the component is referenced elsewhere but not included in this category because it is not needed (e.g. there is no print stylesheet)</li>
+            <li><strong class="govuk-tag">Warn</strong> - the component is not included in this category but a corresponding file for the component exists</li>
+          </ul>
+          <p class="govuk-body">For entries labelled as 'warn' further investigation may be needed, although there still may be a reason why the component is not included in this category.</p>
+        </div>
+      </details>
 
-    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-with-summary-sections">
-      <% @applications.each_with_index do |application, index| %>
-        <div class="govuk-accordion__section ">
-          <div class="govuk-accordion__section-header">
-            <h2 class="govuk-accordion__section-heading">
-              <span class="govuk-accordion__section-button" id="accordion-with-summary-sections-heading-<%= index %>">
-                <%= application[:name] %>
-              </span>
-            </h2>
-            <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-<%= index %>">
-              <% if application[:application_found] %>
-                Warnings:
-                <% if application[:warning_count] > 0 %>
-                  <strong class="govuk-tag govuk-tag--red"><%= application[:warning_count] %></strong>
+      <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-with-summary-sections">
+        <% @applications.each_with_index do |application, index| %>
+          <div class="govuk-accordion__section ">
+            <div class="govuk-accordion__section-header">
+              <h2 class="govuk-accordion__section-heading">
+                <span class="govuk-accordion__section-button" id="accordion-with-summary-sections-heading-<%= index %>">
+                  <%= application[:name] %>
+                </span>
+              </h2>
+              <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-<%= index %>">
+                <% if application[:application_found] %>
+                  Warnings:
+                  <% if application[:warning_count] > 0 %>
+                    <strong class="govuk-tag govuk-tag--red"><%= application[:warning_count] %></strong>
+                  <% else %>
+                    <%= application[:warning_count] %>
+                  <% end %>
                 <% else %>
-                  <%= application[:warning_count] %>
+                  <strong class="govuk-tag govuk-tag--red">Application not found</strong>
                 <% end %>
+              </div>
+            </div>
+            <div id="accordion-with-summary-sections-content-<%= index %>" class="govuk-accordion__section-content" aria-labelledby="accordion-with-summary-sections-heading-<%= index %>">
+              <% if application[:application_found] %>
+                <dl class="govuk-summary-list">
+                  <% application[:summary].each do |item| %>
+                    <div class="govuk-summary-list__row">
+                      <dt class="govuk-summary-list__key">
+                        <%= item[:name] %>
+                      </dt>
+                      <dd class="govuk-summary-list__value">
+                        <%= item[:value] %>
+                      </dd>
+                    </div>
+                  <% end %>
+                </dl>
+
+                <dl class="govuk-summary-list">
+                  <% application[:missing_includes].each do |missing| %>
+                    <div class="govuk-summary-list__row">
+                      <dt class="govuk-summary-list__key">
+                        <%= missing[:name] %>
+                      </dt>
+                      <dd class="govuk-summary-list__value">
+                        <ul class="govuk-list">
+                          <% missing[:values].each do |component| %>
+                            <li>
+                              <% if component[:warning] %>
+                                <strong class="govuk-tag">Warn</strong>
+                              <% else %>
+                                <strong class="govuk-tag govuk-tag--grey">Okay</strong>
+                              <% end %>
+                              <%= component[:component] %>
+                            </li>
+                          <% end %>
+                        </ul>
+                      </dd>
+                    </div>
+                  <% end %>
+                </dl>
               <% else %>
-                <strong class="govuk-tag govuk-tag--red">Application not found</strong>
+                <p class="govuk-body">This application was not found. This could be because you do not have this repository checked out locally.</p>
               <% end %>
             </div>
           </div>
-          <div id="accordion-with-summary-sections-content-<%= index %>" class="govuk-accordion__section-content" aria-labelledby="accordion-with-summary-sections-heading-<%= index %>">
-            <% if application[:application_found] %>
-              <dl class="govuk-summary-list">
-                <% application[:summary].each do |item| %>
-                  <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">
-                      <%= item[:name] %>
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                      <%= item[:value] %>
-                    </dd>
-                  </div>
-                <% end %>
-              </dl>
-
-              <dl class="govuk-summary-list">
-                <% application[:missing_includes].each do |missing| %>
-                  <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">
-                      <%= missing[:name] %>
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                      <ul class="govuk-list">
-                        <% missing[:values].each do |component| %>
-                          <li>
-                            <% if component[:warning] %>
-                              <strong class="govuk-tag">Warn</strong>
-                            <% else %>
-                              <strong class="govuk-tag govuk-tag--grey">Okay</strong>
-                            <% end %>
-                            <%= component[:component] %>
-                          </li>
-                        <% end %>
-                      </ul>
-                    </dd>
-                  </div>
-                <% end %>
-              </dl>
-            <% else %>
-              <p class="govuk-body">This application was not found. This could be because you do not have this repository checked out locally.</p>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-    </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="govuk-body">No applications found.</p>
+    <% end %>
   </div>
 
   <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="components-gem">
     <h2 class="govuk-heading-l">Components</h2>
-    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-      <div class="govuk-accordion__section ">
-        <div class="govuk-accordion__section-header">
-          <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
-              Component files
-            </span>
-          </h2>
-          <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-1">
-            Lists what files each component has
-          </div>
-        </div>
-        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
-          <table class="govuk-table">
-            <thead class="govuk-table__head">
-              <tr class="govuk-table__row">
-                <th scope="col" class="govuk-table__header">Component</th>
-                <th scope="col" class="govuk-table__header">Stylesheet</th>
-                <th scope="col" class="govuk-table__header">Print stylesheet</th>
-                <th scope="col" class="govuk-table__header">JS</th>
-                <th scope="col" class="govuk-table__header">Test</th>
-                <th scope="col" class="govuk-table__header">JS test</th>
-              </tr>
-            </thead>
-            <tbody class="govuk-table__body">
-              <% @components[:component_listing].each do |component| %>
-                <tr class="govuk-table__row">
-                  <th scope="row" class="govuk-table__header">
-                    <a href="<%= component[:link] %>" class="govuk-link"><%= component[:name] %></a>
-                  </th>
-                  <td class="govuk-table__cell">
-                    <% if component[:stylesheet] %>
-                      <strong class="govuk-tag govuk-tag--green">Yes</strong>
-                    <% end %>
-                  </td>
-                  <td class="govuk-table__cell">
-                    <% if component[:print_stylesheet] %>
-                      <strong class="govuk-tag govuk-tag--green">Yes</strong>
-                    <% end %>
-                  </td>
-                  <td class="govuk-table__cell">
-                    <% if component[:javascript] %>
-                      <strong class="govuk-tag govuk-tag--green">Yes</strong>
-                    <% end %>
-                  </td>
-                  <td class="govuk-table__cell">
-                    <% if component[:tests] %>
-                      <strong class="govuk-tag govuk-tag--green">Yes</strong>
-                    <% end %>
-                  </td>
-                  <td class="govuk-table__cell">
-                    <% if component[:js_tests] %>
-                      <strong class="govuk-tag govuk-tag--green">Yes</strong>
-                    <% end %>
-                  </td>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-        </div>
-      </div>
 
-      <div class="govuk-accordion__section ">
-        <div class="govuk-accordion__section-header">
-          <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-              Components containing components
-            </span>
-          </h2>
-          <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-2">
-            Shows which components contain other components
+    <% if @components.any? %>
+      <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+        <div class="govuk-accordion__section ">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+                Component files
+              </span>
+            </h2>
+            <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-1">
+              Lists what files each component has
+            </div>
+          </div>
+          <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+            <table class="govuk-table">
+              <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th scope="col" class="govuk-table__header">Component</th>
+                  <th scope="col" class="govuk-table__header">Stylesheet</th>
+                  <th scope="col" class="govuk-table__header">Print stylesheet</th>
+                  <th scope="col" class="govuk-table__header">JS</th>
+                  <th scope="col" class="govuk-table__header">Test</th>
+                  <th scope="col" class="govuk-table__header">JS test</th>
+                </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+                <% @components[:component_listing].each do |component| %>
+                  <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header">
+                      <a href="<%= component[:link] %>" class="govuk-link"><%= component[:name] %></a>
+                    </th>
+                    <td class="govuk-table__cell">
+                      <% if component[:stylesheet] %>
+                        <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                      <% end %>
+                    </td>
+                    <td class="govuk-table__cell">
+                      <% if component[:print_stylesheet] %>
+                        <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                      <% end %>
+                    </td>
+                    <td class="govuk-table__cell">
+                      <% if component[:javascript] %>
+                        <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                      <% end %>
+                    </td>
+                    <td class="govuk-table__cell">
+                      <% if component[:tests] %>
+                        <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                      <% end %>
+                    </td>
+                    <td class="govuk-table__cell">
+                      <% if component[:js_tests] %>
+                        <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                      <% end %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
           </div>
         </div>
-        <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
-          <dl class="govuk-summary-list">
-            <% @components[:components_containing_components].each do |component| %>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                  <a href="<%= component[:link] %>" class="govuk-link"><%= component[:component] %></a>
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  <%= component[:sub_components].join(', ') %>
-                </dd>
-              </div>
-            <% end %>
-          </dl>
-        </div>
-      </div>
-      <div class="govuk-accordion__section ">
-        <div class="govuk-accordion__section-header">
-          <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-              Components by application
-            </span>
-          </h2>
-          <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-2">
-            Shows which applications use each component
+
+        <div class="govuk-accordion__section ">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+                Components containing components
+              </span>
+            </h2>
+            <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-2">
+              Shows which components contain other components
+            </div>
+          </div>
+          <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+            <dl class="govuk-summary-list">
+              <% @components[:components_containing_components].each do |component| %>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    <a href="<%= component[:link] %>" class="govuk-link"><%= component[:component] %></a>
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <%= component[:sub_components].join(', ') %>
+                  </dd>
+                </div>
+              <% end %>
+            </dl>
           </div>
         </div>
-        <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
-          <dl class="govuk-summary-list">
-            <% @components[:components_by_application].each do |component| %>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                  <%= component[:component] %> (<%= component[:count] %>)
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  <%= component[:list] %>
-                </dd>
-              </div>
-            <% end %>
-          </dl>
+        <div class="govuk-accordion__section ">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+                Components by application
+              </span>
+            </h2>
+            <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-2">
+              Shows which applications use each component
+            </div>
+          </div>
+          <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+            <dl class="govuk-summary-list">
+              <% @components[:components_by_application].each do |component| %>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    <%= component[:component] %> (<%= component[:count] %>)
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <%= component[:list] %>
+                  </dd>
+                </div>
+              <% end %>
+            </dl>
+          </div>
         </div>
       </div>
-    </div>
+    <% else %>
+      <p class="govuk-body">No components found.</p>
+    <% end %>
   </div>
 </div>

--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -29,13 +29,8 @@
           </span>
         </summary>
         <div class="govuk-details__text">
-          <p class="govuk-body">This page shows components included by applications on GOV.UK and component references in templates, stylesheets and javascripts. This includes where a component is referenced in one of these places but not others.</p>
-          <p class="govuk-body">There may be a reason for this. For example, an application may include a component stylesheet but no print stylesheet, because that component has no print stylesheet. The following labelling is used:</p>
-          <ul class="govuk-list govuk-list--number">
-            <li><strong class="govuk-tag govuk-tag--grey">Okay</strong> - the component is referenced elsewhere but not included in this category because it is not needed (e.g. there is no print stylesheet)</li>
-            <li><strong class="govuk-tag">Warn</strong> - the component is not included in this category but a corresponding file for the component exists</li>
-          </ul>
-          <p class="govuk-body">For entries labelled as 'warn' further investigation may be needed, although there still may be a reason why the component is not included in this category.</p>
+          <p class="govuk-body">This page shows information about component use on GOV.UK. This information has been cross referenced with the components in the gem to produce warnings where e.g. a print stylesheet for a component exists but has not been included in an application.</p>
+          <p class="govuk-body">Warnings should be investigated, although there may be a reason why the application has been configured as it is.</p>
         </div>
       </details>
 
@@ -63,6 +58,15 @@
             </div>
             <div id="accordion-with-summary-sections-content-<%= index %>" class="govuk-accordion__section-content" aria-labelledby="accordion-with-summary-sections-heading-<%= index %>">
               <% if application[:application_found] %>
+                <% application[:warnings].each do |warning| %>
+                  <p class="govuk-body">
+                    <strong class="govuk-tag">Warn</strong>
+                    <strong><%= warning[:component] %></strong> - <%= warning[:message] %>
+                  </p>
+                <% end %>
+
+                <h3 class="govuk-heading-m">Components used</h3>
+
                 <dl class="govuk-summary-list">
                   <% application[:summary].each do |item| %>
                     <div class="govuk-summary-list__row">
@@ -70,31 +74,11 @@
                         <%= item[:name] %>
                       </dt>
                       <dd class="govuk-summary-list__value">
-                        <%= item[:value] %>
-                      </dd>
-                    </div>
-                  <% end %>
-                </dl>
-
-                <dl class="govuk-summary-list">
-                  <% application[:missing_includes].each do |missing| %>
-                    <div class="govuk-summary-list__row">
-                      <dt class="govuk-summary-list__key">
-                        <%= missing[:name] %>
-                      </dt>
-                      <dd class="govuk-summary-list__value">
-                        <ul class="govuk-list">
-                          <% missing[:values].each do |component| %>
-                            <li>
-                              <% if component[:warning] %>
-                                <strong class="govuk-tag">Warn</strong>
-                              <% else %>
-                                <strong class="govuk-tag govuk-tag--grey">Okay</strong>
-                              <% end %>
-                              <%= component[:component] %>
-                            </li>
-                          <% end %>
-                        </ul>
+                        <% if item[:value].length > 0 %>
+                          <%= item[:value] %>
+                        <% else %>
+                          None
+                        <% end %>
                       </dd>
                     </div>
                   <% end %>

--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -134,7 +134,7 @@
               </tr>
             </thead>
             <tbody class="govuk-table__body">
-              <% @gem[:component_listing].each do |component| %>
+              <% @components[:component_listing].each do |component| %>
                 <tr class="govuk-table__row">
                   <th scope="row" class="govuk-table__header">
                     <a href="<%= component[:link] %>" class="govuk-link"><%= component[:name] %></a>
@@ -184,7 +184,7 @@
         </div>
         <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
           <dl class="govuk-summary-list">
-            <% @gem[:components_containing_components].each do |component| %>
+            <% @components[:components_containing_components].each do |component| %>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
                   <a href="<%= component[:link] %>" class="govuk-link"><%= component[:component] %></a>
@@ -210,7 +210,7 @@
         </div>
         <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
           <dl class="govuk-summary-list">
-            <% @gem[:components_by_application].each do |component| %>
+            <% @components[:components_by_application].each do |component| %>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
                   <%= component[:component] %> (<%= component[:count] %>)

--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -2,111 +2,227 @@
 
 <%= render 'govuk_publishing_components/components/title', title: "Components audit", margin_top: 0; %>
 
-<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-  <div class="govuk-accordion__section ">
-    <div class="govuk-accordion__section-header">
-      <h2 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
-          Component files
+<div class="govuk-tabs" data-module="govuk-tabs">
+  <h2 class="govuk-tabs__title">
+    Contents
+  </h2>
+  <ul class="govuk-tabs__list">
+    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+      <a class="govuk-tabs__tab" href="#applications">
+        Applications
+      </a>
+    </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#components-gem">
+        Components
+      </a>
+    </li>
+  </ul>
+  <div class="govuk-tabs__panel" id="applications">
+    <h2 class="govuk-heading-l">Applications</h2>
+
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          How to use this information
         </span>
-      </h2>
-      <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-1">
-        Lists what files each component has
+      </summary>
+      <div class="govuk-details__text">
+        <p class="govuk-body">This page shows the components included by applications on GOV.UK, including component references in templates, stylesheets and javascripts. It also shows where a component is referenced in one of these but not others.</p>
+        <p class="govuk-body">There may be a good reason for this. For example, a component may be referenced in a stylesheet and not a print stylesheet, because the component has no print stylesheet. The following labelling is used:</p>
+        <ul class="govuk-list govuk-list--number">
+          <li><strong class="govuk-tag govuk-tag--grey">Okay</strong> means that the component is referenced elsewhere but not included in this category because it is not needed (e.g. there is no print stylesheet)</li>
+          <li><strong class="govuk-tag">Warn</strong> means that the component is not included in this category but a corresponding file for the component exists</li>
+        </ul>
+        <p class="govuk-body">For entries labelled as 'warn' further investigation may be needed, although there still may be a good reason why the component is not included in this category.</p>
       </div>
-    </div>
-    <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
-      <table class="govuk-table">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Component</th>
-            <th scope="col" class="govuk-table__header">Stylesheet</th>
-            <th scope="col" class="govuk-table__header">Print stylesheet</th>
-            <th scope="col" class="govuk-table__header">JS</th>
-            <th scope="col" class="govuk-table__header">Test</th>
-            <th scope="col" class="govuk-table__header">JS test</th>
-          </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-          <% @data[:component_listing].each do |component| %>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header">
-                <a href="<%= component[:link] %>" class="govuk-link"><%= component[:name] %></a>
-              </th>
-              <td class="govuk-table__cell">
-                <% if component[:stylesheet] %>
-                  <strong class="govuk-tag govuk-tag--green">Yes</strong>
+    </details>
+
+    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-with-summary-sections">
+      <% @applications.each_with_index do |application, index| %>
+        <div class="govuk-accordion__section ">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-with-summary-sections-heading-<%= index %>">
+                <%= application[:name] %>
+              </span>
+            </h2>
+            <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-<%= index %>">
+              <% if application[:application_found] %>
+                Warnings:
+                <% if application[:warning_count] > 0 %>
+                  <strong class="govuk-tag govuk-tag--red"><%= application[:warning_count] %></strong>
+                <% else %>
+                  <%= application[:warning_count] %>
                 <% end %>
-              </td>
-              <td class="govuk-table__cell">
-                <% if component[:print_stylesheet] %>
-                  <strong class="govuk-tag govuk-tag--green">Yes</strong>
+              <% else %>
+                <strong class="govuk-tag govuk-tag--red">Application not found</strong>
+              <% end %>
+            </div>
+          </div>
+          <div id="accordion-with-summary-sections-content-<%= index %>" class="govuk-accordion__section-content" aria-labelledby="accordion-with-summary-sections-heading-<%= index %>">
+            <% if application[:application_found] %>
+              <dl class="govuk-summary-list">
+                <% application[:summary].each do |item| %>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      <%= item[:name] %>
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      <%= item[:value] %>
+                    </dd>
+                  </div>
                 <% end %>
-              </td>
-              <td class="govuk-table__cell">
-                <% if component[:javascript] %>
-                  <strong class="govuk-tag govuk-tag--green">Yes</strong>
+              </dl>
+
+              <dl class="govuk-summary-list">
+                <% application[:missing_includes].each do |missing| %>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      <%= missing[:name] %>
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      <ul class="govuk-list">
+                        <% missing[:values].each do |component| %>
+                          <li>
+                            <% if component[:warning] %>
+                              <strong class="govuk-tag">Warn</strong>
+                            <% else %>
+                              <strong class="govuk-tag govuk-tag--grey">Okay</strong>
+                            <% end %>
+                            <%= component[:component] %>
+                          </li>
+                        <% end %>
+                      </ul>
+                    </dd>
+                  </div>
                 <% end %>
-              </td>
-              <td class="govuk-table__cell">
-                <% if component[:tests] %>
-                  <strong class="govuk-tag govuk-tag--green">Yes</strong>
-                <% end %>
-              </td>
-              <td class="govuk-table__cell">
-                <% if component[:js_tests] %>
-                  <strong class="govuk-tag govuk-tag--green">Yes</strong>
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+              </dl>
+            <% else %>
+              <p class="govuk-body">This application was not found. This could be because you do not have this repository checked out locally.</p>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
     </div>
   </div>
 
-  <div class="govuk-accordion__section ">
-    <div class="govuk-accordion__section-header">
-      <h2 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-          Components containing components
-        </span>
-      </h2>
-      <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-2">
-        Shows which components contain other components
-      </div>
-    </div>
-    <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
-      <dl class="govuk-summary-list">
-        <% @data[:components_containing_components].each do |component| %>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              <a href="<%= component[:link] %>" class="govuk-link"><%= component[:component] %></a>
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <%= component[:sub_components].join(', ') %>
-            </dd>
+  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="components-gem">
+    <h2 class="govuk-heading-l">Components</h2>
+    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+      <div class="govuk-accordion__section ">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+              Component files
+            </span>
+          </h2>
+          <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-1">
+            Lists what files each component has
           </div>
-        <% end %>
-      </dl>
-    </div>
-  </div>
-<!--
-  <div class="govuk-accordion__section ">
-    <div class="govuk-accordion__section-header">
-      <h2 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-          Components by application
-        </span>
-      </h2>
-      <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-2">
-        Shows which applications use each component
+        </div>
+        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+          <table class="govuk-table">
+            <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Component</th>
+                <th scope="col" class="govuk-table__header">Stylesheet</th>
+                <th scope="col" class="govuk-table__header">Print stylesheet</th>
+                <th scope="col" class="govuk-table__header">JS</th>
+                <th scope="col" class="govuk-table__header">Test</th>
+                <th scope="col" class="govuk-table__header">JS test</th>
+              </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+              <% @gem[:component_listing].each do |component| %>
+                <tr class="govuk-table__row">
+                  <th scope="row" class="govuk-table__header">
+                    <a href="<%= component[:link] %>" class="govuk-link"><%= component[:name] %></a>
+                  </th>
+                  <td class="govuk-table__cell">
+                    <% if component[:stylesheet] %>
+                      <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                    <% end %>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <% if component[:print_stylesheet] %>
+                      <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                    <% end %>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <% if component[:javascript] %>
+                      <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                    <% end %>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <% if component[:tests] %>
+                      <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                    <% end %>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <% if component[:js_tests] %>
+                      <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                    <% end %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="govuk-accordion__section ">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+              Components containing components
+            </span>
+          </h2>
+          <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-2">
+            Shows which components contain other components
+          </div>
+        </div>
+        <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+          <dl class="govuk-summary-list">
+            <% @gem[:components_containing_components].each do |component| %>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  <a href="<%= component[:link] %>" class="govuk-link"><%= component[:component] %></a>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  <%= component[:sub_components].join(', ') %>
+                </dd>
+              </div>
+            <% end %>
+          </dl>
+        </div>
+      </div>
+      <div class="govuk-accordion__section ">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+              Components by application
+            </span>
+          </h2>
+          <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-2">
+            Shows which applications use each component
+          </div>
+        </div>
+        <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+          <dl class="govuk-summary-list">
+            <% @gem[:components_by_application].each do |component| %>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  <%= component[:component] %> (<%= component[:count] %>)
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  <%= component[:list] %>
+                </dd>
+              </div>
+            <% end %>
+          </dl>
+        </div>
       </div>
     </div>
-    <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
-      <dl class="govuk-summary-list">
-        fixme
-      </dl>
-    </div>
   </div>
--->  
 </div>

--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -1,0 +1,112 @@
+<% content_for :title, "Component audit" %>
+
+<%= render 'govuk_publishing_components/components/title', title: "Components audit", margin_top: 0; %>
+
+<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+  <div class="govuk-accordion__section ">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+          Component files
+        </span>
+      </h2>
+      <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-1">
+        Lists what files each component has
+      </div>
+    </div>
+    <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Component</th>
+            <th scope="col" class="govuk-table__header">Stylesheet</th>
+            <th scope="col" class="govuk-table__header">Print stylesheet</th>
+            <th scope="col" class="govuk-table__header">JS</th>
+            <th scope="col" class="govuk-table__header">Test</th>
+            <th scope="col" class="govuk-table__header">JS test</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @data[:component_listing].each do |component| %>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">
+                <a href="<%= component[:link] %>" class="govuk-link"><%= component[:name] %></a>
+              </th>
+              <td class="govuk-table__cell">
+                <% if component[:stylesheet] %>
+                  <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                <% end %>
+              </td>
+              <td class="govuk-table__cell">
+                <% if component[:print_stylesheet] %>
+                  <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                <% end %>
+              </td>
+              <td class="govuk-table__cell">
+                <% if component[:javascript] %>
+                  <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                <% end %>
+              </td>
+              <td class="govuk-table__cell">
+                <% if component[:tests] %>
+                  <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                <% end %>
+              </td>
+              <td class="govuk-table__cell">
+                <% if component[:js_tests] %>
+                  <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="govuk-accordion__section ">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+          Components containing components
+        </span>
+      </h2>
+      <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-2">
+        Shows which components contain other components
+      </div>
+    </div>
+    <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+      <dl class="govuk-summary-list">
+        <% @data[:components_containing_components].each do |component| %>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              <a href="<%= component[:link] %>" class="govuk-link"><%= component[:component] %></a>
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= component[:sub_components].join(', ') %>
+            </dd>
+          </div>
+        <% end %>
+      </dl>
+    </div>
+  </div>
+<!--
+  <div class="govuk-accordion__section ">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+          Components by application
+        </span>
+      </h2>
+      <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-2">
+        Shows which applications use each component
+      </div>
+    </div>
+    <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+      <dl class="govuk-summary-list">
+        fixme
+      </dl>
+    </div>
+  </div>
+-->  
+</div>

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -2,7 +2,11 @@
 
 <div class="component-markdown">
   <p>Components are packages of template, style, behaviour and documentation that live in your application.</p>
-  <p>See the <a href="https://github.com/alphagov/govuk_publishing_components">govuk_publishing_components gem</a> for further details, or <a href="https://docs.publishing.service.gov.uk/manual/components.html#component-guides">a list of all component guides</a>. Read about how to <a href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/publishing-to-rubygems.md">release a new version of the gem</a>.</p>
+  <p>See the <a href="https://github.com/alphagov/govuk_publishing_components">govuk_publishing_components gem</a> for further details, or <a href="https://docs.publishing.service.gov.uk/manual/components.html#component-guides">a list of all component guides</a>.</p>
+  <ul>
+    <li>Read about how to <a href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/publishing-to-rubygems.md">release a new version of the gem</a></li>
+    <li><a href="/component-guide/audit">View component audits</a></li>
+  </ul>
 </div>
 
 <form role="search" data-module="filter-components" class="component-search">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 GovukPublishingComponents::Engine.routes.draw do
+  get "/audit" => "audit#show", as: :audit
   root to: "component_guide#index", as: :component_guide
   get ":component/preview" => "component_guide#preview", as: :component_preview_all
   get ":component/:example/preview" => "component_guide#preview", as: :component_preview

--- a/spec/component_guide/audit_applications_spec.rb
+++ b/spec/component_guide/audit_applications_spec.rb
@@ -8,11 +8,28 @@ describe "Auditing the components in applications" do
     expected = {
       name: "an application",
       application_found: true,
-      components_in_templates: ["attachment", "contextual breadcrumbs", "contextual footer", "contextual sidebar", "error summary", "feedback", "govspeak", "input", "layout footer", "layout for admin", "layout header", "skip link", "tabs", "title"],
-      components_in_stylesheets: %w[all],
-      components_in_print_stylesheets: %w[all],
-      components_in_javascripts: %w[all],
-      components_in_ruby: %w[none],
+      components_found: [
+        {
+          location: "templates",
+          components: ["contextual breadcrumbs", "contextual footer", "contextual sidebar", "error summary", "feedback", "govspeak", "input", "layout footer", "layout for admin", "layout header", "skip link", "tabs", "title"],
+        },
+        {
+          location: "stylesheets",
+          components: %w[all],
+        },
+        {
+          location: "print_stylesheets",
+          components: %w[all],
+        },
+        {
+          location: "javascripts",
+          components: %w[all],
+        },
+        {
+          location: "ruby",
+          components: [],
+        },
+      ],
     }
 
     expect(application.data).to match(expected)

--- a/spec/component_guide/audit_applications_spec.rb
+++ b/spec/component_guide/audit_applications_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+require_relative "../../app/models/govuk_publishing_components/audit_applications.rb"
+
+describe "Auditing the components in applications" do
+  it "returns correct information" do
+    application = GovukPublishingComponents::AuditApplications.new("#{Dir.pwd}/spec/dummy", "an application")
+
+    expected = {
+      name: "an application",
+      application_found: true,
+      components_in_templates: ["attachment", "contextual breadcrumbs", "contextual footer", "contextual sidebar", "error summary", "feedback", "govspeak", "input", "layout footer", "layout for admin", "layout header", "skip link", "tabs", "title"],
+      components_in_stylesheets: %w[all],
+      components_in_print_stylesheets: %w[all],
+      components_in_javascripts: %w[all],
+      components_in_ruby: %w[none],
+    }
+
+    expect(application.data).to match(expected)
+  end
+end

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -1,0 +1,250 @@
+require "rails_helper"
+require_relative "../../app/models/govuk_publishing_components/audit_comparer.rb"
+
+describe "Comparing data from an application with the components" do
+  gem = {
+    name: "govuk_publishing_components",
+    components: [
+      "component one",
+      "component two",
+      "component three",
+    ],
+    component_stylesheets: [
+      "component one",
+      "component two",
+      "component three",
+    ],
+    component_print_stylesheets: [
+      "component two",
+    ],
+    component_javascripts: [
+      "component one",
+    ],
+    component_tests: [
+      "component one",
+    ],
+    component_js_tests: [
+      "component one",
+    ],
+    components_containing_components: [
+      {
+        component: "component one",
+        sub_components: [
+          "component three",
+        ],
+      },
+    ],
+    component_listing: [],
+  }
+
+  it "returns a comparison for an application using individual components" do
+    application = [
+      {
+        name: "Dummy application",
+        application_found: true,
+        components_in_templates: [
+          "component one",
+          "component two",
+        ],
+        components_in_stylesheets: [
+          "component one",
+          "component two",
+        ],
+        components_in_print_stylesheets: [],
+        components_in_javascripts: [],
+        components_in_ruby: [
+          "component three",
+        ],
+      },
+    ]
+    comparer = GovukPublishingComponents::AuditComparer.new(gem, application)
+
+    expected = [
+      {
+        name: "Dummy application",
+        application_found: true,
+        summary: [
+          {
+            name: "Components in templates",
+            value: "component one, component three, component two",
+          },
+          {
+            name: "Components in stylesheets",
+            value: "component one, component two",
+          },
+          {
+            name: "Components in print stylesheets",
+            value: "",
+          },
+          {
+            name: "Components in javascripts",
+            value: "",
+          },
+          {
+            name: "Components in ruby",
+            value: "component three",
+          },
+        ],
+        missing_includes: [
+          {
+            name: "Not in templates",
+            values: [],
+          },
+          {
+            name: "Not in stylesheets",
+            values: [
+              {
+                warning: true,
+                component: "component three",
+              },
+            ],
+          },
+          {
+            name: "Not in print stylesheets",
+            values: [
+              {
+                warning: false,
+                component: "component one",
+              },
+              {
+                warning: false,
+                component: "component three",
+              },
+              {
+                warning: true,
+                component: "component two",
+              },
+            ],
+          },
+          {
+            name: "Not in javascripts",
+            values: [
+              {
+                warning: true,
+                component: "component one",
+              },
+              {
+                warning: false,
+                component: "component three",
+              },
+              {
+                warning: false,
+                component: "component two",
+              },
+            ],
+          },
+        ],
+        warning_count: 3,
+      },
+    ]
+
+    expect(comparer.data).to match(expected)
+  end
+
+  it "returns a comparison for an application using all components" do
+    application = [
+      {
+        name: "Dummy application",
+        application_found: true,
+        components_in_templates: [
+          "component one",
+          "component two",
+        ],
+        components_in_stylesheets: %w[all],
+        components_in_print_stylesheets: %w[all],
+        components_in_javascripts: %w[all],
+        components_in_ruby: %w[none],
+      },
+    ]
+    comparer = GovukPublishingComponents::AuditComparer.new(gem, application)
+
+    expected = [
+      {
+        name: "Dummy application",
+        application_found: true,
+        summary: [
+          {
+            name: "Components in templates",
+            value: "component one, component three, component two",
+          },
+          {
+            name: "Components in stylesheets",
+            value: "all",
+          },
+          {
+            name: "Components in print stylesheets",
+            value: "all",
+          },
+          {
+            name: "Components in javascripts",
+            value: "all",
+          },
+          {
+            name: "Components in ruby",
+            value: "none",
+          },
+        ],
+        missing_includes: [
+          {
+            name: "Not in templates",
+            values: [],
+          },
+          {
+            name: "Not in stylesheets",
+            values: [
+              {
+                warning: false,
+                component: "component one",
+              },
+              {
+                warning: false,
+                component: "component three",
+              },
+              {
+                warning: false,
+                component: "component two",
+              },
+            ],
+          },
+          {
+            name: "Not in print stylesheets",
+            values: [
+              {
+                warning: false,
+                component: "component one",
+              },
+              {
+                warning: false,
+                component: "component three",
+              },
+              {
+                warning: false,
+                component: "component two",
+              },
+            ],
+          },
+          {
+            name: "Not in javascripts",
+            values: [
+              {
+                warning: false,
+                component: "component one",
+              },
+              {
+                warning: false,
+                component: "component three",
+              },
+              {
+                warning: false,
+                component: "component two",
+              },
+            ],
+          },
+        ],
+        warning_count: 0,
+      },
+    ]
+
+    expect(comparer.data).to match(expected)
+  end
+end

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../app/models/govuk_publishing_components/audit_comparer.rb
 describe "Comparing data from an application with the components" do
   gem = {
     name: "govuk_publishing_components",
-    components: [
+    component_templates: [
       "component one",
       "component two",
       "component three",
@@ -20,12 +20,8 @@ describe "Comparing data from an application with the components" do
     component_javascripts: [
       "component one",
     ],
-    component_tests: [
-      "component one",
-    ],
-    component_js_tests: [
-      "component one",
-    ],
+    component_tests: [],
+    component_js_tests: [],
     components_containing_components: [
       {
         component: "component one",
@@ -42,18 +38,36 @@ describe "Comparing data from an application with the components" do
       {
         name: "Dummy application",
         application_found: true,
-        components_in_templates: [
-          "component one",
-          "component two",
-        ],
-        components_in_stylesheets: [
-          "component one",
-          "component two",
-        ],
-        components_in_print_stylesheets: [],
-        components_in_javascripts: [],
-        components_in_ruby: [
-          "component three",
+        components_found: [
+          {
+            location: "templates",
+            components: [
+              "component one",
+              "component that does not exist",
+            ],
+          },
+          {
+            location: "stylesheets",
+            components: [
+              "component one",
+              "component two",
+              "component four",
+            ],
+          },
+          {
+            location: "print_stylesheets",
+            components: [],
+          },
+          {
+            location: "javascripts",
+            components: [],
+          },
+          {
+            location: "ruby",
+            components: [
+              "component three",
+            ],
+          },
         ],
       },
     ]
@@ -66,11 +80,11 @@ describe "Comparing data from an application with the components" do
         summary: [
           {
             name: "Components in templates",
-            value: "component one, component three, component two",
+            value: "component one, component that does not exist, component three",
           },
           {
             name: "Components in stylesheets",
-            value: "component one, component two",
+            value: "component one, component two, component four",
           },
           {
             name: "Components in print stylesheets",
@@ -85,56 +99,33 @@ describe "Comparing data from an application with the components" do
             value: "component three",
           },
         ],
-        missing_includes: [
+        warnings: [
           {
-            name: "Not in templates",
-            values: [],
+            component: "component that does not exist",
+            message: "Included in templates but component does not exist",
           },
           {
-            name: "Not in stylesheets",
-            values: [
-              {
-                warning: true,
-                component: "component three",
-              },
-            ],
+            component: "component four",
+            message: "Included in stylesheets but component does not exist",
           },
           {
-            name: "Not in print stylesheets",
-            values: [
-              {
-                warning: false,
-                component: "component one",
-              },
-              {
-                warning: false,
-                component: "component three",
-              },
-              {
-                warning: true,
-                component: "component two",
-              },
-            ],
+            component: "component three",
+            message: "Included in templates but not stylesheets",
           },
           {
-            name: "Not in javascripts",
-            values: [
-              {
-                warning: true,
-                component: "component one",
-              },
-              {
-                warning: false,
-                component: "component three",
-              },
-              {
-                warning: false,
-                component: "component two",
-              },
-            ],
+            component: "component one",
+            message: "Included in templates but not javascripts",
+          },
+          {
+            component: "component three",
+            message: "Included in ruby but not stylesheets",
+          },
+          {
+            component: "component two",
+            message: "Included in stylesheets but not templates",
           },
         ],
-        warning_count: 3,
+        warning_count: 6,
       },
     ]
 
@@ -146,14 +137,33 @@ describe "Comparing data from an application with the components" do
       {
         name: "Dummy application",
         application_found: true,
-        components_in_templates: [
-          "component one",
-          "component two",
+        components_found: [
+          {
+            location: "templates",
+            components: [
+              "component one",
+              "component two",
+            ],
+          },
+          {
+            location: "stylesheets",
+            components: %w[all],
+          },
+          {
+            location: "print_stylesheets",
+            components: %w[all],
+          },
+          {
+            location: "javascripts",
+            components: %w[all],
+          },
+          {
+            location: "ruby",
+            components: [
+              "component that does not exist",
+            ],
+          },
         ],
-        components_in_stylesheets: %w[all],
-        components_in_print_stylesheets: %w[all],
-        components_in_javascripts: %w[all],
-        components_in_ruby: %w[none],
       },
     ]
     comparer = GovukPublishingComponents::AuditComparer.new(gem, application)
@@ -181,67 +191,16 @@ describe "Comparing data from an application with the components" do
           },
           {
             name: "Components in ruby",
-            value: "none",
+            value: "component that does not exist",
           },
         ],
-        missing_includes: [
+        warnings: [
           {
-            name: "Not in templates",
-            values: [],
-          },
-          {
-            name: "Not in stylesheets",
-            values: [
-              {
-                warning: false,
-                component: "component one",
-              },
-              {
-                warning: false,
-                component: "component three",
-              },
-              {
-                warning: false,
-                component: "component two",
-              },
-            ],
-          },
-          {
-            name: "Not in print stylesheets",
-            values: [
-              {
-                warning: false,
-                component: "component one",
-              },
-              {
-                warning: false,
-                component: "component three",
-              },
-              {
-                warning: false,
-                component: "component two",
-              },
-            ],
-          },
-          {
-            name: "Not in javascripts",
-            values: [
-              {
-                warning: false,
-                component: "component one",
-              },
-              {
-                warning: false,
-                component: "component three",
-              },
-              {
-                warning: false,
-                component: "component two",
-              },
-            ],
+            component: "component that does not exist",
+            message: "Included in ruby but component does not exist",
           },
         ],
-        warning_count: 0,
+        warning_count: 1,
       },
     ]
 

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../app/models/govuk_publishing_components/audit_comparer.rb
 describe "Comparing data from an application with the components" do
   gem = {
     name: "govuk_publishing_components",
-    component_templates: [
+    component_code: [
       "component one",
       "component two",
       "component three",
@@ -110,22 +110,18 @@ describe "Comparing data from an application with the components" do
           },
           {
             component: "component three",
-            message: "Included in templates but not stylesheets",
+            message: "Included in code but not stylesheets",
           },
           {
             component: "component one",
-            message: "Included in templates but not javascripts",
-          },
-          {
-            component: "component three",
-            message: "Included in ruby but not stylesheets",
+            message: "Included in code but not javascripts",
           },
           {
             component: "component two",
-            message: "Included in stylesheets but not templates",
+            message: "Included in stylesheets but not code",
           },
         ],
-        warning_count: 6,
+        warning_count: 5,
       },
     ]
 
@@ -201,6 +197,92 @@ describe "Comparing data from an application with the components" do
           },
         ],
         warning_count: 1,
+      },
+    ]
+
+    expect(comparer.data).to match(expected)
+  end
+
+  it "returns a comparison for an application using a mixed approach" do
+    application = [
+      {
+        name: "Dummy application",
+        application_found: true,
+        components_found: [
+          {
+            location: "templates",
+            components: [
+              "component two",
+              "component three",
+            ],
+          },
+          {
+            location: "stylesheets",
+            components: [
+              "component one",
+              "component three",
+            ],
+          },
+          {
+            location: "print_stylesheets",
+            components: %w[all],
+          },
+          {
+            location: "javascripts",
+            components: %w[all],
+          },
+          {
+            location: "ruby",
+            components: [
+              "component that does not exist",
+            ],
+          },
+        ],
+      },
+    ]
+    comparer = GovukPublishingComponents::AuditComparer.new(gem, application)
+
+    expected = [
+      {
+        name: "Dummy application",
+        application_found: true,
+        summary: [
+          {
+            name: "Components in templates",
+            value: "component three, component two",
+          },
+          {
+            name: "Components in stylesheets",
+            value: "component one, component three",
+          },
+          {
+            name: "Components in print stylesheets",
+            value: "all",
+          },
+          {
+            name: "Components in javascripts",
+            value: "all",
+          },
+          {
+            name: "Components in ruby",
+            value: "component that does not exist",
+          },
+        ],
+        warnings: [
+          {
+            component: "component that does not exist",
+            message: "Included in ruby but component does not exist",
+          },
+          {
+            component: "component two",
+            message: "Included in code but not stylesheets",
+          },
+          {
+            component: "component one",
+            message: "Included in stylesheets but not code",
+          },
+        ],
+        warning_count: 3,
       },
     ]
 

--- a/spec/component_guide/audit_components_spec.rb
+++ b/spec/component_guide/audit_components_spec.rb
@@ -6,7 +6,7 @@ describe "Auditing the components in the gem" do
     gem = GovukPublishingComponents::AuditComponents.new("#{Dir.pwd}/spec/dummy_gem")
 
     expected = {
-      component_templates: [
+      component_code: [
         "test component",
         "test component containing other component",
       ],

--- a/spec/component_guide/audit_components_spec.rb
+++ b/spec/component_guide/audit_components_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+require_relative "../../app/models/govuk_publishing_components/audit_components.rb"
+
+describe "Auditing the components in the gem" do
+  it "returns correct information" do
+    gem = GovukPublishingComponents::AuditComponents.new("#{Dir.pwd}/spec/dummy_gem")
+
+    expected = {
+      components: [
+        "test component",
+        "test component containing other component",
+      ],
+      component_stylesheets: [
+        "test component",
+      ],
+      component_print_stylesheets: [
+        "test component",
+      ],
+      component_javascripts: [
+        "test component",
+      ],
+      component_tests: [
+        "test component",
+      ],
+      component_js_tests: [
+        "test component",
+      ],
+      components_containing_components: [
+        {
+          component: "test component containing other component",
+          link: "/component-guide/test_component_containing_other_component",
+          sub_components: [
+            "test component",
+          ],
+        },
+      ],
+      component_listing: [
+        {
+          name: "test component",
+          link: "/component-guide/test_component",
+          stylesheet: true,
+          print_stylesheet: true,
+          javascript: true,
+          tests: true,
+          js_tests: true,
+        },
+        {
+          name: "test component containing other component",
+          link: "/component-guide/test_component_containing_other_component",
+          stylesheet: nil,
+          print_stylesheet: nil,
+          javascript: nil,
+          tests: nil,
+          js_tests: nil,
+        },
+      ],
+    }
+
+    expect(gem.data).to match(expected)
+  end
+end

--- a/spec/component_guide/audit_components_spec.rb
+++ b/spec/component_guide/audit_components_spec.rb
@@ -6,7 +6,7 @@ describe "Auditing the components in the gem" do
     gem = GovukPublishingComponents::AuditComponents.new("#{Dir.pwd}/spec/dummy_gem")
 
     expected = {
-      components: [
+      component_templates: [
         "test component",
         "test component containing other component",
       ],

--- a/spec/component_guide/component_audit_spec.rb
+++ b/spec/component_guide/component_audit_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+describe "Component audit page" do
+  it "renders the audit page" do
+    visit "/component-guide/audit"
+    expect(page).to have_title "Component audit - Component Guide"
+  end
+end

--- a/spec/dummy_gem/app/assets/javascripts/govuk_publishing_components/components/test-component.js
+++ b/spec/dummy_gem/app/assets/javascripts/govuk_publishing_components/components/test-component.js
@@ -1,0 +1,1 @@
+// this file is needed to test the component auditing

--- a/spec/dummy_gem/app/assets/stylesheets/govuk_publishing_components/components/_test-component.scss
+++ b/spec/dummy_gem/app/assets/stylesheets/govuk_publishing_components/components/_test-component.scss
@@ -1,0 +1,1 @@
+// this file is needed to test the component auditing

--- a/spec/dummy_gem/app/assets/stylesheets/govuk_publishing_components/components/print/_test-component.scss
+++ b/spec/dummy_gem/app/assets/stylesheets/govuk_publishing_components/components/print/_test-component.scss
@@ -1,0 +1,1 @@
+// this file is needed to test the component auditing

--- a/spec/dummy_gem/app/views/govuk_publishing_components/components/_test-component-containing-other-component.html.erb
+++ b/spec/dummy_gem/app/views/govuk_publishing_components/components/_test-component-containing-other-component.html.erb
@@ -1,0 +1,3 @@
+<div class="test-component-containing-other-component">
+  <%= render "govuk_publishing_components/components/test-component" %>
+</div>

--- a/spec/dummy_gem/app/views/govuk_publishing_components/components/_test-component.html.erb
+++ b/spec/dummy_gem/app/views/govuk_publishing_components/components/_test-component.html.erb
@@ -1,0 +1,3 @@
+<div class="some-test-component">
+  <h1 class="something-inside-test-component">Test component heading</h1>
+</div>

--- a/spec/dummy_gem/spec/components/test_component.rb
+++ b/spec/dummy_gem/spec/components/test_component.rb
@@ -1,0 +1,1 @@
+# this file is needed to test the component auditing

--- a/spec/dummy_gem/spec/javascripts/components/test-component-spec.js
+++ b/spec/dummy_gem/spec/javascripts/components/test-component-spec.js
@@ -1,0 +1,1 @@
+// this file is needed to test the component auditing


### PR DESCRIPTION
## What
Add some auditing to the component guide, to allow us to understand the components, how they are structured and how they are used.

This code is based on the code from a prototype auditor I built recently - thanks to @injms for the suggestion to add it to the component guide instead of having a command line tool.

## Why
As we move into a world of individual component asset inclusion on GOV.UK (and potentially continuous deployment) I'd like to have some confidence that:

- everything is still styled after changes are made
- redundant assets are removed if a component is no longer in use

We also should be making sure that our components are consistent and don't duplicate effort, so this work ties into a wider need to have some kind of [component auditing](https://trello.com/c/OvXd2E84/103-component-audit) in place. This PR is almost an experiment - to see how useful this information is, to prompt new ideas on how to extend it, and also to see if the warnings it outputs could be integrated somewhere into our build process to prevent e.g. unstyled content from being deployed.

## Visual Changes

The `/component-guide/audit` page includes the following.

A big list of our applications, what components they use, and warnings indicating where component assets are being included/not included incorrectly. This bit of the application currently only works locally using the standalone component guide, as it looks for this information assuming you have all the repos checked out in the same directory (we might be able to improve this at some point, but it's a reasonable starting point).

<img width="1139" alt="Screenshot 2020-07-09 at 16 58 03" src="https://user-images.githubusercontent.com/861310/87062782-6bf40280-c205-11ea-9d90-d2a316c77f29.png">

A list of the components and what assets they each have e.g. stylesheet, print stylesheet, JS file. This will help us identify any gaps. I also anticipate extending this to include more information e.g. which components are using which helper modules.

<img width="1020" alt="Screenshot 2020-06-30 at 12 10 51" src="https://user-images.githubusercontent.com/861310/86119894-3cd5e680-bacb-11ea-94d2-287c89b62cca.png">

A list of components that contain other components (because we don't actually have this documented anywhere).

<img width="1009" alt="Screenshot 2020-06-30 at 12 11 01" src="https://user-images.githubusercontent.com/861310/86119978-64c54a00-bacb-11ea-882f-84d09a664510.png">

A list of components and what applications they are used by (again, this will only work locally). Will help to identify any components we don't use.

<img width="1033" alt="Screenshot 2020-06-30 at 12 11 11" src="https://user-images.githubusercontent.com/861310/86120011-74449300-bacb-11ea-9359-f8d1b7924ec6.png">

