### PR TITLE
Add transition countdown component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## 23.6.0
 
+* Add transition countdown component ([PR #1783](https://github.com/alphagov/govuk_publishing_components/pull/1783))
 * Fix hide zeros values within stacked barcharts ([PR #1776](https://github.com/alphagov/govuk_publishing_components/pull/1776))
 * Fix GitHub usage link not showing for all components ([PR #1780](https://github.com/alphagov/govuk_publishing_components/pull/1780))
 * Add heading level to attachment component ([PR #1781](https://github.com/alphagov/govuk_publishing_components/pull/1781))

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -73,4 +73,5 @@
 @import "components/textarea";
 @import "components/title";
 @import "components/translation-nav";
+@import "components/transition-countdown";
 @import "components/warning-text";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -1,3 +1,5 @@
+@import 'transition-countdown';
+
 .gem-c-contextual-sidebar__brexit-cta {
   border-top: 2px solid $govuk-brand-colour;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_transition-countdown.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_transition-countdown.scss
@@ -1,0 +1,125 @@
+$transition-campaign-red: #ff003b;
+$transition-campaign-dark-blue: #1e1348;
+
+.gem-c-transition-countdown {
+  @include govuk-font(19);
+  margin-bottom: govuk-spacing(6);
+}
+
+.gem-c-transition-countdown--cta {
+  background-color: govuk-colour('light-grey', $legacy: 'grey-4');
+  border-top: 4px solid $transition-campaign-red;
+  display: block;
+  padding: govuk-spacing(3);
+  text-decoration: none;
+}
+
+.gem-c-transition-countdown__title {
+  @extend %govuk-heading-m;
+  color: $transition-campaign-dark-blue;
+}
+
+.gem-c-transition-countdown__countdown {
+  margin-top: 0;
+  margin-bottom: govuk-spacing(2);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(0);
+  }
+}
+
+.gem-c-transition-countdown__countdown-number {
+  @include govuk-font($size: 80, $weight: bold, $line-height: 60px);
+
+  min-width: 50px;
+  text-align: center;
+  display: inline-block;
+  background: $transition-campaign-dark-blue;
+  color: govuk-colour('white');
+  position: relative;
+  margin-bottom: govuk-spacing(2);
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(2) govuk-spacing(1);
+  }
+
+  &:after {
+    position: absolute;
+    left: 0;
+    top: 50%;
+    margin-top: -1px;
+    height: 3px;
+    background: govuk-colour('white');
+    content: '';
+    width: 100%;
+    display: block;
+  }
+
+  &:first-child {
+    margin-right: 3px;
+  }
+
+  &:nth-child(2) {
+    margin-right: govuk-spacing(2);
+  }
+}
+
+.gem-c-transition-countdown__countdown-text {
+  @extend %govuk-heading-m;
+
+  display: inline-block;
+  margin-bottom: 0;
+  height: 45px;
+  vertical-align: middle;
+  color: $transition-campaign-dark-blue;
+
+  @include govuk-media-query($from: tablet) {
+    height: 80px;
+  }
+
+  &:after {
+    content: '' / '.'; // Wrap up the countdown-text element in a statement for screen readers
+  }
+}
+
+.gem-c-transition-countdown__text {
+  @extend %govuk-link;
+
+  margin-top: 0;
+  margin-bottom: 0;
+  text-decoration: underline;
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(2);
+  }
+}
+
+.gem-c-transition-countdown:focus {
+  .gem-c-transition-countdown__countdown-number:after {
+    background-color: $govuk-focus-colour;
+  }
+
+  .gem-c-transition-countdown__text {
+    text-decoration: none;
+  }
+}
+
+@include govuk-compatibility(govuk_template) {
+  .gem-c-transition-countdown__title {
+    margin-bottom: govuk-spacing(3);
+  }
+
+  .gem-c-transition-countdown__countdown-number {
+    padding: govuk-spacing(1) 0 0;
+
+    @include govuk-media-query($from: tablet) {
+      padding: govuk-spacing(3) govuk-spacing(1) govuk-spacing(1);
+    }
+  }
+
+  .gem-c-transition-countdown__countdown-text {
+    @include govuk-media-query($from: tablet) {
+      height: 75px;
+    }
+  }
+}

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -1,8 +1,21 @@
 <% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request) %>
 
 <div class="gem-c-contextual-sidebar">
-  <% if navigation.show_brexit_cta? && navigation.step_by_step_count.eql?(0) %>
+  <% if navigation.show_brexit_cta? && navigation.step_by_step_count.zero? %>
     <%= render 'govuk_publishing_components/components/contextual_sidebar/brexit_cta' %>
+  <% elsif navigation.step_by_step_count.zero? %>
+    <%= render 'govuk_publishing_components/components/transition_countdown', {
+      title: t("components.related_navigation.transition.title"),
+      url: t("components.related_navigation.transition.link_path"),
+      text: t("components.related_navigation.transition.link_text"),
+      data_attributes: {
+        "track-category": "relatedLinkClicked",
+        "track-action": "1.0 Transition",
+        "track-label": t("components.related_navigation.transition.link_path"),
+        "track-options": "{'dimension29':'#{t("components.related_navigation.transition.link_text")}'}"
+      },
+      lang: I18n.locale,
+    } %>
   <% end %>
 
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>

--- a/app/views/govuk_publishing_components/components/_transition_countdown.html.erb
+++ b/app/views/govuk_publishing_components/components/_transition_countdown.html.erb
@@ -1,0 +1,34 @@
+<%
+  countdown_clock = GovukPublishingComponents::AppHelpers::CountdownHelper.new
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+
+  heading_level ||= 2
+  title ||= nil
+  text ||= nil
+  url ||= nil
+  data_attributes ||= {}
+  lang ||= 'en'
+  css_classes = %w(gem-c-transition-countdown)
+  css_classes << 'gem-c-transition-countdown--cta' if url
+  css_classes << 'govuk-link' if url
+%>
+
+<% countdown = capture do %>
+  <%= content_tag(shared_helper.get_heading_level, title, class: "gem-c-transition-countdown__title") if title %>
+  <% if countdown_clock.show? %>
+    <%= tag.p class: "gem-c-transition-countdown__countdown" do %>
+      <%= tag.span countdown_clock.days_left.first, class: "gem-c-transition-countdown__countdown-number" %><%= tag.span countdown_clock.days_left.last, class: "gem-c-transition-countdown__countdown-number" %> <%= tag.span countdown_clock.days_text, class: "gem-c-transition-countdown__countdown-text" %>
+    <% end %>
+  <% end %>
+  <%= tag.p text, class: "gem-c-transition-countdown__text" if text %>
+<% end %>
+
+<% if url %>
+  <%= link_to url, class: css_classes, data: data_attributes, lang: lang do %>
+    <%= countdown %>
+  <% end %>
+<% else %>
+  <%= tag.div class: css_classes, lang: lang do %>
+    <%= countdown %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -144,4 +144,3 @@ examples:
                       - text: Find out what you’ll get
                         href: "/settled-status-eu-citizens-families/what-settled-and-presettled-status-means"
                     optional: false
-

--- a/app/views/govuk_publishing_components/components/docs/transition_countdown.yml
+++ b/app/views/govuk_publishing_components/components/docs/transition_countdown.yml
@@ -1,0 +1,17 @@
+name: Transition countdown
+description: A countdown to 01 January 2021 used in the Brexit transition campaign
+body: When a URL is set it acts as a link to actions users need to take to prepare for brexit during the transition period
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+  call_to_action:
+    data:
+      title: Brexit transition
+      text: Check you’re ready for 2021
+      url: "https://www.gov.uk/transition"
+      data_attributes:
+        "track-category": "Transition"
+        "track-action": "Brexit transition"
+        "track-label": "Check you’re ready for 2021"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -11,3 +11,6 @@ cy:
     related_navigation:
       transition:
         link_path: "/transition.cy"
+    transition_countdown:
+      day_to_go: "diwrnod i fynd"
+      days_to_go: "diwrnod i fynd"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -10,7 +10,9 @@ cy:
       contents: Cynnwys
     related_navigation:
       transition:
+        title: "Pontio Brexit"
         link_path: "/transition.cy"
+        link_text: "Gwiriwch eich bod chi'n barod ar gyfer 2021"
     transition_countdown:
       day_to_go: "diwrnod i fynd"
       days_to_go: "diwrnod i fynd"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,7 +74,7 @@ en:
       transition:
         title: "Brexit transition"
         link_path: "/transition"
-        link_text: "Find out what it means for you"
+        link_text: "Check you’re ready for 2021"
     related_footer_navigation:
       collections: "Collections"
       policies: "Policies"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,3 +98,6 @@ en:
     summary_list:
       edit: "Change"
       delete: "Delete"
+    transition_countdown:
+      day_to_go: "day to go"
+      days_to_go: "days to go"

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -34,6 +34,7 @@ require "govuk_publishing_components/presenters/taxonomy_list_helper"
 require "govuk_publishing_components/app_helpers/taxon_breadcrumbs"
 require "govuk_publishing_components/app_helpers/table_helper"
 require "govuk_publishing_components/app_helpers/brand_helper"
+require "govuk_publishing_components/app_helpers/countdown_helper"
 require "govuk_publishing_components/app_helpers/environment"
 
 # Add view and i18n paths for usage outside of a Rails app

--- a/lib/govuk_publishing_components/app_helpers/countdown_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/countdown_helper.rb
@@ -13,9 +13,9 @@ module GovukPublishingComponents
 
       def days_text
         if days_left_integer == 1
-          I18n.t("components.transition_countdown.day_to_go")
+          I18n.t!("components.transition_countdown.day_to_go")
         else
-          I18n.t("components.transition_countdown.days_to_go")
+          I18n.t!("components.transition_countdown.days_to_go")
         end
       end
 
@@ -26,7 +26,7 @@ module GovukPublishingComponents
       end
 
       def today_in_london
-        Time.zone.today
+        Time.find_zone("Europe/London").today
       end
     end
   end

--- a/lib/govuk_publishing_components/app_helpers/countdown_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/countdown_helper.rb
@@ -1,0 +1,33 @@
+module GovukPublishingComponents
+  module AppHelpers
+    class CountdownHelper
+      END_OF_TRANSITION_PERIOD = Date.new(2021, 1, 1)
+
+      def days_left
+        sprintf "%02d", days_left_integer
+      end
+
+      def show?
+        days_left_integer.positive?
+      end
+
+      def days_text
+        if days_left_integer == 1
+          I18n.t("components.transition_countdown.day_to_go")
+        else
+          I18n.t("components.transition_countdown.days_to_go")
+        end
+      end
+
+    private
+
+      def days_left_integer
+        (END_OF_TRANSITION_PERIOD - today_in_london).to_i
+      end
+
+      def today_in_london
+        Time.zone.today
+      end
+    end
+  end
+end

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -71,7 +71,8 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
 @import 'govuk_publishing_components/components/step-by-step-nav-related';
 @import 'govuk_publishing_components/components/tabs';
-@import 'govuk_publishing_components/components/title';"
+@import 'govuk_publishing_components/components/title';
+@import 'govuk_publishing_components/components/transition-countdown';"
     expected_print_sass = "@import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/components/print/back-link';
 @import 'govuk_publishing_components/components/print/button';

--- a/spec/components/transition_countdown_spec.rb
+++ b/spec/components/transition_countdown_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe "Transition call to action", type: :view do
+  def component_name
+    "transition_countdown"
+  end
+
+  day_before_transition_period_ends = Date.new(2020, 12, 31)
+
+  it "renders the countdown when called without attributes" do
+    travel_to day_before_transition_period_ends
+
+    render_component({})
+
+    assert_select ".gem-c-transition-countdown"
+    assert_select ".gem-c-transition-countdown__countdown", text: "01 #{t('components.transition_countdown.day_to_go')}"
+  end
+
+  it "renders the call to action with title, countdown, and content" do
+    travel_to day_before_transition_period_ends
+
+    render_component(
+      title: "Brexit transition",
+      text: "Check you’re ready for 2021",
+      url: "https://www.gov.uk/transition",
+      data_attributes: { "track-category": "brexit" },
+    )
+
+    assert_select ".gem-c-transition-countdown[href='https://www.gov.uk/transition']"
+    assert_select ".gem-c-transition-countdown[data-track-category=brexit]"
+    assert_select ".gem-c-transition-countdown__title", text: "Brexit transition"
+    assert_select ".gem-c-transition-countdown__countdown", text: "01 #{t('components.transition_countdown.day_to_go')}"
+    assert_select ".gem-c-transition-countdown__text", text: "Check you’re ready for 2021"
+  end
+end

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -540,7 +540,7 @@ describe "Contextual navigation" do
   def and_i_see_the_transition_related_links
     within ".gem-c-contextual-sidebar" do
       expect(page).to have_css("h2", text: "Brexit transition")
-      expect(page).to have_link("Find out what it means for you", href: "/transition")
+      expect(page).to have_link(I18n.t("components.related_navigation.transition.link_text"), href: "/transition")
     end
   end
 

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -26,6 +26,7 @@ describe "Contextual navigation" do
     and_i_visit_that_page
     and_i_see_the_transition_contextual_breadcrumbs
     and_i_see_the_transition_related_links
+    and_i_do_not_see_the_transition_call_to_action
   end
 
   scenario "There's a step by step list" do
@@ -33,6 +34,7 @@ describe "Contextual navigation" do
     and_i_visit_that_page
     then_i_see_the_step_by_step
     and_the_step_by_step_header
+    and_i_do_not_see_the_transition_call_to_action
   end
 
   scenario "There's more than one step by step" do
@@ -61,12 +63,14 @@ describe "Contextual navigation" do
     and_i_visit_that_page
     then_i_see_the_related_links_sidebar
     and_the_default_breadcrumbs
+    and_i_see_the_transition_call_to_action
   end
 
   scenario "The page has a topic" do
     given_theres_a_page_with_a_topic
     and_i_visit_that_page
     then_i_see_the_topic_breadcrumb
+    and_i_see_the_transition_call_to_action
   end
 
   scenario "The page has many topics" do
@@ -74,6 +78,7 @@ describe "Contextual navigation" do
     and_i_visit_that_page
     then_i_see_the_topic_breadcrumb
     and_i_see_the_both_topics_in_the_related_navigation_footer
+    and_i_see_the_transition_call_to_action
   end
 
   scenario "It's a HTML Publication document" do
@@ -81,6 +86,7 @@ describe "Contextual navigation" do
     and_the_page_is_an_html_publication_with_that_parent
     and_i_visit_that_page
     then_i_see_home_and_parent_links
+    and_i_see_the_transition_call_to_action
   end
 
   scenario "It's a HTML Publication with a parent with coronavirus taxon" do
@@ -89,6 +95,7 @@ describe "Contextual navigation" do
     and_i_visit_that_page
     then_i_see_home_and_parent_links
     and_i_see_the_coronavirus_contextual_breadcrumbs_for_business
+    and_i_see_the_transition_call_to_action
   end
 
   scenario "A page is tagged to the transition taxon and a step_by_step" do
@@ -97,6 +104,7 @@ describe "Contextual navigation" do
     then_i_see_the_step_by_step
     and_the_step_by_step_header
     and_i_do_not_see_the_transition_contextual_breadcrumbs
+    and_i_do_not_see_the_transition_call_to_action
   end
 
   scenario "It's a HTML Publication with a parent with breadcrumbs" do
@@ -541,6 +549,20 @@ describe "Contextual navigation" do
     within ".gem-c-contextual-sidebar" do
       expect(page).to have_css("h2", text: "Brexit transition")
       expect(page).to have_link(I18n.t("components.related_navigation.transition.link_text"), href: "/transition")
+    end
+  end
+
+  def and_i_see_the_transition_call_to_action
+    within ".gem-c-contextual-sidebar" do
+      expect(page).to have_selector(".gem-c-transition-countdown")
+      expect(page).to have_css(".gem-c-transition-countdown__title", text: I18n.t("components.related_navigation.transition.title"))
+    end
+  end
+
+  def and_i_do_not_see_the_transition_call_to_action
+    within ".gem-c-contextual-sidebar" do
+      expect(page).not_to have_selector(".gem-c-transition-countdown")
+      expect(page).not_to have_css(".gem-c-transition-countdown__title", text: I18n.t("components.related_navigation.transition.title"))
     end
   end
 

--- a/spec/lib/govuk_publishing_components/app_helpers/countdown_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/countdown_helper_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+RSpec.describe GovukPublishingComponents::AppHelpers::CountdownHelper do
+  describe "Countdown helper" do
+    it "gives the days left until end of transition period" do
+      clock = GovukPublishingComponents::AppHelpers::CountdownHelper.new
+      day_before_transition_period_ends = Date.new(2020, 12, 31)
+      travel_to day_before_transition_period_ends
+      expect(clock.days_left).to eql("01")
+    end
+
+    it "returns true until 23.59 on December 31st 2020" do
+      clock = GovukPublishingComponents::AppHelpers::CountdownHelper.new
+      minute_to_midnight_on_brexit_eve = Time.zone.local(2020, 12, 31, 23, 59)
+      travel_to minute_to_midnight_on_brexit_eve
+      expect(clock.show?).to eql(true)
+    end
+
+    it "returns false from midnight on the eve of January 1st 2021" do
+      clock = GovukPublishingComponents::AppHelpers::CountdownHelper.new
+      midnight_on_brexit_eve = Time.zone.local(2020, 12, 31, 24, 0)
+      travel_to midnight_on_brexit_eve
+      expect(clock.show?).to eql(false)
+    end
+
+    it "pluralizes day if necessary" do
+      clock = GovukPublishingComponents::AppHelpers::CountdownHelper.new
+      one_day_left = Date.new(2020, 12, 31)
+      travel_to one_day_left
+      expect(clock.days_text).to eql("day to go")
+
+      two_days_left = Date.new(2020, 12, 30)
+      travel_to two_days_left
+      expect(clock.days_text).to eql("days to go")
+    end
+  end
+end

--- a/spec/lib/govuk_publishing_components/app_helpers/countdown_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/countdown_helper_spec.rb
@@ -3,28 +3,28 @@ require "spec_helper"
 RSpec.describe GovukPublishingComponents::AppHelpers::CountdownHelper do
   describe "Countdown helper" do
     it "gives the days left until end of transition period" do
-      clock = GovukPublishingComponents::AppHelpers::CountdownHelper.new
+      clock = described_class.new
       day_before_transition_period_ends = Date.new(2020, 12, 31)
       travel_to day_before_transition_period_ends
       expect(clock.days_left).to eql("01")
     end
 
     it "returns true until 23.59 on December 31st 2020" do
-      clock = GovukPublishingComponents::AppHelpers::CountdownHelper.new
+      clock = described_class.new
       minute_to_midnight_on_brexit_eve = Time.zone.local(2020, 12, 31, 23, 59)
       travel_to minute_to_midnight_on_brexit_eve
       expect(clock.show?).to eql(true)
     end
 
     it "returns false from midnight on the eve of January 1st 2021" do
-      clock = GovukPublishingComponents::AppHelpers::CountdownHelper.new
+      clock = described_class.new
       midnight_on_brexit_eve = Time.zone.local(2020, 12, 31, 24, 0)
       travel_to midnight_on_brexit_eve
       expect(clock.show?).to eql(false)
     end
 
     it "pluralizes day if necessary" do
-      clock = GovukPublishingComponents::AppHelpers::CountdownHelper.new
+      clock = described_class.new
       one_day_left = Date.new(2020, 12, 31)
       travel_to one_day_left
       expect(clock.days_text).to eql("day to go")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,4 +12,5 @@ Selenium::WebDriver::Remote::Capabilities.chrome(loggingPrefs: { browser: "ALL" 
 RSpec.configure do |config|
   config.include Capybara::DSL
   config.include Helpers::Components, type: :view
+  config.include ActiveSupport::Testing::TimeHelpers
 end


### PR DESCRIPTION
## What
- Add transition countdown component based on the existing Rails logic in `collections` (credits to @hannako for the great work on the countdown mechanism) and a simplified and improved frontend approach
- Show the transition countdown component in the contextual sidebar

## Why
The component is meant to be used on:
- the `/transition` landing page (replacing the current countdown in [`collections`](https://github.com/alphagov/collections/compare/use-transition-countdown-component?expand=1))
- in the contextual sidebar across multiple frontend applications (`frontend`, `government-frontend` and `smart-answers`) when a page is not tagged to a 'brexit' taxon and doesn't show a step-by-step navigation.

[Trello card](https://trello.com/c/GX0JVZ3D)

## Visual Changes
[Preview countdown component](https://govuk-publis-add-transi-sncjcu.herokuapp.com/component-guide/transition_countdown)
[Preview countdown call to action in contextual sidebar](https://govuk-publis-add-transi-sncjcu.herokuapp.com/component-guide/contextual_sidebar/with_transition_call_to_action_and_related_links)

<table>
<tr><th>collections</th><th>government-frontend</th></tr>
<tr><td valign="top">

![localhost_3070_transition](https://user-images.githubusercontent.com/788096/99579192-c122fa80-29d5-11eb-80d9-48acaa7b173d.png)


</td><td valign="top">

![localhost_3090_growing-your-business](https://user-images.githubusercontent.com/788096/99579220-caac6280-29d5-11eb-8db5-7a1fb15927a3.png)


</td></tr>
</table>

The component was tested with [supported browsers and assistive technologies](https://github.com/alphagov/govuk_publishing_components#browser-and-assistive-technology-support).
<details>
<summary>Cross-browser testing captures</summary>

Chrome 86
<img width="302" alt="Chrome86" src="https://user-images.githubusercontent.com/788096/99579379-06dfc300-29d6-11eb-9f00-f7bf72362958.png">

Chrome 86 (focus state)
<img width="300" alt="Chrome86 focused" src="https://user-images.githubusercontent.com/788096/99579380-06dfc300-29d6-11eb-8354-de817d23b042.png">

Edge 86
<img width="303" alt="Edge86" src="https://user-images.githubusercontent.com/788096/99579381-06dfc300-29d6-11eb-8bf2-e0d4f33068f5.png">

Firefox 82
<img width="302" alt="Firefox82" src="https://user-images.githubusercontent.com/788096/99579382-07785980-29d6-11eb-931e-81d981eeca2d.png">

Firefox 82 (custom colours)
<img width="300" alt="Firefox82 custom-colours" src="https://user-images.githubusercontent.com/788096/99579383-0810f000-29d6-11eb-8d8b-29b0830e90f4.png">

IE 8
<img width="301" alt="IE8" src="https://user-images.githubusercontent.com/788096/99579387-0810f000-29d6-11eb-93d4-f4c26e3cf52f.png">

IE 9
<img width="302" alt="IE9" src="https://user-images.githubusercontent.com/788096/99579390-0810f000-29d6-11eb-8866-e65b9098e2b1.png">

IE 10
<img width="302" alt="IE10" src="https://user-images.githubusercontent.com/788096/99579391-08a98680-29d6-11eb-93e7-e70e30c18e50.png">

IE11
<img width="301" alt="IE11" src="https://user-images.githubusercontent.com/788096/99579392-08a98680-29d6-11eb-97fe-77a1e239ac99.png">

### Mobile

Safari 12 on OSX
<img width="302" alt="Safari14" src="https://user-images.githubusercontent.com/788096/99579397-09421d00-29d6-11eb-8f88-0c94cbb8703a.png">

Chrome on Android
<img width="368" alt="Android Chrome" src="https://user-images.githubusercontent.com/788096/99579363-02b3a580-29d6-11eb-899f-ecb6bb44c2df.png">

Samsung Internet on Android
<img width="383" alt="Android Samsung Internet" src="https://user-images.githubusercontent.com/788096/99579378-05ae9600-29d6-11eb-9349-7429c4bae1ba.png">

Chrome on iOS12
<img width="383" alt="iOS12 Chrome" src="https://user-images.githubusercontent.com/788096/99579393-08a98680-29d6-11eb-9ba4-3675e25b54b6.png">

Safari on iOS12
<img width="384" alt="iOS12 Safari" src="https://user-images.githubusercontent.com/788096/99579394-09421d00-29d6-11eb-8c2a-86bd033d57d8.png">

</details>