### PR TITLE
bump to 23.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 23.9.0
 
 * Add support for secondary solid buttons ([PR #1814](https://github.com/alphagov/govuk_publishing_components/pull/1814))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.8.0)
+    govuk_publishing_components (23.9.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.8.0".freeze
+  VERSION = "23.9.0".freeze
 end


### PR DESCRIPTION
* Add support for secondary solid buttons ([PR #1814](https://github.com/alphagov/govuk_publishing_components/pull/1814))
