### PR TITLE
Fix orange outline on global site search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add custom margin support for print link ([PR #1753](https://github.com/alphagov/govuk_publishing_components/pull/1753))
+* Fix orange outline on global site search ([PR #1752](https://github.com/alphagov/govuk_publishing_components/pull/1752))
 
 ## 23.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -36,7 +36,6 @@ $large-input-size: 50px;
 
 .gem-c-search__input[type="search"] { // overly specific to prevent some overrides from outside
   @include govuk-font($size: 19, $line-height: (28 / 19));
-
   padding: 6px;
   margin: 0;
   width: 100%;
@@ -68,6 +67,13 @@ $large-input-size: 50px;
       // `border-width`.
       border-width: $govuk-border-width-form-element * 2;
     }
+  }
+}
+
+@include govuk-compatibility(govuk_template) {
+  //  ultra specific rule overrides focus styling from govuk_template
+  #global-header .gem-c-search__input[type="search"]:focus { // stylelint-disable selector-max-id
+    @extend .gem-c-search__input[type="search"]:focus; // stylelint-disable scss/at-extend-no-missing-placeholder
   }
 }
 


### PR DESCRIPTION
## What
The global header was [recently updated](https://github.com/alphagov/static/pull/2293) to use the search component instead of a hard coded search field.

This resulted in an issue where the input outline is now orange due to more specific styles from `govuk_template` conflicting with the search component styles.

This updates the component styles to be more specific in order to override the CSS from `govuk_template`.


<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
The site search input focus style has an orange outline due to `govuk_template` styles being more specific than the search component styles.
The outline should match the focus style of the search button.
<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
### Before
<img width="1783" alt="Screenshot 2020-10-26 at 14 11 39" src="https://user-images.githubusercontent.com/7116819/97189912-0704ee00-179d-11eb-82e6-ff6796478e72.png">

### After
<img width="1783" alt="Screenshot 2020-10-26 at 14 58 44" src="https://user-images.githubusercontent.com/7116819/97189921-0a987500-179d-11eb-9d1a-8c48c0e649f5.png">


NOTE: as of the time this PR is being created the bug is not live, we caught the issue on staging.


https://trello.com/c/RbD3om74 


