### PR TITLE
Remove jQuery from toggle-input-class JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove jQuery from toggle-input-class JS ([PR #1683](https://github.com/alphagov/govuk_publishing_components/pull/1683))
+
 ## 26.65.1
 
 * Fix search box label colour ([PR #1680](https://github.com/alphagov/govuk_publishing_components/pull/1680))

--- a/app/assets/javascripts/govuk_publishing_components/lib/toggle-input-class-on-focus.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/toggle-input-class-on-focus.js
@@ -1,36 +1,41 @@
+//= require govuk/vendor/polyfills/Element/prototype/classList.js
 /*
   Toggle the class 'focus' on input boxes on element focus/blur
   Used by the search component but generic enough for reuse
 */
+window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  'use strict'
+  function GemToggleInputClassOnFocus () { }
 
-  Modules.GemToggleInputClassOnFocus = function () {
-    this.start = function ($el) {
-      var $toggleTarget = $el.find('.js-class-toggle')
+  GemToggleInputClassOnFocus.prototype.start = function ($module) {
+    this.$module = $module[0]
+    this.toggleTarget = this.$module.querySelector('.js-class-toggle')
+    this.$module.addFocusClass = this.addFocusClass.bind(this)
+    this.$module.removeFocusClassFromEmptyInput = this.removeFocusClassFromEmptyInput.bind(this)
 
-      if (!inputIsEmpty()) {
-        addFocusClass()
-      }
+    if (!this.inputIsEmpty()) {
+      this.addFocusClass()
+    }
 
-      $toggleTarget.on('focus', addFocusClass)
-      $toggleTarget.on('blur', removeFocusClassFromEmptyInput)
+    this.toggleTarget.addEventListener('focus', this.$module.addFocusClass)
+    this.toggleTarget.addEventListener('blur', this.$module.removeFocusClassFromEmptyInput)
+  }
 
-      function inputIsEmpty () {
-        return $toggleTarget.val() === ''
-      }
+  GemToggleInputClassOnFocus.prototype.inputIsEmpty = function () {
+    return this.toggleTarget.value === ''
+  }
 
-      function addFocusClass () {
-        $toggleTarget.addClass('focus')
-      }
+  GemToggleInputClassOnFocus.prototype.addFocusClass = function () {
+    this.toggleTarget.classList.add('focus')
+  }
 
-      function removeFocusClassFromEmptyInput () {
-        if (inputIsEmpty()) {
-          $toggleTarget.removeClass('focus')
-        }
-      }
+  GemToggleInputClassOnFocus.prototype.removeFocusClassFromEmptyInput = function () {
+    if (this.inputIsEmpty()) {
+      this.toggleTarget.classList.remove('focus')
     }
   }
+
+  Modules.GemToggleInputClassOnFocus = GemToggleInputClassOnFocus
 })(window.GOVUK.Modules)

--- a/spec/javascripts/components/toggle-input-class-on-focus-spec.js
+++ b/spec/javascripts/components/toggle-input-class-on-focus-spec.js
@@ -22,12 +22,12 @@ describe('A toggle class module', function () {
     })
 
     it('applies the focus style on focus and removes it on blur', function () {
-      var searchInput = element.find('.js-class-toggle')
-      expect(searchInput.is('.focus')).toBe(false)
-      searchInput.triggerHandler('focus')
-      expect(searchInput.is('.focus')).toBe(true)
-      searchInput.triggerHandler('blur')
-      expect(searchInput.is('.focus')).toBe(false)
+      var searchInput = document.querySelector('.js-class-toggle')
+      expect(searchInput).not.toHaveClass('focus')
+      searchInput.dispatchEvent(new window.Event('focus'))
+      expect(searchInput).toHaveClass('focus')
+      searchInput.dispatchEvent(new window.Event('blur'))
+      expect(searchInput).not.toHaveClass('focus')
     })
   })
 


### PR DESCRIPTION
## What
Remove jQuery dependence from toggle-input-class JS script (used by the search component).

## Why
To reduce our dependency on jQuery.

## Visual Changes
None.
