### PR TITLE
Fix IE11 height bug on image card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix IE11 height bug on image card ([PR #1713](https://github.com/alphagov/govuk_publishing_components/pull/1713))
+
 ## 21.67.0
 
 * Remove jQuery from select.js ([PR #1670](https://github.com/alphagov/govuk_publishing_components/pull/1670))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -29,6 +29,7 @@
 
   @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-spacing(2);
+    height: 100%;
   }
 
   + .gem-c-image-card__text-wrapper {


### PR DESCRIPTION
## What
The recent changes to the source order on the image card introduced a bug affecting IE11. For some reason the image wrapper grows beyond the size of the image it contains. Setting it to any value percentage fixes it, so a 100% height is applied here. It has no knock on effects on other browsers that I can see.  

## Why
Bug reported through Zendesk: https://govuk.zendesk.com/agent/tickets/4250243

## Visual Changes

### Before
![Screenshot 2020-09-28 at 14 24 09](https://user-images.githubusercontent.com/31649453/94437944-5a801e00-0196-11eb-9a6c-4f0888f09a19.png)

### After
![Screenshot 2020-09-28 at 14 22 57](https://user-images.githubusercontent.com/31649453/94437941-594ef100-0196-11eb-87dd-9119fd5bc10b.png)


