### PR TITLE
Feed subscription link accessibility fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Feed subscription link accessibility fix ([PR #1721](https://github.com/alphagov/govuk_publishing_components/pull/1721))
+
 ## 21.68.0
 
 * Set feedback buttons to be transparent ([PR #1719](https://github.com/alphagov/govuk_publishing_components/pull/1719))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -43,6 +43,7 @@
 
   .gem-c-subscription-links__link {
     @extend %govuk-link;
+    display: inline-block;
     text-decoration: none;
     background-repeat: no-repeat;
     background-position: 0 20%;
@@ -69,11 +70,53 @@
 
 .gem-c-subscription-links__icon {
   margin-right: .1em;
+  color: govuk-colour("black");
 }
 
 .gem-c-subscription-links__list-item--small {
   .gem-c-subscription-links__icon {
     @include scale(.9);
     transform-origin: bottom left;
+  }
+}
+
+.gem-c-subscription-links--with-feed-box {
+  .gem-c-subscription-links__list-item {
+    vertical-align: middle;
+  }
+
+  .gem-c-subscription-links__link {
+    &:not(.gem-c-subscription-links__link--feed) {
+      padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
+      border: 1px solid transparent;
+      border-bottom: 1px solid govuk-colour("dark-grey");
+
+      &:focus {
+        border-bottom: 0;
+      }
+    }
+  }
+
+  .gem-c-subscription-links__link--feed {
+    padding: govuk-spacing(2);
+    border: 1px solid $gem-quiet-button-colour;
+    color: $gem-quiet-button-colour;
+    background-color: $gem-secondary-button-background-colour;
+
+    &:visited,
+    &:active,
+    &:focus {
+      text-decoration: none;
+    }
+
+    &:focus {
+      border: 1px solid govuk-colour("yellow");
+      outline: 3px solid transparent;
+    }
+
+    &:hover:not(:focus) {
+      background-color: $gem-secondary-button-hover-background-colour;
+      text-decoration: none;
+    }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -1,69 +1,107 @@
 .gem-c-subscription-links {
   @include govuk-text-colour;
   @include govuk-font(19, $weight: bold);
+}
 
-  .gem-c-subscription-links__hidden-header {
-    @include govuk-visually-hidden;
-  }
+.gem-c-subscription-links__hidden-header {
+  @include govuk-visually-hidden;
+}
 
-  .gem-c-subscription-links__list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
+.gem-c-subscription-links__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
 
-  .gem-c-subscription-links__list--small {
-    @include govuk-font(16);
-  }
+.gem-c-subscription-links__list--small {
+  @include govuk-font(16);
+}
 
-  .gem-c-subscription-links__list-item {
-    display: inline-block;
-    margin-right: govuk-spacing(4);
-    margin-bottom: govuk-spacing(3);
+.gem-c-subscription-links__list-item {
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: govuk-spacing(4);
+  margin-bottom: govuk-spacing(3);
 
-    &:last-child {
-      margin-right: 0;
-    }
-  }
-
-  .gem-c-subscription-links__list-item--small {
-    display: inline-block;
-    margin-left: 0;
+  &:last-child {
     margin-right: 0;
-    margin-bottom: govuk-spacing(2);
+  }
+}
 
-    &:first-child {
-      margin-right: govuk-spacing(2);
-    }
+.gem-c-subscription-links__list-item--small {
+  display: inline-block;
+  margin-left: 0;
+  margin-right: 0;
+  margin-bottom: govuk-spacing(2);
 
-    &:only-child {
-      margin-right: 0;
-    }
+  &:first-child {
+    margin-right: govuk-spacing(2);
   }
 
-  .gem-c-subscription-links__link {
-    @extend %govuk-link;
+  &:only-child {
+    margin-right: 0;
+  }
+}
+
+.gem-c-subscription-links__item {
+  @extend %govuk-link;
+  display: inline-block;
+  text-decoration: none;
+  background-repeat: no-repeat;
+  background-position: 0 20%;
+
+  @include govuk-media-query($from: tablet) {
+    background-position: 0 35%;
+  }
+}
+
+.gem-c-subscription-links__item--button {
+  display: none;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  padding: govuk-spacing(2);
+  border: 1px solid $gem-quiet-button-colour;
+  background-color: $gem-secondary-button-background-colour;
+
+  .js-enabled & {
     display: inline-block;
+  }
+
+  &:not(.brand__color) {
+    color: $govuk-link-colour;
+  }
+
+  &:visited,
+  &:active,
+  &:focus {
     text-decoration: none;
-    background-repeat: no-repeat;
-    background-position: 0 20%;
-
-    @include govuk-media-query($from: tablet) {
-      background-position: 0 35%;
-    }
   }
 
-  .gem-c-subscription-links__feed-box {
-    padding: govuk-spacing(3);
-    margin-bottom: govuk-spacing(3);
-    background: govuk-colour("light-grey", $legacy: "grey-3");
-
-    .js-enabled &.js-hidden {
-      display: none;
-    }
+  &:focus {
+    color: $govuk-focus-text-colour;
+    border: 1px solid $govuk-focus-colour;
+    outline: 3px solid transparent;
   }
 
-  .gem-c-subscription-links__feed-hidden-description {
+  &:hover:not(:focus) {
+    background-color: $gem-secondary-button-hover-background-colour;
+    text-decoration: none;
+  }
+}
+
+.gem-c-subscription-links__feed-box {
+  padding: govuk-spacing(3);
+  margin-bottom: govuk-spacing(3);
+  background: govuk-colour("light-grey", $legacy: "grey-3");
+
+  .js-enabled &.js-hidden {
+    display: none;
+  }
+}
+
+.gem-c-subscription-links__feed-hidden-description {
+  .js-enabled & {
     @include govuk-visually-hidden;
   }
 }
@@ -73,50 +111,19 @@
   color: govuk-colour("black");
 }
 
-.gem-c-subscription-links__list-item--small {
-  .gem-c-subscription-links__icon {
-    @include scale(.9);
-    transform-origin: bottom left;
-  }
+.gem-c-subscription-links__list-item--small .gem-c-subscription-links__icon {
+  @include scale(.9);
+  transform-origin: bottom left;
 }
 
 .gem-c-subscription-links--with-feed-box {
-  .gem-c-subscription-links__list-item {
-    vertical-align: middle;
-  }
-
-  .gem-c-subscription-links__link {
-    &:not(.gem-c-subscription-links__link--feed) {
-      padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
-      border: 1px solid transparent;
-      border-bottom: 1px solid govuk-colour("dark-grey");
-
-      &:focus {
-        border-bottom: 0;
-      }
-    }
-  }
-
-  .gem-c-subscription-links__link--feed {
-    padding: govuk-spacing(2);
-    border: 1px solid $gem-quiet-button-colour;
-    color: $gem-quiet-button-colour;
-    background-color: $gem-secondary-button-background-colour;
-
-    &:visited,
-    &:active,
-    &:focus {
-      text-decoration: none;
-    }
+  .gem-c-subscription-links__item--link {
+    padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
+    border: 1px solid transparent;
+    border-bottom: 1px solid govuk-colour("dark-grey");
 
     &:focus {
-      border: 1px solid govuk-colour("yellow");
-      outline: 3px solid transparent;
-    }
-
-    &:hover:not(:focus) {
-      background-color: $gem-secondary-button-hover-background-colour;
-      text-decoration: none;
+      border-bottom-color: transparent;
     }
   }
 }

--- a/app/views/govuk_publishing_components/components/_subscription-links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription-links.html.erb
@@ -11,6 +11,7 @@
   css_classes = %w( gem-c-subscription-links )
   css_classes << (shared_helper.get_margin_bottom) unless local_assigns[:margin_bottom] == 0
   css_classes << brand_helper.brand_class
+  css_classes << "gem-c-subscription-links--with-feed-box" if sl_helper.feed_link_box_value
 
   data = {"module": "gem-toggle"} if sl_helper.feed_link_box_value
 
@@ -30,8 +31,11 @@
     >
       <% if sl_helper.email_signup_link.present? %>
         <li class="gem-c-subscription-links__list-item<%= ' gem-c-subscription-links__list-item--small' if local_assigns[:small_form] == true %>" >
-          <svg xmlns="http://www.w3.org/2000/svg" width="21" height="15.75" class="gem-c-subscription-links__icon" focusable="false" fill="currentColor" aria-hidden="true"><path d="M19.687 0H1.312C.589 0 0 .587 0 1.313v13.124c0 .726.588 1.313 1.313 1.313h18.374c.725 0 1.313-.587 1.313-1.313V1.313C21 .587 20.412 0 19.687 0zm-2.625 2.625L10.5 7.875l-6.563-5.25h13.126zm1.313 10.5H2.625V3.937L10.5 10.5l7.875-6.563v9.188z"/></svg>
-          <%= link_to sl_helper.email_signup_link_text, sl_helper.email_signup_link, {
+          <% email_link_text = capture do %>
+           <svg xmlns="http://www.w3.org/2000/svg" width="21" height="15.75" class="gem-c-subscription-links__icon" focusable="false" fill="currentColor" aria-hidden="true"><path d="M19.687 0H1.312C.589 0 0 .587 0 1.313v13.124c0 .726.588 1.313 1.313 1.313h18.374c.725 0 1.313-.587 1.313-1.313V1.313C21 .587 20.412 0 19.687 0zm-2.625 2.625L10.5 7.875l-6.563-5.25h13.126zm1.313 10.5H2.625V3.937L10.5 10.5l7.875-6.563v9.188z"/></svg>
+           <%= sl_helper.email_signup_link_text %>
+          <% end %>
+          <%= link_to email_link_text, sl_helper.email_signup_link, {
             class: "gem-c-subscription-links__link #{brand_helper.color_class}",
             data: sl_helper.email_signup_link_data_attributes,
             lang: email_signup_link_text_locale
@@ -41,12 +45,19 @@
 
       <% if sl_helper.feed_link_box_value || sl_helper.feed_link %>
         <li class="gem-c-subscription-links__list-item<%= ' gem-c-subscription-links__list-item--small' if local_assigns[:small_form] == true %>">
-          <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" class="gem-c-subscription-links__icon" focusable="false" fill="currentColor" aria-hidden="true"><path d="M1.996 11A2 2 0 0 0 0 12.993c0 1.101.895 1.99 1.996 1.99 1.106 0 2-.889 2-1.99a2 2 0 0 0-2-1.993zM.002 5.097V7.97c1.872 0 3.632.733 4.958 2.059A6.984 6.984 0 0 1 7.015 15h2.888c0-5.461-4.443-9.903-9.9-9.903zM.006 0v2.876c6.676 0 12.11 5.44 12.11 12.124H15C15 6.731 8.273 0 .006 0z"/></svg>
-          <%= link_to sl_helper.feed_link_text, sl_helper.feed_link,
+          <% feed_icon = capture do %>
+            <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" class="gem-c-subscription-links__icon" focusable="false" fill="currentColor" aria-hidden="true"><path d="M1.996 11A2 2 0 0 0 0 12.993c0 1.101.895 1.99 1.996 1.99 1.106 0 2-.889 2-1.99a2 2 0 0 0-2-1.993zM.002 5.097V7.97c1.872 0 3.632.733 4.958 2.059A6.984 6.984 0 0 1 7.015 15h2.888c0-5.461-4.443-9.903-9.9-9.903zM.006 0v2.876c6.676 0 12.11 5.44 12.11 12.124H15C15 6.731 8.273 0 .006 0z"/></svg>
+          <% end %>
+          <% feed_link_text = capture do %>
+           <%= feed_icon %>
+           <%= sl_helper.feed_link_text %>
+          <% end %>
+          <%= link_to feed_link_text, sl_helper.feed_link,
             {
-              class: "gem-c-subscription-links__link #{brand_helper.color_class}",
+              class: "gem-c-subscription-links__link #{brand_helper.color_class} gem-c-subscription-links__link--feed",
               data: sl_helper.feed_link_data_attributes,
-              lang: feed_link_text_locale
+              lang: feed_link_text_locale,
+              role: sl_helper.feed_link_box_value ? "button" : nil
             }
           %>
         </li>

--- a/app/views/govuk_publishing_components/components/_subscription-links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription-links.html.erb
@@ -36,7 +36,7 @@
            <%= sl_helper.email_signup_link_text %>
           <% end %>
           <%= link_to email_link_text, sl_helper.email_signup_link, {
-            class: "gem-c-subscription-links__link #{brand_helper.color_class}",
+            class: "gem-c-subscription-links__item #{brand_helper.color_class} gem-c-subscription-links__item--link",
             data: sl_helper.email_signup_link_data_attributes,
             lang: email_signup_link_text_locale
           } %>
@@ -45,28 +45,28 @@
 
       <% if sl_helper.feed_link_box_value || sl_helper.feed_link %>
         <li class="gem-c-subscription-links__list-item<%= ' gem-c-subscription-links__list-item--small' if local_assigns[:small_form] == true %>">
-          <% feed_icon = capture do %>
-            <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" class="gem-c-subscription-links__icon" focusable="false" fill="currentColor" aria-hidden="true"><path d="M1.996 11A2 2 0 0 0 0 12.993c0 1.101.895 1.99 1.996 1.99 1.106 0 2-.889 2-1.99a2 2 0 0 0-2-1.993zM.002 5.097V7.97c1.872 0 3.632.733 4.958 2.059A6.984 6.984 0 0 1 7.015 15h2.888c0-5.461-4.443-9.903-9.9-9.903zM.006 0v2.876c6.676 0 12.11 5.44 12.11 12.124H15C15 6.731 8.273 0 .006 0z"/></svg>
-          <% end %>
           <% feed_link_text = capture do %>
-           <%= feed_icon %>
+            <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" class="gem-c-subscription-links__icon" focusable="false" fill="currentColor" aria-hidden="true"><path d="M1.996 11A2 2 0 0 0 0 12.993c0 1.101.895 1.99 1.996 1.99 1.106 0 2-.889 2-1.99a2 2 0 0 0-2-1.993zM.002 5.097V7.97c1.872 0 3.632.733 4.958 2.059A6.984 6.984 0 0 1 7.015 15h2.888c0-5.461-4.443-9.903-9.9-9.903zM.006 0v2.876c6.676 0 12.11 5.44 12.11 12.124H15C15 6.731 8.273 0 .006 0z"/></svg>
            <%= sl_helper.feed_link_text %>
           <% end %>
+          <%= tag.button feed_link_text, {
+            class: "gem-c-subscription-links__item #{brand_helper.color_class} gem-c-subscription-links__item--button",
+            data: sl_helper.feed_link_data_attributes,
+            lang: feed_link_text_locale
+          } if sl_helper.feed_link_box_value %>
           <%= link_to feed_link_text, sl_helper.feed_link,
             {
-              class: "gem-c-subscription-links__link #{brand_helper.color_class} gem-c-subscription-links__link--feed",
+              class: "gem-c-subscription-links__item #{brand_helper.color_class} gem-c-subscription-links__item--link",
               data: sl_helper.feed_link_data_attributes,
-              lang: feed_link_text_locale,
-              role: sl_helper.feed_link_box_value ? "button" : nil
-            }
-          %>
+              lang: feed_link_text_locale
+            } unless sl_helper.feed_link_box_value %>
         </li>
       <% end %>
     </ul>
 
     <% if sl_helper.feed_link_box_value %>
       <div class="gem-c-subscription-links__feed-box js-hidden" id="<%= sl_helper.feed_box_id %>">
-        <p class="gem-c-subscription-links__feed-hidden-description visuallyhidden"><%= sl_helper.feed_link_text %></p>
+        <h3 class="gem-c-subscription-links__feed-hidden-description visuallyhidden govuk-!-margin-top-0"><%= sl_helper.feed_link_text %></h3>
         <div lang="en">
           <%= render "govuk_publishing_components/components/input", {
             label: {

--- a/spec/components/subscription_links_spec.rb
+++ b/spec/components/subscription_links_spec.rb
@@ -11,21 +11,21 @@ describe "subscription links", type: :view do
 
   it "renders an email signup link" do
     render_component(email_signup_link: "/email-signup")
-    assert_select ".gem-c-subscription-links__link[href=\"/email-signup\"]", text: "Get email alerts"
+    assert_select ".gem-c-subscription-links__item[href=\"/email-signup\"]", text: "Get email alerts"
   end
 
   it "renders a feed link" do
     render_component(feed_link: "singapore.atom")
-    assert_select ".gem-c-subscription-links__link[href=\"singapore.atom\"]", text: "Subscribe to feed"
-    assert_select ".gem-c-subscription-links__link[data-controls][data-expanded]", false
+    assert_select ".gem-c-subscription-links__item[href=\"singapore.atom\"]", text: "Subscribe to feed"
+    assert_select ".gem-c-subscription-links__item[data-controls][data-expanded]", false
   end
 
   it "renders both email signup and feed links" do
     render_component(email_signup_link: "email-signup", feed_link: "singapore.atom")
     assert_select ".gem-c-subscription-links[data-module='gem-toggle']", false
     assert_select ".gem-c-subscription-links__list[data-module='track-click']", false
-    assert_select ".gem-c-subscription-links__link[href=\"email-signup\"]", text: "Get email alerts"
-    assert_select ".gem-c-subscription-links__link[href=\"singapore.atom\"]", text: "Subscribe to feed"
+    assert_select ".gem-c-subscription-links__item[href=\"email-signup\"]", text: "Get email alerts"
+    assert_select ".gem-c-subscription-links__item[href=\"singapore.atom\"]", text: "Subscribe to feed"
   end
 
   it "adds margin" do
@@ -45,38 +45,38 @@ describe "subscription links", type: :view do
 
   it "renders custom texts" do
     render_component(email_signup_link: "email-signup", feed_link: "singapore.atom", email_signup_link_text: "Get email!", feed_link_text: "View feed!")
-    assert_select ".gem-c-subscription-links__link[href=\"email-signup\"]", text: "Get email!"
-    assert_select ".gem-c-subscription-links__link[href=\"singapore.atom\"]", text: "View feed!"
+    assert_select ".gem-c-subscription-links__item[href=\"email-signup\"]", text: "Get email!"
+    assert_select ".gem-c-subscription-links__item[href=\"singapore.atom\"]", text: "View feed!"
   end
 
   it "renders with a feed link box" do
     render_component(feed_link_box_value: "http://www.gov.uk", feed_link: "singapore.atom")
     assert_select ".gem-c-subscription-links[data-module=\"gem-toggle\"]"
-    assert_select ".gem-c-subscription-links__link[href=\"singapore.atom\"]", false
+    assert_select ".gem-c-subscription-links__item[href=\"singapore.atom\"]", false
     assert_select ".gem-c-subscription-links__feed-box input[name='feed-reader-box'][value='http://www.gov.uk']"
   end
 
   it "adds branding correctly" do
     render_component(email_signup_link: "email-signup", feed_link: "singapore.atom", brand: "attorney-generals-office")
     assert_select ".gem-c-subscription-links.brand--attorney-generals-office"
-    assert_select ".gem-c-subscription-links__link.brand__color"
-    assert_select ".gem-c-subscription-links__link.brand__color"
+    assert_select ".gem-c-subscription-links__item.brand__color"
+    assert_select ".gem-c-subscription-links__item.brand__color"
   end
 
   it "adds tracking for email signup link" do
     render_component(email_signup_link: "email-signup", email_signup_link_data_attributes: { 'track_category': "test" })
-    assert_select ".gem-c-subscription-links__list[data-module=\"track-click\"] .gem-c-subscription-links__link[data-track-category=\"test\"]"
+    assert_select ".gem-c-subscription-links__list[data-module=\"track-click\"] .gem-c-subscription-links__item[data-track-category=\"test\"]"
   end
 
   it "adds tracking for feed link" do
     render_component(feed_link: "feed", feed_link_data_attributes: { 'track_category': "test" })
-    assert_select ".gem-c-subscription-links__list[data-module=\"track-click\"] .gem-c-subscription-links__link[data-track-category=\"test\"]"
+    assert_select ".gem-c-subscription-links__list[data-module=\"track-click\"] .gem-c-subscription-links__item[data-track-category=\"test\"]"
   end
 
   it "adds tracking for feed link when it is a toggle" do
     render_component(feed_link_box_value: "feed", feed_link_data_attributes: { 'track_category': "test" })
     assert_select ".gem-c-subscription-links[data-module=\"gem-toggle\"]"
-    assert_select ".gem-c-subscription-links__list[data-module=\"track-click\"] .gem-c-subscription-links__link[data-track-category=\"test\"]"
+    assert_select ".gem-c-subscription-links__list[data-module=\"track-click\"] .gem-c-subscription-links__item[data-track-category=\"test\"]"
   end
 
   it "adds small form modifier to the list of links" do
@@ -111,8 +111,8 @@ describe "subscription links", type: :view do
       feed_link_text: "View feed!",
       feed_link_text_locale: "fr",
     )
-    assert_select ".gem-c-subscription-links__link[lang='es']", 1
-    assert_select ".gem-c-subscription-links__link[lang='fr']", 1
+    assert_select ".gem-c-subscription-links__item[lang='es']", 1
+    assert_select ".gem-c-subscription-links__item[lang='fr']", 1
   end
 
   it "no lang attribute is added when not set" do
@@ -122,7 +122,7 @@ describe "subscription links", type: :view do
       feed_link: "singapore.atom",
       feed_link_text: "View feed!",
     )
-    assert_select ".gem-c-subscription-links__link[lang]", false
+    assert_select ".gem-c-subscription-links__item[lang]", false
   end
 
   it "no lang attribute set when locale is set but empty" do
@@ -132,7 +132,7 @@ describe "subscription links", type: :view do
       feed_link: "singapore.atom",
       feed_link_text_locale: "",
     )
-    assert_select ".gem-c-subscription-links__link[lang]", false
+    assert_select ".gem-c-subscription-links__item[lang]", false
   end
 
   it "no lang attribute set when locale is false" do
@@ -142,7 +142,7 @@ describe "subscription links", type: :view do
       feed_link: "singapore.atom",
       feed_link_text_locale: false,
     )
-    assert_select ".gem-c-subscription-links__link[lang]", false
+    assert_select ".gem-c-subscription-links__item[lang]", false
   end
 
   it "no lang attribute set when locale is nil" do
@@ -152,6 +152,6 @@ describe "subscription links", type: :view do
       feed_link: "singapore.atom",
       feed_link_text_locale: nil,
     )
-    assert_select ".gem-c-subscription-links__link[lang]", false
+    assert_select ".gem-c-subscription-links__item[lang]", false
   end
 end


### PR DESCRIPTION
## What
This changes the styling of the subscription links component when the "subscribe to feed" element functions as a button. 

Adjusted the markup of the component to have the `role="button"` attribute. Also, adjusted the styling for the "Get email alerts" link for when the two are side by side, to link the two together visually.

These changes should only take place when the feed button functions as a button. This styling of this component should remain the same in other variations of the component. 
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
There are instances where the "subscribe to feed" link functions as a button.
This discrepancy between the appearance and the function of this element can make it more difficult for screen reader and voice control users to find the information they need.

Example of a page where this problem exists: https://www.gov.uk/world/switzerland 
<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
### Before
<img width="860" alt="Screenshot 2020-10-07 at 16 32 10" src="https://user-images.githubusercontent.com/7116819/95353069-c4957300-08ba-11eb-93ec-2e589b3fd70e.png">
<img width="860" alt="Screenshot 2020-10-07 at 16 32 21" src="https://user-images.githubusercontent.com/7116819/95353071-c52e0980-08ba-11eb-8d77-56b3252e173b.png">

### After


<img width="776" alt="Screenshot 2020-10-08 at 13 02 23" src="https://user-images.githubusercontent.com/7116819/95456072-ae44f100-0966-11eb-969f-b9407a5d5f71.png">
<img width="773" alt="Screenshot 2020-10-08 at 13 02 36" src="https://user-images.githubusercontent.com/7116819/95456074-aedd8780-0966-11eb-8eaa-22a2a64b8188.png">




https://trello.com/c/9fd0GOKl