### PR TITLE
Expand suggested sass ruby coverage

### DIFF
--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -85,6 +85,7 @@ module GovukPublishingComponents
 
       files = Dir["#{@application_path}/app/views/**/*.html.erb"]
       files.concat Dir["#{@application_path}/app/**/*.rb"]
+      files.concat Dir["#{@application_path}/lib/**/*.rb"]
 
       files.each do |file|
         data = File.read(file)


### PR DESCRIPTION
## What
Updating the `Suggested imports for this application` functionality to include looking in the `/lib` directory for component instances in ruby.

## Why
I was just converting `smart-answers` to use [individual component assets](https://github.com/alphagov/smart-answers/pull/4659) and noticed that bits of it were unstyled, because govspeak is included in files inside `/lib`. Haven't seen this before, smart-answers might be unique in this, but the change is still worth doing.

## Visual Changes
None.
