### PR TITLE
Add locale attribute to notice component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove jQuery from toggle-input-class JS ([PR #1683](https://github.com/alphagov/govuk_publishing_components/pull/1683))
+* Add locale attribute to notice component ([PR #1686](https://github.com/alphagov/govuk_publishing_components/pull/1686))
 * Remove aria-expanded attribute from yes feedback button ([PR #1687](https://github.com/alphagov/govuk_publishing_components/pull/1687))
 
 ## 26.65.1

--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -4,6 +4,7 @@
   description_govspeak ||= false
   description ||= yield || false
   aria_live ||= false
+  lang = local_assigns[:lang].presence
   local_assigns[:margin_bottom] ||= 8
   local_assigns[:margin_bottom] = 8 if local_assigns[:margin_bottom] > 9
 
@@ -17,7 +18,7 @@
   description_present = description.present? || description_text.present? || description_govspeak.present?
 %>
 <% if title || description_present %>
-  <%= tag.section class: css_classes, aria: aria_attributes, role: "region" do %>
+  <%= tag.section class: css_classes, aria: aria_attributes, lang: lang, role: "region" do %>
     <% if title %>
       <% if description_present %>
         <%= tag.h2 title, class: "gem-c-notice__title" %>

--- a/app/views/govuk_publishing_components/components/docs/notice.yml
+++ b/app/views/govuk_publishing_components/components/docs/notice.yml
@@ -42,3 +42,11 @@ examples:
       title: 'Your settings have been saved'
       description_govspeak: <p>This is a confirmation message to tell you your settings have been saved</p>
       aria_live: true
+  with_locale:
+    description: |
+      Passing a lang value allows the content of the notice to be labelled as being a different language from surrounding content.
+      The lang attribute must be set to a [valid BCP47 string](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang#Language_tag_syntax). A valid code can be the two or three letter language code - for example, English is en or eng, Korean is ko or kor - but if in doubt please check.
+    data:
+      title: 'This publication was withdrawn on 30 September 2015'
+      description_govspeak: <p>This document is no longer current. We published a new version on 30 September 2015.</p>
+      lang: 'en'

--- a/spec/components/notice_spec.rb
+++ b/spec/components/notice_spec.rb
@@ -76,4 +76,14 @@ describe "Notice", type: :view do
     render_component(title: "Your settings have been saved", aria_live: true)
     assert_select ".gem-c-notice[aria-live=polite]"
   end
+
+  it "adds a lang attribute when lang is provided" do
+    render_component(title: "Your settings have been saved", lang: "en")
+    assert_select ".gem-c-notice[lang=en]"
+  end
+
+  it "adds no lang attribute when lang is not provided" do
+    render_component(title: "Your settings have been saved")
+    assert_select ".gem-c-notice[lang=en]", false
+  end
 end


### PR DESCRIPTION
## What
This is the first part of https://trello.com/c/k5JCHIoZ/382-add-language-attribute-to-withdrawn-banner

This allows us to pass in a lang attribute which is necessary when the notice is in a different language from the rest of the page. The specific use case identified so far is in Withdrawn notices appearing on translated pages.

## Visual Changes
No visual changes, just an extra attribute.
