### PR TITLE
Release 24.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.0.0
 
 * Bump govuk-frontend from 3.10.2 to 3.11.0 ([PR #1911](https://github.com/alphagov/govuk_publishing_components/pull/1911))
 * Rescope Brexit CTA on contextual sidebar ([PR #1910](https://github.com/alphagov/govuk_publishing_components/pull/1910))
@@ -19,7 +19,8 @@
 * BREAKING: Retire gem-level SCSS variables ([PR #1881](https://github.com/alphagov/govuk_publishing_components/pull/1881))
 * BREAKING: Remove duplicate `lib/auto-track-event` script ([PR #1894](https://github.com/alphagov/govuk_publishing_components/pull/1894))
 * BREAKING: Remove copies of files ([PR #1878](https://github.com/alphagov/govuk_publishing_components/pull/1878))
-* BREAKING: Remove list stylesheet ([PR #1874])(https://github.com/alphagov/govuk_publishing_components/pull/1874)
+* BREAKING: Remove list stylesheet ([PR #1874](https://github.com/alphagov/govuk_publishing_components/pull/1874))
+
 ## 23.15.0
 
 * Fix bugs on the feedback component ([PR #1900](https://github.com/alphagov/govuk_publishing_components/pull/1900))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (23.15.0)
+    govuk_publishing_components (24.0.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "23.15.0".freeze
+  VERSION = "24.0.0".freeze
 end


### PR DESCRIPTION
### Release 24.0.0

* Bump govuk-frontend from 3.10.2 to 3.11.0 ([PR #1911](https://github.com/alphagov/govuk_publishing_components/pull/1911))
* Rescope Brexit CTA on contextual sidebar ([PR #1910](https://github.com/alphagov/govuk_publishing_components/pull/1910))
* Update `govspeak` contact heading ([PR #1909](https://github.com/alphagov/govuk_publishing_components/pull/1909))
* Remove `listenForCrossOriginMessages` from CookieBanner ([PR #1906](https://github.com/alphagov/govuk_publishing_components/pull/1906))
* Further step by step nav sidebar design updates ([PR #1893](https://github.com/alphagov/govuk_publishing_components/pull/1893))
* Add rel attribute option to document list ([PR #1903](https://github.com/alphagov/govuk_publishing_components/pull/1903))
* BREAKING: Remove chevron banner component ([PR #1873](https://github.com/alphagov/govuk_publishing_components/pull/1873))
* BREAKING: Retire gem-level SCSS variables ([PR #1881](https://github.com/alphagov/govuk_publishing_components/pull/1881))
* BREAKING: Remove duplicate `lib/auto-track-event` script ([PR #1894](https://github.com/alphagov/govuk_publishing_components/pull/1894))
* BREAKING: Remove copies of files ([PR #1878](https://github.com/alphagov/govuk_publishing_components/pull/1878))
* BREAKING: Remove list stylesheet ([PR #1874](https://github.com/alphagov/govuk_publishing_components/pull/1874))

### Tested with
I'm going to quickly check this across our frontend apps to avoid blocking the deploy pipeline.


- [x] calculators
- [x] collections
- [x] email-alert-frontend
- [x] feedback
- [x] finder-frontend
- [x] frontend
- [x] government-frontend
- [x] info-frontend
- [x] licence-finder
- [x] manuals-frontend
- [x] service-manual-frontend
- [x] smart-answers
- [x] static
- [x] whitehall
