### PR TITLE
Change bar chart numbers and colours to be accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change bar chart numbers and colours to be accessible ([PR #1608](https://github.com/alphagov/govuk_publishing_components/pull/1608))
+
 ## 21.60.0
 
 * Make component auditing more resilient ([PR #1604](https://github.com/alphagov/govuk_publishing_components/pull/1604))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -29,8 +29,9 @@
   $chart-border: govuk-colour("white"); // Chart border colour
   $key-border: govuk-colour("white"); // Key border colour
   $bar-colours: govuk-colour("blue"), govuk-colour("turquoise"), govuk-colour("green"), govuk-colour("light-green"), govuk-colour("yellow"), govuk-colour("orange"), govuk-colour("red"), govuk-colour("bright-purple", $legacy: "bright-red");
-  $bar-cell-colour: #ebebeb;
-  $bar-outdented-colour: #111111;
+  $bar-text-colours: govuk-colour("white"), govuk-colour("black"), govuk-colour("white"), govuk-colour("black"), govuk-colour("black"), govuk-colour("black"), govuk-colour("white"), govuk-colour("white");
+  $bar-cell-colour: govuk-colour("black");
+  $bar-outdented-colour: govuk-colour("black");
 
   // CHART STYLES
   .mc-chart {
@@ -140,6 +141,7 @@
         @for $i from 0 to length($bar-colours) {
           .mc-bar-#{$i + 1} {
             background-color: nth($bar-colours, $i + 1);
+            color: nth($bar-text-colours, $i + 1);
           }
         }
 

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -190,6 +190,51 @@ examples:
             </tr>
           </tbody>
         </table>
+  chart_with_colours:
+    data:
+      block: |
+        <table class="js-barchart-table mc-auto-outdent">
+          <thead>
+            <tr>
+              <th scope="col">Number position</th>
+              <th scope="col">Apples</th>
+              <th scope="col">Oranges</th>
+              <th scope="col">Bananas</th>
+              <th scope="col">Pears</th>
+              <th scope="col">Grapes</th>
+              <th scope="col">Strawberries</th>
+              <th scope="col">Plums</th>
+              <th scope="col">Apricots</th>
+              <th scope="col">Pineapples</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Numbers inside bar</td>
+              <td>16</td>
+              <td>48</td>
+              <td>39</td>
+              <td>50</td>
+              <td>24</td>
+              <td>10</td>
+              <td>62</td>
+              <td>29</td>
+              <td>81</td>
+            </tr>
+            <tr>
+              <td>Numbers outside bar</td>
+              <td>2</td>
+              <td>1</td>
+              <td>2</td>
+              <td>1</td>
+              <td>1</td>
+              <td>3</td>
+              <td>3</td>
+              <td>1</td>
+              <td>2</td>
+            </tr>
+          </tbody>
+        </table>
   address:
     data:
       block: |


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

1. Add an array to set the colour of numbers on govspeak bar charts with multicoloured bars based on the colour of the bar itself eg: the yellow bar has black text, the red bar has white text etc.
2. Add an example of a bar chart with multicoloured bars to the component guide for govspeak.

## Why
<!-- What are the reasons behind this change being made? -->

When a number is positioned inside a bar of a barchart, the colour contrast between the background colour of the bar and the default colour of the text (white) isn't high enough in some cases. It should be at least 4.5:1 or above to meet the WCAG 2.1 AA standard and, where possible, 7:1 to meet WCAG 2.1 AAA.


## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

Before:

<img width="672" alt="Screenshot 2020-07-24 at 16 11 15" src="https://user-images.githubusercontent.com/64783893/88408006-dd69ae80-cdca-11ea-8583-c954ddb564e2.png">

After:

<img width="658" alt="Screenshot 2020-07-24 at 16 11 47" src="https://user-images.githubusercontent.com/64783893/88408023-e22e6280-cdca-11ea-829d-f14d95733bb1.png">

