### PR TITLE
Remove redundant Jenkinsfile config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,12 +3,5 @@
 library("govuk")
 
 node {
-  govuk.buildProject(
-    rubyLintDiff: false,
-    beforeTest: {
-      stage("Install yarn dependencies") {
-        sh("yarn")
-      }
-    }
-  )
+  govuk.buildProject()
 }


### PR DESCRIPTION
Yarn dependencies are now installed automatically by the GOV.UK Jenkinslib, the sassLint option no longer has any affect.