### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@
 * Hide services cookie banner when JavaScript is disabled ([PR #1586](https://github.com/alphagov/govuk_publishing_components/pull/1586))
 * Improve print styles for govspeak info, help and call to action callouts ([PR #1588](https://github.com/alphagov/govuk_publishing_components/pull/1588) )
 * Extend action link component with a small icon variant ([PR #1590](https://github.com/alphagov/govuk_publishing_components/pull/1590) )
+* Add print link component ([PR #1582](https://github.com/alphagov/govuk_publishing_components/pull/1582))
 
 ## 21.56.2
 
 * Fix layout on input with prefix/suffix ([PR #1581](https://github.com/alphagov/govuk_publishing_components/pull/1581))
-* Add print link component ([PR #1582](https://github.com/alphagov/govuk_publishing_components/pull/1582))
 
 ## 21.56.1
 


### PR DESCRIPTION
## What
#1582 was merged after #1584 (Release 21.56.2) and before #1591 (Release 21.57.0), hence it will only be available in 21.57.0.

## Why
Keep the changelog accurate.

## Visual Changes
No visual changes.
