### PR TITLE
Fix print lint attributes from being overwritten

### DIFF
--- a/app/views/govuk_publishing_components/components/_print_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_print_link.html.erb
@@ -5,6 +5,7 @@
   require_js ||= href.nil?
 
   data_attributes[:module] = 'print-link' if require_js
+  data_attributes[:module] = 'button' if href.present?
 
   classes = %w(govuk-link)
   classes << "gem-c-print-link__button" if href.nil?
@@ -27,9 +28,6 @@
       rel: "alternate",
       data: data_attributes,
       role: "button",
-      data: {
-        module: "button",
-      },
     ) %>
   </div>
 <% end %>


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Fix to prevent the `data` attributes on the print link from being overwritten.

## Why
<!-- What are the reasons behind this change being made? -->

The `data-` attributes weren't being correctly added to the component - this was because the data attribute in the template was being overwritten by setting a new `data` parameter rather than adding to the existing data parameter.


## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

None.
