### PR TITLE
Amend share links columns spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Amend share links columns spacing ([PR #1800](https://github.com/alphagov/govuk_publishing_components/pull/1800))
+
 ## 23.7.5
 
 * Update subscription-links default email link text ([PR #1804](https://github.com/alphagov/govuk_publishing_components/pull/1804))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -40,7 +40,7 @@ $share-button-height: 32px;
   left: 0;
   width: $share-button-width;
   height: $share-button-height;
-  vertical-align: top;
+  line-height: $share-button-height;
 }
 
 .direction-rtl {
@@ -61,7 +61,7 @@ $share-button-height: 32px;
   }
 }
 
-$column-width: 150px;
+$column-width: 9.5em;
 
 .gem-c-share-links--columns {
   .gem-c-share-links__list {


### PR DESCRIPTION
## What

This changes the share links columns to use `em` values instead of `px` which means that the width of the link containers increase proportionately to the font size. This should make for a better experience for users who use the text zoom setting in their browser.

<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why

When increasing the font size to 200%, some of the social media links
are overlapping, making them unreadable for users who use this setting.
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/1nrlxFEB

## Visual Changes

### No zoom before
![Screenshot 2020-12-01 at 10 15 21](https://user-images.githubusercontent.com/7116819/100728431-75058c00-33bf-11eb-9a09-8edafb4bbad3.png)


### No zoom after
![Screenshot 2020-12-01 at 10 15 34](https://user-images.githubusercontent.com/7116819/100728440-7636b900-33bf-11eb-95bd-cb1482939d62.png)


### 200% text zoom before
![Screenshot 2020-12-01 at 10 16 00](https://user-images.githubusercontent.com/7116819/100728444-7767e600-33bf-11eb-8798-df946a57bfab.png)

### 200% text zoom after
![Screenshot 2020-12-01 at 10 16 14](https://user-images.githubusercontent.com/7116819/100728449-78007c80-33bf-11eb-87f6-1ba35298abb0.png)



<!-- If the change results in visual changes, show a before and after -->
