### PR TITLE
Bump gem release to 23.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 23.13.0
 
-* Update documentation for the meta tags component ([PR #1870](https://github.com/alphagov/govuk_publishing_components/pull/1870))
+* Update documentation and add new tag options for the meta tags component ([PR #1870](https://github.com/alphagov/govuk_publishing_components/pull/1870))
 
 ## 23.12.3
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.12.3)
+    govuk_publishing_components (23.13.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.12.3".freeze
+  VERSION = "23.13.0".freeze
 end


### PR DESCRIPTION
* Update documentation for the meta tags component ([PR #1870](https://github.com/alphagov/govuk_publishing_components/pull/1870))