### PR TITLE
Add aria-label to government_navigation component

### DIFF
--- a/app/views/govuk_publishing_components/components/_government_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_government_navigation.html.erb
@@ -2,7 +2,7 @@
   active ||= nil
 %>
 
-<nav id="proposition-menu" class="no-proposition-name gem-c-government-navigation">
+<nav id="proposition-menu" class="no-proposition-name gem-c-government-navigation" aria-label="Departments and policy navigation">
   <ul id="proposition-links">
     <li>
       <a class="<%= 'active' if active == 'departments' %>" href="/government/organisations">


### PR DESCRIPTION
## What
Adds a relevant `aria-label` to the government nav component.
Uses the suggested name of "Departments and policy navigation". This was
suggested because in the site footer the section containing the same
links is called "Departments and policy".


## Why
The reason for this change is that the site header links are a nav
element and often appears on pages where other nav elements are present.
When there are multiple navigation landmarks on a page, they should be
labelled in order to help assistive tech users differentiate between
them.

<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->


## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
No visual changes should occur as a result of this


https://trello.com/c/XFKhZwEI