### PR TITLE
Add track click code from static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add track click code from static ([PR #1751](https://github.com/alphagov/govuk_publishing_components/pull/1751))
 * Add heading option to input component ([PR #1747](https://github.com/alphagov/govuk_publishing_components/pull/1747)) MINOR
 * Add analytics from static ([PR #1745](https://github.com/alphagov/govuk_publishing_components/pull/1745)) MINOR
 * **BREAKING** Layout header component always displays product name and environment when provided ([PR #1736](https://github.com/alphagov/govuk_publishing_components/pull/1736))

--- a/app/assets/javascripts/govuk_publishing_components/lib/track-click.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/track-click.js
@@ -1,0 +1,54 @@
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function(Modules) {
+  "use strict";
+
+  Modules.TrackClick = function () {
+    this.start = function (element) {
+      var trackable = '[data-track-category][data-track-action]';
+
+      if (element.is(trackable)) {
+        element.on('click', trackClick);
+      } else {
+        element.on('click', trackable, trackClick);
+      }
+
+      function trackClick(evt) {
+        var $el = $(evt.target),
+            options = {transport: 'beacon'};
+
+        if ( ! $el.is(trackable)) {
+          $el = $el.parents(trackable);
+        }
+
+        var category = $el.attr('data-track-category'),
+            action = $el.attr('data-track-action'),
+            label = $el.attr('data-track-label'),
+            value = $el.attr('data-track-value'),
+            dimension = $el.attr('data-track-dimension'),
+            dimensionIndex = $el.attr('data-track-dimension-index'),
+            extraOptions = $el.attr('data-track-options');
+
+        if (label) {
+          options.label = label;
+        }
+
+        if (value) {
+          options.value = value;
+        }
+
+        if (dimension && dimensionIndex) {
+          options['dimension' + dimensionIndex] = dimension;
+        }
+
+        if (extraOptions) {
+          $.extend(options, JSON.parse(extraOptions));
+        }
+
+        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+          GOVUK.analytics.trackEvent(category, action, options);
+        }
+      }
+    };
+  };
+})(window.GOVUK.Modules);

--- a/app/assets/javascripts/govuk_publishing_components/lib/track-click.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/track-click.js
@@ -1,54 +1,61 @@
+//= require ../vendor/polyfills/closest.js
+
+window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-(function(Modules) {
-  "use strict";
+(function (Modules) {
+  function GemTrackClick () { }
 
-  Modules.TrackClick = function () {
-    this.start = function (element) {
-      var trackable = '[data-track-category][data-track-action]';
+  GemTrackClick.prototype.start = function ($module) {
+    this.$module = $module[0]
+    this.$module.handleClick = this.handleClick.bind(this)
 
-      if (element.is(trackable)) {
-        element.on('click', trackClick);
-      } else {
-        element.on('click', trackable, trackClick);
+    var that = this
+    // add a listener to the whole element
+    this.$module.addEventListener('click', function (e) {
+      that.$module.handleClick(e.target)
+    })
+  }
+
+  GemTrackClick.prototype.handleClick = function (target) {
+    var options = { transport: 'beacon' }
+
+    // if clicked element hasn't got the right attributes, look for a parent that matches
+    if (!target.hasAttribute('data-track-category') && !target.hasAttribute('data-track-action')) {
+      target = target.closest('[data-track-category][data-track-action]')
+    }
+
+    if (target) {
+      var category = target.getAttribute('data-track-category')
+      var action = target.getAttribute('data-track-action')
+      var label = target.getAttribute('data-track-label')
+      var value = target.getAttribute('data-track-value')
+      var dimension = target.getAttribute('data-track-dimension')
+      var dimensionIndex = target.getAttribute('data-track-dimension-index')
+      var extraOptions = target.getAttribute('data-track-options')
+
+      if (label) {
+        options.label = label
       }
 
-      function trackClick(evt) {
-        var $el = $(evt.target),
-            options = {transport: 'beacon'};
-
-        if ( ! $el.is(trackable)) {
-          $el = $el.parents(trackable);
-        }
-
-        var category = $el.attr('data-track-category'),
-            action = $el.attr('data-track-action'),
-            label = $el.attr('data-track-label'),
-            value = $el.attr('data-track-value'),
-            dimension = $el.attr('data-track-dimension'),
-            dimensionIndex = $el.attr('data-track-dimension-index'),
-            extraOptions = $el.attr('data-track-options');
-
-        if (label) {
-          options.label = label;
-        }
-
-        if (value) {
-          options.value = value;
-        }
-
-        if (dimension && dimensionIndex) {
-          options['dimension' + dimensionIndex] = dimension;
-        }
-
-        if (extraOptions) {
-          $.extend(options, JSON.parse(extraOptions));
-        }
-
-        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
-          GOVUK.analytics.trackEvent(category, action, options);
-        }
+      if (value) {
+        options.value = value
       }
-    };
-  };
-})(window.GOVUK.Modules);
+
+      if (dimension && dimensionIndex) {
+        options['dimension' + dimensionIndex] = dimension
+      }
+
+      if (extraOptions) {
+        extraOptions = JSON.parse(extraOptions)
+        for (var k in extraOptions) options[k] = extraOptions[k]
+      }
+
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        window.GOVUK.analytics.trackEvent(category, action, options)
+      }
+    }
+  }
+
+  Modules.GemTrackClick = GemTrackClick
+})(window.GOVUK.Modules)

--- a/spec/javascripts/govuk_publishing_components/lib/track-click.spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/track-click.spec.js
@@ -1,0 +1,198 @@
+describe('A click tracker', function() {
+  "use strict";
+
+  var GOVUK = window.GOVUK
+  var tracker,
+      element;
+
+  beforeEach(function() {
+    tracker = new GOVUK.Modules.TrackClick();
+  });
+
+  it('tracks click events using "beacon" as transport', function() {
+    GOVUK.analytics = { trackEvent: function () {} }
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $('\
+      <div \
+        data-track-category="category"\
+        data-track-action="action"\
+        data-track-label="Foo">\
+        Bar!\
+      </div>\
+    ');
+
+    tracker.start(element);
+
+    element.trigger('click');
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'Foo', transport: 'beacon'});
+  });
+
+  it('tracks clicks with custom dimensions', function() {
+    GOVUK.analytics = { trackEvent: function () {} }
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $(
+      '<a data-track-category="category" \
+          data-track-action="1" \
+          data-track-label="/" \
+          data-track-dimension="dimension-value" \
+          data-track-dimension-index="29" \
+          href="/">Home</a>'
+    );
+
+    tracker.start(element);
+
+    element.trigger('click');
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'category',
+      '1',
+      { label: '/', dimension29: 'dimension-value', transport: 'beacon' }
+    );
+  });
+
+  it('does not set dimension if dimension is not present', function() {
+    GOVUK.analytics = { trackEvent: function () {} }
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $('\
+      <div \
+        data-track-category="category"\
+        data-track-action="action"\
+        data-track-label="Foo"\
+        data-track-dimension-index="29">\
+        Bar!\
+      </div>\
+    ');
+
+    tracker.start(element);
+
+    element.trigger('click');
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'Foo', transport: 'beacon'});
+  });
+
+  it('does not set dimension if dimension index is not present', function() {
+    GOVUK.analytics = { trackEvent: function () {} }
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $('\
+      <div \
+        data-track-category="category"\
+        data-track-action="action"\
+        data-track-label="Foo"\
+        data-track-dimension="Home">\
+        Bar!\
+      </div>\
+    ');
+
+    tracker.start(element);
+
+    element.trigger('click');
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'Foo', transport: 'beacon'});
+  });
+
+  it('tracks clicks with values', function() {
+    GOVUK.analytics = { trackEvent: function () {} }
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $(
+      '<a data-track-category="category" \
+          data-track-action="1" \
+          data-track-label="/" \
+          data-track-value="9" \
+          href="/">Home</a>'
+    );
+
+    tracker.start(element);
+
+    element.trigger('click');
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'category',
+      '1',
+      { label: '/', value: '9', transport: 'beacon' }
+    );
+  });
+
+  it('tracks clicks with arbitrary JSON', function() {
+    GOVUK.analytics = { trackEvent: function () {} }
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $(
+      "<a data-track-category='category' \
+          data-track-action='1' \
+          data-track-label='/' \
+          data-track-options='{\"dimension28\": \"foo\", \"dimension29\": \"bar\"}' \
+          href='/'>Home</a>"
+    );
+
+    tracker.start(element);
+
+    element.trigger('click');
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'category',
+      '1',
+      { label: '/', dimension28: 'foo', dimension29: 'bar', transport: 'beacon' }
+    );
+  });
+
+  it('tracks all trackable links within a container', function() {
+    GOVUK.analytics = { trackEvent: function () {} }
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $('\
+      <div>\
+        <a class="first" href="#" \
+          data-track-category="cat1"\
+          data-track-action="action1"\
+          data-track-label="label1">\
+          Link 1\
+        </a>\
+        <a class="second" href="#" \
+          data-track-category="cat2"\
+          data-track-action="action2"\
+          data-track-label="label2">\
+          Link 2\
+        </a>\
+        <span class="nothing"></span>\
+      </div>\
+    ');
+
+    tracker.start(element);
+
+    element.find('.nothing').trigger('click');
+    expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled();
+
+    element.find('a.first').trigger('click');
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat1', 'action1', {label: 'label1', transport: 'beacon'});
+
+    element.find('a.second').trigger('click');
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat2', 'action2', {label: 'label2', transport: 'beacon'});
+  });
+
+  it('tracks a click correctly when event target is a child element of trackable element', function() {
+    GOVUK.analytics = { trackEvent: function () {} }
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $('\
+      <div>\
+        <a class="first" href="#" \
+          data-track-category="parent-category"\
+          data-track-action="parent-action"\
+          data-track-label="parent-label">\
+          <b><span class="child-of-link">I am a child</span></b>\
+        </a>\
+      </div>\
+    ');
+
+    tracker.start(element);
+
+    element.find('.child-of-link').trigger('click');
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('parent-category', 'parent-action', {label: 'parent-label', transport: 'beacon'});
+  });
+});

--- a/spec/javascripts/govuk_publishing_components/lib/track-click.spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/track-click.spec.js
@@ -1,198 +1,147 @@
-describe('A click tracker', function() {
-  "use strict";
+/* eslint-env jasmine, jquery */
 
+describe('A click tracker', function () {
   var GOVUK = window.GOVUK
-  var tracker,
-      element;
+  var element
 
-  beforeEach(function() {
-    tracker = new GOVUK.Modules.TrackClick();
-  });
+  beforeEach(function () {
+    if (typeof GOVUK.analytics === 'undefined') {
+      GOVUK.analytics = { trackEvent: function () {} }
+    }
+    spyOn(GOVUK.analytics, 'trackEvent')
+  })
 
-  it('tracks click events using "beacon" as transport', function() {
-    GOVUK.analytics = { trackEvent: function () {} }
-    spyOn(GOVUK.analytics, 'trackEvent');
+  afterEach(function () {
+    GOVUK.analytics.trackEvent.calls.reset()
+  })
 
-    element = $('\
-      <div \
-        data-track-category="category"\
-        data-track-action="action"\
-        data-track-label="Foo">\
-        Bar!\
-      </div>\
-    ');
-
-    tracker.start(element);
-
-    element.trigger('click');
-
-    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'Foo', transport: 'beacon'});
-  });
-
-  it('tracks clicks with custom dimensions', function() {
-    GOVUK.analytics = { trackEvent: function () {} }
-    spyOn(GOVUK.analytics, 'trackEvent');
-
+  it('tracks click events using "beacon" as transport', function () {
     element = $(
-      '<a data-track-category="category" \
-          data-track-action="1" \
-          data-track-label="/" \
-          data-track-dimension="dimension-value" \
-          data-track-dimension-index="29" \
-          href="/">Home</a>'
-    );
+      '<div data-module="gem-track-click" data-track-category="category" data-track-action="action" data-track-label="Foo">Bar</div>'
+    )
 
-    tracker.start(element);
+    new GOVUK.Modules.GemTrackClick().start(element)
+    element[0].click()
 
-    element.trigger('click');
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', { label: 'Foo', transport: 'beacon' })
+  })
+
+  it('tracks clicks with custom dimensions', function () {
+    element = $(
+      '<a data-module="gem-track-click" data-track-category="category" data-track-action="1" data-track-label="/" data-track-dimension="dimension-value" data-track-dimension-index="29" href="#">Home</a>'
+    )
+
+    new GOVUK.Modules.GemTrackClick().start(element)
+    element[0].click()
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'category',
       '1',
       { label: '/', dimension29: 'dimension-value', transport: 'beacon' }
-    );
-  });
+    )
+  })
 
-  it('does not set dimension if dimension is not present', function() {
-    GOVUK.analytics = { trackEvent: function () {} }
-    spyOn(GOVUK.analytics, 'trackEvent');
-
-    element = $('\
-      <div \
-        data-track-category="category"\
-        data-track-action="action"\
-        data-track-label="Foo"\
-        data-track-dimension-index="29">\
-        Bar!\
-      </div>\
-    ');
-
-    tracker.start(element);
-
-    element.trigger('click');
-
-    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'Foo', transport: 'beacon'});
-  });
-
-  it('does not set dimension if dimension index is not present', function() {
-    GOVUK.analytics = { trackEvent: function () {} }
-    spyOn(GOVUK.analytics, 'trackEvent');
-
-    element = $('\
-      <div \
-        data-track-category="category"\
-        data-track-action="action"\
-        data-track-label="Foo"\
-        data-track-dimension="Home">\
-        Bar!\
-      </div>\
-    ');
-
-    tracker.start(element);
-
-    element.trigger('click');
-
-    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'Foo', transport: 'beacon'});
-  });
-
-  it('tracks clicks with values', function() {
-    GOVUK.analytics = { trackEvent: function () {} }
-    spyOn(GOVUK.analytics, 'trackEvent');
-
+  it('does not set dimension if dimension is not present', function () {
     element = $(
-      '<a data-track-category="category" \
-          data-track-action="1" \
-          data-track-label="/" \
-          data-track-value="9" \
-          href="/">Home</a>'
-    );
+      '<div data-module="gem-track-click" data-track-category="category" data-track-action="action" data-track-label="Foo" data-track-dimension-index="29">Bar</div>'
+    )
 
-    tracker.start(element);
+    new GOVUK.Modules.GemTrackClick().start(element)
+    element[0].click()
 
-    element.trigger('click');
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', { label: 'Foo', transport: 'beacon' })
+  })
+
+  it('does not set dimension if dimension index is not present', function () {
+    element = $(
+      '<div data-module="gem-track-click" data-track-category="category" data-track-action="action" data-track-label="Foo" data-track-dimension="Home">Bar!</div>'
+    )
+
+    new GOVUK.Modules.GemTrackClick().start(element)
+    element[0].click()
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', { label: 'Foo', transport: 'beacon' })
+  })
+
+  it('tracks clicks with values', function () {
+    element = $(
+      '<a data-module="gem-track-click" data-track-category="category" data-track-action="1" data-track-label="/" data-track-value="9" href="#">Home</a>'
+    )
+
+    new GOVUK.Modules.GemTrackClick().start(element)
+    element[0].click()
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'category',
       '1',
       { label: '/', value: '9', transport: 'beacon' }
-    );
-  });
+    )
+  })
 
-  it('tracks clicks with arbitrary JSON', function() {
+  it('tracks clicks with arbitrary JSON', function () {
     GOVUK.analytics = { trackEvent: function () {} }
-    spyOn(GOVUK.analytics, 'trackEvent');
+    spyOn(GOVUK.analytics, 'trackEvent')
 
     element = $(
-      "<a data-track-category='category' \
-          data-track-action='1' \
-          data-track-label='/' \
-          data-track-options='{\"dimension28\": \"foo\", \"dimension29\": \"bar\"}' \
-          href='/'>Home</a>"
-    );
+      "<a data-module='gem-track-click' data-track-category='category' data-track-action='1' data-track-label='/' data-track-options='{\"dimension28\": \"foo\", \"dimension29\": \"bar\"}' href='#'>Home</a>"
+    )
 
-    tracker.start(element);
-
-    element.trigger('click');
+    new GOVUK.Modules.GemTrackClick().start(element)
+    element[0].click()
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'category',
       '1',
       { label: '/', dimension28: 'foo', dimension29: 'bar', transport: 'beacon' }
-    );
-  });
+    )
+  })
 
-  it('tracks all trackable links within a container', function() {
-    GOVUK.analytics = { trackEvent: function () {} }
-    spyOn(GOVUK.analytics, 'trackEvent');
+  it('tracks all trackable links within a container', function () {
+    element = $(
+      '<div data-module="gem-track-click">' +
+        '<a class="first" href="#" ' +
+          'data-track-category="cat1"' +
+          'data-track-action="action1"' +
+          'data-track-label="label1">' +
+          'Link 1' +
+        '</a>' +
+        '<a class="second" href="#" ' +
+          'data-track-category="cat2"' +
+          'data-track-action="action2"' +
+          'data-track-label="label2">' +
+          'Link 2' +
+        '</a>' +
+        '<span class="nothing"></span>' +
+      '</div>'
+    )
 
-    element = $('\
-      <div>\
-        <a class="first" href="#" \
-          data-track-category="cat1"\
-          data-track-action="action1"\
-          data-track-label="label1">\
-          Link 1\
-        </a>\
-        <a class="second" href="#" \
-          data-track-category="cat2"\
-          data-track-action="action2"\
-          data-track-label="label2">\
-          Link 2\
-        </a>\
-        <span class="nothing"></span>\
-      </div>\
-    ');
+    new GOVUK.Modules.GemTrackClick().start(element)
 
-    tracker.start(element);
+    element.find('.nothing')[0].click()
+    expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
 
-    element.find('.nothing').trigger('click');
-    expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled();
+    element.find('a.first')[0].click()
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat1', 'action1', { label: 'label1', transport: 'beacon' })
 
-    element.find('a.first').trigger('click');
-    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat1', 'action1', {label: 'label1', transport: 'beacon'});
+    element.find('a.second')[0].click()
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat2', 'action2', { label: 'label2', transport: 'beacon' })
+  })
 
-    element.find('a.second').trigger('click');
-    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat2', 'action2', {label: 'label2', transport: 'beacon'});
-  });
+  it('tracks a click correctly when event target is a child element of trackable element', function () {
+    element = $(
+      '<div data-module="gem-track-click">' +
+        '<a class="first" href="#" ' +
+          'data-track-category="parent-category"' +
+          'data-track-action="parent-action"' +
+          'data-track-label="parent-label">' +
+          '<b><span class="child-of-link">I am a child</span></b>' +
+        '</a>' +
+      '</div>'
+    )
 
-  it('tracks a click correctly when event target is a child element of trackable element', function() {
-    GOVUK.analytics = { trackEvent: function () {} }
-    spyOn(GOVUK.analytics, 'trackEvent');
+    new GOVUK.Modules.GemTrackClick().start(element)
 
-    element = $('\
-      <div>\
-        <a class="first" href="#" \
-          data-track-category="parent-category"\
-          data-track-action="parent-action"\
-          data-track-label="parent-label">\
-          <b><span class="child-of-link">I am a child</span></b>\
-        </a>\
-      </div>\
-    ');
-
-    tracker.start(element);
-
-    element.find('.child-of-link').trigger('click');
-    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('parent-category', 'parent-action', {label: 'parent-label', transport: 'beacon'});
-  });
-});
+    element.find('.child-of-link')[0].click()
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('parent-category', 'parent-action', { label: 'parent-label', transport: 'beacon' })
+  })
+})


### PR DESCRIPTION
## What
Add the track click code from static into the gem. This has involved some changes:

- **the code is now a module** which means that it has to be explicitly called using `data-module` on the element to be tracked, whereas previously this was done by the presence of other data attributes alone (`data-track-category` and `data-track-action`)
- **the module has been renamed** because if we did a proper migration (and removed it from `static`) the above change would be a massive breaking change across all of GOV.UK, which we don't have time to deal with right now. Instead, this code will exist as a small semi-duplication, which is less than ideal, but allows us to use it

A side effect of this change was that until the module had been renamed it broke the tests because the `details` component explicitly uses the track click code from `static` for tracking, but because it can't access it the test created a dummy object which deleted the real one from the gem. For reference there are some notes below about how to fix this, which I did before realising renaming the track click code was a better solution.

## Background

The track click code is a simple wrapper to allow easy custom analytics tracking on elements. It should be part of the analytics code but for historical reasons isn't (yet). To make use of it, add `data-module="gem-track-click"` to any element, along with some additional data attributes, and clicking on that element will fire a GA event. You can also put the module on a parent element, then put the tracking attributes on any number of child elements to track them. Note that the elements don't have to be links.

See examples in the tests for further clarity.

## Why

We need to be able to do track click stuff in Accounts, which only has access to code from the gem, not static.

## Visual Changes
None.

## Details component

For reference, here's how to update the details component to use the track click code in the gem, not static.

in `details.js`...

lines 15 and 16:

```
var trackDetails = new window.GOVUK.Modules.TrackClick()
trackDetails.start(element)
```

change to:

```
var trackDetails = new window.GOVUK.Modules.GemTrackClick()
trackDetails.start(element)
```

`details-spec.js`

remove lines 11 to 16:

```
  var callback = jasmine.createSpy()
  GOVUK.Modules.TrackClick = function () {
    this.start = function () {
      callback()
    }
  }
```

update this test as follows:

```
  it('uses built in tracking module when provided with a track-label', function () {
    spyOn(GOVUK.Modules, 'GemTrackClick').and.callThrough()
    loadDetailsComponent()

    $('.govuk-details__summary').click()

    expect(GOVUK.Modules.GemTrackClick).toHaveBeenCalled()
    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('track-category', 'track-action', { transport: 'beacon', label: 'track-label' })
  })
```

Trello card: https://trello.com/c/2gMj38xR/330-build-analytics