### PR TITLE
Bump version to 23.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 23.10.1
 
 * Fixes youtube title bug ([PR #1835](https://github.com/alphagov/govuk_publishing_components/pull/1835))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.10.0)
+    govuk_publishing_components (23.10.1)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.10.0".freeze
+  VERSION = "23.10.1".freeze
 end


### PR DESCRIPTION
Includes
* Fixes youtube title bug ([PR #1835](https://github.com/alphagov/govuk_publishing_components/pull/1835))
