### PR TITLE
Bump version to 23.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unversioned
+## 23.11.0
 
 * Replace transition countdown component with sidebar partial (PR [#1845](https://github.com/alphagov/govuk_publishing_components/pull/1845))
 

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.10.2".freeze
+  VERSION = "23.11.0".freeze
 end


### PR DESCRIPTION
https://trello.com/c/zshkcMQl/743-deploy-31-12-1045pm-update-brexit-transition-sidebar-section-3
https://trello.com/c/8w2ti59g/756-deploy-31-12-1045pm-replace-brexit-branded-sidebar-element-4

This is not a breaking change, since the countdown component only
had one consumer, which is no longer using it.