### PR TITLE
Replace feedback component links with buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add language attribute to feed box ([PR #1706](https://github.com/alphagov/govuk_publishing_components/pull/1706))
+* Replace feedback component links with buttons ([PR #1699](https://github.com/alphagov/govuk_publishing_components/pull/1699)) MINOR
 
 ## 21.66.4
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -173,7 +173,7 @@
 
 .gem-c-feedback__option-list-item:first-child {
   @include govuk-media-query($from: mobile) {
-    margin-right: govuk-spacing(4); 
+    margin-right: govuk-spacing(4);
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -11,7 +11,6 @@
 // hide without js
 // show with js, unless also has the js-hidden class
 .gem-c-feedback__js-show,
-.gem-c-feedback__form,
 .gem-c-feedback__prompt-success,
 .gem-c-feedback__prompt-questions,
 .gem-c-feedback__error-summary {
@@ -26,6 +25,24 @@
   }
 }
 
+// maintain table display for prompt and prompt-questions
+.js-enabled .gem-c-feedback__prompt {
+  @include govuk-media-query($from: tablet) {
+    display: table;
+  }
+}
+
+.js-enabled .gem-c-feedback__prompt-questions {
+  @include govuk-media-query($from: tablet) {
+    display: table-cell;
+  }
+}
+
+// show the default feedback form without js
+.js-enabled .gem-c-feedback__form.js-hidden {
+  display: none;
+}
+
 .gem-c-feedback__prompt-questions {
   text-align: center;
   border-bottom: 1px solid govuk-colour("white");
@@ -34,7 +51,7 @@
 
   @include govuk-media-query($from: tablet) {
     width: 50%;
-    float: left;
+    display: table-cell;
     text-align: left;
     border-bottom: 0;
   }
@@ -45,6 +62,8 @@
 
   @include govuk-media-query($from: tablet) {
     text-align: right;
+    vertical-align: bottom;
+    float: none;
   }
 }
 
@@ -53,6 +72,12 @@
   background-color: govuk-colour("blue");
   color: govuk-colour("white");
   outline: 0;
+
+  @include govuk-media-query($from: tablet) {
+    @include govuk-font(16, $weight: bold);
+    display: table;
+    width: 100%;
+  }
 }
 
 .gem-c-feedback__prompt-question,
@@ -65,13 +90,9 @@
 }
 
 .gem-c-feedback__prompt-question {
+  vertical-align: text-top;
   display: inline-block;
-
-  // There's a global h3 rule in some layouts that interferes with this component
-  margin: 0;
-
-  margin-left: govuk-spacing(4);
-  margin-right: govuk-spacing(4);
+  margin: govuk-spacing(2) govuk-spacing(4);
 
   &:focus {
     outline: 0;
@@ -79,13 +100,26 @@
 
   @include govuk-media-query($from: tablet) {
     margin-left: 0;
+    margin-top: 0;
+    display: block;
+  }
+
+  // This custom media-query is to account for some awkward positioning where the yes and no buttons are too big to sit inline with the prompt question
+  @include govuk-media-query($from: 950px) {
+    display: inline-block;
+    margin-top: govuk-spacing(2);
   }
 }
 
 .gem-c-feedback__prompt-link {
-  @include govuk-link-common;
   @include govuk-font(19);
-  display: inline-block;
+  box-shadow: 0 2px 0 govuk-colour("black");
+  min-width: 100%;
+
+  @include govuk-media-query($from: mobile) {
+    min-width: 100px;
+    margin-bottom: 0;
+  }
 
   @include govuk-media-query($from: tablet) {
     @include govuk-font(16);
@@ -116,12 +150,15 @@
 }
 
 .gem-c-feedback__option-list {
-  display: inline-block;
   list-style-type: none;
   margin: 0;
   padding: 0;
-  margin-right: govuk-spacing(2);
   margin-top: govuk-spacing(2);
+
+  @include govuk-media-query($from: mobile) {
+    display: inline-block;
+    margin-right: govuk-spacing(2);
+  }
 
   @include govuk-media-query($from: tablet) {
     margin-top: 0;
@@ -129,11 +166,15 @@
 }
 
 .gem-c-feedback__option-list-item {
-  display: inline-block;
+  @include govuk-media-query($from: mobile) {
+    display: inline-block;
+  }
 }
 
 .gem-c-feedback__option-list-item:first-child {
-  margin-right: govuk-spacing(7);
+  @include govuk-media-query($from: mobile) {
+    margin-right: govuk-spacing(4); 
+  }
 }
 
 // Feedback form styles
@@ -206,15 +247,8 @@
 }
 
 .gem-c-feedback__close {
-  @include govuk-link-common;
-  @include govuk-link-style-default;
-  @include govuk-font(19);
   float: right;
   margin: 0 govuk-spacing(1) govuk-spacing(2) 0;
-
-  @include govuk-media-query($from: tablet) {
-    padding-top: 0;
-  }
 }
 
 .gem-c-feedback__email-link {

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -4,13 +4,14 @@
   data-track-category="Onsite Feedback"
   data-track-action="GOV.UK Send Form"
   method="post">
-  <a href="#"
-    class="gem-c-feedback__close gem-c-feedback__js-show js-close-form"
+  <button
+    class="govuk-button govuk-button--secondary gem-c-feedback__close gem-c-feedback__js-show js-close-form"
     data-track-category="Onsite Feedback"
     data-track-action="GOV.UK Close Form"
     aria-controls="something-is-wrong"
-    aria-expanded="true"
-    role="button"><%= t("components.feedback.close", default: "Close") %></a>
+    aria-expanded="true">
+    <%= t("components.feedback.close", default: "Close") %>
+  </button>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -4,13 +4,14 @@
   data-track-category="yesNoFeedbackForm"
   data-track-action="Send Form"
   method="post">
-  <a href="#"
-    class="gem-c-feedback__close js-close-form"
+  <button
+    class="govuk-button govuk-button--secondary gem-c-feedback__close js-close-form"
     data-track-category="yesNoFeedbackForm"
     data-track-action="ffFormClose"
     aria-controls="page-is-not-useful"
-    aria-expanded="true"
-    role="button"><%= t("components.feedback.close", default: "Close") %></a>
+    aria-expanded="true">
+    <%= t("components.feedback.close", default: "Close") %>
+  </button>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds" id="survey-wrapper">

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -6,18 +6,10 @@
   <div class="gem-c-feedback__prompt-questions js-prompt-questions">
     <h2 class="gem-c-feedback__prompt-question"><%= t("components.feedback.is_this_page_useful", default: "Is this page useful?") %></h2>
     <!-- Maybe button exists only to try and capture clicks by bots -->
-    <%= link_to t("components.feedback.maybe", default: "Maybe"), contact_govuk_path, {
-        class: 'gem-c-feedback__prompt-link',
-        data: {
-          'track-category' => 'yesNoFeedbackForm',
-          'track-action' => 'ffMaybeClick'
-        },
-        'aria-expanded': false,
-        role: 'button',
-        style: 'display: none;',
-        hidden: 'hidden',
-        'aria-hidden': 'true',
-      } %>
+    <button class="govuk-button govuk-button--secondary gem-c-feedback__prompt-link" data-track-category="yesNoFeedbackForm" data-track-action="ffMaybeClick" aria-expanded="false" style="display: none" hidden="hidden" aria-hidden="true">
+      <%= t("components.feedback.maybe", default: "Maybe") %>
+    </button>
+    
     <ul class="gem-c-feedback__option-list">
       <li class="gem-c-feedback__option-list-item">
         <button class="govuk-button govuk-button--secondary gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -20,30 +20,14 @@
       } %>
     <ul class="gem-c-feedback__option-list">
       <li class="gem-c-feedback__option-list-item">
-        <%= link_to contact_govuk_path, {
-          class: 'gem-c-feedback__prompt-link js-page-is-useful',
-          data: {
-            'track-category' => 'yesNoFeedbackForm',
-            'track-action' => 'ffYesClick'
-          },
-          role: 'button',
-        } do %>
+        <button class="govuk-button govuk-button--secondary gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">
           <%= t("components.feedback.yes", default: "Yes") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_useful", default: "this page is useful") %></span>
-        <% end %>
+        </button>
       </li>
       <li class="gem-c-feedback__option-list-item">
-        <%= link_to contact_govuk_path, {
-          class: 'gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful',
-          data: {
-            'track-category' => 'yesNoFeedbackForm',
-            'track-action' => 'ffNoClick'
-          },
-          'aria-controls': 'page-is-not-useful',
-          'aria-expanded': false,
-          role: 'button',
-        } do %>
+        <button class="govuk-button govuk-button--secondary gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">
           <%= t("components.feedback.no", default: "No") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_not_useful", default: "this page is not useful") %></span>
-        <% end %>
+        </button>
       </li>
     </ul>
   </div>
@@ -51,17 +35,8 @@
     <%= t("components.feedback.thank_you_for_feedback", default: "Thank you for your feedback") %>
   </div>
   <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions">
-    <%= link_to contact_govuk_path, {
-      class: 'gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong',
-      data: {
-        'track-category' => 'Onsite Feedback',
-        'track-action' => 'GOV.UK Open Form'
-      },
-      'aria-controls': 'something-is-wrong',
-      'aria-expanded': false,
-      role: 'button',
-    } do %>
+    <button class="govuk-button govuk-button--secondary gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV-UK Open Form" aria-controls="something-is-wrong" aria-expanded="false">
       <%= t("components.feedback.anything_wrong", default: "Is there anything wrong with this page?") %>
-    <% end %>
+    </button>
   </div>
 </div>

--- a/spec/components/feedback_spec.rb
+++ b/spec/components/feedback_spec.rb
@@ -8,14 +8,14 @@ describe "Feedback", type: :view do
   it "asks the user if the page is useful without javascript enabled" do
     render_component({})
 
-    assert_select ".gem-c-feedback .gem-c-feedback__option-list-item .js-page-is-useful[href='/contact/govuk']", text: "Yes this page is useful"
-    assert_select ".gem-c-feedback .gem-c-feedback__option-list-item .js-page-is-not-useful[href='/contact/govuk']", text: "No this page is not useful"
+    assert_select ".gem-c-feedback .gem-c-feedback__option-list-item .js-page-is-useful", text: "Yes this page is useful"
+    assert_select ".gem-c-feedback .gem-c-feedback__option-list-item .js-page-is-not-useful", text: "No this page is not useful"
   end
 
   it "asks the user if there is anything wrong with the page without javascript enabled" do
     render_component({})
 
-    assert_select ".gem-c-feedback .gem-c-feedback__prompt-link.js-something-is-wrong[href='/contact/govuk']", text: "Is there anything wrong with this page?"
+    assert_select ".gem-c-feedback .gem-c-feedback__prompt-link.js-something-is-wrong", text: "Is there anything wrong with this page?"
   end
 
   it "has required email survey signup form fields" do


### PR DESCRIPTION
## What
Replaces links with `role="button"` on the feedback component for actual buttons. Based on mockups by a designer.

## Why
Controls are presented as links to seeing users but as buttons to screen reader users and they function like buttons. This can cause screen readers users to struggle to find information and can make it more difficult for voice control users to activate a link/button.

## Visual Changes
### Before
**Extra small**
![Screenshot 2020-09-18 at 17 48 53](https://user-images.githubusercontent.com/64783893/93624053-9e756500-f9d7-11ea-8fbb-bae88e875663.png)

**Mobile**
![Screenshot 2020-09-18 at 17 49 43](https://user-images.githubusercontent.com/64783893/93624061-a2a18280-f9d7-11ea-8c16-59dd2f329f29.png)

**Tablet**
![Screenshot 2020-09-18 at 17 50 01](https://user-images.githubusercontent.com/64783893/93624135-c5339b80-f9d7-11ea-8862-8239728ce74b.png)

**Desktop**
![Screenshot 2020-09-18 at 17 50 10](https://user-images.githubusercontent.com/64783893/93624122-bcdb6080-f9d7-11ea-8143-b1538bb3a3cd.png)

### After
**Extra small**
![Screenshot 2020-09-18 at 17 50 31](https://user-images.githubusercontent.com/64783893/93624153-cfee3080-f9d7-11ea-9c53-d560a1f9f9af.png)

**Mobile**
![Screenshot 2020-09-18 at 17 50 48](https://user-images.githubusercontent.com/64783893/93624160-d41a4e00-f9d7-11ea-8707-2c8aae08c6ae.png)

**Tablet**
![Screenshot 2020-09-18 at 17 51 11](https://user-images.githubusercontent.com/64783893/93624173-da102f00-f9d7-11ea-9427-cade4c78ab2f.png)

**Desktop**
![Screenshot 2020-09-18 at 17 51 26](https://user-images.githubusercontent.com/64783893/93624183-ded4e300-f9d7-11ea-97c2-60644f13a401.png)

**Card:** https://trello.com/c/N1VFz9Fv/395-feedback-component-buttons-that-look-like-links