### PR TITLE
Add lang option to organisation logo text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add lang option to organisation logo text ([PR #1700](https://github.com/alphagov/govuk_publishing_components/pull/1700))
 * Add default aria-label for contents list component ([PR #1698](https://github.com/alphagov/govuk_publishing_components/pull/1698))
 
 ## 21.66.2

--- a/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
+++ b/app/views/govuk_publishing_components/components/docs/organisation_logo.yml
@@ -191,3 +191,12 @@ examples:
         brand: cabinet-office
         crest: 'single-identity'
       inline: true
+  with-explicit-language:
+    description: The language attribute on the name of the organisation can be set if required. If this option is not passed, no lang attribute is set.
+    data:
+      organisation:
+        name: Tŷ'r Cwmnïau
+        url: '/government/organisations/companies-house.cy'
+        brand: department-for-business-innovation-skills
+        crest: 'single-identity'
+      lang: "cy"

--- a/lib/govuk_publishing_components/presenters/organisation_logo_helper.rb
+++ b/lib/govuk_publishing_components/presenters/organisation_logo_helper.rb
@@ -11,6 +11,7 @@ module GovukPublishingComponents
         @url = local_assigns[:organisation][:url]
         @crest = local_assigns[:organisation][:crest]
         @image = local_assigns[:organisation][:image] || false
+        @lang = local_assigns[:lang] || nil
         if @image
           @logo_image_src = local_assigns[:organisation][:image][:url] || false
           @logo_image_alt = local_assigns[:organisation][:image][:alt_text] || false
@@ -21,7 +22,7 @@ module GovukPublishingComponents
         if image
           image_tag(logo_image_src, alt: logo_image_alt, class: "gem-c-organisation-logo__image")
         else
-          content_tag("span", name, class: "gem-c-organisation-logo__name")
+          content_tag("span", name, class: "gem-c-organisation-logo__name", lang: @lang)
         end
       end
 

--- a/spec/components/organisation_logo_spec.rb
+++ b/spec/components/organisation_logo_spec.rb
@@ -100,4 +100,14 @@ describe "Organisation logo", type: :view do
     render_component(organisation: { name: "Name", url: "/some-link" }, inline: true)
     assert_select "a.gem-c-organisation-logo__container--inline"
   end
+
+  it "sets the language to en by default" do
+    render_component(organisation: { name: "Name" })
+    assert_select ".gem-c-organisation-logo__name[lang='en']", false
+  end
+
+  it "overrides the language when specified" do
+    render_component(organisation: { name: "Name" }, lang: "cy")
+    assert_select ".gem-c-organisation-logo__name[lang='cy']"
+  end
 end


### PR DESCRIPTION
## What
Add an option to set the `lang` attribute to the text of an organisation logo. If no option is passed, no lang attribute is set.

## Why
An accessibility audit of organisation pages has shown that pages such as https://www.gov.uk/world/organisations/british-consulate-general-chongqing.zh do not mark the org name in English, even though it is in English inside a page of a different language, which is an accessibility failure.

## Visual Changes
None.

Trello card: https://trello.com/c/bQn51uw9/392-update-language-attribute-of-organisation-name-on-world-organisation-embassy-pages
