### PR TITLE
Check that details component exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@
 ## Unreleased
 
 * Add component auditing ([PR #1589](https://github.com/alphagov/govuk_publishing_components/pull/1589))
+* Check that details component exists (to fix bug created in #1597) ([PR #1602](https://github.com/alphagov/govuk_publishing_components/pull/1602))
+
 
 ## 21.58.0
 
 * Fix search component label accessibility ([PR #1594](https://github.com/alphagov/govuk_publishing_components/pull/1594))
 * Add list component ([PR #1595](https://github.com/alphagov/govuk_publishing_components/pull/1595))
+* Remove jQuery from details component ([PR #1597](https://github.com/alphagov/govuk_publishing_components/pull/1597))
 
 ## 21.57.1
 

--- a/app/assets/javascripts/govuk_publishing_components/components/details.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/details.js
@@ -20,9 +20,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var detailsClick = detailsComponent.querySelector('[data-details-track-click]')
         var that = this
 
-        detailsClick.addEventListener('click', function (event) {
-          that.trackDefault(detailsComponent)
-        })
+        if (detailsClick) {
+          detailsClick.addEventListener('click', function (event) {
+            that.trackDefault(detailsComponent)
+          })
+        }
       }
     }
 


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Fixes a bug introduced in #1597 by adding a check to make sure that element is present before adding an event listener to it.

## Why

Before we add an event listener to the details component we should check that the selector has actually found something - or things go wrong.

Unlike `addEventListener`, jQuery's `.on('click', function() { ... })` silently handles nothing being found. This is because the jQuery selector _always_ returns an iterable jQuery object.

The `.on()` listener loops through the jQuery object given to it - which means that if the object has a length of zero then nothing happens and nothing fails.

Using `querySelector` gives an `HTMLElement` object if the element is present or `null` if there are no matches.

Trying to add an event listener to `null` throws an error - this is why a check is required to see if the element exists before trying to add a listener.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
None.