### PR TITLE
Adds Reorderable lists component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Remove lists from summary action links ([PR #1956](https://github.com/alphagov/govuk_publishing_components/pull/1956))
 * Fix GOV.UK Frontend deprecation warning for component-guide print stylesheet ([PR #1961](https://github.com/alphagov/govuk_publishing_components/pull/1961))
 * Update search box button ([PR #1957](https://github.com/alphagov/govuk_publishing_components/pull/1957))
+* Adds Reorderable lists component ([PR #1905](https://github.com/alphagov/govuk_publishing_components/pull/1905))
 
 ## 24.4.1
 

--- a/app/assets/javascripts/govuk_publishing_components/components/reorderable-list.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/reorderable-list.js
@@ -1,0 +1,108 @@
+//= require sortablejs/Sortable.js
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function ReorderableList () { }
+
+  ReorderableList.prototype.start = function ($module) {
+    this.$module = $module[0]
+    this.$upButtons = this.$module.querySelectorAll('.js-reorderable-list-up')
+    this.$downButtons = this.$module.querySelectorAll('.js-reorderable-list-down')
+
+    this.sortable = window.Sortable.create(this.$module, { // eslint-disable-line new-cap
+      chosenClass: 'gem-c-reorderable-list__item--chosen',
+      dragClass: 'gem-c-reorderable-list__item--drag',
+      onSort: function () {
+        this.updateOrderIndexes()
+        this.triggerEvent(this.$module, 'reorder-drag')
+      }.bind(this)
+    })
+
+    if (typeof window.matchMedia === 'function') {
+      this.setupResponsiveChecks()
+    } else {
+      this.sortable.option('disabled', true)
+    }
+
+    var boundOnClickUpButton = this.onClickUpButton.bind(this)
+    this.$upButtons.forEach(function (button) {
+      button.addEventListener('click', boundOnClickUpButton)
+    })
+
+    var boundOnClickDownButton = this.onClickDownButton.bind(this)
+    this.$downButtons.forEach(function (button) {
+      button.addEventListener('click', boundOnClickDownButton)
+    })
+  }
+
+  ReorderableList.prototype.setupResponsiveChecks = function () {
+    var tabletBreakpoint = '40.0625em' // ~640px
+    this.mediaQueryList = window.matchMedia('(min-width: ' + tabletBreakpoint + ')')
+    this.mediaQueryList.addListener(this.checkMode.bind(this))
+    this.checkMode()
+  }
+
+  ReorderableList.prototype.checkMode = function () {
+    this.sortable.option('disabled', !this.mediaQueryList.matches)
+  }
+
+  ReorderableList.prototype.onClickUpButton = function (e) {
+    var item = e.target.closest('.gem-c-reorderable-list__item')
+    var previousItem = item.previousElementSibling
+    if (item && previousItem) {
+      item.parentNode.insertBefore(item, previousItem)
+      this.updateOrderIndexes()
+    }
+    // if triggered by keyboard preserve focus on button
+    if (e.detail === 0) {
+      if (item !== item.parentNode.firstElementChild) {
+        e.target.focus()
+      } else {
+        e.target.nextElementSibling.focus()
+      }
+    }
+    this.triggerEvent(e.target, 'reorder-move-up')
+  }
+
+  ReorderableList.prototype.onClickDownButton = function (e) {
+    var item = e.target.closest('.gem-c-reorderable-list__item')
+    var nextItem = item.nextElementSibling
+    if (item && nextItem) {
+      item.parentNode.insertBefore(item, nextItem.nextElementSibling)
+      this.updateOrderIndexes()
+    }
+    // if triggered by keyboard preserve focus on button
+    if (e.detail === 0) {
+      if (item !== item.parentNode.lastElementChild) {
+        e.target.focus()
+      } else {
+        e.target.previousElementSibling.focus()
+      }
+    }
+    this.triggerEvent(e.target, 'reorder-move-down')
+  }
+
+  ReorderableList.prototype.updateOrderIndexes = function () {
+    var $orderInputs = this.$module.querySelectorAll('.gem-c-reorderable-list__actions input')
+    $orderInputs.forEach(function (input, index) {
+      input.setAttribute('value', index + 1)
+    })
+  }
+
+  ReorderableList.prototype.triggerEvent = function (element, eventName) {
+    var params = { bubbles: true, cancelable: true }
+    var event
+
+    if (typeof window.CustomEvent === 'function') {
+      event = new window.CustomEvent(eventName, params)
+    } else {
+      event = document.createEvent('CustomEvent')
+      event.initCustomEvent(eventName, params.bubbles, params.cancelable)
+    }
+
+    element.dispatchEvent(event)
+  }
+
+  Modules.ReorderableList = ReorderableList
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -56,6 +56,7 @@
 @import "components/print-link";
 @import "components/radio";
 @import "components/related-navigation";
+@import "components/reorderable-list";
 @import "components/search";
 @import "components/select";
 @import "components/share-links";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_reorderable-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_reorderable-list.scss
@@ -1,0 +1,117 @@
+.gem-c-reorderable-list {
+  @include govuk-font(19, bold);
+
+  list-style-type: none;
+  margin-bottom: govuk-spacing(6);
+  margin-top: 0;
+  padding-left: 0;
+  position: relative;
+
+  .govuk-form-group {
+    margin-bottom: 0;
+  }
+}
+
+.gem-c-reorderable-list__item {
+  margin-bottom: govuk-spacing(3);
+  border: 1px solid $govuk-border-colour;
+  padding: govuk-spacing(3);
+}
+
+.gem-c-reorderable-list__item--chosen {
+  background-color: govuk-colour('light-grey');
+  outline: 2px dotted $govuk-border-colour;
+}
+
+.gem-c-reorderable-list__item--drag {
+  background-color: govuk-colour('white');
+  list-style-type: none;
+
+  .gem-c-reorderable-list__actions {
+    visibility: hidden;
+  }
+}
+
+.gem-c-reorderable-list__wrapper {
+  display: block;
+
+  @include govuk-media-query($from: desktop) {
+    display: inline-flex;
+    width: 100%;
+  }
+}
+
+.gem-c-reorderable-list__content {
+  margin-bottom: govuk-spacing(2);
+  @include govuk-media-query($from: desktop) {
+    margin-bottom: 0;
+    flex: 0 1 auto;
+    min-width: 65%;
+  }
+}
+
+.gem-c-reorderable-list__title {
+  margin: 0;
+}
+
+.gem-c-reorderable-list__description {
+  @include govuk-font(16, regular);
+  margin: 0;
+}
+
+.gem-c-reorderable-list__actions {
+  display: block;
+
+  @include govuk-media-query($from: desktop) {
+    flex: 1 0 auto;
+    text-align: right;
+  }
+
+  .gem-c-button {
+    display: none;
+  }
+}
+
+.js-enabled {
+  .gem-c-reorderable-list__item {
+    @include govuk-media-query($from: desktop) {
+      cursor: move;
+    }
+  }
+
+  .gem-c-reorderable-list__actions .govuk-form-group {
+    display: none;
+  }
+
+  .gem-c-reorderable-list__actions .gem-c-button {
+    display: inline-block;
+    margin-left: govuk-spacing(3);
+    width: 80px;
+  }
+
+  .gem-c-reorderable-list__actions .gem-c-button:first-of-type {
+    margin-left: 0;
+
+    @include govuk-media-query($from: desktop) {
+      margin-left: govuk-spacing(3);
+    }
+  }
+
+  .gem-c-reorderable-list__item:first-child .gem-c-button:first-of-type,
+  .gem-c-reorderable-list__item:last-child .gem-c-button:last-of-type {
+    display: none;
+
+    @include govuk-media-query($from: desktop) {
+      display: inline-block;
+      visibility: hidden;
+    }
+  }
+
+  .gem-c-reorderable-list__item:first-child .gem-c-button:last-of-type {
+    margin-left: 0;
+
+    @include govuk-media-query($from: desktop) {
+      margin-left: govuk-spacing(3);
+    }
+  }
+}

--- a/app/views/govuk_publishing_components/components/_reorderable_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_reorderable_list.html.erb
@@ -1,0 +1,45 @@
+<%
+  items ||= []
+  input_name ||= "ordering"
+  data_attributes ||= {}
+  data_attributes[:module] = "reorderable-list"
+%>
+
+<%= tag.ol class: "gem-c-reorderable-list", data: data_attributes do %>
+  <% items.each_with_index do |item, index| %>
+    <%= tag.li class: "gem-c-reorderable-list__item" do %>
+      <%= tag.div class: "gem-c-reorderable-list__wrapper" do %>
+        <%= tag.div class: "gem-c-reorderable-list__content" do %>
+          <%= tag.p item[:title], class: "gem-c-reorderable-list__title" %>
+          <%= tag.p(item[:description], class: "gem-c-reorderable-list__description") if item[:description].present? %>
+        <% end %>
+        <%= tag.div class: "gem-c-reorderable-list__actions" do %>
+          <% label_text = capture do %>
+            Position<span class='govuk-visually-hidden'> for <%= item[:title] %></span>
+          <% end %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: { text: label_text },
+            name: "#{input_name}[#{item[:id]}]",
+            type: "number",
+            value: index + 1,
+            width: 2
+          } %>
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Up",
+            type: "button",
+            aria_label: "Move \"#{item[:title]}\" up",
+            classes: "js-reorderable-list-up",
+            secondary_solid: true
+          } %>
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Down",
+            type: "button",
+            aria_label: "Move \"#{item[:title]}\" down",
+            classes: "js-reorderable-list-down",
+            secondary_solid: true
+          } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/reorderable_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/reorderable_list.yml
@@ -1,0 +1,85 @@
+name: Reorderable list
+description: A list of items that can be reordered
+body: |
+  List items can be reordered by drag and drop or by using the up/down buttons.
+  On small viewports the drag and drop feature is disabled to prevent being triggered
+  when scrolling on touch devices.
+
+  This component uses SortableJS - a JavaScript library for drag and drop interactions.
+  When JavaScript is disabled a set of inputs will be shown allowing users to provide
+  an order index for each item.
+
+  When this component is embedded into a form and that form is submit you will receive a
+  parameter of `ordering` (which can be customised with the `input_name` option).
+  This will contain item ids and ordering positions in a hash.
+
+  For example, for two items with id "a" and "b" that are ordered accordingly,
+  you'd receive a submission of `ordering[a]=1&ordering[b]=2`, which Rails can
+  translate to `"ordering" => { "a" => "1", "b" => "2" }`.
+
+accessibility_criteria: |
+  Buttons in this component must:
+
+  * be keyboard focusable
+  * inform the user about which item they operate on
+  * preserve focus after interacting with them
+examples:
+  default:
+    data:
+      items:
+        - id: "ce99dd60-67dc-11eb-ae93-0242ac130002"
+          title: "Budget 2018"
+        - id: "d321cb86-67dc-11eb-ae93-0242ac130002"
+          title: "Budget 2018 (web)"
+        - id: "63a6d29e-6b6d-4157-9067-84c1a390e352"
+          title: "Impact on households: distributional analysis to accompany Budget 2018"
+        - id: "0a4d377d-68f4-472f-b2e3-ef71dc750f85"
+          title: "Table 2.1: Budget 2018 policy decisions"
+        - id: "5ebd75d7-6c37-4b93-b444-1b7c49757fb9"
+          title: "Table 2.2: Measures announced at Autumn Budget 2017 or earlier that will take effect from November 2018 or later (£ million)"
+  with_description:
+    data:
+      items:
+        - id: "ce99dd60-67dc-11eb-ae93-0242ac130002"
+          title: "Budget 2018"
+          description: "PDF, 2.56MB, 48 pages"
+        - id: "d321cb86-67dc-11eb-ae93-0242ac130002"
+          title: "Budget 2018 (web)"
+          description: "HTML attachment"
+        - id: "63a6d29e-6b6d-4157-9067-84c1a390e352"
+          title: "Impact on households: distributional analysis to accompany Budget 2018"
+          description: "PDF, 592KB, 48 pages"
+        - id: "0a4d377d-68f4-472f-b2e3-ef71dc750f85"
+          title: "Table 2.1: Budget 2018 policy decisions"
+          description: "MS Excel Spreadsheet, 248KB"
+        - id: "5ebd75d7-6c37-4b93-b444-1b7c49757fb9"
+          title: "Table 2.2: Measures announced at Autumn Budget 2017 or earlier that will take effect from November 2018 or later (£ million)"
+          description: "MS Excel Spreadsheet, 248KB"
+  within_form:
+    embed: |
+      <form>
+        <%= component %>
+        <button class="govuk-button" type="submit">Save order</button>
+      </form>
+    data:
+      items:
+        - id: "ce99dd60-67dc-11eb-ae93-0242ac130002"
+          title: "Budget 2018"
+        - id: "d321cb86-67dc-11eb-ae93-0242ac130002"
+          title: "Budget 2018 (web)"
+        - id: "63a6d29e-6b6d-4157-9067-84c1a390e352"
+          title: "Impact on households: distributional analysis to accompany Budget 2018"
+        - id: "0a4d377d-68f4-472f-b2e3-ef71dc750f85"
+          title: "Table 2.1: Budget 2018 policy decisions"
+        - id: "5ebd75d7-6c37-4b93-b444-1b7c49757fb9"
+          title: "Table 2.2: Measures announced at Autumn Budget 2017 or earlier that will take effect from November 2018 or later (£ million)"
+  with_custom_input_name:
+    data:
+      input_name: "attachments[ordering]"
+      items:
+        - id: "5ebd75d7-6c37-4b93-b444-1b7c49757fb9"
+          title: "Budget 2018"
+          description: "PDF, 2.56MB, 48 pages"
+        - id: "0a4d377d-68f4-472f-b2e3-ef71dc750f85"
+          title: "Budget 2020"
+          description: "PDF, 2.56MB, 48 pages"

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = ">= 2.6"
 
-  s.files = Dir["{node_modules/govuk-frontend,node_modules/axe-core,node_modules/jquery,app,config,db,lib}/**/*", "LICENCE.md", "README.md"]
+  s.files = Dir["{node_modules/govuk-frontend,node_modules/axe-core,node_modules/jquery,node_modules/sortablejs,app,config,db,lib}/**/*", "LICENCE.md", "README.md"]
 
   s.add_dependency "govuk_app_config"
   s.add_dependency "kramdown"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "axe-core": "^3.5.4",
     "govuk-frontend": "^3.11.0",
-    "jquery": "1.12.4"
+    "jquery": "1.12.4",
+    "sortablejs": "^1.13.0"
   },
   "devDependencies": {
     "standardx": "^7.0.0",

--- a/spec/components/reorderable_list_spec.rb
+++ b/spec/components/reorderable_list_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+describe "Reorderable list", type: :view do
+  def component_name
+    "reorderable_list"
+  end
+
+  def items
+    [
+      {
+        id: "item-1",
+        title: "Budget 2018",
+        description: "PDF, 2.56MB, 48 pages",
+      },
+      {
+        id: "item-2",
+        title: "Budget 2018 (web)",
+        description: "HTML attachment",
+      },
+      {
+        id: "item-3",
+        title: "Impact on households: distributional analysis to accompany Budget 2018",
+        description: "PDF, 592KB, 48 pages",
+      },
+      {
+        id: "item-3",
+        title: "Table 2.1: Budget 2018 policy decisions",
+        description: "MS Excel Spreadsheet, 248KB",
+      },
+      {
+        id: "item-3",
+        title: "Table 2.2: Measures announced at Autumn Budget 2017 or earlier that will take effect from November 2018 or later (£ million)",
+        description: "MS Excel Spreadsheet, 248KB",
+      },
+    ]
+  end
+
+  it "renders a list of items" do
+    render_component(items: items)
+
+    assert_select ".gem-c-reorderable-list"
+    assert_select ".gem-c-reorderable-list__item", 5
+    assert_select ".gem-c-reorderable-list__item" do |elements|
+      elements.each_with_index do |element, index|
+        assert_select element, ".gem-c-reorderable-list__title", { text: items[index][:title] }
+        assert_select element, ".gem-c-reorderable-list__description", { text: items[index][:description] }
+        assert_select element, ".gem-c-reorderable-list__actions"
+        assert_select element, ".gem-c-reorderable-list__actions .js-reorderable-list-up", { text: "Up" }
+        assert_select element, ".gem-c-reorderable-list__actions .js-reorderable-list-down", { text: "Down" }
+        assert_select element, ".gem-c-reorderable-list__actions input[name='ordering[#{items[index][:id]}]']"
+        assert_select element, ".gem-c-reorderable-list__actions input[value='#{index + 1}']"
+      end
+    end
+  end
+
+  it "renders allows custom input names" do
+    render_component(items: items, input_name: "attachments[ordering]")
+
+    assert_select ".gem-c-reorderable-list"
+    assert_select ".gem-c-reorderable-list__item" do |elements|
+      elements.each_with_index do |element, index|
+        assert_select element, ".gem-c-reorderable-list__actions input[name='attachments[ordering][#{items[index][:id]}]']"
+      end
+    end
+  end
+end

--- a/spec/javascripts/components/reorderable-list-spec.js
+++ b/spec/javascripts/components/reorderable-list-spec.js
@@ -1,0 +1,206 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK, spyOnEvent */
+
+describe('Reorderable list component', function () {
+  'use strict'
+
+  var container
+  var element
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML =
+    '<ol class="gem-c-reorderable-list" data-module="reorderable-list">' +
+      '<li class="gem-c-reorderable-list__item">' +
+        '<div class="gem-c-reorderable-list__wrapper">' +
+          '<div class="gem-c-reorderable-list__content">' +
+            '<p class="gem-c-reorderable-list__title">First attachment</p>' +
+          '</div>' +
+          '<div class="gem-c-reorderable-list__actions">' +
+            '<input name="new_order[]" value="1" class="gem-c-input govuk-input govuk-input--width-2" id="input-278a8924" type="text">' +
+            '<button type="button" class="js-reorderable-list-up">Up</button>' +
+            '<button type="button" class="js-reorderable-list-down">Down</button>' +
+          '</div>' +
+        '</div>' +
+      '</li>' +
+      '<li class="gem-c-reorderable-list__item">' +
+        '<div class="gem-c-reorderable-list__wrapper">' +
+          '<div class="gem-c-reorderable-list__content">' +
+            '<p class="gem-c-reorderable-list__title">Second attachment</p>' +
+          '</div>' +
+          '<div class="gem-c-reorderable-list__actions">' +
+            '<input name="new_order[]" value="2" class="gem-c-input govuk-input govuk-input--width-2" id="input-278a8924" type="text">' +
+            '<button type="button" class="js-reorderable-list-up">Up</button>' +
+            '<button type="button" class="js-reorderable-list-down">Down</button>' +
+          '</div>' +
+        '</div>' +
+      '</li>' +
+    '</ol>'
+
+    document.body.classList.add('js-enabled')
+    document.body.appendChild(container)
+    element = document.querySelector('[data-module="reorderable-list"]')
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
+  describe('when `matchMedia` is not supported', function () {
+    var matchMedia = window.matchMedia
+    var mockMatchMedia
+    var reorderableList
+
+    beforeEach(function () {
+      window.matchMedia = mockMatchMedia
+      reorderableList = new GOVUK.Modules.ReorderableList()
+      spyOn(reorderableList, 'setupResponsiveChecks')
+      reorderableList.start($(element))
+    })
+
+    afterEach(function () {
+      window.matchMedia = matchMedia
+    })
+
+    it('should not setup responsive checks', function () {
+      expect(reorderableList.setupResponsiveChecks).not.toHaveBeenCalled()
+    })
+
+    it('should disable drag and drop', function () {
+      expect(reorderableList.sortable.option('disabled')).toBe(true)
+    })
+  })
+
+  describe('when `matchMedia` is supported', function () {
+    var matchMedia = window.matchMedia
+    var mockMatchMedia = matchMedia
+    var reorderableList
+
+    var matchMediaMock = function (reorderableList, matches) {
+      var bindedcheckMode = reorderableList.checkMode.bind(reorderableList)
+      reorderableList.mediaQueryList = { matches: matches }
+      reorderableList.sortable = new window.Sortable.create(element) // eslint-disable-line new-cap
+      spyOn(reorderableList.sortable, 'option')
+      bindedcheckMode()
+    }
+
+    beforeEach(function () {
+      window.matchMedia = mockMatchMedia
+      reorderableList = new GOVUK.Modules.ReorderableList()
+    })
+
+    afterEach(function () {
+      window.matchMedia = matchMedia
+    })
+
+    it('should setup responsive checks', function () {
+      spyOn(reorderableList, 'setupResponsiveChecks')
+      reorderableList.start($(element))
+
+      expect(reorderableList.setupResponsiveChecks).toHaveBeenCalled()
+    })
+
+    it('should enable drag and drop if rendered on a large device', function () {
+      matchMediaMock(reorderableList, true)
+
+      expect(reorderableList.sortable.option).toHaveBeenCalledWith('disabled', false)
+    })
+
+    it('should disable drag and drop if rendered on a small device', function () {
+      matchMediaMock(reorderableList, false)
+
+      expect(reorderableList.sortable.option).toHaveBeenCalledWith('disabled', true)
+    })
+  })
+
+  describe('when dragging the first element to the bottom', function () {
+    var reorderableList
+    var sortable
+    beforeEach(function () {
+      reorderableList = new GOVUK.Modules.ReorderableList()
+      reorderableList.start($(element))
+      spyOnEvent($(element), 'reorder-drag')
+      sortable = reorderableList.sortable
+      sortable.sort(sortable.toArray().reverse())
+      sortable.options.onSort() // not triggered by 'sort'
+    })
+
+    it('should swaps current item with next item', function () {
+      var firstItemTitle = document.querySelector('li:nth-child(1) .gem-c-reorderable-list__title').textContent
+      var secondItemTitle = document.querySelector('li:nth-child(2) .gem-c-reorderable-list__title').textContent
+      expect(firstItemTitle).toEqual('Second attachment')
+      expect(secondItemTitle).toEqual('First attachment')
+    })
+
+    it('should update the associated indexes', function () {
+      var firstItemNewIndex = document.querySelector('li:nth-child(1) input[type=text]').value
+      var secondItemNewIndex = document.querySelector('li:nth-child(2) input[type=text]').value
+      expect(firstItemNewIndex).toEqual('1')
+      expect(secondItemNewIndex).toEqual('2')
+    })
+
+    it('should trigger a reorder-drag event', function () {
+      expect('reorder-drag').toHaveBeenTriggeredOn($(element))
+    })
+  })
+
+  describe('when clicking the Down button on first item', function () {
+    var reorderableList
+    var firstItemDownButton
+    beforeEach(function () {
+      reorderableList = new GOVUK.Modules.ReorderableList()
+      reorderableList.start($(element))
+      firstItemDownButton = document.querySelector('li:nth-child(1) .js-reorderable-list-down')
+      spyOnEvent(firstItemDownButton, 'reorder-move-down')
+      firstItemDownButton.click()
+    })
+
+    it('should swaps current item with next item', function () {
+      var firstItemTitle = document.querySelector('li:nth-child(1) .gem-c-reorderable-list__title').textContent
+      var secondItemTitle = document.querySelector('li:nth-child(2) .gem-c-reorderable-list__title').textContent
+      expect(firstItemTitle).toEqual('Second attachment')
+      expect(secondItemTitle).toEqual('First attachment')
+    })
+
+    it('should update the associated indexes', function () {
+      var firstItemNewIndex = document.querySelector('li:nth-child(1) input[type=text]').value
+      var secondItemNewIndex = document.querySelector('li:nth-child(2) input[type=text]').value
+      expect(firstItemNewIndex).toEqual('1')
+      expect(secondItemNewIndex).toEqual('2')
+    })
+
+    it('should trigger a reorder-move-down event', function () {
+      expect('reorder-move-down').toHaveBeenTriggeredOn(firstItemDownButton)
+    })
+  })
+
+  describe('when clicking the Up button on the second item', function () {
+    var reorderableList
+    var secondItemUpButton
+    beforeEach(function () {
+      reorderableList = new GOVUK.Modules.ReorderableList()
+      reorderableList.start($(element))
+      secondItemUpButton = document.querySelector('li:nth-child(2) .js-reorderable-list-up')
+      spyOnEvent(secondItemUpButton, 'reorder-move-up')
+      secondItemUpButton.click()
+    })
+
+    it('should swaps current item with previous item', function () {
+      var firstItemTitle = document.querySelector('li:nth-child(1) .gem-c-reorderable-list__title').textContent
+      var secondItemTitle = document.querySelector('li:nth-child(2) .gem-c-reorderable-list__title').textContent
+      expect(firstItemTitle).toEqual('Second attachment')
+      expect(secondItemTitle).toEqual('First attachment')
+    })
+
+    it('should update the associated indexes', function () {
+      var firstItemNewIndex = document.querySelector('li:nth-child(1) input[type=text]').value
+      var secondItemNewIndex = document.querySelector('li:nth-child(2) input[type=text]').value
+      expect(firstItemNewIndex).toEqual('1')
+      expect(secondItemNewIndex).toEqual('2')
+    })
+
+    it('should trigger a reorder-move-up event', function () {
+      expect('reorder-move-up').toHaveBeenTriggeredOn(secondItemUpButton)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2324,6 +2324,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+sortablejs@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.13.0.tgz#3ab2473f8c69ca63569e80b1cd1b5669b51269e9"
+  integrity sha512-RBJirPY0spWCrU5yCmWM1eFs/XgX2J5c6b275/YyxFRgnzPhKl/TDeU2hNR8Dt7ITq66NRPM4UlOt+e5O4CFHg==
+
 source-map@^0.5.0:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"


### PR DESCRIPTION
## What

A list of items that can be reordered

List items can be reordered by drag and drop or by using the up/down buttons. On small viewports the drag and drop feature is disabled to prevent being triggered when scrolling on touch devices.

This component uses SortableJS - a JavaScript library for drag and drop interactions. When JavaScript is disabled a set of inputs will be shown allowing users to provide an order index for each item.

## Why

This is used by publishing tools to allow reordering of lists such as steps in step by step, entries in timelines and order of visual presentation of attachments.

## Disclaimer

This is a port/extension of the work that @alex-ju has done on the content publisher app.

## Demo

https://govuk-publis-add-reorde-g116bw.herokuapp.com/component-guide/reorderable_list

## Visual Changes

![screenshot-localhost_3212-2021 03 03-11_22_34](https://user-images.githubusercontent.com/4599889/109798591-dcc3b100-7c12-11eb-9bd7-820a0c833dd2.png)



### No JS view

<img width="1034" alt="Screenshot 2021-02-05 at 18 41 03" src="https://user-images.githubusercontent.com/4599889/107075285-d2fc8880-67e1-11eb-8c60-abf87b7fa252.png">

https://trello.com/c/SD4pLfen/1086-add-reorder-component-to-govukpublishingcomponents

