### PR TITLE
Display preferred super breadcrumb using query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+* Superbreadcrumb can have a priority taxon selected via query param ([PR #1666](https://github.com/alphagov/govuk_publishing_components/pull/1666))
+
 ## 21.63.3
 
 * Remove jquery from govspeak ([PR #1657](https://github.com/alphagov/govuk_publishing_components/pull/1657))

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -12,14 +12,15 @@ module GovukPublishingComponents
       }.freeze
 
       # Returns the highest priority taxon that has a content_id matching those in PRIORITY_TAXONS
-      def self.call(content_item)
-        new(content_item).breadcrumbs
+      def self.call(content_item, query_parameters = nil)
+        new(content_item, query_parameters).breadcrumbs
       end
 
-      attr_reader :content_item
+      attr_reader :content_item, :query_parameters
 
-      def initialize(content_item)
+      def initialize(content_item, query_parameters = nil)
         @content_item = content_item
+        @query_parameters = query_parameters
       end
 
       def taxon
@@ -56,6 +57,10 @@ module GovukPublishingComponents
 
       def priority_taxon?(taxon)
         PRIORITY_TAXONS.values.include?(taxon["content_id"])
+      end
+
+      def preferred_priority_taxon
+        query_parameters["priority-taxon"] if query_parameters
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -24,7 +24,13 @@ module GovukPublishingComponents
       end
 
       def taxon
-        @taxon ||= priority_taxons.min_by { |t| PRIORITY_TAXONS.values.index(t["content_id"]) }
+        @taxon ||= begin
+          if preferred_priority_taxon
+            priority_taxons.find { |t| t["content_id"] == preferred_priority_taxon }
+          else
+            priority_taxons.min_by { |t| PRIORITY_TAXONS.values.index(t["content_id"]) }
+          end
+        end
       end
 
       def breadcrumbs

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -25,11 +25,8 @@ module GovukPublishingComponents
 
       def taxon
         @taxon ||= begin
-          if preferred_priority_taxon
-            priority_taxons.find { |t| t["content_id"] == preferred_priority_taxon }
-          else
-            priority_taxons.min_by { |t| PRIORITY_TAXONS.values.index(t["content_id"]) }
-          end
+          default_taxon = priority_taxons.min_by { |t| PRIORITY_TAXONS.values.index(t["content_id"]) }
+          preferred_taxon || default_taxon
         end
       end
 
@@ -45,6 +42,12 @@ module GovukPublishingComponents
       end
 
     private
+
+      def preferred_taxon
+        if preferred_priority_taxon
+          priority_taxons.find { |t| t["content_id"] == preferred_priority_taxon }
+        end
+      end
 
       def priority_taxons
         return [] unless content_item["links"].is_a?(Hash)

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -30,7 +30,7 @@ module GovukPublishingComponents
       end
 
       def priority_breadcrumbs
-        @priority_breadcrumbs ||= ContentBreadcrumbsBasedOnPriority.call(content_item)
+        @priority_breadcrumbs ||= ContentBreadcrumbsBasedOnPriority.call(content_item, query_parameters)
       end
 
       def topic_breadcrumbs

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -2,11 +2,23 @@ require "rails_helper"
 
 describe "Contextual navigation" do
   scenario "There is a coronavirus taxon" do
-    given_theres_a_page_with_coronavirus_taxon
+    given_theres_a_page_with_coronavirus_business_taxon
     and_i_visit_that_page
     then_i_see_the_step_by_step
     and_the_step_by_step_header
-    and_i_see_the_coronavirus_contextual_breadcrumbs
+    and_i_see_the_coronavirus_contextual_breadcrumbs_for_business
+  end
+
+  scenario "I see the preferred taxon in the super breadcrumb if I access via a business taxon link" do
+    given_theres_a_page_with_coronavirus_business_taxon
+    then_i_visit_that_page_by_clicking_on_a_priority_taxon_link_for_business
+    and_i_see_the_coronavirus_contextual_breadcrumbs_for_business
+  end
+
+  scenario "I see the preferred taxon in the super breadcrumb if I access via a workers taxon link" do
+    given_theres_a_page_with_coronavirus_workers_taxon
+    then_i_visit_that_page_by_clicking_on_a_priority_taxon_link_for_workers
+    and_i_see_the_coronavirus_contextual_breadcrumbs_for_workers
   end
 
   scenario "There is a transition taxon" do
@@ -71,11 +83,11 @@ describe "Contextual navigation" do
   end
 
   scenario "It's a HTML Publication with a parent with coronavirus taxon" do
-    given_there_is_a_parent_page_with_coronavirus_taxon
+    given_there_is_a_parent_page_with_coronavirus_business_taxon
     and_the_page_is_an_html_publication_with_that_parent
     and_i_visit_that_page
     then_i_see_home_and_parent_links
-    and_i_see_the_coronavirus_contextual_breadcrumbs
+    and_i_see_the_coronavirus_contextual_breadcrumbs_for_business
   end
 
   scenario "A page is tagged to the transition taxon and a step_by_step" do
@@ -296,9 +308,21 @@ describe "Contextual navigation" do
     )
   end
 
-  def given_theres_a_page_with_coronavirus_taxon
+  def given_theres_a_page_with_coronavirus_business_taxon
     live_taxon = taxon_item
-    live_taxon["links"]["parent_taxons"] = [coronavirus_taxon]
+    live_taxon["links"]["parent_taxons"] = [coronavirus_business_taxon]
+
+    content_store_has_random_item(
+      links: {
+        "taxons" => [live_taxon],
+        part_of_step_navs: [random_step_nav_item("step_by_step_nav")],
+      },
+    )
+  end
+
+  def given_theres_a_page_with_coronavirus_workers_taxon
+    live_taxon = taxon_item
+    live_taxon["links"]["parent_taxons"] = [coronavirus_workers_taxon]
 
     content_store_has_random_item(
       links: {
@@ -331,9 +355,9 @@ describe "Contextual navigation" do
     @parent = not_step_by_step_content
   end
 
-  def given_there_is_a_parent_page_with_coronavirus_taxon
+  def given_there_is_a_parent_page_with_coronavirus_business_taxon
     taxon = taxon_item
-    taxon["links"]["parent_taxons"] = [coronavirus_taxon]
+    taxon["links"]["parent_taxons"] = [coronavirus_business_taxon]
 
     @parent = not_step_by_step_content
     @parent["links"]["taxons"] = [taxon]
@@ -377,6 +401,14 @@ describe "Contextual navigation" do
 
   def and_i_visit_that_page_by_clicking_on_a_step_by_step_link
     visit "/contextual-navigation/page-with-contextual-navigation?step-by-step-nav=8ad999bd-8603-40eb-97c0-999cb22047cd"
+  end
+
+  def then_i_visit_that_page_by_clicking_on_a_priority_taxon_link_for_business
+    visit "/contextual-navigation/page-with-contextual-navigation?priority-taxon=65666cdf-b177-4d79-9687-b9c32805e450"
+  end
+
+  def then_i_visit_that_page_by_clicking_on_a_priority_taxon_link_for_workers
+    visit "/contextual-navigation/page-with-contextual-navigation?priority-taxon=b7f57213-4b16-446d-8ded-81955d782680"
   end
 
   def then_i_see_the_step_by_step
@@ -480,9 +512,15 @@ describe "Contextual navigation" do
     end
   end
 
-  def and_i_see_the_coronavirus_contextual_breadcrumbs
+  def and_i_see_the_coronavirus_contextual_breadcrumbs_for_business
     within ".gem-c-contextual-breadcrumbs" do
-      expect(page).to have_link(coronavirus_taxon["title"])
+      expect(page).to have_link(coronavirus_business_taxon["title"])
+    end
+  end
+
+  def and_i_see_the_coronavirus_contextual_breadcrumbs_for_workers
+    within ".gem-c-contextual-breadcrumbs" do
+      expect(page).to have_link(coronavirus_workers_taxon["title"])
     end
   end
 
@@ -572,12 +610,22 @@ describe "Contextual navigation" do
     end
   end
 
-  def coronavirus_taxon
+  def coronavirus_business_taxon
     {
       "content_id" => "65666cdf-b177-4d79-9687-b9c32805e450",
       "api_path" => "/api/content/coronavirus-taxon/businesses-and-self-employed-people",
       "base_path" => "/coronavirus-taxon/businesses-and-self-employed-people",
       "title" => "Businesses and self-employed people",
+      "locale" => "en",
+    }
+  end
+
+  def coronavirus_workers_taxon
+    {
+      "content_id" => "b7f57213-4b16-446d-8ded-81955d782680",
+      "api_path" => "/api/content/coronavirus-taxon/work-and-financial-support",
+      "base_path" => "/coronavirus-taxon/work-and-financial-support",
+      "title" => "Work and financial support during coronavirus",
       "locale" => "en",
     }
   end

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -93,14 +93,24 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
         end
 
         context "with priority-taxon query_parameters" do
-          let(:payload) { [education_taxon, business_taxon] }
-          let(:preferred_content_id) { business_taxon["content_id"] }
-          let(:query_parameters) { { "priority-taxon" => preferred_content_id } }
-
-          subject { described_class.new(send(tagged_to_taxons, payload), query_parameters) }
-
           it "returns the preferred priority taxon" do
-            expect(subject.taxon).to eq(business_taxon)
+            preferred_content_id = business_taxon["content_id"]
+            query_parameters = { "priority-taxon" => preferred_content_id }
+            payload = [education_taxon, business_taxon]
+            content_item = send(tagged_to_taxons, payload)
+            context_breadcrumb = described_class.new(content_item, query_parameters)
+
+            expect(context_breadcrumb.taxon).to eq(business_taxon)
+          end
+
+          it "returns the default taxon if not tagged to priority taxon" do
+            preferred_content_id = business_taxon["content_id"]
+            query_parameters = { "priority-taxon" => preferred_content_id }
+            payload = [education_taxon]
+            content_item = send(tagged_to_taxons, payload)
+            context_breadcrumb = described_class.new(content_item, query_parameters)
+
+            expect(context_breadcrumb.taxon).to eq(education_taxon)
           end
         end
       end

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -91,6 +91,18 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
             expect(subject.taxon).to be_nil
           end
         end
+
+        context "with priority-taxon query_parameters" do
+          let(:payload) { [education_taxon, business_taxon] }
+          let(:preferred_content_id) { business_taxon["content_id"] }
+          let(:query_parameters) { { "priority-taxon" => preferred_content_id } }
+
+          subject { described_class.new(send(tagged_to_taxons, payload), query_parameters) }
+
+          it "returns the preferred priority taxon" do
+            expect(subject.taxon).to eq(business_taxon)
+          end
+        end
       end
 
       describe ".call" do


### PR DESCRIPTION
## What

The superbreadcrumb makes use of the step_by_step_nav_header. 

The superbreadcrumb is displayed if content is tagged with at least one of the priority taxons defined in `ContentBreadcrumbsBasedOnPriority`.

This change allows the superbreadcrumb to be selected using a query string 'priority-taxon' instead of relying on a simple priority order. If the query string is not defined or not matched, it will use the original logic above.

## Why
Previously if a piece of content is tagged to more than one hub page the superbreadcrumb shown to a user is defined by a hierarchy of hubs, and isn't responsive to the hub that a use has navigated from.

This means that a user might go to a piece of content from one hub, but see the superbreadcrumb for a different hub, which is confusing, and doesn't provide a helpful journey back to the hub they've come from

## Visual Changes
None

## To Test/Verify locally
3 repos are required
this repo with the code changes in this PR
`govuk-content-schemas` has sample content `examples/publication/frontend/tagged_to_two_coronavirus_taxons.json `
`government-frontend` to display the sample content using this repo as a gem

### govuk-content-schemas
As of writing the changes are in a branch awaiting merging `add_tagged_to_two_taxons_superbreadcrumbs`
If not yet merged then this branch will need to be checked out.
Follow setup instruction and run using `bundle exec ruby app.rb`
this should now be running on port 4567

### government-frontend
Edit the `Gemfile` of `government-frontend` so that it picks up the local gem for `govuk_publishing_components`
`gem "govuk_publishing_components", path: "../govuk_publishing_components"`
Follow setup instructions.
To run using the local content store (govuk-content-schemas), run using
`PLEK_SERVICE_CONTENT_STORE_URI=http://localhost:4567/api ./startup.sh --dummy`

### Access content
The sample content should now be accessible at
`http://localhost:3090/examples/publication/tagged_to_two_coronavirus_taxons`
and displaying "Work and financial support during coronavirus" super breadcrumb

To change the supercrumbcrumb using the changes in this PR
`http://localhost:3090/examples/publication/tagged_to_two_coronavirus_taxons?priority-taxon=65666cdf-b177-4d79-9687-b9c32805e450`

The sample content should now be displaying "Support for businesses and self-employed people during coronavirus" super breadcrumb


https://trello.com/c/Kdnp9TPC/761-spike-conditional-super-breadcrumb-based-on-which-hub-a-user-has-come-from