### PR TITLE
Hide zero values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix hide zeros values within stacked barcharts ([PR #1776](https://github.com/alphagov/govuk_publishing_components/pull/1776))
+
 ## 23.5.0
 
 * Align JavaScript modules format in components ([PR #1769](https://github.com/alphagov/govuk_publishing_components/pull/1769))

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
@@ -413,7 +413,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
       } else {
         // if it's a stacked graph
-        if (spanWidth > cellWidth && cellVal > 0) {
+        if ((spanWidth > cellWidth && cellVal > 0) || (cellVal < 1)) {
           $cell.classList.add('mc-value-overflow')
         }
       }

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -236,6 +236,47 @@ examples:
             </tr>
           </tbody>
         </table>
+  stacked_chart:
+    data:
+      block: |
+        <table class="js-barchart-table mc-stacked mc-auto-outdent">
+          <thead>
+            <tr>
+              <th scope="col">Colours</th>
+              <th scope="col">Fruits</th>
+              <th scope="col">Vegetables</th>
+              <th scope="col">Beans</th>
+              <th scope="col">Nuts</th>
+              <th scope="col">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Red</td>
+              <td>23</td>
+              <td>9</td>
+              <td>2</td>
+              <td>1</td>
+              <td>35</td>
+            </tr>
+            <tr>
+              <td>Green</td>
+              <td>5</td>
+              <td>33</td>
+              <td>8</td>
+              <td>0</td>
+              <td>46</td>
+            </tr>
+            <tr>
+              <td>Yellow</td>
+              <td>2</td>
+              <td>10</td>
+              <td>0</td>
+              <td>15</td>
+              <td>27</td>
+            </tr>
+          </tbody>
+        </table>
   chart_with_multiple_headings:
     data:
       block: |


### PR DESCRIPTION
## What?

Within `govspeak` `magna-charta` stacked charts, hiding zeros
+
updating docs with example.

## Why?

Zendesk ticket flagged an issue regarding overlapping zeros from Content teams when using Stacked charts
After [discussion (ticket)](https://trello.com/c/ghmrZy8g) solution was to hide zeros.
![image](https://user-images.githubusercontent.com/71266765/98789520-4caaf300-23fa-11eb-9b15-b3acfb86485f.png)

## Visual Changes
**Before:**
![Screenshot 2020-11-11 at 08 33 57](https://user-images.githubusercontent.com/71266765/98789458-38ff8c80-23fa-11eb-836a-268e21b4062e.png)
**After:**
![Screenshot 2020-11-11 at 08 34 10](https://user-images.githubusercontent.com/71266765/98789463-3ac95000-23fa-11eb-86f2-0e580f9334e8.png)

---
The new element to appear [within the docs](https://components.publishing.service.gov.uk/component-guide/govspeak)
![Screenshot 2020-11-12 at 17 42 50](https://user-images.githubusercontent.com/71266765/98976173-f380b380-250e-11eb-8e36-9b9c7b5a488b.png)


## Anything else

[Example page where this type of chart is used](https://www.gov.uk/government/publications/coronavirus-job-retention-scheme-statistics-october-2020/coronavirus-job-retention-scheme-statistics-october-2020#employments-furloughed-over-time-by-gender)

- Attention on this type of chart highlighted some other usability concerns (eg The "total" number isn't clear, this is a total?)
- Small numbers 1-5
- Conversations in general about visual data-use on govuk