### PR TITLE
Update contextual sidebar data track attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   of the commit log.
 
 
+## Unreleased
+
+* Update contextual sidebar data track attributes ([PR #1788](https://github.com/alphagov/govuk_publishing_components/pull/1788))
+
 ## 23.7.0
 
 * Add transition countdown component ([PR #1783](https://github.com/alphagov/govuk_publishing_components/pull/1783))

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -9,10 +9,12 @@
       url: t("components.related_navigation.transition.link_path"),
       text: t("components.related_navigation.transition.link_text"),
       data_attributes: {
+        "module": "track-click",
         "track-category": "relatedLinkClicked",
         "track-action": "1.0 Transition",
         "track-label": t("components.related_navigation.transition.link_path"),
-        "track-options": "{'dimension29':'#{t("components.related_navigation.transition.link_text")}'}"
+        "track-dimension": t("components.related_navigation.transition.link_text"),
+        "track-dimension-index": "29",
       },
       lang: I18n.locale,
     } %>


### PR DESCRIPTION
## What
Update data attributes when calling the transition countdown in the contextual sidebar to match the expectation of our tracking script that lives in static.

## Why
The script requires `data-module="track-click"` to pick-up data-track attributes and have refactored the dimension approach to avoid previous encoding issues.

## Visual Changes
No visual changes

<img width="1223" alt="Screenshot 2020-11-20 at 15 58 05" src="https://user-images.githubusercontent.com/788096/99821344-d5880400-2b49-11eb-8cb9-1251703ce00f.png">

