### PR TITLE
Version 21.65.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 26.65.1
 
 * Fix search box label colour ([PR #1680](https://github.com/alphagov/govuk_publishing_components/pull/1680))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.65.0)
+    govuk_publishing_components (21.65.1)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.65.0".freeze
+  VERSION = "21.65.1".freeze
 end


### PR DESCRIPTION
## 26.65.1

* Fix search box label colour ([PR #1680](https://github.com/alphagov/govuk_publishing_components/pull/1680))
