### PR TITLE
Set up Chrome for JavaScript tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,9 @@ GEM
       rack (>= 1.2.1)
       rake
     jasmine-core (3.5.0)
+    jasmine_selenium_runner (3.0.0)
+      jasmine (~> 3.0)
+      selenium-webdriver (~> 3.8)
     json-schema (2.8.1)
       addressable (>= 2.4)
     kgio (2.11.3)
@@ -316,6 +319,7 @@ DEPENDENCIES
   govuk_schemas (~> 4.0)
   govuk_test (~> 1)
   jasmine (~> 3.5.1)
+  jasmine_selenium_runner (~> 3.0.0)
   pry-byebug
   rspec-rails (~> 4.0)
   rubocop-govuk (~> 3)

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "govuk_schemas", "~> 4.0"
   s.add_development_dependency "govuk_test", "~> 1"
   s.add_development_dependency "jasmine", "~> 3.5.1"
+  s.add_development_dependency "jasmine_selenium_runner", "~> 3.0.0"
   s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rspec-rails", "~> 4.0"
   s.add_development_dependency "rubocop-govuk", "~> 3"

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
@@ -74,17 +74,19 @@ describe('Cookie helper functions', function () {
       GOVUK.setDefaultConsentCookie()
 
       expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_policy', '{"essential":true,"settings":false,"usage":false,"campaigns":false}', Object({ days: 365 }))
-      expect(GOVUK.getConsentCookie()).toEqual({ 'essential': true, 'settings': false, 'usage': false, 'campaigns': false })
+      expect(GOVUK.getConsentCookie()).toEqual({ essential: true, settings: false, usage: false, campaigns: false })
     })
 
-    it('deletes cookies after default consent cookie set', function() {
-      var date = new Date();
-      var days = days || 365;
-      date.setTime(+ date + (days * 86400000)); //24 * 60 * 60 * 1000
+    it('deletes cookies after default consent cookie set', function () {
+      var date = new Date()
+      date.setTime(date.valueOf() + (365 * 24 * 60 * 60 * 1000))
 
-      document.cookie = 'analytics_next_page_call=test;expires=' + date.toGMTString() + ';domain=.' + window.location.hostname + ';path=/'
+      document.cookie = 'analytics_next_page_call=test' +
+        ';expires=' + date.toUTCString() +
+        ';domain=' + window.location.hostname +
+        ';path=/'
 
-      expect(GOVUK.getCookie('analytics_next_page_call')).toBe("test")
+      expect(GOVUK.getCookie('analytics_next_page_call')).toBe('test')
 
       GOVUK.setDefaultConsentCookie()
 
@@ -95,7 +97,7 @@ describe('Cookie helper functions', function () {
     it('can set the consent cookie to approve all cookie categories', function () {
       spyOn(GOVUK, 'setCookie').and.callThrough()
 
-      GOVUK.setConsentCookie({ 'usage': false, 'essential': false })
+      GOVUK.setConsentCookie({ usage: false, essential: false })
 
       expect(GOVUK.getConsentCookie().essential).toBe(false)
       expect(GOVUK.getConsentCookie().usage).toBe(false)
@@ -103,7 +105,7 @@ describe('Cookie helper functions', function () {
       GOVUK.approveAllCookieTypes()
 
       expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}', Object({ days: 365 }))
-      expect(GOVUK.getConsentCookie()).toEqual({ 'essential': true, 'settings': true, 'usage': true, 'campaigns': true })
+      expect(GOVUK.getConsentCookie()).toEqual({ essential: true, settings: true, usage: true, campaigns: true })
     })
 
     it('returns null if the consent cookie does not exist', function () {
@@ -117,14 +119,14 @@ describe('Cookie helper functions', function () {
     })
 
     it('deletes relevant cookies in that category if consent is set to false', function () {
-      GOVUK.setConsentCookie({ 'usage': true })
+      GOVUK.setConsentCookie({ usage: true })
 
       GOVUK.setCookie('analytics_next_page_call', 'this is a usage cookie')
 
       expect(GOVUK.cookie('analytics_next_page_call')).toBe('this is a usage cookie')
 
       spyOn(GOVUK, 'setCookie').and.callThrough()
-      GOVUK.setConsentCookie({ 'usage': false })
+      GOVUK.setConsentCookie({ usage: false })
 
       expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_policy', '{"essential":true,"settings":false,"usage":false,"campaigns":false}', Object({ days: 365 }))
       expect(GOVUK.getConsentCookie().usage).toBe(false)
@@ -134,7 +136,7 @@ describe('Cookie helper functions', function () {
 
   describe('check cookie consent', function () {
     it('returns true if trying to set the consent cookie', function () {
-      expect(GOVUK.checkConsentCookie('cookies_policy', { 'essential': true })).toBe(true)
+      expect(GOVUK.checkConsentCookie('cookies_policy', { essential: true })).toBe(true)
     })
 
     it('returns true if deleting a cookie', function () {
@@ -163,11 +165,11 @@ describe('Cookie helper functions', function () {
     })
 
     it('returns the consent for a given cookie', function () {
-      GOVUK.setConsentCookie({ 'usage': false })
+      GOVUK.setConsentCookie({ usage: false })
 
       expect(GOVUK.checkConsentCookie('analytics_next_page_call', 'set a usage cookie')).toBeFalsy()
 
-      GOVUK.setConsentCookie({ 'usage': true })
+      GOVUK.setConsentCookie({ usage: true })
 
       expect(GOVUK.checkConsentCookie('analytics_next_page_call', 'set a usage cookie')).toBeTruthy()
     })

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,15 +1,10 @@
-# Use this file to set/override Jasmine configuration options
-# You can remove it if you don't need it.
-# This file is loaded *after* jasmine.yml is interpreted.
-#
-# Example: using a different boot file.
-# Jasmine.configure do |config|
-#   config.boot_dir = '/absolute/path/to/boot_dir'
-#   config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
-# end
+require "jasmine_selenium_runner/configure_jasmine"
 
-# Prevent PhantomJS auto install, uses PhantomJS already on your path.
-Jasmine.configure do |config|
-  config.prevent_phantom_js_auto_install = true
-  config.show_console_log = false
+class ChromeHeadlessJasmineConfigurer < JasmineSeleniumRunner::ConfigureJasmine
+  def selenium_options
+    chrome_options = Selenium::WebDriver::Chrome::Options.new
+    chrome_options.headless!
+    chrome_options.add_argument("--no-sandbox")
+    { options: chrome_options }
+  end
 end

--- a/spec/javascripts/support/jasmine_selenium_runner.yml
+++ b/spec/javascripts/support/jasmine_selenium_runner.yml
@@ -1,0 +1,2 @@
+browser: chrome
+configuration_class: ChromeHeadlessJasmineConfigurer


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Replace PhantomJS with Chrome for the JavaScript Jasmine tests .

## Why
<!-- What are the reasons behind this change being made? -->
Because [PhantomJS is no longer in development](https://github.com/ariya/phantomjs/issues/15344) and is out of date. This is impacting our ability to remove jQuery as a dependency because PhantomJS is throwing errors for things that [our browser support matrix](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices) supports, such as `addEventListener` or `NodeList.forEach()`

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
None.