### PR TITLE
Hide native browser show password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Hide native browser show password ([PR #1863](https://github.com/alphagov/govuk_publishing_components/pull/1863))
+
 ## 23.12.1
 
 * Escape dangerous HTML in 'Machine readable metadata' component ([PR #1858](https://github.com/alphagov/govuk_publishing_components/pull/1858))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_show-password.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_show-password.scss
@@ -14,6 +14,10 @@
     &:focus {
       z-index: 1;
     }
+
+    &::-ms-reveal {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
## What / why

- Edge and IE11 now include their own 'show password' option in password inputs
- while this doesn't interfere with our custom functionality to do this, it is a little odd to have both of them there
- fortunately it can be removed using this bit of CSS

Background: https://textslashplain.com/2020/07/29/revealing-passwords/

## Visual Changes

Edge before:

<img width="672" alt="Screenshot 2021-01-11 at 14 49 22" src="https://user-images.githubusercontent.com/861310/104208789-d1c97d00-5428-11eb-97a3-3e33313ec383.png">

IE11 before:

<img width="674" alt="Screenshot 2021-01-11 at 16 16 35" src="https://user-images.githubusercontent.com/861310/104208821-daba4e80-5428-11eb-999d-b43b609bf7b2.png">

After is basically the same thing but without the little eye icon, e.g.

<img width="670" alt="Screenshot 2021-01-11 at 16 20 17" src="https://user-images.githubusercontent.com/861310/104208893-f02f7880-5428-11eb-8b1c-be144d12f4db.png">
