### PR TITLE
Bump to 23.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 23.7.6
 
 * Amend share links columns spacing ([PR #1800](https://github.com/alphagov/govuk_publishing_components/pull/1800))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.7.5)
+    govuk_publishing_components (23.7.6)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.7.5".freeze
+  VERSION = "23.7.6".freeze
 end


### PR DESCRIPTION
## What

Bump gem to  version `23.7.6`

Includes #1800 
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
