### PR TITLE
Fix active state on action link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add track click code from static ([PR #1751](https://github.com/alphagov/govuk_publishing_components/pull/1751))
+* Fix active state on action link ([PR #1749](https://github.com/alphagov/govuk_publishing_components/pull/1749))
 * Add heading option to input component ([PR #1747](https://github.com/alphagov/govuk_publishing_components/pull/1747)) MINOR
 * Add analytics from static ([PR #1745](https://github.com/alphagov/govuk_publishing_components/pull/1745)) MINOR
 * **BREAKING** Layout header component always displays product name and environment when provided ([PR #1736](https://github.com/alphagov/govuk_publishing_components/pull/1736))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -38,10 +38,9 @@ $gem-hover-dark-background: #dddcdb;
     text-decoration: underline;
   }
 
-  &:focus,
-  &:active {
+  &:focus {
     text-decoration: none;
-    color: govuk-colour("black");
+    color: $govuk-focus-text-colour;
   }
 }
 
@@ -193,14 +192,9 @@ $gem-hover-dark-background: #dddcdb;
       color: $gem-hover-dark-background;
     }
 
-    &:focus,
-    &:active {
+    &:focus {
       text-decoration: none;
-      color: govuk-colour("black");
-
-      &:hover {
-        color: govuk-colour("black");
-      }
+      color: $govuk-focus-text-colour;
     }
   }
 


### PR DESCRIPTION
## What
Fix the active state on the action link component by simplifying the styling and rely on default anchor styling for the active state (as we do for any basic links across GOV.UK and within the Design System).

## Why
Causes issues when used in the `light_text` flag.

The component used in the site-wide banner in Safari 14.0:

<img width="1321" alt="Screenshot 2020-10-23 at 17 04 21" src="https://user-images.githubusercontent.com/788096/97027280-6622f280-1552-11eb-90a8-1f53628fbc86.png">

Thank you @conordelahunty for reporting this!

## Visual Changes
<table>
<tr><th>Before `:active`</th><th>After `:active`</th></tr>
<tr><td valign="top">

<img width="960" alt="Screenshot 2020-10-23 at 17 02 49" src="https://user-images.githubusercontent.com/788096/97027048-1e03d000-1552-11eb-91d6-576b1b358d88.png">

</td><td valign="top">

<img width="960" alt="Screenshot 2020-10-23 at 17 03 25" src="https://user-images.githubusercontent.com/788096/97027054-20662a00-1552-11eb-8481-811b6c340c9c.png">

</td></tr>
</table>

[Preview link](https://govuk-publis-fix-active-tkxbuu.herokuapp.com/component-guide/action_link/with_light_text)