### PR TITLE
Remove aria-expanded attribute from yes feedback button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove jQuery from toggle-input-class JS ([PR #1683](https://github.com/alphagov/govuk_publishing_components/pull/1683))
+* Remove aria-expanded attribute from yes feedback button ([PR #1687](https://github.com/alphagov/govuk_publishing_components/pull/1687))
 
 ## 26.65.1
 

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -26,7 +26,6 @@
             'track-category' => 'yesNoFeedbackForm',
             'track-action' => 'ffYesClick'
           },
-          'aria-expanded': false,
           role: 'button',
         } do %>
           <%= t("components.feedback.yes", default: "Yes") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_useful", default: "this page is useful") %></span>


### PR DESCRIPTION
## What
Remove `aria-expanded="false"` from the yes button on the feedback component.

## Why
This attribute doesn't change when the user clicks yes and even then, nothing "expands" even though something is revealed. This attribute is redundant as it's not being used and can be confusing to screen reader users as they're expecting something to expand when they interact with the button.

No visual changes.

**Card:** https://trello.com/b/NLbahOWX/govuk-accessibility-doing