### PR TITLE
Fix PhantomJS creeping back into tasks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,10 @@ PATH
   remote: .
   specs:
     govuk_publishing_components (21.59.0)
-      gds-api-adapters
       govuk_app_config
       kramdown
       plek
       rails (>= 5.0.0.1)
-      rake
       rouge
       sprockets (< 4)
 
@@ -86,8 +84,6 @@ GEM
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
-    foreman (0.85.0)
-      thor (~> 0.19.1)
     gds-api-adapters (67.0.0)
       addressable
       link_header
@@ -128,7 +124,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     kgio (2.11.3)
-    kramdown (2.2.1)
+    kramdown (2.3.0)
       rexml
     link_header (0.0.8)
     logstash-event (1.2.02)
@@ -172,7 +168,7 @@ GEM
     puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.3)
-    rack-cache (1.11.1)
+    rack-cache (1.12.0)
       rack (>= 0.4)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -212,7 +208,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.4)
-    rouge (3.20.0)
+    rouge (3.21.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -300,7 +296,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.7.2)
+    websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
@@ -313,7 +309,6 @@ PLATFORMS
 DEPENDENCIES
   capybara (~> 3.25)
   faker (>= 2.11)
-  foreman (= 0.85)
   gds-api-adapters
   govuk_publishing_components!
   govuk_schemas (~> 4.0)
@@ -321,10 +316,10 @@ DEPENDENCIES
   jasmine (~> 3.5.1)
   jasmine_selenium_runner (~> 3.0.0)
   pry-byebug
+  rake
   rspec-rails (~> 4.0)
   rubocop-govuk (~> 3)
   sassc-rails (~> 2)
-  selenium-webdriver (= 3.142.7)
   uglifier (>= 4.1.0)
   webmock (~> 3.8.3)
   yard

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,5 @@
-begin
-  require "rspec/core/rake_task"
-  RSpec::Core::RakeTask.new(:spec)
-rescue LoadError
-  puts "Running in production mode"
-end
+require "rubocop/rake_task"
+require "rspec/core/rake_task"
 
 APP_RAKEFILE = File.expand_path("spec/dummy/Rakefile", __dir__)
 
@@ -11,6 +7,9 @@ load "rails/tasks/engine.rake"
 load "rails/tasks/statistics.rake"
 
 require "bundler/gem_tasks"
+
+RuboCop::RakeTask.new
+RSpec::Core::RakeTask.new
 
 namespace :assets do
   desc "Test precompiling assets through dummy application"
@@ -29,14 +28,9 @@ namespace :assets do
   end
 end
 
-desc "Run RuboCop linting"
-task lint_ruby: :environment do
-  sh "bundle exec rubocop --format clang"
-end
-
-desc "Run Javascript and Sass linting"
-task lint_js_and_sass: :environment do
+desc "Linting for Ruby, JS and SASS"
+task lint: %i[rubocop environment] do
   sh "yarn run lint"
 end
 
-task default: [:lint_ruby, :lint_js_and_sass, :spec, "app:jasmine:ci"]
+task default: [:lint, :spec, "app:jasmine:ci"]

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -13,33 +13,28 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/alphagov/govuk_publishing_components"
   s.license     = "MIT"
 
-  s.files = Dir["{node_modules/govuk-frontend,node_modules/axe-core,node_modules/jquery,app,config,db,lib}/**/*", "DEVELOPMENT.md", "LICENCE.md", "Rakefile", "README.md"]
+  s.files = Dir["{node_modules/govuk-frontend,node_modules/axe-core,node_modules/jquery,app,config,db,lib}/**/*", "LICENCE.md", "README.md"]
 
-  s.add_dependency "gds-api-adapters"
   s.add_dependency "govuk_app_config"
   s.add_dependency "kramdown"
   s.add_dependency "plek"
   s.add_dependency "rails", ">= 5.0.0.1"
-  s.add_dependency "rake"
   s.add_dependency "rouge"
   s.add_dependency "sprockets", "< 4"
 
   s.add_development_dependency "capybara", "~> 3.25"
-  s.add_development_dependency "foreman", "= 0.85"
-  s.add_development_dependency "gds-api-adapters", ">= 0"
+  s.add_development_dependency "faker", ">= 2.11"
+  s.add_development_dependency "gds-api-adapters"
   s.add_development_dependency "govuk_schemas", "~> 4.0"
   s.add_development_dependency "govuk_test", "~> 1"
   s.add_development_dependency "jasmine", "~> 3.5.1"
   s.add_development_dependency "jasmine_selenium_runner", "~> 3.0.0"
   s.add_development_dependency "pry-byebug"
+  s.add_development_dependency "rake"
   s.add_development_dependency "rspec-rails", "~> 4.0"
   s.add_development_dependency "rubocop-govuk", "~> 3"
   s.add_development_dependency "sassc-rails", "~> 2"
-  s.add_development_dependency "selenium-webdriver", "= 3.142.7"
   s.add_development_dependency "uglifier", ">= 4.1.0"
-  # Webmock is needed to load slimmer test helpers
-  # https://github.com/alphagov/slimmer/issues/201
-  s.add_development_dependency "faker", ">= 2.11"
   s.add_development_dependency "webmock", "~> 3.8.3"
   s.add_development_dependency "yard"
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -3,17 +3,13 @@ require_relative "boot"
 require "action_controller/railtie"
 require "action_view/railtie"
 require "action_mailer/railtie"
-require "rails/test_unit/railtie"
+# We need to load govuk_test before jasmine_selenium runner so webdrivers is
+# initialised.
+require "govuk_test"
+require "jasmine"
+require "jasmine_selenium_runner"
 require "sassc-rails"
-# Require jasmine at runtime allow the app:jasmine:ci task to build correctly
 
-begin
-  require "jasmine"
-rescue LoadError
-  puts "Running in production mode"
-end
-
-Bundler.require(*Rails.groups)
 require "govuk_publishing_components"
 
 module Dummy

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -3,12 +3,17 @@ require_relative "boot"
 require "action_controller/railtie"
 require "action_view/railtie"
 require "action_mailer/railtie"
-# We need to load govuk_test before jasmine_selenium runner so webdrivers is
-# initialised.
-require "govuk_test"
-require "jasmine"
-require "jasmine_selenium_runner"
 require "sassc-rails"
+
+# In a heroku environment we don't have chrome and chromedriver available
+# so loading these gems fails.
+unless ENV["HEROKU"]
+  # We need to load govuk_test before jasmine_selenium runner so webdrivers is
+  # initialised.
+  require "govuk_test"
+  require "jasmine"
+  require "jasmine_selenium_runner"
+end
 
 require "govuk_publishing_components"
 

--- a/spec/javascripts/components/toggle-input-class-on-focus-spec.js
+++ b/spec/javascripts/components/toggle-input-class-on-focus-spec.js
@@ -24,9 +24,9 @@ describe('A toggle class module', function () {
     it('applies the focus style on focus and removes it on blur', function () {
       var searchInput = element.find('.js-class-toggle')
       expect(searchInput.is('.focus')).toBe(false)
-      searchInput.trigger('focus')
+      searchInput.triggerHandler('focus')
       expect(searchInput.is('.focus')).toBe(true)
-      searchInput.trigger('blur')
+      searchInput.triggerHandler('blur')
       expect(searchInput.is('.focus')).toBe(false)
     })
   })
@@ -49,9 +49,9 @@ describe('A toggle class module', function () {
 
     it('does not remove the focus style on blur if the search box already has a value', function () {
       var searchInput = element.find('.js-class-toggle')
-      searchInput.trigger('focus')
+      searchInput.triggerHandler('focus')
       expect(searchInput.is('.focus')).toBe(true)
-      searchInput.trigger('blur')
+      searchInput.triggerHandler('blur')
       expect(searchInput.is('.focus')).toBe(true)
     })
   })


### PR DESCRIPTION
## What

This changes the approach to loading Gems to be more explicit to resolve surprisingly consequences for JS tests. In the  process of this it also removes some gems that aren't needed and moves others, that are only used in dev, to development dependencies.

## Why

In https://github.com/alphagov/govuk_publishing_components/pull/1598 we added the necessary configuration to replace PhantomJS for JS tests with Chromedriver run through Selenium. Unfortunately due to Bundler/load order complexities this didn't apply in all places, most notably the default `rake` task which is run by CI.

## Visual Changes

None, I hope
