### PR TITLE
Release 24.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.1.1
 
 * Fix deprecation warnings when running tests ([PR #1899](https://github.com/alphagov/govuk_publishing_components/pull/1899))
 * Update `govuk-frontend` base SCSS imports ([PR #1922](https://github.com/alphagov/govuk_publishing_components/pull/1922))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.1.0)
+    govuk_publishing_components (24.1.1)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.1.0".freeze
+  VERSION = "24.1.1".freeze
 end


### PR DESCRIPTION
## 24.1.1

* Fix deprecation warnings when running tests ([PR #1899](https://github.com/alphagov/govuk_publishing_components/pull/1899))
* Update `govuk-frontend` base SCSS imports ([PR #1922](https://github.com/alphagov/govuk_publishing_components/pull/1922))
* Remove redundant import in accordion component ([PR #1923](https://github.com/alphagov/govuk_publishing_components/pull/1923))
* Fix toggle click tracking on step-by-steps ([PR #1925](https://github.com/alphagov/govuk_publishing_components/pull/1925))
* Accordion summary design adjustment ([PR #1926](https://github.com/alphagov/govuk_publishing_components/pull/1926))
* Fix `layout_header` layout and spacing issues ([PR #1924](https://github.com/alphagov/govuk_publishing_components/pull/1924))
