### PR TITLE
Version 23.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 23.2.1
 
 * Fix layout header component in IE ([PR #1760](https://github.com/alphagov/govuk_publishing_components/pull/1760))
 * Hide footnotes backlink in print version ([PR #1759](https://github.com/alphagov/govuk_publishing_components/pull/1759))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.2.0)
+    govuk_publishing_components (23.2.1)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.2.0".freeze
+  VERSION = "23.2.1".freeze
 end


### PR DESCRIPTION
## 23.2.1

* Fix layout header component in IE ([PR #1760](https://github.com/alphagov/govuk_publishing_components/pull/1760))
* Hide footnotes backlink in print version ([PR #1759](https://github.com/alphagov/govuk_publishing_components/pull/1759))
