### PR TITLE
Swap out ol for ul on documents list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+
+## Unreleased
+
+* Swap out ol for ul on documents list ([PR #1694](https://github.com/alphagov/govuk_publishing_components/pull/1694)) FIX
+
 ## 21.66.1
 
 * Fix magna charta span width bug ([PR #1691](https://github.com/alphagov/govuk_publishing_components/pull/1691)) FIX

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -15,7 +15,7 @@
 %>
 <% if items.any? %>
   <% unless within_multitype_list %>
-    <ol class="<%= classes %>">
+    <ul class="<%= classes %>">
   <% end %>
     <% items.each do |item| %>
       <% highlight_class = " gem-c-document-list__item--highlight" if item[:highlight] %>
@@ -112,6 +112,6 @@
       </li>
     <% end %>
   <% unless within_multitype_list %>
-    </ol>
+    </ul>
   <% end %>
 <% end %>


### PR DESCRIPTION
## What
Swap out the containing `ol` on the document list component for a `ul` instead.

## Why
It's inappropriate for document lists to sit within an ordered list as they don't convey that they are ordered through presentation. This fails WCAG 1.3.1 as a result.

No visual changes.

**Card:** https://trello.com/c/zeNDQ9hA/374-ordered-list-used-when-list-is-not-ordered
