### PR TITLE
Update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## 21.62.0
-
-* Add new brand colour for FCDO ([PR#1648](https://github.com/alphagov/govuk_publishing_components/pull/1648))
+## Unrelased
 * Hide priority breadcrumb from transition content tagged to a step by step ([PR #1654](https://github.com/alphagov/govuk_publishing_components/pull/1654))
+
+## 21.62.0
+* Add new brand colour for FCDO ([PR#1648](https://github.com/alphagov/govuk_publishing_components/pull/1648))
+
 
 ## 21.61.0
 


### PR DESCRIPTION
## What
Move `Hide priority breadcrumb from transition content tagged to a step by step ([PR #1654]` into the unreleased section.

## Why
PR to release 21.62.0 was merged at the same time as I rebased. Which seems to have done something strange. On the original PR #1654 the change is showing in unreleased, but on master it's showing under 21.62.0. 
