### PR TITLE
Update transition sidebar navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update Brexit sidebar navigation ([PR #1777](https://github.com/alphagov/govuk_publishing_components/pull/1777))
+
 ## 23.5.0
 
 * Align JavaScript modules format in components ([PR #1769](https://github.com/alphagov/govuk_publishing_components/pull/1769))

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
@@ -1,4 +1,6 @@
+<% link_text = t("components.related_navigation.transition.link_text") %>
+<% link_path = t("components.related_navigation.transition.link_path") %>
 <div class="gem-c-contextual-sidebar__brexit-cta govuk-!-margin-bottom-6" data-module="track-click">
-  <h2 class="gem-c-contextual-sidebar__brexit-heading">Transition period</h2>
-  <a href="/transition" class="govuk-link" data-track-category="relatedLinkClicked" data-track-action="1.0 Transition" data-track-label="/transition" data-track-options='{"dimension29":"Find out what it means for you"}'>Find out what it means for you</a>
+  <h2 class="gem-c-contextual-sidebar__brexit-heading"><%= t("components.related_navigation.transition.title") %></h2>
+  <a href="<%= link_path %>" class="govuk-link" data-track-category="relatedLinkClicked" data-track-action="1.0 Transition" data-track-label="<%= link_path %>" data-track-options='{"dimension29":"<%= link_text %>"}'><%= link_text %></a>
 </div>

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
@@ -1,6 +1,6 @@
 <% link_text = t("components.related_navigation.transition.link_text") %>
 <% link_path = t("components.related_navigation.transition.link_path") %>
-<div class="gem-c-contextual-sidebar__brexit-cta govuk-!-margin-bottom-6" data-module="track-click">
+<div class="gem-c-contextual-sidebar__brexit-cta govuk-!-margin-bottom-6" data-module="track-click" lang="en">
   <h2 class="gem-c-contextual-sidebar__brexit-heading"><%= t("components.related_navigation.transition.title") %></h2>
   <a href="<%= link_path %>" class="govuk-link" data-track-category="relatedLinkClicked" data-track-action="1.0 Transition" data-track-label="<%= link_path %>" data-track-options='{"dimension29":"<%= link_text %>"}'><%= link_text %></a>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -6,5 +6,8 @@ cy:
       or: 'neu'
     back_link:
       back: "Yn ôl"
-    contents_list: 
+    contents_list:
       contents: Cynnwys
+    related_navigation:
+      transition:
+        link_path: "/transition.cy"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,10 @@ en:
       topics: "Explore the topic"
       topical_events: "Topical event"
       world_locations: "World locations"
+      transition:
+        title: "Brexit transition"
+        link_path: "/transition"
+        link_text: "Find out what it means for you"
     related_footer_navigation:
       collections: "Collections"
       policies: "Policies"

--- a/spec/components/contextual_sidebar_spec.rb
+++ b/spec/components/contextual_sidebar_spec.rb
@@ -12,4 +12,13 @@ describe "Contextual sidebar", type: :view do
 
     assert_select ".gem-c-contextual-sidebar"
   end
+
+  it "can render in welsh" do
+    I18n.with_locale(:cy) do
+      render_component(
+        content_item: GovukSchemas::RandomExample.for_schema(frontend_schema: "speech"),
+      )
+    end
+    assert_select ".gem-c-contextual-sidebar"
+  end
 end

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -25,6 +25,7 @@ describe "Contextual navigation" do
     given_theres_a_page_with_transition_taxon
     and_i_visit_that_page
     and_i_see_the_transition_contextual_breadcrumbs
+    and_i_see_the_transition_related_links
   end
 
   scenario "There's a step by step list" do
@@ -536,6 +537,13 @@ describe "Contextual navigation" do
     end
   end
 
+  def and_i_see_the_transition_related_links
+    within ".gem-c-contextual-sidebar" do
+      expect(page).to have_css("h2", text: "Brexit transition")
+      expect(page).to have_link("Find out what it means for you", href: "/transition")
+    end
+  end
+
   def then_i_see_the_step_by_step_breadcrumbs
     within ".gem-c-contextual-breadcrumbs" do
       expect(page).to have_link("A step by step page")
@@ -635,7 +643,7 @@ describe "Contextual navigation" do
       "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       "api_path" => "/api/content/transition",
       "base_path" => "/transition",
-      "title" => "Transition period",
+      "title" => "Brexit Transition",
       "locale" => "en",
     }
   end


### PR DESCRIPTION
## What
Updates the heading of the transition sidebar navigation section to reflect the changes elsewhere.

I've also switched to using translation files as this allows us to send viewers of Welsh content to https://www.gov.uk/transition.cy. We don't have translations for the wording at present, so I've added an English language attribute to the section, as it'll always render in this language until we add more translations.

## Why
We've updated the taxon to say "Brexit transition", so this should stay in step with that.

https://trello.com/c/2xCCiDu4/598-update-transition-period-sidebar-navigation

## Visual Changes

Just a text update (apologies for the ropy screenshots)

### Before
![Screenshot 2020-11-11 at 18 28 09](https://user-images.githubusercontent.com/773037/98849886-d0d99680-244b-11eb-9167-a6cd598b9ff9.png)

### After
![Screenshot 2020-11-11 at 18 27 55](https://user-images.githubusercontent.com/773037/98849888-d1722d00-244b-11eb-875b-e5c02a2c3fff.png)

