### PR TITLE
Update Brexit CTA on contextual sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update Brexit CTA on contextual sidebar ([PR #1888](https://github.com/alphagov/govuk_publishing_components/pull/1888))
 * Update document list component with description text modifier and amended design ([PR #1883](https://github.com/alphagov/govuk_publishing_components/pull/1883))
 
 ## 23.13.1

--- a/app/assets/images/govuk_publishing_components/take-action-amber.svg
+++ b/app/assets/images/govuk_publishing_components/take-action-amber.svg
@@ -1,0 +1,4 @@
+<svg width="35" height="35" viewBox="0 0 35 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="17.5" cy="17.5" r="17.5" fill="#FF5800"/>
+<path d="M28.5 10L13.6739 24L6.5 17.2258" stroke="white" stroke-width="3"/>
+</svg>

--- a/app/assets/images/govuk_publishing_components/take-action-green.svg
+++ b/app/assets/images/govuk_publishing_components/take-action-green.svg
@@ -1,0 +1,4 @@
+<svg width="35" height="35" viewBox="0 0 35 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="17.5" cy="17.5" r="17.5" fill="#0EBA72"/>
+<path d="M28.5 10L13.6739 24L6.5 17.2258" stroke="white" stroke-width="3"/>
+</svg>

--- a/app/assets/images/govuk_publishing_components/take-action-red.svg
+++ b/app/assets/images/govuk_publishing_components/take-action-red.svg
@@ -1,0 +1,4 @@
+<svg width="35" height="35" viewBox="0 0 35 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="17.5" cy="17.5" r="17.5" fill="#FF003B"/>
+<path d="M28.5 10.5L13.6739 24.5L6.5 17.7258" stroke="white" stroke-width="3"/>
+</svg>

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -25,6 +25,7 @@ $transition-campaign-dark-blue: #1e1348;
 
   .gem-c-contextual-sidebar__brexit-text {
     @extend %govuk-link;
+    @include govuk-font(16);
 
     margin-top: 0;
     margin-bottom: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -44,33 +44,25 @@ $transition-campaign-dark-blue: #1e1348;
 }
 
 .gem-c-contextual-sidebar__take-action-traffic-lights {
-  margin-top: govuk-spacing(3);
-  text-align: center;
-
-  @include govuk-media-query($from: tablet) {
-    text-align: left;
-  }
+  text-align: left;
+  margin-bottom: govuk-spacing(2);
 }
 
 .gem-c-contextual-sidebar__take-action-traffic-lights > li {
-  margin-bottom: govuk-spacing(1);
   white-space: nowrap;
   display: inline;
-  margin-right: govuk-spacing(3);
+  margin-right: 7px;
+  margin-bottom: govuk-spacing(1);
 }
 
 .gem-c-contextual-sidebar__take-action-traffic-lists-icon {
   vertical-align: middle;
-  margin-top: -5px;
+  margin-top: -2px;
   width: 22px;
-  margin-right: 5px;
-
-  @include govuk-media-query($from: tablet) {
-    width: 28px;
-  }
+  margin-right: 2px;
 }
 
 .gem-c-contextual-sidebar__take-action-traffic-lists-text {
-  @include govuk-font($size: 24, $weight: bold, $line-height: 1.1);
+  @include govuk-font($size: 19, $weight: bold, $line-height: 2);
   vertical-align: middle;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -28,7 +28,7 @@ $transition-campaign-dark-blue: #1e1348;
     @include govuk-font(16);
 
     margin-top: 0;
-    margin-bottom: 0;
+    margin-bottom: govuk-spacing(1);
     text-decoration: underline;
 
     @include govuk-media-query($from: tablet) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -3,26 +3,24 @@ $transition-campaign-dark-blue: #1e1348;
 
 .gem-c-contextual-sidebar__brexit-related-links {
   border-top: 2px solid $govuk-brand-colour;
+}
 
-  .gem-c-contextual-sidebar__brexit-heading {
-    @include govuk-font(19, $weight: bold);
-    padding-top: govuk-spacing(3);
-    margin-bottom: govuk-spacing(2);
-  }
+.gem-c-contextual-sidebar__brexit-heading {
+  @extend %govuk-heading-s;
+  margin-top: govuk-spacing(3);
+  margin-bottom: govuk-spacing(2);
 }
 
 .gem-c-contextual-sidebar__brexit-cta {
-  @include govuk-font(19);
   margin-bottom: govuk-spacing(6);
   background-color: govuk-colour('light-grey', $legacy: 'grey-4');
-  border-top: 4px solid $transition-campaign-red;
+  border-top: 2px solid $transition-campaign-red;
   display: block;
-  padding: govuk-spacing(3);
+  padding: 0 govuk-spacing(3) govuk-spacing(3);
   text-decoration: none;
 
   .gem-c-contextual-sidebar__brexit-heading {
-    @extend %govuk-heading-m;
-    color: $transition-campaign-dark-blue;
+    color: $govuk-text-colour;
   }
 
   .gem-c-contextual-sidebar__brexit-text {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -42,3 +42,35 @@ $transition-campaign-dark-blue: #1e1348;
     text-decoration: none;
   }
 }
+
+.gem-c-contextual-sidebar__take-action-traffic-lights {
+  margin-top: govuk-spacing(3);
+  text-align: center;
+
+  @include govuk-media-query($from: tablet) {
+    text-align: left;
+  }
+}
+
+.gem-c-contextual-sidebar__take-action-traffic-lights > li {
+  margin-bottom: govuk-spacing(1);
+  white-space: nowrap;
+  display: inline;
+  margin-right: govuk-spacing(3);
+}
+
+.gem-c-contextual-sidebar__take-action-traffic-lists-icon {
+  vertical-align: middle;
+  margin-top: -5px;
+  width: 22px;
+  margin-right: 5px;
+
+  @include govuk-media-query($from: tablet) {
+    width: 28px;
+  }
+}
+
+.gem-c-contextual-sidebar__take-action-traffic-lists-text {
+  @include govuk-font($size: 24, $weight: bold, $line-height: 1.1);
+  vertical-align: middle;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -35,12 +35,6 @@ $transition-campaign-dark-blue: #1e1348;
       margin-bottom: govuk-spacing(2);
     }
   }
-
-  @include govuk-compatibility(govuk_template) {
-    .gem-c-contextual-sidebar__brexit-title {
-      margin-bottom: govuk-spacing(3);
-    }
-  }
 }
 
 .gem-c-contextual-sidebar__brexit-cta:focus {

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -32,7 +32,7 @@
     <%= render 'govuk_publishing_components/components/contextual_sidebar/brexit_related_links' %>
   <% end %>
 
-  <% if !navigation.show_brexit_related_links? && navigation.step_by_step_count.zero? && !navigation.transition_countdown_exception? %>
+  <% if navigation.show_brexit_cta? %>
     <%= render 'govuk_publishing_components/components/contextual_sidebar/brexit_cta' %>
   <% end %>
 </div>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -2,10 +2,6 @@
 <% shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns) %>
 
 <div class="gem-c-contextual-sidebar">
-  <% if navigation.show_brexit_related_links? && navigation.step_by_step_count.zero? %>
-    <%= render 'govuk_publishing_components/components/contextual_sidebar/brexit_related_links' %>
-  <% end %>
-
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
     <%# Rendering step by step related items because there are a few but not too many of them %>
     <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links %>
@@ -28,11 +24,7 @@
     } %>
   <% end %>
 
-  <% if navigation.show_brexit_related_links? && navigation.step_by_step_count > 0 %>
-    <%= render 'govuk_publishing_components/components/contextual_sidebar/brexit_related_links' %>
-  <% end %>
-
-  <% if navigation.show_brexit_cta? %>
+  <% if navigation.show_brexit_cta? || navigation.show_brexit_related_links? %>
     <%= render 'govuk_publishing_components/components/contextual_sidebar/brexit_cta' %>
   <% end %>
 </div>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -4,8 +4,6 @@
 <div class="gem-c-contextual-sidebar">
   <% if navigation.show_brexit_related_links? && navigation.step_by_step_count.zero? %>
     <%= render 'govuk_publishing_components/components/contextual_sidebar/brexit_related_links' %>
-  <% elsif navigation.step_by_step_count.zero? && !navigation.transition_countdown_exception? %>
-    <%= render 'govuk_publishing_components/components/contextual_sidebar/brexit_cta' %>
   <% end %>
 
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
@@ -32,5 +30,9 @@
 
   <% if navigation.show_brexit_related_links? && navigation.step_by_step_count > 0 %>
     <%= render 'govuk_publishing_components/components/contextual_sidebar/brexit_related_links' %>
+  <% end %>
+
+  <% if !navigation.show_brexit_related_links? && navigation.step_by_step_count.zero? && !navigation.transition_countdown_exception? %>
+    <%= render 'govuk_publishing_components/components/contextual_sidebar/brexit_cta' %>
   <% end %>
 </div>

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
@@ -16,5 +16,25 @@
     data: data_attributes,
     lang: shared_helper.t_locale("components.related_navigation.transition.title") do %>
   <h2 class="gem-c-contextual-sidebar__brexit-heading"><%= t("components.related_navigation.transition.title") %></h2>
+  <ul class="govuk-list gem-c-contextual-sidebar__take-action-traffic-lights">
+    <li>
+      <%= image_tag 'govuk_publishing_components/take-action-red.svg', class: "gem-c-contextual-sidebar__take-action-traffic-lists-icon", alt: "" %>
+      <span class="gem-c-contextual-sidebar__take-action-traffic-lists-text">
+        <%= t("components.related_navigation.take_action_list.red") %>
+      </span>
+    </li>
+    <li>
+      <%= image_tag 'govuk_publishing_components/take-action-amber.svg', class: "gem-c-contextual-sidebar__take-action-traffic-lists-icon", alt: "" %>
+      <span class="gem-c-contextual-sidebar__take-action-traffic-lists-text">
+        <%= t("components.related_navigation.take_action_list.amber") %>
+      </span>
+    </li>
+    <li>
+      <%= image_tag 'govuk_publishing_components/take-action-green.svg', class: "gem-c-contextual-sidebar__take-action-traffic-lists-icon", alt: "" %>
+      <span class="gem-c-contextual-sidebar__take-action-traffic-lists-text">
+        <%= t("components.related_navigation.take_action_list.green") %>
+      </span>
+    </li>
+  </ul>
   <p class="gem-c-contextual-sidebar__brexit-text"><%= link_text %></p>
 <% end %>

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
@@ -14,6 +14,7 @@
 <%= link_to link_path,
     class: "govuk-link gem-c-contextual-sidebar__brexit-cta",
     data: data_attributes,
+    aria: { label: "#{t("components.related_navigation.take_action_list.aria_label")} #{link_text}" },
     lang: shared_helper.t_locale("components.related_navigation.transition.title") do %>
   <h2 class="gem-c-contextual-sidebar__brexit-heading"><%= t("components.related_navigation.transition.title") %></h2>
   <ul class="govuk-list gem-c-contextual-sidebar__take-action-traffic-lights">

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_related_links.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_related_links.html.erb
@@ -1,6 +1,0 @@
-<% link_text = t("components.related_navigation.transition.link_text") %>
-<% link_path = t("components.related_navigation.transition.link_path") %>
-<div class="gem-c-contextual-sidebar__brexit-related-links govuk-!-margin-bottom-6" data-module="track-click" lang="en">
-  <h2 class="gem-c-contextual-sidebar__brexit-heading"><%= t("components.related_navigation.transition.title") %></h2>
-  <a href="<%= link_path %>" class="govuk-link" data-track-category="relatedLinkClicked" data-track-action="1.0 Transition" data-track-label="<%= link_path %>" data-track-options='{"dimension29":"<%= link_text %>"}'><%= link_text %></a>
-</div>

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -144,7 +144,33 @@ examples:
                       - text: Find out what you’ll get
                         href: "/settled-status-eu-citizens-families/what-settled-and-presettled-status-means"
                     optional: false
-  transition_countdown_exception:
+  with_brexit_cta:
+    description: For documents tagged with certain taxons defined in `brexit_cta_taxon_allow_list` we show a custom Brexit call to action element.
+    data:
+      content_item:
+        title: "Transport news story"
+        content_id: "3c402d90-fe77-49b9-a8aa-1800d4fc2b3d"
+        links:
+          ordered_related_items:
+          - title: Find an apprenticeship
+            base_path: /apply-apprenticeship
+          - title: Training and study at work
+            base_path: /training-study-work-your-rights
+          - title: Careers helpline for teenagers
+            base_path: /careers-helpline-for-teenagers
+          document_collections:
+          - title: Recruit an apprentice (formerly apprenticeship vacancies)
+            base_path: /government/collections/apprenticeship-vacancies
+            document_type: document_collection
+          - title: The future of jobs and skills
+            base_path: /government/collections/the-future-of-jobs-and-skills
+            document_type: document_collection
+          taxons:
+            - content_id: "a4038b29-b332-4f13-98b1-1c9709e216bc"
+              title: "Transport"
+              phase: "live"
+  with_brexit_cta_document_exception:
+    description: Illustrates an exception to showing the custom Brexit call to action element as defined in `brexit_cta_document_type_exceptions`.
     data:
       content_item:
         title: "30 creative teams awarded up to £100,000 each for Festival UK* 2022 R&D project"
@@ -164,3 +190,36 @@ examples:
           - title: The future of jobs and skills
             base_path: /government/collections/the-future-of-jobs-and-skills
             document_type: document_collection
+          taxons:
+            - content_id: "e2ca2f1a-0ff3-43ce-b813-16645ff27904"
+              title: "Society and culture"
+              phase: "live"
+  with_brexit_cta_taxon_exception:
+    description: Illustrates an exception to showing the custom Brexit call to action element as defined in `brexit_cta_taxon_exception_list`.
+    data:
+      content_item:
+        title: "Local transport news story"
+        content_id: "5c82db20-7631-11e4-a3cb-005056011aef"
+        links:
+          ordered_related_items:
+          - title: Find an apprenticeship
+            base_path: /apply-apprenticeship
+          - title: Training and study at work
+            base_path: /training-study-work-your-rights
+          - title: Careers helpline for teenagers
+            base_path: /careers-helpline-for-teenagers
+          document_collections:
+          - title: Recruit an apprentice (formerly apprenticeship vacancies)
+            base_path: /government/collections/apprenticeship-vacancies
+            document_type: document_collection
+          - title: The future of jobs and skills
+            base_path: /government/collections/the-future-of-jobs-and-skills
+            document_type: document_collection
+          taxons:
+            - content_id: "3b4d6319-fcef-4637-b35a-e3df76321894"
+              title: "Local transport"
+              phase: "live"
+              links:
+                parent_taxons:
+                  - content_id: "a4038b29-b332-4f13-98b1-1c9709e216bc"
+                    title: "Transport"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -27,6 +27,9 @@ Rails.application.config.assets.precompile += %w[
   govuk_publishing_components/icon-important.svg
   govuk_publishing_components/chevron-banner/*.svg
   govuk_publishing_components/crests/*.png
+  govuk_publishing_components/take-action-amber.svg
+  govuk_publishing_components/take-action-green.svg
+  govuk_publishing_components/take-action-red.svg
 ]
 
 # GOV.UK Frontend assets

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -12,4 +12,4 @@ cy:
       transition:
         title: "Brexit"
         link_path: "/transition.cy"
-        link_text: "Darganfyddwch sut mae’r rheolau Brexit newydd yn effeithio arnoch chi"
+        link_text: "Gwiriwch beth sydd angen i chi ei wneud"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -13,3 +13,7 @@ cy:
         title: "Brexit"
         link_path: "/transition.cy"
         link_text: "Gwiriwch beth sydd angen i chi ei wneud"
+      take_action_list:
+        red: Gwiriwch
+        amber: Newidiwch
+        green: Ewch

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -17,3 +17,4 @@ cy:
         red: Gwiriwch
         amber: Newidiwch
         green: Ewch
+        aria_label: Ymgyrch slogan Brexit, Gwiriwch, Newidiwch, Ewch.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,7 @@ en:
       transition:
         title: "Brexit"
         link_path: "/transition"
-        link_text: "Check how the new Brexit rules affect you"
+        link_text: "Check what you need to do"
     related_footer_navigation:
       collections: "Collections"
       policies: "Policies"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,10 @@ en:
         title: "Brexit"
         link_path: "/transition"
         link_text: "Check what you need to do"
+      take_action_list:
+        red: Check
+        amber: Change
+        green: Go
     related_footer_navigation:
       collections: "Collections"
       policies: "Policies"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,7 @@ en:
         red: Check
         amber: Change
         green: Go
+        aria_label: Brexit campaign slogan, Check, Change, Go.
     related_footer_navigation:
       collections: "Collections"
       policies: "Policies"

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -235,7 +235,6 @@ module GovukPublishingComponents
 
       def show_brexit_cta?
         brexit_cta_taxon_allow_list? &&
-          !show_brexit_related_links? &&
           step_by_step_count.zero? &&
           !brexit_cta_exception?
       end

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -113,8 +113,131 @@ module GovukPublishingComponents
         tagged_to_brexit? && (page_content_id != brexit_start_page_content_id)
       end
 
-      def transition_countdown_exception?
-        content_item["content_id"] == "c3752802-f091-43a9-ba90-33568fccf391"
+      def brexit_cta_document_exceptions
+        # /government/news/30-creative-teams-awarded-up-to-100000-each-for-festival-uk-2022-rd-project
+        %w[c3752802-f091-43a9-ba90-33568fccf391]
+      end
+
+      def brexit_cta_document_exception?
+        brexit_cta_document_exceptions.include?(content_item["content_id"])
+      end
+
+      def brexit_cta_document_type_exceptions
+        %w[
+          aaib_report
+          answer
+          asylum_support_decision
+          fatality_notice
+          maib_report
+          raib_report
+          simple_smart_answer
+          transaction
+        ]
+      end
+
+      def brexit_cta_document_type_exception?
+        brexit_cta_document_type_exceptions.include?(content_item["document_type"])
+      end
+
+      def brexit_cta_taxon_allow_list
+        # Entering and staying in the UK
+        # Going and being abroad
+        # Corporate information
+        # Transport
+        # Environment
+        # International
+        # Defence and armed forces
+        # Society and culture
+        # Government
+        # Work
+        # Welfare
+        # Money
+        # Business and industry
+        # Health and social care
+        # Education > Further and higher education
+        # Education > Teaching and leadership
+        # Education > Funding and finance for students
+        # Coronavirus (COVID-19)
+        %w[
+          ba3a9702-da22-487f-86c1-8334a730e559
+          9597c30a-605a-4e36-8bc1-47e5cdae41b3
+          a544d48b-1e9e-47fb-b427-7a987c658c14
+          a4038b29-b332-4f13-98b1-1c9709e216bc
+          3cf97f69-84de-41ae-bc7b-7e2cc238fa58
+          37d0fa26-abed-4c74-8835-b3b51ae1c8b2
+          e491505c-77ae-45b2-84be-8c94b94f6a2b
+          e2ca2f1a-0ff3-43ce-b813-16645ff27904
+          e48ab80a-de80-4e83-bf59-26316856a5f9
+          d0f1e5a3-c8f4-4780-8678-994f19104b21
+          dded88e2-f92e-424f-b73e-6ad24a839c51
+          6acc9db4-780e-4a46-92b4-1812e3c2c48a
+          495afdb6-47be-4df1-8b38-91c8adb1eefc
+          8124ead8-8ebc-4faf-88ad-dd5cbcc92ba8
+          dd767840-363e-43ad-8835-c9ab516633de
+          ff00b8b2-dcdb-4659-93c2-291c9be354f3
+          23265b25-7ec3-4960-8517-4ff8d4d92cac
+          5b7b9532-a775-4bd2-a3aa-6ce380184b6c
+        ]
+      end
+
+      def brexit_cta_taxon_allow_list?
+        taxons = content_item.dig("links", "taxons").to_a
+        taxons.each do |taxon|
+          if brexit_cta_taxon_allow_list.include?(taxon["content_id"]) || parent_taxon_include?(taxon, brexit_cta_taxon_allow_list)
+            return true
+          end
+        end
+        false
+      end
+
+      def parent_taxon_include?(taxon, taxon_list)
+        if taxon.present?
+          if taxon.dig("links", "parent_taxons").to_a.any? { |taxon_item| taxon_list.include?(taxon_item["content_id"]) }
+            return true
+          end
+
+          taxon.dig("links", "parent_taxons").to_a.any? { |taxon_item| parent_taxon_include?(taxon_item, taxon_list) }
+        else
+          false
+        end
+      end
+
+      def brexit_cta_taxon_exception_list
+        # Entering and staying in the UK > Immigration offences
+        # Entering and staying in the UK > Inspections of border, immigration and asylum services
+        # Entering and staying in the UK > Refugees, asylum and human rights
+        # Transport > Local transport
+        # Education > Further and higher education > Education in prisons
+        %w[
+          fa13521f-9285-45b0-bd65-4a472a8037e7
+          0fab9131-f877-4286-b4d8-922fbfb402b6
+          08a8a69f-2825-4fe2-a4cf-c83458a5629e
+          3b4d6319-fcef-4637-b35a-e3df76321894
+          6426d1c5-93c8-4659-85d5-1f0d3368a124
+        ]
+      end
+
+      def brexit_cta_taxon_exception_list?
+        taxons = content_item.dig("links", "taxons").to_a
+        taxons.each do |taxon|
+          if brexit_cta_taxon_exception_list.include?(taxon["content_id"]) || parent_taxon_include?(taxon, brexit_cta_taxon_exception_list)
+            return true
+          end
+        end
+        false
+      end
+
+      def brexit_cta_exception?
+        brexit_cta_document_exception? ||
+          brexit_cta_document_type_exception? ||
+          brexit_cta_taxon_exception_list?
+      end
+
+      def show_brexit_cta?
+        brexit_cta_taxon_allow_list? &&
+          !show_brexit_related_links? &&
+          step_by_step_count.zero? &&
+          !brexit_cta_exception?
       end
 
       def step_by_step_count

--- a/spec/components/contextual_sidebar_spec.rb
+++ b/spec/components/contextual_sidebar_spec.rb
@@ -21,4 +21,93 @@ describe "Contextual sidebar", type: :view do
     end
     assert_select ".gem-c-contextual-sidebar"
   end
+
+  it "renders Brexit CTA on allowed taxons" do
+    content_item = {
+      "title" => "Transport news story",
+      "content_id" => "3c402d90-fe77-49b9-a8aa-1800d4fc2b3d",
+      "links" => {
+        "taxons" => [
+          {
+            "content_id" => "13d01427-33b5-4ca4-bf7a-68425f54e236",
+            "title" => "Rail",
+            "phase" => "live",
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "content_id" => "a4038b29-b332-4f13-98b1-1c9709e216bc",
+                  "title" => "Transport",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    render_component(content_item: content_item)
+    assert_select ".gem-c-contextual-sidebar__brexit-cta"
+  end
+
+  it "does not render Brexit CTA when we have a document id exception" do
+    content_item = {
+      "title" => "30 creative teams awarded up to £100,000 each for Festival UK* 2022 R&D project",
+      "content_id" => "c3752802-f091-43a9-ba90-33568fccf391",
+      "links" => {
+        "taxons" => [
+          {
+            "content_id" => "e2ca2f1a-0ff3-43ce-b813-16645ff27904",
+            "title" => "Society and culture",
+            "phase" => "live",
+          },
+        ],
+      },
+    }
+    render_component(content_item: content_item)
+    assert_select ".gem-c-contextual-sidebar__brexit-cta", 0
+  end
+
+  it "does not render Brexit CTA when we have a document type exception" do
+    content_item = {
+      "title" => "Transport news story",
+      "content_id" => "3c402d90-fe77-49b9-a8aa-1800d4fc2b3d",
+      "document_type" => "transaction",
+      "links" => {
+        "taxons" => [
+          {
+            "content_id" => "a4038b29-b332-4f13-98b1-1c9709e216bc",
+            "title" => "Transport",
+            "phase" => "live",
+          },
+        ],
+      },
+    }
+    render_component(content_item: content_item)
+    assert_select ".gem-c-contextual-sidebar__brexit-cta", 0
+  end
+
+  it "does not render Brexit CTA when we have a taxon exception" do
+    content_item = {
+      "title" => "Local transport news story",
+      "content_id" => "5c82db20-7631-11e4-a3cb-005056011aef",
+      "links" => {
+        "taxons" => [
+          {
+            "content_id" => "3b4d6319-fcef-4637-b35a-e3df76321894",
+            "title" => "Local transport",
+            "phase" => "live",
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "content_id" => "a4038b29-b332-4f13-98b1-1c9709e216bc",
+                  "title" => "Transport",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    render_component(content_item: content_item)
+    assert_select ".gem-c-contextual-sidebar__brexit-cta", 0
+  end
 end

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -63,14 +63,12 @@ describe "Contextual navigation" do
     and_i_visit_that_page
     then_i_see_the_related_links_sidebar
     and_the_default_breadcrumbs
-    and_i_see_the_transition_call_to_action
   end
 
   scenario "The page has a topic" do
     given_theres_a_page_with_a_topic
     and_i_visit_that_page
     then_i_see_the_topic_breadcrumb
-    and_i_see_the_transition_call_to_action
   end
 
   scenario "The page has many topics" do
@@ -78,7 +76,6 @@ describe "Contextual navigation" do
     and_i_visit_that_page
     then_i_see_the_topic_breadcrumb
     and_i_see_the_both_topics_in_the_related_navigation_footer
-    and_i_see_the_transition_call_to_action
   end
 
   scenario "It's a HTML Publication document" do
@@ -86,7 +83,6 @@ describe "Contextual navigation" do
     and_the_page_is_an_html_publication_with_that_parent
     and_i_visit_that_page
     then_i_see_home_and_parent_links
-    and_i_see_the_transition_call_to_action
   end
 
   scenario "It's a HTML Publication with a parent with coronavirus taxon" do
@@ -95,7 +91,6 @@ describe "Contextual navigation" do
     and_i_visit_that_page
     then_i_see_home_and_parent_links
     and_i_see_the_coronavirus_contextual_breadcrumbs_for_business
-    and_i_see_the_transition_call_to_action
   end
 
   scenario "A page is tagged to the transition taxon and a step_by_step" do

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -25,8 +25,7 @@ describe "Contextual navigation" do
     given_theres_a_page_with_transition_taxon
     and_i_visit_that_page
     and_i_see_the_transition_contextual_breadcrumbs
-    and_i_see_the_transition_related_links
-    and_i_do_not_see_the_transition_call_to_action
+    and_i_see_the_transition_call_to_action
   end
 
   scenario "There's a step by step list" do
@@ -99,7 +98,7 @@ describe "Contextual navigation" do
     then_i_see_the_step_by_step
     and_the_step_by_step_header
     and_i_do_not_see_the_transition_contextual_breadcrumbs
-    and_i_do_not_see_the_transition_call_to_action
+    and_i_see_the_transition_call_to_action
   end
 
   scenario "It's a HTML Publication with a parent with breadcrumbs" do
@@ -537,13 +536,6 @@ describe "Contextual navigation" do
   def and_i_see_the_transition_contextual_breadcrumbs
     within ".gem-c-contextual-breadcrumbs" do
       expect(page).to have_link(transition_taxon["title"])
-    end
-  end
-
-  def and_i_see_the_transition_related_links
-    within ".gem-c-contextual-sidebar" do
-      expect(page).to have_css("h2", text: I18n.t("components.related_navigation.transition.title"))
-      expect(page).to have_link(I18n.t("components.related_navigation.transition.link_text"), href: "/transition")
     end
   end
 


### PR DESCRIPTION
## What
Update branded Brexit sidebar navigation placement, visual and logic

## Why
To drive engagement through a more targeted approach

## Visual Changes

[Preview component](https://govuk-publis-update-bre-vsk8qa.herokuapp.com/component-guide/contextual_sidebar/with_brexit_cta/preview)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_3212_component-guide_contextual_sidebar_default_preview (1)](https://user-images.githubusercontent.com/788096/105526835-d6b8e700-5cda-11eb-95e0-b973233fc425.png)

</td><td valign="top">

![localhost_3212_component-guide_contextual_sidebar_default_preview](https://user-images.githubusercontent.com/788096/105526843-d91b4100-5cda-11eb-8f11-b306f94e4005.png)

</td></tr>
</table>

## AT testing
<table>
<tr><th>AT</th><th>Result</th></tr>
<tr><td valign="top">JAWS on Chrome</td><td valign="top">

Brexit campaign slogan. Check, change, go. Check what you need to do. link

</td></tr>
<tr><td valign="top">NVDA on Firefox</td><td valign="top">

Brexit campaign slogan. Check, change, go. Check what you need to do. link

</td></tr>
<tr><td valign="top">VoiceOver on iOS</td><td valign="top">

Link, Brexit campaign slogan, Check, Change, Go. Check what you need to do.

</td></tr>
<tr><td valign="top">High Contrast on Edge</td><td valign="top">

<img width="980" alt="Windows High Contrast Edge" src="https://user-images.githubusercontent.com/788096/105696486-50c7b680-5efb-11eb-916b-456e72a4ac1a.png">


</td></tr>
<tr><td valign="top">Custom colours on Firefox</td><td valign="top">

<img width="975" alt="Firefox custom colours" src="https://user-images.githubusercontent.com/788096/105696493-532a1080-5efb-11eb-9242-e8bb855b1cf3.png">


</td></tr>
</table>


[Trello card](https://trello.com/c/XmaPJL11)