### PR TITLE
Remove unneeded list stylesheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * BREAKING: Retire gem-level SCSS variables ([PR #1881](https://github.com/alphagov/govuk_publishing_components/pull/1881))
 * BREAKING: Remove duplicate `lib/auto-track-event` script ([PR #1894](https://github.com/alphagov/govuk_publishing_components/pull/1894))
 * BREAKING: Remove copies of files ([PR #1878](https://github.com/alphagov/govuk_publishing_components/pull/1878))
-
+* BREAKING: Remove list stylesheet ([PR #1874])(https://github.com/alphagov/govuk_publishing_components/pull/1874)
 ## 23.15.0
 
 * Fix bugs on the feedback component ([PR #1900](https://github.com/alphagov/govuk_publishing_components/pull/1900))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_list.scss
@@ -1,1 +1,0 @@
-@import "govuk/components/list/list";

--- a/spec/components/all_components_spec.rb
+++ b/spec/components/all_components_spec.rb
@@ -39,7 +39,7 @@ describe "All components" do
         expect(File).to exist(rspec_file)
       end
 
-      it "has a correctly named SCSS file", not_applicable: component_name.in?(%w[contextual_breadcrumbs admin_analytics contextual_footer contextual_sidebar government_navigation machine_readable_metadata meta_tags google_tag_manager_script]) do
+      it "has a correctly named SCSS file", not_applicable: component_name.in?(%w[admin_analytics contextual_breadcrumbs contextual_footer contextual_sidebar google_tag_manager_script government_navigation list machine_readable_metadata meta_tags]) do
         css_file = "#{__dir__}/../../app/assets/stylesheets/govuk_publishing_components/components/_#{component_name.tr('_', '-')}.scss"
 
         expect(File).to exist(css_file)


### PR DESCRIPTION


## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Removes the unnecessary list stylesheet. Updates the audit to cope with the list component not having a stylesheet.

## Why
<!-- What are the reasons behind this change being made? -->
The list styles are imported with the core parts of GOV.UK Frontend into the [component support stylesheet][1], so the standalone list stylesheet isn't required.

[1]: https://github.com/alphagov/govuk_publishing_components/blob/c25fba341c13e270ae44e8d0add1d02d8e2c0404/app/assets/stylesheets/govuk_publishing_components/component_support.scss#L4

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
None.
