### PR TITLE
Further step by step nav sidebar design updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Further step by step nav sidebar design updates ([PR #1893](https://github.com/alphagov/govuk_publishing_components/pull/1893))
+
 ## 23.15.0
 
 * Fix bugs on the feedback component ([PR #1900](https://github.com/alphagov/govuk_publishing_components/pull/1900))

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -40,11 +40,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.$module.sessionStoreLink = this.$module.sessionStoreLink + '_' + this.$module.uniqueId
     }
 
-    this.$module.upChevronSvg = '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="gem-c-step-nav__chevron">' +
+    this.$module.upChevronSvg = '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">' +
       '<path class="gem-c-step-nav__chevron-stroke" d="M19.5 10C19.5 15.2467 15.2467 19.5 10 19.5C4.75329 19.5 0.499997 15.2467 0.499998 10C0.499999 4.7533 4.7533 0.500001 10 0.500002C15.2467 0.500003 19.5 4.7533 19.5 10Z" stroke="#1D70B8"/>' +
       '<path class="gem-c-step-nav__chevron-stroke" d="M6.32617 12.3262L10 8.65234L13.6738 12.3262" stroke="#1D70B8" stroke-width="2"/>' +
       '</svg>'
-    this.$module.downChevronSvg = '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="gem-c-step-nav__chevron">' +
+    this.$module.downChevronSvg = '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">' +
       '<path class="gem-c-step-nav__chevron-stroke" d="M0.499997 10C0.499998 4.75329 4.75329 0.499999 10 0.499999C15.2467 0.5 19.5 4.75329 19.5 10C19.5 15.2467 15.2467 19.5 10 19.5C4.75329 19.5 0.499997 15.2467 0.499997 10Z" stroke="#1D70B8"/>' +
       '<path class="gem-c-step-nav__chevron-stroke" d="M13.6738 8.67383L10 12.3477L6.32617 8.67383" stroke="#1D70B8" stroke-width="2"/>' +
       '</svg>'
@@ -76,8 +76,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var showall = document.createElement('div')
     showall.className = 'gem-c-step-nav__controls'
     showall.innerHTML = '<button aria-expanded="false" class="gem-c-step-nav__button gem-c-step-nav__button--controls js-step-controls-button">' +
-      this.$module.downChevronSvg +
-      this.$module.actions.showAllText +
+      '<span class="gem-c-step-nav__button-text gem-c-step-nav__button-text--all js-step-controls-button-text">' + this.$module.actions.showAllText + '</span>' +
+      '<span class="gem-c-step-nav__chevron js-step-controls-button-icon">' + this.$module.downChevronSvg + '</span>' +
       '</button>'
 
     var steps = this.$module.querySelectorAll('.gem-c-step-nav__steps')[0]
@@ -93,12 +93,19 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       if (!thisel.querySelectorAll('.js-toggle-link').length) {
         var span = document.createElement('span')
         var showHideSpan = document.createElement('span')
+        var showHideSpanText = document.createElement('span')
+        var showHideSpanIcon = document.createElement('span')
         var commaSpan = document.createElement('span')
         var thisSectionSpan = document.createElement('span')
 
         showHideSpan.className = 'gem-c-step-nav__toggle-link js-toggle-link'
+        showHideSpanText.className = 'gem-c-step-nav__button-text js-toggle-link-text'
+        showHideSpanIcon.className = 'gem-c-step-nav__chevron js-toggle-link-icon'
         commaSpan.className = 'govuk-visually-hidden'
         thisSectionSpan.className = 'govuk-visually-hidden'
+
+        showHideSpan.appendChild(showHideSpanText)
+        showHideSpan.appendChild(showHideSpanIcon)
 
         commaSpan.innerHTML = ', '
         thisSectionSpan.innerHTML = ' this section'
@@ -351,12 +358,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Gemstepnav.prototype.setShowHideAllText = function () {
     var shownSteps = this.$module.querySelectorAll('.step-is-shown').length
+
     // Find out if the number of is-opens == total number of steps
-    if (shownSteps === this.$module.totalSteps) {
-      this.$module.showOrHideAllButton.innerHTML = this.$module.upChevronSvg + this.$module.actions.hideAllText
-    } else {
-      this.$module.showOrHideAllButton.innerHTML = this.$module.downChevronSvg + this.$module.actions.showAllText
-    }
+    var shownStepsIsTotalSteps = shownSteps === this.$module.totalSteps
+
+    this.$module.showOrHideAllButton.querySelector('.js-step-controls-button-text').innerHTML = shownStepsIsTotalSteps ? this.$module.actions.hideAllText : this.$module.actions.showAllText
+    this.$module.showOrHideAllButton.querySelector('.js-step-controls-button-icon').innerHTML = shownStepsIsTotalSteps ? this.$module.upChevronSvg : this.$module.downChevronSvg
   }
 
   Gemstepnav.prototype.StepView = function (stepElement, $module) {
@@ -394,7 +401,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       this.titleButton.setAttribute('aria-expanded', isShown)
       var showHideText = this.stepElement.querySelectorAll('.js-toggle-link')[0]
-      showHideText.innerHTML = isShown ? this.upChevronSvg + this.hideText : this.downChevronSvg + this.showText
+
+      showHideText.querySelector('.js-toggle-link-text').innerHTML = isShown ?  this.hideText : this.showText
+      showHideText.querySelector('.js-toggle-link-icon').innerHTML = isShown ? this.upChevronSvg : this.downChevronSvg
     }
 
     this.isShown = function () {

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -402,7 +402,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.titleButton.setAttribute('aria-expanded', isShown)
       var showHideText = this.stepElement.querySelectorAll('.js-toggle-link')[0]
 
-      showHideText.querySelector('.js-toggle-link-text').innerHTML = isShown ?  this.hideText : this.showText
+      showHideText.querySelector('.js-toggle-link-text').innerHTML = isShown ? this.hideText : this.showText
       showHideText.querySelector('.js-toggle-link-icon').innerHTML = isShown ? this.upChevronSvg : this.downChevronSvg
     }
 

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -41,12 +41,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
 
     this.$module.upChevronSvg = '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="gem-c-step-nav__chevron">' +
-      '<path d="M19.5 10C19.5 15.2467 15.2467 19.5 10 19.5C4.75329 19.5 0.499997 15.2467 0.499998 10C0.499999 4.7533 4.7533 0.500001 10 0.500002C15.2467 0.500003 19.5 4.7533 19.5 10Z" stroke="#1D70B8"/>' +
-      '<path d="M6.32617 12.3262L10 8.65234L13.6738 12.3262" stroke="#1D70B8" stroke-width="2"/>' +
+      '<path class="gem-c-step-nav__chevron-stroke" d="M19.5 10C19.5 15.2467 15.2467 19.5 10 19.5C4.75329 19.5 0.499997 15.2467 0.499998 10C0.499999 4.7533 4.7533 0.500001 10 0.500002C15.2467 0.500003 19.5 4.7533 19.5 10Z" stroke="#1D70B8"/>' +
+      '<path class="gem-c-step-nav__chevron-stroke" d="M6.32617 12.3262L10 8.65234L13.6738 12.3262" stroke="#1D70B8" stroke-width="2"/>' +
       '</svg>'
     this.$module.downChevronSvg = '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="gem-c-step-nav__chevron">' +
-      '<path d="M0.499997 10C0.499998 4.75329 4.75329 0.499999 10 0.499999C15.2467 0.5 19.5 4.75329 19.5 10C19.5 15.2467 15.2467 19.5 10 19.5C4.75329 19.5 0.499997 15.2467 0.499997 10Z" stroke="#1D70B8"/>' +
-      '<path d="M13.6738 8.67383L10 12.3477L6.32617 8.67383" stroke="#1D70B8" stroke-width="2"/>' +
+      '<path class="gem-c-step-nav__chevron-stroke" d="M0.499997 10C0.499998 4.75329 4.75329 0.499999 10 0.499999C15.2467 0.5 19.5 4.75329 19.5 10C19.5 15.2467 15.2467 19.5 10 19.5C4.75329 19.5 0.499997 15.2467 0.499997 10Z" stroke="#1D70B8"/>' +
+      '<path class="gem-c-step-nav__chevron-stroke" d="M13.6738 8.67383L10 12.3477L6.32617 8.67383" stroke="#1D70B8" stroke-width="2"/>' +
       '</svg>'
 
     var stepNavTracker = new this.StepNavTracker(this.$module.uniqueId, this.$module.totalSteps, this.$module.totalLinks)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -77,7 +77,7 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 }
 
 .gem-c-step-nav__button--title {
-  @include step-nav-font(19, $weight: bold, $line-height: 1.4);
+  @include step-nav-font(19, $weight: bold, $line-height: 1.2);
   display: inline-block;
   padding: 0;
   text-align: left;
@@ -109,8 +109,13 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 }
 
 .gem-c-step-nav__chevron {
-  vertical-align: text-top;
-  margin-right: govuk-spacing(1);
+  display: none;
+
+  .gem-c-step-nav--large & {
+    display: inline;
+    vertical-align: text-top;
+    margin-right: govuk-spacing(1);
+  }
 }
 
 .gem-c-step-nav__steps {
@@ -216,19 +221,19 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
   border: solid $stroke-width govuk-colour("mid-grey", $legacy: "grey-2");
 
   .gem-c-step-nav--large & {
-    @include step-nav-font(16, $tablet-size: 19, $weight: bold, $line-height: 23px, $tablet-line-height: 30px);
+    @include step-nav-font(16, $tablet-size: 19, $weight: bold, $line-height: 23px, $tablet-line-height: 34px);
+  }
 
-    @include govuk-media-query($from: tablet) {
-      border-width: $stroke-width-large;
-    }
+  @include govuk-media-query($from: tablet) {
+    border-width: $stroke-width-large;
   }
 }
 
 .gem-c-step-nav__circle--logic {
-  @include step-nav-font(16, $weight: bold, $line-height: 28px);
+  @include step-nav-font(19, $weight: bold, $line-height: 28px);
 
   .gem-c-step-nav--large & {
-    @include step-nav-font(16, $tablet-size: 19, $weight: bold, $line-height: 28px, $tablet-line-height: 34px);
+    @include step-nav-font(19, $tablet-size: 24, $weight: bold, $line-height: 28px, $tablet-line-height: 34px);
   }
 }
 
@@ -252,7 +257,7 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 }
 
 .gem-c-step-nav__header {
-  padding: govuk-spacing(1) 0 govuk-spacing(3);
+  padding: govuk-spacing(1) 0 govuk-spacing(6);
   border-top: $top-border;
 
   .gem-c-step-nav--active & {
@@ -282,7 +287,7 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 
   .gem-c-step-nav--large & {
     @include govuk-media-query($from: tablet) {
-      padding: govuk-spacing(2) 0 govuk-spacing(6);
+      padding-top: govuk-spacing(2);
     }
   }
 }
@@ -311,6 +316,7 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 .gem-c-step-nav__panel {
   @include govuk-text-colour;
   @include step-nav-font(16);
+  padding-bottom: govuk-spacing(5);
 
   .gem-c-step-nav--large & {
     @include step-nav-font(16, $tablet-size: 19);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -236,7 +236,7 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
   box-sizing: border-box;
   position: absolute;
   z-index: 5;
-  top: govuk-spacing(1);
+  top: 3px;
   left: 0;
   width: $number-circle-size;
   height: $number-circle-size;
@@ -247,7 +247,7 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 
   .gem-c-step-nav--large & {
     @include govuk-media-query($from: tablet) {
-      top: govuk-spacing(3);
+      top: 11px;
       width: $number-circle-size-large;
       height: $number-circle-size-large;
     }
@@ -302,6 +302,15 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 
 .gem-c-step-nav__header {
   border-top: $top-border;
+  padding: govuk-spacing(1) 0 govuk-spacing(6);
+
+  .gem-c-step-nav--large & {
+    padding-top: govuk-spacing(2);
+  }
+
+  .js-enabled & {
+    padding: 0;
+  }
 
   .gem-c-step-nav--active & {
     cursor: pointer;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -1,8 +1,7 @@
-$stroke-width: 2px;
-$stroke-width-large: 3px;
+$stroke-width: 1px;
 $number-circle-size: 26px;
 $number-circle-size-large: 35px;
-$top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
+$top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 
 @mixin step-nav-vertical-line ($line-style: solid) {
   content: "";
@@ -21,8 +20,7 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 
 @mixin step-nav-line-position-large {
   left: 0;
-  margin-left: ($number-circle-size-large / 2) - ($stroke-width-large / 2);
-  border-width: $stroke-width-large;
+  margin-left: ($number-circle-size-large / 2) - ($stroke-width / 2);
 }
 
 // custom mixin as govuk-font does undesirable things at different breakpoints
@@ -117,7 +115,7 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
   margin: .5em 0 1.5em;
   padding: 0 0 govuk-spacing(1);
 
-  &:hover {
+  &:hover .gem-c-step-nav__button-text {
     text-decoration: underline;
   }
 
@@ -136,12 +134,26 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 }
 
 .gem-c-step-nav__chevron {
-  display: none;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 5px;
+}
+
+.gem-c-step-nav__button-text {
+  display: inline-block;
+  text-align: left;
+  min-width: 35px;
 
   .gem-c-step-nav--large & {
-    display: inline;
-    vertical-align: text-top;
-    margin-right: govuk-spacing(1);
+    min-width: 40px;
+  }
+}
+
+.gem-c-step-nav__button-text--all {
+  min-width: 87px;
+
+  .gem-c-step-nav--large & {
+    min-width: 100px;
   }
 }
 
@@ -202,7 +214,6 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
       &:before {
         margin-left: $number-circle-size-large / 4;
         width: $number-circle-size-large / 2;
-        border-width: $stroke-width-large;
       }
 
       &:after {
@@ -244,20 +255,26 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 }
 
 .gem-c-step-nav__circle--number {
-  @include step-nav-font(16, $weight: bold, $line-height: 23px);
+  @include step-nav-font(16, $weight: bold, $line-height: 25px);
   border: solid $stroke-width govuk-colour("mid-grey", $legacy: "grey-2");
 
   .gem-c-step-nav--large & {
-    @include step-nav-font(16, $tablet-size: 19, $weight: bold, $line-height: 23px, $tablet-line-height: 34px);
+    @include step-nav-font(16, $tablet-size: 19, $weight: bold, $line-height: 25px, $tablet-line-height: 34px);
   }
 
-  @include govuk-media-query($from: tablet) {
-    border-width: $stroke-width-large;
+  .gem-c-step-nav__step--active & {
+    background-color: govuk-colour("black");
+
+    .gem-c-step-nav__circle-background {
+      text-shadow: none;
+      color: govuk-colour("white")
+    }
   }
 }
 
 .gem-c-step-nav__circle--logic {
   @include step-nav-font(19, $weight: bold, $line-height: 28px);
+  left: 3px;
 
   .gem-c-step-nav--large & {
     @include step-nav-font(19, $tablet-size: 24, $weight: bold, $line-height: 28px, $tablet-line-height: 34px);
@@ -296,7 +313,7 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
       color: $govuk-link-colour;
     }
 
-    .gem-c-step-nav__toggle-link {
+    .gem-c-step-nav__button-text {
       text-decoration: underline;
     }
   }
@@ -428,7 +445,6 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
       &:before {
         left: -(govuk-spacing(9));
         margin-left: ($number-circle-size-large / 2);
-        height: $stroke-width-large;
       }
     }
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -1,5 +1,5 @@
 $stroke-width: 1px;
-$number-circle-size: 26px;
+$number-circle-size: 30px;
 $number-circle-size-large: 35px;
 $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 
@@ -15,12 +15,12 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 
 @mixin step-nav-line-position {
   left: 0;
-  margin-left: ($number-circle-size / 2) - ($stroke-width / 2);
+  margin-left: em(($number-circle-size / 2) - ($stroke-width / 2), 16);
 }
 
 @mixin step-nav-line-position-large {
   left: 0;
-  margin-left: ($number-circle-size-large / 2) - ($stroke-width / 2);
+  margin-left: em(($number-circle-size-large / 2) - ($stroke-width / 2), 16);
 }
 
 // custom mixin as govuk-font does undesirable things at different breakpoints
@@ -104,7 +104,7 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
       color: govuk-colour("black");
     }
 
-    @include step-nav-chevron-focus-state();
+    @include step-nav-chevron-focus-state;
   }
 }
 
@@ -124,7 +124,7 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
   }
 
   &:focus {
-    @include step-nav-chevron-focus-state();
+    @include step-nav-chevron-focus-state;
   }
 }
 
@@ -136,24 +136,28 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 .gem-c-step-nav__chevron {
   display: inline-block;
   vertical-align: middle;
-  margin-left: 5px;
+  margin-left: em(5, 14);
+
+  .gem-c-step-nav--large & {
+    margin-left: em(5, 16);
+  }
 }
 
 .gem-c-step-nav__button-text {
   display: inline-block;
   text-align: left;
-  min-width: 35px;
+  min-width: em(35, 14);
 
   .gem-c-step-nav--large & {
-    min-width: 40px;
+    min-width: em(40, 16);
   }
 }
 
 .gem-c-step-nav__button-text--all {
-  min-width: 87px;
+  min-width: em(87, 14);
 
   .gem-c-step-nav--large & {
-    min-width: 100px;
+    min-width: em(100, 16);
   }
 }
 
@@ -164,23 +168,23 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 
 .gem-c-step-nav__step {
   position: relative;
-  padding-left: govuk-spacing(6) + govuk-spacing(3);
+  padding-left: em(govuk-spacing(6) + govuk-spacing(3), 16);
   list-style: none;
 
   // line down the side of a step
   &:after {
     @include step-nav-vertical-line;
     @include step-nav-line-position;
-    top: govuk-spacing(3);
+    top: em(govuk-spacing(3), 16);
   }
 
   .gem-c-step-nav--large & {
     @include govuk-media-query($from: tablet) {
-      padding-left: govuk-spacing(9);
+      padding-left: em(govuk-spacing(9), 16);
 
       &:after { // stylelint-disable-line max-nesting-depth
         @include step-nav-line-position-large;
-        top: govuk-spacing(6);
+        top: em(govuk-spacing(6), 16);
       }
     }
   }
@@ -238,8 +242,8 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
   z-index: 5;
   top: 3px;
   left: 0;
-  width: $number-circle-size;
-  height: $number-circle-size;
+  width: em($number-circle-size, 16);
+  height: em($number-circle-size, 16);
   color: govuk-colour("black");
   background: govuk-colour("white");
   border-radius: 100px;
@@ -248,14 +252,14 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
   .gem-c-step-nav--large & {
     @include govuk-media-query($from: tablet) {
       top: 11px;
-      width: $number-circle-size-large;
-      height: $number-circle-size-large;
+      width: em($number-circle-size-large, 19);
+      height: em($number-circle-size-large, 19);
     }
   }
 }
 
 .gem-c-step-nav__circle--number {
-  @include step-nav-font(16, $weight: bold, $line-height: 25px);
+  @include step-nav-font(16, $weight: bold, $line-height: 29px);
   border: solid $stroke-width govuk-colour("mid-grey", $legacy: "grey-2");
 
   .gem-c-step-nav--large & {
@@ -267,7 +271,7 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 
     .gem-c-step-nav__circle-background {
       text-shadow: none;
-      color: govuk-colour("white")
+      color: govuk-colour("white");
     }
   }
 }
@@ -275,9 +279,16 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 .gem-c-step-nav__circle--logic {
   @include step-nav-font(19, $weight: bold, $line-height: 28px);
   left: 3px;
+  width: em($number-circle-size, 19);
+  height: em($number-circle-size, 19);
 
   .gem-c-step-nav--large & {
     @include step-nav-font(19, $tablet-size: 24, $weight: bold, $line-height: 28px, $tablet-line-height: 34px);
+
+    @include govuk-media-query($from: tablet) {
+      width: em($number-circle-size-large, 24);
+      height: em($number-circle-size-large, 24);
+    }
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -40,6 +40,13 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
   }
 }
 
+// Adds a focus state for the chevron icon so that it turns black on button focus
+@mixin step-nav-chevron-focus-state {
+  .gem-c-step-nav__chevron-stroke {
+    stroke: govuk-colour("black");
+  }
+}
+
 .gem-c-step-nav {
   margin-bottom: govuk-spacing(6);
 
@@ -79,12 +86,27 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 .gem-c-step-nav__button--title {
   @include step-nav-font(19, $weight: bold, $line-height: 1.2);
   display: inline-block;
-  padding: 0;
+  padding: govuk-spacing(1) 0 0;
   text-align: left;
   color: govuk-colour("black");
+  width: 100%;
 
   .gem-c-step-nav--large & {
     @include step-nav-font(19, $tablet-size: 24, $weight: bold, $line-height: 1.4);
+
+    @include govuk-media_query($from: tablet) {
+      padding-top: govuk-spacing(2);
+    }
+  }
+
+  &:focus {
+    box-shadow: 0 -4px govuk-colour("black");
+
+    .gem-c-step-nav__toggle-link {
+      color: govuk-colour("black");
+    }
+
+    @include step-nav-chevron-focus-state();
   }
 }
 
@@ -92,7 +114,8 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
   @include step-nav-font(14, $line-height: 1);
   position: relative;
   z-index: 1; // this and relative position stops focus outline underlap with border of accordion
-  padding: .5em 0 1.5em;
+  margin: .5em 0 1.5em;
+  padding: 0 0 govuk-spacing(1);
 
   &:hover {
     text-decoration: underline;
@@ -100,6 +123,10 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 
   .gem-c-step-nav--large & {
     @include step-nav-font(14, $tablet-size: 16, $line-height: 1);
+  }
+
+  &:focus {
+    @include step-nav-chevron-focus-state();
   }
 }
 
@@ -257,21 +284,10 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 }
 
 .gem-c-step-nav__header {
-  padding: govuk-spacing(1) 0 govuk-spacing(6);
   border-top: $top-border;
 
   .gem-c-step-nav--active & {
     cursor: pointer;
-  }
-
-  .gem-c-step-nav__button {
-    &:focus {
-      @include govuk-focused-text;
-
-      .gem-c-step-nav__toggle-link {
-        @include govuk-focused-text;
-      }
-    }
   }
 
   &:hover {
@@ -282,12 +298,6 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 
     .gem-c-step-nav__toggle-link {
       text-decoration: underline;
-    }
-  }
-
-  .gem-c-step-nav--large & {
-    @include govuk-media-query($from: tablet) {
-      padding-top: govuk-spacing(2);
     }
   }
 }
@@ -307,6 +317,7 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
   display: block;
   color: $govuk-link-colour;
   text-transform: capitalize;
+  padding-bottom: govuk-spacing(6);
 
   .gem-c-step-nav--large & {
     @include step-nav-font(14, $tablet-size: 16, $line-height: 1.2);

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_step-by-step-nav.scss
@@ -1,7 +1,7 @@
 $grey-2: #bfc1c3;
 $white: #ffffff;
 $number-circle-size: 35px;
-$stroke-width: 3px;
+$stroke-width: 1px;
 
 .gem-c-step-nav:not(.gem-c-step-nav--large),
 .gem-c-step-nav__controls,
@@ -63,7 +63,7 @@ $stroke-width: 3px;
 }
 
 .gem-c-step-nav__circle--number {
-  border: solid 3px $grey-2;
+  border: solid 1px $grey-2;
 }
 
 .gem-c-step-nav__step,

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -72,6 +72,11 @@ examples:
                       - text: Check what age you can drive
                         href: "/vehicles-can-drive"
                     optional: false
+                  - title: Testing the and
+                    logic: and
+                    contents:
+                    - type: paragraph
+                      text: hello hello what's UP
                   - title: Driving lessons and practice
                     contents:
                     - type: paragraph


### PR DESCRIPTION
## What
Makes several design updates to the step by step:

- Alter vertical padding for step titles
- Adjust circle size, logic font size and number/logic positioning
- Reduce border width across component
- Add a black background to the "active" step circle
- Move the chevron icon to the right
- Add a customisation of the focus state for step titles

## Why
The root of this work comes from efforts by the govuk accessibility team to ensure that accordions across govuk are consistent and accessible.

This PR is an iteration on [the recently deployed update to the step by step component](https://github.com/alphagov/govuk_publishing_components/pull/1875). These design changes are both responses to feedback following launch and further improvements based on further conversations between our designer and the original designer. This is also going to feed into [the accordion redesign](https://github.com/alphagov/govuk_publishing_components/pull/1884) happening alongside this.

[Card](https://trello.com/c/ebTxqizo/611-design-tweaks-for-the-step-by-step-accordion)

## Visual Changes
### Full page - before
![Screenshot 2021-01-27 at 10 57 07](https://user-images.githubusercontent.com/64783893/105984801-8bb02280-6092-11eb-9b73-d9209ebbd7ad.png)

### Full page - default
![Screenshot 2021-01-27 at 10 53 47](https://user-images.githubusercontent.com/64783893/105984839-9965a800-6092-11eb-8ae8-1029bca9c015.png)

### Full page - focus states
![Screenshot 2021-01-28 at 09 53 28](https://user-images.githubusercontent.com/64783893/106121290-4f8ec780-614f-11eb-96c6-deaac20e9e6c.png)
![Screenshot 2021-01-28 at 09 53 57](https://user-images.githubusercontent.com/64783893/106121295-51588b00-614f-11eb-95b9-c183fad2a338.png)
![Screenshot 2021-01-28 at 09 54 13](https://user-images.githubusercontent.com/64783893/106121297-51f12180-614f-11eb-9521-d7f823396763.png)

### Full page - no JS
![Screenshot 2021-01-27 at 10 58 33](https://user-images.githubusercontent.com/64783893/105984903-abdfe180-6092-11eb-83fa-4350b91c88fc.png)

### Contextual sidebar - before
![Screenshot 2021-01-27 at 10 59 57](https://user-images.githubusercontent.com/64783893/105984827-94085d80-6092-11eb-829c-68cb9f2b9f35.png)

### Contextual sidebar - default
![Screenshot 2021-01-28 at 09 55 42](https://user-images.githubusercontent.com/64783893/106121325-5cabb680-614f-11eb-9ae5-11349c489387.png)

### Contextual sidebar - focus states
![Screenshot 2021-01-28 at 09 56 11](https://user-images.githubusercontent.com/64783893/106121353-659c8800-614f-11eb-9b11-6b44f2ec68eb.png)
![Screenshot 2021-01-28 at 09 56 22](https://user-images.githubusercontent.com/64783893/106121369-67fee200-614f-11eb-89a3-78420ebf229f.png)
![Screenshot 2021-01-28 at 09 56 36](https://user-images.githubusercontent.com/64783893/106121373-68977880-614f-11eb-8e7c-18f71cfed9ce.png)
![Screenshot 2021-01-28 at 09 56 46](https://user-images.githubusercontent.com/64783893/106121377-69300f00-614f-11eb-9a24-d9f6156d7972.png)

### Contextual sidebar - no JS
![Screenshot 2021-01-27 at 11 02 05](https://user-images.githubusercontent.com/64783893/105984991-cade7380-6092-11eb-8bf9-33eaef5f4c77.png)