### PR TITLE
Quick patch to fix Puma 5.0.1 issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
-    puma (5.0.0)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -329,6 +329,7 @@ DEPENDENCIES
   jasmine (~> 3.6.0)
   jasmine_selenium_runner (~> 3.0.0)
   pry-byebug
+  puma (< 5)
   rake
   rspec-rails (~> 4.0)
   rubocop-govuk (~> 3)

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -30,6 +30,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency "jasmine", "~> 3.6.0"
   s.add_development_dependency "jasmine_selenium_runner", "~> 3.0.0"
   s.add_development_dependency "pry-byebug"
+  # Puma 5.0.1 has a breaking API change with Capybara, hopefully this will
+  # be resolved quickly with 5.0.2
+  s.add_development_dependency "puma", "< 5"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-rails", "~> 4.0"
   s.add_development_dependency "rubocop-govuk", "~> 3"


### PR DESCRIPTION
Puma 5.0.1 was released an hour ago and introduces an API
incompatibility with Capybara [1], which causes the tests to fail for
this project in CI. As this project is a Gem the contents of the
Gemfile.lock are not used to install the gem on CI [2] which means new
versions of dependencies can break builds without us intervening.

This applies a quick fix to get these tests working again while the Puma
situation is resolved. Should this be more than a simple mistake we'll
need to re-release govuk_test to cater for it.

[1]: https://github.com/puma/puma/issues/2388
[2]: https://github.com/alphagov/govuk-jenkinslib/blob/cdd76bbc0fb59e7a13ecc9dd9e6bb4518d6dfc97/vars/govuk.groovy#L654

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
