### PR TITLE
Add password reveal component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add password reveal component ([PR #1794](https://github.com/alphagov/govuk_publishing_components/pull/1794))
 * Add some GOV.UK Accounts specific PII redacts ([PR #1807](https://github.com/alphagov/govuk_publishing_components/pull/1807))
 
 ## 23.7.6

--- a/app/assets/javascripts/govuk_publishing_components/components/show-password.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/show-password.js
@@ -1,0 +1,63 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function ShowPassword () { }
+
+  ShowPassword.prototype.start = function ($module) {
+    this.$module = $module[0]
+    this.input = this.$module.querySelector('.gem-c-input')
+    this.$module.togglePassword = this.togglePassword.bind(this)
+    this.$module.revertToPasswordOnFormSubmit = this.revertToPasswordOnFormSubmit.bind(this)
+    this.input.classList.add('gem-c-input--with-password')
+
+    this.showPasswordText = this.$module.getAttribute('data-show')
+    this.hidePasswordText = this.$module.getAttribute('data-hide')
+    this.shownPassword = this.$module.getAttribute('data-announce-show')
+    this.hiddenPassword = this.$module.getAttribute('data-announce-hide')
+
+    // wrap the input in a new div
+    this.wrapper = document.createElement('div')
+    this.wrapper.classList.add('gem-c-show-password__input-wrapper')
+    this.input.parentNode.insertBefore(this.wrapper, this.input)
+    this.wrapper.appendChild(this.input)
+
+    // create and append the button
+    this.showHide = document.createElement('button')
+    this.showHide.className = 'gem-c-show-password__toggle'
+    this.showHide.setAttribute('aria-controls', this.input.getAttribute('id'))
+    this.showHide.innerHTML = this.showPasswordText
+    this.wrapper.insertBefore(this.showHide, this.input.nextSibling)
+
+    // create and append the status text for screen readers
+    this.statusText = document.createElement('span')
+    this.statusText.classList.add('govuk-visually-hidden')
+    this.statusText.innerHTML = this.hiddenPassword
+    this.statusText.setAttribute('aria-live', 'polite')
+    this.wrapper.insertBefore(this.statusText, this.showHide.nextSibling)
+
+    this.showHide.addEventListener('click', this.$module.togglePassword)
+
+    this.parentForm = this.input.form
+    var disableFormSubmitCheck = this.$module.getAttribute('data-disable-form-submit-check')
+
+    if (this.parentForm && !disableFormSubmitCheck) {
+      this.parentForm.addEventListener('submit', this.$module.revertToPasswordOnFormSubmit)
+    }
+  }
+
+  ShowPassword.prototype.togglePassword = function (event) {
+    event.preventDefault()
+    this.showHide.innerHTML = this.showHide.innerHTML === this.showPasswordText ? this.hidePasswordText : this.showPasswordText
+    this.statusText.innerHTML = this.statusText.innerHTML === this.shownPassword ? this.hiddenPassword : this.shownPassword
+    this.input.setAttribute('type', this.input.getAttribute('type') === 'text' ? 'password' : 'text')
+  }
+
+  ShowPassword.prototype.revertToPasswordOnFormSubmit = function (event) {
+    this.showHide.innerHTML = this.showPasswordText
+    this.statusText.innerHTML = this.hiddenPassword
+    this.input.setAttribute('type', 'password')
+  }
+
+  Modules.ShowPassword = ShowPassword
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -60,6 +60,7 @@
 @import "components/search";
 @import "components/select";
 @import "components/share-links";
+@import "components/show-password";
 @import "components/skip-link";
 @import "components/step-by-step-nav-header";
 @import "components/step-by-step-nav-related";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_show-password.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_show-password.scss
@@ -1,0 +1,61 @@
+.gem-c-show-password__input-wrapper {
+  display: table; // IE fallback
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+
+  @include govuk-media-query($from: mobile) {
+    flex-direction: row;
+  }
+
+  .gem-c-input--with-password {
+    display: table-cell;
+
+    &:focus {
+      z-index: 1;
+    }
+  }
+}
+
+.gem-c-show-password__toggle {
+  @include govuk-font(19);
+  z-index: 0;
+  display: table-cell; // IE fallback
+  padding: govuk-spacing(1) govuk-spacing(3);
+  min-width: 5em; // stops the button width jumping when the text changes
+  color: $govuk-link-colour;
+  text-decoration: underline;
+  background: govuk-colour("white");
+  border: solid 2px $govuk-input-border-colour;
+  white-space: nowrap;
+  cursor: pointer;
+
+  @include govuk-media-query($until: mobile) {
+    padding: govuk-spacing(1);
+    width: 100%;
+    margin-top: -2px;
+    white-space: normal;
+  }
+
+  @include govuk-media-query($from: mobile) {
+    margin-left: -2px;
+  }
+
+  &:hover {
+    color: $govuk-link-hover-colour;
+  }
+
+  &:focus {
+    z-index: 1;
+    background: $govuk-focus-colour;
+    color: $govuk-focus-text-colour;
+    outline: 0;
+  }
+
+  &:active {
+    z-index: 1;
+    background: govuk-colour("white");
+    border-color: $govuk-focus-colour;
+    color: $govuk-link-active-colour;
+  }
+}

--- a/app/views/govuk_publishing_components/components/_show_password.html.erb
+++ b/app/views/govuk_publishing_components/components/_show_password.html.erb
@@ -1,0 +1,40 @@
+<%
+  disable_form_submit_check ||= false
+  label ||= nil
+  value ||= nil
+  id ||= nil
+  name ||= nil
+  autocomplete = "off" unless ['new-password', 'current-password'].include?(autocomplete)
+  describedby ||= nil
+  hint ||= nil
+  error_message ||= nil
+  error_items ||= nil
+
+  if !label
+    raise ArgumentError, "This component requires a label"
+  end
+%>
+<% if label %>
+  <%= tag.div class: "gem-c-show-password",
+    data: {
+      module: "show-password",
+      disable_form_submit_check: disable_form_submit_check,
+      show: t('components.input.show'),
+      hide: t('components.input.hide'),
+      announce_show: t('components.input.announce_show'),
+      announce_hide: t('components.input.announce_hide')
+    } do %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: label,
+        value: value,
+        id: id,
+        name: name,
+        describedby: describedby,
+        hint: hint,
+        error_message: error_message,
+        error_items: error_items,
+        type: "password",
+        autocomplete: autocomplete,
+      } %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/show_password.yml
+++ b/app/views/govuk_publishing_components/components/docs/show_password.yml
@@ -1,0 +1,79 @@
+name: Show password input
+description: A password input field that allows the password to be shown.
+body: |
+  Adds a password reveal button to an input that toggles its type from password to text, revealing the password. Does not appear if JavaScript is disabled.
+
+  Uses a visually hidden bit of text to inform screen reader users of the state of the input rather than announcing the content of the password input when toggled.
+accessibility_criteria: |
+  The component must:
+
+  * indicate to the user that the password has been shown or hidden
+
+  Inputs in the component must:
+
+  * accept focus
+  * be focusable with a keyboard
+  * be usable with a keyboard
+  * be usable with touch
+  * indicate when they have focus
+  * be recognisable as form input elements
+  * have correctly associated labels
+  * be of the appropriate type for their use, e.g. password inputs should be of type 'password'
+
+  Buttons in the component must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - indicate when it has focus
+  - activate when focused and space is pressed
+  - activate when focused and enter is pressed
+govuk_frontend_components:
+  - text-input
+examples:
+  default:
+    data:
+      label:
+        text: Please enter your password
+      value: this is my password
+  disable_form_submit_check:
+    description: The component sets the `autocomplete` attribute on the input to "off" so that browsers don't remember the password. This isn't reliable, so the component reverts the input type back to a password when its parent form is submitted. If this is causing conflicts with other JavaScript on your form, you can set `disable-form-submit-check` to `true` to disable this functionality and implement it yourself.
+    data:
+      label:
+        text: Please enter your password
+      value: this is my password
+      disable_form_submit_check: true
+  set_autocomplete_attribute:
+    description: By default, autocomplete is set to `off`. This can be set to `new-password` or `current-password` to help browsers differentiate between new and current passwords.
+    data:
+      label:
+        text: Please enter your password
+      autocomplete: "current-password"
+      value: this is my password
+  with_attributes:
+    description: The component accepts many but not all of the options that can be passed to a regular input, including `id`, `name` and `describedby` (not shown).
+    data:
+      label:
+        text: Please enter your password
+      value: this is my password
+      id: custom_id
+      name: custom_name
+  with_hint:
+    data:
+      label:
+        text: Please enter your password
+      value: this is my password
+      hint: Your password must be at least twelve thousand characters
+  with_error:
+    data:
+      label:
+        text: Please enter your password
+      value: this is my password
+      error_message: No it isn't
+  with_error_items:
+    data:
+      label:
+        text: Please enter your password
+      value: this is my password
+      error_items:
+      - text: Look I keep telling you
+      - text: This isn't your password

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,11 @@ en:
       what_wrong: "What went wrong?"
       send_me_survey: "Send me the survey"
       send: "Send"
+    input:
+      show: Show
+      hide: Hide
+      announce_show: Your password is shown
+      announce_hide: Your password is hidden
     organisation_schema:
       all_content_search_description: "Find all content from %{organisation}"
     radio:

--- a/spec/components/show_password_spec.rb
+++ b/spec/components/show_password_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe "Show password", type: :view do
+  def component_name
+    "show_password"
+  end
+
+  it "fails to render when no label is given" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  it "renders correctly" do
+    render_component(
+      label: {
+        text: "Your password",
+      },
+    )
+
+    assert_select(".gem-c-show-password[data-module='show-password']")
+    assert_select(".gem-c-show-password[data-show='Show']")
+    assert_select(".gem-c-show-password[data-hide='Hide']")
+    assert_select(".gem-c-show-password[data-announce-show='Your password is shown']")
+    assert_select(".gem-c-show-password[data-announce-hide='Your password is hidden']")
+    assert_select(".gem-c-input[autocomplete='off']")
+    assert_select(".gem-c-input[type='password']")
+  end
+
+  it "renders with autocomplete current password" do
+    render_component(
+      label: {
+        text: "Your password",
+      },
+      autocomplete: "current-password",
+    )
+
+    assert_select(".gem-c-input[autocomplete='current-password']")
+  end
+
+  it "renders with autocomplete off if invalid entry is passed for autocomplete" do
+    render_component(
+      label: {
+        text: "Your password",
+      },
+      autocomplete: "this-is-totally-not-a-thing",
+    )
+
+    assert_select(".gem-c-input[autocomplete='off']")
+  end
+end

--- a/spec/javascripts/components/show-password-spec.js
+++ b/spec/javascripts/components/show-password-spec.js
@@ -1,0 +1,123 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+describe('A show password component', function () {
+  var element
+
+  describe('in password reveal mode', function () {
+    beforeEach(function () {
+      element = $(
+        '<div class="gem-c-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show="Show" data-hide="Hide" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">' +
+          '<div class="govuk-form-group">' +
+            '<label for="input" class="gem-c-label govuk-label">Please enter your password</label>' +
+            '<input name="password" value="this is my password" class="gem-c-input govuk-input" id="input" type="password" autocomplete="off">' +
+          '</div>' +
+        '</div>'
+      )
+      new GOVUK.Modules.ShowPassword().start(element)
+    })
+
+    afterEach(function () {
+      element.remove()
+    })
+
+    it('adds the required elements for password reveal', function () {
+      expect(element.find('.gem-c-show-password__input-wrapper').length).toBe(1)
+      expect(element.find('.gem-c-input.gem-c-input--with-password').length).toBe(1)
+      expect(element.find('.gem-c-show-password__toggle').length).toBe(1)
+      expect(element.find('.gem-c-show-password__toggle').text()).toBe('Show')
+      expect(element.find('.gem-c-show-password__toggle').attr('aria-controls')).toBe('input')
+      expect(element.find('.govuk-visually-hidden').length).toBe(1)
+      expect(element.find('.govuk-visually-hidden').text()).toBe('Your password is hidden')
+    })
+
+    it('reveals the password when clicked', function () {
+      element.find('.gem-c-show-password__toggle').trigger('click')
+
+      expect(element.find('.gem-c-show-password__toggle').text()).toBe('Hide')
+      expect(element.find('input[name="password"]').attr('type')).toBe('text')
+      expect(element.find('.govuk-visually-hidden').text()).toBe('Your password is shown')
+    })
+
+    it('hides the password when clicked again', function () {
+      element.find('.gem-c-show-password__toggle').trigger('click')
+      element.find('.gem-c-show-password__toggle').trigger('click')
+
+      expect(element.find('.gem-c-show-password__toggle').text()).toBe('Show')
+      expect(element.find('input[name="password"]').attr('type')).toBe('password')
+      expect(element.find('.govuk-visually-hidden').text()).toBe('Your password is hidden')
+    })
+  })
+
+  describe('in password reveal mode inside a form', function () {
+    beforeEach(function () {
+      element = $(
+        '<form>' +
+          '<div class="gem-c-show-password" data-module="show-password" data-show="Show" data-hide="Hide" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">' +
+            '<div class="govuk-form-group">' +
+              '<label for="input" class="gem-c-label govuk-label">Please enter your password</label>' +
+              '<input name="password" value="this is my password" class="gem-c-input govuk-input" id="input" type="password" autocomplete="off">' +
+            '</div>' +
+          '</div>' +
+          '<button type="submit">Submit</button>' +
+        '</form>'
+      )
+      $('body').append(element)
+      new GOVUK.Modules.ShowPassword().start(element.find('.gem-c-show-password'))
+      $('body').on('submit', function (e) {
+        e.preventDefault()
+      })
+    })
+
+    afterEach(function () {
+      element.remove()
+      $('body').off()
+    })
+
+    it('reverts the inputs to type password when the form is submitted', function () {
+      element.find('.gem-c-show-password__toggle').trigger('click')
+      expect(element.find('input[name="password"]').attr('type')).toBe('text')
+
+      element.find('button[type="submit"]').click()
+      expect(element.find('.gem-c-show-password__toggle').text()).toBe('Show')
+      expect(element.find('input[name="password"]').attr('type')).toBe('password')
+      expect(element.find('.govuk-visually-hidden').text()).toBe('Your password is hidden')
+    })
+  })
+
+  describe('in password reveal mode inside a form', function () {
+    beforeEach(function () {
+      element = $(
+        '<form>' +
+          '<div class="gem-c-show-password" data-module="show-password" data-disable-form-submit-check="true" data-show="Show" data-hide="Hide" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">' +
+            '<div class="govuk-form-group">' +
+              '<label for="input" class="gem-c-label govuk-label">Please enter your password</label>' +
+              '<input name="password" value="this is my password" class="gem-c-input govuk-input" id="input" type="password" autocomplete="off">' +
+            '</div>' +
+          '</div>' +
+          '<button type="submit">Submit</button>' +
+        '</form>'
+      )
+      $('body').append(element)
+      new GOVUK.Modules.ShowPassword().start(element.find('.gem-c-show-password'))
+      $('body').on('submit', function (e) {
+        e.preventDefault()
+      })
+    })
+
+    afterEach(function () {
+      element.remove()
+      $('body').off()
+    })
+
+    it('doesn\'t revert the inputs to type password when the form is submitted if the disable check flag is set', function () {
+      element.find('.gem-c-show-password__toggle').trigger('click')
+      expect(element.find('input[name="password"]').attr('type')).toBe('text')
+
+      element.find('button[type="submit"]').click()
+      expect(element.find('.gem-c-show-password__toggle').text()).toBe('Hide')
+      expect(element.find('input[name="password"]').attr('type')).toBe('text')
+      expect(element.find('.govuk-visually-hidden').text()).toBe('Your password is shown')
+    })
+  })
+})


### PR DESCRIPTION
## What
Adds a new component for a password input including a show/hide button to toggle the display of the password. Uses the input component.

![Screenshot 2020-12-03 at 13 30 40](https://user-images.githubusercontent.com/861310/101024404-f7cb4a00-356b-11eb-9ffb-5cd3c71f0064.png)

![Screenshot 2020-12-03 at 13 30 49](https://user-images.githubusercontent.com/861310/101024426-fc8ffe00-356b-11eb-897a-f04ed4b27251.png)

![Screenshot 2020-12-03 at 13 30 59](https://user-images.githubusercontent.com/861310/101024438-00bc1b80-356c-11eb-84ee-916350661cb1.png)

![Screenshot 2020-12-03 at 13 31 22](https://user-images.githubusercontent.com/861310/101024457-0580cf80-356c-11eb-9adf-9ed9d55758c5.png)

## Why

We have some (limited) research suggesting it's a feature users want for the GOVUK Accounts registration flow.

## Changes

Build notes:

- the feature works by toggling the input type between `password` and `text`, which makes the text visible
- because this is a JS only feature all of the extra elements are added using JS, which means that if JS is disabled the input appears as normal
- the text for all of the content comes from data attributes appended to the DOM, which in turn comes from the translation files, so this can be translated if needed
- the button remains to the right of the input except on mobile, where it stacks, and the full text is visible

![Screenshot 2020-12-03 at 13 31 35](https://user-images.githubusercontent.com/861310/101024505-14678200-356c-11eb-9458-e5290912c34e.png)


Browser compatibility:

- the layout uses flexbox, which is only partially supported in various versions of IE, but attempting to use the `-ms-flexbox` prefixed version produced some unwanted effects, so I've gone with a display table fallback
- tested in all versions of IE and with the exception of some minor layout problems in the older versions works fine, except for IE8, which doesn't allow the `type` of an input to be changed, for some reason

IE8:

![Screenshot 2020-12-03 at 13 50 48](https://user-images.githubusercontent.com/861310/101026535-edf71600-356e-11eb-95ec-41671ee4b8fc.png)

IE9:

![Screenshot 2020-12-03 at 13 51 14](https://user-images.githubusercontent.com/861310/101026562-f51e2400-356e-11eb-809b-90d3e41cca9b.png)

IE10:

![Screenshot 2020-12-03 at 13 51 33](https://user-images.githubusercontent.com/861310/101026589-ff402280-356e-11eb-8f9b-8625dff3c72c.png)

IE11 (which for some reason is squashed against the edges of the browser, please ignore the edges):

![Screenshot 2020-12-03 at 13 52 43](https://user-images.githubusercontent.com/861310/101026608-06ffc700-356f-11eb-87c2-a96a9d826050.png)

Accessibility:

- initially I thought the accessibility for this would be straightforward as non-sighted users wouldn't need this functionality, however I don't think that's true, as a non-sighted user might also want to check what they've typed in a password input
- the show/hide button has an `aria-controls` attribute pointing to the input
- when the button is pressed with a screenreader, I felt there should be some kind of feedback for non-sighted users to indicate that something has happened. Originally I set the input to have an `aria-live="polite"` attribute, but the result of this was that the value of the input is announced, which is a possible security issue. Instead, I've added a visually hidden bit of text that says "Your password is shown/hidden" and put the `aria-live` attribute on that instead. However, if the user shows the password and then returns the focus to the input, the password gets read aloud anyway, but at least with this method they should be aware of what's happening before their password is announced

Security:

- there's been some concern that submitting a form with a password input set to `type="text"` could cause some problems, particularly with the browser maybe remembering the password value on future visits
- input gets `autocomplete="off"` added to prevent this (but can also be set to `new-password` or `current-password` to help browsers understand how to remember passwords)
- since this isn't 100% supported by browsers, the JS also now detects parent form submission and reverts the input to a password type to further protect users
- if this is found to cause a conflict with other JS on a form, the component also accepts the `disable-form-submit-check` option to disable this code

Trello card: https://trello.com/c/aJeQWmOS/418-add-a-show-password-option-to-account-creation-flow-and-sign-in
