### PR TITLE
Update to v23.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 23.7.2
+* Fix Brexit countdown in the contextual sidebar to use appropriate lang and text direction ([PR #1790](https://github.com/alphagov/govuk_publishing_components/pull/1790))
 
 ## 23.7.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.7.1)
+    govuk_publishing_components (23.7.2)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.7.1".freeze
+  VERSION = "23.7.2".freeze
 end


### PR DESCRIPTION
Includes:
 - Fix Brexit countdown in the contextual sidebar to use appropriate lang and text direction ([PR #1790](https://github.com/alphagov/govuk_publishing_components/pull/1790))
