### PR TITLE
Fix JavaScript linting errors

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,8 +30,13 @@ namespace :assets do
 end
 
 desc "Run RuboCop linting"
-task lint: :environment do
+task lint_ruby: :environment do
   sh "bundle exec rubocop --format clang"
 end
 
-task default: [:lint, :spec, "app:jasmine:ci"]
+desc "Run Javascript and Sass linting"
+task lint_js_and_sass: :environment do
+  sh "npm run lint"
+end
+
+task default: [:lint_ruby, :lint_js_and_sass, :spec, "app:jasmine:ci"]

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -42,8 +42,8 @@ window.GOVUK.Modules.Checkboxes = window.GOVUKFrontend;
               if (typeof options !== 'object' || options === null) {
                 options = {}
               }
-              options['value'] = $checkbox.data('track-value')
-              options['label'] = $checkbox.data('track-label')
+              options.value = $checkbox.data('track-value')
+              options.label = $checkbox.data('track-label')
               window.GOVUK.analytics.trackEvent(category, action, options)
             }
           }

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -405,7 +405,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var dimension28 = $(event.target).closest('.gem-c-step-nav__list').attr('data-length')
 
         if (dimension28) {
-          trackingOptions['dimension28'] = dimension28
+          trackingOptions.dimension28 = dimension28
         }
 
         stepNavTracker.track('stepNavLinkClicked', linkPosition, trackingOptions)
@@ -421,9 +421,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         // dimension28 records the number of links in the step that was shown/hidden (handled in click event)
         if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
           options = options || {}
-          options['dimension26'] = options['dimension26'] || totalSteps.toString()
-          options['dimension27'] = options['dimension27'] || totalLinks.toString()
-          options['dimension96'] = options['dimension96'] || uniqueId
+          options.dimension26 = options.dimension26 || totalSteps.toString()
+          options.dimension27 = options.dimension27 || totalLinks.toString()
+          options.dimension96 = options.dimension96 || uniqueId
           window.GOVUK.analytics.trackEvent(category, action, options)
         }
       }

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -5,31 +5,31 @@
   window.GOVUK = window.GOVUK || {}
 
   var DEFAULT_COOKIE_CONSENT = {
-    'essential': true,
-    'settings': false,
-    'usage': false,
-    'campaigns': false
+    essential: true,
+    settings: false,
+    usage: false,
+    campaigns: false
   }
 
   var COOKIE_CATEGORIES = {
-    'cookies_policy': 'essential',
-    'seen_cookie_message': 'essential',
-    'cookie_preferences_set': 'essential',
-    'cookies_preferences_set': 'essential',
+    cookies_policy: 'essential',
+    seen_cookie_message: 'essential',
+    cookie_preferences_set: 'essential',
+    cookies_preferences_set: 'essential',
     '_email-alert-frontend_session': 'essential',
-    'licensing_session': 'essential',
-    'govuk_contact_referrer': 'essential',
-    'multivariatetest_cohort_coronavirus_extremely_vulnerable_rate_limit': 'essential',
-    'dgu_beta_banner_dismissed': 'settings',
-    'global_bar_seen': 'settings',
-    'govuk_browser_upgrade_dismisssed': 'settings',
-    'govuk_not_first_visit': 'settings',
-    'analytics_next_page_call': 'usage',
-    '_ga': 'usage',
-    '_gid': 'usage',
-    '_gat': 'usage',
+    licensing_session: 'essential',
+    govuk_contact_referrer: 'essential',
+    multivariatetest_cohort_coronavirus_extremely_vulnerable_rate_limit: 'essential',
+    dgu_beta_banner_dismissed: 'settings',
+    global_bar_seen: 'settings',
+    govuk_browser_upgrade_dismisssed: 'settings',
+    govuk_not_first_visit: 'settings',
+    analytics_next_page_call: 'usage',
+    _ga: 'usage',
+    _gid: 'usage',
+    _gat: 'usage',
     'JS-Detection': 'usage',
-    'TLSversion': 'usage'
+    TLSversion: 'usage'
   }
 
   /*
@@ -69,10 +69,10 @@
 
   window.GOVUK.approveAllCookieTypes = function () {
     var approvedConsent = {
-      'essential': true,
-      'settings': true,
-      'usage': true,
-      'campaigns': true
+      essential: true,
+      settings: true,
+      usage: true,
+      campaigns: true
     }
 
     window.GOVUK.setCookie('cookies_policy', JSON.stringify(approvedConsent), { days: 365 })

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -112,12 +112,14 @@
             var eventData = event.data
             var eventTarget = event.target
             var states = {
+              /* eslint-disable quote-props */
               '-1': 'VideoUnstarted',
-              0: 'VideoEnded',
-              1: 'VideoPlaying',
-              2: 'VideoPaused',
-              3: 'VideoBuffering',
-              5: 'VideoCued'
+              '0': 'VideoEnded',
+              '1': 'VideoPlaying',
+              '2': 'VideoPaused',
+              '3': 'VideoBuffering',
+              '5': 'VideoCued'
+              /* eslint-enable */
             }
             if (states[eventData] && options.tracking && options.tracking.hasTracking &&
                 window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -21,7 +21,7 @@
     for (var i = 0; i < $youtubeLinks.length; ++i) {
       var $link = $youtubeLinks[i]
       var href = $link.getAttribute('href')
-      var hasTracking = $link.getAttribute('data-youtube-player-analytics') == "true"
+      var hasTracking = $link.hasAttribute('data-youtube-player-analytics')
       var options = {
         link: $link
       }
@@ -33,7 +33,7 @@
         }
       }
 
-      if (href.includes("/live_stream")) {
+      if (href.includes('/live_stream')) {
         var channelId = YoutubeLinkEnhancement.parseLivestream(href)
 
         if (!this.hasDisabledEmbed($link) && channelId) {
@@ -67,19 +67,19 @@
     youtubeVideoContainer.className += 'gem-c-govspeak__youtube-video'
     youtubeVideoContainer.innerHTML = '<span id="' + elementId + '" data-video-id="' + id + '"></span>'
 
-    options['title'] = $link.textContent
+    options.title = $link.textContent
 
     parentContainer.replaceChild(youtubeVideoContainer, parentPara)
     this.insertVideo(elementId, options)
   }
 
   YoutubeLinkEnhancement.prototype.insertVideo = function (elementId, options) {
-    var channelId = ""
-    var videoId = ""
+    var channelId = ''
+    var videoId = ''
 
     if (options.channel) {
       channelId = options.channel
-      videoId = "live_stream"
+      videoId = 'live_stream'
     } else {
       videoId = options.videoId
     }
@@ -112,16 +112,15 @@
             var eventData = event.data
             var eventTarget = event.target
             var states = {
-              "-1": "VideoUnstarted",
-              "0": "VideoEnded",
-              "1": "VideoPlaying",
-              "2": "VideoPaused",
-              "3": "VideoBuffering",
-              "5": "VideoCued"
+              '-1': 'VideoUnstarted',
+              0: 'VideoEnded',
+              1: 'VideoPlaying',
+              2: 'VideoPaused',
+              3: 'VideoBuffering',
+              5: 'VideoCued'
             }
-            if (states[eventData] && options.tracking && options.tracking.hasTracking
-                && window.GOVUK.analytics && window.GOVUK.analytics.trackEvent)
-            {
+            if (states[eventData] && options.tracking && options.tracking.hasTracking &&
+                window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
               var tracking = {
                 category: options.tracking.category,
                 action: states[eventData],
@@ -192,8 +191,7 @@
         params[part[0]] = part[1]
       }
       return params.v
-    }
-    else if (url.indexOf('youtu.be') > -1) {
+    } else if (url.indexOf('youtu.be') > -1) {
       parts = url.split('/')
       return parts.pop()
     }

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -402,11 +402,11 @@ describe('Feedback component', function () {
       expect(request.url).toBe('/contact/govuk/page_improvements')
       expect(request.method).toBe('POST')
       expect(request.data()).toEqual({
-        'url': ['http://example.com/path/to/page'],
-        'what_doing': ['I was looking for some information about local government.'],
-        'what_wrong': ['The background should be green.'],
-        'referrer': ['unknown'],
-        'javascript_enabled': ['true']
+        url: ['http://example.com/path/to/page'],
+        what_doing: ['I was looking for some information about local government.'],
+        what_wrong: ['The background should be green.'],
+        referrer: ['unknown'],
+        javascript_enabled: ['true']
       })
     })
 


### PR DESCRIPTION


## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

This was mostly:

 - changing the way objects are accessed
 - swapping double quotes for single quotes
 - objects keys with quotes having quotes remove

And one change of `getAttribute` to `hasAttribute` to check whether an attribute is present without needing a comparison.

## Why
<!-- What are the reasons behind this change being made? -->
Because [we should lint with Standard](https://gds-way.cloudapps.digital/manuals/programming-languages/js.html#linting) - and another branch I'm working on was failing Standard listing.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
None.