### PR TITLE
Fix chart glitch when source table has row headers

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
@@ -49,8 +49,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     // true if it's a 'multiple' table
     // this means multiple bars per rows, but not stacked.
-    var moreThanTwoTDs = this.$table.querySelectorAll('tbody tr')[0].querySelectorAll('td').length > 2
-    this.options.multiple = !this.options.stacked && (this.$table.classList.contains('mc-multiple') || moreThanTwoTDs)
+    var moreThanTwoCells = this.$table.querySelectorAll('tbody tr')[0].querySelectorAll('th, td').length > 2
+
+    this.options.multiple = !this.options.stacked && (this.$table.classList.contains('mc-multiple') || moreThanTwoCells)
 
     // set the outdent options
     // which can be set via classes or overriden by setting the value to true
@@ -118,11 +119,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     tr.classList.add('mc-tr')
 
     var output = ''
-    var allTheTHs = this.$table.querySelectorAll('th')
+    var allTheTHsInTableHead = this.$table.querySelectorAll('thead th')
 
-    for (var i = 0; i < allTheTHs.length; i++) {
+    for (var i = 0; i < allTheTHsInTableHead.length; i++) {
       output += '<div class="mc-th">'
-      output += allTheTHs[i].innerHTML
+      output += allTheTHsInTableHead[i].innerHTML
       output += '</div>'
     }
 
@@ -143,11 +144,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       tr.classList.add('mc-tr')
 
       var cellsOutput = ''
-      var allTheTds = allTheTbodyTrs[i].querySelectorAll('td')
+      var allTheTableBodyCells = allTheTbodyTrs[i].querySelectorAll('th, td')
 
-      for (var j = 0; j < allTheTds.length; j++) {
+      for (var j = 0; j < allTheTableBodyCells.length; j++) {
         cellsOutput += '<div class="mc-td">'
-        cellsOutput += allTheTds[j].innerHTML
+        cellsOutput += allTheTableBodyCells[j].innerHTML
         cellsOutput += '</div>'
       }
       tr.innerHTML = cellsOutput

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -236,6 +236,20 @@ examples:
             </tr>
           </tbody>
         </table>
+  chart_with_multiple_headings:
+    data:
+      block: |
+        <table id="multiple-table-chart" class="js-barchart-table mc-multiple">
+          <caption>Multiple Table</caption>
+          <thead>
+            <tr><th>Some Data</th><th>YES</th><th>NO</th><th>MAYBE</th></tr>
+          </thead>
+          <tbody>
+            <tr><th>Testing One</th><td>5</td><td>6</td><td>11</td></tr>
+            <tr><th>Testing Two</th><td>6</td><td>2</td><td>8</td></tr>
+            <tr><th>Testing Three</th><td>3</td><td>9</td><td>12</td></tr>
+          </tbody>
+        </table>
   address:
     data:
       block: |

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
@@ -62,6 +62,19 @@ describe('Magna charta', function () {
       '</tbody>' +
     '</table>'
 
+  var multiple3 =
+    '<table id="multiple3" class="">' +
+      '<caption>Multiple Table</caption>' +
+      '<thead>' +
+        '<tr><th>Some Data</th><th>YES</th><th>NO</th><th>MAYBE</th></tr>' +
+      '</thead>' +
+      '<tbody>' +
+        '<tr><th>Testing One</th><td>5</td><td>6</td><td>11</td></tr>' +
+        '<tr><th>Testing Two</th><td>6</td><td>2</td><td>8</td></tr>' +
+        '<tr><th>Testing Three</th><td>3</td><td>9</td><td>12</td></tr>' +
+      '</tbody>' +
+    '</table>'
+
   var negative =
     '<table id="negative" class="mc-negative">' +
       '<thead>' +
@@ -186,6 +199,25 @@ describe('Magna charta', function () {
       element = $('<div/>').attr('id', 'test-magna-charta').html(multiple2)
       $('body').append(element)
       magna = new GOVUK.Modules.MagnaCharta().start(element.find('#multiple2')[0], { returnReference: true })
+      graph = element.find('.mc-chart')
+      table = element.find('table')
+    })
+
+    afterEach(function () {
+      $('body').find('#test-magna-charta').remove()
+    })
+
+    it('the graph of a multiple table is given a class', function () {
+      expect(graph).toHaveClass('mc-multiple')
+      expect(magna.options.multiple).toBe(true)
+    })
+  })
+
+  describe('creating a graph of a multiple table with row headings', function () {
+    beforeEach(function () {
+      element = $('<div/>').attr('id', 'test-magna-charta').html(multiple3)
+      $('body').append(element)
+      magna = new GOVUK.Modules.MagnaCharta().start(element.find('#multiple3')[0], { returnReference: true })
       graph = element.find('.mc-chart')
       table = element.find('table')
     })


### PR DESCRIPTION
## What
Makes sure that Magna Charta (which is used by the Govspeak component) can correctly render charts when tables with row headings are used.

Adds an example of a chart with multiple headings to the Govspeak component docs.

And adds a test to make sure that tables with row headers are rendered correctly.

## Why

Govspeak (the markdown gem) can now generated tables with row headings using the correct `th` element. Previously these were unavailable, which led to a lot of tables that couldn't be understood by assistive technologies such as screenreaders.

But using a `th` as a row heading broke Magna Charta's automatically generated chart - the `th` would be ignored and the first `td` used instead. This has led to charts being incorrectly displayed.

## Visual changes

Example table:

```html
<table id="multiple-table-chart" class="js-barchart-table mc-multiple">
  <caption>Multiple Table</caption>
  <thead>
    <tr>
      <th>Some Data</th>
      <th>YES</th>
      <th>NO</th>
      <th>MAYBE</th></tr>
  </thead>
  <tbody>
    <tr>
      <th>Testing One</th>
      <td>5</td><td>6</td>
      <td>11</td>
    </tr>
    <tr>
      <th>Testing Two</th>
      <td>6</td>
      <td>2</td>
      <td>8</td>
    </tr>
    <tr>
      <th>Testing Three</th>
      <td>3</td>
      <td>9</td>
      <td>12</td>
    </tr>
  </tbody>
</table>
```

<table id="multiple-table-chart" class="js-barchart-table mc-multiple">
  <caption>Multiple Table</caption>
  <thead>
    <tr>
      <th>Some Data</th>
      <th>YES</th>
      <th>NO</th>
      <th>MAYBE</th></tr>
  </thead>
  <tbody>
    <tr>
      <th>Testing One</th>
      <td>5</td><td>6</td>
      <td>11</td>
    </tr>
    <tr>
      <th>Testing Two</th>
      <td>6</td>
      <td>2</td>
      <td>8</td>
    </tr>
    <tr>
      <th>Testing Three</th>
      <td>3</td>
      <td>9</td>
      <td>12</td>
    </tr>
  </tbody>
</table>

Before:

![image](https://user-images.githubusercontent.com/1732331/98252557-007f2f00-1f72-11eb-93ca-7a8d7502986a.png)

After:

![image](https://user-images.githubusercontent.com/1732331/98251078-2c011a00-1f70-11eb-944f-c2e6891b5290.png)
