### PR TITLE
Fix for search input misalignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix for search input misalignment ([PR #1823](https://github.com/alphagov/govuk_publishing_components/pull/1823))
+
 ## 23.9.1
 
 * Disable the transition countdown on a certain page ([PR #1821](https://github.com/alphagov/govuk_publishing_components/pull/1821))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -36,10 +36,10 @@ $large-input-size: 50px;
 
 .gem-c-search__input[type="search"] { // overly specific to prevent some overrides from outside
   @include govuk-font($size: 19, $line-height: (28 / 19));
-  padding: 6px;
   margin: 0;
   width: 100%;
-  height: em(34, 16);
+  height: em(40, 16);
+  padding: em(6, 16);
   border: $govuk-border-width-form-element solid $govuk-input-border-colour;
   background: govuk-colour("white");
   border-radius: 0; //otherwise iphones apply an automatic border radius
@@ -47,6 +47,10 @@ $large-input-size: 50px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  @include govuk-media-query($from: tablet) {
+    height: em(40, 19);
+    padding: em(6, 19);
+  }
 
   // the .focus class is added by JS and ensures that the input remains above the label once clicked/filled in
   &:focus,


### PR DESCRIPTION
## What?

Fix to resolve visual mis-alignment on certain uses of the search gem component

## Why

As part of [this PR](https://github.com/alphagov/govuk_publishing_components/pull/1793) this introduced an issue, I noticed there were other instances of the search that were being impacted by this change. This PR is a fix to resolve noticed issues.

## Visuals?

**Before** (left) **After** (right)
[Gem mobile use](https://components.publishing.service.gov.uk/component-guide/search) - fix
<img width="873" alt="Screenshot 2020-12-11 at 13 59 09" src="https://user-images.githubusercontent.com/71266765/101923156-f67eca80-3bc6-11eb-82f7-3b2502c1a57f.png">

Gem Desktop (use slight misalignment)
<img width="1440" alt="Screenshot 2020-12-11 at 13 57 53" src="https://user-images.githubusercontent.com/71266765/101923161-f8e12480-3bc6-11eb-885a-56cffb0bb83a.png">

Various other uses no visual change

<img width="815" alt="Screenshot 2020-12-11 at 13 56 38" src="https://user-images.githubusercontent.com/71266765/101923168-faaae800-3bc6-11eb-9d63-29d84c620a09.png">

<img width="536" alt="Screenshot 2020-12-11 at 13 56 24" src="https://user-images.githubusercontent.com/71266765/101923175-fc74ab80-3bc6-11eb-8f1b-87a9cf393a11.png">

<img width="534" alt="Screenshot 2020-12-11 at 13 56 06" src="https://user-images.githubusercontent.com/71266765/101923179-fe3e6f00-3bc6-11eb-81a2-ca4ef65cb2e4.png">