### PR TITLE
Bump gem version to 23.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 23.13.1
 
 * Bump govuk-frontend from 3.9.1 to 3.10.2 ([PR #1838](https://github.com/alphagov/govuk_publishing_components/pull/1838))
 * Update design for step by step navigation to improve accessibility ([PR #1875](https://github.com/alphagov/govuk_publishing_components/pull/1875))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.13.0)
+    govuk_publishing_components (23.13.1)
       govuk_app_config
       kramdown
       plek
@@ -271,7 +271,7 @@ GEM
     rubocop-rspec (1.42.0)
       rubocop (>= 0.87.0)
     ruby-progressbar (1.10.1)
-    ruby2_keywords (0.0.2)
+    ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
     safe_yaml (1.0.5)
     sassc (2.3.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.13.0".freeze
+  VERSION = "23.13.1".freeze
 end


### PR DESCRIPTION
* Bump govuk-frontend from 3.9.1 to 3.10.2 ([PR #1838](https://github.com/alphagov/govuk_publishing_components/pull/1838))
* Update design for step by step navigation to improve accessibility ([PR #1875](https://github.com/alphagov/govuk_publishing_components/pull/1875))