### PR TITLE
Bump gem version to 21.65.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.65.2
 
 * Remove jQuery from toggle-input-class JS ([PR #1683](https://github.com/alphagov/govuk_publishing_components/pull/1683))
+* Remove aria-current="false" from breadcrumbs ([PR #1685](https://github.com/alphagov/govuk_publishing_components/pull/1685))
 * Add locale attribute to notice component ([PR #1686](https://github.com/alphagov/govuk_publishing_components/pull/1686))
 * Remove aria-expanded attribute from yes feedback button ([PR #1687](https://github.com/alphagov/govuk_publishing_components/pull/1687))
 
-## 26.65.1
+## 21.65.1
 
 * Fix search box label colour ([PR #1680](https://github.com/alphagov/govuk_publishing_components/pull/1680))
 * Feedback form errors frontend workaround ([PR #1684](https://github.com/alphagov/govuk_publishing_components/pull/1684))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.65.1)
+    govuk_publishing_components (21.65.2)
       govuk_app_config
       kramdown
       plek
@@ -105,7 +105,7 @@ GEM
       rest-client (~> 2.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk_app_config (2.2.2)
+    govuk_app_config (2.3.0)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 3.1.0)
       statsd-ruby (~> 1.4.0)
@@ -220,7 +220,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.4)
-    rouge (3.22.0)
+    rouge (3.23.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.65.1".freeze
+  VERSION = "21.65.2".freeze
 end


### PR DESCRIPTION
This release PR is to fix a mixup with the changelog for the live gem. Tidies up the changelog so that there aren't any unreleased features.