### PR TITLE
Add brand colour for FCDO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Replace jQuery in checkboxes.js ([PR #1620](https://github.com/alphagov/govuk_publishing_components/pull/1620))
 * Add lang attribute to image card date/time element ([PR #1642](https://github.com/alphagov/govuk_publishing_components/pull/1642))
 * Add priority breadcrumb to content tagged to the transition taxon ([PR #1646](https://github.com/alphagov/govuk_publishing_components/pull/1646))
+* Add new brand colour for FCDO ([PR#1648](https://github.com/alphagov/govuk_publishing_components/pull/1648))
 
 ## 21.60.3
 

--- a/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
@@ -4,3 +4,11 @@
 @import "govuk/settings/all";
 @import "govuk/tools/all";
 @import "govuk/helpers/all";
+$govuk-colours-organisations: map-merge(
+  $govuk-colours-organisations,
+  (
+    "foreign-commonwealth-development-office": (
+      colour: #012169
+    )
+  )
+);


### PR DESCRIPTION
## What
Add a new brand colour for the FCDO department. This colour is used on the organisation page in dividing lines, icons, link text colour etc. after it is selected in Whitehall.

## Why
The brand colour is used in the new organisation page. The brand colours come from [govuk-frontend](https://github.com/alphagov/govuk-frontend/), however since there may be some time before it is release again, we have
added it to the govuk_publishing_components so we can get it deployed.

[Related pull request in govuk-frontend](https://github.com/alphagov/govuk-frontend/pull/1918#pullrequestreview-469159049)
[Trello card](https://trello.com/c/s0NySL7Q/2098-add-new-brand-colour-for-fcdo)