### PR TITLE
[DO NOT MERGE] Feedback component lang

### DIFF
--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -8,7 +8,7 @@
   path_without_pii = utf_encode(request.fullpath.gsub(email_regex, '[email]'))
 %>
 
-<div class="gem-c-feedback" data-module="feedback">
+<div class="gem-c-feedback" data-module="feedback" lang="en">
   <%= render "govuk_publishing_components/components/feedback/yes_no_banner" %>
   <%= render "govuk_publishing_components/components/feedback/problem_form", url_without_pii: url_without_pii %>
   <%= render "govuk_publishing_components/components/feedback/survey_signup_form", path_without_pii: path_without_pii %>


### PR DESCRIPTION
**EDIT:** needs a bit of looking into, to investigate if the issue would be better fixed at a localised application level vs at a component level;  please don't review/merge this yet



## What

This adds `lang="en"` to the feedback component to correctly indicate the language the component is in. This is subject to change if/when we end up translating this component into other languages.

## Why 
As of right now, the feedback component is not localised.

On some translated pages, most of the content will be in the specified language, however the feedback component is in English and not clearly marked as such. This is a WCAG fail.

Example page: https://www.gov.uk/government/organisations/nuclear-decommissioning-authority.cy 

The content on this page is in Welsh, marked with `lang="cy"`.
The feedback component is in English and sits inside the  `lang="cy"` wrapper. 
In the absence of a relevant Welsh translation, the second best solution is to add `lang="en"` to the feedback component, to indicate language accurately. 