### PR TITLE
Update show password component tests

### DIFF
--- a/spec/javascripts/components/show-password-spec.js
+++ b/spec/javascripts/components/show-password-spec.js
@@ -27,6 +27,7 @@ describe('A show password component', function () {
       expect(element.find('.gem-c-show-password__toggle').length).toBe(1)
       expect(element.find('.gem-c-show-password__toggle').text()).toBe('Show')
       expect(element.find('.gem-c-show-password__toggle').attr('aria-controls')).toBe('input')
+      expect(element.find('.gem-c-show-password__toggle').attr('type')).toBe('button')
       expect(element.find('.govuk-visually-hidden').length).toBe(1)
       expect(element.find('.govuk-visually-hidden').text()).toBe('Your password is hidden')
     })


### PR DESCRIPTION

## What

Update `show password` component spec to check that the type of the password visibility toggle button is "button".

Following on from this PR where I implemented the change but I forgot to update the test:
https://github.com/alphagov/govuk_publishing_components/pull/1826
