### PR TITLE
Get analytics code ready for use in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Get analytics code ready for use in production ([PR #1767](https://github.com/alphagov/govuk_publishing_components/pull/1767))
+
 ## 23.11.1
 
 * Update Brexit CTA copy in contextual sidebar ([PR #1851](https://github.com/alphagov/govuk_publishing_components/pull/1851))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/external-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/external-link-tracker.js
@@ -10,7 +10,6 @@
     var externalLinkUploadCustomDimension = options.externalLinkUploadCustomDimension
     var currentHost = GOVUK.analyticsPlugins.externalLinkTracker.getHostname()
     var externalLinkSelector = 'a[href^="http"]:not(a[href*="' + currentHost + '"])'
-
     $('body').on('click', externalLinkSelector, trackClickEvent)
 
     function trackClickEvent (evt) {
@@ -33,7 +32,6 @@
 
         GOVUK.analytics.setDimension(externalLinkUploadCustomDimension, externalLinkToJoinUploadOn)
       }
-
       GOVUK.analytics.trackEvent('External Link Clicked', href, options)
     }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/pii.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/pii.js
@@ -7,6 +7,7 @@
   var EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
   var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9](?!refund)[ABD-HJLNPQ-Z]{2,3}/gi
   var DATE_PATTERN = /\d{4}(-?)\d{2}(-?)\d{2}/g
+  var ESCAPE_REGEX_PATTERN = /[|\\{}()[\]^$+*?.]/g
 
   // specific URL parameters to be redacted from accounts URLs
   var RESET_PASSWORD_TOKEN_PATTERN = /reset_password_token=[a-zA-Z0-9-]+/g
@@ -21,9 +22,24 @@
     return ($('meta[name="govuk:static-analytics:strip-postcodes"]').length > 0)
   }
 
+  function queryStringParametersToStrip () {
+    var value = $('meta[name="govuk:static-analytics:strip-query-string-parameters"]').attr('content')
+    var parameters = []
+
+    if (value) {
+      var split = value.split(',')
+      for (var i = 0; i < split.length; i++) {
+        parameters.push(split[i].trim())
+      }
+    }
+
+    return parameters
+  }
+
   var pii = function () {
     this.stripDatePII = shouldStripDates()
     this.stripPostcodePII = shouldStripPostcodes()
+    this.queryStringParametersToStrip = queryStringParametersToStrip()
   }
 
   pii.prototype.stripPII = function (value) {
@@ -43,6 +59,7 @@
     stripped = stripped.replace(RESET_PASSWORD_TOKEN_PATTERN, 'reset_password_token=[reset_password_token]')
     stripped = stripped.replace(UNLOCK_TOKEN_PATTERN, 'unlock_token=[unlock_token]')
     stripped = stripped.replace(STATE_PATTERN, 'state=[state]')
+    stripped = this.stripQueryStringParameters(stripped)
 
     if (this.stripDatePII === true) {
       stripped = stripped.replace(DATE_PATTERN, '[date]')
@@ -75,6 +92,17 @@
       array[i] = this.stripPII(elem)
     }
     return array
+  }
+
+  pii.prototype.stripQueryStringParameters = function (string) {
+    for (var i = 0; i < this.queryStringParametersToStrip.length; i++) {
+      var parameter = this.queryStringParametersToStrip[i]
+      var escaped = parameter.replace(ESCAPE_REGEX_PATTERN, '\\$&')
+      var regexp = new RegExp('((?:\\?|&)' + escaped + '=)(?:[^&#\\s]*)', 'g')
+      string = string.replace(regexp, '$1[' + parameter + ']')
+    }
+
+    return string
   }
 
   GOVUK.Pii = pii

--- a/app/assets/javascripts/govuk_publishing_components/analytics/pii.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/pii.js
@@ -5,7 +5,7 @@
 
   var GOVUK = global.GOVUK || {}
   var EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
-  var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9][ABD-HJLNPQ-Z]{2}/gi
+  var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9](?!refund)[ABD-HJLNPQ-Z]{2,3}/gi
   var DATE_PATTERN = /\d{4}(-?)\d{2}(-?)\d{2}/g
 
   // specific URL parameters to be redacted from accounts URLs

--- a/spec/javascripts/components/checkboxes-spec.js
+++ b/spec/javascripts/components/checkboxes-spec.js
@@ -73,10 +73,6 @@ describe('Checkboxes component', function () {
     expectedRedOptions = { label: 'red', value: '1', dimension28: 'wubbalubbadubdub', dimension29: 'Pickle Rick' }
     expectedBlueOptions = { label: 'blue', value: '2', dimension28: 'Get schwifty', dimension29: 'Squanch' }
 
-    if (typeof GOVUK.analytics === 'undefined') {
-      GOVUK.analytics = { trackEvent: function () {} }
-    }
-
     spyOn(GOVUK.analytics, 'trackEvent')
   })
 
@@ -128,7 +124,9 @@ describe('Checkboxes component', function () {
     $checkbox.trigger('click')
     expect($checkbox.is(':checked')).toBe(true)
 
-    GOVUK.analytics.trackEvent.calls.reset()
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
 
     $checkbox.trigger('click')
     expect($checkbox.is(':checked')).toBe(false)

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -101,9 +101,6 @@ describe('Cookie banner', function () {
   })
 
   it('sets consent cookie when accepting cookies', function () {
-    if (typeof GOVUK.analyticsInit === 'undefined') {
-      GOVUK.analyticsInit = function () {}
-    }
     spyOn(GOVUK, 'analyticsInit')
     spyOn(GOVUK, 'setCookie').and.callThrough()
 

--- a/spec/javascripts/components/details-spec.js
+++ b/spec/javascripts/components/details-spec.js
@@ -4,10 +4,6 @@
 describe('Details component', function () {
   var FIXTURE
 
-  if (typeof GOVUK.analytics === 'undefined') {
-    GOVUK.analytics = { trackEvent: function () {} }
-  }
-
   var callback = jasmine.createSpy()
   GOVUK.Modules.TrackClick = function () {
     this.start = function () {
@@ -34,7 +30,9 @@ describe('Details component', function () {
   })
 
   afterEach(function () {
-    GOVUK.analytics.trackEvent.calls.reset()
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
   })
 
   it('uses built in tracking module when provided with a track-label', function () {

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -95,7 +95,9 @@ describe('Feedback component', function () {
   })
 
   afterEach(function () {
-    GOVUK.analytics.trackEvent.calls.reset()
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
   })
 
   it('hides the forms', function () {

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -88,9 +88,6 @@ describe('Feedback component', function () {
 
   beforeEach(function () {
     window.setFixtures(FIXTURE)
-    if (typeof GOVUK.analytics === 'undefined') {
-      GOVUK.analytics = { trackEvent: function () {} }
-    }
     spyOn(GOVUK.analytics, 'trackEvent')
   })
 
@@ -127,6 +124,8 @@ describe('Feedback component', function () {
     expect($('.js-toggle-form[aria-controls="something-is-wrong"]').attr('aria-expanded')).toBe('false')
   })
 
+  // note that this test will always fail in the browser if you disable 'run tests in random order'
+  // because the page auto reloads so the referrer will be localhost
   it('should append a hidden "referrer" field to the form', function () {
     loadFeedbackComponent()
 

--- a/spec/javascripts/components/select-spec.js
+++ b/spec/javascripts/components/select-spec.js
@@ -5,12 +5,10 @@ describe('Track select change', function () {
   var tracker
   var $element
 
-  if (typeof GOVUK.analytics === 'undefined') {
-    GOVUK.analytics = { trackEvent: function () {} }
-  }
-
   afterEach(function () {
-    GOVUK.analytics.trackEvent.calls.reset()
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
   })
 
   describe('by default', function () {

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -103,9 +103,6 @@ describe('A stepnav module', function () {
     expectedstepnavContentCount = $element.find('.gem-c-step-nav__step').first().find('.js-link').length
     expectedstepnavLinkCount = $element.find('.gem-c-step-nav__list-item').length
 
-    if (typeof GOVUK.analytics === 'undefined') {
-      GOVUK.analytics = { trackEvent: function () {} }
-    }
     spyOn(GOVUK.analytics, 'trackEvent')
   })
 

--- a/spec/javascripts/components/toggle-spec.js
+++ b/spec/javascripts/components/toggle-spec.js
@@ -6,9 +6,11 @@ describe('A toggle module', function () {
 
   var element
 
-  if (typeof GOVUK.analytics === 'undefined') {
-    GOVUK.analytics = { trackEvent: function () {} }
-  }
+  afterEach(function () {
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
+  })
 
   describe('when starting', function () {
     beforeEach(function () {

--- a/spec/javascripts/govuk_publishing_components/analytics/analytics.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/analytics.spec.js
@@ -24,6 +24,15 @@ describe('GOVUK.Analytics', function () {
     })
   })
 
+  afterEach(function () {
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
+    if (GOVUK.analytics.setDimension.calls) {
+      GOVUK.analytics.setDimension.calls.reset()
+    }
+  })
+
   describe('when created', function () {
     beforeEach(function () {
       universalSetupArguments = window.ga.calls.allArgs()

--- a/spec/javascripts/govuk_publishing_components/analytics/auto-track-event.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/auto-track-event.spec.js
@@ -9,19 +9,17 @@ describe('An auto event tracker', function () {
     element
 
   beforeEach(function () {
-    if (typeof GOVUK.analytics === 'undefined') {
-      GOVUK.analytics = { trackEvent: function () {} }
-    }
     tracker = new GOVUK.Modules.AutoTrackEvent()
+    spyOn(GOVUK.analytics, 'trackEvent')
   })
 
   afterEach(function () {
-    GOVUK.analytics.trackEvent.calls.reset()
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
   })
 
   it('tracks non-interactive events on start', function () {
-    spyOn(GOVUK.analytics, 'trackEvent')
-
     element = $(
       '<div ' +
         'data-track-category="category"' +
@@ -36,8 +34,6 @@ describe('An auto event tracker', function () {
   })
 
   it('can track non-interactive events with optional label and value', function () {
-    spyOn(GOVUK.analytics, 'trackEvent')
-
     element = $(
       '<div ' +
         'data-track-category="category"' +

--- a/spec/javascripts/govuk_publishing_components/analytics/download-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/download-link-tracker.spec.js
@@ -23,23 +23,20 @@ describe('GOVUK.analyticsPlugins.downloadLinkTracker', function () {
 
     $('html').on('click', function (evt) { evt.preventDefault() })
     $('body').append($links)
-
-    if (typeof GOVUK.analytics === 'undefined') {
-      GOVUK.analytics = { trackEvent: function () {} }
-    }
     GOVUK.analyticsPlugins.downloadLinkTracker({ selector: 'a[href$=".pdf"], a[href$=".xslt"], a[href$=".doc"], a[href$=".png"]' })
+    spyOn(GOVUK.analytics, 'trackEvent')
   })
 
   afterEach(function () {
     $('html').off()
     $('body').off()
     $links.remove()
-    GOVUK.analytics.trackEvent.calls.reset()
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
   })
 
   it('listens to clicks on links that match the selector', function () {
-    spyOn(GOVUK.analytics, 'trackEvent')
-
     $('.download-links a').each(function () {
       $(this).trigger('click')
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalled()
@@ -54,14 +51,11 @@ describe('GOVUK.analyticsPlugins.downloadLinkTracker', function () {
   })
 
   it('listens to click events on elements within download links', function () {
-    spyOn(GOVUK.analytics, 'trackEvent')
-
     $('.download-links a img').trigger('click')
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('Download Link Clicked', '/an/image/link.png', { transport: 'beacon' })
   })
 
   it('tracks a download link as an event with link text as the label', function () {
-    spyOn(GOVUK.analytics, 'trackEvent')
     $('.download-links a').trigger('click')
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(

--- a/spec/javascripts/govuk_publishing_components/analytics/ecommerce.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/ecommerce.spec.js
@@ -292,9 +292,7 @@ describe('Ecommerce reporter for results pages', function () {
     })
   })
 
-  // this test passes when run individually but fails with the other tests
-  // not needed but will require fixing when analytics are fully migrated from static
-  xit('tracks clicks on search results', function () {
+  it('tracks clicks on search results', function () {
     element = $(
       '<div data-ecommerce-start-index="1" data-search-query="search query">' +
         '<a data-ecommerce-row data-ecommerce-path="/path/to/page" data-ecommerce-content-id="AAAA-1111"></a>' +
@@ -338,9 +336,7 @@ describe('Ecommerce reporter for results pages', function () {
     })
   })
 
-  // this test passes when run individually but fails with the other tests
-  // not needed but will require fixing when analytics are fully migrated from static
-  xit('tracks clicks with product variants', function () {
+  it('tracks clicks with product variants', function () {
     element = $(
       '<div data-ecommerce-start-index="1" data-search-query="search query" data-ecommerce-variant="variant-x">' +
         '<a data-ecommerce-row data-ecommerce-path="/path/to/page" data-ecommerce-content-id="AAAA-1111"></a>' +
@@ -385,9 +381,7 @@ describe('Ecommerce reporter for results pages', function () {
     })
   })
 
-  // this test passes when run individually but fails with the other tests
-  // not needed but will require fixing when analytics are fully migrated from static
-  xit('tracks clicks with different event labels', function () {
+  it('tracks clicks with different event labels', function () {
     element = $(
       '<div> ' +
         '<div data-analytics-ecommerce data-list-title="First list" data-ecommerce-start-index="1" data-search-query="search query">' +

--- a/spec/javascripts/govuk_publishing_components/analytics/ecommerce.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/ecommerce.spec.js
@@ -28,10 +28,13 @@ describe('Ecommerce reporter for results pages', function () {
     window.GOVUK.analyticsInit()
     ecommerce = new GOVUK.Ecommerce()
     GOVUK.analytics.gaClientId = '12345.67890'
-    if (typeof window.ga === 'undefined') {
-      window.ga = function () {}
-    }
     spyOn(window, 'ga')
+  })
+
+  afterEach(function () {
+    if (window.ga.calls) {
+      window.ga.calls.reset()
+    }
   })
 
   it('requires content id or path', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics/error-tracking.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/error-tracking.spec.js
@@ -7,14 +7,13 @@ describe('GOVUK.analyticsPlugins.error', function () {
   GOVUK.analyticsPlugins.error({ filenameMustMatch: /gov\.uk/ })
 
   beforeEach(function () {
-    if (typeof GOVUK.analytics === 'undefined') {
-      GOVUK.analytics = { trackEvent: function () {} }
-    }
     spyOn(GOVUK.analytics, 'trackEvent')
   })
 
   afterEach(function () {
-    GOVUK.analytics.trackEvent.calls.reset()
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
   })
 
   xit('sends errors to Google Analytics', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics/external-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/external-link-tracker.spec.js
@@ -41,9 +41,7 @@ describe('GOVUK.analyticsPlugins.externalLinkTracker', function () {
     }
   })
 
-  // this test passes when run individually but fails with the other tests
-  // not needed but will require fixing when analytics are fully migrated from static
-  xit('listens to click events on only external links', function () {
+  it('listens to click events on only external links', function () {
     GOVUK.analyticsPlugins.externalLinkTracker({ externalLinkUploadCustomDimension: 36 })
 
     $('.external-links a').each(function () {
@@ -94,9 +92,7 @@ describe('GOVUK.analyticsPlugins.externalLinkTracker', function () {
       'External Link Clicked', 'http://www.nationalarchives.gov.uk', { transport: 'beacon', label: 'National Archives' })
   })
 
-  // this test passes when run individually but fails with the other tests
-  // not needed but will require fixing when analytics are fully migrated from static
-  xit('does not duplicate the url info if a custom dimension is not provided', function () {
+  it('does not duplicate the url info if a custom dimension is not provided', function () {
     GOVUK.analyticsPlugins.externalLinkTracker()
     $('.external-links a').trigger('click')
 

--- a/spec/javascripts/govuk_publishing_components/analytics/google-analytics-universal-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/google-analytics-universal-tracker.spec.js
@@ -29,6 +29,13 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
     $('head').find('meta[name="govuk:static-analytics:strip-dates"]').remove()
     $('head').find('meta[name="govuk:static-analytics:strip-postcodes"]').remove()
     $('[src="https://www.google-analytics.com/analytics.js"]').remove()
+
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
+    if (GOVUK.analytics.setDimension.calls) {
+      GOVUK.analytics.setDimension.calls.reset()
+    }
   })
 
   it('can load the libraries needed to run universal Google Analytics', function () {
@@ -204,7 +211,14 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
   })
 
   describe('when tracking all events', function () {
-    window.history.replaceState(null, null, '?address=an.email@digital.cabinet-office.gov.uk&postcode=sw11wa&date=2019-01-01')
+    beforeAll(function () {
+      window.history.replaceState(null, null, '?address=an.email@digital.cabinet-office.gov.uk&postcode=sw11wa&date=2019-01-01')
+    })
+
+    afterAll(function () {
+      var href = window.location.href.replace('?address=an.email@digital.cabinet-office.gov.uk&postcode=sw11wa&date=2019-01-01', '')
+      window.history.replaceState(null, null, href)
+    })
 
     it('removes any pii from the location', function () {
       expect(window.ga.calls.mostRecent().args[2]).toContain('address=[email]')
@@ -233,10 +247,20 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
   describe('adding a linked tracker', function () {
     var callIndex
 
+    beforeAll(function () {
+      window.history.replaceState(null, null, '?address=an.email@digital.cabinet-office.gov.uk&postcode=sw11wa&date=2019-01-01')
+    })
+
+    afterAll(function () {
+      var href = window.location.href.replace('?address=an.email@digital.cabinet-office.gov.uk&postcode=sw11wa&date=2019-01-01', '')
+      window.history.replaceState(null, null, href)
+    })
+
     beforeEach(function () {
       callIndex = window.ga.calls.count()
       universal.addLinkedTrackerDomain('UA-123456', 'testTracker', ['some.service.gov.uk'])
     })
+
     it('creates a tracker for the ID', function () {
       expect(window.ga.calls.argsFor(callIndex)).toEqual(['create', 'UA-123456', 'auto', Object({ name: 'testTracker' })])
     })

--- a/spec/javascripts/govuk_publishing_components/analytics/mailto-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/mailto-link-tracker.spec.js
@@ -18,24 +18,20 @@ describe('GOVUK.analyticsPlugins.mailtoLinkTracker', function () {
 
     $('html').on('click', function (evt) { evt.preventDefault() })
     $('body').append($links)
-
-    if (typeof GOVUK.analytics === 'undefined') {
-      GOVUK.analytics = { trackEvent: function () {} }
-    }
-
     GOVUK.analyticsPlugins.mailtoLinkTracker()
+    spyOn(GOVUK.analytics, 'trackEvent')
   })
 
   afterEach(function () {
     $('html').off()
     $('body').off()
     $links.remove()
-    GOVUK.analytics.trackEvent.calls.reset()
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
   })
 
   it('listens to click events on mailto links', function () {
-    spyOn(GOVUK.analytics, 'trackEvent')
-
     $('.mailto-links a').each(function () {
       $(this).trigger('click')
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalled()
@@ -44,7 +40,6 @@ describe('GOVUK.analyticsPlugins.mailtoLinkTracker', function () {
   })
 
   it('tracks mailto addresses and link text', function () {
-    spyOn(GOVUK.analytics, 'trackEvent')
     $('.mailto-links a').trigger('click')
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
@@ -55,8 +50,6 @@ describe('GOVUK.analyticsPlugins.mailtoLinkTracker', function () {
   })
 
   it('listens to click events on elements within mailto links', function () {
-    spyOn(GOVUK.analytics, 'trackEvent')
-
     $('.mailto-links a img').trigger('click')
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'Mailto Link Clicked', 'mailto:name3@email.com', { transport: 'beacon' })

--- a/spec/javascripts/govuk_publishing_components/analytics/pii.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/pii.spec.js
@@ -127,6 +127,40 @@ describe('GOVUK.PII', function () {
     })
   })
 
+  describe('when there is a govuk:static-analytics:strip-query-string-parameters meta tag present', function () {
+    afterEach(function () {
+      resetHead()
+    })
+
+    it('strips specified query strings that are identified in a string', function () {
+      pageWantsQueryStringParametersStripped(['strip-parameter-1', 'strip-parameter-2'])
+      pii = new GOVUK.Pii()
+      var string = pii.stripPII('this is a string with a url /test?strip-parameter-1=secret&strip-parameter-2=more-secret')
+      expect(string).toEqual('this is a string with a url /test?strip-parameter-1=[strip-parameter-1]&strip-parameter-2=[strip-parameter-2]')
+    })
+
+    it('can strip query strings with special characters', function () {
+      pageWantsQueryStringParametersStripped(['parameter[]'])
+      pii = new GOVUK.Pii()
+      var string = pii.stripPII('/url?parameter[]=secret&parameter[]=more-secret')
+      expect(string).toEqual('/url?parameter[]=[parameter[]]&parameter[]=[parameter[]]')
+    })
+
+    it('matches a URL with a fragment', function () {
+      pageWantsQueryStringParametersStripped(['parameter'])
+      pii = new GOVUK.Pii()
+      var string = pii.stripPII('/url?parameter=secret#anchor')
+      expect(string).toEqual('/url?parameter=[parameter]#anchor')
+    })
+
+    it('doesn\'t match params without a query string prefix', function () {
+      pageWantsQueryStringParametersStripped(['parameter'])
+      pii = new GOVUK.Pii()
+      var string = pii.stripPII('parameter=secret')
+      expect(string).toEqual('parameter=secret')
+    })
+  })
+
   describe('when there is a a govuk:static-analytics:strip-dates meta tag present', function () {
     beforeEach(function () {
       pageWantsDatesStripped()
@@ -143,6 +177,7 @@ describe('GOVUK.PII', function () {
   function resetHead () {
     $('head').find('meta[name="govuk:static-analytics:strip-postcodes"]').remove()
     $('head').find('meta[name="govuk:static-analytics:strip-dates"]').remove()
+    $('head').find('meta[name="govuk:static-analytics:strip-query-string-parameters"]').remove()
   }
 
   function pageWantsDatesStripped () {
@@ -151,5 +186,9 @@ describe('GOVUK.PII', function () {
 
   function pageWantsPostcodesStripped () {
     $('head').append('<meta name="govuk:static-analytics:strip-postcodes" value="does not matter" />')
+  }
+
+  function pageWantsQueryStringParametersStripped (parameters) {
+    $('head').append('<meta name="govuk:static-analytics:strip-query-string-parameters" content="' + parameters.join(', ') + '" />')
   }
 })

--- a/spec/javascripts/govuk_publishing_components/analytics/pii.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/pii.spec.js
@@ -122,8 +122,8 @@ describe('GOVUK.PII', function () {
 
     it('observes the meta tag and strips out postcodes', function () {
       expect(pii.stripPostcodePII).toEqual(true)
-      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date')
-      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a 2019-01-21 date')
+      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a long GL194LYX postcode, this is a 2019-01-21 date, this is a p800refund')
+      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a long [postcode] postcode, this is a 2019-01-21 date, this is a p800refund')
     })
   })
 

--- a/spec/javascripts/govuk_publishing_components/analytics/scroll-tracker-spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/scroll-tracker-spec.js
@@ -10,6 +10,9 @@ describe('GOVUK.ScrollTracker', function () {
   afterEach(function () {
     jasmine.clock().uninstall()
     $(window).unbind('scroll')
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
   })
 
   describe('enabling on correct pages', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics/static-analytics-spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/static-analytics-spec.js
@@ -19,6 +19,12 @@ describe('GOVUK.StaticAnalytics', function () {
     })
   })
 
+  afterEach(function () {
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
+  })
+
   describe('when created', function () {
     var pageViewObject
 
@@ -951,6 +957,7 @@ describe('GOVUK.StaticAnalytics', function () {
         analytics = new GOVUK.StaticAnalytics({ universalId: 'universal-id' })
         pageViewObject = getPageViewObject()
         expect(pageViewObject.dimension23).toEqual('fr')
+        $('.test-fixture').remove()
       })
 
       it('sets the page language as "unknown" if the main element has no lang attribute as a custom dimension', function () {
@@ -963,6 +970,7 @@ describe('GOVUK.StaticAnalytics', function () {
         analytics = new GOVUK.StaticAnalytics({ universalId: 'universal-id' })
         pageViewObject = getPageViewObject()
         expect(pageViewObject.dimension23).toEqual('unknown')
+        $('.test-fixture').remove()
       })
     })
 

--- a/spec/javascripts/govuk_publishing_components/lib/track-click.spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/track-click.spec.js
@@ -5,14 +5,14 @@ describe('A click tracker', function () {
   var element
 
   beforeEach(function () {
-    if (typeof GOVUK.analytics === 'undefined') {
-      GOVUK.analytics = { trackEvent: function () {} }
-    }
     spyOn(GOVUK.analytics, 'trackEvent')
   })
 
   afterEach(function () {
-    GOVUK.analytics.trackEvent.calls.reset()
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
+    element.remove()
   })
 
   it('tracks click events using "beacon" as transport', function () {
@@ -79,9 +79,6 @@ describe('A click tracker', function () {
   })
 
   it('tracks clicks with arbitrary JSON', function () {
-    GOVUK.analytics = { trackEvent: function () {} }
-    spyOn(GOVUK.analytics, 'trackEvent')
-
     element = $(
       "<a data-module='gem-track-click' data-track-category='category' data-track-action='1' data-track-label='/' data-track-options='{\"dimension28\": \"foo\", \"dimension29\": \"bar\"}' href='#'>Home</a>"
     )

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -13,6 +13,13 @@ var resetCookies = function () {
   document.cookie.split(';').forEach(function (c) { document.cookie = c.replace(/^ +/, '').replace(/=.*/, '=;expires=' + new Date().toUTCString() + ';path=/') })
 }
 
+// external-link-tracker.js adds a click event to the body for matching links
+// gets called once in production but multiple times in testing e.g. in static-analytics-spec
+// every time it does `new GOVUK.StaticAnalytics()` so need to remove this using .off()
+beforeEach(function () {
+  $('body').off()
+})
+
 afterEach(function () {
   resetCookies()
 })

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -1,5 +1,14 @@
 /* eslint-env jasmine, jquery */
 
+beforeAll(function () {
+  window.GOVUK.analyticsVars = window.GOVUK.analyticsVars || {}
+  window.GOVUK.analyticsVars.gaProperty = "UA-11111111-11"
+  window.GOVUK.analyticsVars.gaPropertyCrossDomain = "UA-222222222-2"
+  window.GOVUK.analyticsVars.linkedDomains = ['www.gov.uk']
+  delete ga
+  window.GOVUK.analyticsInit()
+})
+
 var resetCookies = function () {
   document.cookie.split(';').forEach(function (c) { document.cookie = c.replace(/^ +/, '').replace(/=.*/, '=;expires=' + new Date().toUTCString() + ';path=/') })
 }


### PR DESCRIPTION
## What
Make changes to the analytics code in the gem, ready for use on live GOV.UK, to replace the existing copy of the code in `static`.

- improve how analytics code is called in the tests and modify previous tests that mocked the analytics objects (causing the new analytics tests to fail)
- re-enable and fix disabled tests in external link tracker and ecommerce analytics tests
- copy across changes in analytics code in static made since the analytics code was copied into the gem

## Why
We want to get this analytics code ready for use in production.

## Visual Changes
None.

Trello cards:

- https://trello.com/c/p3UtkNtE/420-resolve-the-two-copies-of-analytics-code
- https://trello.com/c/epZ12grR/110-migrate-analytics-code-into-the-gem
