### PR TITLE
Allow requests for all domains e.g. <app>.dev.gov.uk

### DIFF
--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -12,6 +12,9 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  # Allow requests for all domains e.g. <app>.dev.gov.uk
+  config.hosts.clear
+
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true

--- a/spec/lib/govuk_publishing_components/presenters/machine_readable/html_publication_schema_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/machine_readable/html_publication_schema_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe GovukPublishingComponents::Presenters::HtmlPublicationSchema do
 
     it "behaves like an article" do
       expect(structured_data["@type"]).to eql("Article")
-      expect(structured_data["articleBody"]).to eq(page.body)
+      expect(structured_data["articleBody"].to_s).to eq(page.body)
     end
 
     context "when one heading present" do


### PR DESCRIPTION
## What
Allow requests for all domains e.g. <app>.dev.gov.uk

## Why
To allow local development and cross-browser/device testing in Browserstack

## Visual Changes
No visual changes
