### PR TITLE
Add govspeak to radio component description

### DIFF
--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -11,12 +11,12 @@
   inline ||= false
   is_page_heading ||= false
 
-  if ['s', 'm', 'l', 'xl'].include?(heading_size)
+  if ["s", "m", "l", "xl"].include?(heading_size)
     size = heading_size
   elsif is_page_heading
-    size = 'xl'
+    size = "xl"
   else
-    size = 'm'
+    size = "m"
   end
 
   description ||= nil
@@ -58,7 +58,11 @@
     <% end %>
 
     <% if description.present? %>
-      <%= tag.div description, class: "govuk-body" %>
+      <% output_description = render "govuk_publishing_components/components/govspeak" do %>
+        <%= tag.div description, class: "govuk-body" %>
+      <% end %>
+
+      <%= output_description %>
     <% end %>
 
     <% if hint %>
@@ -78,11 +82,11 @@
 
     <%= content_tag :div, class: radio_classes,
       data: {
-        module: ('govuk-radios' if has_conditional)
+        module: ("govuk-radios" if has_conditional)
       } do %>
       <% items.each_with_index do |item, index| %>
         <% if item === :or %>
-          <%= tag.div t('components.radio.or'), class: "govuk-radios__divider" %>
+          <%= tag.div t("components.radio.or"), class: "govuk-radios__divider" %>
         <% else %>
           <%
             item_next = items[index + 1] unless index === items.size - 1

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -149,6 +149,21 @@ examples:
         text: "Green"
       - value: "blue"
         text: "Blue"
+  with_markup_in_the_description:
+    data:
+      name: "radio-group-description"
+      heading: "What is your favourite flavours?"
+      description: |
+        <p>The flavour of Skittles has changed over the years. The original flavours were orange, lemon, lime, blackcurrent, and strawberry - new flavours include mint, sweet heat, citrus punch, and pomegranate. For even more, read <a href="https://en.wikipedia.org/wiki/List_of_Skittles_products" rel="noopener">the full list of Skittle flavours on Wikipedia</a>.</p>
+      items:
+      - value: "strawberry"
+        text: "Strawberry"
+      - value: "lemon"
+        text: "Lemon"
+      - value: "apple"
+        text: "Apple"
+      - value: "blackcurrent"
+        text: "Blackcurrent"
   with_description_and_hint:
     data:
       name: "radio-group-description"

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -552,16 +552,14 @@ describe "Radio", type: :view do
     render_component(
       name: "favourite-skittle",
       heading: "What is your favourite skittle?",
-      description: render(
-        "govuk_publishing_components/components/govspeak",
-        content: "<p>This is a description about skittles.</p>".html_safe,
-      ),
+      description: sanitize("<ul><li>This is a list item</li><li>This is another list item</li></ul>"),
       items: [
         { label: "Red", value: "red" },
         { label: "Blue", value: "blue" },
       ],
     )
-    assert_select ".govuk-body", "This is a description about skittles."
+    assert_select ".gem-c-govspeak .govuk-body ul li", "This is a list item"
+    assert_select ".gem-c-govspeak .govuk-body ul li:nth-child(2)", "This is another list item"
   end
 end
 


### PR DESCRIPTION
## What
Wrapped the radio component's description in a govspeak component so that any markup used in the description is properly displayed. An example in the docs has been added for this use case, and the test has been updated.

## Why

The radio component wrapped the description in a `div` element that has a `govuk-body` class. This is okay if there's only a single paragraph of text for the description; but the correct styles aren't added if markup is used in the description.

This happens on several of the simple smart answers in `frontend`.

Wrapping the description in a govspeak component and a `govuk-body` class means that both strings that doesn't contain any markup and strings that do contain markup will inherit the appropriate styles. Thanks CSS!

Changing the way the component accepts a description wasn't an option as this flaw is already being used in production - the needs to be used for markup _and_ for text.

Regex could've been used to test whether the string started with an HTML element (for example: `/^<[a-z]>/`), and then only if there was markup present - but I thought that was too conservative in what the description parameter could successfully accept.

## Visual Changes

### From [question 3 of 'Continue to live in the UK if you're an EU, EEA or Swiss citizen'](https://www.gov.uk/staying-uk-eu-citizen/y/yes/no)

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/1732331/88083544-1a3f6680-cb7b-11ea-896f-d0c2e00c8dfe.png) | ![image](https://user-images.githubusercontent.com/1732331/88083510-0dbb0e00-cb7b-11ea-9b07-dfb809bf0d21.png) |


### From [question 1 of 'Tell DVLA you've sold, transferred or bought a vehicle'](https://www.gov.uk/sold-bought-vehicle/y)

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/1732331/88083924-87eb9280-cb7b-11ea-9552-7ae6b6d63dd4.png) | ![image](https://user-images.githubusercontent.com/1732331/88083892-7dc99400-cb7b-11ea-87b1-d2d64e320e99.png) |


### From [question 4 of 'Check if you need to send a Self Assessment tax return'](https://www.gov.uk/check-if-you-need-tax-return/y/no/less-than-50-000/no)

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/1732331/88083443-f419c680-cb7a-11ea-8f1f-a22c026cc9b7.png) | ![image](https://user-images.githubusercontent.com/1732331/88083382-df3d3300-cb7a-11ea-9111-ca1017388263.png) |

