### PR TITLE
Bump version to 23.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   of the commit log.
 
 
-## Unreleased
+## 23.6.0
 
 * Fix hide zeros values within stacked barcharts ([PR #1776](https://github.com/alphagov/govuk_publishing_components/pull/1776))
 * Fix GitHub usage link not showing for all components ([PR #1780](https://github.com/alphagov/govuk_publishing_components/pull/1780))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.5.1)
+    govuk_publishing_components (23.6.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.5.1".freeze
+  VERSION = "23.6.0".freeze
 end


### PR DESCRIPTION
Includes:
* Fix hide zeros values within stacked barcharts ([PR #1776](https://github.com/alphagov/govuk_publishing_components/pull/1776))
* Fix GitHub usage link not showing for all components ([PR #1780](https://github.com/alphagov/govuk_publishing_components/pull/1780))
* Add heading level to attachment component ([PR #1781](https://github.com/alphagov/govuk_publishing_components/pull/1781))

