### PR TITLE
Cover more JavaScript files with Standard linter

### DIFF
--- a/app/assets/javascripts/component_guide/accessibility-test.js
+++ b/app/assets/javascripts/component_guide/accessibility-test.js
@@ -31,11 +31,11 @@
 
     axe.run(selector, axeOptions, function (err, results) {
       if (err) {
-        return callback('aXe Error: ' + err)
+        return callback(new Error('aXe Error: ' + err))
       }
 
       if (typeof results === 'undefined') {
-        return callback('aXe Error: Expected results but none returned')
+        return callback(new Error('aXe Error: Expected results but none returned'))
       }
 
       var consoleErrorText = _consoleErrorText(results.violations, results.url)

--- a/app/assets/javascripts/component_guide/accessibility-test.js
+++ b/app/assets/javascripts/component_guide/accessibility-test.js
@@ -34,20 +34,20 @@
         return callback('aXe Error: ' + err)
       }
 
-      if (typeof results === "undefined") {
+      if (typeof results === 'undefined') {
         return callback('aXe Error: Expected results but none returned')
       }
 
       var consoleErrorText = _consoleErrorText(results.violations, results.url)
-      var bodyClass = results.violations.length === 0 ? "js-test-a11y-success" : "js-test-a11y-failed"
-      document.body.classList.add(bodyClass);
-      document.body.classList.add("js-test-a11y-finished");
+      var bodyClass = results.violations.length === 0 ? 'js-test-a11y-success' : 'js-test-a11y-failed'
+      document.body.classList.add(bodyClass)
+      document.body.classList.add('js-test-a11y-finished')
 
       callback(undefined, consoleErrorText, _processAxeResultsForPage(results))
     })
   }
 
-  var _consoleErrorText = function(violations, url) {
+  var _consoleErrorText = function (violations, url) {
     if (violations.length !== 0) {
       return (
         '\n' + 'Accessibility issues at ' +
@@ -69,28 +69,28 @@
     }
   }
 
-  var _processAxeResultsForPage = function(results) {
+  var _processAxeResultsForPage = function (results) {
     return {
       violations: _mapSummaryAndCause(results.violations),
       incompleteWarnings: _mapSummaryAndCause(results.incomplete)
     }
   }
 
-  var _mapSummaryAndCause = function(resultsArray) {
+  var _mapSummaryAndCause = function (resultsArray) {
     return resultsArray.map(function (result) {
       var cssSelector = result.nodes.map(function (node) {
-                          return {
-                            'selector': node.target,
-                            'reasons': node.any.map(function(item) {
-                              return item.message
-                            })
-                          }
-                        })
+        return {
+          selector: node.target,
+          reasons: node.any.map(function (item) {
+            return item.message
+          })
+        }
+      })
       return {
-        'id': result.id,
-        'summary': result.help,
-        'selectors': cssSelector,
-        'url': result.helpUrl
+        id: result.id,
+        summary: result.help,
+        selectors: cssSelector,
+        url: result.helpUrl
       }
     })
   }
@@ -127,7 +127,7 @@
         // Section to announce the overall problem.
         var headerNodeLink = document.createElement('a')
         headerNodeLink.href = result.url
-        headerNodeLink.textContent = "(see guidance)"
+        headerNodeLink.textContent = '(see guidance)'
 
         var headerNode = document.createElement('h3')
         headerNode.textContent = result.summary + ' (' + result.id + ') '

--- a/app/assets/javascripts/component_guide/filter-components.js
+++ b/app/assets/javascripts/component_guide/filter-components.js
@@ -1,35 +1,35 @@
-(function() {
-  window.GOVUK = window.GOVUK || {};
+(function () {
+  window.GOVUK = window.GOVUK || {}
 
-  window.GOVUK.FilterComponents = function filterList(searchTerm) {
-    var itemsToFilter = document.querySelectorAll('.component-list li');
+  window.GOVUK.FilterComponents = function filterList (searchTerm) {
+    var itemsToFilter = document.querySelectorAll('.component-list li')
 
-    for (var i = 0; i < itemsToFilter.length; i++ ) {
-      var currentComponent = itemsToFilter[i];
-      var componentText = currentComponent.innerText.toLowerCase();
+    for (var i = 0; i < itemsToFilter.length; i++) {
+      var currentComponent = itemsToFilter[i]
+      var componentText = currentComponent.innerText.toLowerCase()
 
       if (componentText.includes(searchTerm.toLowerCase())) {
-        currentComponent.classList.remove('component-guide-hidden');
+        currentComponent.classList.remove('component-guide-hidden')
       } else {
-        currentComponent.classList.add('component-guide-hidden');
+        currentComponent.classList.add('component-guide-hidden')
       }
     }
-  };
+  }
 
-  var formElement = document.querySelector('[data-module=filter-components]');
+  var formElement = document.querySelector('[data-module=filter-components]')
 
   if (formElement) {
-    var searchField = formElement.querySelector('input');
+    var searchField = formElement.querySelector('input')
 
     // We don't want the form to submit/refresh the page on enter key
-    formElement.addEventListener('submit', function(e) { e.preventDefault(); });
+    formElement.addEventListener('submit', function (e) { e.preventDefault() })
 
-    searchField.addEventListener('input', function(e) {
-      var searchTerm = searchField.value;
-      window.GOVUK.FilterComponents(searchTerm);
-    });
+    searchField.addEventListener('input', function (e) {
+      var searchTerm = searchField.value
+      window.GOVUK.FilterComponents(searchTerm)
+    })
 
     // trigger search if search query exists in query string on page load
-    window.GOVUK.FilterComponents(searchField.value);
+    window.GOVUK.FilterComponents(searchField.value)
   }
-})();
+})()

--- a/app/assets/javascripts/component_guide/visual-regression.js
+++ b/app/assets/javascripts/component_guide/visual-regression.js
@@ -42,16 +42,17 @@
   }
 
   var _processComparisonURL = function (url) {
+    var appName
     var href = url.href
     var host = url.host
 
     if (href.includes('dev.gov.uk/component-guide')) {
-      var appName = host.split('.')[0]
+      appName = host.split('.')[0]
       return _forceHTTPS(href.replace(host, appName + '.herokuapp.com'))
     } else if (href.includes('dev.gov.uk')) {
       return _forceHTTPS(href.replace(host, 'www.gov.uk'))
     } else if (href.includes('-pr-')) {
-      var appName = host.split('-pr')[0]
+      appName = host.split('-pr')[0]
       return _forceHTTPS(href.replace(host, appName + '.herokuapp.com'))
     } else {
       throw new Error('Visual Diff Tool: You need to run this tool against a page running on your local dev environment')

--- a/app/assets/javascripts/component_guide/visual-regression.js
+++ b/app/assets/javascripts/component_guide/visual-regression.js
@@ -2,69 +2,69 @@
   window.GOVUK = window.GOVUK || {}
 
   window.GOVUK.VisualDiffTool = function (currentWindowLocation) {
-    var visualDiffSelector = 'visual-diff';
-    var existingIframe = document.getElementById(visualDiffSelector);
-    var windowLocation = currentWindowLocation || window.location;
+    var visualDiffSelector = 'visual-diff'
+    var existingIframe = document.getElementById(visualDiffSelector)
+    var windowLocation = currentWindowLocation || window.location
 
     if (existingIframe) {
-      existingIframe.parentNode.removeChild(existingIframe);
-      document.body.style.filter = null;
+      existingIframe.parentNode.removeChild(existingIframe)
+      document.body.style.filter = null
     } else {
-      var iframe = document.createElement('iframe');
-      iframe.id =  visualDiffSelector;
-      iframe.setAttribute('scrolling', 'no');
+      var iframe = document.createElement('iframe')
+      iframe.id = visualDiffSelector
+      iframe.setAttribute('scrolling', 'no')
       _setElementStyles(iframe, {
-        'width': '100%',
-        'height': document.body.scrollHeight + 'px',
-        'position': 'absolute',
-        'top': '0',
+        width: '100%',
+        height: document.body.scrollHeight + 'px',
+        position: 'absolute',
+        top: '0',
         'pointer-events': 'none',
-        'border': '0'
-      });
-      iframe.style.setProperty('z-index', '999','important');
+        border: '0'
+      })
+      iframe.style.setProperty('z-index', '999', 'important')
 
       // For browsers that support it, do mix-blend-mode diff
       if ('mix-blend-mode' in document.body.style) {
-        _setElementStyles(iframe, {'mix-blend-mode': 'difference'});
-        document.body.style.filter = 'invert(100%)';
+        _setElementStyles(iframe, { 'mix-blend-mode': 'difference' })
+        document.body.style.filter = 'invert(100%)'
       } else {
         // Else do a simple overlay of the live page for comparison (IE and Edge)
-        _setElementStyles(iframe, {'opacity': '0.7'});
+        _setElementStyles(iframe, { opacity: '0.7' })
       }
 
-      iframe.src = _processComparisonURL(windowLocation);
+      iframe.src = _processComparisonURL(windowLocation)
 
       if (iframe.src) {
-        document.body.appendChild(iframe);
-        console.log("comparing to " + iframe.src);
+        document.body.appendChild(iframe)
+        console.log('comparing to ' + iframe.src)
       }
     }
-  };
-
-  var _processComparisonURL = function (url) {
-    var href = url.href;
-    var host = url.host;
-
-    if (href.includes('dev.gov.uk/component-guide')) {
-      var appName = host.split('.')[0];
-      return _forceHTTPS(href.replace(host, appName + '.herokuapp.com'));
-    } else if (href.includes('dev.gov.uk')) {
-      return _forceHTTPS(href.replace(host, 'www.gov.uk'));
-    } else if (href.includes('-pr-')) {
-      var appName = host.split('-pr')[0];
-      return _forceHTTPS(href.replace(host, appName + '.herokuapp.com'));
-    } else {
-      throw new Error('Visual Diff Tool: You need to run this tool against a page running on your local dev environment');
-    }
-  };
-
-  var _forceHTTPS = function(href) {
-    return href.replace('http://', 'https://');
   }
 
-  var _setElementStyles = function(element, styles) {
-    for (var style in styles) {
-      element.style[style] = styles[style];
+  var _processComparisonURL = function (url) {
+    var href = url.href
+    var host = url.host
+
+    if (href.includes('dev.gov.uk/component-guide')) {
+      var appName = host.split('.')[0]
+      return _forceHTTPS(href.replace(host, appName + '.herokuapp.com'))
+    } else if (href.includes('dev.gov.uk')) {
+      return _forceHTTPS(href.replace(host, 'www.gov.uk'))
+    } else if (href.includes('-pr-')) {
+      var appName = host.split('-pr')[0]
+      return _forceHTTPS(href.replace(host, appName + '.herokuapp.com'))
+    } else {
+      throw new Error('Visual Diff Tool: You need to run this tool against a page running on your local dev environment')
     }
-  };
-})(window, document);
+  }
+
+  var _forceHTTPS = function (href) {
+    return href.replace('http://', 'https://')
+  }
+
+  var _setElementStyles = function (element, styles) {
+    for (var style in styles) {
+      element.style[style] = styles[style]
+    }
+  }
+})(window, document)

--- a/package.json
+++ b/package.json
@@ -3,13 +3,16 @@
   "name": "govuk_publishing_components",
   "license": "MIT",
   "scripts": {
-    "lint:js": "standard 'app/assets/javascripts/govuk_publishing_components/**/*.js' && standard 'spec/javascripts/components/**/*.js'",
+    "lint:js": "standard 'app/assets/javascripts/**/*.js' 'spec/javascripts/**/*.js'",
     "lint:scss": "sass-lint 'app/assets/stylesheets/**/*.scss' -v -q",
     "lint": "yarn run lint:js && yarn run lint:scss"
   },
   "standard": {
     "ignore": [
-      "app/assets/javascripts/govuk_publishing_components/vendor/**/*.js"
+      "app/assets/javascripts/component_guide/vendor/**/*.js",
+      "app/assets/javascripts/govuk_publishing_components/vendor/**/*.js",
+      "spec/javascripts/helpers/*.js",
+      "spec/javascripts/vendor/*.js"
     ]
   },
   "dependencies": {

--- a/spec/javascripts/components/toggle-input-class-on-focus-spec.js
+++ b/spec/javascripts/components/toggle-input-class-on-focus-spec.js
@@ -14,7 +14,7 @@ describe('A toggle class module', function () {
     beforeEach(function () {
       element = $(
         '<div data-module="gem-toggle-input-class-on-focus">' +
-            '<input type="search" class="js-class-toggle"/>' +
+          '<input type="search" class="js-class-toggle"/>' +
         '</div>')
       $('body').append(element)
       toggle = new GOVUK.Modules.GemToggleInputClassOnFocus()

--- a/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
+++ b/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
@@ -80,7 +80,7 @@ describe('AccessibilityTest', function () {
       // Protect against test failing if PhantomJS updated
       if (!(document.querySelector('svg').children instanceof HTMLCollection)) {
         axeOptions = window.axe.run.calls.argsFor(0)
-        expect(axeOptions['restoreScroll']).toBe(undefined)
+        expect(axeOptions.restoreScroll).toBe(undefined)
       }
       done()
     })
@@ -169,8 +169,8 @@ describe('AccessibilityTest', function () {
     addToDom('<a href="#">Link</a>', 'a { background-image: url("/"); }')
 
     AccessibilityTest(TEST_SELECTOR, function (err, violations, pageResults) {
-      expect(pageResults.incompleteWarnings[0].summary).toBe("Elements must have sufficient color contrast")
-      expect(pageResults.incompleteWarnings[0].url).toBe("https://dequeuniversity.com/rules/axe/3.5/color-contrast?application=axeAPI")
+      expect(pageResults.incompleteWarnings[0].summary).toBe('Elements must have sufficient color contrast')
+      expect(pageResults.incompleteWarnings[0].url).toBe('https://dequeuniversity.com/rules/axe/3.5/color-contrast?application=axeAPI')
       expect(pageResults.incompleteWarnings[0].selectors[0].selector[0]).toBe('a[href="\\#"]')
       expect(pageResults.incompleteWarnings[0].selectors[0].reasons[0]).toBe('Element\'s background color could not be determined due to a background image')
       done()
@@ -181,8 +181,8 @@ describe('AccessibilityTest', function () {
     addToDom('<img src=""><a href="#">Low contrast</a>', 'a { background: white; color: #ddd }')
 
     AccessibilityTest(TEST_SELECTOR, function (err, violations, pageResults) {
-      expect(pageResults.violations[0].summary).toBe("Elements must have sufficient color contrast")
-      expect(pageResults.violations[0].url).toBe("https://dequeuniversity.com/rules/axe/3.5/color-contrast?application=axeAPI")
+      expect(pageResults.violations[0].summary).toBe('Elements must have sufficient color contrast')
+      expect(pageResults.violations[0].url).toBe('https://dequeuniversity.com/rules/axe/3.5/color-contrast?application=axeAPI')
       expect(pageResults.violations[0].selectors[0].selector[0]).toBe('a[href="\\#"]')
       expect(pageResults.violations[0].selectors[0].reasons[0]).toBe('Element has insufficient color contrast of 1.35 (foreground color: #dddddd, background color: #ffffff, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1')
       done()

--- a/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
+++ b/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
@@ -1,4 +1,5 @@
-/* global describe, afterEach, it, expect, spyOn */
+/* eslint-env jasmine */
+/* global HTMLCollection */
 
 var TEST_SELECTOR = '.js-test-a11y'
 
@@ -70,16 +71,16 @@ describe('AccessibilityTest', function () {
   // https://github.com/dequelabs/axe-core/issues/525
   it('should prevent aXe from erroring when SVG is present by disabling restoreScroll', function (done) {
     spyOn(window.axe, 'run').and.callThrough()
-    addToDom('<div style="height: 1000px; width: 100px;"></div><svg class="svg" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">\
-                <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>\
-              </svg>')
+    addToDom('<div style="height: 1000px; width: 100px;"></div><svg class="svg" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">' +
+                '<path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>' +
+              '</svg>')
 
     AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
       expect(err).toBe(undefined)
 
       // Protect against test failing if PhantomJS updated
       if (!(document.querySelector('svg').children instanceof HTMLCollection)) {
-        axeOptions = window.axe.run.calls.argsFor(0)
+        var axeOptions = window.axe.run.calls.argsFor(0)
         expect(axeOptions.restoreScroll).toBe(undefined)
       }
       done()
@@ -89,7 +90,7 @@ describe('AccessibilityTest', function () {
   it('should add a class to the body when it finishes', function (done) {
     addToDom('<div>text</div>')
 
-    AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
+    AccessibilityTest(TEST_SELECTOR, function () {
       expect(document.body.classList.contains('js-test-a11y-finished')).toBe(true)
       done()
     })
@@ -98,7 +99,7 @@ describe('AccessibilityTest', function () {
   it('should add a class to the body when it finds no violations', function (done) {
     addToDom('<div>text</div>')
 
-    AccessibilityTest(TEST_SELECTOR, function (err, violations, incompleteWarnings) {
+    AccessibilityTest(TEST_SELECTOR, function () {
       expect(document.body.classList.contains('js-test-a11y-success')).toBe(true)
       done()
     })
@@ -168,7 +169,7 @@ describe('AccessibilityTest', function () {
   it('process incomplete warnings into object for rendering in guide', function (done) {
     addToDom('<a href="#">Link</a>', 'a { background-image: url("/"); }')
 
-    AccessibilityTest(TEST_SELECTOR, function (err, violations, pageResults) {
+    AccessibilityTest(TEST_SELECTOR, function (_err, _violations, pageResults) {
       expect(pageResults.incompleteWarnings[0].summary).toBe('Elements must have sufficient color contrast')
       expect(pageResults.incompleteWarnings[0].url).toBe('https://dequeuniversity.com/rules/axe/3.5/color-contrast?application=axeAPI')
       expect(pageResults.incompleteWarnings[0].selectors[0].selector[0]).toBe('a[href="\\#"]')
@@ -180,7 +181,7 @@ describe('AccessibilityTest', function () {
   it('process violations into object for rendering in guide', function (done) {
     addToDom('<img src=""><a href="#">Low contrast</a>', 'a { background: white; color: #ddd }')
 
-    AccessibilityTest(TEST_SELECTOR, function (err, violations, pageResults) {
+    AccessibilityTest(TEST_SELECTOR, function (_err, _violations, pageResults) {
       expect(pageResults.violations[0].summary).toBe('Elements must have sufficient color contrast')
       expect(pageResults.violations[0].url).toBe('https://dequeuniversity.com/rules/axe/3.5/color-contrast?application=axeAPI')
       expect(pageResults.violations[0].selectors[0].selector[0]).toBe('a[href="\\#"]')

--- a/spec/javascripts/govuk_publishing_components/FilterComponentsSpec.js
+++ b/spec/javascripts/govuk_publishing_components/FilterComponentsSpec.js
@@ -1,81 +1,81 @@
 /* global describe, afterEach, it, expect */
 
-var FilterComponents = window.GOVUK.FilterComponents;
+var FilterComponents = window.GOVUK.FilterComponents
 
-function addFormInput() {
-  var form = document.createElement('form');
-  form.setAttribute('data-module', 'filter-components');
-  document.body.appendChild(form);
+function addFormInput () {
+  var form = document.createElement('form')
+  form.setAttribute('data-module', 'filter-components')
+  document.body.appendChild(form)
 };
 
-function removeFormInput() {
+function removeFormInput () {
   form = document.querySelector('form')
   document.body.removeChild(form)
 }
 
-function addComponents() {
-  var list = document.createElement('ul');
-  list.classList.add("component-list");
+function addComponents () {
+  var list = document.createElement('ul')
+  list.classList.add('component-list')
 
   // Set up accordion component
-  var accordionLi = document.createElement('li');
-  var accordionLink = document.createElement('a');
-  var accordionP = document.createElement('p');
-  accordionLink.innerText = "Accordion";
-  accordionP.innerText = "A group of expanding/collapsing sections";
-  accordionLi.setAttribute('id', 'accordion');
-  accordionLi.appendChild(accordionP);
-  accordionLi.appendChild(accordionLink);
+  var accordionLi = document.createElement('li')
+  var accordionLink = document.createElement('a')
+  var accordionP = document.createElement('p')
+  accordionLink.innerText = 'Accordion'
+  accordionP.innerText = 'A group of expanding/collapsing sections'
+  accordionLi.setAttribute('id', 'accordion')
+  accordionLi.appendChild(accordionP)
+  accordionLi.appendChild(accordionLink)
 
   // Set up back link component
-  var backLinkLi = document.createElement('li');
-  var backLink = document.createElement('a');
-  var backLinkP = document.createElement('p');
-  backLink.innerText = "Back link";
-  backLinkP.innerText = "A link used to help users get back, useful when not using other navigation such as breadcrumbs";
-  backLinkLi.setAttribute('id', 'back-link');
-  backLinkLi.appendChild(backLinkP);
-  backLinkLi.appendChild(backLink);
+  var backLinkLi = document.createElement('li')
+  var backLink = document.createElement('a')
+  var backLinkP = document.createElement('p')
+  backLink.innerText = 'Back link'
+  backLinkP.innerText = 'A link used to help users get back, useful when not using other navigation such as breadcrumbs'
+  backLinkLi.setAttribute('id', 'back-link')
+  backLinkLi.appendChild(backLinkP)
+  backLinkLi.appendChild(backLink)
 
-  list.appendChild(accordionLi);
-  list.appendChild(backLinkLi);
+  list.appendChild(accordionLi)
+  list.appendChild(backLinkLi)
 
-  document.body.appendChild(list);
+  document.body.appendChild(list)
 };
 
-describe('FilterComponents', function() {
-  beforeAll(function() {
-    addFormInput();
-    addComponents();
-  });
-
-  afterAll(function() {
-    removeFormInput();
+describe('FilterComponents', function () {
+  beforeAll(function () {
+    addFormInput()
+    addComponents()
   })
 
-  it('hides all components that do not match search criteria', function() {
-    FilterComponents("Accordion");
+  afterAll(function () {
+    removeFormInput()
+  })
 
-    expect(document.getElementById('back-link').classList.toString()).toBe('component-guide-hidden');
-  });
+  it('hides all components that do not match search criteria', function () {
+    FilterComponents('Accordion')
 
-  it('shows all components that match search criteria', function() {
-    FilterComponents("Accordion");
+    expect(document.getElementById('back-link').classList.toString()).toBe('component-guide-hidden')
+  })
 
-    expect(document.getElementById('accordion').classList.toString()).toBe('');
-  });
+  it('shows all components that match search criteria', function () {
+    FilterComponents('Accordion')
 
-  it('searches both the component name and description', function() {
-    FilterComponents("navigation");
+    expect(document.getElementById('accordion').classList.toString()).toBe('')
+  })
 
-    expect(document.getElementById('back-link').classList.toString()).toBe('');
-    expect(document.getElementById('accordion').classList.toString()).toBe('component-guide-hidden');
-  });
+  it('searches both the component name and description', function () {
+    FilterComponents('navigation')
 
-  it('the search is not case-sensitive', function() {
-    FilterComponents("ACCORDION");
+    expect(document.getElementById('back-link').classList.toString()).toBe('')
+    expect(document.getElementById('accordion').classList.toString()).toBe('component-guide-hidden')
+  })
 
-    expect(document.getElementById('accordion').classList.toString()).toBe('');
-    expect(document.getElementById('back-link').classList.toString()).toBe('component-guide-hidden');
-  });
-});
+  it('the search is not case-sensitive', function () {
+    FilterComponents('ACCORDION')
+
+    expect(document.getElementById('accordion').classList.toString()).toBe('')
+    expect(document.getElementById('back-link').classList.toString()).toBe('component-guide-hidden')
+  })
+})

--- a/spec/javascripts/govuk_publishing_components/FilterComponentsSpec.js
+++ b/spec/javascripts/govuk_publishing_components/FilterComponentsSpec.js
@@ -1,4 +1,4 @@
-/* global describe, afterEach, it, expect */
+/* eslint-env jasmine */
 
 var FilterComponents = window.GOVUK.FilterComponents
 
@@ -9,7 +9,7 @@ function addFormInput () {
 };
 
 function removeFormInput () {
-  form = document.querySelector('form')
+  var form = document.querySelector('form')
   document.body.removeChild(form)
 }
 

--- a/spec/javascripts/govuk_publishing_components/VisualRegressionSpec.js
+++ b/spec/javascripts/govuk_publishing_components/VisualRegressionSpec.js
@@ -1,4 +1,4 @@
-/* global describe, afterEach, it, expect */
+/* eslint-env jasmine */
 
 var VisualDiffTool = window.GOVUK.VisualDiffTool
 var windowLocation

--- a/spec/javascripts/govuk_publishing_components/VisualRegressionSpec.js
+++ b/spec/javascripts/govuk_publishing_components/VisualRegressionSpec.js
@@ -1,58 +1,57 @@
 /* global describe, afterEach, it, expect */
 
-var VisualDiffTool = window.GOVUK.VisualDiffTool;
-var windowLocation;
+var VisualDiffTool = window.GOVUK.VisualDiffTool
+var windowLocation
 
 describe('VisualDiffTool', function () {
-
   describe('throws errors', function () {
     it('throws error if not running on local page', function () {
-      expect(VisualDiffTool).toThrow();
-    });
-  });
+      expect(VisualDiffTool).toThrow()
+    })
+  })
 
-  describe('URL processing', function() {
-    beforeEach(function() {
-      spyOn(console, 'log').and.callThrough();
-    });
+  describe('URL processing', function () {
+    beforeEach(function () {
+      spyOn(console, 'log').and.callThrough()
+    })
 
-    afterEach(function() {
+    afterEach(function () {
       // We need to call this again to 'turn off' the diff tool that's running from each test
-      VisualDiffTool();
-      windowLocation = null;
-    });
+      VisualDiffTool()
+      windowLocation = null
+    })
 
-    it('compares dev.gov.uk to gov.uk', function() {
+    it('compares dev.gov.uk to gov.uk', function () {
       windowLocation = {
         href: 'http://government-frontend.dev.gov.uk',
         host: 'government-frontend.dev.gov.uk'
-      };
+      }
 
-      VisualDiffTool(windowLocation);
+      VisualDiffTool(windowLocation)
 
-      expect(console.log.calls.mostRecent().args[0]).toContain("https://www.gov.uk");
-    });
+      expect(console.log.calls.mostRecent().args[0]).toContain('https://www.gov.uk')
+    })
 
-    it('compares local component guide to heroku deploy', function() {
+    it('compares local component guide to heroku deploy', function () {
       windowLocation = {
         href: 'http://government-frontend.dev.gov.uk/component-guide',
         host: 'government-frontend.dev.gov.uk'
-      };
+      }
 
-      VisualDiffTool(windowLocation);
+      VisualDiffTool(windowLocation)
 
-      expect(console.log.calls.mostRecent().args[0]).toContain("https://government-frontend.herokuapp.com/component-guide");
-    });
+      expect(console.log.calls.mostRecent().args[0]).toContain('https://government-frontend.herokuapp.com/component-guide')
+    })
 
-    it('compares pr heroku app to master heroku deploy', function() {
+    it('compares pr heroku app to master heroku deploy', function () {
       windowLocation = {
         href: 'https://government-frontend-pr-100.herokuapp.com',
         host: 'government-frontend-pr-100.herokuapp.com'
-      };
+      }
 
-      VisualDiffTool(windowLocation);
+      VisualDiffTool(windowLocation)
 
-      expect(console.log.calls.mostRecent().args[0]).toContain("https://government-frontend.herokuapp.com");
-    });
-  });
-});
+      expect(console.log.calls.mostRecent().args[0]).toContain('https://government-frontend.herokuapp.com')
+    })
+  })
+})

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/barchart-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/barchart-enhancement-spec.js
@@ -1,3 +1,6 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
 describe('Barchart enhancement', function () {
   var chartHtml = '<table class="js-barchart-table mc-auto-outdent">' +
                     '<tbody>' +

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
@@ -6,7 +6,7 @@ describe('Youtube link enhancement', function () {
       container = document.createElement('div')
     })
 
-    afterEach(function() {
+    afterEach(function () {
       document.body.removeChild(container)
     })
 
@@ -110,7 +110,7 @@ describe('Youtube link enhancement', function () {
       container = document.createElement('div')
     })
 
-    afterEach(function() {
+    afterEach(function () {
       document.body.removeChild(container)
     })
 

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement-spec.js
@@ -1,3 +1,6 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
 describe('Youtube link enhancement', function () {
   describe('embed behaviour', function () {
     var container


### PR DESCRIPTION
## What

This widens the range of files covered by the JS linter, standard so that it covers all of the JS files we (GOV.UK) maintain for this repository.

## Why

The linter wasn't covering all files so approaches taken in some files would fail the linter, as they were linted, whereas others wouldn't, as they were not.