### PR TITLE
Add type="button" to Show/Hide password button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix for search input misalignment ([PR #1823](https://github.com/alphagov/govuk_publishing_components/pull/1823))
+* Add type="button" to Show/Hide password button ([PR #1826](https://github.com/alphagov/govuk_publishing_components/pull/1826))
 
 ## 23.9.1
 

--- a/app/assets/javascripts/govuk_publishing_components/components/show-password.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/show-password.js
@@ -26,6 +26,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.showHide = document.createElement('button')
     this.showHide.className = 'gem-c-show-password__toggle'
     this.showHide.setAttribute('aria-controls', this.input.getAttribute('id'))
+    this.showHide.setAttribute('type', 'button')
     this.showHide.innerHTML = this.showPasswordText
     this.wrapper.insertBefore(this.showHide, this.input.nextSibling)
 


### PR DESCRIPTION
This is aiming to fix a bug where in the context of a form that contains a show password component, when the user hits Enter on any of the input fields in the form, the browser toggles the passwords visibility (instead of the expected behaviour, which would be to submit the form).

[Recording of the problem](https://drive.google.com/file/d/1soIp-4pWwtnvdD0ttJ_dySnesAmlN-w4/view?usp=sharing) 

The browser assumes that if you press the enter key in any of the fields, you want to submit the form and fires the click event on the first button, even when the button is not `type="submit"`. On a form that contains this component, the 1st button could be the Show/Hide form button, hence this bug.

Adding `type="button"` attribute to the show/hide element would resolve this issue, as it would now be clear to the browser that this is not a submit button.

https://trello.com/c/aJeQWmOS

---- 
**Note:** in the component guide, the `show-password` component is previewed standalone, and this bug only occurs within the context of a form. However, the bug can be replicated fairly easily by modifying the HTML and adding a `form` wrapper around the component. 


