### PR TITLE
Bump to 21.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.62.0
 
 * Add new brand colour for FCDO ([PR#1648](https://github.com/alphagov/govuk_publishing_components/pull/1648))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.61.0)
+    govuk_publishing_components (21.62.0)
       govuk_app_config
       kramdown
       plek
@@ -220,7 +220,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.4)
-    rouge (3.21.0)
+    rouge (3.22.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -276,7 +276,7 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-raven (3.0.0)
+    sentry-raven (3.0.2)
       faraday (>= 1.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.61.0".freeze
+  VERSION = "21.62.0".freeze
 end


### PR DESCRIPTION
* Add new brand colour for FCDO ([PR#1648](https://github.com/alphagov/govuk_publishing_components/pull/1648))

