### PR TITLE
Add data attributes to layout footer component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix bugs on the feedback component ([PR #1900](https://github.com/alphagov/govuk_publishing_components/pull/1900))
+* Add data attributes to layout footer component ([PR #1904](https://github.com/alphagov/govuk_publishing_components/pull/1904))
 
 ## 23.14.0
 

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -6,7 +6,7 @@
   classes << "gem-c-layout-footer--border" if with_border
 %>
 <%= tag.footer class: classes, role: "contentinfo" do %>
-  <div class="govuk-width-container ">
+  <div class="govuk-width-container" data-module="track-click">
     <% if navigation.any? %>
       <div class="govuk-footer__navigation">
         <% navigation.each do |item| %>
@@ -31,7 +31,10 @@
                     <% if item[:href] && item[:text] %>
                       <li class="govuk-footer__list-item">
                         <%
-                          attributes = { class: "govuk-footer__link" }.merge(item.fetch(:attributes, {}))
+                          attributes = {
+                            class: "govuk-footer__link",
+                            "data-track-category": "footerClicked"
+                          }.merge(item.fetch(:attributes, {}))
                           attributes[:rel] = "noopener" if attributes[:target] == "_blank" && !attributes[:rel]
                         %>
                         <%= link_to item[:text], item[:href], attributes %>


### PR DESCRIPTION
## What 
The `layout_footer` currently used in Accounts does not have the same data attributes for tracking as the footer on the main site. 

Add data attributes for click tracking to the layout footer component to match the attributes of the hard coded footer in static.
I hard coded `data-track-category` to `footerClicked` as it the value of this attribute should be the same for every link in the footer.

## Why
So that we can have click event tracking on the GOVUK Account footer. 
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->


Goes hand in hand with this [pull request](https://github.com/alphagov/govuk-account-manager-prototype/pull/665).

------

https://trello.com/c/9A6UPqi8