### PR TITLE
Fix footer classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update Brexit CTA on contextual sidebar ([PR #1888](https://github.com/alphagov/govuk_publishing_components/pull/1888))
+* Fix footer classes ([PR #1898](https://github.com/alphagov/govuk_publishing_components/pull/1898))
 * Update document list component with description text modifier and amended design ([PR #1883](https://github.com/alphagov/govuk_publishing_components/pull/1883))
 
 ## 23.13.1

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -2,8 +2,10 @@
   meta ||= []
   navigation ||= []
   with_border ||= false
+  classes = %w(gem-c-layout-footer govuk-footer)
+  classes << "gem-c-layout-footer--border" if with_border
 %>
-<footer class="gem-c-layout-footer govuk-footer<%= " gem-c-layout-footer--border" if with_border %>" role="contentinfo">
+<%= tag.footer class: classes, role: "contentinfo" do %>
   <div class="govuk-width-container ">
     <% if navigation.any? %>
       <div class="govuk-footer__navigation">
@@ -80,4 +82,4 @@
       </div>
     </div>
   </div>
-</footer>
+<% end %>

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -3,7 +3,7 @@
   navigation ||= []
   with_border ||= false
 %>
-<footer class="gem-c-layout-footer govuk-footer <%= "gem-c-layout-footer--border" if with_border %> role="contentinfo">
+<footer class="gem-c-layout-footer govuk-footer<%= " gem-c-layout-footer--border" if with_border %>" role="contentinfo">
   <div class="govuk-width-container ">
     <% if navigation.any? %>
       <div class="govuk-footer__navigation">


### PR DESCRIPTION
## What / why
The main `class` declaration for the footer component was missing a closing `"`. Then I decided to make it more readable as well.

## Visual Changes
None.
