### PR TITLE
Add rel attribute option to document list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Further step by step nav sidebar design updates ([PR #1893](https://github.com/alphagov/govuk_publishing_components/pull/1893))
+* Add rel attribute option to document list ([PR #1903](https://github.com/alphagov/govuk_publishing_components/pull/1903))
 
 ## 23.15.0
 

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -29,12 +29,21 @@
           item_classes = "gem-c-document-list__item-title #{brand_helper.color_class} #{title_with_context_class if item[:link][:context]}"
 
           if item[:link][:path]
+            rel = [
+              "external",
+              "nofollow",
+              "noopener",
+              "noreferrer",
+              "opener",
+            ].include?(item[:link][:rel]) ? item[:link][:rel] : nil
+
             link_to(
               item[:link][:text],
               item[:link][:path],
               data: item[:link][:data_attributes],
               class: "#{item_classes} gem-c-document-list__item-link",
-              lang: item[:link][:locale].presence
+              lang: item[:link][:locale].presence,
+              rel: rel,
             )
           else
             content_tag(

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -305,3 +305,21 @@ examples:
           path: '/become-an-apprentice'
           description: 'Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship.'
           full_size_description: true
+  with_rel_link_attribute:
+    description: |
+      The [rel attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel) is an option attribute to dictate the relationship between the document being linked to and the current page. This is predominantly used by search engines to help index journeys through a website.
+      
+      On GOV.UK, this is typically used to dictate an external website being linked to with `rel="external"`, however this component supports:
+      
+      - external
+      - nofollow
+      - noopener
+      - noreferrer
+      - opener
+    data:
+      items:
+      - link:
+          text: 'Report Fraud'
+          path: 'https://www.actionfraud.police.uk/contact-us'
+          rel: 'external'
+          description: "Contact Action Fraud to report fraud and cyber crime, or to tell them you've been the victim of a scam."

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -473,4 +473,30 @@ describe "Document list", type: :view do
     assert_select ".gem-c-document-list__attribute[lang=\"cy\"]", text: "Data tryloywder"
     assert_select ".gem-c-document-list__attribute:not([lang=\"cy\"])", text: "English text"
   end
+
+  it "adds rel attribute to elements only when rel is passed" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: "Report Fraud",
+            path: "https://www.actionfraud.police.uk/contact-us",
+            rel: "external",
+          },
+        },
+        {
+          link: {
+            text: "Child Benefit",
+            path: "/contact-child-benefit-office",
+            rel: "bad value",
+          },
+        },
+      ],
+    )
+
+    link = ".gem-c-document-list__item-link"
+
+    assert_select "#{link}[href=\"https://www.actionfraud.police.uk/contact-us\"][rel=\"external\"]", text: "Report Fraud"
+    assert_select "#{link}[href=\"/contact-child-benefit-office\"]:not([rel])", text: "Child Benefit"
+  end
 end


### PR DESCRIPTION
## What
Add a `rel` option to the document list component which gets applied to the markup as an attribute on the document link.

## Why
We use the `rel` attribute in govuk content to dictate links to external sites, principally for use by search engines. This has emerged as a requirement for the document list component where it's being used to link to external sites. [Read more about what the rel attribute is and how it can be used here](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel).

No visual changes.