### PR TITLE
Add heading option to panel component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add heading option to panel component ([PR #1741](https://github.com/alphagov/govuk_publishing_components/pull/1741)) MINOR
 * Force contents list title to always be Contents or regional equivalent ([PR #1734](https://github.com/alphagov/govuk_publishing_components/pull/1734)) BREAKING
 
 ## 21.69.0

--- a/app/views/govuk_publishing_components/components/_panel.html.erb
+++ b/app/views/govuk_publishing_components/components/_panel.html.erb
@@ -2,9 +2,11 @@
   description ||= false
   prepend ||= false
   append ||= false
+
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 %>
 <div class="gem-c-panel govuk-panel govuk-panel--confirmation">
-  <h2 class="govuk-panel__title">
+  <%= content_tag(shared_helper.get_heading_level, class: "govuk-panel__title") do %>
     <% if prepend %>
       <span class="gem-c-panel__prepend">
         <%= prepend %>
@@ -18,7 +20,8 @@
         <%= append %>
       </span>
     <% end %>
-  </h2>
+  <% end %>
+
   <% if description %>
     <div class="govuk-panel__body">
       <%= description %>

--- a/app/views/govuk_publishing_components/components/docs/panel.yml
+++ b/app/views/govuk_publishing_components/components/docs/panel.yml
@@ -23,3 +23,7 @@ examples:
       prepend: The next bank holiday in England and Wales is
       title: 19 April
       append: Good Friday
+  with_different_heading_level:
+    data:
+      title: This is a H1
+      heading_level: 1

--- a/spec/components/panel_spec.rb
+++ b/spec/components/panel_spec.rb
@@ -32,4 +32,21 @@ describe "Panel", type: :view do
     assert_select ".gem-c-panel__prepend", text: "Prepended content"
     assert_select ".gem-c-panel__append", text: "Appended content"
   end
+
+  it "renders with a default heading level of 2" do
+    render_component(
+      title: "Application complete",
+    )
+
+    assert_select "h2.govuk-panel__title", text: "Application complete"
+  end
+
+  it "renders with a different heading level" do
+    render_component(
+      title: "Application complete",
+      heading_level: 1,
+    )
+
+    assert_select "h1.govuk-panel__title", text: "Application complete"
+  end
 end


### PR DESCRIPTION
## What
Update the panel component to accept an option to set the heading level.

- previously was a hard coded H2
- now defaults to a H2 but can be passed a different level if required
- uses the shared helper for this functionality, which already has tests for e.g. passing invalid values

## Why
This is needed for a page where there is no H1 and the panel component is the first thing on the page.

## Visual Changes
<img width="959" alt="Screenshot 2020-10-19 at 10 45 54" src="https://user-images.githubusercontent.com/861310/96429069-6b054080-11f8-11eb-9248-d281463cb5f1.png">

Related to https://trello.com/c/eI2DqKFx/348-accounts-feedback-screen