### PR TITLE
Add default aria-label for contents list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add default aria-label for contents list component ([PR #1698](https://github.com/alphagov/govuk_publishing_components/pull/1698))
 
 ## 21.66.2
 

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -1,6 +1,6 @@
 <%-
   cl_helper = GovukPublishingComponents::Presenters::ContentsListHelper.new(local_assigns)
-  aria_label ||= nil
+  aria_label ||= "Contents"
   format_numbers ||= false
   hide_title ||= false
 

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -17,9 +17,7 @@ accessibility_criteria: |
   - inform the user how many items are in the list
   - convey the content structure
   - indicate the current page when contents span different pages, and not link to itself
-
-  The contents list may:
-  - include an aria-label to contextualise the list if helpful
+  - include an aria-label to contextualise the list
 
   Links with formatted numbers must separate the number and text with a space for correct screen reader pronunciation. This changes pronunciation from "1 dot Item" to "1 Item".
 shared_accessibility_criteria:
@@ -67,8 +65,8 @@ examples:
           active: true
         - href: "#third-thing"
           text: Third thing
-  aria_label:
-    description: 'An aria-label string can be used to contextualise the navigation for assistive technology.'
+  with_custom_aria_label:
+    description: 'An aria-label string should be used to contextualise the navigation for assistive technology. Defaults to "Contents" if aria-label is not passed.'
     data:
       aria_label: "Pages in this guide"
       contents:

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -115,6 +115,11 @@ describe "Contents list", type: :view do
     assert_select "#{nested_link_selector} .gem-c-contents-list__numbered-text", count: 0
   end
 
+  it "defaults to an aria label of 'Contents' when aria label is not supplied" do
+    render_component(contents: contents_list_with_active_item)
+    assert_select ".gem-c-contents-list[aria-label=\"Contents\"]"
+  end
+
   it "aria label is rendered when supplied" do
     render_component(contents: contents_list_with_active_item, aria_label: "All pages in this guide")
     assert_select ".gem-c-contents-list[aria-label=\"All pages in this guide\"]"


### PR DESCRIPTION
## What
Updates aria label for the contents list component so that aria label
defaults to "Contents" unless a custom aria label is supplied.

## Why
The contents list component is a nav element, and often appears on pages which
have other nav elements. When there are multiple navigation landmarks on
a page, they should be labelled to help assistive technology users
differentiate between them.


<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->


<!-- What are the reasons behind this change being made? -->

## Visual Changes
No visual changes should occur as a result of this change.
<!-- If the change results in visual changes, show a before and after -->




https://trello.com/c/XFKhZwEI
