### PR TITLE
Change GOVUK Modules scope to document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Tidy component filenames ([PR #1848](https://github.com/alphagov/govuk_publishing_components/pull/1848))
 * Add print styling for magna charta component ([PR #1867](https://github.com/alphagov/govuk_publishing_components/pull/1867))
 * Add custom aria label option for layout header nav ([PR #1865](https://github.com/alphagov/govuk_publishing_components/pull/1865))
+* Change GOVUK Modules scope to document ([PR #1869](https://github.com/alphagov/govuk_publishing_components/pull/1869))
 
 ## 23.12.2
 

--- a/app/assets/javascripts/govuk_publishing_components/modules.js
+++ b/app/assets/javascripts/govuk_publishing_components/modules.js
@@ -7,7 +7,7 @@
 
   GOVUK.modules = {
     find: function (container) {
-      container = container || $('body')
+      container = container || $(document)
 
       var modules
       var moduleSelector = '[data-module]'

--- a/spec/javascripts/govuk_publishing_components/modules.spec.js
+++ b/spec/javascripts/govuk_publishing_components/modules.spec.js
@@ -6,13 +6,36 @@ describe('GOVUK Modules', function () {
   'use strict'
   var GOVUK = window.GOVUK
 
-  it('finds modules', function () {
+  it('finds modules in body', function () {
     var module = $('<div data-module="a-module"></div>')
     $('body').append(module)
 
     expect(GOVUK.modules.find().length).toBe(1)
     expect(GOVUK.modules.find().eq(0).is('[data-module="a-module"]')).toBe(true)
     module.remove()
+  })
+
+  it('finds modules in head', function () {
+    var module = $('<meta name="fake-meta" content="blah" data-module="a-module">')
+    $('head').append(module)
+
+    expect(GOVUK.modules.find().length).toBe(1)
+    expect(GOVUK.modules.find().eq(0).is('[data-module="a-module"]')).toBe(true)
+    module.remove()
+  })
+
+  it('finds modules in a page', function () {
+    var headModule = $('<meta name="fake-meta" content="blah" data-module="head-module">')
+    $('head').append(headModule)
+
+    var bodyModule = $('<div data-module="body-module"></div>')
+    $('body').append(bodyModule)
+
+    expect(GOVUK.modules.find().length).toBe(2)
+    expect(GOVUK.modules.find().eq(0).is('[data-module="head-module"]')).toBe(true)
+    expect(GOVUK.modules.find().eq(1).is('[data-module="body-module"]')).toBe(true)
+    headModule.remove()
+    bodyModule.remove()
   })
 
   it('finds modules in a container', function () {


### PR DESCRIPTION
## What

Change the scope to document rather than just body

## Why

This is done to support module within the head ie. on meta tags.

This also brings the scope in line with GOVUK Design system where document is used rather than the body.
