### PR TITLE
Fix panel component disjointed heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Remove jquery from toggle code ([PR #1649](https://github.com/alphagov/govuk_publishing_components/pull/1649))
 * Add role="alert" to cookie banner confirmation ([PR #1658](https://github.com/alphagov/govuk_publishing_components/pull/1658))
 * Remove jquery from step by step component ([PR #1645](https://github.com/alphagov/govuk_publishing_components/pull/1645))
+* Fix panel component disjointed heading ([PR #1660](https://github.com/alphagov/govuk_publishing_components/pull/1660))
 
 ## 21.63.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_panel.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_panel.scss
@@ -9,6 +9,12 @@
   @include govuk-font($size: 24, $weight: bold);
 }
 
-.gem-c-panel__prepend ~ .govuk-panel__title {
+.gem-c-panel__prepend ~ .govuk-panel__title-text {
   margin-bottom: govuk-spacing(3);
+}
+
+.gem-c-panel__append,
+.gem-c-panel__prepend,
+.govuk-panel__title-text {
+  display: block;
 }

--- a/app/views/govuk_publishing_components/components/_panel.html.erb
+++ b/app/views/govuk_publishing_components/components/_panel.html.erb
@@ -4,22 +4,24 @@
   append ||= false
 %>
 <div class="gem-c-panel govuk-panel govuk-panel--confirmation">
-  <% if prepend %>
-    <div class="gem-c-panel__prepend">
-      <%= prepend %>
-    </div>
-  <% end %>
   <h2 class="govuk-panel__title">
-    <%= title %>
+    <% if prepend %>
+      <span class="gem-c-panel__prepend">
+        <%= prepend %>
+      </span>
+    <% end %>
+    <span class="govuk-panel__title-text">
+      <%= title %>
+    </span>
+    <% if append %>
+      <span class="gem-c-panel__append">
+        <%= append %>
+      </span>
+    <% end %>
   </h2>
   <% if description %>
     <div class="govuk-panel__body">
       <%= description %>
-    </div>
-  <% end %>
-  <% if append %>
-    <div class="gem-c-panel__append">
-      <%= append %>
     </div>
   <% end %>
 </div>

--- a/spec/components/panel_spec.rb
+++ b/spec/components/panel_spec.rb
@@ -17,7 +17,7 @@ describe "Panel", type: :view do
       description: "Description",
     )
 
-    assert_select ".govuk-panel__title", text: "Application complete"
+    assert_select ".govuk-panel__title .govuk-panel__title-text", text: "Application complete"
     assert_select ".govuk-panel__body", text: "Description"
   end
 
@@ -28,7 +28,7 @@ describe "Panel", type: :view do
       append: "Appended content",
     )
 
-    assert_select ".govuk-panel__title", text: "Application complete"
+    assert_select ".govuk-panel__title .govuk-panel__title-text", text: "Application complete"
     assert_select ".gem-c-panel__prepend", text: "Prepended content"
     assert_select ".gem-c-panel__append", text: "Appended content"
   end


### PR DESCRIPTION
## What
On the panel component, move the optional prepended text and appended text into the same block as the `text` for the heading.




## Why

The prepended text, heading text, and appended text on the panel component should be in the same block.

The issue with the prepended and appended text being outside the heading element is that they provide context for the heading. Screen reader users might be confused by the incomplete heading and not understand it out of context when they are navigating a page according to its headings.

### Example of the issue
The panel text on https://www.gov.uk/bank-holidays for each next bank holiday is disjointed. It should be in the same block level element.
```
  <div>
    The next bank holiday in England and Wales is
  </div>
  <h2>
    31 August
  </h2>
  <div>
      Summer bank holiday
  </div>
```





https://trello.com/c/9eXF6FRF