### PR TITLE
Format machine-readable output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Make component auditing more resilient ([PR #1604](https://github.com/alphagov/govuk_publishing_components/pull/1604))
 * Add more font sizes to heading component ([PR #1587](https://github.com/alphagov/govuk_publishing_components/pull/1587))
+* Format machine-readable output ([PR #1617](https://github.com/alphagov/govuk_publishing_components/pull/1617))
 
 ## 21.59.0
 

--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -10,7 +10,7 @@
 %>
 
 <script type="application/ld+json">
-  <%= raw breadcrumb_presenter.structured_data.to_json %>
+  <%= raw JSON.pretty_generate(breadcrumb_presenter.structured_data) %>
 </script>
 
 <div class="<%= classes %>" data-module="track-click">

--- a/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
@@ -9,7 +9,7 @@
 <% structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(page).structured_data %>
 
 <script type="application/ld+json">
-  <%= raw structured_data.to_json %>
+  <%= raw JSON.pretty_generate(structured_data) %>
 </script>
 
 <link rel="canonical" href="<%= page.canonical_url %>" />

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
@@ -25,7 +25,7 @@
 %>
 <% if title %>
   <script type="application/ld+json">
-    <%= raw breadcrumb_presenter.structured_data.to_json %>
+    <%= raw JSON.pretty_generate(breadcrumb_presenter.structured_data) %>
   </script>
 
   <div class="<%= classes %>" data-module="track-click">


### PR DESCRIPTION
## What 

Format output of machine readable components to make them slightly more human-readable too :-)

## Why

At present, the emitted json is all on one line. This makes it hard to read, (which is particularly important when looking at [the docs](https://components.publishing.service.gov.uk/component-guide/machine_readable_metadata)) but also difficult to evolve using tools like [the rich results testing tool](https://search.google.com/test/rich-results).

Formatting it nicely adds a few characters to the page, but allows for greater scrutiny, improvement and (possibly) adoption by 3rd parties.

## Visual changes (sort of)

It turns (using the breadcrumbs on https://www.gov.uk/universal-credit as an
example):

```
{"@context":"http://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"item":{"name":"Home","@id":"https://www.gov.uk/"}},{"@type":"ListItem","position":2,"item":{"name":"How to claim Universal Credit: step by step","@id":"https://www.gov.uk/how-to-claim-universal-credit"}}]}
```

into:

```
{
  "@context": "http://schema.org",
  "@type": "BreadcrumbList",
  "itemListElement": [
    {
      "@type": "ListItem",
      "position": 1,
      "item": {
        "name": "Home",
        "@id": "https://www.gov.uk/"
      }
    },
    {
      "@type": "ListItem",
      "position": 2,
      "item": {
        "name": "How to claim Universal Credit: step by step",
        "@id": "https://www.gov.uk/how-to-claim-universal-credit"
      }
    }
  ]
}
```
