### PR TITLE
Fix layout_header layout and spacing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Remove redundant import in accordion component ([PR #1923](https://github.com/alphagov/govuk_publishing_components/pull/1923))
 * Fix toggle click tracking on step-by-steps ([PR #1925](https://github.com/alphagov/govuk_publishing_components/pull/1925))
 * Accordion summary design adjustment ([PR #1926](https://github.com/alphagov/govuk_publishing_components/pull/1926))
+* Fix `layout_header` layout and spacing issues ([PR #1924](https://github.com/alphagov/govuk_publishing_components/pull/1924))
 
 ## 24.1.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -31,7 +31,7 @@
 }
 
 .gem-c-layout-header--search-left {
-  .gem-c-header__menu-button {
+  .gem-c-header__menu-button.govuk-header__menu-button {
     margin-top: - govuk-spacing(7);
     left: 0;
   }
@@ -70,7 +70,7 @@
       margin-top: 0;
     }
 
-    .gem-c-header__content {
+    .gem-c-header__content.govuk-header__content {
       @include govuk-grid-column(two-thirds);
       padding-left: govuk-spacing(6);
       padding-right: govuk-spacing(1);
@@ -78,10 +78,16 @@
   }
 }
 
+.gem-c-layout-header__search.govuk-grid-column-one-third-from-desktop,
+.gem-c-layout-header__logo.govuk-grid-column-one-third-from-desktop,
+.gem-c-layout-header__search.govuk-grid-column-one-third,
+.gem-c-layout-header__logo.govuk-grid-column-two-thirds {
+  padding-right: 0;
+  padding-left: 0;
+}
+
 .gem-c-layout-header__logo,
 .gem-c-layout-header__search {
-  padding: 0;
-
   @include govuk-media-query($until: "tablet") {
     margin-bottom: govuk-spacing(3);
   }
@@ -96,8 +102,9 @@
   }
 }
 
-.gem-c-header__content {
+.gem-c-header__content.govuk-header__content {
   width: auto;
+  padding-left: 0;
 
   @include govuk-media-query($from: desktop) {
     float: right;
@@ -158,4 +165,13 @@
   @include govuk-media-query($from: tablet) {
     display: block;
   }
+}
+
+.govuk-header__menu-button.gem-c-header__menu-button {
+  top: govuk-spacing(4);
+  right: 0;
+}
+
+.gem-c-header__nav {
+  clear: both;
 }


### PR DESCRIPTION
## What
Fix header navigation layout issue which happens on tablet breakpoints on GOVUK Accounts. 
Fix spacing issue which occurs when `layout_header` is used by applications using `static`.


## Why
Currently, the layout header component looks different in the context of `static` vs in isolation. This is because this component shares some classes with the hardcoded `#global-header` from static, as well as some layout classes from the Design System.  
- on the account manager, which does not use `static`, the layout header navigation does not align as intended with the rest of the header on tablet breakpoints
### Before
<img width="1334" alt="Screenshot 2021-02-11 at 16 59 55" src="https://user-images.githubusercontent.com/7116819/107673499-f914a380-6c8d-11eb-9bc4-53c40848e814.png">

### After

<img width="1335" alt="Screenshot 2021-02-11 at 16 57 54" src="https://user-images.githubusercontent.com/7116819/107673498-f87c0d00-6c8d-11eb-804f-8afe93cff48c.png">

- in the context of an application that uses `static` (screenshots below are from `finder-frontend`), the layout header  inherits some styles from `static`. Additionally, application CSS conflicts with the `layout_header` CSS resulting in spacing issues, such as extra padding pictured below

Before | After
------------ | -------------
<img width="368" alt="Screenshot 2021-02-11 at 17 09 00" src="https://user-images.githubusercontent.com/7116819/107673925-5577c300-6c8e-11eb-9e82-5616c3cdd661.png"> |  <img width="362" alt="Screenshot 2021-02-11 at 17 09 37" src="https://user-images.githubusercontent.com/7116819/107673928-56105980-6c8e-11eb-8429-3517af13f823.png">


### Before 

<img width="1399" alt="Screenshot 2021-02-11 at 17 01 29" src="https://user-images.githubusercontent.com/7116819/107673917-54df2c80-6c8e-11eb-815f-29eae7695695.png">

### After
<img width="1400" alt="Screenshot 2021-02-11 at 17 02 05" src="https://user-images.githubusercontent.com/7116819/107673921-5577c300-6c8e-11eb-834d-fe8278b0cad6.png">


This aims to address some of these problems by removing unnecessary classes, as well as increasing `layout_header` CSS specificity where this CSS might be overruled by external styles from either `static` or the parent application's stylesheet.
