### PR TITLE
Update subscription links default email link text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update subscription-links default email link text ([PR #1804](https://github.com/alphagov/govuk_publishing_components/pull/1804))
+
 ## 23.7.4
 
 * Fix to update the current list bullet numbered SVG into a responsive version so it scales correctly via zoom-text-only / improves a11y considerations ([PR #1799](https://github.com/alphagov/govuk_publishing_components/pull/1799))

--- a/app/views/govuk_publishing_components/components/docs/subscription-links.yml
+++ b/app/views/govuk_publishing_components/components/docs/subscription-links.yml
@@ -1,5 +1,5 @@
 name: Subscription links
-description: Links to ‘Get email alerts’ and ‘Subscribe to feed’
+description: Links to ‘Get emails’ and ‘Subscribe to feed’
 body: |
   <strong>NOTE: This component includes a h2 heading by default but can be suppressed by using `hide_heading` option (see below)<strong>
 accessibility_criteria: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,7 +92,7 @@ en:
     step_by_step_nav_related:
       part_of: "Part of"
     subscription_links:
-      email_signup_link_text: "Get email alerts"
+      email_signup_link_text: "Get emails"
       feed_link_text: "Subscribe to feed"
       subscriptions: "Subscriptions"
     summary_list:

--- a/lib/govuk_publishing_components/presenters/subscription_links_helper.rb
+++ b/lib/govuk_publishing_components/presenters/subscription_links_helper.rb
@@ -14,13 +14,13 @@ module GovukPublishingComponents
       def email_signup_link_text
         return @local_assigns[:email_signup_link_text] if @local_assigns[:email_signup_link_text]
 
-        I18n.t("govuk_component.subscription_links.email_signup_link_text", default: "Get email alerts")
+        I18n.t("components.subscription_links.email_signup_link_text")
       end
 
       def feed_link_text
         return @local_assigns[:feed_link_text] if @local_assigns[:feed_link_text]
 
-        I18n.t("govuk_component.subscription_links.feed_link_text", default: "Subscribe to feed")
+        I18n.t("components.subscription_links.feed_link_text")
       end
 
       def component_data_is_valid?

--- a/spec/components/subscription_links_spec.rb
+++ b/spec/components/subscription_links_spec.rb
@@ -11,7 +11,7 @@ describe "subscription links", type: :view do
 
   it "renders an email signup link" do
     render_component(email_signup_link: "/email-signup")
-    assert_select ".gem-c-subscription-links__item[href=\"/email-signup\"]", text: "Get email alerts"
+    assert_select ".gem-c-subscription-links__item[href=\"/email-signup\"]", text: "Get emails"
   end
 
   it "renders a feed link" do
@@ -24,7 +24,7 @@ describe "subscription links", type: :view do
     render_component(email_signup_link: "email-signup", feed_link: "singapore.atom")
     assert_select ".gem-c-subscription-links[data-module='gem-toggle']", false
     assert_select ".gem-c-subscription-links__list[data-module='track-click']", false
-    assert_select ".gem-c-subscription-links__item[href=\"email-signup\"]", text: "Get email alerts"
+    assert_select ".gem-c-subscription-links__item[href=\"email-signup\"]", text: "Get emails"
     assert_select ".gem-c-subscription-links__item[href=\"singapore.atom\"]", text: "Subscribe to feed"
   end
 


### PR DESCRIPTION
Update subscription links default text

This has been an agreed content change for emails links as we move away
from the terminology 'alert'.

Also removes the `default` argument as I'm struggling to see why we need
it in this instance. Using `default` also meant that a misconfigured locale
path was being covered up which has been corrected.

## Before

<img width="809" alt="Screenshot 2020-12-02 at 11 35 03" src="https://user-images.githubusercontent.com/24479188/100867726-7f448a80-3492-11eb-9268-db2548ddf719.png">

## After

<img width="852" alt="Screenshot 2020-12-02 at 11 34 13" src="https://user-images.githubusercontent.com/24479188/100867751-853a6b80-3492-11eb-98cd-386d7bb72c7a.png">


Trello:
https://trello.com/c/ssSnzp2L/640-remove-alert-from-all-the-sign-up-links
