### PR TITLE
Remove listenForCrossOriginMessages from CookieBanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove `listenForCrossOriginMessages` from CookieBanner ([PR #1906](https://github.com/alphagov/govuk_publishing_components/pull/1906))
 * Further step by step nav sidebar design updates ([PR #1893](https://github.com/alphagov/govuk_publishing_components/pull/1893))
 * Add rel attribute option to document list ([PR #1903](https://github.com/alphagov/govuk_publishing_components/pull/1903))
 

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -85,10 +85,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.cookieBannerConfirmationMessage.style.display = 'block'
   }
 
-  CookieBanner.prototype.listenForCrossOriginMessages = function () {
-    window.addEventListener('message', this.receiveMessage.bind(this), false)
-  }
-
   CookieBanner.prototype.isInCookiesPage = function () {
     return window.location.pathname === '/help/cookies'
   }


### PR DESCRIPTION

## What
Remove `listenForCrossOriginMessages` from `CookieBanner` JS module

## Why
This function is a leftover from https://github.com/alphagov/govuk_publishing_components/pull/995 and it's not being used.

## Visual Changes
No visual changes.

Thanks to @36degrees for spotting this!
