### PR TITLE
Bump version to 23.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 23.5.1
 
 * Update Brexit sidebar navigation ([PR #1777](https://github.com/alphagov/govuk_publishing_components/pull/1777))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.5.0)
+    govuk_publishing_components (23.5.1)
       govuk_app_config
       kramdown
       plek
@@ -221,7 +221,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.4)
-    rouge (3.24.0)
+    rouge (3.25.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.5.0".freeze
+  VERSION = "23.5.1".freeze
 end


### PR DESCRIPTION
Includes:

- [Update Brexit sidebar navigation](https://github.com/alphagov/govuk_publishing_components/pull/1777)

