### PR TITLE
Update cookies banner to align it with govuk-frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update cookies banner ([PR #1918](https://github.com/alphagov/govuk_publishing_components/pull/1918))
+
 ## 24.1.1
 
 * Fix deprecation warnings when running tests ([PR #1899](https://github.com/alphagov/govuk_publishing_components/pull/1899))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Unreleased
 
-* Update cookies banner ([PR #1918](https://github.com/alphagov/govuk_publishing_components/pull/1918))
+* Update cookies banner to align it with govuk-frontend ([PR #1918](https://github.com/alphagov/govuk_publishing_components/pull/1918))
 
 ## 24.1.1
 

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -9,10 +9,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.hideCookieMessage = this.hideCookieMessage.bind(this)
     this.$module.showConfirmationMessage = this.showConfirmationMessage.bind(this)
     this.$module.setCookieConsent = this.setCookieConsent.bind(this)
+    this.$module.rejectCookieConsent = this.rejectCookieConsent.bind(this)
 
     this.$module.cookieBanner = document.querySelector('.gem-c-cookie-banner')
     this.$module.cookieBannerConfirmationMessage = this.$module.querySelector('.gem-c-cookie-banner__confirmation')
-
+    this.$module.cookieBannerConfirmationMessageText = this.$module.querySelector('.gem-c-cookie-banner__confirmation-message')
     this.setupCookieMessage()
   }
 
@@ -24,9 +25,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
     }
 
-    this.$acceptCookiesLink = this.$module.querySelector('button[data-accept-cookies]')
-    if (this.$acceptCookiesLink) {
-      this.$acceptCookiesLink.addEventListener('click', this.$module.setCookieConsent)
+    this.$acceptCookiesButton = this.$module.querySelector('button[data-accept-cookies]')
+    if (this.$acceptCookiesButton) {
+      this.$acceptCookiesButton.style.display = 'block'
+      this.$acceptCookiesButton.addEventListener('click', this.$module.setCookieConsent)
+    }
+
+    this.$rejectCookiesButton = this.$module.querySelector('button[data-reject-cookies]')
+    if (this.$rejectCookiesButton) {
+      this.$rejectCookiesButton.style.display = 'block'
+      this.$rejectCookiesButton.addEventListener('click', this.$module.rejectCookieConsent)
     }
 
     this.showCookieMessage()
@@ -56,6 +64,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   CookieBanner.prototype.hideCookieMessage = function (event) {
     if (this.$module) {
+      this.$module.hidden = true
       this.$module.style.display = 'none'
       window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
     }
@@ -66,6 +75,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   CookieBanner.prototype.setCookieConsent = function () {
+    if (this.$acceptCookiesButton.getAttribute('data-cookie-types') === 'all') {
+      this.$module.cookieBannerConfirmationMessageText.insertAdjacentHTML('afterbegin', 'You have accepted additional cookies. ')
+    }
     window.GOVUK.approveAllCookieTypes()
     this.$module.showConfirmationMessage()
     this.$module.cookieBannerConfirmationMessage.focus()
@@ -78,11 +90,19 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
   }
 
-  CookieBanner.prototype.showConfirmationMessage = function () {
-    this.$cookieBannerMainContent = document.querySelector('.gem-c-cookie-banner__wrapper')
+  CookieBanner.prototype.rejectCookieConsent = function () {
+    this.$module.cookieBannerConfirmationMessageText.insertAdjacentHTML('afterbegin', 'You have rejected additional cookies. ')
+    this.$module.showConfirmationMessage()
+    this.$module.cookieBannerConfirmationMessage.focus()
+    window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
+  }
 
-    this.$cookieBannerMainContent.style.display = 'none'
+  CookieBanner.prototype.showConfirmationMessage = function () {
+    this.$cookieBannerMainContent = document.querySelector('.js-banner-wrapper')
+
+    this.$cookieBannerMainContent.hidden = true
     this.$module.cookieBannerConfirmationMessage.style.display = 'block'
+    this.$module.cookieBannerConfirmationMessage.hidden = false
   }
 
   CookieBanner.prototype.isInCookiesPage = function () {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -1,3 +1,4 @@
+@import "govuk/components/cookie-banner/cookie-banner";
 $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
 
 .js-enabled {
@@ -7,48 +8,12 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
 }
 
 .gem-c-cookie-banner {
-  @include govuk-font($size: 16);
-  padding: govuk-spacing(2) 0;
   background-color: $govuk-cookie-banner-background;
 }
 
-.gem-c-cookie-banner--services {
+// can't be used without js so implement there
+.gem-c-cookie-banner .gem-c-button {
   display: none;
-}
-
-.gem-c-cookie-banner__message {
-  display: inline-block;
-  padding-bottom: govuk-spacing(2);
-
-  @include govuk-font($size: 16);
-  @include govuk-media-query($from: desktop) {
-    padding-right: govuk-spacing(4);
-  }
-}
-
-.gem-c-cookie-banner__button {
-  &.govuk-grid-column-one-half-from-desktop {
-    padding: 0;
-  }
-
-  .govuk-button {
-    @include govuk-media-query($from: desktop) {
-      width: 90%;
-    }
-
-    @include govuk-media-query($until: desktop) {
-      margin-bottom: govuk-spacing(4);
-    }
-  }
-}
-
-// Only show accept button if users have js and can accept
-.gem-c-cookie-banner__button-accept {
-  display: none;
-}
-
-.js-enabled .gem-c-cookie-banner__button-accept {
-  display: inline-block;
 }
 
 .gem-c-cookie-banner__confirmation {
@@ -81,51 +46,11 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
   }
 }
 
-.gem-c-cookie-banner__hide-button {
-  @include govuk-font($size: 19);
-  outline: 0;
-  border: 0;
-  background: none;
-  text-decoration: underline;
-  color: $govuk-link-colour;
-  padding: govuk-spacing(0);
-  margin-top: govuk-spacing(2);
-
-  &:hover {
-    color: $govuk-link-hover-colour;
-    cursor: pointer;
-  }
-
-  &:focus {
-    @include govuk-focused-text;
-  }
-
-  @include govuk-media-query($from: desktop) {
-    margin-top: govuk-spacing(0);
-    position: absolute;
-    right: govuk-spacing(1);
-  }
-}
-
-.gem-c-cookie-banner__buttons--flex {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-
-  .govuk-button,
-  .gem-c-cookie-banner__link {
-    flex-grow: 1;
-    flex-basis: 10rem;
-    margin-right: govuk-spacing(3);
-    margin-bottom: govuk-spacing(3);
-  }
-}
-
 // Override the styles from govuk_template
 // stylelint-disable selector-max-id
 .gem-c-cookie-banner#global-cookie-message {
   background-color: $govuk-cookie-banner-background;
-  padding: govuk-spacing(4) 0;
+  padding: 0;
   box-sizing: border-box;
 
   .gem-c-cookie-banner__message,
@@ -135,18 +60,13 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
     @include govuk-font($size: 19);
   }
 
-  .gem-c-cookie-banner__message {
-    margin-bottom: 0;
-  }
-
   p {
     @include govuk-font($size: 19);
     margin: 0 0 govuk-spacing(2) 0;
   }
 
-  .gem-c-cookie-banner__confirmation-message {
-    @include govuk-media-query($from: desktop) {
-      margin-bottom: 0;
-    }
+  .gem-c-cookie-banner__message,
+  .gem-c-cookie-banner__confirmation {
+    margin-bottom: - govuk-spacing(2);
   }
 }

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -1,72 +1,83 @@
 <%
   id ||= 'global-cookie-message'
-  title ||= "Tell us whether you accept cookies"
-  text ||= raw("We use <a class='govuk-link' href='/help/cookies'>cookies to collect information</a> about how you use GOV.UK. We use this information to make the website work as well as possible and improve government services.")
+  title ||= "Cookies on GOV.UK"
+  text ||= ["We use some essential cookies to make this website work.", "We’d like to set additional cookies to understand how you use GOV.UK, remember your settings and improve government services.", "We also use cookies set by other sites to help us deliver content from their services."]
+  if text.kind_of?(Array)
+    newtext = ""
+    text.each do |t|
+      newtext += "<p class='govuk-body'>#{t}</p>"
+    end
+    text = newtext
+  else
+    text = "<p class='govuk-body'>#{text}</p>"
+  end
+  text = raw(text)
+
   cookie_preferences_href ||= "/help/cookies"
-  confirmation_message ||= raw("You’ve accepted all cookies. You can <a class='govuk-link' href='#{cookie_preferences_href}' data-module='track-click' data-track-category='cookieBanner' data-track-action='Cookie banner settings clicked from confirmation'>change your cookie settings</a> at any time.")
+  confirmation_message ||= raw("You can <a class='govuk-link' href='#{cookie_preferences_href}' data-module='track-click' data-track-category='cookieBanner' data-track-action='Cookie banner settings clicked from confirmation'>change your cookie settings</a> at any time.")
   services_cookies ||= nil
   css_classes = %w(gem-c-cookie-banner govuk-clearfix)
   css_classes << "gem-c-cookie-banner--services" if services_cookies
 %>
-
 <div id="<%= id %>" class="<%= css_classes.join(' ') %>" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet>
-  <div class="gem-c-cookie-banner__wrapper govuk-width-container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <div class="gem-c-cookie-banner__message">
-          <h2 class="govuk-heading-m"><%= title %></h2>
-          <p class="govuk-body"><%= text %></p>
+  <div class="govuk-cookie-banner js-banner-wrapper" role="region" aria-label="<%= title %>">
+    <div class="gem-c-cookie-banner__message govuk-cookie-banner__message govuk-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-cookie-banner__heading govuk-heading-m"><%= title %></h2>
+          <div class="govuk-cookie-banner__content">
+            <%= text %>
+          </div>
         </div>
-        <% if services_cookies %>
-          <div class="gem-c-cookie-banner__buttons gem-c-cookie-banner__buttons--flex">
+      </div>
+      <% if services_cookies %>
+          <div class="govuk-button-group">
             <%= render "govuk_publishing_components/components/button", {
+              name: "cookies",
               text: services_cookies.dig(:yes, :text) || "Yes",
-              inline_layout: true,
               data_attributes: { module: "track-click", "accept-cookies": "true", }.merge(services_cookies.dig(:yes, :data_attributes) || {})
             } %>
             <%= render "govuk_publishing_components/components/button", {
+              name: "cookies",
               text: services_cookies.dig(:no, :text) || "No",
-              inline_layout: true,
-              data_attributes: { module: "track-click", "hide-cookie-banner": "true", }.merge(services_cookies.dig(:no, :data_attributes) || {})
+              data_attributes: { module: "track-click", "reject-cookies": "true", }.merge(services_cookies.dig(:no, :data_attributes) || {})
             } %>
             <% if services_cookies[:cookie_preferences] %>
-              <%= link_to services_cookies.dig(:cookie_preferences, :text), services_cookies.dig(:cookie_preferences, :href), class: "gem-c-cookie-banner__link govuk-link" %>
+              <%= link_to services_cookies.dig(:cookie_preferences, :text), services_cookies.dig(:cookie_preferences, :href), class: "govuk-link" %>
             <% end %>
           </div>
         <% else %>
-          <div class="gem-c-cookie-banner__buttons">
-            <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
-              <%= render "govuk_publishing_components/components/button", {
-                text: "Accept all cookies",
-                inline_layout: true,
+          <div class="govuk-button-group">
+            <%= render "govuk_publishing_components/components/button", {
+                name: "cookies",
+                text: "Accept additional cookies",
                 data_attributes: {
                   module: "track-click",
                   "accept-cookies": "true",
                   "track-category": "cookieBanner",
-                  "track-action": "Cookie banner accepted"
+                  "track-action": "Cookie banner accepted",
+                  "cookie-types": "all",
                 }
-              } %>
-            </div>
-            <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
-              <%= render "govuk_publishing_components/components/button", {
-                text: "Set cookie preferences",
-                href: cookie_preferences_href,
-                inline_layout: true,
+            } %>
+            <%= render "govuk_publishing_components/components/button", {
+                name: "cookies",
+                text: "Reject additional cookies",
                 data_attributes: {
                   module: "track-click",
+                  "reject-cookies": "true",
                   "track-category": "cookieBanner",
-                  "track-action": "Cookie banner settings clicked"
+                  "track-action": "Cookie banner rejected",
                 }
-              } %>
-            </div>
+            } %>
+            <a class="govuk-link" href="<%= cookie_preferences_href %>">View cookies</a>
           </div>
         <% end %>
-      </div>
     </div>
   </div>
-
-  <div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1">
+  <div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1" hidden>
     <p class="gem-c-cookie-banner__confirmation-message" role="alert"><%= confirmation_message %></p>
-    <button class="gem-c-cookie-banner__hide-button" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide</button>
+    <div class="govuk-button-group">
+      <button class="gem-c-cookie-banner__hide-button govuk-button" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide this message</button>
+    </div>
   </div>
 </div>

--- a/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/cookie_banner.yml
@@ -1,6 +1,8 @@
 name: Cookie banner
 description: Help users manage their personal data by telling them when you store cookies on their device.
 body: |
+  By default the cookie banner is shown to all users with just a link to the settings page. If JS is on this is enhanced to show accept/reject buttons if preferences aren't set, or to hide the banner if they are.
+
   Setting `data-hide-cookie-banner="true"` on any link inside the banner will overwrite the default action and when clicked will dismiss the cookie banner for a period of 365 days (approx. 1 year).
 
   If the examples below are not showing the banner, make sure the `cookies_preferences_set` cookie is not present or is set to false.
@@ -18,6 +20,13 @@ examples:
       title: "Can we store analytics cookies on your device?"
       text: "This is some custom text in my cookie banner which lets users know what we're using cookies for. I can also include a link to the <a class='govuk-link' href='/cookies'>cookies page</a>"
       confirmation_message: "You’ve accepted all cookies."
+
+  with_multi_paragraph_custom_content:
+    data:
+      title: "Can we store analytics cookies on your device?"
+      text: ["This is some custom text in my cookie banner.","There are three paragraphs.","They are passed as an array"]
+      confirmation_message: "You’ve accepted all cookies."
+
   with_custom_cookie_preferences_href:
     data:
       cookie_preferences_href: "/cookies"

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -8,27 +8,33 @@ describe "Cookie banner", type: :view do
   it "renders with default values" do
     render_component({})
     assert_select '.gem-c-cookie-banner[id="global-cookie-message"][data-module="cookie-banner"]'
-    assert_select ".govuk-width-container .gem-c-cookie-banner__message",
-                  text: "Tell us whether you accept cookies
-          We use cookies to collect information about how you use GOV.UK. We use this information to make the website work as well as possible and improve government services."
+    assert_select ".govuk-cookie-banner__heading", text: "Cookies on GOV.UK"
+    assert_select ".govuk-cookie-banner__content p:nth-child(1)", text: "We use some essential cookies to make this website work."
+    assert_select ".govuk-cookie-banner__content p:nth-child(2)", text: "We’d like to set additional cookies to understand how you use GOV.UK, remember your settings and improve government services."
+    assert_select ".govuk-cookie-banner__content p:nth-child(3)", text: "We also use cookies set by other sites to help us deliver content from their services."
     assert_select 'button[data-hide-cookie-banner="true"]'
   end
 
   it "renders a button for accepting cookies" do
     render_component({})
-    assert_select ".gem-c-cookie-banner__buttons .gem-c-button", text: "Accept all cookies"
-    assert_select '.gem-c-cookie-banner__buttons .gem-c-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner accepted"]'
+    assert_select ".govuk-button-group .gem-c-button", text: "Accept additional cookies"
+    assert_select '.govuk-button-group .gem-c-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner accepted"]'
   end
 
-  it "renders a button for viewing cookie settings" do
+  it "renders a button for rejecting cookies" do
     render_component({})
-    assert_select ".gem-c-cookie-banner__buttons .gem-c-button", text: "Set cookie preferences"
-    assert_select '.gem-c-cookie-banner__buttons .gem-c-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner settings clicked"]'
+    assert_select ".govuk-button-group .gem-c-button", text: "Reject additional cookies"
+    assert_select '.govuk-button-group .gem-c-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner rejected"]'
+  end
+
+  it "renders a link for viewing cookie settings" do
+    render_component({})
+    assert_select ".govuk-button-group .govuk-link", text: "View cookies"
   end
 
   it "renders a confirmation message" do
     render_component({})
-    assert_select ".gem-c-cookie-banner__confirmation-message", text: "You’ve accepted all cookies. You can change your cookie settings at any time."
+    assert_select ".gem-c-cookie-banner__confirmation-message", text: "You can change your cookie settings at any time."
   end
 
   it "renders a link to the settings page within the confirmation message" do
@@ -40,7 +46,7 @@ describe "Cookie banner", type: :view do
   it "renders a hide link within the confirmation banner" do
     render_component({})
 
-    assert_select ".gem-c-cookie-banner__confirmation .gem-c-cookie-banner__hide-button", text: "Hide"
+    assert_select ".gem-c-cookie-banner__confirmation .gem-c-cookie-banner__hide-button", text: "Hide this message"
     assert_select '.gem-c-cookie-banner__hide-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Hide cookie banner"]'
   end
 
@@ -51,15 +57,24 @@ describe "Cookie banner", type: :view do
       confirmation_message: "You’ve accepted all cookies.",
     )
     assert_select ".gem-c-cookie-banner__message .govuk-heading-m", text: "Can we store analytics cookies on your device?"
-    assert_select ".gem-c-cookie-banner__message .govuk-body", text: "This is some custom text with a link to the cookies page"
+    assert_select ".govuk-cookie-banner__content", text: "This is some custom text with a link to the cookies page"
     assert_select ".govuk-link[href='/cookies']", text: "cookies page"
     assert_select ".gem-c-cookie-banner__confirmation-message", text: "You’ve accepted all cookies."
   end
 
+  it "renders with multi paragraph content" do
+    render_component(
+      title: "Can we store analytics cookies on your device?",
+      text: ["Paragraph 1", "Paragraph 2"],
+      confirmation_message: "You’ve accepted all cookies.",
+    )
+    assert_select "p.govuk-body", text: "Paragraph 1"
+    assert_select "p.govuk-body", text: "Paragraph 2"
+  end
+
   it "renders with a custom preferences page link" do
     render_component(cookie_preferences_href: "/cookies")
-    assert_select ".gem-c-cookie-banner__button-settings a[href='/cookies']", text: "Set cookie preferences"
-    assert_select '.gem-c-cookie-banner__button-settings a[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner settings clicked"]'
+    assert_select ".govuk-button-group a[href='/cookies']", text: "View cookies"
 
     # Check that the confirmation message also includes the custom URL
     assert_select ".gem-c-cookie-banner__confirmation-message a[href='/cookies']", text: "change your cookie settings"
@@ -91,8 +106,8 @@ describe "Cookie banner", type: :view do
     )
 
     assert_select ".gem-c-cookie-banner.gem-c-cookie-banner--services"
-    assert_select ".gem-c-cookie-banner__buttons--flex button[data-module=track-click][data-track-category=cookieBanner][data-accept-cookies=true]", text: "Yes"
-    assert_select ".gem-c-cookie-banner__buttons--flex button[data-module=track-click][data-track-category=cookieBanner][data-hide-cookie-banner=true]", text: "No"
-    assert_select ".gem-c-cookie-banner__buttons--flex .gem-c-cookie-banner__link[href='/cookies']", text: "How we use cookies"
+    assert_select ".govuk-button-group button[data-module=track-click][data-track-category=cookieBanner][data-accept-cookies=true]", text: "Yes"
+    assert_select ".govuk-button-group button[data-module=track-click][data-track-category=cookieBanner][data-reject-cookies=true]", text: "No"
+    assert_select ".govuk-button-group .govuk-link[href='/cookies']", text: "How we use cookies"
   end
 end

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -12,22 +12,35 @@ describe('Cookie banner', function () {
 
   beforeEach(function () {
     container = document.createElement('div')
+
     container.innerHTML =
-      '<div id="global-cookie-message" class="gem-c-cookie-banner" data-module="cookie-banner">' +
-        '<div class="gem-c-cookie-banner__wrapper govuk-width-container" data-cookie-banner-main="true">' +
-          '<p class="gem-c-cookie-banner__message">GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised.</p>' +
-          '<div class="gem-c-cookie-banner__buttons">' +
-            '<button class="gem-c-button govuk-button gem-c-button--secondary-quiet gem-c-button--inline" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">Accept cookies</button>' +
-            '<a class="gem-c-button govuk-button gem-c-button--secondary-quiet gem-c-button--inline" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="/help/cookies">Cookie settings</a>' +
+    '<div id="global-cookie-message" class="gem-c-cookie-banner govuk-clearfix" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet="" style="display: block;">' +
+      '<div class="govuk-cookie-banner js-banner-wrapper" role="region" aria-label="Cookies on GOV.UK">' +
+        '<div class="gem-c-cookie-banner__message govuk-cookie-banner__message govuk-width-container govuk-body">' +
+          '<div class="govuk-grid-row">' +
+            '<div class="govuk-grid-column-two-thirds">' +
+              '<h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on GOV.UK</h2>' +
+              '<div class="govuk-cookie-banner__content">' +
+                '<p class="govuk-body">We use some essential cookies to make this website work</p>' +
+                '<p class="govuk-body">We\'d like to set additional cookies to understand how you use GOV.UK, remember your settings and improve government services.</p>' +
+                '<p class="govuk-body">We also use cookies set by other sites to help us deliver content from their services.</p>' +
+              '</div>' +
+            '</div>' +
+          '</div>' +
+          '<div class="govuk-button-group">' +
+            '<button class="gem-c-button govuk-button" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted" data-cookie-types="all" style="display: block;">Accept additional cookies</button>' +
+            '<button class="gem-c-button govuk-button" type="submit" data-module="track-click" data-reject-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner rejected" style="display: block;">Reject additional cookies</button>' +
+            '<a class="govuk-link" href="/help/cookies">View cookies</a>' +
           '</div>' +
         '</div>' +
-        '<div class="gem-c-cookie-banner__confirmation govuk-width-container" data-cookie-banner-confirmation="true" style="display: none;">' +
-          '<p class="gem-c-cookie-banner__confirmation-message">' +
-            'You have accepted all cookies' +
-          '</p>' +
-          '<button class="gem-c-cookie-banner__hide-button" data-hide-cookie-banner="true">Hide</button>' +
+      '</div>' +
+      '<div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1" hidden="">' +
+        '<p class="gem-c-cookie-banner__confirmation-message" role="alert">You can <a class="govuk-link" href="/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.</p>' +
+        '<div class="govuk-button-group">' +
+          '<button class="gem-c-cookie-banner__hide-button govuk-button" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide this message</button>' +
         '</div>' +
-      '</div>'
+      '</div>' +
+    '</div>'
 
     document.body.appendChild(container)
     // set and store consent for all as a basis of comparison
@@ -47,7 +60,7 @@ describe('Cookie banner', function () {
     var element = document.querySelector('[data-module="cookie-banner"]')
     new GOVUK.Modules.CookieBanner().start($(element))
 
-    var cookieBannerMain = document.querySelector('.gem-c-cookie-banner__wrapper')
+    var cookieBannerMain = document.querySelector('.js-banner-wrapper')
     var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
 
     expect(element).toBeVisible()
@@ -62,7 +75,7 @@ describe('Cookie banner', function () {
 
     new GOVUK.Modules.CookieBanner().start($(element))
 
-    var cookieBannerMain = document.querySelector('.gem-c-cookie-banner__wrapper')
+    var cookieBannerMain = document.querySelector('.js-banner-wrapper')
     var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
 
     expect(element).toBeVisible()
@@ -150,8 +163,8 @@ describe('Cookie banner', function () {
     new GOVUK.Modules.CookieBanner().start($(element))
 
     var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
-    var mainCookieBanner = document.querySelector('div[data-cookie-banner-main]')
-    var confirmationMessage = document.querySelector('div[data-cookie-banner-confirmation]')
+    var mainCookieBanner = document.querySelector('.gem-c-cookie-banner__message')
+    var confirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
 
     expect(mainCookieBanner).toBeVisible()
     expect(confirmationMessage).toBeHidden()


### PR DESCRIPTION
## What
Update cookies banner to inherit the Design System cookie banner component

## Why
This brings our cookie banner in line with the design system in terms of look and feel and follows their guidance for compliance. The biggest differences:

- Adds a reject button to the default implementation and plumbs it into the js
- Hides things with the hidden attribute instead of relying on styles (which fails if a user or browser blocks CSS)
- Use the new design system button group for button layout
- Made the hide button on the confirmation message look like a button

## Visual Changes

### Before
![Screenshot 2021-02-12 at 14 40 42](https://user-images.githubusercontent.com/31649453/107781974-6c76ed80-6d40-11eb-86af-965d93af0a67.png)

### After
![Screenshot 2021-02-12 at 14 40 09](https://user-images.githubusercontent.com/31649453/107781976-6d0f8400-6d40-11eb-9dfe-97d47767b4ee.png)

### Before
![Screenshot 2021-02-12 at 14 40 57](https://user-images.githubusercontent.com/31649453/107781973-6c76ed80-6d40-11eb-8d2f-16ed479270ae.png)

### After
![Screenshot 2021-02-12 at 14 41 13](https://user-images.githubusercontent.com/31649453/107781971-6bde5700-6d40-11eb-9f5f-d2e1cd9287da.png)
