### PR TITLE
Add priority breadcrumb to content tagged to the transition taxon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add public/frontend layout component ([PR #1265](https://github.com/alphagov/govuk_publishing_components/pull/1265))
 * Replace jQuery in checkboxes.js ([PR #1620](https://github.com/alphagov/govuk_publishing_components/pull/1620))
 * Add lang attribute to image card date/time element ([PR #1642](https://github.com/alphagov/govuk_publishing_components/pull/1642))
+* Add priority breadcrumb to content tagged to the transition taxon ([PR #1646](https://github.com/alphagov/govuk_publishing_components/pull/1646))
 
 ## 21.60.3
 

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -8,6 +8,7 @@ module GovukPublishingComponents
         education_coronavirus: "272308f4-05c8-4d0d-abc7-b7c2e3ccd249",
         worker_coronavirus: "b7f57213-4b16-446d-8ded-81955d782680",
         business_coronavirus: "65666cdf-b177-4d79-9687-b9c32805e450",
+        transition_period: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       }.freeze
 
       # Returns the highest priority taxon that has a content_id matching those in PRIORITY_TAXONS

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
     }
   end
 
+  let(:transition_period_taxon) do
+    {
+      "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+      "base_path" => "/transition",
+      "title" => "Transition",
+    }
+  end
+
   let(:other_taxon) do
     {
       "content_id" => SecureRandom.uuid,
@@ -57,6 +65,14 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
 
           it "returns the worker taxon" do
             expect(subject.taxon).to eq(worker_taxon)
+          end
+        end
+
+        context "with transition taxon" do
+          let(:payload) { [transition_period_taxon] }
+
+          it "returns the worker taxon" do
+            expect(subject.taxon).to eq(transition_period_taxon)
           end
         end
 


### PR DESCRIPTION
## What
Add the transition taxon to the list of priority taxons. This will result in a transition super breadcrumb being rendered on pages that are tagged directly (or indirectly via a parent) to the transition taxon.

<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
Metric/hypothesis suggestion - with the superbreadcrumb in place users are more likely to go to transition landing page after landing directly from google onto a piece of transition tagged content. This would be good because we will have increased engagement and awareness of transition content and the need to take action to prepare.

## Visual Changes

### Before
<img width="1087" alt="Screenshot 2020-08-17 at 14 10 33" src="https://user-images.githubusercontent.com/17908089/90400073-cfd6da00-e093-11ea-808a-c884587582ef.png">

### After 
<img width="1107" alt="Screenshot 2020-08-17 at 14 10 46" src="https://user-images.githubusercontent.com/17908089/90400124-e715c780-e093-11ea-9188-561e61f64d69.png">

Trello https://trello.com/c/OtFElqJ3/385-summon-the-superbreadcrumb-%F0%9F%A6%B8%E2%99%80%EF%B8%8F-for-pages-tagged-to-the-transition-topic