### PR TITLE
Fix magna charta span width bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix magna charta span width bug ([PR #1691](https://github.com/alphagov/govuk_publishing_components/pull/1691)) FIX
+
 ## 21.66.0
 
 * Remove jQuery from toggle-input-class JS ([PR #1683](https://github.com/alphagov/govuk_publishing_components/pull/1683))

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
@@ -396,14 +396,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var $cell = cells[i]
       var cellVal = parseFloat(this.utils.stripValue($cell.innerText), 10)
       var $cellSpan = $cell.querySelector('span')
-      var spanWidth = parseFloat(window.getComputedStyle($cellSpan, null).width.replace('px', '')) + 10 // +10 just for extra padding
-      var cellWidth = parseFloat(window.getComputedStyle($cell, null).width.replace('px', ''))
+      var spanWidth = $cell.querySelector('span').offsetWidth + 5 // +5 just for extra padding
+      var cellWidth = $cell.offsetWidth
 
       if (!this.options.stacked) {
       // if it's 0, it is effectively outdented
         if (cellVal === 0) { $cell.classList.add('mc-bar-outdented') }
 
-        if ((this.options.autoOutdent && spanWidth > cellWidth) || this.options.outdentAll) {
+        if ((this.options.autoOutdent && spanWidth >= cellWidth) || this.options.outdentAll) {
           $cell.classList.add('mc-bar-outdented')
           $cellSpan.style.marginLeft = '100%'
           $cellSpan.style.display = 'inline-block'

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -188,6 +188,12 @@ examples:
             <tr>
               <td>row 2</td><td>15</td>
             </tr>
+            <tr>
+              <td>row 3</td><td>2</td>
+            </tr>
+            <tr>
+              <td>row 4</td><td>48</td>
+            </tr>
           </tbody>
         </table>
   chart_with_colours:


### PR DESCRIPTION
## What
Amends the js for magna charta (charts for govspeak) to fix a bug on charts.

## Why
[A user has pointed out a bug on barcharts](https://www.gov.uk/government/publications/uk-house-price-index-summary-march-2020/uk-house-price-index-summary-march-2020#housing-transaction-distributions). Some investigation found that the `mc-bar-outdented` class isn't being applying where it needs to be because the `spanWidth` variable was returning NaN (because the computed style width was returning auto instead of an actual px value).

This amends the js to use `offsetWidth` instead, returning the class addition to it's intended functionality.

## Visual Changes

### Before
![Screenshot 2020-09-15 at 11 12 13](https://user-images.githubusercontent.com/64783893/93198851-7bcc1d80-f745-11ea-8c8a-cdb66b2591c1.png)

### After
![Screenshot 2020-09-15 at 11 12 36](https://user-images.githubusercontent.com/64783893/93198866-7e2e7780-f745-11ea-9615-926cee6ae079.png)
