### PR TITLE
Release v23.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 23.0.0
+
+Note - this is version 23.0.0 due to a previously yanked version using 22.0.0; this release is unrelated to the yanked version.
 
 * Add track click code from static ([PR #1751](https://github.com/alphagov/govuk_publishing_components/pull/1751))
 * Fix active state on action link ([PR #1749](https://github.com/alphagov/govuk_publishing_components/pull/1749))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (21.69.0)
+    govuk_publishing_components (23.0.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "21.69.0".freeze
+  VERSION = "23.0.0".freeze
 end


### PR DESCRIPTION
Note - this is version 23.0.0 due to a previously yanked version using v22.0.0; this release is unrelated to the yanked version.

* Add track click code from static ([PR #1751](https://github.com/alphagov/govuk_publishing_components/pull/1751))
* Fix active state on action link ([PR #1749](https://github.com/alphagov/govuk_publishing_components/pull/1749))
* Add heading option to input component ([PR #1747](https://github.com/alphagov/govuk_publishing_components/pull/1747)) MINOR
* Add analytics from static ([PR #1745](https://github.com/alphagov/govuk_publishing_components/pull/1745)) MINOR
* **BREAKING** Layout header component always displays product name and environment when provided ([PR #1736](https://github.com/alphagov/govuk_publishing_components/pull/1736))
* Add heading option to panel component ([PR #1741](https://github.com/alphagov/govuk_publishing_components/pull/1741)) MINOR
* **BREAKING** Force contents list title to always be Contents or regional equivalent ([PR #1734](https://github.com/alphagov/govuk_publishing_components/pull/1734))
* **BREAKING** Remove ability to pass Govspeak unsanitized HTML ([PR #1632](https://github.com/alphagov/govuk_publishing_components/pull/1632))
