### PR TITLE
Fix toggle click tracking on step-by-steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Update `govuk-frontend` base SCSS imports ([PR #1922](https://github.com/alphagov/govuk_publishing_components/pull/1922))
 * Remove redundant import in accordion component ([PR #1923](https://github.com/alphagov/govuk_publishing_components/pull/1923))
+* Fix toggle click tracking on step-by-steps ([PR #1925](https://github.com/alphagov/govuk_publishing_components/pull/1925))
 
 ## 24.1.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -141,6 +141,10 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
   .gem-c-step-nav--large & {
     margin-left: em(5, 16);
   }
+
+  svg {
+    pointer-events: none;
+  }
 }
 
 .gem-c-step-nav__button-text {


### PR DESCRIPTION
## What
In #1893 we added an SVG to the step by step navigation continuing to rely on the same logic for tracking, but the way the toggle click tracking script is designed expects the element triggering the click event to be an HTMLElement, not a path element, which causes a hard error and fails to send data to GA. With this change, we avoid capturing events at the SVG level, which means they will bubble and be captured by the parent HTMLElement.

## Why

- step-by-step-nav script fails on pages when users click the SVG element
- we are losing tracking data since 9 Feb

## Visual Changes
No visual changes

Example page: https://www.gov.uk/apply-transit-visa

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1440" alt="before-track" src="https://user-images.githubusercontent.com/788096/107788066-dc3ca680-6d47-11eb-9d3d-e43455fb9d17.png">

</td><td valign="top">

<img width="1436" alt="after-track" src="https://user-images.githubusercontent.com/788096/107788095-e8286880-6d47-11eb-84f4-82c62551e85e.png">

</td></tr>
<tr><td valign="top">

<img width="1439" alt="before-js" src="https://user-images.githubusercontent.com/788096/107788118-f1b1d080-6d47-11eb-9203-8fe60ab37a08.png">


</td><td valign="top">

No JavaScript errors

</td></tr>
</table>
