### PR TITLE
Update step by step show/hide text to be more verbose for screen readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+
+## Unreleased
+
+* Update step by step show/hide text to be more verbose for screen readers ([PR #1701](https://github.com/alphagov/govuk_publishing_components/pull/1701)) FIX
+
 ## 21.67.1
 
 * Fix IE11 height bug on image card ([PR #1713](https://github.com/alphagov/govuk_publishing_components/pull/1713))

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -80,9 +80,21 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       if (!thisel.querySelectorAll('.js-toggle-link').length) {
         var span = document.createElement('span')
-        span.className = 'gem-c-step-nav__toggle-link js-toggle-link'
-        span.setAttribute('aria-hidden', true)
-        span.setAttribute('hidden', 'hidden')
+        var showHideSpan = document.createElement('span')
+        var commaSpan = document.createElement('span')
+        var thisSectionSpan = document.createElement('span')
+
+        showHideSpan.className = 'gem-c-step-nav__toggle-link js-toggle-link'
+        commaSpan.className = 'govuk-visually-hidden'
+        thisSectionSpan.className = 'govuk-visually-hidden'
+
+        commaSpan.innerHTML = ', '
+        thisSectionSpan.innerHTML = ' this section'
+
+        span.appendChild(commaSpan)
+        span.appendChild(showHideSpan)
+        span.appendChild(thisSectionSpan)
+
         thisel.querySelectorAll('.js-step-title-button')[0].appendChild(span)
       }
     }


### PR DESCRIPTION
## What
Removes the attributes from the text `show` (or `hide` if the step is open) [on the step by step nav component](https://components.publishing.service.gov.uk/component-guide/step_by_step_nav) that would hide it from assistive technologies and updates the surrounding markup to be more verbose for screen reader users. What is dictated to screen reader users before and after:

- Before: `Heading level 2, Do a thing` or, with show/hide hiding attributes removed, `heading level 2, Do a thing show`
- After: `Heading level 2, Do a thing, show this section`

## Why
A WCAG fail has been raised around the step by step nav component. Because show/hide are hidden from assistive tech, voice control users aren't able to dictate something like "click show" because their software wont be able to find it. This exposes the show/hide text to users and amends the surrounding markup so that what gets read out to screen reader users makes sense.

No visual changes.

**Card:** https://trello.com/c/auI7Wf4Y/373-step-nav-full-button-text-not-available-to-at


