### PR TITLE
Add lang attribute to image card date element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add public/frontend layout component ([PR #1265](https://github.com/alphagov/govuk_publishing_components/pull/1265))
 * Replace jQuery in checkboxes.js ([PR #1620](https://github.com/alphagov/govuk_publishing_components/pull/1620))
+* Add lang attribute to image card date/time element ([PR #1642](https://github.com/alphagov/govuk_publishing_components/pull/1642))
 
 ## 21.60.3
 

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -45,7 +45,7 @@ module GovukPublishingComponents
 
         content_tag(:p, class: "gem-c-image-card__context") do
           if @context[:date]
-            date = content_tag(:time, l(@context[:date], format: "%e %B %Y"), datetime: @context[:date].iso8601)
+            date = content_tag(:time, l(@context[:date], format: "%e %B %Y"), datetime: @context[:date].iso8601, lang: "en")
             dash = content_tag(:span, " — ", 'aria-hidden': true)
 
             if @context[:text]


### PR DESCRIPTION
## What
This adds a `lang="en"` attribute to the image card component.
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->
The way the date/time is formatted means it will always be in English even when the contents of the page are in a different language. If we don't clearly indicate the language of the element, it fails WCAG 2.1 A 3.1.2 when it's viewed in the context of a translated page.

https://trello.com/c/uA7mDUvI

