### PR TITLE
Layout header component always displays product name and environment when provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 
 ## Unreleased
 
+* **BREAKING** Layout header component always displays product name and environment when provided ([PR #1736](https://github.com/alphagov/govuk_publishing_components/pull/1736))
 * Add heading option to panel component ([PR #1741](https://github.com/alphagov/govuk_publishing_components/pull/1741)) MINOR
-* Force contents list title to always be Contents or regional equivalent ([PR #1734](https://github.com/alphagov/govuk_publishing_components/pull/1734)) BREAKING
+* **BREAKING** Force contents list title to always be Contents or regional equivalent ([PR #1734](https://github.com/alphagov/govuk_publishing_components/pull/1734))
 
 ## 21.69.0
 

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -47,7 +47,6 @@
 
     <% unless omit_header %>
       <%= render "govuk_publishing_components/components/layout_header", {
-        environment: "public",
         search: show_search,
         # layout-header will always have border-bottom, unless the layout is full width
         remove_bottom_border: full_width,

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -1,6 +1,6 @@
 <%
-  product_name ||= "Publishing"
-  public_environment = environment.eql?("public")
+  product_name ||= nil
+  environment ||= nil
   full_width ||= false
   search ||= false
   search_left ||= false
@@ -8,8 +8,9 @@
   remove_bottom_border ||= false
   search_left ||= false
   width_class = full_width ? "govuk-header__container--full-width" : "govuk-width-container"
+
   header_classes = %w(gem-c-layout-header govuk-header)
-  header_classes << "gem-c-layout-header--#{environment}"
+  header_classes << "gem-c-layout-header--#{environment}" if environment
   header_classes << "gem-c-layout-header--no-bottom-border" if remove_bottom_border
   header_classes << "gem-c-layout-header--search-left" if search_left
 %>
@@ -19,7 +20,7 @@
     <% if search_left %>
       <div class="govuk-grid-row govuk-!-margin-left-0 govuk-!-margin-right-0">
         <div class="gem-c-layout-header__logo govuk-grid-column-one-third-from-desktop">
-          <%= render "govuk_publishing_components/components/layout_header/header_logo", public_environment: public_environment, environment: environment, product_name: product_name %>
+          <%= render "govuk_publishing_components/components/layout_header/header_logo", environment: environment, product_name: product_name %>
         </div>
       </div>
       <div class="govuk-grid-row govuk-!-margin-left-0 govuk-!-margin-right-0">
@@ -33,7 +34,7 @@
     <% else %>
       <div class="govuk-grid-row govuk-!-margin-left-0 govuk-!-margin-right-0">
         <div class="gem-c-layout-header__logo govuk-grid-column-two-thirds">
-          <%= render "govuk_publishing_components/components/layout_header/header_logo", public_environment: public_environment, environment: environment, product_name: product_name %>
+          <%= render "govuk_publishing_components/components/layout_header/header_logo", environment: environment, product_name: product_name %>
         </div>
         <div class="govuk-header__content gem-c-header__content">
           <%= render "govuk_publishing_components/components/layout_header/navigation_items", navigation_items: navigation_items  %>

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -44,7 +44,6 @@ examples:
     description: This supports pages where the search appears on the left with multiple navigation links on the right, such as the [How government works](https://www.gov.uk/government/how-government-works) page
     data:
       search_left: true
-      environment: public
       navigation_items:
       - text: Departments
         href: "item-1"
@@ -71,10 +70,8 @@ examples:
     description: This is useful for pages where a large full-width banner is the first thing to appear on the page, for example, the [GOV.UK homepage](https://www.gov.uk)
     data:
       remove_bottom_border: true
-      environment: 'public'
   with_search_bar:
     data:
-      environment: 'public'
       search: true
 
 accessibility_criteria: |

--- a/app/views/govuk_publishing_components/components/layout_header/_header_logo.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_header_logo.html.erb
@@ -11,10 +11,12 @@
         GOV.UK
       </span>
     </span>
-    <% unless public_environment %>
+    <% if product_name %>
       <span class="govuk-header__product-name gem-c-header__product-name">
         <%= product_name %>
       </span>
+    <% end %>
+    <% if environment %>
       <span class="gem-c-environment-tag govuk-tag gem-c-environment-tag--<%= environment %>">
         <%= environment %>
       </span>

--- a/spec/components/layout_header_spec.rb
+++ b/spec/components/layout_header_spec.rb
@@ -11,16 +11,24 @@ describe "Layout header", type: :view do
     assert_select ".govuk-header"
   end
 
-  it "renders the header with environment modifier class" do
+  it "renders the header without environment tag if no environment is given" do
+    render_component({})
+
+    assert_select ".gem-c-environment-tag", 0
+  end
+
+  it "renders the header with environment tag and environment modifier class" do
     render_component(environment: "staging")
 
     assert_select ".govuk-header.gem-c-layout-header--staging"
+    assert_select ".gem-c-environment-tag", text: "staging"
   end
 
   it "renders the product name" do
     render_component(environment: "staging", product_name: "Product name")
 
     assert_select ".govuk-header__product-name", text: "Product name"
+    assert_select ".gem-c-environment-tag", text: "staging"
   end
 
   it "renders at a constrained width by default" do
@@ -35,11 +43,10 @@ describe "Layout header", type: :view do
     assert_select ".govuk-header__container--full-width"
   end
 
-  it "does not render the product name and environment tag if environment is 'public'" do
-    render_component(environment: "public", product_name: "Product name")
+  it "renders the product name if given" do
+    render_component(product_name: "Product name")
 
-    assert_select ".gem-c-header__product-name", 0
-    assert_select ".gem-c-environment-tag", 0
+    assert_select ".govuk-header__product-name", text: "Product name"
   end
 
   it "renders the header with navigation items" do

--- a/spec/dummy/app/views/layouts/dummy_admin_layout.html.erb
+++ b/spec/dummy/app/views/layouts/dummy_admin_layout.html.erb
@@ -1,4 +1,7 @@
-<% environment = %w[development production staging integration example].sample %>
+<%
+  environment = %w[development production staging integration example].sample
+  product_name = "Publishing"
+%>
 
 <%= render 'govuk_publishing_components/components/layout_for_admin', {
   environment: environment,
@@ -7,6 +10,7 @@
   <%= render "govuk_publishing_components/components/skip_link" %>
   <%= render "govuk_publishing_components/components/layout_header", {
     environment: environment,
+    product_name: product_name,
     navigation_items: [
       {text: "John Doe", href: "#profile"},
       {text: "Log out", href: "#logout"}


### PR DESCRIPTION
## What
- the product name wasn't shown in the header if the environment is 'public'
- product name defaulted to 'Publishing' even if not explicitly passed to the component
- now changed so the product name is shown regardless of the environment, but only shown if it is explicitly passed to the component

**Note that this is potentially a breaking change for the following reasons**

This change means that the component guide changes so most of the examples now don't have a product name, only the example showing the product name has one. This change may have some consequences for applications currently using this component. Specifically:

- [coronavirus vulnerable people service](https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/blob/092e527b41aa656a822154c442c9822976ea5de5/app/views/layouts/application.html.erb#L44) are currently using it
- [collections publisher](https://github.com/alphagov/collections-publisher/blob/4895f0006085953180c63fcde09c3507cbee256d/app/views/layouts/admin_layout.html.erb#L12) is also using it (but interestingly actively blanking the product name in order not to show it, which feels like a workaround)

Thanks to @kevindew for hunting these down ☝️ 

Additionally, the [layout for admin component](https://github.com/alphagov/govuk_publishing_components/blob/master/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb#L1) repeats the behaviour of this component, by setting the product name to 'Publishing' by default, which seems unnecessary to have in two places.

## Why
We want to use the header component in GOV.UK accounts, and the design requires the public environment with the product name shown.

## Visual Changes

The default option for the component was previously to show the product name, even though one was not explicitly passed. Now, no product name is shown unless it is explicitly passed.

- Default [before](https://components.publishing.service.gov.uk/component-guide/layout_header/default/preview) and [after](https://govuk-publis-show-produ-pxdfg7.herokuapp.com/component-guide/layout_header/default/preview)

Before | After
------- | -------
<img width="957" alt="Screenshot 2020-10-15 at 09 35 42" src="https://user-images.githubusercontent.com/861310/96099691-6d4f5e00-0ecb-11eb-83a2-046d7f4d5ea4.png"> | <img width="961" alt="Screenshot 2020-10-15 at 09 36 01" src="https://user-images.githubusercontent.com/861310/96099732-78a28980-0ecb-11eb-9a33-8818677d59d5.png">
<img width="964" alt="Screenshot 2020-10-15 at 09 36 14" src="https://user-images.githubusercontent.com/861310/96099759-81935b00-0ecb-11eb-8530-661de3db42e5.png"> | <img width="964" alt="Screenshot 2020-10-15 at 09 36 14" src="https://user-images.githubusercontent.com/861310/96099759-81935b00-0ecb-11eb-8530-661de3db42e5.png">

Trello card: https://trello.com/c/A7f6AkF3/309-accounts-home-page
