### PR TITLE
Minor adjustment to action link icon spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 21.57.1
+
+* Minor adjustment to action link icon spacing ([PR #1593](https://github.com/alphagov/govuk_publishing_components/pull/1593))
+
 ## 21.57.0
 
 * Hide services cookie banner when JavaScript is disabled ([PR #1586](https://github.com/alphagov/govuk_publishing_components/pull/1586))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.57.0)
+    govuk_publishing_components (21.57.1)
       gds-api-adapters
       govuk_app_config
       kramdown

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -136,7 +136,7 @@
 
   &:before {
     height: 30px;
-    width: 30px;
+    width: 35px;
     background-repeat: no-repeat;
     background-size: 25px auto;
     background-position: 0 2px;

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.57.0".freeze
+  VERSION = "21.57.1".freeze
 end


### PR DESCRIPTION
Add 5px to increase space between arrow and text in the small/dark icon versions of the arrow link component, as requested by Mia

Before (left) vs after (right)

<img width="1678" alt="Screenshot 2020-06-25 at 17 48 31" src="https://user-images.githubusercontent.com/7116819/85762942-26670e00-b70c-11ea-94fa-127c0c9f420c.png">



https://trello.com/c/oB87oGqD


