### PR TITLE
Set feedback buttons to be transparent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Set feedback buttons to be transparent ([PR #1719](https://github.com/alphagov/govuk_publishing_components/pull/1719))
 
 ## 21.67.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -90,7 +90,7 @@
 }
 
 .gem-c-feedback__prompt-question {
-  vertical-align: text-top;
+  vertical-align: top;
   display: inline-block;
   margin: govuk-spacing(2) govuk-spacing(4);
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -121,7 +121,7 @@
   &:hover {
     // backup style for browsers that don't support rgba
     background: govuk-colour("black");
-    background: rgba(govuk-colour("black"), 0.2);
+    background: rgba(govuk-colour("black"), .2);
   }
 
   @include govuk-media-query($from: mobile) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -113,8 +113,16 @@
 
 .gem-c-feedback__prompt-link {
   @include govuk-font(19);
-  box-shadow: 0 2px 0 govuk-colour("black");
+  background: transparent;
+  box-shadow: 0 2px 0 govuk-colour("white");
+  border: 1px govuk-colour("white") solid;
   min-width: 100%;
+
+  &:hover {
+    // backup style for browsers that don't support rgba
+    background: govuk-colour("black");
+    background: rgba(govuk-colour("black"), 0.2);
+  }
 
   @include govuk-media-query($from: mobile) {
     min-width: 100px;

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -28,7 +28,7 @@
   </div>
   <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions">
     <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV-UK Open Form" aria-controls="something-is-wrong" aria-expanded="false">
-      <%= t("components.feedback.anything_wrong", default: "Is there anything wrong with this page?") %>
+      <%= t("components.feedback.something_wrong", default: "There is something wrong with this page") %>
     </button>
   </div>
 </div>

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -6,18 +6,18 @@
   <div class="gem-c-feedback__prompt-questions js-prompt-questions">
     <h2 class="gem-c-feedback__prompt-question"><%= t("components.feedback.is_this_page_useful", default: "Is this page useful?") %></h2>
     <!-- Maybe button exists only to try and capture clicks by bots -->
-    <button class="govuk-button govuk-button--secondary gem-c-feedback__prompt-link" data-track-category="yesNoFeedbackForm" data-track-action="ffMaybeClick" aria-expanded="false" style="display: none" hidden="hidden" aria-hidden="true">
+    <button data-track-category="yesNoFeedbackForm" data-track-action="ffMaybeClick" aria-expanded="false" style="display: none" hidden="hidden" aria-hidden="true">
       <%= t("components.feedback.maybe", default: "Maybe") %>
     </button>
     
     <ul class="gem-c-feedback__option-list">
       <li class="gem-c-feedback__option-list-item">
-        <button class="govuk-button govuk-button--secondary gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">
+        <button class="govuk-button gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">
           <%= t("components.feedback.yes", default: "Yes") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_useful", default: "this page is useful") %></span>
         </button>
       </li>
       <li class="gem-c-feedback__option-list-item">
-        <button class="govuk-button govuk-button--secondary gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">
+        <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">
           <%= t("components.feedback.no", default: "No") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_not_useful", default: "this page is not useful") %></span>
         </button>
       </li>
@@ -27,7 +27,7 @@
     <%= t("components.feedback.thank_you_for_feedback", default: "Thank you for your feedback") %>
   </div>
   <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions">
-    <button class="govuk-button govuk-button--secondary gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV-UK Open Form" aria-controls="something-is-wrong" aria-expanded="false">
+    <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV-UK Open Form" aria-controls="something-is-wrong" aria-expanded="false">
       <%= t("components.feedback.anything_wrong", default: "Is there anything wrong with this page?") %>
     </button>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,7 @@ en:
       is_useful: "this page is useful"
       is_not_useful: "this page is not useful"
       thank_you_for_feedback: "Thank you for your feedback"
-      anything_wrong: "Is there anything wrong with this page?"
+      something_wrong: "There is something wrong with this page"
       close: "Close"
       help_us_improve_govuk: "Help us improve GOV.UK"
       more_about_visit: "To help us improve GOV.UK, we’d like to know more about your visit today. We’ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don’t worry we won’t send you spam or share your email address with anyone."

--- a/spec/components/feedback_spec.rb
+++ b/spec/components/feedback_spec.rb
@@ -15,7 +15,7 @@ describe "Feedback", type: :view do
   it "asks the user if there is anything wrong with the page without javascript enabled" do
     render_component({})
 
-    assert_select ".gem-c-feedback .gem-c-feedback__prompt-link.js-something-is-wrong", text: "Is there anything wrong with this page?"
+    assert_select ".gem-c-feedback .gem-c-feedback__prompt-link.js-something-is-wrong", text: "There is something wrong with this page"
   end
 
   it "has required email survey signup form fields" do


### PR DESCRIPTION
## What
This PR:

- changes the styling of the buttons on the feedback component to be transparent with a white background
- changes the text on the "something wrong" button from `Is there anything wrong with this page?` to `There is something wrong with this page`
- [fixes a display issue on IE11](https://github.com/alphagov/govuk_publishing_components/issues/1709)

## Why
The original button re-design to the feedback component was designed and developed quite quickly so that it can be pushed through in time for the accessibility deadline. It has been pointed out that on some pages, notably pages with CTAs or forms, that these quite bright buttons are a bit distracting. This softens the buttons so that they still look like buttons but are less intrusive.

The text change on the "something wrong" button was an additional suggestion post deployment. As the interaction is now much more clearly a button, a question doesn't make as much sense as a descriptor for a user interaction. The new text is a bit more indicative of a user making a decision with their button press.

## Visual Changes
### Before
![Screenshot 2020-10-01 at 09 54 09](https://user-images.githubusercontent.com/64783893/94789713-30647100-03cd-11eb-93ca-6e4dbaafc1ca.png)

### After
![Screenshot 2020-10-01 at 09 53 57](https://user-images.githubusercontent.com/64783893/94789736-38241580-03cd-11eb-900d-89abdb521aaf.png)

