### PR TITLE
Mobile search toggle button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Remove jQuery from toggle-input-class JS ([PR #1683](https://github.com/alphagov/govuk_publishing_components/pull/1683))
 * Add locale attribute to notice component ([PR #1686](https://github.com/alphagov/govuk_publishing_components/pull/1686))
 * Remove aria-expanded attribute from yes feedback button ([PR #1687](https://github.com/alphagov/govuk_publishing_components/pull/1687))
+* Mobile search toggle button ([PR #1682](https://github.com/alphagov/govuk_publishing_components/pull/1682))
 
 ## 26.65.1
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
@@ -10,7 +10,7 @@
     for (i = 0, _i = els.length; i < _i; i++) {
       els[i].addEventListener('click', function (e) {
         e.preventDefault()
-        var target = document.getElementById(this.getAttribute('href').substr(1))
+        var target = this.getAttribute('href') ? document.getElementById(this.getAttribute('href').substr(1)) : document.getElementById(this.getAttribute('data-search-toggle-for'))
         var targetClass = target.getAttribute('class') || ''
         var sourceClass = this.getAttribute('class') || ''
 
@@ -21,8 +21,10 @@
         }
         if (sourceClass.indexOf('js-visible') !== -1) {
           this.setAttribute('class', sourceClass.replace(/(^|\s)js-visible(\s|$)/, ''))
+          this.innerText = 'Show search'
         } else {
           this.setAttribute('class', sourceClass + ' js-visible')
+          this.innerText = 'Hide search'
         }
         this.setAttribute('aria-expanded', this.getAttribute('aria-expanded') !== 'true')
         target.setAttribute('aria-hidden', target.getAttribute('aria-hidden') === 'false')

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -213,11 +213,11 @@ $large-input-size: 50px;
 }
 
 .search-toggle {
+  display: none;
   background-color: govuk-colour("blue");
   background-image: image-url("govuk_publishing_components/search-button.png");
   background-position: 0 50%;
   background-repeat: no-repeat;
-  display: block;
   float: right;
   height: 30px;
   margin: -46px 0;
@@ -225,6 +225,7 @@ $large-input-size: 50px;
   padding: 0;
   text-indent: -5000px;
   width: 36px;
+  border: 0;
 
   &:focus {
     border-width: 0;
@@ -249,5 +250,11 @@ $large-input-size: 50px;
 
   @include govuk-media-query($from: tablet) {
     display: none;
+  }
+
+  @include govuk-media-query($until: tablet) {
+    .js-enabled & {
+      display: block;
+    }
   }
 }

--- a/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
@@ -1,4 +1,4 @@
-<a href="#search" class="search-toggle js-header-toggle">Search</a>
+<button class="search-toggle js-header-toggle" data-search-toggle-for="search">Show search</button>
 <form id="search" class="gem-c-layout-header__search-form govuk-clearfix" action="/search" method="get" role="search">
   <%= render "govuk_publishing_components/components/search", {
     id: "site-search-text",


### PR DESCRIPTION
## What
- Modify search toggle button to use button markup instead of an anchor tag, to more closely match the presentation and function of this element.
- Hide element when Javascript is disabled as the element is not functional without JS.
- Modify element text to more accurately represent what the element does ("Show/Hide search" depending on the state)

## Why
The button that opens/closes the layout header search form on mobile is not actually a button, but an anchor tag. Therefore, it does not behave as a button (for instance, it does not activate when using the space key)

This is semantically incorrect and cannot be easily understood by screen reader users, or used by voice control users.


<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
