### PR TITLE
Bump version to 23.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 23.5.2
 
-## Unreleased
-
-* Fix hide zeros values within stacked barcharts ([PR #1776](https://github.com/alphagov/govuk_publishing_components/pull/1776))
+* Fix to hide zeros values within stacked barcharts ([PR #1776](https://github.com/alphagov/govuk_publishing_components/pull/1776))
 
 ## 23.5.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.5.1)
+    govuk_publishing_components (23.5.2)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.5.1".freeze
+  VERSION = "23.5.2".freeze
 end


### PR DESCRIPTION
Fix hide zeros values within stacked barcharts

## What?

Includes: [Fix to hide zeros values within stacked barcharts](https://github.com/alphagov/govuk_publishing_components/pull/1776)