### PR TITLE
Release 21.69.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 21.69.0
 
 * Update action link component to support simple light arrow ([PR #1739](https://github.com/alphagov/govuk_publishing_components/pull/1739))
 * Update print component to look like a button ([PR #1735](https://github.com/alphagov/govuk_publishing_components/pull/1735)) MINOR

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.68.1)
+    govuk_publishing_components (21.69.0)
       govuk_app_config
       kramdown
       plek
@@ -220,7 +220,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.4)
-    rouge (3.23.0)
+    rouge (3.24.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.68.1".freeze
+  VERSION = "21.69.0".freeze
 end


### PR DESCRIPTION
Includes:

* Update action link component to support simple light arrow ([PR #1739](https://github.com/alphagov/govuk_publishing_components/pull/1739))
* Update print component to look like a button ([PR #1735](https://github.com/alphagov/govuk_publishing_components/pull/1735))
* Add legacy colour to subscription links ([PR #1731](https://github.com/alphagov/govuk_publishing_components/pull/1731))

