### PR TITLE
Add links to component guide

### DIFF
--- a/app/views/govuk_publishing_components/component_guide/example.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/example.html.erb
@@ -12,7 +12,10 @@
     <div class="component-markdown">
       <%= raw(@component_example.html_description) %>
     </div>
-    <h2 class="component-doc-h2">How it looks</h2>
+    <h2 class="component-doc-h2">
+      How it looks
+      <small>(<a href="<%= component_preview_path(@component_doc.id, @component_example.id) %>" class="govuk-link">preview</a>)</small>
+    </h2>
     <%= render partial: "govuk_publishing_components/component_guide/component_doc/preview", locals: { component_doc: @component_doc, example: @component_example } %>
 
     <h2 class="component-doc-h2">How to call this example</h2>

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -29,7 +29,9 @@
     </div>
   </div>
 
-  <h2 class="component-doc-h2">How it looks
+  <h2 class="component-doc-h2">
+    <a href="<%= component_example_path(@component_doc.id, "default") %>" class="govuk-link">How it looks</a>
+    <small>(<a href="<%= component_preview_path(@component_doc.id, "default") %>" class="govuk-link">preview</a>)</small>
     <small>(<a href="<%= component_preview_all_path(@component_doc.id) %>" class="govuk-link">preview all</a>)</small>
   </h2>
   <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, example: @component_doc.example %>


### PR DESCRIPTION

## What
- make first 'how it looks' heading link to the default example in the component guide for that component
- add 'preview' link for the first example into the same heading, before 'preview all'
- add 'preview' link to the 'how it looks' heading on the default example page

## Why
I've found the lack of this navigation occasionally frustrating for quite a while now. It's not a huge problem, and I know the URLs to type, but I think this makes navigating the component guide fractionally easier.

## Visual Changes
Before | After
------ | ------
<img width="630" alt="Screenshot 2020-08-19 at 11 02 18" src="https://user-images.githubusercontent.com/861310/90621924-50204b00-e20c-11ea-920e-c4f412ffbfb3.png"> | <img width="631" alt="Screenshot 2020-08-19 at 11 02 25" src="https://user-images.githubusercontent.com/861310/90621944-56aec280-e20c-11ea-9f89-7b97da6d3979.png">
<img width="449" alt="Screenshot 2020-08-19 at 11 03 20" src="https://user-images.githubusercontent.com/861310/90621960-5d3d3a00-e20c-11ea-946c-37414816d675.png"> | <img width="446" alt="Screenshot 2020-08-19 at 11 03 27" src="https://user-images.githubusercontent.com/861310/90621977-63cbb180-e20c-11ea-9ab7-7223e59051e8.png">


