### PR TITLE
Add option to remove border from document list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fix bugs on the feedback component ([PR #1900](https://github.com/alphagov/govuk_publishing_components/pull/1900))
 * Add data attributes to layout footer component ([PR #1904](https://github.com/alphagov/govuk_publishing_components/pull/1904))
+* Add option to remove border from document list items ([PR #1907](https://github.com/alphagov/govuk_publishing_components/pull/1907))
 
 ## 23.14.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -29,6 +29,12 @@
   }
 }
 
+.gem-c-document-list--no-top-border {
+  .gem-c-document-list__item {
+    border-top: none;
+  }
+}
+
 .gem-c-document-list__item-title--context {
   margin-right: govuk-spacing(2);
 

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -5,6 +5,7 @@
   classes << " gem-c-document-list--top-margin" if local_assigns[:margin_top]
   classes << " gem-c-document-list--bottom-margin" if local_assigns[:margin_bottom]
   classes << " gem-c-document-list--no-underline" if local_assigns[:remove_underline]
+  classes << " gem-c-document-list--no-top-border" if local_assigns[:remove_top_border]
 
   within_multitype_list ||= false
   within_multitype_list_class = " gem-c-document-list__multi-list" if within_multitype_list

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -195,6 +195,23 @@ examples:
           public_updated_at: 2017-07-19 15:01:48
           document_type: 'Statistical data set'
         subtext: 'First published during the 1996 Conservative Government'
+  without_top_border_on_list_element:
+    description: Several interfaces across GOV.UK benefit from the semantics of the document list but have their own bespoke designs, sometimes meaning that the visual border element doesn't gel with said interface. Removing it using the below attribute allows for cleaner visual fidelity in this instances.
+    data:
+      remove_top_border: true
+      items:
+      - link:
+          text: 'Department for Education – Statistics at DfE'
+          path: '/government/organisations/department-for-education/about/statistics'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Corporate information'
+      - link:
+          text: 'State-funded school inspections and outcomes: management information'
+          path: '/government/organisations/department-for-education/about/statistics'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Statistical data set'
   highlighted_result:
     description: Highlight one or more of the items in the list. This is used on finders to provide a 'top result' for a search. The `highlight_text` parameter is optional.
     data:

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -261,6 +261,22 @@ describe "Document list", type: :view do
     assert_select ".gem-c-document-list.gem-c-document-list--no-underline"
   end
 
+  it "removes the top border from list items" do
+    render_component(
+      remove_top_border: true,
+      items: [
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+          },
+        },
+      ],
+    )
+
+    assert_select ".gem-c-document-list.gem-c-document-list--no-top-border"
+  end
+
   it "highlights items" do
     render_component(
       items: [


### PR DESCRIPTION
## What
Adds an optional attribute to the document list component that removes the border visual element from document list items.

## Why
The document list component is currently being used in collections publisher and content publisher and the recent visual change was missed in these apps and [caused some visual disparity](https://github.com/alphagov/govuk_publishing_components/pull/1883). This removes the border element which is the source of said visual discrepancy. This decision is weighted by the fact that there is a plan to eventually [extract the docs list item as a standalone component](https://github.com/alphagov/govuk_publishing_components/compare/extract-document-item-component) meaning there is an appetite for this to not use the border in certain interfaces, such as the publishing apps.

## Visual Changes
### Before
![Screenshot 2021-02-05 at 12 09 22](https://user-images.githubusercontent.com/64783893/107033452-3c15d900-67ad-11eb-98f0-424649638ea5.png)

### After
![Screenshot 2021-02-05 at 12 17 41](https://user-images.githubusercontent.com/64783893/107033465-3f10c980-67ad-11eb-8817-13472028a81d.png)
