### PR TITLE
Add link tracking to GovSpeak component

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/govspeak.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/govspeak.js
@@ -11,6 +11,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.embedYoutube()
     }
 
+    if (this.$module.getAttribute('data-track-links-category')) {
+      this.trackLinks($module)
+    }
+
     this.createBarcharts()
   }
 
@@ -22,6 +26,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   Govspeak.prototype.createBarcharts = function () {
     var enhancement = new window.GOVUK.GovspeakBarchartEnhancement(this.$module)
     enhancement.init()
+  }
+
+  Govspeak.prototype.trackLinks = function ($module) {
+    var tracking = new window.GOVUK.Modules.GovspeakTrackLinks()
+    tracking.start($module)
   }
 
   Modules.Govspeak = Govspeak

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/govspeak-track-links.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/govspeak-track-links.js
@@ -1,0 +1,31 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function GovspeakTrackLinks () { }
+
+  GovspeakTrackLinks.prototype.start = function ($module) {
+    $module = $module[0]
+    var category = $module.getAttribute('data-track-links-category')
+    var links = $module.querySelectorAll('a')
+
+    for (var i = 0; i < links.length; i++) {
+      links[i].addEventListener('click', function (event) {
+        this.sendLinkClickEvent(event, category)
+      }.bind(this))
+    }
+  }
+
+  GovspeakTrackLinks.prototype.sendLinkClickEvent = function (event, category) {
+    window.GOVUK.analytics.trackEvent(
+      category,
+      event.target.innerText,
+      {
+        transport: 'beacon',
+        label: event.target.getAttribute('href')
+      }
+    )
+  }
+
+  Modules.GovspeakTrackLinks = GovspeakTrackLinks
+})(window.GOVUK.Modules)

--- a/app/views/govuk_publishing_components/components/_govspeak.html.erb
+++ b/app/views/govuk_publishing_components/components/_govspeak.html.erb
@@ -1,13 +1,22 @@
 <%
+  track_links ||= false
+  track_links_category ||= nil
+  track_links = false unless track_links_category.present?
+  
   direction_class = "direction-#{direction}" if local_assigns.include?(:direction)
   disable_youtube_expansions = local_assigns.fetch(:disable_youtube_expansions) if local_assigns.include?(:disable_youtube_expansions)
 
   classes = []
+  classes << "gem-c-govspeak govuk-govspeak"
   classes << direction_class if direction_class
   classes << "disable-youtube" if disable_youtube_expansions
+
+  data_attributes = {}
+  data_attributes[:module] = "govspeak"
+  data_attributes[:track_links_category] = track_links_category if track_links
 %>
 
-<div class="gem-c-govspeak govuk-govspeak <%= classes.join(" ") %>" data-module="govspeak">
+<%= tag.div(class: classes, data: data_attributes) do %>
   <% if local_assigns.include?(:content) %>
     <% if content.html_safe? %>
       <%= content %>
@@ -28,4 +37,4 @@
   <% elsif block_given? %>
     <%= yield %>
   <% end %>
-</div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -815,3 +815,12 @@ examples:
           <a role="button" class="gem-c-button govuk-button" href="https://gov.uk/random">Button</a>
           <a class="gem-c-button govuk-button govuk-button--start" role="button" href="https://gov.uk/random"> Start button <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path></svg></a>
         </p>
+  link_tracking:
+    data:
+      track_links: true
+      track_links_category: briefings-page
+      block: |
+        <p>
+          <a href="https://gov.uk">Link 1</a>
+          <a href="https://gov.uk/random">Link 2</a>
+        </p>

--- a/spec/components/govspeak_spec.rb
+++ b/spec/components/govspeak_spec.rb
@@ -37,4 +37,31 @@ describe "Govspeak", type: :view do
 
     expect(rendered).to include("content-via-block")
   end
+
+  it "can track links" do
+    render_component(
+      track_links: true,
+      track_links_category: "testing-blah",
+      content: "<a href='/blah'>link tracking</a>".html_safe,
+    )
+
+    assert_select "[data-track-links-category='testing-blah']"
+  end
+
+  it "doesn't track links when links tracking isn't passed in" do
+    render_component(
+      content: "<a href='/blah'>link tracking</a>".html_safe,
+    )
+
+    assert_select "[data-track-links-category]", false
+  end
+
+  it "doesn't track links if tracking category isn't passed in" do
+    render_component(
+      track_links: true,
+      content: "<a href='/blah'>link tracking</a>".html_safe,
+    )
+
+    assert_select "[data-track-links-category]", false
+  end
 end

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/govspeak-track-links-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/govspeak-track-links-spec.js
@@ -1,0 +1,67 @@
+/* eslint-env jasmine, jquery */
+var GOVUK = window.GOVUK
+
+describe('Govspeak Track Links', function () {
+  var tracker
+  var element
+
+  beforeEach(function () {
+    spyOn(GOVUK.analytics, 'trackEvent')
+  })
+
+  afterEach(function () {
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
+  })
+
+  describe('Single link', function () {
+    beforeEach(function () {
+      element = document.createElement('div')
+      element.setAttribute('data-track-links-category', 'Content page 1')
+      element.innerHTML = '<a href="/blah/blahhhh">Blahh</a>'
+
+      tracker = new GOVUK.Modules.GovspeakTrackLinks()
+      tracker.start($(element))
+    })
+
+    it('sends a ga event when link is clicked', function () {
+      element.querySelector('a').dispatchEvent(new window.Event('click'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Content page 1', 'Blahh', { transport: 'beacon', label: '/blah/blahhhh' }
+      )
+    })
+  })
+
+  describe('Multiple links', function () {
+    beforeEach(function () {
+      element = document.createElement('div')
+      element.setAttribute('data-track-links-category', 'Content page 2')
+      element.innerHTML = '<a href="/blah/blahhhh">Blahh</a>'
+      element.innerHTML += '<a href="/blah/blahhhh2">Blahh2</a>'
+      element.innerHTML += '<a href="https://www.external-link.com">External link blahhh</a>'
+
+      tracker = new GOVUK.Modules.GovspeakTrackLinks()
+      tracker.start($(element))
+    })
+
+    it('sends ga events for all links clicked', function () {
+      element
+        .querySelectorAll('a')
+        .forEach(function (link) {
+          link.dispatchEvent(new window.Event('click'))
+        })
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Content page 2', 'Blahh', { transport: 'beacon', label: '/blah/blahhhh' }
+      )
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Content page 2', 'Blahh2', { transport: 'beacon', label: '/blah/blahhhh2' }
+      )
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Content page 2', 'External link blahhh', { transport: 'beacon', label: 'https://www.external-link.com' }
+      )
+    })
+  })
+})


### PR DESCRIPTION
## What
Option to track all links rendered within a GovSpeak component

## Why
This will allow us to add custom tracking to content pages where tracking is required for reporting purposes.

https://trello.com/c/BHqdvxKg/688-set-up-analytics-for-briefing-video-page