### PR TITLE
Remove jquery from step by step component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add role="alert" to cookie banner confirmation ([PR #1658](https://github.com/alphagov/govuk_publishing_components/pull/1658))
+* Remove jquery from step by step component ([PR #1645](https://github.com/alphagov/govuk_publishing_components/pull/1645))
 
 ## 21.63.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -1,4 +1,6 @@
-/* eslint-env jquery */
+//= require govuk/vendor/polyfills/Element/prototype/classList.js
+//= require ../vendor/polyfills/closest.js
+//= require ../vendor/polyfills/indexOf.js
 
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -4,429 +4,489 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  'use strict'
+  function Gemstepnav () { }
 
-  Modules.Gemstepnav = function () {
-    var actions = {} // stores text for JS appended elements 'show' and 'hide' on steps, and 'show/hide all' button
-    var rememberShownStep = false
-    var stepNavSize
-    var sessionStoreLink = 'govuk-step-nav-active-link'
-    var activeLinkClass = 'gem-c-step-nav__list-item--active'
-    var activeStepClass = 'gem-c-step-nav__step--active'
-    var activeLinkHref = '#content'
-    var uniqueId
+  Gemstepnav.prototype.start = function ($module) {
+    this.$module = $module[0]
+    this.$module.actions = {} // stores text for JS appended elements 'show' and 'hide' on steps, and 'show/hide all' button
+    this.$module.rememberShownStep = false
+    this.$module.stepNavSize = false
+    this.$module.sessionStoreLink = 'govuk-step-nav-active-link'
+    this.$module.activeLinkClass = 'gem-c-step-nav__list-item--active'
+    this.$module.activeStepClass = 'gem-c-step-nav__step--active'
+    this.$module.activeLinkHref = '#content'
+    this.$module.uniqueId = false
 
-    this.start = function ($element) {
-      // Indicate that js has worked
-      $element.addClass('gem-c-step-nav--active')
+    // Indicate that js has worked
+    this.$module.classList.add('gem-c-step-nav--active')
 
-      // Prevent FOUC, remove class hiding content
-      $element.removeClass('js-hidden')
+    // Prevent FOUC, remove class hiding content
+    this.$module.classList.remove('js-hidden')
 
-      stepNavSize = $element.hasClass('gem-c-step-nav--large') ? 'Big' : 'Small'
-      rememberShownStep = !!$element.filter('[data-remember]').length && stepNavSize === 'Big'
-      var $steps = $element.find('.js-step')
-      var $stepHeaders = $element.find('.js-toggle-panel')
-      var totalSteps = $element.find('.js-panel').length
-      var totalLinks = $element.find('.gem-c-step-nav__link').length
-      var $showOrHideAllButton
+    this.$module.stepNavSize = this.$module.classList.contains('gem-c-step-nav--large') ? 'Big' : 'Small'
+    this.$module.rememberShownStep = !!this.$module.hasAttribute('data-remember') && this.$module.stepNavSize === 'Big'
 
-      uniqueId = $element.data('id') || false
+    this.$module.steps = this.$module.querySelectorAll('.js-step')
+    this.$module.stepHeaders = this.$module.querySelectorAll('.js-toggle-panel')
+    this.$module.totalSteps = this.$module.querySelectorAll('.js-panel').length
+    this.$module.totalLinks = this.$module.querySelectorAll('.gem-c-step-nav__link').length
+    this.$module.showOrHideAllButton = false
 
-      if (uniqueId) {
-        sessionStoreLink = sessionStoreLink + '_' + uniqueId
+    this.$module.uniqueId = this.$module.getAttribute('data-id') || false
+
+    if (this.$module.uniqueId) {
+      this.$module.sessionStoreLink = this.$module.sessionStoreLink + '_' + this.$module.uniqueId
+    }
+
+    var stepNavTracker = new this.StepNavTracker(this.$module.uniqueId, this.$module.totalSteps, this.$module.totalLinks)
+
+    this.getTextForInsertedElements()
+    this.addButtonstoSteps()
+    this.addShowHideAllButton()
+    this.addShowHideToggle()
+    this.addAriaControlsAttrForShowHideAllButton()
+
+    this.ensureOnlyOneActiveLink()
+    this.showPreviouslyOpenedSteps()
+
+    this.bindToggleForSteps(stepNavTracker)
+    this.bindToggleShowHideAllButton(stepNavTracker)
+    this.bindComponentLinkClicks(stepNavTracker)
+  }
+
+  Gemstepnav.prototype.getTextForInsertedElements = function () {
+    this.$module.actions.showText = this.$module.getAttribute('data-show-text')
+    this.$module.actions.hideText = this.$module.getAttribute('data-hide-text')
+    this.$module.actions.showAllText = this.$module.getAttribute('data-show-all-text')
+    this.$module.actions.hideAllText = this.$module.getAttribute('data-hide-all-text')
+  }
+
+  Gemstepnav.prototype.addShowHideAllButton = function () {
+    var showall = document.createElement('div')
+    showall.className = 'gem-c-step-nav__controls'
+    showall.innerHTML = '<button aria-expanded="false" class="gem-c-step-nav__button gem-c-step-nav__button--controls js-step-controls-button">' + this.$module.actions.showAllText + '</button>'
+
+    var steps = this.$module.querySelectorAll('.gem-c-step-nav__steps')[0]
+    this.$module.insertBefore(showall, steps)
+
+    this.$module.showOrHideAllButton = this.$module.querySelectorAll('.js-step-controls-button')[0]
+  }
+
+  Gemstepnav.prototype.addShowHideToggle = function () {
+    for (var i = 0; i < this.$module.stepHeaders.length; i++) {
+      var thisel = this.$module.stepHeaders[i]
+
+      if (!thisel.querySelectorAll('.js-toggle-link').length) {
+        var span = document.createElement('span')
+        span.className = 'gem-c-step-nav__toggle-link js-toggle-link'
+        span.setAttribute('aria-hidden', true)
+        span.setAttribute('hidden', 'hidden')
+        thisel.querySelectorAll('.js-step-title-button')[0].appendChild(span)
       }
+    }
+  }
 
-      var stepNavTracker = new StepNavTracker(totalSteps, totalLinks, uniqueId)
+  Gemstepnav.prototype.headerIsOpen = function (stepHeader) {
+    return (typeof stepHeader.parentNode.getAttribute('show') !== 'undefined')
+  }
 
-      getTextForInsertedElements()
-      addButtonstoSteps()
-      addShowHideAllButton()
-      addShowHideToggle()
-      addAriaControlsAttrForShowHideAllButton()
+  Gemstepnav.prototype.addAriaControlsAttrForShowHideAllButton = function () {
+    var ariaControlsValue = this.$module.querySelectorAll('.js-panel')[0].getAttribute('id')
+    this.$module.showOrHideAllButton.setAttribute('aria-controls', ariaControlsValue)
+  }
 
-      ensureOnlyOneActiveLink()
-      showPreviouslyOpenedSteps()
+  // called by show all/hide all, sets all steps accordingly
+  Gemstepnav.prototype.setAllStepsShownState = function (isShown) {
+    var data = []
 
-      bindToggleForSteps(stepNavTracker)
-      bindToggleShowHideAllButton(stepNavTracker)
-      bindComponentLinkClicks(stepNavTracker)
+    for (var i = 0; i < this.$module.steps.length; i++) {
+      var stepView = new this.StepView(this.$module.steps[i], this.$module.actions.showText, this.$module.actions.hideText)
+      stepView.setIsShown(isShown)
 
-      function getTextForInsertedElements () {
-        actions.showText = $element.attr('data-show-text')
-        actions.hideText = $element.attr('data-hide-text')
-        actions.showAllText = $element.attr('data-show-all-text')
-        actions.hideAllText = $element.attr('data-hide-all-text')
+      if (isShown) {
+        data.push(this.$module.steps[i].getAttribute('id'))
       }
+    }
 
-      function addShowHideAllButton () {
-        $element.prepend('<div class="gem-c-step-nav__controls"><button aria-expanded="false" class="gem-c-step-nav__button gem-c-step-nav__button--controls js-step-controls-button">' + actions.showAllText + '</button></div>')
+    if (isShown) {
+      this.saveToSessionStorage(this.$module.uniqueId, JSON.stringify(data))
+    } else {
+      this.removeFromSessionStorage(this.$module.uniqueId)
+    }
+  }
+
+  // called on load, determines whether each step should be open or closed
+  Gemstepnav.prototype.showPreviouslyOpenedSteps = function () {
+    var data = this.loadFromSessionStorage(this.$module.uniqueId) || []
+
+    for (var i = 0; i < this.$module.steps.length; i++) {
+      var thisel = this.$module.steps[i]
+      var id = thisel.getAttribute('id')
+      var stepView = new this.StepView(thisel, this.$module.actions.showText, this.$module.actions.hideText)
+      var shouldBeShown = thisel.hasAttribute('data-show')
+
+      // show the step if it has been remembered or if it has the 'data-show' attribute
+      if ((this.$module.rememberShownStep && data.indexOf(id) > -1) || (shouldBeShown && shouldBeShown !== 'undefined')) {
+        stepView.setIsShown(true)
+      } else {
+        stepView.setIsShown(false)
       }
+    }
 
-      function addShowHideToggle () {
-        $stepHeaders.each(function () {
-          var linkText = actions.showText // eslint-disable-line no-unused-vars
+    if (data.length > 0) {
+      this.$module.showOrHideAllButton.setAttribute('aria-expanded', true)
+      this.setShowHideAllText()
+    }
+  }
 
-          if (headerIsOpen($(this))) {
-            linkText = actions.hideText
-          }
+  Gemstepnav.prototype.addButtonstoSteps = function () {
+    for (var i = 0; i < this.$module.steps.length; i++) {
+      var thisel = this.$module.steps[i]
+      var title = thisel.querySelectorAll('.js-step-title')[0]
+      var contentId = thisel.querySelectorAll('.js-panel')[0].getAttribute('id')
+      var titleText = title.textContent || title.innerText // IE8 fallback
 
-          if (!$(this).find('.js-toggle-link').length) {
-            $(this).find('.js-step-title-button').append(
-              '<span class="gem-c-step-nav__toggle-link js-toggle-link" aria-hidden="true" hidden></span>'
-            )
-          }
-        })
-      }
-
-      function headerIsOpen ($stepHeader) {
-        return (typeof $stepHeader.closest('.js-step').data('show') !== 'undefined')
-      }
-
-      function addAriaControlsAttrForShowHideAllButton () {
-        var ariaControlsValue = $element.find('.js-panel').first().attr('id')
-
-        $showOrHideAllButton = $element.find('.js-step-controls-button')
-        $showOrHideAllButton.attr('aria-controls', ariaControlsValue)
-      }
-
-      // called by show all/hide all, sets all steps accordingly
-      function setAllStepsShownState (isShown) {
-        var data = []
-
-        $.each($steps, function () {
-          var stepView = new StepView($(this))
-          stepView.setIsShown(isShown)
-
-          if (isShown) {
-            data.push($(this).attr('id'))
-          }
-        })
-
-        if (isShown) {
-          saveToSessionStorage(uniqueId, JSON.stringify(data))
-        } else {
-          removeFromSessionStorage(uniqueId)
-        }
-      }
-
-      // called on load, determines whether each step should be open or closed
-      function showPreviouslyOpenedSteps () {
-        var data = loadFromSessionStorage(uniqueId) || []
-
-        $.each($steps, function () {
-          var id = $(this).attr('id')
-          var stepView = new StepView($(this))
-
-          // show the step if it has been remembered or if it has the 'data-show' attribute
-          if ((rememberShownStep && data.indexOf(id) > -1) || typeof $(this).attr('data-show') !== 'undefined') {
-            stepView.setIsShown(true)
-          } else {
-            stepView.setIsShown(false)
-          }
-        })
-
-        if (data.length > 0) {
-          $showOrHideAllButton.attr('aria-expanded', true)
-          setShowHideAllText()
-        }
-      }
-
-      function addButtonstoSteps () {
-        $.each($steps, function () {
-          var $step = $(this)
-          var $title = $step.find('.js-step-title')
-          var contentId = $step.find('.js-panel').first().attr('id')
-
-          $title.wrapInner(
-            '<span class="js-step-title-text"></span>'
-          )
-
-          $title.wrapInner(
-            '<button ' +
+      title.outerHTML =
+        '<span class="js-step-title">' +
+          '<button ' +
             'class="gem-c-step-nav__button gem-c-step-nav__button--title js-step-title-button" ' +
             'aria-expanded="false" aria-controls="' + contentId + '">' +
-            '</button>'
-          )
-        })
-      }
+              '<span class="js-step-title-text">' + titleText + '</span>' +
+          '</button>' +
+        '</span>'
+    }
+  }
 
-      function bindToggleForSteps (stepNavTracker) {
-        $element.find('.js-toggle-panel').click(function (event) {
-          var $step = $(this).closest('.js-step')
+  Gemstepnav.prototype.bindToggleForSteps = function (stepNavTracker) {
+    var that = this
+    var togglePanels = this.$module.querySelectorAll('.js-toggle-panel')
 
-          var stepView = new StepView($step)
-          stepView.toggle()
+    for (var i = 0; i < togglePanels.length; i++) {
+      togglePanels[i].addEventListener('click', function (event) {
+        var stepView = new that.StepView(this.parentNode, that.$module.actions.showText, that.$module.actions.hideText)
+        stepView.toggle()
 
-          var stepIsOptional = typeof $step.data('optional') !== 'undefined'
-          var toggleClick = new StepToggleClick(event, stepView, $steps, stepNavTracker, stepIsOptional)
-          toggleClick.track()
+        var stepIsOptional = this.parentNode.hasAttribute('data-optional')
+        var toggleClick = new that.StepToggleClick(event, stepView, stepNavTracker, stepIsOptional, that.$module.stepNavSize)
+        toggleClick.trackClick()
 
-          setShowHideAllText()
-          rememberStepState($step)
-        })
-      }
+        that.setShowHideAllText()
+        that.rememberStepState(this.parentNode)
+      })
+    }
+  }
 
-      // if the step is open, store its id in session store
-      // if the step is closed, remove its id from session store
-      function rememberStepState ($step) {
-        if (rememberShownStep) {
-          var data = JSON.parse(loadFromSessionStorage(uniqueId)) || []
-          var thisstep = $step.attr('id')
-          var shown = $step.hasClass('step-is-shown')
+  // if the step is open, store its id in session store
+  // if the step is closed, remove its id from session store
+  Gemstepnav.prototype.rememberStepState = function (step) {
+    if (this.$module.rememberShownStep) {
+      var data = JSON.parse(this.loadFromSessionStorage(this.$module.uniqueId)) || []
+      var thisstep = step.getAttribute('id')
+      var shown = step.classList.contains('step-is-shown')
 
-          if (shown) {
-            data.push(thisstep)
-          } else {
-            var i = data.indexOf(thisstep)
-            if (i > -1) {
-              data.splice(i, 1)
-            }
-          }
-          saveToSessionStorage(uniqueId, JSON.stringify(data))
+      if (shown) {
+        data.push(thisstep)
+      } else {
+        var i = data.indexOf(thisstep)
+        if (i > -1) {
+          data.splice(i, 1)
         }
       }
+      this.saveToSessionStorage(this.$module.uniqueId, JSON.stringify(data))
+    }
+  }
 
-      // tracking click events on links in step content
-      function bindComponentLinkClicks (stepNavTracker) {
-        $element.find('.js-link').click(function (event) {
-          var linkClick = new componentLinkClick(event, stepNavTracker, $(this).attr('data-position')) // eslint-disable-line no-new, new-cap
-          linkClick.track()
-          var thisLinkHref = $(this).attr('href')
+  // tracking click events on links in step content
+  Gemstepnav.prototype.bindComponentLinkClicks = function (stepNavTracker) {
+    var jsLinks = this.$module.querySelectorAll('.js-link')
+    var that = this
 
-          if ($(this).attr('rel') !== 'external') {
-            saveToSessionStorage(sessionStoreLink, $(this).attr('data-position'))
-          }
+    for (var i = 0; i < jsLinks.length; i++) {
+      jsLinks[i].addEventListener('click', function (event) {
+        var dataPosition = this.getAttribute('data-position')
+        var linkClick = new that.ComponentLinkClick(event, stepNavTracker, dataPosition, that.$module.stepNavSize)
+        linkClick.trackClick()
 
-          if (thisLinkHref === activeLinkHref) {
-            setOnlyThisLinkActive($(this))
-            setActiveStepClass()
-          }
-        })
-      }
-
-      function saveToSessionStorage (key, value) {
-        window.sessionStorage.setItem(key, value)
-      }
-
-      function loadFromSessionStorage (key) {
-        return window.sessionStorage.getItem(key)
-      }
-
-      function removeFromSessionStorage (key) {
-        window.sessionStorage.removeItem(key)
-      }
-
-      function setOnlyThisLinkActive (clicked) {
-        $element.find('.' + activeLinkClass).removeClass(activeLinkClass)
-        clicked.parent().addClass(activeLinkClass)
-      }
-
-      // if a link occurs more than once in a step nav, the backend doesn't know which one to highlight
-      // so it gives all those links the 'active' attribute and highlights the last step containing that link
-      // if the user clicked on one of those links previously, it will be in the session store
-      // this code ensures only that link and its corresponding step have the highlighting
-      // otherwise it accepts what the backend has already passed to the component
-      function ensureOnlyOneActiveLink () {
-        var $activeLinks = $element.find('.js-list-item.' + activeLinkClass)
-
-        if ($activeLinks.length <= 1) {
-          return
+        if (this.getAttribute('rel') !== 'external') {
+          that.saveToSessionStorage(that.$module.sessionStoreLink, dataPosition)
         }
 
-        var lastClicked = loadFromSessionStorage(sessionStoreLink) || $element.find('.' + activeLinkClass).first().attr('data-position')
-
-        // it's possible for the saved link position value to not match any of the currently duplicate highlighted links
-        // so check this otherwise it'll take the highlighting off all of them
-        if (!$element.find('.js-link[data-position="' + lastClicked + '"]').parent().hasClass(activeLinkClass)) {
-          lastClicked = $element.find('.' + activeLinkClass).first().find('.js-link').attr('data-position')
+        if (this.getAttribute('href') === that.$module.activeLinkHref) {
+          that.setOnlyThisLinkActive(this)
+          that.setActiveStepClass()
         }
-        removeActiveStateFromAllButCurrent($activeLinks, lastClicked)
-        setActiveStepClass()
-      }
+      })
+    }
+  }
 
-      function removeActiveStateFromAllButCurrent ($activeLinks, current) {
-        $activeLinks.each(function () {
-          if ($(this).find('.js-link').attr('data-position').toString() !== current.toString()) {
-            $(this).removeClass(activeLinkClass)
-            $(this).find('.visuallyhidden').remove()
-          }
-        })
-      }
+  Gemstepnav.prototype.saveToSessionStorage = function (key, value) {
+    window.sessionStorage.setItem(key, value)
+  }
 
-      function setActiveStepClass () {
-        $element.find('.' + activeStepClass).removeClass(activeStepClass).removeAttr('data-show')
-        $element.find('.' + activeLinkClass).closest('.gem-c-step-nav__step').addClass(activeStepClass).attr('data-show', '')
-      }
+  Gemstepnav.prototype.loadFromSessionStorage = function (key, value) {
+    return window.sessionStorage.getItem(key)
+  }
 
-      function bindToggleShowHideAllButton (stepNavTracker) {
-        $showOrHideAllButton = $element.find('.js-step-controls-button')
-        $showOrHideAllButton.on('click', function () {
-          var shouldshowAll
+  Gemstepnav.prototype.removeFromSessionStorage = function (key) {
+    window.sessionStorage.removeItem(key)
+  }
 
-          if ($showOrHideAllButton.text() === actions.showAllText) {
-            $showOrHideAllButton.text(actions.hideAllText)
-            $element.find('.js-toggle-link').html(actions.hideText)
-            shouldshowAll = true
+  Gemstepnav.prototype.setOnlyThisLinkActive = function (clicked) {
+    var allActiveLinks = this.$module.querySelectorAll('.' + this.$module.activeLinkClass)
+    for (var i = 0; i < allActiveLinks.length; i++) {
+      allActiveLinks[i].classList.remove(this.$module.activeLinkClass)
+    }
+    clicked.parentNode.classList.add(this.$module.activeLinkClass)
+  }
 
-            stepNavTracker.track('pageElementInteraction', 'stepNavAllShown', {
-              label: actions.showAllText + ': ' + stepNavSize
-            })
-          } else {
-            $showOrHideAllButton.text(actions.showAllText)
-            $element.find('.js-toggle-link').html(actions.showText)
-            shouldshowAll = false
+  // if a link occurs more than once in a step nav, the backend doesn't know which one to highlight
+  // so it gives all those links the 'active' attribute and highlights the last step containing that link
+  // if the user clicked on one of those links previously, it will be in the session store
+  // this code ensures only that link and its corresponding step have the highlighting
+  // otherwise it accepts what the backend has already passed to the component
+  Gemstepnav.prototype.ensureOnlyOneActiveLink = function () {
+    var activeLinks = this.$module.querySelectorAll('.js-list-item.' + this.$module.activeLinkClass)
 
-            stepNavTracker.track('pageElementInteraction', 'stepNavAllHidden', {
-              label: actions.hideAllText + ': ' + stepNavSize
-            })
-          }
-
-          setAllStepsShownState(shouldshowAll)
-          $showOrHideAllButton.attr('aria-expanded', shouldshowAll)
-          setShowHideAllText()
-
-          return false
-        })
-      }
-
-      function setShowHideAllText () {
-        var shownSteps = $element.find('.step-is-shown').length
-        // Find out if the number of is-opens == total number of steps
-        if (shownSteps === totalSteps) {
-          $showOrHideAllButton.text(actions.hideAllText)
-        } else {
-          $showOrHideAllButton.text(actions.showAllText)
-        }
-      }
+    if (activeLinks.length <= 1) {
+      return
     }
 
-    function StepView ($stepElement) {
-      var $titleLink = $stepElement.find('.js-step-title-button')
-      var $stepContent = $stepElement.find('.js-panel')
+    var loaded = this.loadFromSessionStorage(this.$module.sessionStoreLink)
+    var activeParent = this.$module.querySelectorAll('.' + this.$module.activeLinkClass)[0]
+    var activeChild = activeParent.firstChild
+    var foundLink = activeChild.getAttribute('data-position')
+    var lastClicked = loaded || foundLink // the value saved has priority
 
-      this.title = $stepElement.find('.js-step-title-text').text().trim()
-      this.element = $stepElement
+    // it's possible for the saved link position value to not match any of the currently duplicate highlighted links
+    // so check this otherwise it'll take the highlighting off all of them
+    var checkLink = this.$module.querySelectorAll('[data-position="' + lastClicked + '"]')[0]
 
-      this.show = show
-      this.hide = hide
-      this.toggle = toggle
-      this.setIsShown = setIsShown
-      this.isShown = isShown
-      this.isHidden = isHidden
-      this.numberOfContentItems = numberOfContentItems
-
-      function show () {
-        setIsShown(true)
+    if (checkLink) {
+      if (!checkLink.parentNode.classList.contains(this.$module.activeLinkClass)) {
+        lastClicked = checkLink
       }
-
-      function hide () {
-        setIsShown(false)
-      }
-
-      function toggle () {
-        setIsShown(isHidden())
-      }
-
-      function setIsShown (isShown) {
-        $stepElement.toggleClass('step-is-shown', isShown)
-        $stepContent.toggleClass('js-hidden', !isShown)
-        $titleLink.attr('aria-expanded', isShown)
-        $stepElement.find('.js-toggle-link').html(isShown ? actions.hideText : actions.showText)
-      }
-
-      function isShown () {
-        return $stepElement.hasClass('step-is-shown')
-      }
-
-      function isHidden () {
-        return !isShown()
-      }
-
-      function numberOfContentItems () {
-        return $stepContent.find('.js-link').length
-      }
+    } else {
+      lastClicked = foundLink
     }
 
-    function StepToggleClick (event, stepView, $steps, stepNavTracker, stepIsOptional) {
-      this.track = trackClick
-      var $target = $(event.target)
+    this.removeActiveStateFromAllButCurrent(activeLinks, lastClicked)
+    this.setActiveStepClass()
+  }
 
-      function trackClick () {
-        var trackingOptions = { label: trackingLabel(), dimension28: stepView.numberOfContentItems().toString() }
-        stepNavTracker.track('pageElementInteraction', trackingAction(), trackingOptions)
-      }
-
-      function trackingLabel () {
-        return $target.closest('.js-toggle-panel').attr('data-position') + ' - ' + stepView.title + ' - ' + locateClickElement() + ': ' + stepNavSize + isOptional()
-      }
-
-      // returns index of the clicked step in the overall number of steps
-      function stepIndex () { // eslint-disable-line no-unused-vars
-        return $steps.index(stepView.element) + 1
-      }
-
-      function trackingAction () {
-        return (stepView.isHidden() ? 'stepNavHidden' : 'stepNavShown')
-      }
-
-      function locateClickElement () {
-        if (clickedOnIcon()) {
-          return iconType() + ' click'
-        } else if (clickedOnHeading()) {
-          return 'Heading click'
-        } else {
-          return 'Elsewhere click'
-        }
-      }
-
-      function clickedOnIcon () {
-        return $target.hasClass('js-toggle-link')
-      }
-
-      function clickedOnHeading () {
-        return $target.hasClass('js-step-title-text')
-      }
-
-      function iconType () {
-        return (stepView.isHidden() ? 'Minus' : 'Plus')
-      }
-
-      function isOptional () {
-        return (stepIsOptional ? ' ; optional' : '')
-      }
-    }
-
-    function componentLinkClick (event, stepNavTracker, linkPosition) {
-      this.track = trackClick
-
-      function trackClick () {
-        var trackingOptions = { label: $(event.target).attr('href') + ' : ' + stepNavSize }
-        var dimension28 = $(event.target).closest('.gem-c-step-nav__list').attr('data-length')
-
-        if (dimension28) {
-          trackingOptions.dimension28 = dimension28
-        }
-
-        stepNavTracker.track('stepNavLinkClicked', linkPosition, trackingOptions)
-      }
-    }
-
-    // A helper that sends a custom event request to Google Analytics if
-    // the GOVUK module is setup
-    function StepNavTracker (totalSteps, totalLinks, uniqueId) {
-      this.track = function (category, action, options) {
-        // dimension26 records the total number of expand/collapse steps in this step nav
-        // dimension27 records the total number of links in this step nav
-        // dimension28 records the number of links in the step that was shown/hidden (handled in click event)
-        if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
-          options = options || {}
-          options.dimension26 = options.dimension26 || totalSteps.toString()
-          options.dimension27 = options.dimension27 || totalLinks.toString()
-          options.dimension96 = options.dimension96 || uniqueId
-          window.GOVUK.analytics.trackEvent(category, action, options)
+  Gemstepnav.prototype.removeActiveStateFromAllButCurrent = function (activeLinks, current) {
+    for (var i = 0; i < activeLinks.length; i++) {
+      var thisel = activeLinks[i]
+      if (thisel.querySelectorAll('.js-link')[0].getAttribute('data-position').toString() !== current.toString()) {
+        thisel.classList.remove(this.$module.activeLinkClass)
+        var visuallyHidden = thisel.querySelectorAll('.visuallyhidden')
+        if (visuallyHidden.length) {
+          visuallyHidden[0].parentNode.removeChild(visuallyHidden[0])
         }
       }
     }
   }
+
+  Gemstepnav.prototype.setActiveStepClass = function () {
+    // remove the 'active/open' state from all steps
+    var allActiveSteps = this.$module.querySelectorAll('.' + this.$module.activeStepClass)
+    for (var i = 0; i < allActiveSteps.length; i++) {
+      allActiveSteps[i].classList.remove(this.$module.activeStepClass)
+      allActiveSteps[i].removeAttribute('data-show')
+    }
+
+    // find the current page link and apply 'active/open' state to parent step
+    var activeLink = this.$module.querySelectorAll('.' + this.$module.activeLinkClass)[0]
+    if (activeLink) {
+      var activeStep = activeLink.closest('.gem-c-step-nav__step')
+      activeStep.classList.add(this.$module.activeStepClass)
+      activeStep.setAttribute('data-show', '')
+    }
+  }
+
+  Gemstepnav.prototype.bindToggleShowHideAllButton = function (stepNavTracker) {
+    var that = this
+
+    this.$module.showOrHideAllButton.addEventListener('click', function (event) {
+      var shouldshowAll
+      var showHideTexts = that.$module.querySelectorAll('.js-toggle-link')
+      var textContent = this.textContent || this.innerText
+
+      if (textContent === that.$module.actions.showAllText) {
+        that.$module.showOrHideAllButton.textContent = that.$module.actions.hideAllText
+        for (var i = 0; i < showHideTexts.length; i++) {
+          showHideTexts[i].innerHTML = that.$module.actions.hideText
+        }
+        shouldshowAll = true
+
+        stepNavTracker.trackClick('pageElementInteraction', 'stepNavAllShown', {
+          label: that.$module.actions.showAllText + ': ' + that.$module.stepNavSize
+        })
+      } else {
+        that.$module.showOrHideAllButton.textContent = that.$module.actions.showAllText
+        for (var j = 0; j < showHideTexts.length; j++) {
+          showHideTexts[j].innerHTML = that.$module.actions.showText
+        }
+        shouldshowAll = false
+
+        stepNavTracker.trackClick('pageElementInteraction', 'stepNavAllHidden', {
+          label: that.$module.actions.hideAllText + ': ' + that.$module.stepNavSize
+        })
+      }
+
+      that.setAllStepsShownState(shouldshowAll)
+      that.$module.showOrHideAllButton.setAttribute('aria-expanded', shouldshowAll)
+      that.setShowHideAllText()
+
+      return false
+    })
+  }
+
+  Gemstepnav.prototype.setShowHideAllText = function () {
+    var shownSteps = this.$module.querySelectorAll('.step-is-shown').length
+    // Find out if the number of is-opens == total number of steps
+    if (shownSteps === this.$module.totalSteps) {
+      this.$module.showOrHideAllButton.textContent = this.$module.actions.hideAllText
+    } else {
+      this.$module.showOrHideAllButton.textContent = this.$module.actions.showAllText
+    }
+  }
+
+  Gemstepnav.prototype.StepView = function (stepElement, showText, hideText) {
+    this.stepElement = stepElement
+    this.stepContent = this.stepElement.querySelectorAll('.js-panel')[0]
+    this.titleButton = this.stepElement.querySelectorAll('.js-step-title-button')[0]
+    var textElement = this.stepElement.querySelectorAll('.js-step-title-text')[0]
+    this.title = textElement.textContent || textElement.innerText
+    this.title = this.title.replace(/^\s+|\s+$/g, '') // this is 'trim' but supporting IE8
+    this.showText = showText
+    this.hideText = hideText
+
+    this.show = function () {
+      this.setIsShown(true)
+    }
+
+    this.hide = function () {
+      this.setIsShown(false)
+    }
+
+    this.toggle = function () {
+      this.setIsShown(this.isHidden())
+    }
+
+    this.setIsShown = function (isShown) {
+      if (isShown) {
+        this.stepElement.classList.add('step-is-shown')
+        this.stepContent.classList.remove('js-hidden')
+      } else {
+        this.stepElement.classList.remove('step-is-shown')
+        this.stepContent.classList.add('js-hidden')
+      }
+
+      this.titleButton.setAttribute('aria-expanded', isShown)
+      var showHideText = this.stepElement.querySelectorAll('.js-toggle-link')[0]
+      showHideText.innerHTML = isShown ? this.hideText : this.showText
+    }
+
+    this.isShown = function () {
+      return this.stepElement.classList.contains('step-is-shown')
+    }
+
+    this.isHidden = function () {
+      return !this.isShown()
+    }
+
+    this.numberOfContentItems = function () {
+      return this.stepContent.querySelectorAll('.js-link').length
+    }
+  }
+
+  Gemstepnav.prototype.StepToggleClick = function (event, stepView, stepNavTracker, stepIsOptional, stepNavSize) {
+    this.target = event.target
+    this.stepIsOptional = stepIsOptional
+    this.stepNavSize = stepNavSize
+
+    this.trackClick = function () {
+      var trackingOptions = { label: this.trackingLabel(), dimension28: stepView.numberOfContentItems().toString() }
+      stepNavTracker.trackClick('pageElementInteraction', this.trackingAction(), trackingOptions)
+    }
+
+    this.trackingLabel = function () {
+      var clickedNearbyToggle = this.target.closest('.js-step').querySelectorAll('.js-toggle-panel')[0]
+      return clickedNearbyToggle.getAttribute('data-position') + ' - ' + stepView.title + ' - ' + this.locateClickElement() + ': ' + this.stepNavSize + this.isOptional()
+    }
+
+    // returns index of the clicked step in the overall number of steps
+    this.stepIndex = function () { // eslint-disable-line no-unused-vars
+      return this.$module.steps.index(stepView.element) + 1
+    }
+
+    this.trackingAction = function () {
+      return (stepView.isHidden() ? 'stepNavHidden' : 'stepNavShown')
+    }
+
+    this.locateClickElement = function () {
+      if (this.clickedOnIcon()) {
+        return this.iconType() + ' click'
+      } else if (this.clickedOnHeading()) {
+        return 'Heading click'
+      } else {
+        return 'Elsewhere click'
+      }
+    }
+
+    this.clickedOnIcon = function () {
+      return this.target.classList.contains('js-toggle-link')
+    }
+
+    this.clickedOnHeading = function () {
+      return this.target.classList.contains('js-step-title-text')
+    }
+
+    this.iconType = function () {
+      return (stepView.isHidden() ? 'Minus' : 'Plus')
+    }
+
+    this.isOptional = function () {
+      return (this.stepIsOptional ? ' ; optional' : '')
+    }
+  }
+
+  Gemstepnav.prototype.ComponentLinkClick = function (event, stepNavTracker, linkPosition, size) {
+    this.size = size
+    this.target = event.target
+
+    this.trackClick = function () {
+      var trackingOptions = { label: this.target.getAttribute('href') + ' : ' + this.size }
+      var dimension28 = this.target.closest('.gem-c-step-nav__list').getAttribute('data-length')
+
+      if (dimension28) {
+        trackingOptions.dimension28 = dimension28
+      }
+
+      stepNavTracker.trackClick('stepNavLinkClicked', linkPosition, trackingOptions)
+    }
+  }
+
+  // A helper that sends a custom event request to Google Analytics if
+  // the GOVUK module is setup
+  Gemstepnav.prototype.StepNavTracker = function (uniqueId, totalSteps, totalLinks) {
+    this.totalSteps = totalSteps
+    this.totalLinks = totalLinks
+    this.uniqueId = uniqueId
+
+    this.trackClick = function (category, action, options) {
+      // dimension26 records the total number of expand/collapse steps in this step nav
+      // dimension27 records the total number of links in this step nav
+      // dimension28 records the number of links in the step that was shown/hidden (handled in click event)
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        options = options || {}
+        options.dimension26 = options.dimension26 || this.totalSteps.toString()
+        options.dimension27 = options.dimension27 || this.totalLinks.toString()
+        options.dimension96 = options.dimension96 || this.uniqueId
+        window.GOVUK.analytics.trackEvent(category, action, options)
+      }
+    }
+  }
+
+  Modules.Gemstepnav = Gemstepnav
 })(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/lib.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib.js
@@ -1,1 +1,2 @@
+// = require_tree ./vendor/polyfills/
 // = require_tree ./lib

--- a/app/assets/javascripts/govuk_publishing_components/vendor/polyfills/closest.js
+++ b/app/assets/javascripts/govuk_publishing_components/vendor/polyfills/closest.js
@@ -1,0 +1,23 @@
+// https://plainjs.com/javascript/traversing/get-closest-element-by-selector-39/
+// matches polyfill
+this.Element && function(ElementPrototype) {
+  ElementPrototype.matches = ElementPrototype.matches ||
+  ElementPrototype.matchesSelector ||
+  ElementPrototype.webkitMatchesSelector ||
+  ElementPrototype.msMatchesSelector ||
+  function(selector) {
+    var node = this, nodes = (node.parentNode || node.document).querySelectorAll(selector), i = -1;
+    while (nodes[++i] && nodes[i] != node);
+    return !!nodes[i];
+  }
+}(Element.prototype);
+
+// closest polyfill
+this.Element && function(ElementPrototype) {
+  ElementPrototype.closest = ElementPrototype.closest ||
+  function(selector) {
+    var el = this;
+    while (el.matches && !el.matches(selector)) el = el.parentNode;
+    return el.matches ? el : null;
+  }
+}(Element.prototype);

--- a/app/assets/javascripts/govuk_publishing_components/vendor/polyfills/indexOf.js
+++ b/app/assets/javascripts/govuk_publishing_components/vendor/polyfills/indexOf.js
@@ -1,0 +1,9 @@
+// https://gist.github.com/heathcliff/7161329
+if (!Array.prototype.indexOf) {
+  Array.prototype.indexOf = function(obj, start) {
+    for (var i = (start || 0), j = this.length; i < j; i++) {
+      if (this[i] === obj) { return i }
+    }
+    return -1
+  }
+}

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -5,7 +5,6 @@ describe('A stepnav module', function () {
   'use strict'
 
   var $element
-  var stepnav
   var html =
     '<div data-module="gemstepnav" class="gem-c-step-nav js-hidden" data-id="unique-id" data-show-text="Show" data-hide-text="Hide" data-show-all-text="Show all" data-hide-all-text="Hide all">' +
       '<ol class="gem-c-step-nav__steps">' +
@@ -25,7 +24,7 @@ describe('A stepnav module', function () {
           '<div class="gem-c-step-nav__panel js-panel" id="step-panel-topic-step-one-1">' +
             '<ol class="gem-c-step-nav__list" data-length="1">' +
               '<li class="gem-c-step-nav__list-item js-list-item">' +
-                '<a href="/link1" class="gem-c-step-nav__link js-link" data-position="1.1">Link 1</a>' +
+                '<a href="#link1" class="gem-c-step-nav__link js-link" data-position="1.1">Link 1</a>' +
               '</li>' +
             '</ol>' +
           '</div>' +
@@ -46,10 +45,10 @@ describe('A stepnav module', function () {
           '<div class="gem-c-step-nav__panel js-panel" id="step-panel-topic-step-two-1">' +
             '<ol class="gem-c-step-nav__list" data-length="2">' +
               '<li class="gem-c-step-nav__list-item js-will-be-an-active-link js-list-item">' +
-                '<a href="/link2" class="gem-c-step-nav__link js-link" data-position="2.1"><span class="visuallyhidden">You are currently viewing: </span>Link 2</a>' +
+                '<a href="#link2" class="gem-c-step-nav__link js-link" data-position="2.1"><span class="visuallyhidden">You are currently viewing: </span>Link 2</a>' +
               '</li>' +
               '<li class="gem-c-step-nav__list-item js-list-item">' +
-                '<a href="/link3" class="gem-c-step-nav__link js-link" data-position="2.2">Link 3</a>' +
+                '<a href="#link3" class="gem-c-step-nav__link js-link" data-position="2.2">Link 3</a>' +
               '</li>' +
               '<li class="gem-c-step-nav__list-item js-will-be-an-active-link js-list-item">' +
                 '<a href="#content" class="gem-c-step-nav__link js-link" data-position="2.3"><span class="visuallyhidden">You are currently viewing: </span>Link 4</a>' +
@@ -73,13 +72,13 @@ describe('A stepnav module', function () {
           '<div class="gem-c-step-nav__panel js-panel" id="step-panel-topic-step-three-1">' +
             '<ol class="gem-c-step-nav__list" data-length="5">' +
               '<li class="gem-c-step-nav__list-item js-will-be-an-active-link js-list-item">' +
-                '<a href="/link4" class="gem-c-step-nav__link js-link" data-position="3.1"><span class="visuallyhidden">You are currently viewing: </span>Link 5</a>' +
+                '<a href="#link4" class="gem-c-step-nav__link js-link" data-position="3.1"><span class="visuallyhidden">You are currently viewing: </span>Link 5</a>' +
               '</li>' +
               '<li class="gem-c-step-nav__list-item js-will-be-an-active-link js-list-item">' +
-                '<a href="/link5" class="gem-c-step-nav__link js-link" data-position="3.2"><span class="visuallyhidden">You are currently viewing: </span>Link 6</a>' +
+                '<a href="#link5" class="gem-c-step-nav__link js-link" data-position="3.2"><span class="visuallyhidden">You are currently viewing: </span>Link 6</a>' +
               '</li>' +
               '<li class="gem-c-step-nav__list-item js-list-item">' +
-                '<a href="http://www.gov.uk" class="gem-c-step-nav__link js-link" data-position="3.3" rel="external">Link 7</a>' +
+                '<a href="#www.gov.uk" class="gem-c-step-nav__link js-link" data-position="3.3" rel="external">Link 7</a>' +
               '</li>' +
               '<li class="gem-c-step-nav__list-item js-will-be-an-active-link js-list-item">' +
                 '<a href="#content" class="gem-c-step-nav__link js-link" data-position="3.4"><span class="visuallyhidden">You are currently viewing: </span>Link 8</a>' +
@@ -98,9 +97,8 @@ describe('A stepnav module', function () {
   var expectedstepnavLinkCount = 0
 
   beforeEach(function () {
-    stepnav = new GOVUK.Modules.Gemstepnav()
     $element = $(html)
-    stepnav.start($element)
+    new GOVUK.Modules.Gemstepnav().start($element)
     expectedstepnavStepCount = $element.find('.gem-c-step-nav__step').length
     expectedstepnavContentCount = $element.find('.gem-c-step-nav__step').first().find('.js-link').length
     expectedstepnavLinkCount = $element.find('.gem-c-step-nav__list-item').length
@@ -233,15 +231,15 @@ describe('A stepnav module', function () {
   describe('Opening a step', function () {
     // When a step is open (testing: toggleStep, openStep)
     it('has a class of step-is-shown', function () {
-      var $stepLink = $element.find('.gem-c-step-nav__header .gem-c-step-nav__button--title')
-      var $step = $element.find('.gem-c-step-nav__step')
+      var $stepLink = $element.find('.gem-c-step-nav__header .gem-c-step-nav__button--title').first()
+      var $step = $element.find('.gem-c-step-nav__step').first()
       $stepLink.click()
       expect($step).toHaveClass('step-is-shown')
     })
 
     // When a step is open (testing: toggleState, setExpandedState)
     it('has a an aria-expanded attribute and the value is true', function () {
-      var $stepLink = $element.find('.gem-c-step-nav__header .gem-c-step-nav__button--title')
+      var $stepLink = $element.find('.gem-c-step-nav__header .gem-c-step-nav__button--title').first()
       $stepLink.click()
       expect($stepLink).toHaveAttr('aria-expanded', 'true')
     })
@@ -253,7 +251,7 @@ describe('A stepnav module', function () {
       }
       spyOn(GOVUK.analytics, 'trackEvent')
 
-      var $stepLink = $element.find('.gem-c-step-nav__header .js-step-title-text')
+      var $stepLink = $element.find('.gem-c-step-nav__header .js-step-title-text').first()
       $stepLink.click()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavShown', {
@@ -387,11 +385,10 @@ describe('A stepnav module', function () {
 
   describe('when the option to remember which steps are open is on', function () {
     beforeEach(function () {
-      stepnav = new GOVUK.Modules.Gemstepnav()
       $element = $(html)
       $element.attr('data-remember', true)
       $element.addClass('gem-c-step-nav--large')
-      stepnav.start($element)
+      new GOVUK.Modules.Gemstepnav().start($element)
     })
 
     afterEach(function () {
@@ -448,12 +445,11 @@ describe('A stepnav module', function () {
         store = {}
       })
 
-      stepnav = new GOVUK.Modules.Gemstepnav()
       $element = $(html)
       $element.attr('data-remember', true)
       $element.addClass('gem-c-step-nav--large')
       window.sessionStorage.setItem('unique-id', '["topic-step-one","topic-step-three"]')
-      stepnav.start($element)
+      new GOVUK.Modules.Gemstepnav().start($element)
     })
 
     afterEach(function () {
@@ -501,12 +497,11 @@ describe('A stepnav module', function () {
         store = {}
       })
 
-      stepnav = new GOVUK.Modules.Gemstepnav()
       $element = $(html)
       $element.attr('data-remember', true)
       $element.addClass('gem-c-step-nav--large')
       window.sessionStorage.setItem('unique-id', '["topic-step-one","topic-step-two","topic-step-three"]')
-      stepnav.start($element)
+      new GOVUK.Modules.Gemstepnav().start($element)
     })
 
     afterEach(function () {
@@ -534,11 +529,10 @@ describe('A stepnav module', function () {
         store = {}
       })
 
-      stepnav = new GOVUK.Modules.Gemstepnav()
       $element = $(html)
       $element.attr('data-remember', true)
       window.sessionStorage.setItem('unique-id', '["topic-step-one","topic-step-two","topic-step-three"]')
-      stepnav.start($element)
+      new GOVUK.Modules.Gemstepnav().start($element)
     })
 
     afterEach(function () {
@@ -561,10 +555,9 @@ describe('A stepnav module', function () {
 
   describe('when a step is supposed to be shown by default', function () {
     beforeEach(function () {
-      stepnav = new GOVUK.Modules.Gemstepnav()
       $element = $(html)
       $element.find('#topic-step-two').attr('data-show', '')
-      stepnav.start($element)
+      new GOVUK.Modules.Gemstepnav().start($element)
     })
 
     it('shows the step it\'s supposed to', function () {
@@ -583,19 +576,18 @@ describe('A stepnav module', function () {
 
   describe('When tracking a big step nav', function () {
     beforeEach(function () {
-      stepnav = new GOVUK.Modules.Gemstepnav()
       $element = $(html)
       $element.addClass('gem-c-step-nav--large')
-      stepnav.start($element)
-    })
+      new GOVUK.Modules.Gemstepnav().start($element)
 
-    it('triggers a google analytics custom event when clicking on the title on a big stepnav', function () {
       GOVUK.analytics = {
         trackEvent: function () {
         }
       }
       spyOn(GOVUK.analytics, 'trackEvent')
+    })
 
+    it('triggers a google analytics custom event when clicking on the title on a big stepnav', function () {
       var $stepLink = $element.find('.gem-c-step-nav__header .js-step-title-text')
       $stepLink.click()
 
@@ -609,12 +601,6 @@ describe('A stepnav module', function () {
     })
 
     it('triggers a google analytics custom event when clicking on the icon on a big stepnav', function () {
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      }
-      spyOn(GOVUK.analytics, 'trackEvent')
-
       var $stepIcon = $element.find('.js-toggle-link')
       $stepIcon.click()
 
@@ -628,12 +614,6 @@ describe('A stepnav module', function () {
     })
 
     it('triggers a google analytics custom event when clicking in space in the header on a big stepnav', function () {
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      }
-      spyOn(GOVUK.analytics, 'trackEvent')
-
       var $stepHeader = $element.find('.gem-c-step-nav__header').first()
       $stepHeader.click()
 
@@ -647,12 +627,6 @@ describe('A stepnav module', function () {
     })
 
     it('triggers a google analytics custom event when hiding by clicking on the title on a big stepnav', function () {
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      }
-      spyOn(GOVUK.analytics, 'trackEvent')
-
       var $stepLink = $element.find('.gem-c-step-nav__header .js-step-title-text')
       $stepLink.click()
       $stepLink.click()
@@ -667,12 +641,6 @@ describe('A stepnav module', function () {
     })
 
     it('triggers a google analytics custom event when hiding by clicking on the icon on a big stepnav', function () {
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      }
-      spyOn(GOVUK.analytics, 'trackEvent')
-
       var $stepIcon = $element.find('.js-toggle-link')
       $stepIcon.click()
       $stepIcon.click()
@@ -687,12 +655,6 @@ describe('A stepnav module', function () {
     })
 
     it('triggers a google analytics custom event when hiding by clicking in space in the header on a big stepnav', function () {
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      }
-      spyOn(GOVUK.analytics, 'trackEvent')
-
       var $stepHeader = $element.find('.gem-c-step-nav__header')
       $stepHeader.click()
       $stepHeader.click()
@@ -707,11 +669,6 @@ describe('A stepnav module', function () {
     })
 
     it('triggers a google analytics custom event when clicking the "Show all" button on a big stepnav', function () {
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      }
-      spyOn(GOVUK.analytics, 'trackEvent')
       clickShowHideAll()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllShown', {
@@ -723,11 +680,6 @@ describe('A stepnav module', function () {
     })
 
     it('triggers a google analytics custom event when clicking the "Hide all" button on a big stepnav', function () {
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      }
-      spyOn(GOVUK.analytics, 'trackEvent')
       clickShowHideAll()
       clickShowHideAll()
 
@@ -740,15 +692,10 @@ describe('A stepnav module', function () {
     })
 
     it('triggers a google analytics custom event when clicking a panel link on a big stepnav', function () {
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      }
-      spyOn(GOVUK.analytics, 'trackEvent')
-      $element.find('.js-link').first().click()
+      $element.find('.js-link').first()[0].click()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('stepNavLinkClicked', '1.1', {
-        label: '/link1 : Big',
+        label: '#link1 : Big',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
         dimension28: expectedstepnavContentCount.toString(),
@@ -764,11 +711,11 @@ describe('A stepnav module', function () {
     }
     spyOn(GOVUK.analytics, 'trackEvent')
 
-    var $panelLink = $element.find('.js-link').first()
-    $panelLink.click()
+    var $panelLink = $element.find('.js-link')
+    $panelLink[0].click()
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('stepNavLinkClicked', '1.1', {
-      label: '/link1 : Small',
+      label: '#link1 : Small',
       dimension26: expectedstepnavStepCount.toString(),
       dimension27: expectedstepnavLinkCount.toString(),
       dimension28: expectedstepnavContentCount.toString(),
@@ -797,10 +744,9 @@ describe('A stepnav module', function () {
 
   describe('in a double dot situation', function () {
     beforeEach(function () {
-      stepnav = new GOVUK.Modules.Gemstepnav()
       $element = $(html)
       $element.find('.js-will-be-an-active-link').addClass('gem-c-step-nav__list-item--active')
-      stepnav.start($element)
+      new GOVUK.Modules.Gemstepnav().start($element)
     })
 
     afterEach(function () {
@@ -809,12 +755,12 @@ describe('A stepnav module', function () {
     })
 
     it('puts a clicked link in session storage', function () {
-      $element.find('.js-link[data-position="3.1"]').click()
+      $element.find('.js-link[data-position="3.1"]')[0].click()
       expect(window.sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe('3.1')
     })
 
     it('does not put an external clicked link in session storage', function () {
-      $element.find('.js-link[data-position="3.3"]').click()
+      $element.find('.js-link[data-position="3.3"]')[0].click()
       expect(window.sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe(null)
     })
 
@@ -836,7 +782,7 @@ describe('A stepnav module', function () {
     it('highlights a clicked #content link and its parent step, and removes other highlighting', function () {
       expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1)
 
-      var $firstLink = $element.find('.js-link[data-position="3.4"]')
+      var $firstLink = $element.find('.js-link[data-position="3.4"]')[0]
       $firstLink.click()
       expect(window.sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe('3.4')
       expect($firstLink.closest('.js-list-item')).toHaveClass('gem-c-step-nav__list-item--active')
@@ -844,7 +790,7 @@ describe('A stepnav module', function () {
       expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1)
       expect($element.find(('.gem-c-step-nav__step--active')).length).toBe(1)
 
-      var $secondLink = $element.find('.js-link[data-position="3.5"]')
+      var $secondLink = $element.find('.js-link[data-position="3.5"]')[0]
       $secondLink.click()
       expect(window.sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe('3.5')
       expect($secondLink.closest('.js-list-item')).toHaveClass('gem-c-step-nav__list-item--active')
@@ -869,11 +815,10 @@ describe('A stepnav module', function () {
         store = {}
       })
 
-      stepnav = new GOVUK.Modules.Gemstepnav()
       $element = $(html)
       $element.find('.js-will-be-an-active-link').addClass('gem-c-step-nav__list-item--active')
       window.sessionStorage.setItem('govuk-step-nav-active-link_unique-id', '3.5')
-      stepnav.start($element)
+      new GOVUK.Modules.Gemstepnav().start($element)
     })
 
     afterEach(function () {
@@ -888,6 +833,9 @@ describe('A stepnav module', function () {
     })
   })
 
+  // it's possible that the stored value for active link is invalid - perhaps because the step nav id matches
+  // another one that already stored a value. In this situation we want to make sure the code behaves sensibly
+  // i.e. it doesn't fail to find the stored link and remove the active styling from everything
   describe('in a double dot situation where a clicked link that is not highlighted is already stored on page load', function () {
     beforeEach(function () {
       var store = {}
@@ -903,11 +851,10 @@ describe('A stepnav module', function () {
         store = {}
       })
 
-      stepnav = new GOVUK.Modules.Gemstepnav()
       $element = $(html)
       $element.find('.js-will-be-an-active-link').addClass('gem-c-step-nav__list-item--active')
       window.sessionStorage.setItem('govuk-step-nav-active-link_unique-id', 'definitelynotvalid')
-      stepnav.start($element)
+      new GOVUK.Modules.Gemstepnav().start($element)
     })
 
     afterEach(function () {
@@ -916,8 +863,8 @@ describe('A stepnav module', function () {
     })
 
     it('highlights only one link', function () {
-      expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1)
-      expect($element.find(('.gem-c-step-nav__step--active')).length).toBe(1)
+      expect($element.find('.gem-c-step-nav__list-item--active').length).toBe(1)
+      expect($element.find('.gem-c-step-nav__step--active').length).toBe(1)
     })
   })
 
@@ -926,8 +873,7 @@ describe('A stepnav module', function () {
       $element = $(html)
       $element.find('.js-will-be-an-active-link').addClass('gem-c-step-nav__list-item--active')
       $element.find('.gem-c-step-nav__step').removeClass('gem-c-step-nav__step--active')
-      stepnav = new GOVUK.Modules.Gemstepnav()
-      stepnav.start($element)
+      new GOVUK.Modules.Gemstepnav().start($element)
     })
 
     afterEach(function () {
@@ -943,10 +889,10 @@ describe('A stepnav module', function () {
 
   describe('if no unique id is set', function () {
     beforeEach(function () {
-      stepnav = new GOVUK.Modules.Gemstepnav()
       $element = $(html)
       $element.removeAttr('data-id')
-      stepnav.start($element)
+      new GOVUK.Modules.Gemstepnav().start($element)
+
       GOVUK.analytics = {
         trackEvent: function () {
         }
@@ -1065,10 +1011,10 @@ describe('A stepnav module', function () {
     })
 
     it('triggers a google analytics custom event when clicking on a panel link', function () {
-      $element.find('.js-link').first().click()
+      $element.find('.js-link').first()[0].click()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('stepNavLinkClicked', '1.1', {
-        label: '/link1 : Small',
+        label: '#link1 : Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
         dimension28: expectedstepnavContentCount.toString(),


### PR DESCRIPTION
## What
- remove jquery from the step by step navigation component
- not removing jquery from the test as jasmine has its own jquery, but this has required some changes to make the tests run properly

## Why
We want to remove our dependency on jquery.

## Visual Changes
None.

## IE support

I've made a few changes to the code to try to support older versions of IE. The big change is adding polyfills for `indexOf` and `closest`, without which the component breaks. I've also put in non-polyfill workarounds to avoid using `textContent`, `forEach` and `prepend`, which means the code isn't perhaps as elegant as it could be, but I think this is reasonable.

We don't support IE8 but people still use it. Ideally we'd rewrite the component JS to fail gracefully on older browsers so that the component is left in a usable state (e.g. all steps expanded by default) but that's beyond the scope of this PR.