### PR TITLE
Retire more gem-level SCSS variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* BREAKING: Retire more gem-level SCSS variables ([PR #1881](https://github.com/alphagov/govuk_publishing_components/pull/1881))
 * Bump govuk-frontend from 3.9.1 to 3.10.2 ([PR #1838](https://github.com/alphagov/govuk_publishing_components/pull/1838))
 
 ## 23.13.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
@@ -1,5 +1,5 @@
 .gem-c-error-alert {
-  color: $gem-text-colour;
+  color: $govuk-text-colour;
   padding: govuk-spacing(3);
   border: $gem-border-width-mobile solid $gem-error-colour;
   @include govuk-responsive-margin(8, "bottom");

--- a/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_error-alert.scss
@@ -1,12 +1,12 @@
 .gem-c-error-alert {
   color: $govuk-text-colour;
   padding: govuk-spacing(3);
-  border: $gem-border-width-mobile solid $gem-error-colour;
+  border: $govuk-border-width-narrow solid $govuk-error-colour;
   @include govuk-responsive-margin(8, "bottom");
 
   @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(4);
-    border-width: $gem-border-width-tablet;
+    border-width: $govuk-border-width;
   }
 }
 
@@ -32,5 +32,5 @@
 }
 
 .gem-c-error-alert:focus {
-  outline: $gem-focus-width solid $gem-focus-colour;
+  outline: $govuk-focus-width solid $govuk-focus-colour;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
@@ -1,5 +1,5 @@
 .gem-c-success-alert {
-  color: $gem-text-colour;
+  color: $govuk-text-colour;
   padding: $gem-spacing-scale-3;
   border: $gem-border-width-mobile solid $gem-success-colour;
   @include govuk-responsive-margin(8, "bottom");

--- a/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
@@ -1,12 +1,12 @@
 .gem-c-success-alert {
   color: $govuk-text-colour;
   padding: $gem-spacing-scale-3;
-  border: $gem-border-width-mobile solid $gem-success-colour;
+  border: $govuk-border-width-narrow solid $govuk-success-colour;
   @include govuk-responsive-margin(8, "bottom");
 
   @include govuk-media-query($from: tablet) {
     padding: $gem-spacing-scale-4;
-    border-width: $gem-border-width-tablet;
+    border-width: $govuk-border-width;
   }
 }
 
@@ -32,5 +32,5 @@
 }
 
 .gem-c-success-alert:focus {
-  outline: $gem-focus-width solid $gem-focus-colour;
+  outline: $govuk-focus-width solid $govuk-focus-colour;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_variables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_variables.scss
@@ -9,14 +9,3 @@ $gem-spacing-scale-5: 30px;
 $gem-spacing-scale-6: 40px;
 $gem-spacing-scale-7: 50px;
 $gem-spacing-scale-8: 60px;
-
-// Border widths
-$gem-border-width-mobile: 4px;
-$gem-border-width-tablet: 5px;
-
-// Focus
-$gem-focus-width: 3px;
-$gem-focus-colour: $govuk-focus-colour;
-
-$gem-error-colour: govuk-colour("red");
-$gem-success-colour: govuk-colour("green");

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_variables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_variables.scss
@@ -10,13 +10,9 @@ $gem-spacing-scale-6: 40px;
 $gem-spacing-scale-7: 50px;
 $gem-spacing-scale-8: 60px;
 
-$gem-secondary-text-colour: $govuk-secondary-text-colour;
-
 // Border widths
 $gem-border-width-mobile: 4px;
 $gem-border-width-tablet: 5px;
-$gem-border-width-form-element: 2px;
-$gem-border-width-error: 4px;
 
 // Focus
 $gem-focus-width: 3px;

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_variables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_variables.scss
@@ -10,7 +10,6 @@ $gem-spacing-scale-6: 40px;
 $gem-spacing-scale-7: 50px;
 $gem-spacing-scale-8: 60px;
 
-$gem-text-colour: $govuk-text-colour;
 $gem-secondary-text-colour: $govuk-secondary-text-colour;
 
 // Border widths


### PR DESCRIPTION
## What
Retire all gem-level SCSS variables.

## Why
Can be replaced with `govuk-frontend` variables and they're not being used elsewhere anymore.

GitHub alphagov-level searches below:
 - [$gem-text-colour](https://github.com/search?q=org%3Aalphagov+%22gem-text-colour%22&type=code)
 - [$gem-secondary-text-colour](https://github.com/search?q=org%3Aalphagov+%22gem-secondary-text-colour%22&type=code)
 - [$gem-border-width-form-element](https://github.com/search?q=org%3Aalphagov+%22gem-border-width-form-element%22&type=code)
 - [$gem-border-width-error](https://github.com/search?q=org%3Aalphagov+%22gem-border-width-error%22&type=code)
 - [$gem-border-width-mobile](https://github.com/search?q=org%3Aalphagov+%22gem-border-width-mobile%22&type=code)
 - [$gem-border-width-tablet](https://github.com/search?q=org%3Aalphagov+%22gem-border-width-tablet%22&type=code)
 - [$gem-focus-width](https://github.com/search?q=org%3Aalphagov+%22gem-focus-width%22&type=code)
 - [$gem-focus-colour](https://github.com/search?q=org%3Aalphagov+%22gem-focus-colour%22&type=code)
 - [$gem-error-colour](https://github.com/search?q=org%3Aalphagov+%22gem-error-colour%22&type=code)
 - [$gem-success-colour](https://github.com/search?q=org%3Aalphagov+%22gem-focus-colour%22&type=code)

Follow up on https://github.com/alphagov/govuk_publishing_components/pull/1879

## Visual Changes
n/a
