### PR TITLE
Remove redundant import in accordion component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update `govuk-frontend` base SCSS imports ([PR #1922](https://github.com/alphagov/govuk_publishing_components/pull/1922))
+* Remove redundant import in accordion component ([PR #1923](https://github.com/alphagov/govuk_publishing_components/pull/1923))
 
 ## 24.1.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
@@ -1,5 +1,3 @@
-@import "govuk_publishing_components/component_support";
-
 $gem-c-accordion-border-width: 3px;
 $gem-c-accordion-bottom-border-width: 1px;
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_accordion.scss
@@ -2,6 +2,7 @@
 //
 // TODO: Replace with the print styles that will come from GOV.UK Frontend.
 
+@import "govuk_publishing_components/component_support";
 @import "../accordion";
 
 // Open all of the accordion sections.


### PR DESCRIPTION
## What
Remove redundant import in the accordion component that was accidentally introduced in #1884. 

We do however need it for the print stylesheet, as we have two [applications requiring the `components/print/accordion` but not the `component_support`](https://github.com/alphagov/collections/blob/master/app/assets/stylesheets/print.scss#L2). This could potentially be fixed in future by removing `component_support` from `print/_accordion` and updating the suggested print imports to include `component_support`.

## Why
This import resulted in a considerable increase in our render-blocking resources.

## Visual Changes
No visual changes
