### PR TITLE
Update data-module on layout header and footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 
 ## Unreleased
 
+* Update `data-module` on layout header and footer ([PR #1913](https://github.com/alphagov/govuk_publishing_components/pull/1913))
 * Update design of accordion component ([PR #1884](https://github.com/alphagov/govuk_publishing_components/pull/1884))
-  
+
 ## 24.0.0
 
 * Bump govuk-frontend from 3.10.2 to 3.11.0 ([PR #1911](https://github.com/alphagov/govuk_publishing_components/pull/1911))

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -6,7 +6,7 @@
   classes << "gem-c-layout-footer--border" if with_border
 %>
 <%= tag.footer class: classes, role: "contentinfo" do %>
-  <div class="govuk-width-container" data-module="track-click">
+  <div class="govuk-width-container" data-module="gem-track-click">
     <% if navigation.any? %>
       <div class="govuk-footer__navigation">
         <% navigation.each do |item| %>

--- a/app/views/govuk_publishing_components/components/layout_header/_header_logo.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_header_logo.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-header__logo gem-c-header__logo">
-  <a href="/" class="govuk-header__link govuk-header__link--homepage" data-module="track-click" data-track-category="homeLinkClicked" data-track-action="homeHeader">
+  <a href="/" class="govuk-header__link govuk-header__link--homepage" data-module="gem-track-click" data-track-category="homeLinkClicked" data-track-action="homeHeader">
     <span class="govuk-header__logotype">
       <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
         <path fill="currentColor" fill-rule="evenodd"


### PR DESCRIPTION
## What
Change value of `data-module` attribute to "gem-track-click" on the layout header and layout footer components.


## Why
The reason behind this change is that click tracking is not working on these elements on GOVUK Accounts. 
That is because Accounts does not use `static` and therefore also does not use the [track-click script](https://github.com/alphagov/static/blob/master/app/assets/javascripts/modules/track-click.js) which  enables click tracking on modules with the `data-module="track-click"` attribute.

Changing the value of this attribute to "gem-track-click" means that the header and footer will work with the [component gem's track-click script](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/lib/track-click.js) instead.




https://trello.com/c/9A6UPqi8