### PR TITLE
Remove ability to pass Govspeak unsanitized HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * **BREAKING** Layout header component always displays product name and environment when provided ([PR #1736](https://github.com/alphagov/govuk_publishing_components/pull/1736))
 * Add heading option to panel component ([PR #1741](https://github.com/alphagov/govuk_publishing_components/pull/1741)) MINOR
 * **BREAKING** Force contents list title to always be Contents or regional equivalent ([PR #1734](https://github.com/alphagov/govuk_publishing_components/pull/1734))
+* **BREAKING** Remove ability to pass Govspeak unsanitized HTML ([PR #1632](https://github.com/alphagov/govuk_publishing_components/pull/1632))
 
 ## 21.69.0
 

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -12,22 +12,18 @@
     <% if content.html_safe? %>
       <%= content %>
     <% else %>
-      <% puts "
-        You've passed in unsanitised HTML into the govspeak component as the
-        `content` param.
+      <% raise "
+        You've passed in unsanitised HTML into the Govspeak component as the
+        `content` parameter.
 
-        Passing in unsafe HTML is deprecated and will be removed in a future
-        version. You need to pass in a block instead or use the `capture` helper.
-
-        See the component guide for examples.
-
-        If you're 100% sure there's no unsanitised user input in the string you
-        could also call `.html_safe` on the string or use the `raw` helper before
-        passing it in.
+        To fix this use a `do` block with the sanitize method - see
+        https://components.publishing.service.gov.uk/component-guide/govspeak/
+        for the updated documentation and
+        https://github.com/alphagov/govuk_publishing_components/pull/1632/
+        for further examples.
 
         Called from #{caller_locations.find { |l| l.to_s.include?('.erb') }}
         " %>
-      <%= raw content %>
     <% end %>
   <% elsif block_given? %>
     <%= yield %>

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -24,12 +24,7 @@ examples:
     data:
       block: |
         <h2>This is a title</h2>
-          <p>This is some body text with <a href=#>a link</a></p>
-  with_content:
-    data:
-      content: |
-        <h2>This is a title</h2>
-        <p>This is some body text with <a href=#>a link</a></p>
+          <p>This is some body text with <a href="https://example.com">a link</a>.</p>
   heading_levels:
     data:
       block: |


### PR DESCRIPTION
# What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Removes the ability for the Govspeak component to use unsanitized HTML. This changes updates the current non-breaking message to raise an errror whenever non-sanitised HTML is given to the Govspeak component.

This is a **breaking change**.

I've added (another) column to the [frontend apps spreadsheet](https://docs.google.com/spreadsheets/d/1J-0IPyr2ycPuw1IWOIoX0o9Tk9nF35D0DJdsj_ylLQE/edit#gid=0) to highlight which apps will need to be updated, which have already been updated, and which don't use Govspeak at all.

## Why
<!-- What are the reasons behind this change being made? -->
This was marked as deprecated more than two years ago and should be removed (or the message saying it's deprecated should be removed.)

This means that apps that have:

```erb
<%= render "govuk_publishing_components/components/govspeak", {
  content: some_html_in_a_variable_from_elsewhere.html_safe,
} %>
```

should be changed to:

```erb
<%= render "govuk_publishing_components/components/govspeak", {} do %>
  <%= sanitize(some_html_in_a_variable_from_elsewhere) %>
<% end %>
```

or 

```erb
<%= render "govuk_publishing_components/components/govspeak", {} do %>
  <p>This is some body text with <a href=#>a link</a></p>
<% end %>
```

See https://github.com/alphagov/frontend/pull/2444 for an example of these changes.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

None.
