### PR TITLE
Extend auditing

### DIFF
--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -3,37 +3,37 @@ module GovukPublishingComponents
     attr_reader :data
 
     def initialize(path, name)
-      templates = Dir["#{path}/app/views/**/*.erb"]
-      stylesheets = Dir["#{path}/app/assets/stylesheets/**/*.scss"]
-      javascripts = Dir["#{path}/app/assets/javascripts/**/*.js"]
-
-      find_components = /(?<=govuk_publishing_components\/components\/)[\/a-zA-Z_-]+(?=['"])/
-
-      @find_all_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components/
-      find_stylesheets = /(?<=@import ["']{1}govuk_publishing_components\/components\/)(?!print\/)+[a-zA-Z_-]+(?=['"])/
-
-      @find_all_print_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components_print/
-      find_print_stylesheets = /(?<=@import ["']{1}govuk_publishing_components\/components\/print\/)[a-zA-Z_-]+(?=['"])/
-
-      @find_all_javascripts = /\/\/[ ]*= require govuk_publishing_components\/all_components/
-      find_javascripts = /(?<=require govuk_publishing_components\/components\/)[a-zA-Z_-]+/
-
-      components_in_templates = find_components(templates, find_components, "templates") || []
-      components_in_stylesheets = find_components(stylesheets, find_stylesheets, "stylesheets") || []
-      components_in_print_stylesheets = find_components(stylesheets, find_print_stylesheets, "print_stylesheets") || []
-      components_in_javascripts = find_components(javascripts, find_javascripts, "javascripts") || []
-
-      ruby_paths = %w[/app/helpers/ /app/presenters/ /lib/]
-      components_in_ruby = []
-      ruby_paths.each do |ruby_path|
-        components_in_ruby << find_components(Dir["#{path}#{ruby_path}**/*.{rb,erb}"], find_components, "ruby") || []
-      end
-      components_in_ruby = components_in_ruby.flatten.uniq
-
       application_found = application_exists(path)
       components_found = []
 
       if application_found
+        templates = Dir["#{path}/app/views/**/*.erb"]
+        stylesheets = Dir["#{path}/app/assets/stylesheets/**/*.scss"]
+        javascripts = Dir["#{path}/app/assets/javascripts/**/*.js"]
+
+        find_components = /(?<=govuk_publishing_components\/components\/)[\/a-zA-Z_-]+(?=['"])/
+
+        @find_all_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components/
+        find_stylesheets = /(?<=@import ["']{1}govuk_publishing_components\/components\/)(?!print\/)+[a-zA-Z_-]+(?=['"])/
+
+        @find_all_print_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components_print/
+        find_print_stylesheets = /(?<=@import ["']{1}govuk_publishing_components\/components\/print\/)[a-zA-Z_-]+(?=['"])/
+
+        @find_all_javascripts = /\/\/[ ]*= require govuk_publishing_components\/all_components/
+        find_javascripts = /(?<=require govuk_publishing_components\/components\/)[a-zA-Z_-]+/
+
+        components_in_templates = find_components(templates, find_components, "templates") || []
+        components_in_stylesheets = find_components(stylesheets, find_stylesheets, "stylesheets") || []
+        components_in_print_stylesheets = find_components(stylesheets, find_print_stylesheets, "print_stylesheets") || []
+        components_in_javascripts = find_components(javascripts, find_javascripts, "javascripts") || []
+
+        ruby_paths = %w[/app/helpers/ /app/presenters/ /lib/]
+        components_in_ruby = []
+        ruby_paths.each do |ruby_path|
+          components_in_ruby << find_components(Dir["#{path}#{ruby_path}**/*.{rb,erb}"], find_components, "ruby") || []
+        end
+        components_in_ruby = components_in_ruby.flatten.uniq
+
         components_found = [
           {
             location: "templates",

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -36,6 +36,7 @@ module GovukPublishingComponents
           warnings = []
           warnings << warn_about_missing_components(result[:components_found])
           warnings << warn_about_missing_assets(result[:components_found])
+          warnings << warn_about_style_overrides(result[:gem_style_references])
           warnings = warnings.flatten
 
           data << {
@@ -65,6 +66,7 @@ module GovukPublishingComponents
             ],
             warnings: warnings,
             warning_count: warnings.length,
+            gem_style_references: result[:gem_style_references],
           }
         else
           data << {
@@ -148,6 +150,17 @@ module GovukPublishingComponents
 
     def component_does_not_exist(component)
       !@gem_data[:component_code].include?(component) unless component == "all"
+    end
+
+    def warn_about_style_overrides(results)
+      warnings = []
+
+      results.each do |result|
+        warnings << create_warning("Possible component style override", result) if result.include? ".scss"
+        warnings << create_warning("Possible hard coded component markup", result) if [".html", ".rb"].any? { |needle| result.include? needle }
+      end
+
+      warnings
     end
 
     def find_missing(needle, haystack)

--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -20,7 +20,11 @@
       </li>
     </ul>
     <div class="govuk-tabs__panel" id="applications">
-      <h2 class="govuk-heading-l">Applications</h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Applications",
+        font_size: "l",
+        margin_bottom: 6
+      } %>
 
       <% if @applications.any? %>
         <details class="govuk-details" data-module="govuk-details">
@@ -66,7 +70,12 @@
                     </p>
                   <% end %>
 
-                  <h3 class="govuk-heading-m">Components used</h3>
+                  <%= render "govuk_publishing_components/components/heading", {
+                    text: "Components used",
+                    font_size: "m",
+                    margin_bottom: 4,
+                    heading_level: 3,
+                  } %>
 
                   <dl class="govuk-summary-list">
                     <% application[:summary].each do |item| %>
@@ -84,6 +93,22 @@
                       </div>
                     <% end %>
                   </dl>
+
+                  <% if application[:gem_style_references].any? %>
+                    <%= render "govuk_publishing_components/components/heading", {
+                      text: "Component references",
+                      font_size: "m",
+                      margin_bottom: 4,
+                      heading_level: 3,
+                    } %>
+
+                    <p class="govuk-body">This shows instances of `gem-c-` classes found in the application. If a reference is found in a stylesheet or in code a warning is created, as this could be a style override or hard coded component markup.</p>
+                    <ul class="govuk-list govuk-list--bullet">
+                      <% application[:gem_style_references].each do |ref| %>
+                        <li><%= ref %></li>
+                      <% end %>
+                    </ul>
+                  <% end %>
                 <% else %>
                   <p class="govuk-body">This application was not found. This could be because you do not have this repository checked out locally.</p>
                 <% end %>
@@ -97,7 +122,11 @@
     </div>
 
     <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="components-gem">
-      <h2 class="govuk-heading-l">Components</h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Components",
+        font_size: "l",
+        margin_bottom: 6,
+      } %>
 
       <% if @components.any? %>
         <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">

--- a/spec/component_guide/audit_applications_spec.rb
+++ b/spec/component_guide/audit_applications_spec.rb
@@ -3,11 +3,11 @@ require_relative "../../app/models/govuk_publishing_components/audit_application
 
 describe "Auditing the components in applications" do
   it "returns correct information" do
-    path = File.join(File.dirname(__FILE__), "../dummy")
-    application = GovukPublishingComponents::AuditApplications.new(path, "an application")
+    path = File.join(Dir.pwd, "/spec/dummy")
+    application = GovukPublishingComponents::AuditApplications.new(path, "govuk_publishing_components")
 
     expected = {
-      name: "an application",
+      name: "govuk_publishing_components",
       application_found: true,
       components_found: [
         {
@@ -30,6 +30,10 @@ describe "Auditing the components in applications" do
           location: "ruby",
           components: ["button", "govspeak", "print link"],
         },
+      ],
+      gem_style_references: [
+        "app/assets/stylesheets/application.scss",
+        "app/views/layouts/dummy_admin_layout.html.erb",
       ],
     }
 

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -117,6 +117,7 @@ describe "Comparing data from an application with the components" do
             ],
           },
         ],
+        gem_style_references: [],
       },
     ]
     comparer = GovukPublishingComponents::AuditComparer.new(gem, application)
@@ -170,6 +171,7 @@ describe "Comparing data from an application with the components" do
           },
         ],
         warning_count: 5,
+        gem_style_references: [],
       },
     ]
 
@@ -208,6 +210,7 @@ describe "Comparing data from an application with the components" do
             ],
           },
         ],
+        gem_style_references: [],
       },
     ]
     comparer = GovukPublishingComponents::AuditComparer.new(gem, application)
@@ -245,6 +248,7 @@ describe "Comparing data from an application with the components" do
           },
         ],
         warning_count: 1,
+        gem_style_references: [],
       },
     ]
 
@@ -286,6 +290,11 @@ describe "Comparing data from an application with the components" do
             ],
           },
         ],
+        gem_style_references: [
+          "a_made_up_application/app/assets/stylesheets/application.scss",
+          "a_made_up_application/app/assets/stylesheets/application.js",
+          "a_made_up_application/app/views/layouts/dummy_admin_layout.html",
+        ],
       },
     ]
     comparer = GovukPublishingComponents::AuditComparer.new(gem, application)
@@ -316,6 +325,11 @@ describe "Comparing data from an application with the components" do
             value: "component that does not exist",
           },
         ],
+        gem_style_references: [
+          "a_made_up_application/app/assets/stylesheets/application.scss",
+          "a_made_up_application/app/assets/stylesheets/application.js",
+          "a_made_up_application/app/views/layouts/dummy_admin_layout.html",
+        ],
         warnings: [
           {
             component: "component that does not exist",
@@ -329,8 +343,16 @@ describe "Comparing data from an application with the components" do
             component: "component one",
             message: "Included in stylesheets but not code",
           },
+          {
+            component: "Possible component style override",
+            message: "a_made_up_application/app/assets/stylesheets/application.scss",
+          },
+          {
+            component: "Possible hard coded component markup",
+            message: "a_made_up_application/app/views/layouts/dummy_admin_layout.html",
+          },
         ],
-        warning_count: 3,
+        warning_count: 5,
       },
     ]
 

--- a/spec/dummy/app/assets/stylesheets/application.scss
+++ b/spec/dummy/app/assets/stylesheets/application.scss
@@ -1,1 +1,7 @@
 @import "govuk_publishing_components/all_components";
+
+/*
+  this is for testing the auditing code
+
+  .gem-c-something {}
+*/

--- a/spec/dummy/app/views/layouts/dummy_admin_layout.html.erb
+++ b/spec/dummy/app/views/layouts/dummy_admin_layout.html.erb
@@ -20,3 +20,8 @@
   </div>
   <%= render "govuk_publishing_components/components/layout_footer" %>
 <% end %>
+
+<%
+  # this is for testing the auditing code
+  # <div class="gem-c-something"></div>
+%>


### PR DESCRIPTION
## What
Extend the auditing code to check applications to find any instances of `gem-c-` classes in stylesheets or code, and raise a warning in the auditing page if found.

## Why
This will help us spot instances of component style overrides (which can break component isolation) or hard coded component markup (which can leave pages broken if the component is changed).

## Visual Changes

Any instances found are added to the existing list of warnings.

<img width="944" alt="Screenshot 2020-07-24 at 08 54 08" src="https://user-images.githubusercontent.com/861310/88371265-98725780-cd8b-11ea-871f-716f9f20a72b.png">

All instances are also listed after the warnings.

<img width="941" alt="Screenshot 2020-07-24 at 08 54 22" src="https://user-images.githubusercontent.com/861310/88371364-ca83b980-cd8b-11ea-84eb-4390cc9f4bae.png">

The code checks all the places that components are currently searched in (stylesheets, templates, javascripts, ruby code) but doesn't raise a warning if the instance is a javascript file, as attaching events to components on an application level seems like it might not cause problems? Happy to discuss this approach though.
