### PR TITLE
Release 21.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.65.0
 
 * Step by step nav header updated to use heading ([PR #1671](https://github.com/alphagov/govuk_publishing_components/pull/1671))
-* Increase icon size and allow transparent icons on action link component ([PR #1674](https://github.com/alphagov/govuk_publishing_components/pull/1671))
+* Increase icon size and allow transparent icons on action link component ([PR #1674](https://github.com/alphagov/govuk_publishing_components/pull/1674))
 
 ## 21.64.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.64.0)
+    govuk_publishing_components (21.65.0)
       govuk_app_config
       kramdown
       plek
@@ -105,11 +105,11 @@ GEM
       rest-client (~> 2.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk_app_config (2.2.1)
+    govuk_app_config (2.2.2)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 3.1.0)
       statsd-ruby (~> 1.4.0)
-      unicorn (>= 5.4, < 5.6)
+      unicorn (>= 5.4, < 5.7)
     govuk_schemas (4.1.1)
       json-schema (~> 2.8.0)
     govuk_test (1.0.3)
@@ -297,7 +297,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    unicorn (5.5.5)
+    unicorn (5.6.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     webdrivers (4.3.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.64.0".freeze
+  VERSION = "21.65.0".freeze
 end


### PR DESCRIPTION
## 21.65.0

* Step by step nav header updated to use heading ([PR #1671](https://github.com/alphagov/govuk_publishing_components/pull/1671))
* Increase icon size and allow transparent icons on action link component ([PR #1674](https://github.com/alphagov/govuk_publishing_components/pull/1674))
