### PR TITLE
Bump version to 21.63.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.63.3
 
 * Remove jquery from govspeak ([PR #1657](https://github.com/alphagov/govuk_publishing_components/pull/1657))
+* Add h2 tag into legend by default ([PR #1665](https://github.com/alphagov/govuk_publishing_components/pull/1665))
 
 ## 21.63.2
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.63.2)
+    govuk_publishing_components (21.63.3)
       govuk_app_config
       kramdown
       plek
@@ -276,7 +276,7 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-raven (3.0.3)
+    sentry-raven (3.0.4)
       faraday (>= 1.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.63.2".freeze
+  VERSION = "21.63.3".freeze
 end


### PR DESCRIPTION
* Remove jquery from govspeak ([PR #1657](https://github.com/alphagov/govuk_publishing_components/pull/1657))
* Add h2 tag into legend by default ([PR #1665](https://github.com/alphagov/govuk_publishing_components/pull/1665)) (I forgot to add this to the changelog in the PR itself which is why it wasn't here before)
