### PR TITLE
Hide footnotes backlink in print version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix layout header component in IE ([PR #1760](https://github.com/alphagov/govuk_publishing_components/pull/1760))
+* Hide footnotes backlink in print version ([PR #1759](https://github.com/alphagov/govuk_publishing_components/pull/1759))
 
 ## 23.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_govspeak.scss
@@ -58,6 +58,10 @@
 
   .footnotes {
     border-top: 1px solid $govuk-text-colour;
+
+    a[role="doc-backlink"] {
+      display: none;
+    }
   }
 
   .legislative-list {


### PR DESCRIPTION
Example page where footnotes are used: https://www.gov.uk/government/publications/our-plan-to-rebuild-the-uk-governments-covid-19-recovery-strategy/our-plan-to-rebuild-the-uk-governments-covid-19-recovery-strategy 

## What
Hides the footnotes "back link" in the print version.
By "back link" I am referring to this thing ⬇️ 

<img width="723" alt="Screenshot 2020-10-26 at 19 21 30" src="https://user-images.githubusercontent.com/7116819/97730965-74ca5600-1acc-11eb-8782-db7fda76128f.png">
 
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
The footnotes are numbered for easy reference. Having the "back link" in the print version just adds noise as they are really only intended for the web. 
<!-- What are the reasons behind this change being made? -->

## Visual Changes
### Print version before: has backlink 🙅🏻‍♀️ 
<img width="1000" alt="Screenshot 2020-10-30 at 16 29 48" src="https://user-images.githubusercontent.com/7116819/97731646-531d9e80-1acd-11eb-9d8a-ceda92f41d56.png">

### Print version after: no backlink 🎉 

<img width="997" alt="Screenshot 2020-10-30 at 16 30 53" src="https://user-images.githubusercontent.com/7116819/97731656-544ecb80-1acd-11eb-9063-996b53e8f8d2.png">
<!-- If the change results in visual changes, show a before and after -->

https://trello.com/c/SJyttlVo
