### PR TITLE
Replace 'includes' with a method compatible with Internet Explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix display of embedded YouTube videos for Internet Explorer users ([PR #1640](https://github.com/alphagov/govuk_publishing_components/pull/1640))
 
 ## 21.60.2
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -33,7 +33,7 @@
         }
       }
 
-      if (href.includes('/live_stream')) {
+      if (href.indexOf('/live_stream') >= 0) {
         var channelId = YoutubeLinkEnhancement.parseLivestream(href)
 
         if (!this.hasDisabledEmbed($link) && channelId) {


### PR DESCRIPTION
## What
We are using the string `includes` method, which is not compatible with Internet Explorer (see
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes).

Therefore replacing with a workaround that is compatible with Internet Explorer.

## Why
This prevents the YouTube videos from being embedded for anyone using Internet Explorer.  The following errors appears in the browser's console:
```
Object doesn't support property or method 'includes'
```

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4189366