### PR TITLE
Fix the on blue logic for the search component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix the on blue logic for the search component ([PR #1663](https://github.com/alphagov/govuk_publishing_components/pull/1663))
+
 ## 21.63.1
 
 * Remove jquery from toggle code ([PR #1649](https://github.com/alphagov/govuk_publishing_components/pull/1649))

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -2,12 +2,16 @@
   size ||= ""
   no_border ||= false
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-  classes = %w(gem-c-search gem-c-search--on-white)
+  classes = %w(gem-c-search)
   classes << (shared_helper.get_margin_top)
   classes << (shared_helper.get_margin_bottom) if local_assigns[:margin_bottom]
   classes << "gem-c-search--large" if size == 'large'
   classes << "gem-c-search--no-border" if no_border
-  classes << "gem-c-search--on-govuk-blue" if local_assigns[:on_govuk_blue].eql?(true)
+  if local_assigns[:on_govuk_blue].eql?(true)
+    classes << "gem-c-search--on-govuk-blue"
+  else
+    classes << "gem-c-search--on-white"
+  end
   classes << "gem-c-search--separate-label" if local_assigns.include?(:inline_label)
 
   value ||= ""


### PR DESCRIPTION
## What
Fix the logic for the `on-white` and `on-blue` stylings for the search component.

## Why
Search box (on blue option) on the homepage isn't appearing correctly.

## Visual Changes

Before:

<img width="704" alt="Screenshot 2020-08-27 at 11 39 47" src="https://user-images.githubusercontent.com/861310/91432757-1c6fa180-e85a-11ea-9df4-bb908a4d699e.png">

<img width="676" alt="Screenshot 2020-08-27 at 11 39 51" src="https://user-images.githubusercontent.com/861310/91432773-2396af80-e85a-11ea-8bc2-0d3738cf8ef0.png">

After:

<img width="897" alt="Screenshot 2020-08-27 at 11 41 01" src="https://user-images.githubusercontent.com/861310/91432827-37421600-e85a-11ea-855c-439df7394aa9.png">

<img width="896" alt="Screenshot 2020-08-27 at 11 41 07" src="https://user-images.githubusercontent.com/861310/91432843-3c9f6080-e85a-11ea-9663-877165705b33.png">
