### PR TITLE
Hide transition priority breadcrumb if content is part of Step by Step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add new brand colour for FCDO ([PR#1648](https://github.com/alphagov/govuk_publishing_components/pull/1648))
+* Hide priority breadcrumb from transition content tagged to a step by step ([PR #1654](https://github.com/alphagov/govuk_publishing_components/pull/1654))
 
 ## 21.61.0
 

--- a/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
+++ b/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
@@ -18,12 +18,17 @@ module GovukPublishingComponents
       end
 
       def priority_breadcrumbs
+        return if hide_priority_breadcrumb?
         return parent_item_navigation.priority_breadcrumbs if content_item_navigation.html_publication_with_parent?
 
         content_item_navigation.priority_breadcrumbs
       end
 
     private
+
+      def hide_priority_breadcrumb?
+        content_item_navigation.content_tagged_to_current_step_by_step? && content_item_navigation.tagged_to_brexit?
+      end
 
       def best_match_option
         return content_item_options unless content_item_navigation.html_publication_with_parent?

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -9,6 +9,12 @@ describe "Contextual navigation" do
     and_i_see_the_coronavirus_contextual_breadcrumbs
   end
 
+  scenario "There is a transition taxon" do
+    given_theres_a_page_with_transition_taxon
+    and_i_visit_that_page
+    and_i_see_the_transition_contextual_breadcrumbs
+  end
+
   scenario "There's a step by step list" do
     given_theres_a_page_with_a_step_by_step
     and_i_visit_that_page
@@ -70,6 +76,14 @@ describe "Contextual navigation" do
     and_i_visit_that_page
     then_i_see_home_and_parent_links
     and_i_see_the_coronavirus_contextual_breadcrumbs
+  end
+
+  scenario "A page is tagged to the transition taxon and a step_by_step" do
+    given_theres_a_page_with_transition_taxon_tagged_to_step_by_step
+    and_i_visit_that_page
+    then_i_see_the_step_by_step
+    and_the_step_by_step_header
+    and_i_do_not_see_the_transition_contextual_breadcrumbs
   end
 
   scenario "It's a HTML Publication with a parent with breadcrumbs" do
@@ -294,6 +308,25 @@ describe "Contextual navigation" do
     )
   end
 
+  def given_theres_a_page_with_transition_taxon_tagged_to_step_by_step
+    given_theres_a_page_with_transition_taxon(part_of_step_navs: true)
+  end
+
+  def given_theres_a_page_with_transition_taxon(part_of_step_navs: nil)
+    live_taxon = taxon_item
+    live_taxon["links"]["parent_taxons"] = [transition_taxon]
+    links = { "taxons" => [live_taxon] }
+
+    if part_of_step_navs == true
+      links[:part_of_step_navs] = []
+      links[:part_of_step_navs] << random_step_nav_item("step_by_step_nav")
+    end
+
+    content_store_has_random_item(
+      links: links,
+    )
+  end
+
   def given_there_is_a_non_step_by_step_parent_page
     @parent = not_step_by_step_content
   end
@@ -453,6 +486,18 @@ describe "Contextual navigation" do
     end
   end
 
+  def and_i_do_not_see_the_transition_contextual_breadcrumbs
+    within ".gem-c-contextual-breadcrumbs" do
+      expect(page).not_to have_link(transition_taxon["title"])
+    end
+  end
+
+  def and_i_see_the_transition_contextual_breadcrumbs
+    within ".gem-c-contextual-breadcrumbs" do
+      expect(page).to have_link(transition_taxon["title"])
+    end
+  end
+
   def then_i_see_the_step_by_step_breadcrumbs
     within ".gem-c-contextual-breadcrumbs" do
       expect(page).to have_link("A step by step page")
@@ -533,6 +578,16 @@ describe "Contextual navigation" do
       "api_path" => "/api/content/coronavirus-taxon/businesses-and-self-employed-people",
       "base_path" => "/coronavirus-taxon/businesses-and-self-employed-people",
       "title" => "Businesses and self-employed people",
+      "locale" => "en",
+    }
+  end
+
+  def transition_taxon
+    {
+      "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+      "api_path" => "/api/content/transition",
+      "base_path" => "/transition",
+      "title" => "Transition period",
       "locale" => "en",
     }
   end


### PR DESCRIPTION
## What
Hide transition priority breadcrumb if content is part of Step by Step.

## Why
Because having both breadcrumbs is confusing.

## Visual Changes

### Before
<img width="1148" alt="Screenshot 2020-08-20 at 13 24 14" src="https://user-images.githubusercontent.com/17908089/90769650-7ca99500-e2e8-11ea-8260-4cf64ea59455.png">

### After
<img width="913" alt="Screenshot 2020-08-20 at 13 26 03" src="https://user-images.githubusercontent.com/17908089/90769787-b67a9b80-e2e8-11ea-9232-b53d6e562dee.png">
