### PR TITLE
Add legacy colour to subscription links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add legacy colour to subscription links ([PR #1731](https://github.com/alphagov/govuk_publishing_components/pull/1731)) FIX
+
 ## 21.68.1
 
 * Adding hover styling for action link ([PR #1728](https://github.com/alphagov/govuk_publishing_components/pull/1728))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -120,7 +120,7 @@
   .gem-c-subscription-links__item--link {
     padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
     border: 1px solid transparent;
-    border-bottom: 1px solid govuk-colour("dark-grey");
+    border-bottom: 1px solid govuk-colour("dark-grey", $legacy: "grey-1");
 
     &:focus {
       border-bottom-color: transparent;


### PR DESCRIPTION
## What
Add a legacy colour to the use of `govuk-colour` in subscription links.

## Why
Whitehall is still dependent on the legacy colours, which wasn't included originally, causing a build fail in CI on [this PR](https://github.com/alphagov/whitehall/pull/5839).

<img width="834" alt="Screenshot 2020-10-13 at 09 35 39" src="https://user-images.githubusercontent.com/861310/95836611-8e7f4580-0d37-11eb-9a90-98523b99fa25.png">


## Visual Changes
None.