### PR TITLE
Release 23.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 23.11.1
 
 * Update Brexit CTA copy in contextual sidebar ([PR #1851](https://github.com/alphagov/govuk_publishing_components/pull/1851))
 * Extend component auditing ([PR #1796](https://github.com/alphagov/govuk_publishing_components/pull/1796))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.10.2)
+    govuk_publishing_components (23.11.1)
       govuk_app_config
       kramdown
       plek
@@ -94,9 +94,11 @@ GEM
     execjs (2.7.0)
     faker (2.12.0)
       i18n (>= 1.6, < 2)
-    faraday (1.1.0)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
+    faraday-net_http (1.0.0)
     ffi (1.12.2)
     gds-api-adapters (67.2.1)
       addressable
@@ -106,11 +108,11 @@ GEM
       rest-client (~> 2.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk_app_config (2.8.0)
-      logstasher (>= 1.2.2, < 1.4.0)
+    govuk_app_config (2.8.1)
+      logstasher (>= 1.2.2, < 2.2.0)
       sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.4.0)
-      unicorn (>= 5.4, < 5.8)
+      unicorn (>= 5.4, < 5.9)
     govuk_schemas (4.2.0)
       json-schema (~> 2.8.0)
     govuk_test (2.0.0)
@@ -140,10 +142,8 @@ GEM
     kramdown (2.3.0)
       rexml
     link_header (0.0.8)
-    logstash-event (1.2.02)
-    logstasher (1.3.0)
-      activesupport (>= 4.0)
-      logstash-event (~> 1.2.0)
+    logstasher (2.1.5)
+      activesupport (>= 5.2)
       request_store
     loofah (2.7.0)
       crass (~> 1.0.2)
@@ -300,7 +300,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    unicorn (5.7.0)
+    unicorn (5.8.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     webdrivers (4.4.1)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.11.0".freeze
+  VERSION = "23.11.1".freeze
 end


### PR DESCRIPTION
### 23.11.1
* Update Brexit CTA copy in contextual sidebar ([PR #1851](https://github.com/alphagov/govuk_publishing_components/pull/1851))
* Extend component auditing ([PR #1796](https://github.com/alphagov/govuk_publishing_components/pull/1796))

Note the `Gemfile.lock` was not updated in https://github.com/alphagov/govuk_publishing_components/pull/1846, hence the jump from 23.10.2 to 23.11.1
