### PR TITLE
Add support for custom heading size for checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add more font sizes to heading component ([PR #1587](https://github.com/alphagov/govuk_publishing_components/pull/1587))
 * Format machine-readable output ([PR #1617](https://github.com/alphagov/govuk_publishing_components/pull/1617))
 * Add support for custom sizes for radio page headers ([PR #1616](https://github.com/alphagov/govuk_publishing_components/pull/1616))
+* Add support for custom heading size for checkboxes ([PR #1623](https://github.com/alphagov/govuk_publishing_components/pull/1623))
 
 ## 21.59.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_checkboxes.scss
@@ -46,3 +46,7 @@
     @include govuk-visually-hidden;
   }
 }
+
+.gem-c-checkboxes__heading-text {
+  margin: 0;
+}

--- a/app/views/govuk_publishing_components/components/docs/checkboxes.yml
+++ b/app/views/govuk_publishing_components/components/docs/checkboxes.yml
@@ -184,6 +184,10 @@ examples:
         - label: "Blue"
           value: "blue"
   with_custom_heading_size:
+    description: |
+      This allows the size of the legend to be changed. Valid options are s, m, l, xl, defaulting to m if no option is passed. 
+
+      If the is_page_heading option is true and heading_size is not set, the text size will be xl.
     data:
       name: "favourite_colour"
       heading: "What is your favourite colour?"

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -14,7 +14,6 @@ module GovukPublishingComponents
                   :id,
                   :hint_text,
                   :description,
-                  :heading_size,
                   :heading_caption,
                   :has_exclusive
 
@@ -35,9 +34,8 @@ module GovukPublishingComponents
 
         @id = options[:id] || "checkboxes-#{SecureRandom.hex(4)}"
         @heading = options[:heading] || nil
-        @heading_size = options[:heading_size]
-        @heading_size = "m" unless %w[s m l xl].include?(@heading_size)
         @heading_caption = options[:heading_caption] || nil
+        @heading_size = options[:heading_size] || nil
         @is_page_heading = options[:is_page_heading]
         @description = options[:description] || nil
         @no_hint_text = options[:no_hint_text]
@@ -60,20 +58,30 @@ module GovukPublishingComponents
         end
       end
 
+      def size
+        if %w[s m l xl].include?(@heading_size)
+          @heading_size
+        elsif @is_page_heading
+          "xl"
+        else
+          "m"
+        end
+      end
+
       def heading_markup
         return unless @heading.present?
 
         if @is_page_heading
           content_tag(
             :legend,
-            class: "govuk-fieldset__legend govuk-fieldset__legend--xl gem-c-title",
+            class: "govuk-fieldset__legend govuk-fieldset__legend--#{size}",
           ) do
-            concat content_tag(:span, heading_caption, class: "govuk-caption-xl") if heading_caption.present?
-            concat content_tag(:h1, @heading, class: "gem-c-title__text")
+            concat content_tag(:span, heading_caption, class: "govuk-caption-#{size}") if heading_caption.present?
+            concat content_tag(:h1, @heading, class: "gem-c-checkboxes__heading-text govuk-fieldset__heading")
           end
         else
           classes = %w[govuk-fieldset__legend]
-          classes << "govuk-fieldset__legend--#{@heading_size}"
+          classes << "govuk-fieldset__legend--#{size}"
           classes << "gem-c-checkboxes__legend--hidden" if @visually_hide_heading
 
           content_tag(:legend, @heading, class: classes)

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -416,6 +416,52 @@ describe "Checkboxes", type: :view do
     assert_select "legend h1", text: "What is your favourite skittle?"
   end
 
+  it "renders checkboxes with custom sized page heading and caption" do
+    render_component(
+      name: "favourite_colour",
+      heading_caption: "Question 3 of 9",
+      heading: "What is your favourite skittle?",
+      heading_size: "l",
+      is_page_heading: true,
+      description: "This is a description about skittles.",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+      ],
+    )
+    assert_select "legend span.govuk-caption-l", text: "Question 3 of 9"
+    assert_select "legend.govuk-fieldset__legend--l h1", text: "What is your favourite skittle?"
+  end
+
+  it "renders checkboxes with default size for page heading and caption if no custom heading size is passed in" do
+    render_component(
+      name: "favourite_colour",
+      heading_caption: "Question 3 of 9",
+      heading: "What is your favourite skittle?",
+      is_page_heading: true,
+      description: "This is a description about skittles.",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+      ],
+    )
+    assert_select "legend span.govuk-caption-xl", text: "Question 3 of 9"
+    assert_select "legend.govuk-fieldset__legend--xl h1", text: "What is your favourite skittle?"
+  end
+
+  it "renders checkboxes with default size for heading if no custom heading size or page heading option is passed in" do
+    render_component(
+      name: "favourite_colour",
+      heading: "What is your favourite skittle?",
+      description: "This is a description about skittles.",
+      items: [
+        { label: "Red", value: "red" },
+        { label: "Green", value: "green" },
+      ],
+    )
+    assert_select "legend.govuk-fieldset__legend--m", text: "What is your favourite skittle?"
+  end
+
   it "renders no caption if the header is not a page heading" do
     render_component(
       name: "favourite_colour",


### PR DESCRIPTION
## What
Add custom page header size support for checkboxes.

## Why
This allows long questions to be displayed as page titles on applications like smart answers.

## Visual Changes

### Before

![Screenshot 2020-07-23 at 12 32 53](https://user-images.githubusercontent.com/4599889/88282033-a9b25a00-cce0-11ea-9c30-3fd38cca1bf9.png)


### After

![Screenshot 2020-07-23 at 12 33 00](https://user-images.githubusercontent.com/4599889/88282038-ad45e100-cce0-11ea-95d3-c2e84208ec2f.png)
