### PR TITLE
Update document list component with description text modifier and amended design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update document list component with description text modifier and amended design ([PR #1883](https://github.com/alphagov/govuk_publishing_components/pull/1883))
+
 ## 23.13.1
 
 * Bump govuk-frontend from 3.9.1 to 3.10.2 ([PR #1838](https://github.com/alphagov/govuk_publishing_components/pull/1838))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -7,14 +7,10 @@
 
 .gem-c-document-list__item {
   overflow: hidden;
-  margin-bottom: govuk-spacing(4);
-  padding-bottom: govuk-spacing(4);
-  border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(5);
+  padding-top: govuk-spacing(2);
+  border-top: 1px solid $govuk-border-colour;
   list-style: none;
-
-  &:last-child {
-    border-bottom: 0;
-  }
 }
 
 .gem-c-document-list__item-title {
@@ -52,7 +48,7 @@
 }
 
 .gem-c-document-list__subtext {
-  margin: govuk-spacing(1) 0 0 0;
+  margin: 0;
 }
 
 .gem-c-document-list__item-description,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -60,6 +60,10 @@
   @include govuk-font($size: 16, $line-height: 1.5);
 }
 
+.gem-c-document-list__item-description--full-size {
+  @include govuk-font($size: 19);
+}
+
 .gem-c-document-list__item-metadata {
   padding: 0;
 }

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -50,7 +50,7 @@
         <% end %>
 
         <% if item[:link][:description] %>
-          <p class="gem-c-document-list__item-description" ><%= item[:link][:description] %></p>
+          <p class="gem-c-document-list__item-description <%= "gem-c-document-list__item-description--full-size" if item[:link][:full_size_description] %>"><%= item[:link][:description] %></p>
         <% end %>
 
         <% if item[:metadata] %>

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -280,3 +280,11 @@ examples:
           document_type: 'Data tryloywder'
           locale:
             document_type: 'cy'
+  with_full_size_description_text:
+    data:
+      items:
+      - link:
+          text: 'Become an apprentice'
+          path: '/become-an-apprentice'
+          description: 'Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship.'
+          full_size_description: true


### PR DESCRIPTION
## What
A few updates to [the document list component](https://components.publishing.service.gov.uk/component-guide/document_list):

1. Adds a `full_size_description` modifier to `link` objects that increases the size of description text to the standard 19.
2. Amends the design of list items.
3. Remove some unnecessary margin from the `subtext` element

## Why
This is prompted by work within the govuk accessibility team whilst assessing if we should replace the [list of links on the contacts page](https://www.gov.uk/contact) with the document list component. We've decided to proceed with this on the condition that we make a couple of design amends for the new context, the principal change being allowing for full size description text.

The design change to list items is something that has been planned within the design community for some time but hasn't been given the attention it needs. This design has been agreed upon and reviewed within said community.

The subtext change is just to reduce style verbosity a bit. The visual change, in my opinion, is so insignificant here that I won't be including it in the visual changes.

## Visual Changes
### Before
![Screenshot 2021-01-20 at 17 25 49](https://user-images.githubusercontent.com/64783893/105216162-1b614880-5b4a-11eb-8235-89694b2a09c4.png)

### After (with description modifier AND new design)
![Screenshot 2021-01-20 at 17 41 49](https://user-images.githubusercontent.com/64783893/105216233-2ddb8200-5b4a-11eb-8725-ff5993c648dd.png)

[Card](https://trello.com/c/Hx76hGvU/554-update-feedback-app-to-use-components)