### PR TITLE
Improve suggested component asset functionality

### DIFF
--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -83,9 +83,9 @@ module GovukPublishingComponents
     def components_in_use
       matches = []
 
-      files = Dir["#{@application_path}/app/views/**/*.html.erb"]
+      files = Dir["#{@application_path}/app/views/**/*.erb"]
       files.concat Dir["#{@application_path}/app/**/*.rb"]
-      files.concat Dir["#{@application_path}/lib/**/*.rb"]
+      files.concat Dir["#{@application_path}/lib/**/*.{rb,erb}"]
 
       files.each do |file|
         data = File.read(file)


### PR DESCRIPTION
##  What
- the suggested component sass/js functionality was missing some components in smart answers, because of the unusual structure of the code there
- this change expands the search criteria for files from .html.erb to all .erb files in the view, plus any .erb files in /lib
- now finds all components in smart answers

## Why

Because https://github.com/alphagov/smart-answers/pull/4659 missed the print link component, and had to be corrected in https://github.com/alphagov/smart-answers/pull/4673

## Visual Changes
None.
