### PR TITLE
Update success notice component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update success notice component ([PR #1929](https://github.com/alphagov/govuk_publishing_components/pull/1929))
+
 ## 24.8.0
 
 * Add cookie ([PR #1999](https://github.com/alphagov/govuk_publishing_components/pull/1999)) PATCH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,5 +343,8 @@ DEPENDENCIES
   webmock (~> 3.8.3)
   yard
 
+RUBY VERSION
+   ruby 2.6.6p146
+
 BUNDLED WITH
    1.17.3

--- a/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss
@@ -1,36 +1,5 @@
-.gem-c-success-alert {
-  color: $govuk-text-colour;
-  padding: govuk-spacing(3);
-  border: $govuk-border-width-narrow solid $govuk-success-colour;
-  @include govuk-responsive-margin(8, "bottom");
-
-  @include govuk-media-query($from: tablet) {
-    padding: govuk-spacing(4);
-    border-width: $govuk-border-width;
-  }
-}
+@import "govuk/components/notification-banner/notification-banner";
 
 .gem-c-success-alert__message {
   @include govuk-font(19, $weight: bold);
-  margin: 0;
-}
-
-.gem-c-success-summary__title {
-  margin-top: 0;
-  margin-bottom: govuk-spacing(3);
-
-  @include govuk-media-query($from: tablet) {
-    margin-bottom: govuk-spacing(4);
-  }
-
-  @include govuk-font(24, $weight: bold);
-}
-
-.gem-c-success-summary__body {
-  @include govuk-font(19);
-  margin: 0;
-}
-
-.gem-c-success-alert:focus {
-  outline: $govuk-focus-width solid $govuk-focus-colour;
 }

--- a/app/views/govuk_publishing_components/components/_success_alert.html.erb
+++ b/app/views/govuk_publishing_components/components/_success_alert.html.erb
@@ -1,10 +1,25 @@
 <% description ||= nil %>
 
-<%= tag.div class: "gem-c-success-alert", data: { module: "initial-focus" }, role: "alert", tabindex: "-1" do %>
-  <% if description.present? %>
-    <%= tag.h2 message, class: "gem-c-success-summary__title" %>
-    <%= tag.div description, class: "gem-c-success-summary__body" %>
-  <% else %>
-    <%= tag.p message, class: "gem-c-success-alert__message" %>
-  <% end %>
+<%= tag.div class: "gem-c-success-alert govuk-notification-banner govuk-notification-banner--success",
+  role: "alert",
+  tabindex: "-1",
+  aria: {
+    labelledby: "govuk-notification-banner-title",
+  },
+  data: {
+    module: "initial-focus",
+  } do %>
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      <%= t("govuk_component.success_alert.success", default: "Success") %>
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <% if description.present? %>
+      <%= tag.h3 message, class: "govuk-notification-banner__heading" %>
+      <%= tag.div description %>
+    <% else %>
+      <%= tag.p message, class: "govuk-body gem-c-success-alert__message" %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/success_alert.yml
+++ b/app/views/govuk_publishing_components/components/docs/success_alert.yml
@@ -1,5 +1,7 @@
 name: Success alert
 description: Used at the top of the page, to summarise a successful user action.
+govuk_frontend_components:
+  - notification-banner
 accessibility_criteria: |
   - should be focused on page load, to ensure the message is noticed by
     assistive tech

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,8 @@ en:
       hide_password: "Hide password"
       announce_show: "Your password is shown"
       announce_hide: "Your password is hidden"
+    success_alert:
+      success: "Success"
     print_link:
       text: "Print this page"
     skip_link:

--- a/spec/components/success_alert_spec.rb
+++ b/spec/components/success_alert_spec.rb
@@ -5,7 +5,7 @@ describe "Success Alert", type: :view do
     "success_alert"
   end
 
-  it "shows the error message" do
+  it "shows the message" do
     render_component(message: "Foo")
     assert_select ".gem-c-success-alert__message", text: "Foo"
   end
@@ -13,7 +13,7 @@ describe "Success Alert", type: :view do
   it "allows a block to be given for description" do
     render_component(message: "Foo", description: "Bar")
 
-    assert_select ".gem-c-success-summary__title", text: "Foo"
-    assert_select ".gem-c-success-summary__body", text: "Bar"
+    assert_select ".govuk-notification-banner__heading", text: "Foo"
+    assert_select ".govuk-notification-banner__content div", text: "Bar"
   end
 end


### PR DESCRIPTION
## What
Updates the [success alert component](https://components.publishing.service.gov.uk/component-guide/success_alert) to be inline with the design system [success variant of the notification banner component](https://design-system.service.gov.uk/components/notification-banner/).

## Why
This is a final piece of work to make sure that our cookie banner and general cookie strategy is inline with design system guidance. The design system [cookie page](https://design-system.service.gov.uk/patterns/cookies-page/) uses their notifications banner so this is just to make sure we're consistent.

[Card](https://trello.com/c/B3zI99d8/654-make-sure-cookies-page-is-in-line-with-design-system-guidance)

[Relevant page](https://www.gov.uk/help/cookies)

## Visual Changes
### Before
<img width="656" alt="Screenshot 2021-03-25 at 15 44 38" src="https://user-images.githubusercontent.com/64783893/112516804-91bf3880-8d8f-11eb-98ec-ab4160680367.png">

### After
<img width="661" alt="Screenshot 2021-03-25 at 15 55 20" src="https://user-images.githubusercontent.com/64783893/112516822-9552bf80-8d8f-11eb-91c5-f38b2eb5ecb8.png">
