### PR TITLE
Fix cookie banner preview in the component guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix cookie banner preview in the component guide ([PR #1935](https://github.com/alphagov/govuk_publishing_components/pull/1935))
+
 ## 24.2.0
 
 * Update cookies banner to align it with govuk-frontend ([PR #1918](https://github.com/alphagov/govuk_publishing_components/pull/1918))

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -262,14 +262,6 @@ html {
   }
 }
 
-// Hide survey banner
-// stylelint-disable selector-max-id
-#user-satisfaction-survey-container,
-#global-cookie-message {
-  display: none;
-}
-// stylelint-enable selector-max-id
-
 // Rouge syntax highlighting
 // Based on https://github.com/alphagov/tech-docs-template/blob/master/template/source/stylesheets/palette/_syntax-highlighting.scss
 


### PR DESCRIPTION
## What
Fix cookie banner preview in the component guide

## Why
To be able to check the no-JS version. Fixes #1932.

## Visual Changes
No visual changes (apart from it appearing in the component guide preview).

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1439" alt="Screenshot 2021-02-16 at 13 05 58" src="https://user-images.githubusercontent.com/788096/108066777-bbca6000-7057-11eb-9827-86c70054e8c3.png">


</td><td valign="top">

<img width="1439" alt="Screenshot 2021-02-16 at 13 05 35" src="https://user-images.githubusercontent.com/788096/108066783-be2cba00-7057-11eb-8e55-254191acd525.png">


</td></tr>
</table>
