### PR TITLE
Fixes youtube title bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fixes youtube title bug ([PR #1835](https://github.com/alphagov/govuk_publishing_components/pull/1835))
+
 ## 23.10.0
 
 * Add a data attribute to indicate a link or form should be decorated as if it were a cross-domain link ([PR #1811](https://github.com/alphagov/govuk_publishing_components/pull/1811))

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -105,8 +105,10 @@
         events: {
           onReady: function (event) {
             // update iframe title attribute once video is ready
+            // this is done to let screen reader users know that they are focused on a video
+            // https://github.com/alphagov/govuk_publishing_components/pull/908#discussion_r302913995
             var videoTitle = options.title
-            event.target.f.title = videoTitle + ' (video)'
+            event.target.getIframe().title = videoTitle + ' (video)'
           },
           onStateChange: function (event) {
             var eventData = event.data


### PR DESCRIPTION
# What

Replaces unstable method of setting the title to a stable method

# Why

The previous way was unstable and youtube changes these variables on a regular basis

