### PR TITLE
Fix Rails deprecation warning for autoloading during initialisation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix Rails deprecation warning for autoloading during initialisation ([PR #1837](https://github.com/alphagov/govuk_publishing_components/pull/1837))
+
 ## 23.10.1
 
 * Fixes youtube title bug ([PR #1835](https://github.com/alphagov/govuk_publishing_components/pull/1835))

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -37,14 +37,16 @@ require "govuk_publishing_components/app_helpers/brand_helper"
 require "govuk_publishing_components/app_helpers/countdown_helper"
 require "govuk_publishing_components/app_helpers/environment"
 
-# Add view and i18n paths for usage outside of a Rails app
-ActionController::Base.append_view_path(
-  File.expand_path("app/views", GovukPublishingComponents::Config.gem_directory),
-)
-
+# Add i18n paths and views for usage outside of a Rails app
 I18n.load_path.unshift(
   *Dir.glob(File.expand_path("config/locales/*.yml", GovukPublishingComponents::Config.gem_directory)),
 )
+
+ActiveSupport.on_load(:action_controller) do
+  ActionController::Base.append_view_path(
+    File.expand_path("app/views", GovukPublishingComponents::Config.gem_directory),
+  )
+end
 
 module GovukPublishingComponents
   def self.render(component, options = {})


### PR DESCRIPTION
See https://github.com/alphagov/govuk_publishing_components/pull/1831 this PR is opened to fix that one being closed by mistake.