### PR TITLE
Bump gem to 21.66.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   of the commit log.
 
 
-## Unreleased
+## 21.66.2
 
 * Swap out ol for ul on documents list ([PR #1694](https://github.com/alphagov/govuk_publishing_components/pull/1694)) FIX
 * Search toggle inner text fix ([PR #1696](https://github.com/alphagov/govuk_publishing_components/pull/1696)) FIX

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.66.1)
+    govuk_publishing_components (21.66.2)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.66.1".freeze
+  VERSION = "21.66.2".freeze
 end


### PR DESCRIPTION
Bumps `govuk_publishing_components` to 21.66.2.

Includes:
* Swap out ol for ul on documents list ([PR #1694](https://github.com/alphagov/govuk_publishing_components/pull/1694)) FIX
* Search toggle inner text fix ([PR #1696](https://github.com/alphagov/govuk_publishing_components/pull/1696)) FIX

