### PR TITLE
Add print styling for magna charta component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add print styling for magna charta component ([PR #1867](https://github.com/alphagov/govuk_publishing_components/pull/1867))
+
 ## 23.12.2
 
 * Hide native browser show password ([PR #1863](https://github.com/alphagov/govuk_publishing_components/pull/1863))

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_govspeak.scss
@@ -72,4 +72,9 @@
       list-style: none;
     }
   }
+
+  .mc-toggle-button,
+  .mc-chart-container {
+    display: none;
+  }
 }


### PR DESCRIPTION
## What
Adds `display: none` to print styling for specific elements within the magna charta bar chart component.

## Why
To address a bug raised for print styles where bar charts will duplicate data on print due to the chart element and the original table both being visible.

## Visual Changes
### Before
![Screenshot 2021-01-14 at 10 03 22](https://user-images.githubusercontent.com/64783893/104576177-c1dfb200-564f-11eb-80a1-08f97835b064.png)

### After
![Screenshot 2021-01-14 at 10 01 31](https://user-images.githubusercontent.com/64783893/104576005-91981380-564f-11eb-9810-1f66e75c353a.png)

[Card](https://trello.com/c/a1wOFE76/2006-markdown-charts-dont-print)