### PR TITLE
Version 23.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 23.10.2
 
 * Fix Rails deprecation warning for autoloading during initialisation ([PR #1837](https://github.com/alphagov/govuk_publishing_components/pull/1837))
 * Turn off the Brexit countdown clock at 23.30 on Brexit eve ([PR #1841](https://github.com/alphagov/govuk_publishing_components/pull/1841))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.10.1)
+    govuk_publishing_components (23.10.2)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.10.1".freeze
+  VERSION = "23.10.2".freeze
 end


### PR DESCRIPTION
- Fix Rails deprecation warning for autoloading during initialisation
- Turn off the Brexit countdown clock at 23.30 on Brexit eve
