### PR TITLE
Brexit countdown language and direction fix

### DIFF
--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -1,4 +1,5 @@
 <% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request) %>
+<% shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns) %>
 
 <div class="gem-c-contextual-sidebar">
   <% if navigation.show_brexit_cta? && navigation.step_by_step_count.zero? %>
@@ -16,7 +17,7 @@
         "track-dimension": t("components.related_navigation.transition.link_text"),
         "track-dimension-index": "29",
       },
-      lang: I18n.locale,
+      lang: shared_helper.t_locale("components.related_navigation.transition.title"),
     } %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/_related_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_related_navigation.html.erb
@@ -1,4 +1,5 @@
 <% related_nav_helper = GovukPublishingComponents::Presenters::RelatedNavigationHelper.new(local_assigns) %>
+<% shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns) %>
 
 <% if related_nav_helper.related_navigation? %>
   <% random = SecureRandom.hex(4) %>
@@ -8,7 +9,7 @@
       <h2 id="related-nav-related_items-<%= random %>"
           class="gem-c-related-navigation__main-heading"
           data-track-count="sidebarRelatedItemSection"
-          <%= related_nav_helper.t_lang(
+          <%= shared_helper.t_lang(
               "components.related_#{local_assigns[:context]}_navigation.related_content",
               default: 'components.related_navigation.related_content'
             )
@@ -28,6 +29,7 @@
 
       <%= render 'govuk_publishing_components/components/related_navigation/section',
         related_nav_helper: related_nav_helper,
+        shared_helper: shared_helper,
         section_title: section_title,
         links: links,
         section_index: section_index,

--- a/app/views/govuk_publishing_components/components/_transition_countdown.html.erb
+++ b/app/views/govuk_publishing_components/components/_transition_countdown.html.erb
@@ -7,10 +7,11 @@
   text ||= nil
   url ||= nil
   data_attributes ||= {}
-  lang ||= 'en'
+  lang ||= "en"
+  direction ||= "ltr"
   css_classes = %w(gem-c-transition-countdown)
-  css_classes << 'gem-c-transition-countdown--cta' if url
-  css_classes << 'govuk-link' if url
+  css_classes << "gem-c-transition-countdown--cta" if url
+  css_classes << "govuk-link" if url
 %>
 
 <% countdown = capture do %>
@@ -24,11 +25,11 @@
 <% end %>
 
 <% if url %>
-  <%= link_to url, class: css_classes, data: data_attributes, lang: lang do %>
+  <%= link_to url, class: css_classes, data: data_attributes, lang: lang, dir: direction do %>
     <%= countdown %>
   <% end %>
 <% else %>
-  <%= tag.div class: css_classes, lang: lang do %>
+  <%= tag.div class: css_classes, lang: lang, dir: direction do %>
     <%= countdown %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -28,7 +28,7 @@
           link[:path],
           class: related_nav_helper.section_css_class("gem-c-related-navigation__section-link", section_title, link, (index >= section_link_limit)),
           rel: link[:rel],
-          lang: related_nav_helper.t_locale_check(link[:locale]),
+          lang: shared_helper.t_locale_check(link[:locale]),
           data: {
             track_category: 'relatedLinkClicked',
             track_action: "#{section_index}.#{index} #{related_nav_helper.construct_section_heading(section_title) || t('components.related_navigation.related_content')}",

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -97,47 +97,7 @@ module GovukPublishingComponents
         related_navigation.flat_map(&:last).any?
       end
 
-      def t_locale(content, options = {})
-        # Check if the content string has a translation
-        content_translation_available = translation_present?(content)
-
-        # True, return locale
-        this_locale = I18n.locale if content_translation_available
-        # If false, return default locale
-        this_locale = I18n.default_locale unless content_translation_available
-
-        # Check if default string passed in
-        if options[:default].present?
-          # Check if the default string has a translation
-          default_translation_available = translation_present?(options[:default])
-          # If true, return locale
-          this_locale = I18n.locale if default_translation_available
-          # If false, return default_locale
-          this_locale = I18n.default_locale unless default_translation_available
-        end
-
-        this_locale
-      end
-
-      def t_lang(content, options = {})
-        locale = t_locale(content, options)
-        "lang=#{locale}" unless locale.eql?(I18n.locale)
-      end
-
-      def t_locale_check(locale)
-        locale.presence unless locale.to_s.eql?(I18n.locale.to_s)
-      end
-
     private
-
-      def translation_present?(content)
-        default_string = "This is a string to act as a default for the `I18n.translate` method. Comparing the result reveals if there is a translation in the i18n files."
-        I18n.translate(
-          content,
-          default: default_string,
-          fallback: false,
-        ) != default_string
-      end
 
       def related_items
         related_quick_links = content_item_details_for("quick_links")

--- a/lib/govuk_publishing_components/presenters/shared_helper.rb
+++ b/lib/govuk_publishing_components/presenters/shared_helper.rb
@@ -30,6 +30,48 @@ module GovukPublishingComponents
 
         "span"
       end
+
+      def t_locale(content, options = {})
+        # Check if the content string has a translation
+        content_translation_available = translation_present?(content)
+
+        # True, return locale
+        this_locale = I18n.locale if content_translation_available
+        # If false, return default locale
+        this_locale = I18n.default_locale unless content_translation_available
+
+        # Check if default string passed in
+        if options[:default].present?
+          # Check if the default string has a translation
+          default_translation_available = translation_present?(options[:default])
+          # If true, return locale
+          this_locale = I18n.locale if default_translation_available
+          # If false, return default_locale
+          this_locale = I18n.default_locale unless default_translation_available
+        end
+
+        this_locale
+      end
+
+      def t_lang(content, options = {})
+        locale = t_locale(content, options)
+        "lang=#{locale}" unless locale.eql?(I18n.locale)
+      end
+
+      def t_locale_check(locale)
+        locale.presence unless locale.to_s.eql?(I18n.locale.to_s)
+      end
+
+    private
+
+      def translation_present?(content)
+        default_string = "This is a string to act as a default for the `I18n.translate` method. Comparing the result reveals if there is a translation in the i18n files."
+        I18n.translate(
+          content,
+          default: default_string,
+          fallback: false,
+        ) != default_string
+      end
     end
   end
 end

--- a/spec/lib/govuk_publishing_components/components/shared_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/shared_helper_spec.rb
@@ -1,5 +1,9 @@
 RSpec.describe GovukPublishingComponents::Presenters::SharedHelper do
   describe "Shared component helper" do
+    after(:each) do
+      I18n.locale = :en
+    end
+
     it "returns a default margin class" do
       shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({})
       margin_class = shared_helper.get_margin_bottom
@@ -51,6 +55,56 @@ RSpec.describe GovukPublishingComponents::Presenters::SharedHelper do
       expect {
         GovukPublishingComponents::Presenters::SharedHelper.new(classes: "js-okay not-cool-man")
       }.to raise_error(ArgumentError, "Passed classes must be prefixed with `js-`")
+    end
+
+    it "returns nil if given locale is same as page locale" do
+      default_locale = I18n.locale
+      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({})
+
+      expect(shared_helper.t_locale_check(default_locale)).to be nil
+    end
+
+    it "returns a locale if different to the page locale" do
+      locale = "ar"
+      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({})
+
+      expect(shared_helper.t_locale_check(locale)).to eq locale
+    end
+
+    it "returns the language attribute if translation is not present" do
+      I18n.locale = :de
+
+      translation_key = "this.is.a.key.that.should.not.be.found.to.test.the.translation"
+      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({})
+
+      expect(shared_helper.t_lang(translation_key)).to eq "lang=en"
+    end
+
+    it "returns no language attribute if translation is present" do
+      I18n.locale = :fr
+
+      translation_key = "components.contents_list.contents"
+      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({})
+
+      expect(shared_helper.t_lang(translation_key)).to be nil
+    end
+
+    it "returns the locale if translation is not present" do
+      I18n.locale = :de
+
+      translation_key = "this.is.a.key.that.should.not.be.found.to.test.the.translation"
+      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({})
+
+      expect(shared_helper.t_locale(translation_key)).to eq :en
+    end
+
+    it "returns no locale if translation is present and using default locale" do
+      I18n.locale = :fr
+
+      translation_key = "components.contents_list.contents"
+      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({})
+
+      expect(shared_helper.t_locale(translation_key)).to be :fr
     end
   end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Update the countdown component to check whether a translation is available before setting the language element; and set the direction to `ltr`.

## Why
<!-- What are the reasons behind this change being made? -->

When used on pages that are in right to left lanuages (such as Arabic) and without a translation available, the countdown displayed the number of days left in reverse. 

It was also tagged as being in the page's language even when there was no translation available, which led to the countdown displaying English but being tagged as being in another language.

The translation check is done for the "components.related_navigation.transition.title" key only as I think that it's a reasonable assumption that if the title isn't translated then the text won't be either. Ideally there would be a check for both, but for the moment this will ensure that it is fixed. If and when further languages are added then this should be reassessed. 

The text direction can be hard-coded to `ltr` because there are currently only two translations available for this text - Welsh and English. Both of these languages are left to right.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/1732331/99983195-732a4000-2da3-11eb-8f1b-80fe309f72d6.png) | ![image](https://user-images.githubusercontent.com/1732331/99983114-5d1c7f80-2da3-11eb-9d62-dc81323d5c47.png) |





