### PR TITLE
Fix text overflow bug in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix text overflow bug in Firefox ([PR #1764](https://github.com/alphagov/govuk_publishing_components/pull/1764))
 * Tidy component filenames ([PR #1848](https://github.com/alphagov/govuk_publishing_components/pull/1848))
 * Add print styling for magna charta component ([PR #1867](https://github.com/alphagov/govuk_publishing_components/pull/1867))
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
@@ -4,6 +4,11 @@
   border-top: govuk-spacing(2) solid govuk-colour("blue");
 }
 
+.govuk-footer__list-item {
+  display: inline-block;
+  width: 99%;
+}
+
 .gem-c-layout-footer .govuk-footer__list {
   padding-bottom: govuk-spacing(7);
 }


### PR DESCRIPTION
## What

Fix a layout bug in Firefox that was causing single column list items to column wrap into the next column. Wasn't occurring in any other browsers, because apparently only Firefox doesn't support the `break-inside` property, so this is a bit of a workaround, but including it for other browsers just in case.

Tested in Firefox, Chrome, Edge, everything back to IE8.

## Why

The layout footer component is now being used live, in Accounts 😱 

## Visual Changes

Before: 

<img width="961" alt="Screenshot 2020-11-04 at 14 26 37" src="https://user-images.githubusercontent.com/861310/98123758-31942c80-1eaa-11eb-88f5-1dfb46ddb225.png">

After:

<img width="971" alt="Screenshot 2020-11-04 at 14 26 49" src="https://user-images.githubusercontent.com/861310/98123784-36f17700-1eaa-11eb-81bb-73de9ba47d05.png">
