### PR TITLE
Version 23.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## 23.7.7
+## 23.8.0
 
 * Add password reveal component ([PR #1794](https://github.com/alphagov/govuk_publishing_components/pull/1794))
+
+## 23.7.7
+
 * Add some GOV.UK Accounts specific PII redacts ([PR #1807](https://github.com/alphagov/govuk_publishing_components/pull/1807))
 
 ## 23.7.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.7.7)
+    govuk_publishing_components (23.8.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.7.7".freeze
+  VERSION = "23.8.0".freeze
 end


### PR DESCRIPTION
## 23.8.0

* Add password reveal component ([PR #1794](https://github.com/alphagov/govuk_publishing_components/pull/1794))

Includes a correction to the CHANGELOG - the show password component seems to have been listed in release 23.7.7 for some reason.