### PR TITLE
Extend action link component with a small icon variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Hide services cookie banner when JavaScript is disabled ([PR #1586](https://github.com/alphagov/govuk_publishing_components/pull/1586))
 * Improve print styles for govspeak info, help and call to action callouts ([PR #1588](https://github.com/alphagov/govuk_publishing_components/pull/1588) )
+* Extend action link component with a small icon variant ([PR #1590](https://github.com/alphagov/govuk_publishing_components/pull/1590) )
 
 ## 21.56.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -118,6 +118,16 @@
 }
 
 .gem-c-action-link--dark-icon {
+  &:before {
+    // sass-lint:disable no-duplicate-properties
+    background: image-url("govuk_publishing_components/action-link-arrow--dark.png");
+    background: image-url("govuk_publishing_components/action-link-arrow--dark.svg"), linear-gradient(transparent, transparent);
+    // sass-lint:enable no-duplicate-properties
+  }
+}
+
+.gem-c-action-link--dark-icon,
+.gem-c-action-link--small-icon {
   max-width: none;
 
   @include govuk-media-query($until: tablet) {
@@ -125,12 +135,8 @@
   }
 
   &:before {
-    width: 30px;
     height: 30px;
-    // sass-lint:disable no-duplicate-properties
-    background: image-url("govuk_publishing_components/action-link-arrow--dark.png");
-    background: image-url("govuk_publishing_components/action-link-arrow--dark.svg"), linear-gradient(transparent, transparent);
-    // sass-lint:enable no-duplicate-properties
+    width: 30px;
     background-repeat: no-repeat;
     background-size: 25px auto;
     background-position: 0 2px;

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -11,6 +11,7 @@
   light_text ||= false
   simple ||= false
   dark_icon ||= false
+  small_icon ||= false
   nhs_icon ||= false
   data ||= nil
   classes ||= nil
@@ -18,6 +19,7 @@
   css_classes = %w(gem-c-action-link)
   css_classes << "gem-c-action-link--light-text" if light_text
   css_classes << "gem-c-action-link--dark-icon" if dark_icon
+  css_classes << "gem-c-action-link--small-icon" if small_icon
   css_classes << "gem-c-action-link--nhs" if nhs_icon
   css_classes << "gem-c-action-link--simple" if simple
   css_classes << "gem-c-action-link--with-subtext" if subtext

--- a/app/views/govuk_publishing_components/components/docs/action_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/action_link.yml
@@ -75,6 +75,11 @@ examples:
       text: Getting financial help and keeping your business safe
       href: "/financial-help"
       simple: true
+  with_small_icon:
+    data:
+      text: Coronavirus (COVID-19)
+      href: "/my-test-page"
+      small_icon: true
   with_dark_icon:
     data:
       text: Coronavirus (COVID-19)

--- a/spec/components/action_link_spec.rb
+++ b/spec/components/action_link_spec.rb
@@ -91,6 +91,15 @@ describe "Action link", type: :view do
     assert_select ".gem-c-action-link--dark-icon"
   end
 
+  it "renders small icon version" do
+    render_component(
+      text: "Get more info",
+      href: "/coronavirus",
+      small_icon: true,
+    )
+    assert_select ".gem-c-action-link--small-icon"
+  end
+
   it "renders NHS icon version" do
     render_component(
       text: "Get more info",


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
Extend action link component with a small icon variant.
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
There is a requirement for a small icon version of the default (dark arrow on yellow background) action link component.
The design has been tweaked in order to have two such links on the Coronavirus landing page header.

![image](https://user-images.githubusercontent.com/7116819/85701885-c48bb180-b6d5-11ea-919f-d6bdca4b60dc.png)



https://trello.com/c/oB87oGqD
<!-- What are the reasons behind this change being made? -->
