### PR TITLE
Update document list documentation

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -1,16 +1,16 @@
 name: Document list
 description: An ordered list of documents including a document type, when updated and a link.
 body: |
-  Outputs a list to documents, based on an array of document data. This may include:
+  Outputs a list to documents, based on an array of document data. A "document" in this context can be an asset (such as a ODT or other downloadable document) or a web page.
+  
+  The component can display:
 
-  * document title
-  * link to the document
-  * last updated date object
-  * document type
+  * a document title
+  * a link to the document
+  * a last updated date object
+  * a document type
 
   Tracking can be added to the links by supplying optional data attributes for each.
-
-  Documents are presented in an ordered list as the component expects that the ordering of the documents is relevant.
 accessibility_criteria: |
   The component must:
 


### PR DESCRIPTION
## What
Updates the document list documentation to specify what a document is in the context of this component plus a few other little touchups.

## Why
Whilst working on govuk accessibility there was some confusion about if this should be used for a particular use case on the grounds that nobody was clear what a "document" was eg: there was some thought that it should be used for downloadable ODTs/literal documents. I raised this in a govuk frontenders catchup and folks agreed it was fine as it is and is being used suitably already but maybe a way to mitigate confusion would be to update the docs to be clear about what a document actually is.

The ordered list line has been removed as this is no longer presented in an ordered list.

Docs only so no changelog update.