### PR TITLE
Fix layout header component in IE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix layout header component in IE ([PR #1760](https://github.com/alphagov/govuk_publishing_components/pull/1760))
+
 ## 23.2.0
 
 * Change analytics calls ([PR #1757](https://github.com/alphagov/govuk_publishing_components/pull/1757))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -104,11 +104,16 @@
   }
 }
 
+.govuk-header__logotype {
+  vertical-align: middle;
+}
+
 .gem-c-header__product-name {
   display: none;
 
   @include govuk-media-query($from: tablet) {
     display: inline-block;
+    vertical-align: middle;
   }
 }
 


### PR DESCRIPTION
##  What / why
Fix the appearance of the layout header component on IE11 and down.

## Visual Changes

Before (IE11)

<img width="917" alt="Screenshot 2020-11-02 at 12 52 05" src="https://user-images.githubusercontent.com/861310/97870739-47b7b680-1d0b-11eb-81a7-67e79bc27e89.png">

After (IE11)

<img width="916" alt="Screenshot 2020-11-02 at 12 52 51" src="https://user-images.githubusercontent.com/861310/97870769-500ff180-1d0b-11eb-9bd7-5e18bddf9a1f.png">

The change results in a tiny difference for Chrome, before:

<img width="842" alt="Screenshot 2020-11-02 at 12 53 00" src="https://user-images.githubusercontent.com/861310/97870797-5b631d00-1d0b-11eb-868d-61fda7a25eca.png">

After:

<img width="837" alt="Screenshot 2020-11-02 at 12 53 13" src="https://user-images.githubusercontent.com/861310/97870808-6027d100-1d0b-11eb-9aef-d62bb638013c.png">

Trello card: https://trello.com/c/ICDC0esK/368-accounts-snag-list-%F0%9F%8C%AD
