### PR TITLE
Escape dangerous HTML in 'Machine readable metadata' component

### DIFF
--- a/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
@@ -9,7 +9,7 @@
 <% structured_data = GovukPublishingComponents::Presenters::SchemaOrg.new(page).structured_data %>
 
 <script type="application/ld+json">
-  <%= raw JSON.pretty_generate(structured_data) %>
+  <%= raw(json_escape(JSON.pretty_generate(structured_data))) %>
 </script>
 
 <link rel="canonical" href="<%= page.canonical_url %>" />


### PR DESCRIPTION
Trello: https://trello.com/c/YhIIykse/2291-3-fix-cross-site-scripting-vulnerabilities

## What
Applies sanitisation to structured data JSON in the machine readable
metadata component.

`json_escape` replaces `&`, `>` and `<` characters with their
unicode equivalents: https://apidock.com/rails/ERB/Util/json_escape
I've managed to retain the pretty-print functionality, after
initially plugging this hole with a `.to_json`, which ActiveRecord
escapes automatically.

## Why
Currently, any HTML included in the structured data gets rendered
as-is, breaking the validity of the page and opening up an attack
vector whereby the publisher could inject arbitrary JavaScript
into the page (however unlikely). It should be sanitised before it
is rendered.

## Visual Changes
N/A