### PR TITLE
Fix bugs on the feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix bugs on the feedback component ([PR #1900](https://github.com/alphagov/govuk_publishing_components/pull/1900))
+
 ## 23.14.0
 
 * Update Brexit CTA on contextual sidebar ([PR #1888](https://github.com/alphagov/govuk_publishing_components/pull/1888))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -8,41 +8,6 @@
   }
 }
 
-// hide without js
-// show with js, unless also has the js-hidden class
-.gem-c-feedback__js-show,
-.gem-c-feedback__prompt-success,
-.gem-c-feedback__prompt-questions,
-.gem-c-feedback__error-summary {
-  display: none;
-
-  .js-enabled & {
-    display: block;
-
-    &.js-hidden {
-      display: none;
-    }
-  }
-}
-
-// maintain table display for prompt and prompt-questions
-.js-enabled .gem-c-feedback__prompt {
-  @include govuk-media-query($from: tablet) {
-    display: table;
-  }
-}
-
-.js-enabled .gem-c-feedback__prompt-questions {
-  @include govuk-media-query($from: tablet) {
-    display: table-cell;
-  }
-}
-
-// show the default feedback form without js
-.js-enabled .gem-c-feedback__form.js-hidden {
-  display: none;
-}
-
 .gem-c-feedback__prompt-questions {
   text-align: center;
   border-bottom: 1px solid govuk-colour("white");
@@ -137,15 +102,6 @@
 .gem-c-feedback__email-link,
 .gem-c-feedback__prompt-link {
   position: relative;
-
-  &:after {
-    content: "";
-    position: absolute;
-    top: -14px;
-    right: -14px;
-    left: -14px;
-    bottom: -14px;
-  }
 }
 
 .gem-c-feedback__prompt-link:link,
@@ -281,4 +237,39 @@
   &:focus {
     outline: $govuk-focus-width solid $govuk-focus-colour;
   }
+}
+
+// hide without js
+// show with js, unless also has the js-hidden class
+.gem-c-feedback__js-show,
+.gem-c-feedback__prompt-success,
+.gem-c-feedback__prompt-questions,
+.gem-c-feedback__error-summary {
+  display: none;
+
+  .js-enabled & {
+    display: block;
+
+    &.js-hidden {
+      display: none;
+    }
+  }
+}
+
+// maintain table display for prompt and prompt-questions
+.js-enabled .gem-c-feedback__prompt {
+  @include govuk-media-query($from: tablet) {
+    display: table;
+  }
+}
+
+.js-enabled .gem-c-feedback__prompt-questions {
+  @include govuk-media-query($from: tablet) {
+    display: table-cell;
+  }
+}
+
+// show the default feedback form without js
+.js-enabled .gem-c-feedback__form.js-hidden {
+  display: none;
 }


### PR DESCRIPTION
## What
Alters some minor styling for the feedback component.

## Why
This is to address https://github.com/alphagov/govuk_publishing_components/issues/1825 and https://github.com/alphagov/govuk_publishing_components/issues/1889. The first issue is addressed by removing a now unnecessary `after` styling rule. The second by moving the js hiding styles to the bottom of the stylesheet to prevent them being undermined by style rules that cascade later in the stylesheet.

## Visual Changes
### Before - 1825
![Screenshot 2021-02-01 at 14 40 01](https://user-images.githubusercontent.com/64783893/106491630-fad0b100-64ae-11eb-978a-6cc01755af95.png)

### After - 1825
![Screenshot 2021-02-01 at 14 39 37](https://user-images.githubusercontent.com/64783893/106491674-0328ec00-64af-11eb-932f-aab68e448316.png)

### Before - 1889
![Screenshot 2021-02-01 at 14 40 51](https://user-images.githubusercontent.com/64783893/106491647-fd330b00-64ae-11eb-9712-70715f5a423e.png)

### After - 1889
![Screenshot 2021-02-01 at 14 40 25](https://user-images.githubusercontent.com/64783893/106491688-0623dc80-64af-11eb-869e-441d7ea64503.png)
