### PR TITLE
Update `govuk-frontend` base SCSS imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update `govuk-frontend` base SCSS imports ([PR #1922](https://github.com/alphagov/govuk_publishing_components/pull/1922))
+
 ## 24.1.0
 
 * Update `data-module` on layout header and footer ([PR #1913](https://github.com/alphagov/govuk_publishing_components/pull/1913))

--- a/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
@@ -1,9 +1,7 @@
 // This file should be included in an application prior to specific components
 // It provides govuk-frontend but adds no weight to the compiled CSS
 @import "components/helpers/govuk-frontend-settings";
-@import "govuk/settings/all";
-@import "govuk/tools/all";
-@import "govuk/helpers/all";
+@import "govuk/base";
 $govuk-colours-organisations: map-merge(
   $govuk-colours-organisations,
   (

--- a/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
@@ -2,11 +2,3 @@
 // It provides govuk-frontend but adds no weight to the compiled CSS
 @import "components/helpers/govuk-frontend-settings";
 @import "govuk/base";
-$govuk-colours-organisations: map-merge(
-  $govuk-colours-organisations,
-  (
-    "foreign-commonwealth-development-office": (
-      colour: #012169
-    )
-  )
-);


### PR DESCRIPTION
## What
Clean up `govuk_frontend_support.scss`

## Why
It's [recommended to import base instead of settings, tools, helpers](https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md#import-settings-tools-and-helpers-css-in-one-line) since `govuk-frontend` 3.7.0

The [FCDO colour is already available](https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md#fixes-5) since `govuk-frontend` 3.9.0 

### Note
In `govuk-frontend` 4.0.0 we [won't be able to import `core` and `overrides` without `base`](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/component_support.scss#L4-L7), which means that our [`component_support.scss`](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/component_support.scss) must import [`govuk_frontend_support.scss`](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss) by default [instead of doing it separately/optionally at the app level](https://github.com/alphagov/collections/blob/master/app/assets/stylesheets/application.scss#L7-L8).

## Visual Changes
No visual changes
