### PR TITLE
Update Brexit CTA copy in contextual sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update Brexit CTA copy in contextual sidebar ([PR #1851](https://github.com/alphagov/govuk_publishing_components/pull/1851))
 * Extend component auditing ([PR #1796](https://github.com/alphagov/govuk_publishing_components/pull/1796))
 
 ## 23.11.0

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -12,4 +12,4 @@ cy:
       transition:
         title: "Brexit"
         link_path: "/transition.cy"
-        link_text: "Darganfyddwch sut mae’r rheolau newydd yn effeithio arnoch chi"
+        link_text: "Darganfyddwch sut mae’r rheolau Brexit newydd yn effeithio arnoch chi"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,7 @@ en:
       transition:
         title: "Brexit"
         link_path: "/transition"
-        link_text: "Check how the new rules affect you"
+        link_text: "Check how the new Brexit rules affect you"
     related_footer_navigation:
       collections: "Collections"
       policies: "Policies"


### PR DESCRIPTION
## What
Update Brexit CTA copy in the contextual sidebar component

## Why
See background in [Trello card](https://trello.com/c/vFkN8alA)

## Visual Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="960" alt="Screenshot 2021-01-06 at 10 51 10" src="https://user-images.githubusercontent.com/788096/103760546-2924b300-500d-11eb-8e1c-b1cc8d24c74f.png">
<img width="960" alt="Screenshot 2021-01-06 at 10 51 21" src="https://user-images.githubusercontent.com/788096/103760552-2cb83a00-500d-11eb-9b2d-c659c7ce6dd6.png">


</td><td valign="top">

<img width="960" alt="Screenshot 2021-01-06 at 10 50 33" src="https://user-images.githubusercontent.com/788096/103760566-2f1a9400-500d-11eb-8467-2b10b83cc0fb.png">
<img width="960" alt="Screenshot 2021-01-06 at 10 50 47" src="https://user-images.githubusercontent.com/788096/103760572-304bc100-500d-11eb-91ef-28ac1abc67a4.png">


</td></tr>
</table>
