### PR TITLE
Update print component to look like a button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update print component to look like a button ([PR #1735](https://github.com/alphagov/govuk_publishing_components/pull/1735)) MINOR
 * Add legacy colour to subscription links ([PR #1731](https://github.com/alphagov/govuk_publishing_components/pull/1731)) FIX
 
 ## 21.68.1

--- a/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
@@ -1,3 +1,6 @@
+$gem-c-print-link-background-width: 16px;
+$gem-c-print-link-background-height: 18px;
+
 .gem-c-print-link {
   display: none;
   margin-bottom: 2em;
@@ -14,39 +17,41 @@
   }
 }
 
-.gem-c-print-link__link {
-  background: image-url("govuk_publishing_components/icon-print.png") no-repeat 10px 50%;
-
-  margin-left: -10px;
-  padding: .5em .5em .5em 38px;
+.gem-c-print-link__link,
+.gem-c-print-link__button {
+  background: image-url("govuk_publishing_components/icon-print.png") no-repeat govuk-spacing(2) 50%;
+  background-size: $gem-c-print-link-background-width $gem-c-print-link-background-height;
+  padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) (govuk-spacing(4) + $gem-c-print-link-background-width);
 
   @include govuk-device-pixel-ratio($ratio: 2) {
     background-image: image-url("govuk_publishing_components/icon-print-2x.png");
-    background-size: 16px 18px;
   }
 
+  &:hover {
+    background-color: govuk-colour("light-grey");
+  }
+}
+
+.gem-c-print-link__link {
+  box-shadow: inset 0 0 0 1px $govuk-border-colour;
+  text-decoration: none;
+
   &:focus {
-    @include govuk-focused-text;
+    border: 0;
+    box-shadow: 0 $govuk-focus-width $govuk-text-colour;
   }
 }
 
 .gem-c-print-link__button {
   @extend %govuk-body-s;
-  background: image-url("govuk_publishing_components/icon-print.png") no-repeat 10px 50%;
-  border: 0;
+  border: 1px solid $govuk-border-colour;
   color: $govuk-link-colour;
   cursor: pointer;
-  margin: 0;
-  margin-left: -10px;
-  padding: .5em .5em .5em 38px;
-  text-decoration: underline;
-
-  @include govuk-device-pixel-ratio($ratio: 2) {
-    background-image: image-url("govuk_publishing_components/icon-print-2x.png");
-    background-size: 16px 18px;
-  }
+  margin: govuk-spacing(0);
 
   &:focus {
     @include govuk-focused-text;
+    background-color: $govuk-focus-colour;
+    border-color: transparent;
   }
 }

--- a/app/views/govuk_publishing_components/components/_print_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_print_link.html.erb
@@ -2,15 +2,19 @@
   text ||= t('components.print_link.text')
   href ||= nil
   data_attributes ||= {}
-
   require_js ||= href.nil?
+
   data_attributes[:module] = 'print-link' if require_js
+
+  classes = %w(govuk-link)
+  classes << "gem-c-print-link__button" if href.nil?
+  classes << "gem-c-print-link__link govuk-link--no-visited-state" if href.present?
 %>
 
 <% if require_js %>
   <div class="gem-c-print-link" >
     <%= content_tag(:button, text, {
-        class: %w(gem-c-print-link__button govuk-link),
+        class: classes,
         data: data_attributes
     }) %>
   </div>
@@ -19,9 +23,13 @@
     <%= link_to(
       text,
       href,
-      class: %w(gem-c-print-link__link govuk-link),
+      class: classes,
       rel: "alternate",
-      data: data_attributes
+      data: data_attributes,
+      role: "button",
+      data: {
+        module: "button",
+      },
     ) %>
   </div>
 <% end %>


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Updates the print link component to look like a button as it's actually a button in the markup.

Updates the link variant of this component to act as a button as well by using `data-module="button"`; this means it can now be selected with [spacebar], just like a button.

## Why
<!-- What are the reasons behind this change being made? -->

This component failed WCAG 2.1 success criteria 1.3.1:

> Information, structure, and relationships conveyed through presentation can be programmatically determined or are available in text.




Trello card: https://trello.com/c/Hk1Ir65Z

## Visual Changes

Before:
![image](https://user-images.githubusercontent.com/1732331/95985553-a1b81100-0e1c-11eb-9b8a-abac29e98779.png)


After:
![image](https://user-images.githubusercontent.com/1732331/95989626-6ae4f980-0e22-11eb-8836-dfeab58e60f2.png)


Hover before:
![image](https://user-images.githubusercontent.com/1732331/95986167-797ce200-0e1d-11eb-96f6-071320906989.png)


Hover after:
![image](https://user-images.githubusercontent.com/1732331/95989739-936cf380-0e22-11eb-9581-0a635cf39511.png)


Active before:

![image](https://user-images.githubusercontent.com/1732331/95986192-84377700-0e1d-11eb-9b45-0a2eca1eb602.png)


Active after:

![image](https://user-images.githubusercontent.com/1732331/95989832-ad0e3b00-0e22-11eb-820f-45e7958efbca.png)


Focus before:

![image](https://user-images.githubusercontent.com/1732331/95986223-8dc0df00-0e1d-11eb-9442-834d328d7c86.png)

Focus after:

![image](https://user-images.githubusercontent.com/1732331/95989854-b4cddf80-0e22-11eb-8a5f-dde421195b9b.png)


