### PR TITLE
Fix search box label colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix search box label colour ([PR #1680](https://github.com/alphagov/govuk_publishing_components/pull/1680))
+
 ## 21.65.0
 
 * Step by step nav header updated to use heading ([PR #1671](https://github.com/alphagov/govuk_publishing_components/pull/1671))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -10,6 +10,7 @@ $large-input-size: 50px;
   @include govuk-font($size: 19, $line-height: $input-size);
   display: block;
   background: govuk-colour("white");
+  color: $govuk-text-colour;
 
   h1 {
     @include govuk-font($size: 19, $line-height: $input-size);
@@ -129,10 +130,6 @@ $large-input-size: 50px;
 }
 
 .gem-c-search--on-govuk-blue {
-  .gem-c-search__label {
-    color: govuk-colour("white");
-  }
-
   .gem-c-search__input {
     border-width: 0;
 


### PR DESCRIPTION
## What
Fixes display of search label on blue background when JS is disabled, and the label is shown outside of the search box.

Previous work: https://github.com/alphagov/govuk_publishing_components/pull/1676 (thanks to @danacotoran)

## Why
Search label was unreadable.

## Visual Changes
Before:

<img width="958" alt="Screenshot 2020-09-10 at 12 07 15" src="https://user-images.githubusercontent.com/861310/92721563-37640a80-f35e-11ea-883d-b62aaabfb3c9.png">

After:

<img width="956" alt="Screenshot 2020-09-10 at 12 07 21" src="https://user-images.githubusercontent.com/861310/92721581-3c28be80-f35e-11ea-8c47-f8711cf57198.png">

