### PR TITLE
Remove jquery from toggle code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove jquery from toggle code ([PR #1649](https://github.com/alphagov/govuk_publishing_components/pull/1649))
 * Add role="alert" to cookie banner confirmation ([PR #1658](https://github.com/alphagov/govuk_publishing_components/pull/1658))
 * Remove jquery from step by step component ([PR #1645](https://github.com/alphagov/govuk_publishing_components/pull/1645))
 

--- a/app/assets/javascripts/govuk_publishing_components/dependencies.js
+++ b/app/assets/javascripts/govuk_publishing_components/dependencies.js
@@ -9,9 +9,4 @@ $(document).ready(function () {
   'use strict'
 
   window.GOVUK.modules.start()
-
-  // Static has a Toggle module in here we have a GemToggle module, we can't
-  // easily change govspeak to use GemToggle but we can use the GemToggle module
-  var gemToggle = new window.GOVUK.Modules.GemToggle()
-  gemToggle.start($('[data-module=toggle]'))
 })

--- a/app/assets/javascripts/govuk_publishing_components/lib/toggle.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/toggle.js
@@ -1,14 +1,14 @@
 /*
   Toggle the display of elements
 
-  Use as follows:
+  Basic use:
 
   <div data-module="gem-toggle">
-    <a href="#" data-controls="target" data-expanded="true">
-      Show more
+    <a href="#" data-controls="target1" data-expanded="false">
+      Show/hide
     </a>
-    <div id="target" class="js-hidden">
-      Content to be toggled
+    <div id="target1" class="js-hidden">
+      Content hidden on page load
     </div>
   </div>
 
@@ -21,18 +21,65 @@
   the `js-hidden` class to the element you wish to hide in
   your template, the module will not do this for you.
 
-  `data-controls` can contain more than one element, space
-  separated.
-
   Use `data-toggle-class` on the parent element to set the
   class that is toggled. Defaults to `js-hidden`.
+
+  Content shown by default:
+
+  <div data-module="gem-toggle">
+    <a href="#" data-controls="target2" data-expanded="true">
+      Show/hide
+    </a>
+    <div id="target2">
+      Content shown on page load
+    </div>
+  </div>
+
+  Change text when clicked:
+
+  <div data-module="gem-toggle">
+    <a href="#" data-controls="target3" data-expanded="true" data-toggled-text="Show more">
+      Show less
+    </a>
+    <div id="target3">
+      Content shown on page load, toggle text changes depending on state
+    </div>
+  </div>
 
   Use `data-toggled-text` on the trigger element to set the
   text shown when the element is toggled. Defaults to not
   changing.
 
+  Show/hide multiple elements:
+
+  <div data-module="gem-toggle">
+    <a href="#" data-controls="target4 target5" data-expanded="false">
+      Show/hide
+    </a>
+    <div id="target4" class="js-hidden">
+      Content hidden on page load
+    </div>
+    <div id="target5" class="js-hidden">
+      Content hidden on page load
+    </div>
+  </div>
+
+  `data-controls` can contain more than one element, space
+  separated.
+
+  With tracking:
+
+  <div data-module="gem-toggle">
+    <a href="#" data-controls="target6" data-expanded="true" data-track-category="category" data-track-action="action" data-toggled-text="Show more">
+      Show less
+    </a>
+    <div id="target6">
+      Content shown on page load, tracked when expanded and collapsed
+    </div>
+  </div>
+
   Use `data-track-category` and `data-track-action` together
-  to enable analytics on the element. The label will be
+  to enable analytics on the element. The track label will be
   determined based on the text present within the element
   at the time it was clicked.
 */

--- a/spec/javascripts/components/toggle-spec.js
+++ b/spec/javascripts/components/toggle-spec.js
@@ -4,155 +4,154 @@
 describe('A toggle module', function () {
   'use strict'
 
-  var toggle
+  var element
 
   GOVUK.analytics = {
     trackEvent: function () {}
   }
 
-  beforeEach(function () {
-    toggle = new GOVUK.Modules.GemToggle()
-  })
-
   describe('when starting', function () {
-    var element = $(
-      '<div>' +
-        '<a href="#" class="my-toggle" data-expanded="false" data-controls="target">Toggle</a>' +
-        '<div id="target">Target</div>' +
-      '</div>')
+    beforeEach(function () {
+      var html =
+        '<div>' +
+          '<a href="#" class="my-toggle" data-expanded="false" data-controls="target">Toggle</a>' +
+          '<div id="target">Target</div>' +
+        '</div>'
+      element = $(html)
+      new GOVUK.Modules.GemToggle().start(element)
+    })
 
     it('adds aria attributes to toggles', function () {
-      toggle.start(element)
-
-      var $toggle = element.find('.my-toggle')
-      expect($toggle.attr('role')).toBe('button')
-      expect($toggle.attr('aria-expanded')).toBe('false')
-      expect($toggle.attr('aria-controls')).toBe('target')
+      var trigger = element.find('.my-toggle')
+      expect(trigger.attr('role')).toBe('button')
+      expect(trigger.attr('aria-expanded')).toBe('false')
+      expect(trigger.attr('aria-controls')).toBe('target')
     })
   })
 
   describe('when clicking a toggle', function () {
-    var element
-
     beforeEach(function () {
-      element = $(
-        '<div>' +
-          '<a href="#" class="my-toggle" data-expanded="false" data-controls="target" data-track-category="category" data-track-action="action" data-toggled-text="Show fewer">Toggle</a>' +
-          '<div id="target" class="js-hidden">Target</div>' +
-        '</div>')
+      spyOn(GOVUK.analytics, 'trackEvent')
 
-      toggle.start(element)
-      element.find('.my-toggle').trigger('click')
+      var html =
+        '<div>' +
+          '<a href="#" class="my-toggle" data-expanded="false" data-controls="target" data-toggled-text="Show fewer">Toggle</a>' +
+          '<div id="target" class="js-hidden">Target</div>' +
+        '</div>'
+      element = $(html)
+      new GOVUK.Modules.GemToggle().start(element)
+      element.find('.my-toggle')[0].click()
     })
 
     it('toggles the display of a target', function () {
       expect(element.find('#target').is('.js-hidden')).toBe(false)
-      element.find('.my-toggle').trigger('click')
+      element.find('.my-toggle')[0].click()
       expect(element.find('#target').is('.js-hidden')).toBe(true)
     })
 
     it('updates the aria-expanded attribute on the toggle', function () {
       expect(element.find('.my-toggle').attr('aria-expanded')).toBe('true')
 
-      element.find('.my-toggle').trigger('click')
+      element.find('.my-toggle')[0].click()
       expect(element.find('.my-toggle').attr('aria-expanded')).toBe('false')
     })
 
     it('updates the text shown in the toggle link when expanded if such text is supplied', function () {
-      expect(element.find('.my-toggle').data('toggled-text')).toBe('Toggle')
+      expect(element.find('.my-toggle').attr('data-toggled-text')).toBe('Toggle')
       expect(element.find('.my-toggle').text()).toBe('Show fewer')
-      element.find('.my-toggle').trigger('click')
-      expect(element.find('.my-toggle').data('toggled-text')).toBe('Show fewer')
+      element.find('.my-toggle')[0].click()
+      expect(element.find('.my-toggle').attr('data-toggled-text')).toBe('Show fewer')
       expect(element.find('.my-toggle').text()).toBe('Toggle')
     })
 
     it('does not track when element is not trackable', function () {
-      spyOn(GOVUK.analytics, 'trackEvent')
-
-      element = $(
-        '<div>' +
-          '<a href="#" class="my-toggle" data-expanded="false" data-controls="target" data-toggled-text="Show fewer">Toggle</a>' +
-          '<div id="target" class="js-hidden">Target</div>' +
-        '</div>')
-
-      toggle = new GOVUK.Modules.GemToggle()
-      toggle.start(element)
-      element.find('.my-toggle').trigger('click')
-
       expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
     })
+  })
 
-    it('tracks the toggle click correctly when collapsing and data-toggle-text is present', function () {
+  describe('when clicking a toggle that is tracked', function () {
+    beforeEach(function () {
       spyOn(GOVUK.analytics, 'trackEvent')
 
-      expect(element.find('#target').is('.js-hidden')).toBe(false)
-      element.find('.my-toggle').trigger('click')
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', Object({ label: 'Show fewer' }))
+      var html =
+        '<div>' +
+          '<a href="#" class="my-toggle" data-expanded="false" data-controls="target" data-track-category="category" data-track-action="action" data-toggled-text="Show fewer">Toggle</a>' +
+          '<div id="target" class="js-hidden">Target</div>' +
+        '</div>'
+      element = $(html)
+      new GOVUK.Modules.GemToggle().start(element)
+      element.find('.my-toggle')[0].click()
     })
 
-    it('tracks the toggle click correctly when expanding and data-toggle-text is present', function () {
-      spyOn(GOVUK.analytics, 'trackEvent')
-
-      element.find('.my-toggle').trigger('click')
-      expect(element.find('#target').is('.js-hidden')).toBe(true)
-      element.find('.my-toggle').trigger('click')
+    it('tracks the toggle click correctly when data-toggle-text is present', function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', Object({ label: 'Toggle' }))
     })
 
-    it('tracks the toggle click correctly when expanding and data-toggle-text is not present ', function () {
+    it('tracks the toggle click correctly when collapsing and expanding and data-toggle-text is present', function () {
+      element.find('.my-toggle')[0].click()
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', Object({ label: 'Show fewer' }))
+      element.find('.my-toggle')[0].click()
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', Object({ label: 'Toggle' }))
+    })
+  })
+
+  describe('when clicking a toggle that is tracked', function () {
+    beforeEach(function () {
       spyOn(GOVUK.analytics, 'trackEvent')
 
-      element = $(
+      var html =
         '<div>' +
           '<a href="#" class="my-toggle" data-expanded="false" data-controls="target" data-track-category="category" data-track-action="action">Original Link Text</a>' +
           '<div id="target" class="js-hidden">Target</div>' +
-        '</div>')
+        '</div>'
+      element = $(html)
+      new GOVUK.Modules.GemToggle().start(element)
+      element.find('.my-toggle')[0].click()
+    })
 
-      toggle = new GOVUK.Modules.GemToggle()
-      toggle.start(element)
-      element.find('.my-toggle').trigger('click')
+    it('tracks the toggle click correctly when expanding and data-toggle-text is not present ', function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', Object({ label: 'Original Link Text' }))
-
-      element.find('.my-toggle').trigger('click')
+      element.find('.my-toggle')[0].click()
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', Object({ label: 'Original Link Text' }))
     })
   })
 
   describe('when clicking a toggle that controls multiple targets', function () {
     it('toggles the display of each target', function () {
-      var element = $(
+      var html =
         '<div>' +
           '<a href="#" class="my-toggle" data-expanded="false" data-controls="target another-target">Toggle</a>' +
           '<div id="target" class="js-hidden">Target</div>' +
           '<div id="another-target" class="js-hidden">Another target</div>' +
-        '</div>')
+        '</div>'
+      element = $(html)
+      new GOVUK.Modules.GemToggle().start(element)
 
-      toggle.start(element)
       expect(element.find('#target').is('.js-hidden')).toBe(true)
       expect(element.find('#another-target').is('.js-hidden')).toBe(true)
 
-      element.find('.my-toggle').trigger('click')
+      element.find('.my-toggle')[0].click()
       expect(element.find('#target').is('.js-hidden')).toBe(false)
       expect(element.find('#another-target').is('.js-hidden')).toBe(false)
 
-      element.find('.my-toggle').trigger('click')
+      element.find('.my-toggle')[0].click()
       expect(element.find('#target').is('.js-hidden')).toBe(true)
       expect(element.find('#another-target').is('.js-hidden')).toBe(true)
     })
   })
 
   describe('when a custom class is given', function () {
-    var element = $(
-      '<div data-toggle-class="myclass">' +
-        '<a href="#" class="my-toggle" data-expanded="true" data-controls="target">Toggle</a>' +
-        '<div id="target">Target</div>' +
-      '</div>')
-
     it('toggles the given class', function () {
-      toggle.start(element)
+      var html =
+        '<div data-toggle-class="myclass">' +
+          '<a href="#" class="my-toggle" data-expanded="true" data-controls="target">Toggle</a>' +
+          '<div id="target">Target</div>' +
+        '</div>'
+      element = $(html)
+      new GOVUK.Modules.GemToggle().start(element)
 
       expect(element.find('#target').is('.myclass')).toBe(false)
-      element.find('.my-toggle').trigger('click')
+      element.find('.my-toggle')[0].click()
       expect(element.find('#target').is('.myclass')).toBe(true)
     })
   })


### PR DESCRIPTION
## What
Remove jquery from `toggle.js`. Also expands the documentation for the code.

## Why
We want to remove our dependency on jquery.

## Visual Changes
None.
