### PR TITLE
Fix GitHub usage link not showing for all components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Unreleased
 
 * Fix hide zeros values within stacked barcharts ([PR #1776](https://github.com/alphagov/govuk_publishing_components/pull/1776))
+* Fix GitHub usage link not showing for all components ([PR #1780](https://github.com/alphagov/govuk_publishing_components/pull/1780))
 
 ## 23.5.1
 

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -22,10 +22,9 @@
           <div class="component-markdown">
             <%= raw(@component_doc.html_body) %>
           </div>
-
-          <p class="govuk-body"><%= link_to "Search for usage of this component on GitHub", @component_doc.github_search_url, class: "govuk-link" %></p>
         </div>
       <% end %>
+      <p class="govuk-body"><%= link_to "Search for usage of this component on GitHub", @component_doc.github_search_url, class: "govuk-link" %></p>
     </div>
   </div>
 


### PR DESCRIPTION
## What
For some unknown (and potentially unintended) reason we only show the GitHub usage link if the component has a description definition in the associated yaml. This results in some components missing the link. I fixed this by moving the link outside the conditional statement.

## Why
To have the GitHub usage link visible on all components.

## Visual Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1438" alt="Screenshot 2020-11-16 at 12 46 53" src="https://user-images.githubusercontent.com/788096/99254219-e95dfe00-2809-11eb-90c0-efaaaf24cca4.png">


</td><td valign="top">

<img width="1440" alt="Screenshot 2020-11-16 at 12 46 38" src="https://user-images.githubusercontent.com/788096/99254228-ec58ee80-2809-11eb-903b-19e4f1200943.png">


</td></tr>
</table>
