### PR TITLE
Bump gem to 24.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.1.0
 
 * Update `data-module` on layout header and footer ([PR #1913](https://github.com/alphagov/govuk_publishing_components/pull/1913))
 * Update design of accordion component ([PR #1884](https://github.com/alphagov/govuk_publishing_components/pull/1884))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.0.0)
+    govuk_publishing_components (24.1.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.0.0".freeze
+  VERSION = "24.1.0".freeze
 end


### PR DESCRIPTION
Includes 
* Update `data-module` on layout header and footer ([PR #1913](https://github.com/alphagov/govuk_publishing_components/pull/1913)) – Patch/fix
* Update design of accordion component ([PR #1884](https://github.com/alphagov/govuk_publishing_components/pull/1884)) – Minor