### PR TITLE
Update to responsive bullet SVG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix to update the current list bullet numbered SVG into a responsive version so it scales correctly via zoom-text-only / improves a11y considerations ([PR #1799](https://github.com/alphagov/govuk_publishing_components/pull/1799))
+
 ## 23.7.3
 
 * Fix to resolve input zoom-text overlap ([PR #1793](https://github.com/alphagov/govuk_publishing_components/pull/1793))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_steps.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_steps.scss
@@ -12,10 +12,10 @@
 
     @for $i from 1 through 30 {
       &:nth-child(#{$i}) {
-        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='250' height='250'%3E%3Ccircle cx='125' cy='125' r='100' fill='black' /%3E%3Ctext x='50%25' y='50%25' text-anchor='middle' alignment-baseline='middle' font-family='sans-serif' font-size='100px' fill='white'%3E#{$i}%3C/text%3E%3C/svg%3E");
+        background-image: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 250 250' preserveAspectRatio='xMinYMin meet'%3E%3Cg%3E%3Ccircle r='50%25' cx='50%25' cy='50%25' class='circle-back'%3E%3C/circle%3E%3Ctext x='50%25' y='50%25' text-anchor='middle' dy='0.3em' font-family='nta,arial,sans-serif' font-size='8rem' fill='%23ffffff'%3E#{$i}%3C/text%3E%3C/g%3E%3C/svg%3E ");
         background-repeat: no-repeat;
-        background-position: left 10px;
-        background-size: 35px 35px;
+        background-position: .2em .7em;
+        background-size: 1.4em 1.4em;
       }
     }
   }


### PR DESCRIPTION
## What?

Updating the current list bullet numbered SVG into a responsive version so it scales correctly via zoom-text-only / improves a11y considerations 

## Why?

_"Step numbers don't get bigger with bigger font size"_ - [Ticket] (https://trello.com/c/RurRepSL)
Fail of WCAG SC 1.4.4

## Visual Changes

[Example page under _FOI request_](https://www.gov.uk/government/organisations/companies-house)

Before > After (100% - Chrome)

![Screenshot 2020-11-27 at 18 24 37](https://user-images.githubusercontent.com/71266765/100477772-4480d200-30e1-11eb-8d44-db20add8a6ee.png)

Before > After (@ 200% - Firefox)

<img width="1438" alt="Screenshot 2020-11-27 at 18 46 41" src="https://user-images.githubusercontent.com/71266765/100477767-4185e180-30e1-11eb-90ed-4c13ddb75901.png">

Before > After (100% - Firefox)

<img width="1440" alt="Screenshot 2020-11-27 at 17 57 35" src="https://user-images.githubusercontent.com/71266765/100477799-56fb0b80-30e1-11eb-82fd-07557cc705e9.png">

Before > After (@ 200% - Firefox)
<img width="1440" alt="Screenshot 2020-11-27 at 17 58 05" src="https://user-images.githubusercontent.com/71266765/100477793-52ceee00-30e1-11eb-927f-989935a2c04d.png">

IE11 

<img width="1440" alt="Screenshot 2020-11-27 at 18 01 01" src="https://user-images.githubusercontent.com/71266765/100478211-5a42c700-30e2-11eb-9d90-f34db9ab9b5d.png">

## Anything else?

Vertically aligns better for FF and uses "NTA" font when available.


