### PR TITLE
Hover style for action link

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -1,3 +1,5 @@
+$gem-hover-dark-background: #dddcdb;
+
 .gem-c-action-link {
   display: table;
 
@@ -171,10 +173,18 @@
       color: govuk-colour("white");
     }
 
+    &:hover {
+      color: $gem-hover-dark-background;
+    }
+
     &:focus,
     &:active {
       text-decoration: none;
       color: govuk-colour("black");
+
+      &:hover {
+        color: govuk-colour("black");
+      }
     }
   }
 


### PR DESCRIPTION
## What?

- Adding a (potentially global) component hover style colour for white text on a dark background - starting with action link.

There was a request from Design to update a missing hover state on the [action link](https://components.publishing.service.gov.uk/component-guide/action_link) on [corona virus landing page.](https://www.gov.uk/coronavirus)
Ticket: https://trello.com/c/mBN0xr04

## Why?
Updating the [corona virus](https://www.gov.uk/coronavirus) landing page action link with a unique hover style in complete isolation is not ideal. 
Users will have have a mix of hover styles even within the same page. For example, this also impacts [Bread Crumbs](https://components.publishing.service.gov.uk/component-guide/contextual_breadcrumbs) which is also on this page.

This prompted a wider discussion, white text (while on a coloured background) + hover styles do not exists within the Component Guide and there is [already an issue ](https://github.com/alphagov/govuk-frontend/issues/1417) raised about ensuring consistent hover styles across gov.uk

As a result Design actioned a [wider exploration piece](https://www.figma.com/file/BJBSVtwDgdZPOfQnf3kimJ/Exploration?node-id=67%3A2) to discover a colour that met AA standards and was a perceivable change within multiple contexts. The result was the solution `#DDDCDB`

## Visual Changes

<!-- If the change results in visual changes, show a before and after -->
![Oct-08-2020 18-24-00](https://user-images.githubusercontent.com/71266765/95492741-756f4100-0993-11eb-9018-d0741a50281e.gif)

## Anything Else?

- Updating landing page in insolation is deemed too granular, approach to update the action link gem, prompt conversation to update wider `publishing_components` will also start parallel conversation with the Design System team and double check any blind spots with accessibility.

[Draft PR to prompt Frontend discussion](https://github.com/alphagov/govuk_publishing_components/pull/1726) 

_"Contrast accessibility requirements technically pass, although it's fairly close. Not sure what accessibility requirements for hover states are, but presumably they're required."_

![image](https://user-images.githubusercontent.com/71266765/95727031-9379c180-0c71-11eb-84b7-56ccc6ac78f9.png)