### PR TITLE
Add white background to absolute positioned search label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove jquery from govspeak ([PR #1657](https://github.com/alphagov/govuk_publishing_components/pull/1657))
+* Add white background to absolute positioned search label ([PR #1667](https://github.com/alphagov/govuk_publishing_components/pull/1667))
 
 ## 21.63.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -24,6 +24,7 @@ $large-input-size: 50px;
     padding-left: govuk-spacing(3);
     z-index: 1;
     color: $govuk-secondary-text-colour;
+    background-color: govuk-colour("white");
   }
 
   // match label colour with the label component colour


### PR DESCRIPTION
## What
Give search field label a white background when label is absolutely
positioned over the search field.


## Why
Even though the search label is absolutely positioned over the search
field, under some circumstances it might be displayed over the blue
background (when someone linearises the page, uses their own user styles
or increases the font size)
Dark grey on dark blue fails colour contrast requirements.

![image](https://user-images.githubusercontent.com/7116819/91959281-4fa1ad00-ed00-11ea-96b0-c479fd296741.png)



https://trello.com/c/49aclxyn