### PR TITLE
Add a data attribute to indicate a link or form should be decorated as if it were a cross-domain link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add a data attribute to indicate a link or form should be decorated as if it were a cross-domain link ([PR #1811](https://github.com/alphagov/govuk_publishing_components/pull/1811))
+
 ## 23.9.2
 
 * Fix for search input misalignment ([PR #1823](https://github.com/alphagov/govuk_publishing_components/pull/1823))
 * Add type="button" to Show/Hide password button ([PR #1826](https://github.com/alphagov/govuk_publishing_components/pull/1826))
 * Amend Show/Hide password button CSS ([PR #1828](https://github.com/alphagov/govuk_publishing_components/pull/1828))
+
+>>>>>>> 13252807 (Add CHANGELOG entry)
 
 ## 23.9.1
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics.js
@@ -14,3 +14,4 @@
 //= require ./analytics/ecommerce
 //= require ./analytics/init
 //= require ./analytics/scroll-tracker
+//= require ./analytics/explicit-cross-domain-links

--- a/app/assets/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.js
@@ -1,0 +1,34 @@
+;(function (global) {
+  'use strict'
+
+  var GOVUK = global.GOVUK || {}
+  GOVUK.Modules = GOVUK.Modules || {}
+
+  GOVUK.Modules.ExplicitCrossDomainLinks = function () {
+    this.start = function ($module) {
+      var element = $module[0]
+
+      if (!global.ga) { return }
+
+      global.ga(function () {
+        var trackers = global.ga.getAll()
+
+        if (!trackers.length) { return }
+
+        var linker = new global.gaplugins.Linker(trackers[0])
+
+        var attrAction = element.getAttribute('action')
+        if (attrAction) {
+          element.setAttribute('action', linker.decorate(attrAction))
+        }
+
+        var attrHref = element.getAttribute('href')
+        if (attrHref) {
+          element.href = linker.decorate(attrHref)
+        }
+      })
+    }
+  }
+
+  global.GOVUK = GOVUK
+})(window)

--- a/spec/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.spec.js
@@ -1,0 +1,81 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+describe('Explicit cross-domain linker', function () {
+  'use strict'
+
+  var explicitCrossDomainLinks
+  var element
+  var linker
+  var trackers
+
+  beforeEach(function () {
+    window.ga = function (callback) {
+      window.ga = {
+        getAll: function () {
+          return trackers
+        }
+      }
+
+      callback()
+    }
+
+    window.gaplugins = {
+      Linker: function () {}
+    }
+
+    linker = {
+      decorate: function () {}
+    }
+
+    explicitCrossDomainLinks = new GOVUK.Modules.ExplicitCrossDomainLinks()
+
+    spyOn(window.gaplugins, 'Linker').and.returnValue(linker)
+    spyOn(linker, 'decorate').and.returnValue('/somewhere?_ga=abc123')
+  })
+
+  afterEach(function () {
+    element.remove()
+    delete window.ga
+    delete window.gaplugins
+  })
+
+  describe('links', function () {
+    beforeEach(function () {
+      element = $('<a href="/somewhere">')
+    })
+
+    it('leaves the link href if unchanged there are no trackers in ga', function () {
+      trackers = []
+      explicitCrossDomainLinks.start(element)
+      expect(element.attr('href')).toEqual('/somewhere')
+    })
+
+    it('modifies the link href to append ids from ga to the destination url', function () {
+      trackers = [{ ga_mock: 'foobar' }]
+      explicitCrossDomainLinks.start(element)
+      expect(element.attr('href')).toEqual('/somewhere?_ga=abc123')
+    })
+  })
+
+  describe('forms', function () {
+    beforeEach(function () {
+      element = $('<form method="POST" action="/somewhere">' +
+               '<input type="hidden" name="key" value="value" />' +
+               '<button type="submit">Create a GOV.UK account</button>' +
+             '</form>')
+    })
+
+    it('leaves the form action if unchanged there are no trackers in ga', function () {
+      trackers = []
+      explicitCrossDomainLinks.start(element)
+      expect(element.attr('action')).toEqual('/somewhere')
+    })
+
+    it('modifies the form action to append ids from ga to the destination url', function () {
+      trackers = [{ ga_mock: 'foobar' }]
+      explicitCrossDomainLinks.start(element)
+      expect(element.attr('action')).toEqual('/somewhere?_ga=abc123')
+    })
+  })
+})


### PR DESCRIPTION
## What
Add a data attribute to indicate a link or form should be decorated as if it were a cross-domain link.

## Why
GOV.UK uses cross-domain analytics (only if the user has consented to cookies on both domains, of course) to give a joined up view of how users interact with government. So naturally this has to work with GOV.UK Accounts too, or we’ll have an ever-growing blind spot in this joined up view.

Cross-domain analytics works by sticking a `_ga` query param onto cross-domain links, which the analytics code at the link destination picks up. The problem is that with accounts, most of the cross-domain stuff is in the form of OAuth journeys: we have cross-domain *redirects*. So we have non-cross-domain links which may do a cross-domain redirect; for example, navigating from an unauthenticated part of a service to an authenticated part, the link is a normal internal link, but it’ll redirect a logged-out user to the accounts domain.

So that these cross-domain redirects don't become an analytics blind spot, we need to do two things:

1. Add the `_ga` param to internal links and forms which *may* redirect (this PR)
2. Ensure that any such redirects preserve the param

## Visual Changes
N/A

---

[Trello card](https://trello.com/c/ISYymNsg/426-fix-cross-domain-tracking-on-redirects)