### PR TITLE
Add heading level option to input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add heading option to input component ([PR #1747](https://github.com/alphagov/govuk_publishing_components/pull/1747)) MINOR
 * Add analytics from static ([PR #1745](https://github.com/alphagov/govuk_publishing_components/pull/1745)) MINOR
 * **BREAKING** Layout header component always displays product name and environment when provided ([PR #1736](https://github.com/alphagov/govuk_publishing_components/pull/1736))
 * Add heading option to panel component ([PR #1741](https://github.com/alphagov/govuk_publishing_components/pull/1741)) MINOR

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -1,4 +1,6 @@
 <%
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+
   id ||= "input-#{SecureRandom.hex(4)}"
   value ||= nil
   type ||= "text"
@@ -22,6 +24,7 @@
   error_id = "error-#{SecureRandom.hex(4)}"
   search_icon ||= nil
   heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
+  heading_level ||= nil
   prefix ||= nil
   suffix ||= nil
 
@@ -53,10 +56,20 @@
 
 <%= content_tag :div, class: form_group_css_classes do %>
   <% if label %>
-    <%= render "govuk_publishing_components/components/label", {
-      html_for: id,
-      heading_size: heading_size
-    }.merge(label.symbolize_keys) %>
+    <% label_markup = capture do %>
+      <%= render "govuk_publishing_components/components/label", {
+        html_for: id,
+        heading_size: heading_size
+      }.merge(label.symbolize_keys) %>
+    <% end %>
+
+    <% if heading_level %>
+      <%= content_tag(shared_helper.get_heading_level, class: "govuk-label-wrapper") do %>
+        <%= label_markup %>
+      <% end %>
+    <% else %>
+      <%= label_markup %>
+    <% end %>
   <% end %>
 
   <% if hint %>

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -125,12 +125,16 @@ examples:
       name: "search-box"
       type: "search"
       search_icon: true
-  with_custom_label_size:
-    description: Make the label different sizes. Valid options are 's', 'm', 'l' and 'xl'.
+  with_label_as_heading:
+    description: |
+      Wraps the label in a heading tag. Valid options are 1 to 6. To adjust the size of the label/heading, use the `heading_size` option. Valid options are 's', 'm', 'l' and 'xl'.
+
+      Based on the [heading/label pattern](https://design-system.service.gov.uk/patterns/question-pages/) in the Design System.
     data:
       label:
-        text: "What is your name?"
+        text: "This is a heading 1 and a label"
       name: "name"
+      heading_level: 1
       heading_size: "l"
   with_prefix:
     description: To help users understand how the input should look like. Often used for units of measurement.

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -215,6 +215,26 @@ describe "Input", type: :view do
     assert_select ".govuk-label.govuk-label--xl"
   end
 
+  it "renders the label wrapped in a heading" do
+    render_component(
+      label: { text: "Where's your head at?" },
+      name: "heading",
+      heading_level: 3,
+    )
+
+    assert_select "h3.govuk-label-wrapper .govuk-label", text: "Where's your head at?"
+  end
+
+  it "only renders a label wrapped in a heading if specified" do
+    render_component(
+      label: { text: "What is your email address?" },
+      name: "email-address",
+      heading_size: "xl",
+    )
+
+    assert_select ".govuk-label-wrapper", false
+  end
+
   it "renders text input with prefix" do
     render_component(
       label: { text: "Cost per item, in pounds" },


### PR DESCRIPTION
## What
- allows the label for the input to be wrapped in a heading tag, for situations where the input is the first or only thing on a page, and no other suitable heading is appropriate
- based on https://design-system.service.gov.uk/patterns/question-pages/

## Why
Needed for a page in accounts where the label/input is the only thing on the page.

## Visual Changes

<img width="945" alt="Screenshot 2020-10-23 at 19 52 47" src="https://user-images.githubusercontent.com/861310/97042716-5c58b980-1569-11eb-8cd6-1b5ba0ce1e3f.png">


Trello card: https://trello.com/c/pI5hMyeb/329-create-account-flow-frontend
