### PR TITLE
Update search component input label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Feed subscription link accessibility fix ([PR #1721](https://github.com/alphagov/govuk_publishing_components/pull/1721))
+* Update search component input label ([PR #1727](https://github.com/alphagov/govuk_publishing_components/pull/1727))
 
 ## 21.68.0
 

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -16,7 +16,7 @@
 
   value ||= ""
   id ||= "search-main-" + SecureRandom.hex(4)
-  label_text ||= "Search GOV.UK"
+  label_text ||= "Search on GOV.UK"
   name ||= 'q'
   aria_controls ||= nil
 %>

--- a/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
@@ -2,7 +2,6 @@
 <form id="search" class="gem-c-layout-header__search-form govuk-clearfix" action="/search" method="get" role="search">
   <%= render "govuk_publishing_components/components/search", {
     id: "site-search-text",
-    label_text: "Search",
     no_border: true,
     margin_bottom: 0
   } %>


### PR DESCRIPTION
## What
Update layout header component search label to "Search on GOV.UK".
Update search component to have "Search on GOV.UK as the default text.


## Why
The site search box is labelled inconsistently throughout the site (The label for the search box is "Search on GOV.UK" on the homepage and "Search" on sub pages)

This is a fail of WCAG SC 3.2.4: **Consistent Identification**.
<!-- What are the reasons behind this change being made? -->

https://trello.com/c/RbD3om74
