### PR TITLE
Search label background colour fix for no JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Search label background colour fix for no JS ([PR #1676](https://github.com/alphagov/govuk_publishing_components/pull/1676))
+
 ## 21.65.0
 
 * Step by step nav header updated to use heading ([PR #1671](https://github.com/alphagov/govuk_publishing_components/pull/1671))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -9,7 +9,6 @@ $large-input-size: 50px;
 .gem-c-search__label {
   @include govuk-font($size: 19, $line-height: $input-size);
   display: block;
-  background: govuk-colour("white");
 
   h1 {
     @include govuk-font($size: 19, $line-height: $input-size);
@@ -24,6 +23,7 @@ $large-input-size: 50px;
     padding-left: govuk-spacing(3);
     z-index: 1;
     color: $govuk-secondary-text-colour;
+    background: govuk-colour("white");
   }
 
   // match label colour with the label component colour

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -129,13 +129,7 @@ $large-input-size: 50px;
 }
 
 .gem-c-search--on-govuk-blue {
-  .gem-c-search__label {
-    color: govuk-colour("white");
-  }
-
   .gem-c-search__input {
-    border-width: 0;
-
     // no need for black outline as there is enough contrast
     // with the blue background
     &:focus {
@@ -151,24 +145,9 @@ $large-input-size: 50px;
       background-color: lighten(govuk-colour("black"), 5%);
     }
   }
-
-  .js-enabled & {
-    .gem-c-search__label {
-      color: $govuk-secondary-text-colour;
-    }
-  }
 }
 
 .gem-c-search--on-white {
-  .gem-c-search__submit {
-    background-color: govuk-colour("blue");
-    color: govuk-colour("white");
-
-    &:hover {
-      background-color: lighten(govuk-colour("blue"), 5%);
-    }
-  }
-
   .gem-c-search__input[type="search"] {
     border-right-width: 0;
 
@@ -179,9 +158,30 @@ $large-input-size: 50px;
   }
 }
 
-.gem-c-search--no-border {
+.gem-c-search--on-white,
+.gem-c-search--on-govuk-black {
+  .gem-c-search__submit {
+    background-color: govuk-colour("blue");
+    color: govuk-colour("white");
+
+    &:hover {
+      background-color: lighten(govuk-colour("blue"), 5%);
+    }
+  }
+}
+
+.gem-c-search--on-govuk-blue,
+.gem-c-search--on-govuk-black {
   .gem-c-search__input[type="search"] {
     border: 0;
+  }
+
+  .gem-c-search__label {
+    color: govuk-colour("white");
+
+    .js-enabled & {
+      color: $govuk-secondary-text-colour;
+    }
   }
 }
 

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -9,6 +9,8 @@
   classes << "gem-c-search--no-border" if no_border
   if local_assigns[:on_govuk_blue].eql?(true)
     classes << "gem-c-search--on-govuk-blue"
+  elsif local_assigns[:on_govuk_black].eql?(true)
+    classes << "gem-c-search--on-govuk-black"
   else
     classes << "gem-c-search--on-white"
   end

--- a/app/views/govuk_publishing_components/components/docs/search.yml
+++ b/app/views/govuk_publishing_components/components/docs/search.yml
@@ -24,17 +24,16 @@ examples:
   stop_the_label_appearing_inline:
     data:
       inline_label: false
-  no_border:
-    description: Sometimes we don't need the grey border surrounding the input field, such as when the component is used on a black background
-    data:
-      no_border: true
-    context:
-      black_background: true
   for_use_on_govuk_blue_background:
     data:
       on_govuk_blue: true
     context:
       dark_background: true
+  for_use_on_govuk_black_background:
+    data:
+      on_govuk_black: true
+    context:
+      black_background: true
   change_label_text:
     data:
       label_text: "Search"

--- a/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
@@ -3,7 +3,7 @@
   <%= render "govuk_publishing_components/components/search", {
     id: "site-search-text",
     label_text: "Search",
-    no_border: true,
+    on_govuk_black: true,
     margin_bottom: 0
   } %>
 </form>

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -10,14 +10,24 @@ describe "Search", type: :view do
     assert_select ".gem-c-search.gem-c-search--on-white"
   end
 
-  it "renders a search box for a dark background" do
+  it "renders a search box for a blue background" do
     render_component(on_govuk_blue: true)
     assert_select ".gem-c-search.gem-c-search--on-govuk-blue"
   end
 
-  it "doesn't render a search box for a dark background if the parameter is invalid" do
+  it "doesn't render a search box for a blue background if the parameter is invalid" do
     render_component(on_govuk_blue: "dummy")
     assert_select ".gem-c-search.gem-c-search--on-govuk-blue", false
+  end
+
+  it "renders a search box for a black background" do
+    render_component(on_govuk_black: true)
+    assert_select ".gem-c-search.gem-c-search--on-govuk-black"
+  end
+
+  it "doesn't render a search box for a black background if the parameter is invalid" do
+    render_component(on_govuk_black: "dummy")
+    assert_select ".gem-c-search.gem-c-search--on-govuk-black", false
   end
 
   it "renders a search box with a custom label text" do


### PR DESCRIPTION






## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Ensure search label only has a white background when it is absolutely
positioned over the input field. 

## Why
<!-- What are the reasons behind this change being made? -->

The search label is not absolutely positioned with JS disabled which leads to the below issue:

### No JS homepage before
<img width="1079" alt="Screenshot 2020-09-09 at 15 03 49" src="https://user-images.githubusercontent.com/7116819/92608856-c238fc80-f2ad-11ea-8010-8be90d8626fe.png">

### No JS homepage after
<img width="1110" alt="Screenshot 2020-09-09 at 15 06 04" src="https://user-images.githubusercontent.com/7116819/92609066-07f5c500-f2ae-11ea-889f-a2c8fa7f1551.png">

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

### Before (JS disabled)
<img width="895" alt="Screenshot 2020-09-09 at 18 13 12" src="https://user-images.githubusercontent.com/7116819/92630810-4a2c0000-f2c8-11ea-9360-5c9b7a3529e2.png">

### After (JS disabled)
<img width="893" alt="Screenshot 2020-09-09 at 18 13 38" src="https://user-images.githubusercontent.com/7116819/92630818-5021e100-f2c8-11ea-9283-326a50bace17.png">
