### PR TITLE
Fix image card link text in high contrast mode in IE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix image card link text in high contrast mode in IE ([PR #1732](https://github.com/alphagov/govuk_publishing_components/pull/1732))
+
 ## 23.3.0
 
 * Change how analytics variables are passed ([PR #1762](https://github.com/alphagov/govuk_publishing_components/pull/1762))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -88,6 +88,7 @@
     height: 100%;
     $ie-background: rgba(255, 255, 255, 0);
     background: $ie-background; // because internet explorer
+    -ms-high-contrast-adjust: none;
   }
 
   @include govuk-media-query($from: mobile, $until: tablet) {


### PR DESCRIPTION
## What
The [`-ms-high-contrast-adjust` property](https://developer.mozilla.org/en-US/docs/Archive/Web/CSS/-ms-high-contrast-adjust) prevents IE modifying the background colour and hiding the text and image in high contrast mode.

## Why
When Windows is in high contrast mode, IE will remove convert any transparency and this element will then block the image and title text being visible. High contrast mode also seems to disable the z-index.

## Visual Changes
Before:
![image](https://user-images.githubusercontent.com/3120611/95850779-3ea97a00-0d49-11eb-84b5-edb44e7316fe.png)
After:
![image](https://user-images.githubusercontent.com/3120611/95851063-a3fd6b00-0d49-11eb-9f27-9157aa23a0f9.png)