### PR TITLE
Add h2 tag into legend by default

### DIFF
--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -53,7 +53,9 @@
           <%= tag.h1 heading, class: "gem-c-radio__heading-text govuk-fieldset__heading" %>
         <% end %>
       <% else %>
-        <%= tag.legend heading, class: legend_classes %>
+        <%= tag.legend class: legend_classes do %>
+          <%= tag.h2 heading, class: "govuk-fieldset__heading" %>
+        <% end %>
       <% end %>
     <% end %>
 


### PR DESCRIPTION
## What
Adds a h2 tag inside the legend tag within the radio component.

## Why
This was raised during the accessibility audit of govuk. On the [cookie page](gov.uk/help/cookies), all the headings are legends. As well as this being confusing to users because these look like headings, it mens that this page can't be navigated through using the headings. This solution of putting headings within the legends is the solution used by the [design system for radio buttons](https://design-system.service.gov.uk/components/radios/stacked/index.html). This solution has been backed up by Anika and the content community.

No intended visual changes.

**Card:** https://trello.com/c/mCncj7BE/328-cookies-page-missing-headings
