### PR TITLE
Bump version to 21.64.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.64.0
+
 * Superbreadcrumb can have a priority taxon selected via query param ([PR #1666](https://github.com/alphagov/govuk_publishing_components/pull/1666))
 
 ## 21.63.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.63.3)
+    govuk_publishing_components (21.64.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.63.3".freeze
+  VERSION = "21.64.0".freeze
 end


### PR DESCRIPTION
## What
Release for 'Superbreadcrumb can have a priority taxon selected via query param'
