### PR TITLE
Update magna charter experience for screen reader users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## 23.12.1
 
 * Escape dangerous HTML in 'Machine readable metadata' component ([PR #1858](https://github.com/alphagov/govuk_publishing_components/pull/1858))
+* Update magna charter experience for screen reader users ([PR #1787](https://github.com/alphagov/govuk_publishing_components/pull/1787))
 
 ## 23.12.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -270,15 +270,26 @@
     text-align: left;
   }
 
-  .mc-toggle-link {
-    display: block;
-    margin-top: 30px;
+  .mc-toggle-button {
+    @extend %govuk-body-s;
+    border: 1px solid $govuk-border-colour;
+    color: $govuk-link-colour;
+    cursor: pointer;
+    margin: govuk-spacing(0);
+    padding: govuk-spacing(2);
+    background-color: govuk-colour("white");
+
+    &:focus {
+      @include govuk-focused-text;
+      background-color: $govuk-focus-colour;
+      border-color: transparent;
+    }
   }
 
   // Hides the original table
-  .visually-hidden,
-  .visually-hidden caption {
-    @include govuk-visually-hidden;
+  .mc-hidden,
+  .mc-hidden caption {
+    display: none;
 
     // It's reapplied to captions because Firefox can't hide
     // table captions unless it's applied directly to it. Go figure.

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
@@ -6,6 +6,7 @@ describe('Magna charta', function () {
 
   var element
   var magna
+  var graphContainer
   var graph
   var table
   var toggle
@@ -120,8 +121,9 @@ describe('Magna charta', function () {
       $('body').append(element)
       magna = new GOVUK.Modules.MagnaCharta().start(element.find('#single')[0], { returnReference: true })
       graph = element.find('.mc-chart')
+      graphContainer = element.find('.mc-chart-container')
       table = element.find('table')
-      toggle = element.find('.mc-toggle-link')
+      toggle = element.find('.mc-toggle-button')
     })
 
     afterEach(function () {
@@ -138,13 +140,13 @@ describe('Magna charta', function () {
 
     it('running toggle switches between chart and table', function () {
       toggle[0].click()
-      expect(table).not.toHaveClass('visually-hidden')
-      expect(graph).toHaveClass('visually-hidden')
+      expect(table).not.toHaveClass('mc-hidden')
+      expect(graphContainer).toHaveClass('mc-hidden')
 
       // toggle it back
       toggle[0].click()
-      expect(table).toHaveClass('visually-hidden')
-      expect(graph).not.toHaveClass('visually-hidden')
+      expect(table).toHaveClass('mc-hidden')
+      expect(graphContainer).not.toHaveClass('mc-hidden')
     })
 
     it('new chart div contains all table bits as divs', function () {
@@ -184,7 +186,9 @@ describe('Magna charta', function () {
     })
 
     it('new chart is inserted into DOM after table', function () {
-      expect(table.next()).toHaveClass('mc-chart')
+      var chartContainer = table.next()
+      expect(chartContainer).toHaveClass('mc-chart-container')
+      expect(chartContainer.children(':first')).toHaveClass('mc-chart')
     })
 
     it('bars are given classes to track what number they are', function () {
@@ -298,6 +302,7 @@ describe('Magna charta', function () {
         returnReference: true
       })
       graph = element.find('.mc-chart')
+      graphContainer = element.find('.mc-chart-container')
       table = element.find('table')
     })
 
@@ -306,14 +311,14 @@ describe('Magna charta', function () {
     })
 
     it('doesnt show the chart initially', function () {
-      expect(table).not.toHaveClass('visually-hidden')
-      expect(graph).toHaveClass('visually-hidden')
+      expect(table).not.toHaveClass('mc-hidden')
+      expect(graphContainer).toHaveClass('mc-hidden')
     })
 
     it('graph is shown when toggle is called', function () {
-      element.find('.mc-toggle-link')[0].click()
-      expect(table).toHaveClass('visually-hidden')
-      expect(graph).not.toHaveClass('visually-hidden')
+      element.find('.mc-toggle-button')[0].click()
+      expect(table).toHaveClass('mc-hidden')
+      expect(graphContainer).not.toHaveClass('mc-hidden')
     })
   })
 


### PR DESCRIPTION
## What
Alters the behaviour for magna charta rendered bar charts for screen reader users.

Currently, screen reader users will only be able to interpret the table portion of the chart, regardless of if it's visible or not, and ignore the toggle button and visualised chart entirely. This PR alters the behaviour to the following:

1. Screen reader users will encounter the button first, which will dictate to them "Change to table and accessible view".
2. If they try to interact with the chart, the message: "This content is not accessible - switch to table" will be announced.
2. When they click the button, "table visible" will be announced.
3. The user can now interact with the table.
4. Clicking the link again, which will now read "Change to chart view" will swap back to chart and announce "chart visible".

This PR also amends the toggle link itself to be a button element as opposed to a link and styles the element to look like a button. This is using a replication of the [print link element](https://components.publishing.service.gov.uk/component-guide/print_link).

## Why
At the foundation, this PR is solving a WCAG failure of SC 4.1.2 because the toggle button cannot be programatically determined aka: it isn't clear what the button is for. Hiding the button and mocking a DOM of just the table for screen reader users is a risk because it impacts other assistive tech users, specifically voice control users or screen reader users who can see from interacting. The content changes along with the announcement that this solution adds communicates the intent of the button in a way that accounts for all users, meeting the success criterion.

The change to the toggle link is firstly to ensure that the toggle link is semantically correct as it behaves like a button not a link and secondly to fix a bug when screen reader users interact with this link where it will sometimes follow the hash previously applied to the link element and send the screen reader's focus to the top of the page, potentially disorienting screen reader users.

## Visual changes
## Before
![Screenshot 2021-01-07 at 17 29 03](https://user-images.githubusercontent.com/64783893/103924513-0af2ac00-510e-11eb-9c82-5d7029858f90.png)
![Screenshot 2021-01-07 at 17 29 14](https://user-images.githubusercontent.com/64783893/103924525-0e863300-510e-11eb-8876-a3f96f4b4497.png)

## After
![Screenshot 2021-01-07 at 17 29 24](https://user-images.githubusercontent.com/64783893/103924537-12b25080-510e-11eb-968c-81f1684ec99e.png)
![Screenshot 2021-01-07 at 17 29 34](https://user-images.githubusercontent.com/64783893/103924546-15ad4100-510e-11eb-823e-ec500c9cb547.png)

[Card](https://trello.com/c/qWOALsrL/434-role-of-bar-chart-link-cannot-be-programmatically-determined)
