### PR TITLE
Remove aria-current="false" from breadcrumbs

### DIFF
--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -17,16 +17,13 @@
   <ol class="govuk-breadcrumbs__list">
     <% breadcrumbs.each_with_index do |crumb, index| %>
       <% breadcrumb = GovukPublishingComponents::Presenters::Breadcrumb.new(crumb, index) %>
-        <li class="govuk-breadcrumbs__list-item" aria-current="<%= breadcrumb.aria_current %>">
+        <li class="govuk-breadcrumbs__list-item">
         <% if breadcrumb.is_link? %>
           <%= link_to(
             breadcrumb[:title],
             breadcrumb.path,
             data: breadcrumb.tracking_data(breadcrumbs.length),
             class: "govuk-breadcrumbs__link",
-            aria: {
-              current: breadcrumb.aria_current,
-            }
           ) %>
         <% else %>
           <%= breadcrumb[:title] %>

--- a/lib/govuk_publishing_components/presenters/breadcrumbs.rb
+++ b/lib/govuk_publishing_components/presenters/breadcrumbs.rb
@@ -49,10 +49,6 @@ module GovukPublishingComponents
         crumb[:url]
       end
 
-      def aria_current
-        "false"
-      end
-
       def tracking_data(breadcrumbs_length)
         data = {
           track_category: "breadcrumbClicked",


### PR DESCRIPTION
## What
Removes all instances of `aria-current="false"` from the breadcrumbs component.

## Why
[Aria-current="false" has no semantic meaning and is the default attribute for aria-current](https://www.digitala11y.com/aria-current-state/). As there's no need for it on either the list or link item and we don't display the current breadcrumb as a rule, it makes more sense to not use it and keep our markup tidy.

No visual changes.
