### PR TITLE
Bump components gem to version 23.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 23.12.2
 
 * Hide native browser show password ([PR #1863](https://github.com/alphagov/govuk_publishing_components/pull/1863))
+* Update magna charter experience for screen reader users ([PR #1787](https://github.com/alphagov/govuk_publishing_components/pull/1787))
 
 ## 23.12.1
 
 * Escape dangerous HTML in 'Machine readable metadata' component ([PR #1858](https://github.com/alphagov/govuk_publishing_components/pull/1858))
-* Update magna charter experience for screen reader users ([PR #1787](https://github.com/alphagov/govuk_publishing_components/pull/1787))
 
 ## 23.12.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.12.1)
+    govuk_publishing_components (23.12.2)
       govuk_app_config
       kramdown
       plek
@@ -102,7 +102,7 @@ GEM
       faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
-    faraday-net_http (1.0.0)
+    faraday-net_http (1.0.1)
     ffi (1.12.2)
     gds-api-adapters (68.2.0)
       addressable

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.12.1".freeze
+  VERSION = "23.12.2".freeze
 end


### PR DESCRIPTION
* Hide native browser show password ([PR #1863](https://github.com/alphagov/govuk_publishing_components/pull/1863))
* Update magna charter experience for screen reader users ([PR #1787](https://github.com/alphagov/govuk_publishing_components/pull/1787))