### PR TITLE
Add optional lang parameter to image card component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+
+## Unreleased
+
+* Add optional lang parameter to image card component ([PR #1634](https://github.com/alphagov/govuk_publishing_components/pull/1634))
+
 ## 21.60.1
 
 * Change bar chart numbers and colours to be accessible ([PR #1608](https://github.com/alphagov/govuk_publishing_components/pull/1608))

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -7,7 +7,7 @@
 <% if card_helper.href || card_helper.extra_links.any? %>
   <div class="gem-c-image-card <%= "gem-c-image-card--large" if card_helper.large %> <%= brand_helper.brand_class %>"
     <%= "data-module=track-click" if card_helper.is_tracking? %>
-  >
+    <%= "lang=#{card_helper.lang}" if card_helper.lang %>>
     <%= card_helper.image %>
 
     <div class="gem-c-image-card__text-wrapper">

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -9,6 +9,7 @@ accessibility_criteria: |
 
   - include alt text for images when present
   - not have duplicate links for the image and the text
+  - if the contents of the component are in a different language than the rest of the document, include an appropriate `lang` attribute to correctly identify the language used in the component
 shared_accessibility_criteria:
   - link
 examples:
@@ -191,7 +192,7 @@ examples:
     description: Can be used for links to people pages to indicate payment type
     data:
       href: "/government/people/"
-      image_src: "http://placekitten.com/215/140"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
       image_alt: "some meaningful alt text please"
       context:
         text: "The Rt Hon"
@@ -204,3 +205,14 @@ examples:
         }
       ]
       extra_links_no_indent: true
+  with_lang:
+    description: |
+      Pass through an appropriate `lang` to set a HTML lang attribute for the component.
+      
+      The `lang` attribute **must** be set to a [valid BCP47 string](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang#Language_tag_syntax). A valid code can be the two or three letter language code - for example, English is `en` or `eng`, Korean is `ko` or `kor` - but if in doubt please check.
+    data:
+      href: "/not-a-page"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      image_alt: "some meaningful alt text please"
+      heading_text: Yr hyn rydym ni'n ei wneud
+      lang: cy

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
       include ActionView::Helpers
       include ActionView::Context
 
-      attr_reader :href, :href_data_attributes, :extra_links, :large, :extra_links_no_indent, :heading_text, :metadata
+      attr_reader :href, :href_data_attributes, :extra_links, :large, :extra_links_no_indent, :heading_text, :metadata, :lang
 
       def initialize(local_assigns)
         @href = local_assigns[:href]
@@ -18,6 +18,7 @@ module GovukPublishingComponents
         @heading_text = local_assigns[:heading_text]
         @extra_links_no_indent = local_assigns[:extra_links_no_indent]
         @metadata = local_assigns[:metadata]
+        @lang = local_assigns[:lang]
       end
 
       def is_tracking?

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -98,4 +98,9 @@ describe "ImageCard", type: :view do
     render_component(href: "#", metadata: "Unpaid")
     assert_select ".gem-c-image-card__metadata", text: "Unpaid"
   end
+
+  it "applies lang attribute when lang is specified" do
+    render_component(href: "#", lang: "cy")
+    assert_select ".gem-c-image-card[lang='cy']"
+  end
 end


### PR DESCRIPTION
## What
Introduce the ability to pass an (optional) lang parameter to specify language on the image card component.

## Why
This is necessary due to the fact that there are instances on the site where a page will be in Welsh, but certain components on the page will display data in English as there is no Welsh translation for those parts of the page. This is a Web Accessibility fail.

A concrete example is [here](https://www.gov.uk/government/organisations/nuclear-decommissioning-authority.cy)  where even though the document is a Welsh translation, the ministers information is all in English.

----------


Goes hand in hand with https://github.com/alphagov/collections/pull/1853

https://trello.com/c/4znXL1Bn
