### PR TITLE
Turn off the Brexit Countdown Clock at 23.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix Rails deprecation warning for autoloading during initialisation ([PR #1837](https://github.com/alphagov/govuk_publishing_components/pull/1837))
+* Turn off the Brexit countdown clock at 23.30 on Brexit eve ([PR #1841](https://github.com/alphagov/govuk_publishing_components/pull/1841))
 
 ## 23.10.1
 

--- a/lib/govuk_publishing_components/app_helpers/countdown_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/countdown_helper.rb
@@ -1,18 +1,18 @@
 module GovukPublishingComponents
   module AppHelpers
     class CountdownHelper
-      END_OF_TRANSITION_PERIOD = Date.new(2021, 1, 1)
+      END_OF_TRANSITION_PERIOD = Time.new(2020, 12, 31, 23, 59).in_time_zone("Europe/London")
 
       def days_left
-        sprintf "%02d", days_left_integer
+        sprintf "%02d", days_left_until_deadline
       end
 
       def show?
-        days_left_integer.positive?
+        minutes_left_until_deadline >= 30
       end
 
       def days_text
-        if days_left_integer == 1
+        if days_left_until_deadline == 1
           I18n.t!("components.transition_countdown.day_to_go")
         else
           I18n.t!("components.transition_countdown.days_to_go")
@@ -21,12 +21,20 @@ module GovukPublishingComponents
 
     private
 
-      def days_left_integer
-        (END_OF_TRANSITION_PERIOD - today_in_london).to_i
+      def days_left_until_deadline
+        (minutes_left_until_deadline / 60 / 24).ceil
       end
 
-      def today_in_london
-        Time.find_zone("Europe/London").today
+      def minutes_left_until_deadline
+        (seconds_left_until_deadline / 60)
+      end
+
+      def seconds_left_until_deadline
+        END_OF_TRANSITION_PERIOD - now_in_london
+      end
+
+      def now_in_london
+        Time.now.in_time_zone("Europe/London")
       end
     end
   end

--- a/lib/govuk_publishing_components/app_helpers/countdown_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/countdown_helper.rb
@@ -1,7 +1,7 @@
 module GovukPublishingComponents
   module AppHelpers
     class CountdownHelper
-      END_OF_TRANSITION_PERIOD = Time.new(2020, 12, 31, 23, 59).in_time_zone("Europe/London")
+      DEADLINE = Time.new(2020, 12, 31, 23, 59)
 
       def days_left
         sprintf "%02d", days_left_until_deadline
@@ -30,11 +30,19 @@ module GovukPublishingComponents
       end
 
       def seconds_left_until_deadline
-        END_OF_TRANSITION_PERIOD - now_in_london
+        end_of_transition_period - now_in_london
+      end
+
+      def end_of_transition_period
+        london_time_zone(DEADLINE)
       end
 
       def now_in_london
-        Time.now.in_time_zone("Europe/London")
+        london_time_zone(Time.now)
+      end
+
+      def london_time_zone(time)
+        time.in_time_zone("Europe/London")
       end
     end
   end

--- a/spec/lib/govuk_publishing_components/app_helpers/countdown_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/countdown_helper_spec.rb
@@ -4,32 +4,32 @@ RSpec.describe GovukPublishingComponents::AppHelpers::CountdownHelper do
   describe "Countdown helper" do
     it "gives the days left until end of transition period" do
       clock = described_class.new
-      day_before_transition_period_ends = Date.new(2020, 12, 31)
-      travel_to day_before_transition_period_ends
+      nine_am_on_brexit_eve = Time.zone.local(2020, 12, 31, 9, 0)
+      travel_to nine_am_on_brexit_eve
       expect(clock.days_left).to eql("01")
     end
 
-    it "returns true until 23.59 on December 31st 2020" do
+    it "returns true until 23.29 on December 31st 2020" do
       clock = described_class.new
-      minute_to_midnight_on_brexit_eve = Time.zone.local(2020, 12, 31, 23, 59)
-      travel_to minute_to_midnight_on_brexit_eve
+      one_minute_before_component_shut_off_time = Time.zone.local(2020, 12, 31, 23, 29)
+      travel_to one_minute_before_component_shut_off_time
       expect(clock.show?).to eql(true)
     end
 
-    it "returns false from midnight on the eve of January 1st 2021" do
+    it "returns false from 23.31 on December 31st 2020" do
       clock = described_class.new
-      midnight_on_brexit_eve = Time.zone.local(2020, 12, 31, 24, 0)
-      travel_to midnight_on_brexit_eve
+      one_minute_after_component_shut_off_time = Time.zone.local(2020, 12, 31, 23, 30)
+      travel_to one_minute_after_component_shut_off_time
       expect(clock.show?).to eql(false)
     end
 
     it "pluralizes day if necessary" do
       clock = described_class.new
-      one_day_left = Date.new(2020, 12, 31)
+      one_day_left = Time.zone.local(2020, 12, 31, 9, 0)
       travel_to one_day_left
       expect(clock.days_text).to eql("day to go")
 
-      two_days_left = Date.new(2020, 12, 30)
+      two_days_left = Time.zone.local(2020, 12, 30, 9, 0)
       travel_to two_days_left
       expect(clock.days_text).to eql("days to go")
     end


### PR DESCRIPTION
## What
Update the Brexit CountdownClock component so that it is hidden from 23.30 on Brexit eve. 

## Why
Currently the component is set to turn itself off at the midnight.  Due to caching, this might leave us in a situation where we are still showing the countdown after midnight. 

## Visual Changes
There are no visual changes.

Related PR: https://github.com/alphagov/collections/pull/2184

---
[Trello](https://trello.com/c/NrxFXJ0e/726-update-logic-to-remove-countdown-visual-at-1130pm-vs-1159pm-on-31-december?menu=filter&filter=member:jessjones11)