### PR TITLE
Add margin support for print link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add custom margin support for print link ([PR #1753](https://github.com/alphagov/govuk_publishing_components/pull/1753))
+
 ## 23.0.0
 
 Note - this is version 23.0.0 due to a previously yanked version using 22.0.0; this release is unrelated to the yanked version.

--- a/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
@@ -3,8 +3,6 @@ $gem-c-print-link-background-height: 18px;
 
 .gem-c-print-link {
   display: none;
-  margin-bottom: 2em;
-  margin-top: 2em;
 }
 
 .gem-c-print-link.gem-c-print-link--show-without-js {

--- a/app/views/govuk_publishing_components/components/_print_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_print_link.html.erb
@@ -3,33 +3,40 @@
   href ||= nil
   data_attributes ||= {}
   require_js ||= href.nil?
+  margin_top ||= 3
+  margin_bottom ||= 3
 
-  data_attributes[:module] = 'print-link' if require_js
+  data_attributes[:module] = require_js ? "print-link" : "button"
+
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({
+    margin_top: margin_top,
+    margin_bottom: margin_bottom
+  })
+
+  wrapper_classes = %w(gem-c-print-link)
+  wrapper_classes << "gem-c-print-link--show-without-js" unless require_js
+  wrapper_classes << (shared_helper.get_margin_top)
+  wrapper_classes << (shared_helper.get_margin_bottom)
 
   classes = %w(govuk-link)
   classes << "gem-c-print-link__button" if href.nil?
   classes << "gem-c-print-link__link govuk-link--no-visited-state" if href.present?
 %>
 
-<% if require_js %>
-  <div class="gem-c-print-link" >
+<%= tag.div class: wrapper_classes do %>
+  <% if require_js %>
     <%= content_tag(:button, text, {
         class: classes,
         data: data_attributes
     }) %>
-  </div>
-<% else %>
-  <div class="gem-c-print-link gem-c-print-link--show-without-js">
+  <% else %>
     <%= link_to(
       text,
       href,
       class: classes,
       rel: "alternate",
       data: data_attributes,
-      role: "button",
-      data: {
-        module: "button",
-      },
+      role: "button"
     ) %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/print_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/print_link.yml
@@ -22,3 +22,8 @@ examples:
         track-category: "printButton"
         track-action: "clicked"
         track-label: "Print this page"
+  with_custom_margins:
+    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having margin level 3 on top and bottom.
+    data:
+      margin_top: 0
+      margin_bottom: 4

--- a/spec/components/print_link_spec.rb
+++ b/spec/components/print_link_spec.rb
@@ -9,6 +9,8 @@ describe "Print link", type: :view do
     render_component({})
 
     assert_select ".gem-c-print-link"
+    assert_select ".gem-c-print-link.govuk-\\!-margin-top-3"
+    assert_select ".gem-c-print-link.govuk-\\!-margin-bottom-3"
     assert_select(
       "button.gem-c-print-link__button",
       text: "Print this page",
@@ -35,6 +37,21 @@ describe "Print link", type: :view do
     assert_select ".gem-c-print-link"
     assert_select(
       'a.gem-c-print-link__link[href="/print"]',
+      text: "Print this page",
+    )
+  end
+
+  it "renders with custom margin" do
+    render_component({
+      margin_top: 0,
+      margin_bottom: 4,
+    })
+
+    assert_select ".gem-c-print-link"
+    assert_select ".gem-c-print-link.govuk-\\!-margin-top-0"
+    assert_select ".gem-c-print-link.govuk-\\!-margin-bottom-4"
+    assert_select(
+      "button.gem-c-print-link__button",
       text: "Print this page",
     )
   end


### PR DESCRIPTION
## What
This change adds support for custom margin-top and bottom using the shared helper.
This retains a similar margin top and bottom - previously 2em (16px) but now govuk-spacing level 3 (around 15px).

## Why
The print link is now being used in multiple apps across GOVUK, therefore, needs to be able to match the styling of each app or placement within a page.

## Visual Changes
None - retains all existing styles.

## Demo
https://govuk-publis-add-margin-rq2byv.herokuapp.com/component-guide/print_link