### PR TITLE
Add support for custom sizes for radio page headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Make component auditing more resilient ([PR #1604](https://github.com/alphagov/govuk_publishing_components/pull/1604))
 * Add more font sizes to heading component ([PR #1587](https://github.com/alphagov/govuk_publishing_components/pull/1587))
 * Format machine-readable output ([PR #1617](https://github.com/alphagov/govuk_publishing_components/pull/1617))
+* Add support for custom sizes for radio page headers ([PR #1616](https://github.com/alphagov/govuk_publishing_components/pull/1616))
 
 ## 21.59.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_radio.scss
@@ -1,1 +1,5 @@
 @import "govuk/components/radios/radios";
+
+.gem-c-radio__heading-text {
+  margin: 0;
+}

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -6,10 +6,18 @@
   label ||= nil
   heading ||= nil
   heading_caption ||= nil
+  heading_size ||= nil
   small ||= false
   inline ||= false
   is_page_heading ||= false
-  heading_size = 'm' unless ['s', 'm', 'l', 'xl'].include?(heading_size)
+
+  if ['s', 'm', 'l', 'xl'].include?(heading_size)
+    size = heading_size
+  elsif is_page_heading
+    size = 'xl'
+  else
+    size = 'm'
+  end
 
   description ||= nil
   hint ||= nil
@@ -28,7 +36,7 @@
   radio_classes << "govuk-radios--inline" if inline
 
   legend_classes = %w(govuk-fieldset__legend)
-  legend_classes << "govuk-fieldset__legend--#{heading_size}"
+  legend_classes << "govuk-fieldset__legend--#{size}"
 
   aria = "#{hint_id} #{"#{error_id}" if has_error}".strip if hint or has_error
 
@@ -40,9 +48,9 @@
 
     <% if heading.present? %>
       <% if is_page_heading %>
-        <%= tag.legend class: "govuk-fieldset__legend govuk-fieldset__legend--xl gem-c-title" do %>
-          <%= tag.span(heading_caption, class: "govuk-caption-xl") if heading_caption.present? %>
-          <%= tag.h1 heading, class: "gem-c-title__text" %>
+        <%= tag.legend class: legend_classes do %>
+          <%= tag.span(heading_caption, class: "govuk-caption-#{size}") if heading_caption.present? %>
+          <%= tag.h1 heading, class: "gem-c-radio__heading-text govuk-fieldset__heading" %>
         <% end %>
       <% else %>
         <%= tag.legend heading, class: legend_classes %>

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -183,6 +183,10 @@ examples:
       - value: "blue"
         text: "Blue"
   with_custom_heading_size:
+    description: |
+      This allows the size of the legend to be changed. Valid options are s, m, l, xl, defaulting to m if no option is passed. 
+
+      If the is_page_heading option is true and heading_size is not set, the text size will be xl.
     data:
       name: "radio-group-description"
       heading: "What is your favourite colour?"

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -149,6 +149,52 @@ describe "Radio", type: :view do
     assert_select "legend span.govuk-caption-xl", false
   end
 
+  it "renders radio-group with a custom page heading size" do
+    render_component(
+      name: "favourite-skittle",
+      heading: "What is your favourite skittle?",
+      heading_caption: "Question 3 of 9",
+      heading_size: "l",
+      is_page_heading: true,
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Blue", value: "blue" },
+      ],
+    )
+    assert_select ".govuk-radios"
+    assert_select "legend.govuk-fieldset__legend--l h1.govuk-fieldset__heading", text: "What is your favourite skittle?"
+    assert_select "legend span.govuk-caption-l", "Question 3 of 9"
+  end
+
+  it "renders radio-group with no custom page heading size" do
+    render_component(
+      name: "favourite-skittle",
+      heading: "What is your favourite skittle?",
+      heading_caption: "Question 3 of 9",
+      is_page_heading: true,
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Blue", value: "blue" },
+      ],
+    )
+    assert_select ".govuk-radios"
+    assert_select "legend.govuk-fieldset__legend--xl h1.govuk-fieldset__heading", text: "What is your favourite skittle?"
+    assert_select "legend span.govuk-caption-xl", "Question 3 of 9"
+  end
+
+  it "renders radio-group with heading size m if no custom size or page heading option is passed in" do
+    render_component(
+      name: "favourite-skittle",
+      heading: "What is your favourite skittle?",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Blue", value: "blue" },
+      ],
+    )
+    assert_select ".govuk-radios"
+    assert_select "legend.govuk-fieldset__legend--m", text: "What is your favourite skittle?"
+  end
+
   it "renders radio-group with custom heading size" do
     render_component(
       name: "favourite-skittle",


### PR DESCRIPTION
## What
Add custom page header size support for radio inputs.

## Why
This allows long questions to be displayed as page titles on applications like smart answers.

## Visual Changes
### Before
![Screenshot 2020-07-21 at 13 01 16](https://user-images.githubusercontent.com/4599889/88053196-519a1d00-cb53-11ea-8b03-577f384b68fa.png)

### After
![Screenshot 2020-07-21 at 13 01 25](https://user-images.githubusercontent.com/4599889/88053231-5bbc1b80-cb53-11ea-954d-b20460940ff6.png)

