### PR TITLE
Amend Show/Hide password button CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fix for search input misalignment ([PR #1823](https://github.com/alphagov/govuk_publishing_components/pull/1823))
 * Add type="button" to Show/Hide password button ([PR #1826](https://github.com/alphagov/govuk_publishing_components/pull/1826))
+* Amend Show/Hide password button CSS ([PR #1828](https://github.com/alphagov/govuk_publishing_components/pull/1828))
 
 ## 23.9.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_show-password.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_show-password.scss
@@ -39,6 +39,8 @@
 
   @include govuk-media-query($from: mobile) {
     margin-left: -2px;
+    margin-top: 0;
+    margin-bottom: 0;
   }
 
   &:hover {


### PR DESCRIPTION
It looks like user agent stylesheets are adding margin top and bottom to the show/hide password button, causing some slight misalignment on macOS Safari as well as iOS Chrome and Safari browsers. This overrides those default styles so that the button aligns properly with the input field.

 iOS Safari before |  iOS Safari after
------------ | -------------
![Screenshot 2020-12-15 at 14 48 40](https://user-images.githubusercontent.com/7116819/102230789-31de0980-3ee5-11eb-8846-bbd8c21b0fc8.png) | ![Screenshot 2020-12-15 at 14 48 59](https://user-images.githubusercontent.com/7116819/102230793-3276a000-3ee5-11eb-9c91-9995c1f70927.png)

### macOS Safari before
![Screenshot 2020-12-15 at 14 49 35](https://user-images.githubusercontent.com/7116819/102230796-330f3680-3ee5-11eb-8888-d1e7aa23ae57.png)

### macOS Safari after
![Screenshot 2020-12-15 at 14 52 18](https://user-images.githubusercontent.com/7116819/102230798-330f3680-3ee5-11eb-9ea7-703d7f647e5e.png)



https://trello.com/c/aJeQWmOS
