### PR TITLE
Fix search component label accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix search component label accessibility ([PR #1594](https://github.com/alphagov/govuk_publishing_components/pull/1594))
+
 ## 21.57.1
 
 * Minor adjustment to action link icon spacing ([PR #1593](https://github.com/alphagov/govuk_publishing_components/pull/1593))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -9,6 +9,7 @@ $large-input-size: 50px;
 .gem-c-search__label {
   @include govuk-font($size: 19, $line-height: $input-size);
   display: block;
+  background: govuk-colour("white");
 
   h1 {
     @include govuk-font($size: 19, $line-height: $input-size);
@@ -17,8 +18,10 @@ $large-input-size: 50px;
 
   .js-enabled & {
     position: absolute;
-    left: govuk-spacing(3);
-    top: 1px;
+    left: 2px;
+    top: 2px;
+    bottom: 2px;
+    padding-left: govuk-spacing(3);
     z-index: 1;
     color: $govuk-secondary-text-colour;
   }
@@ -201,6 +204,8 @@ $large-input-size: 50px;
 .gem-c-search--separate-label {
   .gem-c-search__label {
     position: relative;
+    top: auto;
     left: auto;
+    padding-left: 0;
   }
 }


### PR DESCRIPTION
## What
- when the page is linearized ([web developer toolbar](https://chrispederick.com/work/web-developer/), miscellaneous, linearize page) the absolutely positioned label for the search input (which is pretending to be placeholder text) appears before the search input and is unreadable on a blue background
- this fixes this by adding a white background to the label, so the appearance is unchanged in the normal view but readable when linearized

## Why
As raised by @selfthinker 

## Visual Changes

Before (normal view)

<img width="712" alt="Screenshot 2020-06-30 at 16 15 02" src="https://user-images.githubusercontent.com/861310/86145218-96034180-baee-11ea-98c8-fa16c59fc7f7.png">

Before (linearized)

<img width="709" alt="Screenshot 2020-06-30 at 16 15 17" src="https://user-images.githubusercontent.com/861310/86145273-a61b2100-baee-11ea-9e4e-b267807e4e65.png">

After (linearized)

<img width="899" alt="Screenshot 2020-06-30 at 17 01 44" src="https://user-images.githubusercontent.com/861310/86149118-702c6b80-baf3-11ea-9f00-c4df9450cfed.png">

After when focussed (linearized)

<img width="895" alt="Screenshot 2020-06-30 at 17 01 53" src="https://user-images.githubusercontent.com/861310/86149131-7589b600-baf3-11ea-86dc-adba812bad00.png">

After with some custom colours applied

<img width="899" alt="Screenshot 2020-06-30 at 17 10 44" src="https://user-images.githubusercontent.com/861310/86149995-af0ef100-baf4-11ea-8f5a-c63ff367ae1c.png">
