### PR TITLE
Add language attribute to feed box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add language attribute to feed box ([PR #1706](https://github.com/alphagov/govuk_publishing_components/pull/1706))
+
 ## 21.66.4
+
 * Reorder image card elements ([PR #1695](https://github.com/alphagov/govuk_publishing_components/pull/1695)) FIX
 
 ## 21.66.3

--- a/app/views/govuk_publishing_components/components/_subscription-links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription-links.html.erb
@@ -56,13 +56,15 @@
     <% if sl_helper.feed_link_box_value %>
       <div class="gem-c-subscription-links__feed-box js-hidden" id="<%= sl_helper.feed_box_id %>">
         <p class="gem-c-subscription-links__feed-hidden-description visuallyhidden"><%= sl_helper.feed_link_text %></p>
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: "Copy and paste this URL into your feed reader"
-          },
-          name: "feed-reader-box",
-          value: feed_link_box_value
-        } %>
+        <div lang="en">
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: "Copy and paste this URL into your feed reader"
+            },
+            name: "feed-reader-box",
+            value: feed_link_box_value
+          } %>
+        </div>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
## What
Add `lang="en"` to the element that can appear when the feed link is configured to toggle a box for copying and pasting the link.

<img width="897" alt="Screenshot 2020-09-22 at 17 07 48" src="https://user-images.githubusercontent.com/861310/93908147-33d56980-fcf6-11ea-99cf-4dddd0c9179c.png">

Added a new element for this to wrap the input and label only, because for some reason the text of the feed link is repeated inside the existing wrapping element, which is passed to the component and cannot be guaranteed to be English, as opposed to the rest of the text, which comes from the component and is.

## Why
Needed on pages like https://www.gov.uk/world/taiwan/news.zh-tw

## Visual Changes
None.

Trello card: https://trello.com/c/T0DDhI5x/391-update-language-attribute-in-subscription-links-component-of-world-organisation-embassy-pages
