### PR TITLE
Update design for step by step navigation to improve accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Bump govuk-frontend from 3.9.1 to 3.10.2 ([PR #1838](https://github.com/alphagov/govuk_publishing_components/pull/1838))
+* Update design for step by step navigation to improve accessibility ([PR #1875](https://github.com/alphagov/govuk_publishing_components/pull/1875))
 
 ## 23.13.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -333,34 +333,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var that = this
 
     this.$module.showOrHideAllButton.addEventListener('click', function (event) {
-      var shouldshowAll
-      var showHideTexts = that.$module.querySelectorAll('.js-toggle-link')
       var textContent = this.textContent || this.innerText
+      var shouldShowAll = textContent === that.$module.actions.showAllText
 
-      if (textContent === that.$module.actions.showAllText) {
-        that.$module.showOrHideAllButton.innerHTML = that.$module.upChevronSvg + that.$module.actions.hideAllText
-        for (var i = 0; i < showHideTexts.length; i++) {
-          showHideTexts[i].innerHTML = that.$module.upChevronSvg + that.$module.actions.hideText
-        }
-        shouldshowAll = true
+      // Fire GA click tracking
+      stepNavTracker.trackClick('pageElementInteraction', (shouldShowAll ? 'stepNavAllShown' : 'stepNavAllHidden'), {
+        label: (shouldShowAll ? that.$module.actions.showAllText : that.$module.actions.hideAllText) + ': ' + that.$module.stepNavSize
+      })
 
-        stepNavTracker.trackClick('pageElementInteraction', 'stepNavAllShown', {
-          label: that.$module.actions.showAllText + ': ' + that.$module.stepNavSize
-        })
-      } else {
-        that.$module.showOrHideAllButton.innerHTML = that.$module.downChevronSvg + that.$module.actions.showAllText
-        for (var j = 0; j < showHideTexts.length; j++) {
-          showHideTexts[j].innerHTML = that.$module.downChevronSvg + that.$module.actions.showText
-        }
-        shouldshowAll = false
-
-        stepNavTracker.trackClick('pageElementInteraction', 'stepNavAllHidden', {
-          label: that.$module.actions.hideAllText + ': ' + that.$module.stepNavSize
-        })
-      }
-
-      that.setAllStepsShownState(shouldshowAll)
-      that.$module.showOrHideAllButton.setAttribute('aria-expanded', shouldshowAll)
+      that.setAllStepsShownState(shouldShowAll)
+      that.$module.showOrHideAllButton.setAttribute('aria-expanded', shouldShowAll)
       that.setShowHideAllText()
 
       return false

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -40,6 +40,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.$module.sessionStoreLink = this.$module.sessionStoreLink + '_' + this.$module.uniqueId
     }
 
+    this.$module.upChevronSvg = '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="gem-c-step-nav__chevron">' +
+      '<path d="M19.5 10C19.5 15.2467 15.2467 19.5 10 19.5C4.75329 19.5 0.499997 15.2467 0.499998 10C0.499999 4.7533 4.7533 0.500001 10 0.500002C15.2467 0.500003 19.5 4.7533 19.5 10Z" stroke="#1D70B8"/>' +
+      '<path d="M6.32617 12.3262L10 8.65234L13.6738 12.3262" stroke="#1D70B8" stroke-width="2"/>' +
+      '</svg>'
+    this.$module.downChevronSvg = '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="gem-c-step-nav__chevron">' +
+      '<path d="M0.499997 10C0.499998 4.75329 4.75329 0.499999 10 0.499999C15.2467 0.5 19.5 4.75329 19.5 10C19.5 15.2467 15.2467 19.5 10 19.5C4.75329 19.5 0.499997 15.2467 0.499997 10Z" stroke="#1D70B8"/>' +
+      '<path d="M13.6738 8.67383L10 12.3477L6.32617 8.67383" stroke="#1D70B8" stroke-width="2"/>' +
+      '</svg>'
+
     var stepNavTracker = new this.StepNavTracker(this.$module.uniqueId, this.$module.totalSteps, this.$module.totalLinks)
 
     this.getTextForInsertedElements()
@@ -66,7 +75,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   Gemstepnav.prototype.addShowHideAllButton = function () {
     var showall = document.createElement('div')
     showall.className = 'gem-c-step-nav__controls'
-    showall.innerHTML = '<button aria-expanded="false" class="gem-c-step-nav__button gem-c-step-nav__button--controls js-step-controls-button">' + this.$module.actions.showAllText + '</button>'
+    showall.innerHTML = '<button aria-expanded="false" class="gem-c-step-nav__button gem-c-step-nav__button--controls js-step-controls-button">' +
+      this.$module.downChevronSvg +
+      this.$module.actions.showAllText +
+      '</button>'
 
     var steps = this.$module.querySelectorAll('.gem-c-step-nav__steps')[0]
     this.$module.insertBefore(showall, steps)
@@ -114,7 +126,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var data = []
 
     for (var i = 0; i < this.$module.steps.length; i++) {
-      var stepView = new this.StepView(this.$module.steps[i], this.$module.actions.showText, this.$module.actions.hideText)
+      var stepView = new this.StepView(this.$module.steps[i], this.$module)
       stepView.setIsShown(isShown)
 
       if (isShown) {
@@ -136,7 +148,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     for (var i = 0; i < this.$module.steps.length; i++) {
       var thisel = this.$module.steps[i]
       var id = thisel.getAttribute('id')
-      var stepView = new this.StepView(thisel, this.$module.actions.showText, this.$module.actions.hideText)
+      var stepView = new this.StepView(thisel, this.$module)
       var shouldBeShown = thisel.hasAttribute('data-show')
 
       // show the step if it has been remembered or if it has the 'data-show' attribute
@@ -177,7 +189,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     for (var i = 0; i < togglePanels.length; i++) {
       togglePanels[i].addEventListener('click', function (event) {
-        var stepView = new that.StepView(this.parentNode, that.$module.actions.showText, that.$module.actions.hideText)
+        var stepView = new that.StepView(this.parentNode, that.$module)
         stepView.toggle()
 
         var stepIsOptional = this.parentNode.hasAttribute('data-optional')
@@ -326,9 +338,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var textContent = this.textContent || this.innerText
 
       if (textContent === that.$module.actions.showAllText) {
-        that.$module.showOrHideAllButton.textContent = that.$module.actions.hideAllText
+        that.$module.showOrHideAllButton.innerHTML = that.$module.upChevronSvg + that.$module.actions.hideAllText
         for (var i = 0; i < showHideTexts.length; i++) {
-          showHideTexts[i].innerHTML = that.$module.actions.hideText
+          showHideTexts[i].innerHTML = that.$module.upChevronSvg + that.$module.actions.hideText
         }
         shouldshowAll = true
 
@@ -336,9 +348,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           label: that.$module.actions.showAllText + ': ' + that.$module.stepNavSize
         })
       } else {
-        that.$module.showOrHideAllButton.textContent = that.$module.actions.showAllText
+        that.$module.showOrHideAllButton.innerHTML = that.$module.downChevronSvg + that.$module.actions.showAllText
         for (var j = 0; j < showHideTexts.length; j++) {
-          showHideTexts[j].innerHTML = that.$module.actions.showText
+          showHideTexts[j].innerHTML = that.$module.downChevronSvg + that.$module.actions.showText
         }
         shouldshowAll = false
 
@@ -359,21 +371,23 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var shownSteps = this.$module.querySelectorAll('.step-is-shown').length
     // Find out if the number of is-opens == total number of steps
     if (shownSteps === this.$module.totalSteps) {
-      this.$module.showOrHideAllButton.textContent = this.$module.actions.hideAllText
+      this.$module.showOrHideAllButton.innerHTML = this.$module.upChevronSvg + this.$module.actions.hideAllText
     } else {
-      this.$module.showOrHideAllButton.textContent = this.$module.actions.showAllText
+      this.$module.showOrHideAllButton.innerHTML = this.$module.downChevronSvg + this.$module.actions.showAllText
     }
   }
 
-  Gemstepnav.prototype.StepView = function (stepElement, showText, hideText) {
+  Gemstepnav.prototype.StepView = function (stepElement, $module) {
     this.stepElement = stepElement
     this.stepContent = this.stepElement.querySelectorAll('.js-panel')[0]
     this.titleButton = this.stepElement.querySelectorAll('.js-step-title-button')[0]
     var textElement = this.stepElement.querySelectorAll('.js-step-title-text')[0]
     this.title = textElement.textContent || textElement.innerText
     this.title = this.title.replace(/^\s+|\s+$/g, '') // this is 'trim' but supporting IE8
-    this.showText = showText
-    this.hideText = hideText
+    this.showText = $module.actions.showText
+    this.hideText = $module.actions.hideText
+    this.upChevronSvg = $module.upChevronSvg
+    this.downChevronSvg = $module.downChevronSvg
 
     this.show = function () {
       this.setIsShown(true)
@@ -398,7 +412,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       this.titleButton.setAttribute('aria-expanded', isShown)
       var showHideText = this.stepElement.querySelectorAll('.js-toggle-link')[0]
-      showHideText.innerHTML = isShown ? this.hideText : this.showText
+      showHideText.innerHTML = isShown ? this.upChevronSvg + this.hideText : this.downChevronSvg + this.showText
     }
 
     this.isShown = function () {

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -177,7 +177,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           '<button ' +
             'class="gem-c-step-nav__button gem-c-step-nav__button--title js-step-title-button" ' +
             'aria-expanded="false" aria-controls="' + contentId + '">' +
-              '<span class="js-step-title-text">' + titleText + '</span>' +
+              '<span class="gem-c-step-nav__title-text js-step-title-text">' + titleText + '</span>' +
           '</button>' +
         '</span>'
     }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -56,7 +56,6 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 
 .gem-c-step-nav__controls {
   padding: 3px 3px 0 0;
-  text-align: right;
 }
 
 .gem-c-step-nav__button {
@@ -93,12 +92,20 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
   @include step-nav-font(14, $line-height: 1);
   position: relative;
   z-index: 1; // this and relative position stops focus outline underlap with border of accordion
-  padding: .5em 0;
-  text-decoration: underline;
+  padding: .5em 0 1.5em;
+
+  &:hover {
+    text-decoration: underline;
+  }
 
   .gem-c-step-nav--large & {
     @include step-nav-font(14, $tablet-size: 16, $line-height: 1);
   }
+}
+
+.gem-c-step-nav__title-text {
+  display: block;
+  margin-bottom: govuk-spacing(1);
 }
 
 .gem-c-step-nav__chevron {
@@ -186,7 +193,7 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
   box-sizing: border-box;
   position: absolute;
   z-index: 5;
-  top: govuk-spacing(3);
+  top: govuk-spacing(1);
   left: 0;
   width: $number-circle-size;
   height: $number-circle-size;
@@ -197,7 +204,7 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 
   .gem-c-step-nav--large & {
     @include govuk-media-query($from: tablet) {
-      top: govuk-spacing(6);
+      top: govuk-spacing(3);
       width: $number-circle-size-large;
       height: $number-circle-size-large;
     }
@@ -245,7 +252,7 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 }
 
 .gem-c-step-nav__header {
-  padding: govuk-spacing(3) 0;
+  padding: govuk-spacing(1) 0 govuk-spacing(3);
   border-top: $top-border;
 
   .gem-c-step-nav--active & {
@@ -275,7 +282,7 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 
   .gem-c-step-nav--large & {
     @include govuk-media-query($from: tablet) {
-      padding: govuk-spacing(6) 0;
+      padding: govuk-spacing(2) 0 govuk-spacing(6);
     }
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -101,6 +101,11 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
   }
 }
 
+.gem-c-step-nav__chevron {
+  vertical-align: text-top;
+  margin-right: govuk-spacing(1);
+}
+
 .gem-c-step-nav__steps {
   padding: 0;
   margin: 0;

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
@@ -24,8 +24,8 @@
     <%= "data-id=#{tracking_id}" if tracking_id %>
     data-show-text="<%= t("govuk_component.step_by_step_nav.show", default: "show") %>"
     data-hide-text="<%= t("govuk_component.step_by_step_nav.hide", default: "hide") %>"
-    data-show-all-text="<%= t("govuk_component.step_by_step_nav.show_all", default: "Show all") %>"
-    data-hide-all-text="<%= t("govuk_component.step_by_step_nav.hide_all", default: "Hide all") %>"
+    data-show-all-text="<%= t("govuk_component.step_by_step_nav.show_all", default: "Show all steps") %>"
+    data-hide-all-text="<%= t("govuk_component.step_by_step_nav.hide_all", default: "Hide all steps") %>"
   >
     <ol class="gem-c-step-nav__steps">
       <% steps.each_with_index do |step, step_index| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,8 +92,8 @@ en:
     step_by_step_nav:
       show: "Show"
       hide: "Hide"
-      show_all: "Show all"
-      hide_all: "Hide all"
+      show_all: "Show all steps"
+      hide_all: "Hide all steps"
     step_by_step_nav_related:
       part_of: "Part of"
     subscription_links:

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -6,7 +6,7 @@ describe('A stepnav module', function () {
 
   var $element
   var html =
-    '<div data-module="gemstepnav" class="gem-c-step-nav js-hidden" data-id="unique-id" data-show-text="Show" data-hide-text="Hide" data-show-all-text="Show all" data-hide-all-text="Hide all">' +
+    '<div data-module="gemstepnav" class="gem-c-step-nav js-hidden" data-id="unique-id" data-show-text="Show" data-hide-text="Hide" data-show-all-text="Show all steps" data-hide-all-text="Hide all steps">' +
       '<ol class="gem-c-step-nav__steps">' +
         '<li class="gem-c-step-nav__step js-step" id="topic-step-one" data-track-count="stepnavStep">' +
           '<div class="gem-c-step-nav__header js-toggle-panel" data-position="1">' +
@@ -130,11 +130,13 @@ describe('A stepnav module', function () {
     var $showHideAllButton = $element.find('.js-step-controls-button')
 
     expect($showHideAllButton).toExist()
-    expect($showHideAllButton).toHaveText('Show all')
+    expect($showHideAllButton).toHaveText('Show all steps')
     // It has an aria-expanded false attribute as all steps are hidden
     expect($showHideAllButton).toHaveAttr('aria-expanded', 'false')
     // It has an aria-controls attribute that includes all the step_content IDs
     expect($showHideAllButton).toHaveAttr('aria-controls', 'step-panel-topic-step-one-1')
+    // It generates a chevron SVG icon for visual affordance
+    expect($showHideAllButton.find('.gem-c-step-nav__chevron')).toExist()
   })
 
   it('has no steps which have an shown state', function () {
@@ -162,10 +164,12 @@ describe('A stepnav module', function () {
     expect($stepHeader).toContainElement('.gem-c-step-nav__toggle-link')
     $stepHeader.find('.gem-c-step-nav__toggle-link').each(function () {
       expect($(this)).toHaveText('Show')
+      // It generates a chevron SVG icon for visual affordance
+      expect($(this).find('.gem-c-step-nav__chevron')).toExist()
     })
   })
 
-  describe('Clicking the "Show all" button', function () {
+  describe('Clicking the "Show all steps" button', function () {
     beforeEach(function () {
       clickShowHideAll()
     })
@@ -180,8 +184,8 @@ describe('A stepnav module', function () {
       expect($element.find('.js-step-title-button[aria-expanded="true"]').length).toEqual(stepCount)
     })
 
-    it('changes the Show/Hide all button text to "Hide all"', function () {
-      expect($element.find('.js-step-controls-button')).toContainText('Hide all')
+    it('changes the Show/Hide all button text to "Hide all steps"', function () {
+      expect($element.find('.js-step-controls-button')).toContainText('Hide all steps')
     })
 
     it('changes all the "show" elements to say "hide"', function () {
@@ -192,7 +196,7 @@ describe('A stepnav module', function () {
 
     it('triggers a google analytics custom event', function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllShown', {
-        label: 'Show all: Small',
+        label: 'Show all steps: Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
         dimension96: 'unique-id'
@@ -200,14 +204,14 @@ describe('A stepnav module', function () {
     })
   })
 
-  describe('Clicking the "Hide all" button', function () {
+  describe('Clicking the "Hide all steps" button', function () {
     beforeEach(function () {
       clickShowHideAll()
       clickShowHideAll()
     })
 
-    it('changes the Show/Hide all button text to "Show all"', function () {
-      expect($element.find('.js-step-controls-button')).toContainText('Show all')
+    it('changes the Show/Hide all button text to "Show all steps"', function () {
+      expect($element.find('.js-step-controls-button')).toContainText('Show all steps')
     })
 
     it('changes all the "hide" elements to say "show"', function () {
@@ -218,7 +222,7 @@ describe('A stepnav module', function () {
 
     it('triggers a google analytics custom event', function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllHidden', {
-        label: 'Hide all: Small',
+        label: 'Hide all steps: Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
         dimension96: 'unique-id'
@@ -376,7 +380,7 @@ describe('A stepnav module', function () {
       expect(window.sessionStorage.getItem('unique-id')).toBe('[]')
     })
 
-    it('remembers opened and closed steps using show/hide all', function () {
+    it('remembers opened and closed steps using show/hide all steps', function () {
       var $showHideAllButton = $element.find('.js-step-controls-button')
       var $stepLink2 = $element.find('#topic-step-two .js-toggle-panel')
 
@@ -390,7 +394,7 @@ describe('A stepnav module', function () {
       expect(window.sessionStorage.getItem('unique-id')).toBe('["topic-step-one","topic-step-two","topic-step-three"]')
 
       $showHideAllButton.click() // hide all
-      expect(window.sessionStorage.getItem('unique-id')).toBe(null) // 'hide all' removes the session data entirely
+      expect(window.sessionStorage.getItem('unique-id')).toBe(null) // 'hide all steps' removes the session data entirely
     })
   })
 
@@ -442,7 +446,7 @@ describe('A stepnav module', function () {
 
     it('sets the show all/hide all button text correctly', function () {
       var $showHideAllButton = $element.find('.js-step-controls-button')
-      expect($showHideAllButton).toHaveText('Show all')
+      expect($showHideAllButton).toHaveText('Show all steps')
     })
   })
 
@@ -474,7 +478,7 @@ describe('A stepnav module', function () {
 
     it('sets the show all/hide all button text correctly', function () {
       var $showHideAllButton = $element.find('.js-step-controls-button')
-      expect($showHideAllButton).toHaveText('Hide all')
+      expect($showHideAllButton).toHaveText('Hide all steps')
     })
   })
 
@@ -626,23 +630,23 @@ describe('A stepnav module', function () {
       })
     })
 
-    it('triggers a google analytics custom event when clicking the "Show all" button on a big stepnav', function () {
+    it('triggers a google analytics custom event when clicking the "Show all steps" button on a big stepnav', function () {
       clickShowHideAll()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllShown', {
-        label: 'Show all: Big',
+        label: 'Show all steps: Big',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
         dimension96: 'unique-id'
       })
     })
 
-    it('triggers a google analytics custom event when clicking the "Hide all" button on a big stepnav', function () {
+    it('triggers a google analytics custom event when clicking the "Hide all steps" button on a big stepnav', function () {
       clickShowHideAll()
       clickShowHideAll()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllHidden', {
-        label: 'Hide all: Big',
+        label: 'Hide all steps: Big',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
         dimension96: 'unique-id'
@@ -844,7 +848,7 @@ describe('A stepnav module', function () {
       clickShowHideAll()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllShown', {
-        label: 'Show all: Small',
+        label: 'Show all steps: Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
         dimension96: false
@@ -856,7 +860,7 @@ describe('A stepnav module', function () {
       clickShowHideAll()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'stepNavAllHidden', {
-        label: 'Hide all: Small',
+        label: 'Hide all steps: Small',
         dimension26: expectedstepnavStepCount.toString(),
         dimension27: expectedstepnavLinkCount.toString(),
         dimension96: false


### PR DESCRIPTION
## What
Updates the design of the [step by step navigation component](https://components.publishing.service.gov.uk/component-guide/step_by_step_nav), specifically:

- Add an up/down chevron icon for improved visual affordance
- Move the show/hide all button at the top of the component over to the left so that it's easier for zoomed screen users to use
- Alter spacing

## Why
This is part of an effort to align the different types of accordion across govuk to follow a single style and reduce confusion for users and meet [WCAG SC 3.2.4](https://www.w3.org/TR/UNDERSTANDING-WCAG20/consistent-behavior-consistent-functionality.html).

## Visual Changes
### Before
<img width="703" alt="Screenshot 2021-01-18 at 16 51 55" src="https://user-images.githubusercontent.com/64783893/104944052-8b3acc00-59ae-11eb-81ac-cdaf15ab6693.png">

### After
![Screenshot 2021-01-18 at 18 44 01](https://user-images.githubusercontent.com/64783893/104952825-29359300-59bd-11eb-9101-a5ae362bbe7f.png)

[Card](https://trello.com/c/S4Yr0CgY/606-update-step-by-step-accordion)