### PR TITLE
Reorder image card elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add default aria-label for contents list component ([PR #1698](https://github.com/alphagov/govuk_publishing_components/pull/1698))
+* Reorder image card elements ([PR #1695](https://github.com/alphagov/govuk_publishing_components/pull/1695)) FIX
 
 ## 21.66.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -3,6 +3,25 @@
   @include govuk-text-colour;
   position: relative;
   margin-bottom: govuk-spacing(6);
+  display: flex;
+  display: -ms-flexbox;
+  flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+
+  @include govuk-media-query($from: mobile, $until: tablet) {
+    display: block;
+
+    .gem-c-image-card__text-wrapper {
+      float: right;
+      padding-left: 0;
+    }
+  }
+}
+
+.gem-c-image-card__header-and-context-wrapper {
+  display: flex;
+  flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
 }
 
 .gem-c-image-card__image-wrapper {
@@ -135,7 +154,11 @@
 }
 
 .gem-c-image-card--large.gem-c-image-card {
+  display: flex;
   margin: 0 0 govuk-spacing(6) 0;
+  @include govuk-media-query($from: tablet) {
+    display: block;
+  }
 }
 
 .gem-c-image-card--large {
@@ -161,6 +184,7 @@
     overflow: hidden;
 
     @include govuk-media-query($from: tablet) {
+      float: right;
       padding: 0 govuk-spacing(3);
       margin-bottom: 0;
     }
@@ -178,5 +202,14 @@
 
   .gem-c-image-card__description {
     @include govuk-font(19);
+  }
+}
+
+.gem-c-image-card--no-image {
+  .gem-c-image-card__text-wrapper {
+    @include govuk-media-query($from: mobile, $until: tablet) {
+      float: left;
+      padding: 0 govuk-spacing(3);
+    }
   }
 }

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -3,32 +3,32 @@
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
   card_helper = GovukPublishingComponents::Presenters::ImageCardHelper.new(local_assigns)
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  classes = "gem-c-image-card"
+  classes << " gem-c-image-card--large" if card_helper.large
+  classes << " gem-c-image-card--no-image" unless defined?(image_src)
 %>
 <% if card_helper.href || card_helper.extra_links.any? %>
-  <div class="gem-c-image-card <%= "gem-c-image-card--large" if card_helper.large %> <%= brand_helper.brand_class %>"
+  <div class="<%= classes %> <%= brand_helper.brand_class %>"
     <%= "data-module=track-click" if card_helper.is_tracking? %>
     <%= "lang=#{card_helper.lang}" if card_helper.lang %>>
-    <%= card_helper.image %>
-
     <div class="gem-c-image-card__text-wrapper">
-      <%= card_helper.context %>
-
-      <% if card_helper.heading_text %>
-        <%= content_tag(shared_helper.get_heading_level,
-          class: "gem-c-image-card__title") do %>
-            <% if card_helper.href %>
-              <%= link_to card_helper.heading_text, card_helper.href,
-                class: "gem-c-image-card__title-link #{brand_helper.color_class}",
-                data: card_helper.href_data_attributes
-              %>
-            <% else %>
-              <%= card_helper.heading_text %>
-            <% end %>
+      <div class="gem-c-image-card__header-and-context-wrapper">
+        <% if card_helper.heading_text %>
+          <%= content_tag(shared_helper.get_heading_level,
+            class: "gem-c-image-card__title") do %>
+              <% if card_helper.href %>
+                <%= link_to card_helper.heading_text, card_helper.href,
+                  class: "gem-c-image-card__title-link #{brand_helper.color_class}",
+                  data: card_helper.href_data_attributes
+                %>
+              <% else %>
+                <%= card_helper.heading_text %>
+              <% end %>
+          <% end %>
         <% end %>
-      <% end %>
-
+        <%= card_helper.context %>
+      </div>
       <%= card_helper.description %>
-
       <% if card_helper.extra_links.any? %>
         <ul class="gem-c-image-card__list <%= "gem-c-image-card__list--indented" if not card_helper.extra_links_no_indent %>">
           <% card_helper.extra_links.each do |link| %>
@@ -41,10 +41,10 @@
           <% end %>
         </ul>
       <% end %>
-
       <% if card_helper.metadata %>
         <p class="gem-c-image-card__metadata"><%= card_helper.metadata %></p>
       <% end %>
     </div>
+    <%= card_helper.image %>
   </div>
 <% end %>

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -77,6 +77,11 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card__list-item .brand__color"
   end
 
+  it "labels a no-image version" do
+    render_component(href: "#", heading_text: "test", extra_links: [{ href: "/1", text: "link1" }], brand: "attorney-generals-office")
+    assert_select ".gem-c-image-card--no-image"
+  end
+
   it "renders a large version" do
     render_component(href: "#", large: true)
     assert_select ".gem-c-image-card.gem-c-image-card--large"


### PR DESCRIPTION
## What

https://trello.com/c/mprRX2H8/376-confusing-order-of-content-for-featured-items-on-organisation-pages

Previously the source content for the image card was in a confusing order. Although it was clear from the design which elements belonged together, this was not reflected in the underlying page, with the heading coming after the image and contextual text. This switches the elements around and then uses CSS to realign them as before.

Order before:
- image
- context
- heading
- description and links

Order afterwards: 
- heading
- context
- description and links
- image

## Why
This improves the semantics of the page source and means that users who linearise the page will see the content and headings more clearly associated.

## Visual Changes
There are no intended visual changes. These screenshots are the updated code plugged into a collections page (http://collections.dev.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy) :

![Screenshot 2020-09-17 at 14 52 46](https://user-images.githubusercontent.com/31649453/93480773-b674b800-f8f5-11ea-884f-898666dcebd2.png)
![Screenshot 2020-09-17 at 14 53 01](https://user-images.githubusercontent.com/31649453/93480781-b7a5e500-f8f5-11ea-9b1a-f5167a10d718.png)
![Screenshot 2020-09-17 at 14 53 26](https://user-images.githubusercontent.com/31649453/93480782-b83e7b80-f8f5-11ea-86a0-d8f595a40ed7.png)

