### PR TITLE
Feedback form errors frontend workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix search box label colour ([PR #1680](https://github.com/alphagov/govuk_publishing_components/pull/1680))
+* Feedback form errors frontend workaround ([PR #1684](https://github.com/alphagov/govuk_publishing_components/pull/1684))
 
 ## 21.65.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -8,19 +8,23 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Modules.Feedback = function () {
     this.start = function ($element) {
+      this.element = $element[0]
+      this.somethingIsWrongForm = this.element.querySelector('#something-is-wrong')
+      this.surveyForm = this.element.querySelector('#page-is-not-useful')
       this.$prompt = $element.find('.js-prompt')
       this.$fields = $element.find('.gem-c-feedback__form-field')
       this.$forms = $element.find('.js-feedback-form')
       this.$toggleForms = $element.find('.js-toggle-form')
       this.$closeForms = $element.find('.js-close-form')
+      this.activeForm = false
       this.$activeForm = false
       this.$pageIsUsefulButton = $element.find('.js-page-is-useful')
       this.$pageIsNotUsefulButton = $element.find('.js-page-is-not-useful')
       this.$somethingIsWrongButton = $element.find('.js-something-is-wrong')
       this.$promptQuestions = $element.find('.js-prompt-questions')
       this.$promptSuccessMessage = $element.find('.js-prompt-success')
-      this.$somethingIsWrongForm = $element.find('#something-is-wrong')
-      this.$surveyForm = $element.find('#page-is-not-useful')
+      this.$somethingIsWrongForm = $(this.somethingIsWrongForm)
+      this.$surveyForm = $(this.surveyForm)
       this.$surveyWrapper = $element.find('#survey-wrapper')
 
       var that = this
@@ -103,23 +107,23 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       function setHiddenValues () {
         that.$somethingIsWrongForm.append('<input type="hidden" name="javascript_enabled" value="true"/>')
         that.$somethingIsWrongForm.append($('<input type="hidden" name="referrer">').val(document.referrer || 'unknown'))
-        that.$somethingIsWrongForm.data('invalidInfoError', [
+        that.somethingIsWrongForm.invalidInfoError = [
           '<h2>',
           '  Sorry, we’re unable to send your message as you haven’t given us any information.',
           '</h2>',
           '<p>Please tell us what you were doing or what went wrong</p>'
-        ].join(''))
+        ].join('')
       }
 
       function setHiddenValuesNotUsefulForm (gaClientId) {
         var currentPathName = window.location.pathname.replace(/[^\s=?&]+(?:@|%40)[^\s=?&]+/, '[email]')
         var finalPathName = encodeURI(currentPathName)
-        that.$surveyForm.data('invalidInfoError', [
+        that.surveyForm.invalidInfoError = [
           '<h2>',
           '  Sorry, we’re unable to send your message as you haven’t given us a valid email address. ',
           '</h2>',
           '<p>Enter an email address in the correct format, like name@example.com</p>'
-        ].join(''))
+        ].join('')
         if (document.querySelectorAll('[name="email_survey_signup[ga_client_id]"]').length === 0) {
           that.$surveyForm.append($('<input name="email_survey_signup[ga_client_id]" type="hidden">').val(gaClientId || '0'))
         }
@@ -135,7 +139,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function toggleForm (formId) {
-        that.$activeForm = $element.find('#' + formId)
+        that.activeForm = that.element.querySelector('#' + formId)
+        that.$activeForm = $(that.activeForm)
         that.$activeForm.toggleClass(jshiddenClass)
         that.$prompt.toggleClass(jshiddenClass)
 
@@ -169,11 +174,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           '<p>If the problem persists, we have other ways for you to provide',
           ' feedback on the <a href="/contact/govuk">contact page</a>.</p>'
         ].join('')
-
         // if the response is not a 404 or 500, show the error message if it exists
         // otherwise show the generic message
-        // this covers the 422 status the feedback application return for empty fields
-        // for all other, show generic error
         if (typeof (error.responseJSON) !== 'undefined') {
           error = typeof (error.responseJSON.message) === 'undefined' ? genericError : error.responseJSON.message
 
@@ -181,8 +183,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
             error = genericError
           }
         } else if (error.status === 422) {
-          error = that.$activeForm.data('invalidInfoError') || genericError
+          // there's clobbering by nginx on all 422 requests, which is why the response returns a rendered html page instead of the expected JSON
+          // this is a temporary workaround to ensure that are are displaying relevant error messages to the users
+          error = that.activeForm.invalidInfoError || genericError
         } else {
+          // for all other, show generic error
           error = genericError
         }
         var $errors = that.$activeForm.find('.js-errors')

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -103,12 +103,23 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       function setHiddenValues () {
         that.$somethingIsWrongForm.append('<input type="hidden" name="javascript_enabled" value="true"/>')
         that.$somethingIsWrongForm.append($('<input type="hidden" name="referrer">').val(document.referrer || 'unknown'))
+        that.$somethingIsWrongForm.data('invalidInfoError', [
+          '<h2>',
+          '  Sorry, we’re unable to send your message as you haven’t given us any information.',
+          '</h2>',
+          '<p>Please tell us what you were doing or what went wrong</p>'
+        ].join(''))
       }
 
       function setHiddenValuesNotUsefulForm (gaClientId) {
         var currentPathName = window.location.pathname.replace(/[^\s=?&]+(?:@|%40)[^\s=?&]+/, '[email]')
         var finalPathName = encodeURI(currentPathName)
-
+        that.$surveyForm.data('invalidInfoError', [
+          '<h2>',
+          '  Sorry, we’re unable to send your message as you haven’t given us a valid email address. ',
+          '</h2>',
+          '<p>Enter an email address in the correct format, like name@example.com</p>'
+        ].join(''))
         if (document.querySelectorAll('[name="email_survey_signup[ga_client_id]"]').length === 0) {
           that.$surveyForm.append($('<input name="email_survey_signup[ga_client_id]" type="hidden">').val(gaClientId || '0'))
         }
@@ -169,6 +180,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           if (error === 'email survey sign up failure') {
             error = genericError
           }
+        } else if (error.status === 422) {
+          error = that.$activeForm.data('invalidInfoError') || genericError
         } else {
           error = genericError
         }


### PR DESCRIPTION
## Why
This aims to address issues with WCAG SC: 3.3.1 and 3.3.3 for the "No" and "Is there anything wrong with this page?" feedback forms. 
When submitting an empty form, the erroring fields are not identified. [3.3.1]
When submitting an empty form, the error message is very vague. [3.3.3]

There was a previous attempt to fix this issue here https://github.com/alphagov/feedback/pull/758

Here is what happens when there is an attempt to submit the form without any data.
The generic "something went wrong" message is displayed – this is unhelpful to the user as they cannot identify what went wrong:
![image](https://user-images.githubusercontent.com/7116819/92921787-9e4ff500-f42c-11ea-82e7-46ce31df83d4.png)



## What

When invalid data is submitted, the server responds with a `422` status.
However instead of the intended JSON response, it returns a rendered html page. The frontend defaults to the generic error message which is very vague and fails WCAG.

This is tricky to fix from the backend side right now as there is clobbering by nginx on all `422` requests. This implements a frontend workaround for the time being. If a JSON response is not present, and the status code is `422`, the frontend generates the error messages that would have otherwise been sent over from the backend. The error messages were copied from here https://github.com/alphagov/feedback/pull/758 

https://trello.com/c/2D0Dyn7k


## Visual Changes
Before: invalid email address, generic error message:
![image](https://user-images.githubusercontent.com/7116819/92922057-13bbc580-f42d-11ea-958f-bd67ac163639.png)

Before: invalid email address, more relevant error message:
<img width="985" alt="Screenshot 2020-09-11 at 12 49 22" src="https://user-images.githubusercontent.com/7116819/92922167-4796eb00-f42d-11ea-937b-b3dae97d592c.png">

