### PR TITLE
Converts track options correctly when passed in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Align JavaScript modules format in components ([PR #1769](https://github.com/alphagov/govuk_publishing_components/pull/1769))
+* Converts track options correctly when passed in ([PR #1772](https://github.com/alphagov/govuk_publishing_components/pull/1772))
 
 ## 23.4.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/details.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/details.js
@@ -34,6 +34,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var trackAction = element.getAttribute('data-track-action')
       var trackOptions = element.getAttribute('data-track-options')
 
+      if (trackOptions) {
+        trackOptions = JSON.parse(trackOptions)
+      }
+
       if (typeof trackOptions !== 'object' || trackOptions === null) {
         trackOptions = {}
       }

--- a/spec/javascripts/components/details-spec.js
+++ b/spec/javascripts/components/details-spec.js
@@ -76,4 +76,17 @@ describe('Details component', function () {
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('track-category', 'track-action', { label: 'closed' })
   })
+
+  it('allows custom track options', function () {
+    $('.gem-c-details').attr('data-track-action', 'track-action')
+    $('.gem-c-details').attr('data-track-category', 'track-category')
+    $('.gem-c-details').attr('data-track-options', '{"value":"track-value"}')
+    $('.gem-c-details').attr('data-track-label', null)
+
+    loadDetailsComponent()
+
+    $('.govuk-details__summary').click()
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('track-category', 'track-action', { label: 'open', value: 'track-value' })
+  })
 })


### PR DESCRIPTION
# What
Converts track options correctly when passed in

# Why
To allow options to be passed into track event function


## Visual Changes
none

https://trello.com/c/3U1QEEK1/584-add-event-tracking-to-track-how-many-times-request-accessible-format-is-clicked
