### PR TITLE
Add spacing to cookie banner confirmation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add spacing to cookie banner confirmation message ([PR #1936](https://github.com/alphagov/govuk_publishing_components/pull/1936))
 * Fix Sass warning for extending a compound selector ([PR #1933](https://github.com/alphagov/govuk_publishing_components/pull/1933))
 
 ## 24.3.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -46,11 +46,18 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
   }
 }
 
+// Override style from design system so we can have consistent
+// padding on the the banner and the confirmation
+
+.govuk-cookie-banner {
+  padding-top: 0;
+}
+
 // Override the styles from govuk_template
 // stylelint-disable selector-max-id
 .gem-c-cookie-banner#global-cookie-message {
   background-color: $govuk-cookie-banner-background;
-  padding: 0;
+  padding: govuk-spacing(3) 0 0 0;
   box-sizing: border-box;
 
   .gem-c-cookie-banner__message,


### PR DESCRIPTION
## What
Add spacing to cookie banner confirmation message

## Why
It currently sits too close to the top of the browser

## Visual Changes

### Before
![Screenshot 2021-02-17 at 11 29 16](https://user-images.githubusercontent.com/31649453/108198502-97cc5480-7113-11eb-815b-c865dab58669.png)

### After
![Screenshot 2021-02-17 at 11 28 53](https://user-images.githubusercontent.com/31649453/108198506-9b5fdb80-7113-11eb-95ec-fc2db766931a.png)

![Screenshot 2021-02-17 at 11 35 28](https://user-images.githubusercontent.com/31649453/108198961-3c4e9680-7114-11eb-93d9-2d7d01db90b3.png)
