### PR TITLE
Version 21.66.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.66.3
 
 * Add lang option to organisation logo text ([PR #1700](https://github.com/alphagov/govuk_publishing_components/pull/1700))
 * Add default aria-label for contents list component ([PR #1698](https://github.com/alphagov/govuk_publishing_components/pull/1698))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.66.2)
+    govuk_publishing_components (21.66.3)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.66.2".freeze
+  VERSION = "21.66.3".freeze
 end


### PR DESCRIPTION
## 21.66.3

* Add lang option to organisation logo text ([PR #1700](https://github.com/alphagov/govuk_publishing_components/pull/1700))
* Add default aria-label for contents list component ([PR #1698](https://github.com/alphagov/govuk_publishing_components/pull/1698))
