### PR TITLE
Fix govuk-frontend deprecation on component_support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix govuk-frontend deprecation on component_support ([PR #1934](https://github.com/alphagov/govuk_publishing_components/pull/1934))
+
 ## 24.2.0
 
 * Update cookies banner to align it with govuk-frontend ([PR #1918](https://github.com/alphagov/govuk_publishing_components/pull/1918))

--- a/app/assets/stylesheets/govuk_publishing_components/component_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/component_support.scss
@@ -1,6 +1,7 @@
 // This file should be included in an application prior to specific components
 // It provides supporting gem component helpers and mixins
 // and everything else from govuk-frontend not included in govuk_frontend_support
+@import "govuk/base";
 @import "govuk/core/all";
 @import "govuk/objects/all";
 @import "govuk/utilities/all";


### PR DESCRIPTION
govuk-frontend now expects govuk/base to be imported before any other
files.

This fixes deprecation warnings such as:

```
I, [2021-02-16T11:17:55.276774 #25445]  INFO -- : Writing /Users/kevindew/govuk/collections/public/assets/collections/component_guide/visual-regression-7a6fbecb638d5f96b24d97212b0044b0b3d9e195c0ea5543612dba4347f5ec2e.js.gz
WARNING: Importing items from the core layer without first importing `base` is deprecated, and will no longer work as of GOV.UK Frontend v4.0.
         on line 2:3 of ../../.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/govuk_publishing_components-24.1.1/node_modules/govuk-frontend/govuk/core/_links.scss
         from line 1:9 of ../../.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/govuk_publishing_components-24.1.1/node_modules/govuk-frontend/govuk/core/_all.scss
         from line 4:9 of ../../.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/govuk_publishing_components-24.1.1/app/assets/stylesheets/govuk_publishing_components/component_support.scss
         from line 5:9 of ../../.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/govuk_publishing_components-24.1.1/app/assets/stylesheets/govuk_publishing_components/components/print/_accordion.scss
         from line 6:9 of ../../.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/govuk_publishing_components-24.1.1/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
         from line 1:9 of ../../.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/govuk_publishing_components-24.1.1/app/assets/stylesheets/component_guide/print.scss
```

This actual import doesn't output any CSS it just imports files that, as
of GOV.UK Frontend 3.9, are imported automatically [1] and this will no
longer happen in GOV.UK Frontend 4.0.

[1]: https://github.com/alphagov/govuk-frontend/blob/8748418071b7e753a2085b409d10e1c2fb40990e/src/govuk/core/_links.scss#L1-L5
