### PR TITLE
Mark show password component as experimental

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/show_password.yml
+++ b/app/views/govuk_publishing_components/components/docs/show_password.yml
@@ -1,9 +1,11 @@
-name: Show password input
+name: Show password input (experimental)
 description: A password input field that allows the password to be shown.
 body: |
   Adds a password reveal button to an input that toggles its type from password to text, revealing the password. Does not appear if JavaScript is disabled.
 
   Uses a visually hidden bit of text to inform screen reader users of the state of the input rather than announcing the content of the password input when toggled.
+
+  This component is currently experimental. If you are using it, please feed back any research findings to the Accounts team.
 accessibility_criteria: |
   The component must:
 


### PR DESCRIPTION
## What
Mark show password component as experimental

## Why
As per [our guidance](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/develop-component.md).

## Visual Changes
No visual changes
