### PR TITLE
Bump to 23.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 23.12.1
+
+* Escape dangerous HTML in 'Machine readable metadata' component ([PR #1858](https://github.com/alphagov/govuk_publishing_components/pull/1858))
+
 ## 23.12.0
 
 * Get analytics code ready for use in production ([PR #1767](https://github.com/alphagov/govuk_publishing_components/pull/1767))

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.12.0".freeze
+  VERSION = "23.12.1".freeze
 end


### PR DESCRIPTION
This release also contains some dependency bumps via #1856, #1857,
#1859 and #1860. I've deliberately ignored #1838 as it is a
minor bump and is likely to affect how things render visually, so
best reviewed manually by a frontend dev.

Trello: https://trello.com/c/YhIIykse/2291-3-fix-cross-site-scripting-vulnerabilities