### PR TITLE
Fix `get_component_name_from_full_path`

### DIFF
--- a/app/models/govuk_publishing_components/audit_components.rb
+++ b/app/models/govuk_publishing_components/audit_components.rb
@@ -64,7 +64,7 @@ module GovukPublishingComponents
     end
 
     def get_component_name_from_full_path(path)
-      path.gsub("/_", "/")
+      path.gsub(/.*\K\/_/, "/")
         .gsub(@templates_full_path, "")
         .gsub(".html.erb", "")
         .gsub(".erb", "")


### PR DESCRIPTION
## What
Jenkins generates working paths based on branch names, sometimes starting with an underscore (e.g. `/var/lib/jenkins/workspace/_replace-jquery-in-checkboxes-js/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb`). In such cases `get_component_name_from_full_path` matches all `/_` occurrences and replaces them with `/` messing the path then failing to read the dummy file. The whole model file should ideally be covered by unit testing to avoid such fails.

## Why
To prevent PRs (such as #1419, #1620 or #1622) from silently failing in CI. Ideally, the functions in models should be covered by unit tests.

## Visual Changes
No visual changes
