### PR TITLE
Search toggle inner text fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Unreleased
 
 * Swap out ol for ul on documents list ([PR #1694](https://github.com/alphagov/govuk_publishing_components/pull/1694)) FIX
+* Search toggle inner text fix ([PR #1696](https://github.com/alphagov/govuk_publishing_components/pull/1696)) FIX
 
 ## 21.66.1
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
@@ -13,6 +13,7 @@
         var target = this.getAttribute('href') ? document.getElementById(this.getAttribute('href').substr(1)) : document.getElementById(this.getAttribute('data-search-toggle-for'))
         var targetClass = target.getAttribute('class') || ''
         var sourceClass = this.getAttribute('class') || ''
+        var isSearchToggle = sourceClass.match('search-toggle')
 
         if (targetClass.indexOf('js-visible') !== -1) {
           target.setAttribute('class', targetClass.replace(/(^|\s)js-visible(\s|$)/, ''))
@@ -21,10 +22,14 @@
         }
         if (sourceClass.indexOf('js-visible') !== -1) {
           this.setAttribute('class', sourceClass.replace(/(^|\s)js-visible(\s|$)/, ''))
-          this.innerText = 'Show search'
+          if (isSearchToggle) {
+            this.innerText = 'Show search'
+          }
         } else {
           this.setAttribute('class', sourceClass + ' js-visible')
-          this.innerText = 'Hide search'
+          if (isSearchToggle) {
+            this.innerText = 'Hide search'
+          }
         }
         this.setAttribute('aria-expanded', this.getAttribute('aria-expanded') !== 'true')
         target.setAttribute('aria-hidden', target.getAttribute('aria-hidden') === 'false')


### PR DESCRIPTION
## What
Only change header toggle button inner text to "show/hide search" depending on open/closed state if the target is the search toggle button.

## Why
The search menu uses the same `js-header-toggle` class as the search toggle button in the site header on mobile.

This lead to an issue where the secondary navigation toggle button text would change to "Show/Hide search", which was only supposed to be applied to the search toggle.

### PROBLEM ❌
<img width="498" alt="Screenshot 2020-09-18 at 09 58 59" src="https://user-images.githubusercontent.com/7116819/93578963-d3f95e80-f995-11ea-8f5d-eaa7897b6c74.png">
<img width="502" alt="Screenshot 2020-09-18 at 09 59 09" src="https://user-images.githubusercontent.com/7116819/93578968-d52a8b80-f995-11ea-892e-664d461dfd45.png">


## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
Fixes aforementioned problem. The toggle text for the header links should be "Menu", not "Hide/show search"
