### PR TITLE
Make component auditing code more resilient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Make component auditing more resilient ([PR #1604](https://github.com/alphagov/govuk_publishing_components/pull/1604))
 * Add more font sizes to heading component ([PR #1587](https://github.com/alphagov/govuk_publishing_components/pull/1587))
 
 ## 21.59.0

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -503,3 +503,9 @@ $code-delete-bg: #fadddd;
     color: $code-09;
   }
 }
+
+.sticky-table-header {
+  position: sticky;
+  top: 0;
+  background: govuk-colour("white");
+}

--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -7,8 +7,8 @@ module GovukPublishingComponents
       applications = analyse_applications(File.expand_path("..", path))
       compared_data = AuditComparer.new(components.data, applications)
 
-      @applications = compared_data.data
-      @components = compared_data.gem_data
+      @applications = compared_data.data || []
+      @components = compared_data.gem_data || []
     end
 
   private

--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -7,7 +7,7 @@ module GovukPublishingComponents
       applications = analyse_applications(File.expand_path("..", path))
       compared_data = AuditComparer.new(components.data, applications)
 
-      @applications = compared_data.data || []
+      @applications = compared_data.applications_data || []
       @components = compared_data.gem_data || []
     end
 

--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -33,10 +33,10 @@ module GovukPublishingComponents
 
       components_in_ruby = components_in_ruby.flatten.uniq
 
-      @data = {
-        name: name,
-        application_found: application_exists(path),
-        components_found: [
+      application_found = application_exists(path)
+      components_found = []
+      if application_found
+        components_found = [
           {
             location: "templates",
             components: components_in_templates,
@@ -57,7 +57,13 @@ module GovukPublishingComponents
             location: "ruby",
             components: components_in_ruby,
           },
-        ],
+        ]
+      end
+
+      @data = {
+        name: name,
+        application_found: application_found,
+        components_found: components_found,
       }
     end
 
@@ -69,11 +75,10 @@ module GovukPublishingComponents
       files.each do |file|
         src = File.read(file)
         components_found << find_match(find, src, type)
+      rescue StandardError
+        puts "File #{file} not found"
       end
 
-      components_found.flatten.uniq.sort
-    rescue StandardError
-      puts "File #{file} not found"
       components_found.flatten.uniq.sort
     end
 

--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -3,11 +3,11 @@ module GovukPublishingComponents
     attr_reader :data
 
     def initialize(path, name)
-      templates = Dir["#{path}/app/views/**/*.html.erb"]
+      templates = Dir["#{path}/app/views/**/*.erb"]
       stylesheets = Dir["#{path}/app/assets/stylesheets/**/*.scss"]
       javascripts = Dir["#{path}/app/assets/javascripts/**/*.js"]
 
-      find_templates = /(?<=govuk_publishing_components\/components\/)[\/a-zA-Z_-]+(?=['"])/
+      find_components = /(?<=govuk_publishing_components\/components\/)[\/a-zA-Z_-]+(?=['"])/
 
       @find_all_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components/
       find_stylesheets = /(?<=@import ["']{1}govuk_publishing_components\/components\/)(?!print)+[a-zA-Z_-]+(?=['"])/
@@ -18,23 +18,21 @@ module GovukPublishingComponents
       @find_all_javascripts = /\/\/[ ]*= require govuk_publishing_components\/all_components/
       find_javascripts = /(?<=require govuk_publishing_components\/components\/)[a-zA-Z_-]+/
 
-      components_in_templates = find_components(templates, find_templates, "templates") || []
+      components_in_templates = find_components(templates, find_components, "templates") || []
       components_in_stylesheets = find_components(stylesheets, find_stylesheets, "stylesheets") || []
       components_in_print_stylesheets = find_components(stylesheets, find_print_stylesheets, "print_stylesheets") || []
       components_in_javascripts = find_components(javascripts, find_javascripts, "javascripts") || []
 
-      find_ruby = /(?<=render\(["']{1}govuk_publishing_components\/components\/)[a-zA-Z_-]+/
       ruby_paths = %w[/app/helpers/ /app/presenters/ /lib/]
-
       components_in_ruby = []
       ruby_paths.each do |ruby_path|
-        components_in_ruby << find_components(Dir["#{path}#{ruby_path}**/*.rb"], find_ruby, "ruby") || []
+        components_in_ruby << find_components(Dir["#{path}#{ruby_path}**/*.{rb,erb}"], find_components, "ruby") || []
       end
-
       components_in_ruby = components_in_ruby.flatten.uniq
 
       application_found = application_exists(path)
       components_found = []
+
       if application_found
         components_found = [
           {

--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -10,7 +10,7 @@ module GovukPublishingComponents
       find_components = /(?<=govuk_publishing_components\/components\/)[\/a-zA-Z_-]+(?=['"])/
 
       @find_all_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components/
-      find_stylesheets = /(?<=@import ["']{1}govuk_publishing_components\/components\/)(?!print)+[a-zA-Z_-]+(?=['"])/
+      find_stylesheets = /(?<=@import ["']{1}govuk_publishing_components\/components\/)(?!print\/)+[a-zA-Z_-]+(?=['"])/
 
       @find_all_print_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components_print/
       find_print_stylesheets = /(?<=@import ["']{1}govuk_publishing_components\/components\/print\/)[a-zA-Z_-]+(?=['"])/

--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -72,6 +72,9 @@ module GovukPublishingComponents
       end
 
       components_found.flatten.uniq.sort
+    rescue StandardError
+      puts "File #{file} not found"
+      components_found.flatten.uniq.sort
     end
 
     def find_match(find, src, type)

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -1,12 +1,12 @@
 module GovukPublishingComponents
   class AuditComparer
-    attr_reader :data, :gem_data
+    attr_reader :applications_data, :gem_data
 
     def initialize(gem_data, results)
       if gem_data[:gem_found]
         @gem_data = gem_data
-        @data = sort_results(results)
-        @gem_data[:components_by_application] = get_components_by_application
+        @applications_data = sort_results(results)
+        @gem_data[:components_by_application] = get_components_by_application || []
       end
     end
 
@@ -20,51 +20,58 @@ module GovukPublishingComponents
       data = []
 
       results.each do |result|
-        templates = result[:components_found].find { |c| c[:location] == "templates" }
-        stylesheets = result[:components_found].find { |c| c[:location] == "stylesheets" }
-        print_stylesheets = result[:components_found].find { |c| c[:location] == "print_stylesheets" }
-        javascripts = result[:components_found].find { |c| c[:location] == "javascripts" }
-        ruby = result[:components_found].find { |c| c[:location] == "ruby" }
+        if result[:application_found]
+          templates = result[:components_found].find { |c| c[:location] == "templates" }
+          stylesheets = result[:components_found].find { |c| c[:location] == "stylesheets" }
+          print_stylesheets = result[:components_found].find { |c| c[:location] == "print_stylesheets" }
+          javascripts = result[:components_found].find { |c| c[:location] == "javascripts" }
+          ruby = result[:components_found].find { |c| c[:location] == "ruby" }
 
-        @all_stylesheets = true if stylesheets[:components].include?("all")
-        @all_print_stylesheets = true if print_stylesheets[:components].include?("all")
-        @all_javascripts = true if javascripts[:components].include?("all")
+          @all_stylesheets = true if stylesheets[:components].include?("all")
+          @all_print_stylesheets = true if print_stylesheets[:components].include?("all")
+          @all_javascripts = true if javascripts[:components].include?("all")
 
-        templates[:components] = include_any_components_within_components(templates[:components])
+          templates[:components] = include_any_components_within_components(templates[:components])
 
-        warnings = []
-        warnings << warn_about_missing_components(result[:components_found])
-        warnings << warn_about_missing_assets(result[:components_found])
-        warnings = warnings.flatten
+          warnings = []
+          warnings << warn_about_missing_components(result[:components_found])
+          warnings << warn_about_missing_assets(result[:components_found])
+          warnings = warnings.flatten
 
-        data << {
-          name: result[:name],
-          application_found: result[:application_found],
-          summary: [
-            {
-              name: "Components in templates",
-              value: templates[:components].flatten.uniq.sort.join(", "),
-            },
-            {
-              name: "Components in stylesheets",
-              value: stylesheets[:components].join(", "),
-            },
-            {
-              name: "Components in print stylesheets",
-              value: print_stylesheets[:components].join(", "),
-            },
-            {
-              name: "Components in javascripts",
-              value: javascripts[:components].join(", "),
-            },
-            {
-              name: "Components in ruby",
-              value: ruby[:components].join(", "),
-            },
-          ],
-          warnings: warnings,
-          warning_count: warnings.length,
-        }
+          data << {
+            name: result[:name],
+            application_found: result[:application_found],
+            summary: [
+              {
+                name: "Components in templates",
+                value: templates[:components].flatten.uniq.sort.join(", "),
+              },
+              {
+                name: "Components in stylesheets",
+                value: stylesheets[:components].join(", "),
+              },
+              {
+                name: "Components in print stylesheets",
+                value: print_stylesheets[:components].join(", "),
+              },
+              {
+                name: "Components in javascripts",
+                value: javascripts[:components].join(", "),
+              },
+              {
+                name: "Components in ruby",
+                value: ruby[:components].join(", "),
+              },
+            ],
+            warnings: warnings,
+            warning_count: warnings.length,
+          }
+        else
+          data << {
+            name: result[:name],
+            application_found: result[:application_found],
+          }
+        end
       end
 
       data
@@ -149,12 +156,16 @@ module GovukPublishingComponents
 
     def get_components_by_application
       results = []
+      found_something = false
 
       @gem_data[:component_listing].each do |component|
         found_in_applications = []
 
-        @data.each do |application|
+        @applications_data.each do |application|
+          next unless application[:application_found]
+
           name = application[:name]
+          found_something = true
 
           application[:summary].each do |item|
             found_in_applications << name if item[:value].include?(component[:name])
@@ -168,7 +179,7 @@ module GovukPublishingComponents
         }
       end
 
-      results
+      results if found_something
     end
   end
 end

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -3,9 +3,11 @@ module GovukPublishingComponents
     attr_reader :data, :gem_data
 
     def initialize(gem_data, results)
-      @gem_data = gem_data
-      @data = sort_results(results)
-      @gem_data[:components_by_application] = get_components_by_application
+      if gem_data[:gem_found]
+        @gem_data = gem_data
+        @data = sort_results(results)
+        @gem_data[:components_by_application] = get_components_by_application
+      end
     end
 
   private

--- a/app/models/govuk_publishing_components/audit_components.rb
+++ b/app/models/govuk_publishing_components/audit_components.rb
@@ -6,7 +6,7 @@ module GovukPublishingComponents
       @data = {
         gem_found: false,
       }
-      compile_data(path) if Dir.exist?(path)
+      @data = compile_data(path) if Dir.exist?(path)
     end
 
   private
@@ -35,7 +35,7 @@ module GovukPublishingComponents
       @component_tests = find_files(tests, [path, tests_path].join("/"))
       @component_js_tests = find_files(js_tests, [path, js_tests_path].join("/"))
 
-      @data = {
+      {
         gem_found: true,
         component_code: @components,
         component_stylesheets: @component_stylesheets,

--- a/app/models/govuk_publishing_components/audit_components.rb
+++ b/app/models/govuk_publishing_components/audit_components.rb
@@ -3,6 +3,15 @@ module GovukPublishingComponents
     attr_reader :data
 
     def initialize(path)
+      @data = {
+        gem_found: false,
+      }
+      compile_data(path) if Dir.exist?(path)
+    end
+
+  private
+
+    def compile_data(path)
       templates_path = "app/views/govuk_publishing_components/components"
       stylesheets_path = "app/assets/stylesheets/govuk_publishing_components/components"
       print_stylesheets_path = "app/assets/stylesheets/govuk_publishing_components/components/print"
@@ -27,6 +36,7 @@ module GovukPublishingComponents
       @component_js_tests = find_files(js_tests, [path, js_tests_path].join("/"))
 
       @data = {
+        gem_found: true,
         component_code: @components,
         component_stylesheets: @component_stylesheets,
         component_print_stylesheets: @component_print_stylesheets,
@@ -37,8 +47,6 @@ module GovukPublishingComponents
         component_listing: list_all_component_details,
       }
     end
-
-  private
 
     def find_files(files, replace)
       files.map { |file| clean_file_name(file.gsub(replace, "")) }.sort

--- a/app/models/govuk_publishing_components/audit_components.rb
+++ b/app/models/govuk_publishing_components/audit_components.rb
@@ -19,7 +19,7 @@ module GovukPublishingComponents
       tests_path = "spec/components"
       js_tests_path = "spec/javascripts/components"
 
-      templates = Dir["#{path}/#{templates_path}/*.html.erb"]
+      templates = Dir["#{path}/#{templates_path}/*.erb"]
       stylesheets = Dir["#{path}/#{stylesheets_path}/*.scss"]
       print_stylesheets = Dir["#{path}/#{print_stylesheets_path}/*.scss"]
       javascripts = Dir["#{path}/#{javascripts_path}/*.js"]
@@ -53,11 +53,22 @@ module GovukPublishingComponents
     end
 
     def clean_file_name(name)
-      name.tr("/_-", " ").gsub(".html.erb", "").gsub(".scss", "").gsub(".js", "").gsub("spec", "").gsub(".rb", "").strip
+      name.tr("/_-", " ")
+        .gsub(".html.erb", "")
+        .gsub(".erb", "")
+        .gsub(".scss", "")
+        .gsub(".js", "")
+        .gsub("spec", "")
+        .gsub(".rb", "")
+        .strip
     end
 
     def get_component_name_from_full_path(path)
-      path.gsub("/_", "/").gsub(@templates_full_path, "").gsub(".html.erb", "").tr('\"\'', "")
+      path.gsub("/_", "/")
+        .gsub(@templates_full_path, "")
+        .gsub(".html.erb", "")
+        .gsub(".erb", "")
+        .tr('\"\'', "")
     end
 
     def get_component_link(component)

--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -2,224 +2,228 @@
 
 <%= render 'govuk_publishing_components/components/title', title: "Components audit", margin_top: 0; %>
 
-<div class="govuk-tabs" data-module="govuk-tabs">
-  <h2 class="govuk-tabs__title">
-    Contents
-  </h2>
-  <ul class="govuk-tabs__list">
-    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-      <a class="govuk-tabs__tab" href="#applications">
-        Applications
-      </a>
-    </li>
-    <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#components-gem">
-        Components
-      </a>
-    </li>
-  </ul>
-  <div class="govuk-tabs__panel" id="applications">
-    <h2 class="govuk-heading-l">Applications</h2>
+<% if ENV["MAIN_COMPONENT_GUIDE"] %>
+  <div class="govuk-tabs" data-module="govuk-tabs">
+    <h2 class="govuk-tabs__title">
+      Contents
+    </h2>
+    <ul class="govuk-tabs__list">
+      <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+        <a class="govuk-tabs__tab" href="#applications">
+          Applications
+        </a>
+      </li>
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="#components-gem">
+          Components
+        </a>
+      </li>
+    </ul>
+    <div class="govuk-tabs__panel" id="applications">
+      <h2 class="govuk-heading-l">Applications</h2>
 
-    <% if @applications.any? %>
-      <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            How to use this information
-          </span>
-        </summary>
-        <div class="govuk-details__text">
-          <p class="govuk-body">This page shows information about component use on GOV.UK. This information has been cross referenced with the components in the gem to produce warnings where e.g. a print stylesheet for a component exists but has not been included in an application.</p>
-          <p class="govuk-body">Warnings should be investigated, although there may be a reason why the application has been configured as it is. Note that 'code' can refer to templates or ruby code.</p>
-        </div>
-      </details>
+      <% if @applications.any? %>
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              How to use this information
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <p class="govuk-body">This page shows information about component use on GOV.UK. This information has been cross referenced with the components in the gem to produce warnings where e.g. a print stylesheet for a component exists but has not been included in an application.</p>
+            <p class="govuk-body">Warnings should be investigated, although there may be a reason why the application has been configured as it is. Note that 'code' can refer to templates or ruby code.</p>
+          </div>
+        </details>
 
-      <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-with-summary-sections">
-        <% @applications.each_with_index do |application, index| %>
-          <div class="govuk-accordion__section ">
-            <div class="govuk-accordion__section-header">
-              <h2 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button" id="accordion-with-summary-sections-heading-<%= index %>">
-                  <%= application[:name] %>
-                </span>
-              </h2>
-              <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-<%= index %>">
-                <% if application[:application_found] %>
-                  Warnings:
-                  <% if application[:warning_count] > 0 %>
-                    <strong class="govuk-tag govuk-tag--red"><%= application[:warning_count] %></strong>
+        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-with-summary-sections">
+          <% @applications.each_with_index do |application, index| %>
+            <div class="govuk-accordion__section ">
+              <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                  <span class="govuk-accordion__section-button" id="accordion-with-summary-sections-heading-<%= index %>">
+                    <%= application[:name] %>
+                  </span>
+                </h2>
+                <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-<%= index %>">
+                  <% if application[:application_found] %>
+                    Warnings:
+                    <% if application[:warning_count] > 0 %>
+                      <strong class="govuk-tag govuk-tag--red"><%= application[:warning_count] %></strong>
+                    <% else %>
+                      <%= application[:warning_count] %>
+                    <% end %>
                   <% else %>
-                    <%= application[:warning_count] %>
+                    <strong class="govuk-tag govuk-tag--red">Application not found</strong>
                   <% end %>
+                </div>
+              </div>
+              <div id="accordion-with-summary-sections-content-<%= index %>" class="govuk-accordion__section-content" aria-labelledby="accordion-with-summary-sections-heading-<%= index %>">
+                <% if application[:application_found] %>
+                  <% application[:warnings].each do |warning| %>
+                    <p class="govuk-body">
+                      <strong class="govuk-tag">Warn</strong>
+                      <strong><%= warning[:component] %></strong> - <%= warning[:message] %>
+                    </p>
+                  <% end %>
+
+                  <h3 class="govuk-heading-m">Components used</h3>
+
+                  <dl class="govuk-summary-list">
+                    <% application[:summary].each do |item| %>
+                      <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                          <%= item[:name] %>
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                          <% if item[:value].length > 0 %>
+                            <%= item[:value] %>
+                          <% else %>
+                            None
+                          <% end %>
+                        </dd>
+                      </div>
+                    <% end %>
+                  </dl>
                 <% else %>
-                  <strong class="govuk-tag govuk-tag--red">Application not found</strong>
+                  <p class="govuk-body">This application was not found. This could be because you do not have this repository checked out locally.</p>
                 <% end %>
               </div>
             </div>
-            <div id="accordion-with-summary-sections-content-<%= index %>" class="govuk-accordion__section-content" aria-labelledby="accordion-with-summary-sections-heading-<%= index %>">
-              <% if application[:application_found] %>
-                <% application[:warnings].each do |warning| %>
-                  <p class="govuk-body">
-                    <strong class="govuk-tag">Warn</strong>
-                    <strong><%= warning[:component] %></strong> - <%= warning[:message] %>
-                  </p>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="govuk-body">No applications found.</p>
+      <% end %>
+    </div>
+
+    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="components-gem">
+      <h2 class="govuk-heading-l">Components</h2>
+
+      <% if @components.any? %>
+        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+          <div class="govuk-accordion__section ">
+            <div class="govuk-accordion__section-header">
+              <h2 class="govuk-accordion__section-heading">
+                <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+                  Component files
+                </span>
+              </h2>
+              <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-1">
+                Lists what files each component has
+              </div>
+            </div>
+            <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+              <table class="govuk-table">
+                <thead class="govuk-table__head">
+                  <tr class="govuk-table__row">
+                    <th scope="col" class="govuk-table__header sticky-table-header">Component</th>
+                    <th scope="col" class="govuk-table__header sticky-table-header">Stylesheet</th>
+                    <th scope="col" class="govuk-table__header sticky-table-header">Print stylesheet</th>
+                    <th scope="col" class="govuk-table__header sticky-table-header">JS</th>
+                    <th scope="col" class="govuk-table__header sticky-table-header">Test</th>
+                    <th scope="col" class="govuk-table__header sticky-table-header">JS test</th>
+                  </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                  <% @components[:component_listing].each do |component| %>
+                    <tr class="govuk-table__row">
+                      <th scope="row" class="govuk-table__header">
+                        <a href="<%= component[:link] %>" class="govuk-link"><%= component[:name] %></a>
+                      </th>
+                      <td class="govuk-table__cell">
+                        <% if component[:stylesheet] %>
+                          <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                        <% end %>
+                      </td>
+                      <td class="govuk-table__cell">
+                        <% if component[:print_stylesheet] %>
+                          <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                        <% end %>
+                      </td>
+                      <td class="govuk-table__cell">
+                        <% if component[:javascript] %>
+                          <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                        <% end %>
+                      </td>
+                      <td class="govuk-table__cell">
+                        <% if component[:tests] %>
+                          <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                        <% end %>
+                      </td>
+                      <td class="govuk-table__cell">
+                        <% if component[:js_tests] %>
+                          <strong class="govuk-tag govuk-tag--green">Yes</strong>
+                        <% end %>
+                      </td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="govuk-accordion__section ">
+            <div class="govuk-accordion__section-header">
+              <h2 class="govuk-accordion__section-heading">
+                <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+                  Components containing components
+                </span>
+              </h2>
+              <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-2">
+                Shows which components contain other components
+              </div>
+            </div>
+            <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+              <dl class="govuk-summary-list">
+                <% @components[:components_containing_components].each do |component| %>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      <a href="<%= component[:link] %>" class="govuk-link"><%= component[:component] %></a>
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      <%= component[:sub_components].join(', ') %>
+                    </dd>
+                  </div>
                 <% end %>
-
-                <h3 class="govuk-heading-m">Components used</h3>
-
+              </dl>
+            </div>
+          </div>
+          <div class="govuk-accordion__section ">
+            <div class="govuk-accordion__section-header">
+              <h2 class="govuk-accordion__section-heading">
+                <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+                  Components by application
+                </span>
+              </h2>
+              <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-2">
+                Shows which applications use each component
+              </div>
+            </div>
+            <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+              <% if @components[:components_by_application].any? %>
                 <dl class="govuk-summary-list">
-                  <% application[:summary].each do |item| %>
+                  <% @components[:components_by_application].each do |component| %>
                     <div class="govuk-summary-list__row">
                       <dt class="govuk-summary-list__key">
-                        <%= item[:name] %>
+                        <%= component[:component] %> (<%= component[:count] %>)
                       </dt>
                       <dd class="govuk-summary-list__value">
-                        <% if item[:value].length > 0 %>
-                          <%= item[:value] %>
-                        <% else %>
-                          None
-                        <% end %>
+                        <%= component[:list] %>
                       </dd>
                     </div>
                   <% end %>
                 </dl>
               <% else %>
-                <p class="govuk-body">This application was not found. This could be because you do not have this repository checked out locally.</p>
+                <p class="govuk-body">Sorry, no applications found.</p>
               <% end %>
             </div>
           </div>
-        <% end %>
-      </div>
-    <% else %>
-      <p class="govuk-body">No applications found.</p>
-    <% end %>
+        </div>
+      <% else %>
+        <p class="govuk-body">No components found.</p>
+      <% end %>
+    </div>
   </div>
-
-  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="components-gem">
-    <h2 class="govuk-heading-l">Components</h2>
-
-    <% if @components.any? %>
-      <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-        <div class="govuk-accordion__section ">
-          <div class="govuk-accordion__section-header">
-            <h2 class="govuk-accordion__section-heading">
-              <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
-                Component files
-              </span>
-            </h2>
-            <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-1">
-              Lists what files each component has
-            </div>
-          </div>
-          <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
-            <table class="govuk-table">
-              <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                  <th scope="col" class="govuk-table__header sticky-table-header">Component</th>
-                  <th scope="col" class="govuk-table__header sticky-table-header">Stylesheet</th>
-                  <th scope="col" class="govuk-table__header sticky-table-header">Print stylesheet</th>
-                  <th scope="col" class="govuk-table__header sticky-table-header">JS</th>
-                  <th scope="col" class="govuk-table__header sticky-table-header">Test</th>
-                  <th scope="col" class="govuk-table__header sticky-table-header">JS test</th>
-                </tr>
-              </thead>
-              <tbody class="govuk-table__body">
-                <% @components[:component_listing].each do |component| %>
-                  <tr class="govuk-table__row">
-                    <th scope="row" class="govuk-table__header">
-                      <a href="<%= component[:link] %>" class="govuk-link"><%= component[:name] %></a>
-                    </th>
-                    <td class="govuk-table__cell">
-                      <% if component[:stylesheet] %>
-                        <strong class="govuk-tag govuk-tag--green">Yes</strong>
-                      <% end %>
-                    </td>
-                    <td class="govuk-table__cell">
-                      <% if component[:print_stylesheet] %>
-                        <strong class="govuk-tag govuk-tag--green">Yes</strong>
-                      <% end %>
-                    </td>
-                    <td class="govuk-table__cell">
-                      <% if component[:javascript] %>
-                        <strong class="govuk-tag govuk-tag--green">Yes</strong>
-                      <% end %>
-                    </td>
-                    <td class="govuk-table__cell">
-                      <% if component[:tests] %>
-                        <strong class="govuk-tag govuk-tag--green">Yes</strong>
-                      <% end %>
-                    </td>
-                    <td class="govuk-table__cell">
-                      <% if component[:js_tests] %>
-                        <strong class="govuk-tag govuk-tag--green">Yes</strong>
-                      <% end %>
-                    </td>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        <div class="govuk-accordion__section ">
-          <div class="govuk-accordion__section-header">
-            <h2 class="govuk-accordion__section-heading">
-              <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-                Components containing components
-              </span>
-            </h2>
-            <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-2">
-              Shows which components contain other components
-            </div>
-          </div>
-          <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
-            <dl class="govuk-summary-list">
-              <% @components[:components_containing_components].each do |component| %>
-                <div class="govuk-summary-list__row">
-                  <dt class="govuk-summary-list__key">
-                    <a href="<%= component[:link] %>" class="govuk-link"><%= component[:component] %></a>
-                  </dt>
-                  <dd class="govuk-summary-list__value">
-                    <%= component[:sub_components].join(', ') %>
-                  </dd>
-                </div>
-              <% end %>
-            </dl>
-          </div>
-        </div>
-        <div class="govuk-accordion__section ">
-          <div class="govuk-accordion__section-header">
-            <h2 class="govuk-accordion__section-heading">
-              <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-                Components by application
-              </span>
-            </h2>
-            <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-2">
-              Shows which applications use each component
-            </div>
-          </div>
-          <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
-            <% if @components[:components_by_application].any? %>
-              <dl class="govuk-summary-list">
-                <% @components[:components_by_application].each do |component| %>
-                  <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">
-                      <%= component[:component] %> (<%= component[:count] %>)
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                      <%= component[:list] %>
-                    </dd>
-                  </div>
-                <% end %>
-              </dl>
-            <% else %>
-              <p class="govuk-body">Sorry, no applications found.</p>
-            <% end %>
-          </div>
-        </div>
-      </div>
-    <% else %>
-      <p class="govuk-body">No components found.</p>
-    <% end %>
-  </div>
-</div>
+<% else %>
+  <p class="govuk-body">Component auditing is only available when the component guide is running locally as a standalone app.</p>
+<% end %>

--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -115,12 +115,12 @@
             <table class="govuk-table">
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                  <th scope="col" class="govuk-table__header">Component</th>
-                  <th scope="col" class="govuk-table__header">Stylesheet</th>
-                  <th scope="col" class="govuk-table__header">Print stylesheet</th>
-                  <th scope="col" class="govuk-table__header">JS</th>
-                  <th scope="col" class="govuk-table__header">Test</th>
-                  <th scope="col" class="govuk-table__header">JS test</th>
+                  <th scope="col" class="govuk-table__header sticky-table-header">Component</th>
+                  <th scope="col" class="govuk-table__header sticky-table-header">Stylesheet</th>
+                  <th scope="col" class="govuk-table__header sticky-table-header">Print stylesheet</th>
+                  <th scope="col" class="govuk-table__header sticky-table-header">JS</th>
+                  <th scope="col" class="govuk-table__header sticky-table-header">Test</th>
+                  <th scope="col" class="govuk-table__header sticky-table-header">JS test</th>
                 </tr>
               </thead>
               <tbody class="govuk-table__body">

--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -199,18 +199,22 @@
             </div>
           </div>
           <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
-            <dl class="govuk-summary-list">
-              <% @components[:components_by_application].each do |component| %>
-                <div class="govuk-summary-list__row">
-                  <dt class="govuk-summary-list__key">
-                    <%= component[:component] %> (<%= component[:count] %>)
-                  </dt>
-                  <dd class="govuk-summary-list__value">
-                    <%= component[:list] %>
-                  </dd>
-                </div>
-              <% end %>
-            </dl>
+            <% if @components[:components_by_application].any? %>
+              <dl class="govuk-summary-list">
+                <% @components[:components_by_application].each do |component| %>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      <%= component[:component] %> (<%= component[:count] %>)
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      <%= component[:list] %>
+                    </dd>
+                  </div>
+                <% end %>
+              </dl>
+            <% else %>
+              <p class="govuk-body">Sorry, no applications found.</p>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -5,7 +5,9 @@
   <p>See the <a href="https://github.com/alphagov/govuk_publishing_components">govuk_publishing_components gem</a> for further details, or <a href="https://docs.publishing.service.gov.uk/manual/components.html#component-guides">a list of all component guides</a>.</p>
   <ul>
     <li>Read about how to <a href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/publishing-to-rubygems.md">release a new version of the gem</a></li>
-    <li><a href="/component-guide/audit">View component audits</a></li>
+    <% if ENV["MAIN_COMPONENT_GUIDE"] %>
+      <li><a href="/component-guide/audit">View component audits</a></li>
+    <% end %>
   </ul>
 </div>
 

--- a/spec/component_guide/audit_applications_spec.rb
+++ b/spec/component_guide/audit_applications_spec.rb
@@ -3,7 +3,8 @@ require_relative "../../app/models/govuk_publishing_components/audit_application
 
 describe "Auditing the components in applications" do
   it "returns correct information" do
-    application = GovukPublishingComponents::AuditApplications.new("#{Dir.pwd}/spec/dummy", "an application")
+    path = File.join(File.dirname(__FILE__), "../dummy")
+    application = GovukPublishingComponents::AuditApplications.new(path, "an application")
 
     expected = {
       name: "an application",

--- a/spec/component_guide/audit_applications_spec.rb
+++ b/spec/component_guide/audit_applications_spec.rb
@@ -28,7 +28,7 @@ describe "Auditing the components in applications" do
         },
         {
           location: "ruby",
-          components: [],
+          components: ["button", "govspeak", "print link"],
         },
       ],
     }

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -78,7 +78,7 @@ describe "Comparing data from an application with the components" do
     ]
     comparer = GovukPublishingComponents::AuditComparer.new(gem_not_found, application)
     expected = nil
-    expect(comparer.data).to match(expected)
+    expect(comparer.applications_data).to match(expected)
   end
 
   it "returns a comparison for an application using individual components" do
@@ -173,7 +173,7 @@ describe "Comparing data from an application with the components" do
       },
     ]
 
-    expect(comparer.data).to match(expected)
+    expect(comparer.applications_data).to match(expected)
   end
 
   it "returns a comparison for an application using all components" do
@@ -248,7 +248,7 @@ describe "Comparing data from an application with the components" do
       },
     ]
 
-    expect(comparer.data).to match(expected)
+    expect(comparer.applications_data).to match(expected)
   end
 
   it "returns a comparison for an application using a mixed approach" do
@@ -334,6 +334,6 @@ describe "Comparing data from an application with the components" do
       },
     ]
 
-    expect(comparer.data).to match(expected)
+    expect(comparer.applications_data).to match(expected)
   end
 end

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -3,6 +3,7 @@ require_relative "../../app/models/govuk_publishing_components/audit_comparer.rb
 
 describe "Comparing data from an application with the components" do
   gem = {
+    gem_found: true,
     name: "govuk_publishing_components",
     component_code: [
       "component one",
@@ -32,6 +33,53 @@ describe "Comparing data from an application with the components" do
     ],
     component_listing: [],
   }
+
+  gem_not_found = {
+    gem_found: false,
+  }
+
+  it "behaves appropriately if the gem components were not found" do
+    application = [
+      {
+        name: "Dummy application",
+        application_found: true,
+        components_found: [
+          {
+            location: "templates",
+            components: [
+              "component one",
+              "component that does not exist",
+            ],
+          },
+          {
+            location: "stylesheets",
+            components: [
+              "component one",
+              "component two",
+              "component four",
+            ],
+          },
+          {
+            location: "print_stylesheets",
+            components: [],
+          },
+          {
+            location: "javascripts",
+            components: [],
+          },
+          {
+            location: "ruby",
+            components: [
+              "component three",
+            ],
+          },
+        ],
+      },
+    ]
+    comparer = GovukPublishingComponents::AuditComparer.new(gem_not_found, application)
+    expected = nil
+    expect(comparer.data).to match(expected)
+  end
 
   it "returns a comparison for an application using individual components" do
     application = [

--- a/spec/component_guide/audit_components_spec.rb
+++ b/spec/component_guide/audit_components_spec.rb
@@ -2,10 +2,23 @@ require "rails_helper"
 require_relative "../../app/models/govuk_publishing_components/audit_components.rb"
 
 describe "Auditing the components in the gem" do
-  it "returns correct information" do
-    gem = GovukPublishingComponents::AuditComponents.new("#{Dir.pwd}/spec/dummy_gem")
+  it "fails gracefully if the gem is not found" do
+    path = File.join(File.dirname(__FILE__), "not/a/real/directory")
+    gem = GovukPublishingComponents::AuditComponents.new(path)
 
     expected = {
+      gem_found: false,
+    }
+
+    expect(gem.data).to match(expected)
+  end
+
+  it "returns correct information" do
+    path = File.join(File.dirname(__FILE__), "../dummy_gem")
+    gem = GovukPublishingComponents::AuditComponents.new(path)
+
+    expected = {
+      gem_found: true,
       component_code: [
         "test component",
         "test component containing other component",

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -60,6 +60,7 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/layout-footer';
 @import 'govuk_publishing_components/components/layout-for-admin';
 @import 'govuk_publishing_components/components/layout-header';
+@import 'govuk_publishing_components/components/print-link';
 @import 'govuk_publishing_components/components/related-navigation';
 @import 'govuk_publishing_components/components/skip-link';
 @import 'govuk_publishing_components/components/step-by-step-nav';
@@ -68,7 +69,7 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/tabs';
 @import 'govuk_publishing_components/components/title';"
 
-    expect(page).to have_selector(".component-doc-h2", text: "Gem components used by this app (13)")
+    expect(page).to have_selector(".component-doc-h2", text: "Gem components used by this app (15)")
     expect(page).to have_selector(".govuk-details__summary-text", text: "Suggested imports for this application")
 
     expect(page.find(:css, 'textarea[name="main-sass"]', visible: false).value).to eq(expected_main_sass)
@@ -97,6 +98,7 @@ describe "Component guide index" do
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/print-link
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/tabs"
 

--- a/spec/dummy/lib/test_file_1.rb
+++ b/spec/dummy/lib/test_file_1.rb
@@ -1,0 +1,4 @@
+# this is a test file used to check component auditing functionality
+
+thing = false
+render("govuk_publishing_components/components/govspeak") { content.html_safe } unless thing

--- a/spec/dummy/lib/test_file_2.erb
+++ b/spec/dummy/lib/test_file_2.erb
@@ -1,0 +1,11 @@
+# this is a test file used to check component auditing functionality
+
+<% if false %>
+  <%= render "govuk_publishing_components/components/print_link", text: "Print this page" %>
+<% end %>
+
+<%
+  if false
+    render("govuk_publishing_components/components/button")
+  end
+%>


### PR DESCRIPTION
## What
The auditing code makes a lot of assumptions about being able to find specific directories, which means it's liable to errors or unexpected output when it can't find them. For example, when it's running on review apps sometimes it can't find itself, which meant that it was throwing up a ton of 'component does not exist' warnings when it shouldn't have been.

Additionally, some things should be shown or not shown depending on whether the auditing code has been able to find them - for example, if it can't find any applications it shouldn't display (blank) information about component usage in applications.

Additionally improves the scope of the auditing code by relaxing some of the restrictions on file extensions and regexes when looking for component instances in ruby. This was prompted by the auditing missing a component in smart answers.

## Why
Code should be robust.

## Visual Changes
None.
