### PR TITLE
Fix github searching for components

### DIFF
--- a/app/models/govuk_publishing_components/component_doc.rb
+++ b/app/models/govuk_publishing_components/component_doc.rb
@@ -69,7 +69,7 @@ module GovukPublishingComponents
     end
 
     def github_search_url
-      params = { q: "org:alphagov #{partial_path}", type: "Code" }
+      params = { q: "org:alphagov components/components/#{id}", type: "Code" }
       "https://github.com/search?#{params.to_query}"
     end
 


### PR DESCRIPTION
## What
Changes the github search query to remove `govuk_publishing_` from the current search query (`org:alphagov govuk_publishing_components/components/[component_id]`), leaving the current query as:

```
org:alphagov components/components/[component_id]
```

## Why
The usage search feature in our component docs (the link that reads "Search for usage of this component on GitHub" on each component page) hasn't been working for a month or so. Exactly why isn't clear, there's a suspicion that this was just an update to github's punctuation settings on search. This solution gets around these weird rules by removing the underscores from before the first slash. It's a bit of a janky solution, ideally we'd search for the string like before for more consistent coverage, but it does work.

No visual changes.

Docs only so no changelog update.
