### PR TITLE
Add linting to default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,4 +29,9 @@ namespace :assets do
   end
 end
 
-task default: [:spec, "app:jasmine:ci"]
+desc "Run RuboCop linting"
+task lint: :environment do
+  sh "bundle exec rubocop --format clang"
+end
+
+task default: [:lint, :spec, "app:jasmine:ci"]


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Adds rubocop linting to the default rake task.

## Why
<!-- What are the reasons behind this change being made? -->
I keep getting caught out by linting errors being thrown in Jenkins because I forget to run them locally as linting isn't part of the default `bundle exec rake` task. 

Adding the linting to the default will make it easier to remember and (hopefully) will cause more linting errors to be caught locally rather than in Jenkins.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
None.