### PR TITLE
Add heading level to attachment component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Fix hide zeros values within stacked barcharts ([PR #1776](https://github.com/alphagov/govuk_publishing_components/pull/1776))
 * Fix GitHub usage link not showing for all components ([PR #1780](https://github.com/alphagov/govuk_publishing_components/pull/1780))
+* Add heading level to attachment component ([PR #1781](https://github.com/alphagov/govuk_publishing_components/pull/1781))
 
 ## 23.5.1
 

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -5,6 +5,7 @@
   hide_order_copy_link ||= false
   attributes = []
   data_attributes ||= {}
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   if attachment.content_type_name
     content = if attachment.content_type_abbr
@@ -50,11 +51,11 @@
   <% end %>
 
   <%= tag.div class: "gem-c-attachment__details" do %>
-    <%= tag.h2 class: "gem-c-attachment__title" do %>
+    <%= content_tag(shared_helper.get_heading_level, class: "gem-c-attachment__title") do %>
       <%= link_to attachment.title, attachment.url,
-            class: "govuk-link gem-c-attachment__link",
-            target: target,
-            data: data_attributes %>
+      class: "govuk-link gem-c-attachment__link",
+      target: target,
+      data: data_attributes %>
     <% end %>
 
     <% if attachment.reference.present? %>

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -158,3 +158,13 @@ examples:
         unique_reference: "2942"
         unnumbered_hoc_paper: true
       hide_order_copy_link: true
+  with_custom_heading_level:
+    description: Default is `h2`.
+    data:
+      heading_level: 3
+      attachment:
+        title: "Department for Transport information asset register"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/747661/department-for-transport-information-asset-register.csv
+        filename: department-for-transport-information-asset-register.csv
+        content_type: text/csv
+        file_size: 20000

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -178,4 +178,14 @@ describe "Attachment", type: :view do
     )
     assert_select ".gem-c-attachment__metadata:nth-of-type(3) .govuk-link", false
   end
+
+  it "displays a custom heading level if heading_level is specified" do
+    render_component(heading_level: 3, attachment: { title: "Attachment", url: "https://gov.uk/attachment" })
+    assert_select "h3.gem-c-attachment__title .gem-c-attachment__link", text: "Attachment"
+  end
+
+  it "defaults to h2 if heading_level is not specified" do
+    render_component(attachment: { title: "Attachment", url: "https://gov.uk/attachment" })
+    assert_select "h2.gem-c-attachment__title .gem-c-attachment__link", text: "Attachment"
+  end
 end


### PR DESCRIPTION
## What
Introduce ability to override default `heading_level` on the attachment
component.


<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
The component is currently hard coded to use `h2` which isn't very
flexible. This component is often used as a child of a section of a
page, in which case the heading level of the component should be
adjusted to reflect the hierarchy of the content.

<!-- What are the reasons behind this change being made? -->

## Visual Changes
No visual changes should occur as a result.
<!-- If the change results in visual changes, show a before and after -->

https://trello.com/c/KzyicaBh
