### PR TITLE
Fix to resolve input zoom-text overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## 23.7.2
 * Fix Brexit countdown in the contextual sidebar to use appropriate lang and text direction ([PR #1790](https://github.com/alphagov/govuk_publishing_components/pull/1790))
+* Fix to resolve input zoom-text overlap ([PR #1793](https://github.com/alphagov/govuk_publishing_components/pull/1793))
 
 ## 23.7.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/component_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/component_support.scss
@@ -9,6 +9,7 @@
 @import "govuk_publishing_components/components/helpers/variables";
 @import "govuk_publishing_components/components/helpers/brand-colours";
 @import "govuk_publishing_components/components/helpers/link";
+@import "govuk_publishing_components/components/helpers/px-to-em";
 @import "govuk_publishing_components/components/mixins/govuk-template-link-focus-override";
 @import "govuk_publishing_components/components/mixins/media-down";
 @import "govuk_publishing_components/components/mixins/margins";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -39,7 +39,7 @@ $large-input-size: 50px;
   padding: 6px;
   margin: 0;
   width: 100%;
-  height: $input-size;
+  height: em(34, 16);
   border: $govuk-border-width-form-element solid $govuk-input-border-colour;
   background: govuk-colour("white");
   border-radius: 0; //otherwise iphones apply an automatic border radius


### PR DESCRIPTION
## What?

Text bleeds outside the bounding box within the UI search input element - while zooming-text-only at 200% within Firefox, this disrupts the experience for users that have increased their text sizes (a11y)

Using existing helper to resolve. [Ticket 1](https://trello.com/c/xjR2uZnf) & [Ticket 2](https://trello.com/c/4ydEeRoq)

## Why?

As pixels are being used for layout / positioning and not relative units the element doesn't scale correctly text only zoom is used.

## Anything Else

The Design System tackles this / solves this problem by using:

```
    @if $govuk-typography-use-rem {
      height: govuk-px-to-rem(34px);
    }
```

I believe this will be a short-term fix while most apps go through a migration to adopt the Design System fully.

## Visual Changes

Before

![Screenshot 2020-11-23 at 19 33 16](https://user-images.githubusercontent.com/71266765/100073633-aa493180-2e35-11eb-9f4f-23734dc2614f.png)

After

![Screenshot 2020-11-23 at 19 32 48](https://user-images.githubusercontent.com/71266765/100073654-af0de580-2e35-11eb-90eb-8f170e7012af.png)

This update also impacts other uses of Search, Before:

![Screenshot 2020-11-23 at 19 52 19](https://user-images.githubusercontent.com/71266765/100073882-f72d0800-2e35-11eb-9eb9-cc6f798b57a2.png)

After 

![Screenshot 2020-11-23 at 19 52 37](https://user-images.githubusercontent.com/71266765/100073905-fd22e900-2e35-11eb-8011-cf9c9e3df678.png)

IE11 testing:

![Screenshot 2020-11-24 at 09 08 25](https://user-images.githubusercontent.com/71266765/100074324-80443f00-2e36-11eb-9e61-05e4dc9a5335.png)

IE8 testing:

![Screenshot 2020-11-24 at 09 08 01](https://user-images.githubusercontent.com/71266765/100074293-79b5c780-2e36-11eb-9e92-b1094bc2e7a6.png)



