### PR TITLE
Explicitly set box sizing on inputs

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -12,6 +12,7 @@
   margin: 0;
   min-width: 0;
   padding: govuk-spacing(1);
+  box-sizing: border-box;
 
   &.gem-c-input--search-icon {
     padding-left: govuk-spacing(6);


### PR DESCRIPTION
## What / why
Explicitly set box sizing on inputs, as this is being overwritten by govuk template (or something in static), which is causing layout problems.

Example:

<img width="346" alt="Screenshot 2020-09-10 at 09 30 02" src="https://user-images.githubusercontent.com/861310/92713480-ee5a8900-f352-11ea-840e-7a11480338ee.png">

Fix:

<img width="412" alt="Screenshot 2020-09-10 at 10 47 14" src="https://user-images.githubusercontent.com/861310/92713548-029e8600-f353-11ea-8e19-3ff64fef5cda.png">

Related to: https://github.com/alphagov/collections/pull/1899