### PR TITLE
Change how analytics variables are passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change how analytics variables are passed ([PR #1762](https://github.com/alphagov/govuk_publishing_components/pull/1762))
+
 ## 23.2.1
 
 * Fix layout header component in IE ([PR #1760](https://github.com/alphagov/govuk_publishing_components/pull/1760))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/init.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/init.js
@@ -1,8 +1,14 @@
-var analyticsInit = function (gaProperty, gaPropertyCrossDomain, linkedDomains) {
+var analyticsInit = function () {
   'use strict'
 
-  var consentCookie = window.GOVUK.getConsentCookie()
+  var analyticsVars = window.GOVUK.analyticsVars || false
+  if (analyticsVars) {
+    var gaProperty = window.GOVUK.analyticsVars.gaProperty || false
+    var gaPropertyCrossDomain = window.GOVUK.analyticsVars.gaPropertyCrossDomain || false
+    var linkedDomains = window.GOVUK.analyticsVars.linkedDomains || false
+  }
 
+  var consentCookie = window.GOVUK.getConsentCookie()
   var dummyAnalytics = {
     addLinkedTrackerDomain: function () {},
     setDimension: function () {},
@@ -23,22 +29,24 @@ var analyticsInit = function (gaProperty, gaPropertyCrossDomain, linkedDomains) 
     // Load Google Analytics libraries
     window.GOVUK.StaticAnalytics.load()
 
-    // Use document.domain in dev, preview and staging so that tracking works
-    // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
-    var cookieDomain = (document.domain === 'www.gov.uk') ? '.www.gov.uk' : document.domain
+    if (gaProperty) {
+      // Use document.domain in dev, preview and staging so that tracking works
+      // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
+      var cookieDomain = (document.domain === 'www.gov.uk') ? '.www.gov.uk' : document.domain
 
-    // Configure profiles, setup custom vars, track initial pageview
-    var analytics = new window.GOVUK.StaticAnalytics({
-      universalId: gaProperty,
-      cookieDomain: cookieDomain,
-      allowLinker: true
-    })
+      // Configure profiles, setup custom vars, track initial pageview
+      var analytics = new window.GOVUK.StaticAnalytics({
+        universalId: gaProperty,
+        cookieDomain: cookieDomain,
+        allowLinker: true
+      })
 
-    // Make interface public for virtual pageviews and events
-    window.GOVUK.analytics = analytics
+      // Make interface public for virtual pageviews and events
+      window.GOVUK.analytics = analytics
 
-    if (linkedDomains && linkedDomains.length > 0) {
-      window.GOVUK.analytics.addLinkedTrackerDomain(gaPropertyCrossDomain, 'govuk', linkedDomains)
+      if (linkedDomains && linkedDomains.length > 0) {
+        window.GOVUK.analytics.addLinkedTrackerDomain(gaPropertyCrossDomain, 'govuk', linkedDomains)
+      }
     }
   } else {
     window.GOVUK.analytics = dummyAnalytics

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -5,9 +5,10 @@ describe('Cookie banner', function () {
   'use strict'
 
   var container
-
   var DEFAULT_COOKIE_CONSENT
   var ALL_COOKIE_CONSENT
+  window.GOVUK.analyticsVars = window.GOVUK.analyticsVars || {}
+  window.GOVUK.analyticsVars.gaProperty = 'UA-123456-7'
 
   beforeEach(function () {
     container = document.createElement('div')

--- a/spec/javascripts/govuk_publishing_components/analytics/auto-track-event.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/auto-track-event.spec.js
@@ -5,7 +5,6 @@ var $ = window.jQuery
 describe('An auto event tracker', function () {
   'use strict'
   var GOVUK = window.GOVUK
-
   var tracker,
     element
 

--- a/spec/javascripts/govuk_publishing_components/analytics/download-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/download-link-tracker.spec.js
@@ -5,7 +5,6 @@ var $ = window.jQuery
 describe('GOVUK.analyticsPlugins.downloadLinkTracker', function () {
   'use strict'
   var GOVUK = window.GOVUK
-
   var $links
 
   beforeEach(function () {

--- a/spec/javascripts/govuk_publishing_components/analytics/mailto-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/mailto-link-tracker.spec.js
@@ -5,7 +5,6 @@ var $ = window.jQuery
 describe('GOVUK.analyticsPlugins.mailtoLinkTracker', function () {
   'use strict'
   var GOVUK = window.GOVUK
-
   var $links
 
   beforeEach(function () {

--- a/spec/javascripts/govuk_publishing_components/analytics/static-analytics-spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/static-analytics-spec.js
@@ -12,6 +12,7 @@ describe('GOVUK.StaticAnalytics', function () {
     spyOn(window, 'ga')
     spyOn(GOVUK.analyticsPlugins, 'printIntent')
     spyOn(GOVUK.analyticsPlugins, 'error')
+
     analytics = new GOVUK.StaticAnalytics({
       universalId: 'universal-id',
       cookieDomain: '.www.gov.uk'


### PR DESCRIPTION
## What
Change how variables for the ga property and cross domain tracking configuration are passed to the `analyticsInit` function.

## Why
A previous change passed these variables to the `analyticsInit` function so that different applications could use different configurations. Turned out that this approach didn't work with the cookie banner, because it also calls the same function as part of its internal code, and can't access those variables.

Passing these variables from an application into multiple places is too complicated, so the solution is to define the variables as attached to the GOVUK object, so they can be referenced from anywhere in the code.

This requires some tweaks to the tests to make them pass correctly. There are still some issues with the tests that will be addressed prior to the big static move, ecommerce spec is creating errors `Cannot read property 'gaClientId' of undefined` that are only visible in the console if tests are run headless with GA tracking shown, doesn't actually cause a test failure but needs addressing.

## Visual Changes
None.
