### PR TITLE
[WIP] Add column list component

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -34,6 +34,7 @@
 @import "components/file-upload";
 @import "components/govspeak-html-publication";
 @import "components/govspeak";
+@import "components/column-list";
 @import "components/heading";
 @import "components/highlight-boxes";
 @import "components/hint";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_column-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_column-list.scss
@@ -1,0 +1,20 @@
+.gem-c-column-list {
+  columns: 1;
+
+  @include govuk-media-query($from: tablet) {
+    columns: 2;
+  }
+
+  @include govuk-media-query($from: desktop) {
+    columns: 3;
+  }
+}
+
+.gem-c-column-list__item {
+  display: inline-block;
+  width: 100%;
+}
+
+.gem-c-column-list__heading {
+  margin-bottom: govuk-spacing(1);
+}

--- a/app/views/govuk_publishing_components/components/_column_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_column_list.html.erb
@@ -1,7 +1,6 @@
 <%
   items ||= []
 %>
-
 <% if items.any? %>
   <ul class="govuk-list gem-c-column-list">
     <% items.each do |item| %>

--- a/app/views/govuk_publishing_components/components/_column_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_column_list.html.erb
@@ -1,0 +1,7 @@
+<%
+  items ||= []
+%>
+
+<% if items.any? %>
+
+<% end %>

--- a/app/views/govuk_publishing_components/components/_column_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_column_list.html.erb
@@ -3,5 +3,14 @@
 %>
 
 <% if items.any? %>
-
+  <ul class="govuk-list gem-c-column-list">
+    <% items.each do |item| %>
+      <li class="gem-c-column-list__item">
+        <h3 class="govuk-heading-s gem-c-column-list__heading">
+          <%= link_to item[:heading], item[:href], class: "govuk-link" %>
+        </h3>
+        <p class="govuk-body"><%= item[:text] %></p>
+      </li>
+    <% end %>
+  </ul>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/column_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/column_list.yml
@@ -1,0 +1,218 @@
+name: Column list
+description: The column list component can be used to display a column of content items.
+body: |
+  The markup for this component makes use of the unordered list `columns` attribute. This allows it to be ingested like a typical list by screen readers but allowing sighted users to see an organised column layout.
+
+  The original intent of this component was to account for the topics collections on the homepages of both [GOV.UK](https://gov.uk) and [data.gov.uk](https://data.gov.uk).
+accessibility_criteria: |
+  The column list component must:
+  
+    - include clear identification of what the intent of the column list is eg: a heading
+    - state how many items are in the list
+  
+  The items in a column list must:
+
+    - include appropriate text spacing, as per the guidance in [WCAG 1.4.12](https://www.w3.org/TR/WCAG21/#text-spacing)
+    - be navigable via screen readers, either via typical screen reader navigation or via screen reader heading navigation
+
+  Links within items in a column list must:
+
+    - accept focus
+    - be focusable with a keyboard
+    - be usable with a keyboard
+    - indicate when they have focus
+    - change in appearance when touched (in the touch-down state)
+    - change in appearance when hovered
+    - be usable with touch
+    - be usable with voice commands
+    - have visible text
+    - have meaningful text
+examples:
+  default:
+    data:
+      items:
+        - heading: "Business and economy"
+          text: "Small businesses, industry, imports, exports and trade"
+          href: "#business-and-economy"
+        - heading: "Crime and justice"
+          text: "Courts, police, prison, offenders, borders and immigration"
+          href: "#crime-and-justice"
+        - heading: "Defence"
+          text: "Armed forces, health and safety, search and rescue"
+          href: "#defence"
+        - heading: "Education"
+          text: "Students, training, qualifications and the National Curriculum"
+          href: "#education"
+        - heading: "Environment"
+          text: "Weather, flooding, rivers, air quality, geology and agriculture"
+          href: "#environment"
+  example_of_managed_columns:
+    description: The browser will always try to display list items in a column lists in such a way that each column contains as close to the same number of items as possible. In the below example, the number of items provided is such that the browser will only use 2 columns instead of 1.
+    data:
+      items:
+        - heading: "Business and economy"
+          text: "Small businesses, industry, imports, exports and trade"
+          href: "#business-and-economy"
+        - heading: "Crime and justice"
+          text: "Courts, police, prison, offenders, borders and immigration"
+          href: "#crime-and-justice"
+        - heading: "Defence"
+          text: "Armed forces, health and safety, search and rescue"
+          href: "#defence"
+        - heading: "Education"
+          text: "Students, training, qualifications and the National Curriculum"
+          href: "#education"
+  only_one_item:
+    data:
+      items:
+        - heading: "A lonely list item"
+          text: "Floating through the vast expanse, hoping that they'll find romance"
+          href: "#all-alone"
+  one_item_with_an_extreme_heading_length:
+    data:
+      items:
+        - heading: "Business and economy"
+          text: "Small businesses, industry, imports, exports and trade"
+          href: "#business-and-economy"
+        - heading: "Crime and justice"
+          text: "Courts, police, prison, offenders, borders and immigration"
+          href: "#crime-and-justice"
+        - heading: "Defence"
+          text: "Armed forces, health and safety, search and rescue"
+          href: "#defence"
+        - heading: "Education in the United Kingdom is a devolved matter with each of the countries of the United Kingdom having separate systems under separate governments: the UK Government is responsible for England; whilst the Scottish Government, the Welsh Government and the Northern Ireland Executive are responsible for Scotland, Wales and Northern Ireland, respectively"
+          text: "Students, training, qualifications and the National Curriculum"
+          href: "#education"
+        - heading: "Environment"
+          text: "Weather, flooding, rivers, air quality, geology and agriculture"
+          href: "#environment"
+  one_item_with_an_extreme_description_length:
+    data:
+      items:
+        - heading: "Business and economy"
+          text: "Small businesses, industry, imports, exports and trade"
+          href: "#business-and-economy"
+        - heading: "Crime and justice"
+          text: "Courts, police, prison, offenders, borders and immigration"
+          href: "#crime-and-justice"
+        - heading: "Defence"
+          text: "During the 1920s and 1930s, British civil servants and politicians, looking back at the performance of the state during the First World War, concluded that there was a need for greater co-ordination between the three services that made up the armed forces of the United Kingdom—the Royal Navy, the British Army and the Royal Air Force. The formation of a united ministry of defence was rejected by David Lloyd George's coalition government in 1921; but the Chiefs of Staff Committee was formed in 1923, for the purposes of inter-service co-ordination. As rearmament became a concern during the 1930s, Stanley Baldwin created the position of Minister for Co-ordination of Defence. Lord Chatfield held the post until the fall of Neville Chamberlain's government in 1940; his success was limited by his lack of control over the existing Service departments and his limited political influence."
+          href: "#defence"
+        - heading: "Education"
+          text: "Students, training, qualifications and the National Curriculum"
+          href: "#education"
+        - heading: "Environment"
+          text: "Weather, flooding, rivers, air quality, geology and agriculture"
+          href: "#environment"
+  items_without_descriptions:
+    data:
+      items:
+        - heading: "Business and economy"
+          href: "#business-and-economy"
+        - heading: "Crime and justice"
+          href: "#crime-and-justice"
+        - heading: "Defence"
+          href: "#defence"
+        - heading: "Education"
+          href: "#education"
+        - heading: "Environment"
+          href: "#environment"
+  items_without_hrefs:
+    description: Currently, this component requires that item headings are links, however if a href is not passed then the href in the link defaults to the page that the user is currently on. This is strongly discouraged as it can disorient the user, who will have expected a link to take them somewhere and find themselves on the same page. 
+    data:
+      items:
+        - heading: "Business and economy"
+          text: "Small businesses, industry, imports, exports and trade"
+        - heading: "Crime and justice"
+          text: "Courts, police, prison, offenders, borders and immigration"
+        - heading: "Defence"
+          text: "Armed forces, health and safety, search and rescue"
+        - heading: "Education"
+          text: "Students, training, qualifications and the National Curriculum"
+        - heading: "Environment"
+          text: "Weather, flooding, rivers, air quality, geology and agriculture"
+  several_extreme_examples_together:
+    data:
+      items:
+        - heading: "Item 1"
+          text: "A nice, normal item"
+          href: "#"
+        - heading: "Item 2"
+          href: "#"
+        - heading: "Item 3 has a really long title it just seems to go on for ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever"
+          text: "But it has a normal description"
+          href: "#"
+        - heading: "Item 4"
+          text: "Item 4 has a really long description. This one also goes on for ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever"
+          href: "#"
+        - heading: "Item 5"
+          text: "This item has no href, which defaults to the page the user is currently on"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"
+        - heading: "item 6"
+          text: "There are many of item 6"
+          href: "#"

--- a/spec/components/column_list_spec.rb
+++ b/spec/components/column_list_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+describe "Column list", type: :view do
+  def component_name
+    "column_list"
+  end
+
+  it "renders nothing when no data is given" do
+    assert_empty render_component({})
+  end
+
+  it "renders nothing when an empty items array is passed" do
+    assert_empty render_component({
+      items: [],
+      title: "Should not render",
+    })
+  end
+
+  it "renders the correct number of items passed to it" do
+    render_component({
+      items: [
+        {
+          heading: "Business and economy",
+          text: "Small businesses, industry, imports, exports and trade",
+          href: "#business-and-economy",
+        },
+        {
+          heading: "Crime and justice",
+          text: "Courts, police, prison, offenders, borders and immigration",
+          href: "#crime-and-justice",
+        },
+        {
+          heading: "Defence",
+          text: "Armed forces, health and safety, search and rescue",
+          href: "#defence",
+        },
+        {
+          heading: "Education",
+          text: "Students, training, qualifications and the National Curriculum",
+          href: "#education",
+        },
+        {
+          heading: "Environment",
+          text: "Weather, flooding, rivers, air quality, geology and agriculture",
+          href: "#environment",
+        },
+      ],
+    })
+
+    list_item = "li.gem-c-column-list__item"
+
+    assert_select list_item, count: 5
+    assert_select list_item do
+      assert_select "h3.govuk-heading-s.gem-c-column-list__heading"
+      assert_select ".govuk-link"
+      assert_select ".govuk-body"
+    end
+  end
+end


### PR DESCRIPTION
## What
Adds the column list component to the components list.

## Why
The component has been created to account for 2 similar patterns within govuk:

- [The gov.uk homepage](https://www.gov.uk/)
- [The data.gov.uk homepage](https://data.gov.uk/)

This will allow for consistent markup across both instances of the pattern.

Some additional benefits to this component are that on the gov.uk homepage implementation, the 3 columns are 3 separate unordered lists. This may be confusing for screen reader users as this topic block is for all intents and purposes is a single list of topics. As well as this, there is the option to extend this component to act as a "layout" manager for other existing components.

### Browser compatibility note
There is a point of contention around the use of the `columns` attribute to manage the layout of this component as the implementation has been shown to be sketchy on safari and firefox presently. There are 2 issues currently open on govuk-frontend regarding this in the context of the footer component: [issue 1](https://github.com/alphagov/govuk-frontend/issues/1889), [issue 2](https://github.com/alphagov/govuk-frontend/issues/1888). I have tested this component against multiple browsers and ~haven't encountered any issues~ will post the issues I find in the comments of this PR, however as part of the review for this component, please take the time to test across multiple browsers, in particular against accessibility criteria like screen reader and keyboard navigation.

## What it looks like
![Screenshot 2020-11-10 at 16 33 20](https://user-images.githubusercontent.com/64783893/98702607-7d474a00-2372-11eb-8d8c-dffd5af30600.png)

See the component docs page on the PR deploy for more details.