### PR TITLE
Add anchor navigation feature to accordions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fix cookie banner preview in the component guide ([PR #1935](https://github.com/alphagov/govuk_publishing_components/pull/1935))
 * Implements scroll tracking for the covid pages ([PR #1942](https://github.com/alphagov/govuk_publishing_components/pull/1942))
+* Add anchor navigation feature to accordions ([PR #1937](https://github.com/alphagov/govuk_publishing_components/pull/1937))
 
 ## 24.2.0
 

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -5,6 +5,7 @@
   id ||= "default-id-#{SecureRandom.hex(4)}"
   items ||= []
   condensed ||= false
+  anchor_navigation ||= false
 
   accordion_classes = %w(gem-c-accordion)
   accordion_classes << 'gem-c-accordion--condensed' if condensed
@@ -12,14 +13,13 @@
 
   data_attributes ||= {}
   data_attributes[:module] = 'gem-accordion'
+  data_attributes[:anchor_navigation] = anchor_navigation
 %>
 <% if items.any? %>
   <%= tag.div(class: accordion_classes, id: id, data: data_attributes) do %>
     <% items.each_with_index do |item, i| %>
       <%
         index = i + 1
-
-        item[:data_attributes] ||= nil
 
         section_classes = %w(gem-c-accordion__section)
         section_classes << 'gem-c-accordion__section--expanded' if item[:expanded]
@@ -29,7 +29,7 @@
 
       <%= tag.section(class: section_classes) do %>
         <div class="gem-c-accordion__section-header">
-          <%= content_tag(shared_helper.get_heading_level, class: 'gem-c-accordion__section-heading') do %>
+          <%= content_tag(shared_helper.get_heading_level, class: 'gem-c-accordion__section-heading', id: item[:heading][:id]) do %>
             <%= tag.span(item[:heading][:text], id: "#{id}-heading-#{index}", data: item[:data_attributes], class: 'gem-c-accordion__section-button') %>
           <% end %>
           <%= tag.div(item[:summary][:text], id: "#{id}-summary-#{index}", class: summary_classes) if item[:summary].present? %>

--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -274,6 +274,35 @@ examples:
             text: "How people read"
           content:
             html: "<p class='govuk-body'>This is the content for How people read.</p>"
+  with_the_anchor_link_navigation:
+    description: |
+      Some apps require custom ids per accordion section heading for linking between those specific sections, sometimes across multiple pages. An example of this is on manuals pages where multiple manuals will each include large sets of accordions and will reference between specific sections for ease of access to that content. [Live example](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#associations).
+
+      This feature automatically opens accordions when an anchor link is clicked within another accordion that links to either the id of an accordion section heading or an id within the content of an accordion. This will also automatically navigate to and open accordions on page load using the same rules.
+
+      This feature won't be used if the `anchor_navigation` flag isn't passed as true to mitigate performance risk from event listeners on a large number of links.
+
+      Unlike with the accordion-wide custom id attribute, any ids passed to accordion headings as part of this feature aren't stored in `localStorage` so don't need to be unique across your domain, but **should still be unique in the context of the page**.
+    data:
+      anchor_navigation: true
+      items:
+        - heading:
+            text: "Writing well for the web"
+            id: "writing-well-for-the-web"
+          content:
+            html: "<p class='govuk-body'>This is the content for Writing well for the web.</p>"
+        - heading:
+            text: "Writing well for specialists"
+          content:
+            html: "<p class='govuk-body'>This is the content for Writing well for specialists.</p>"
+        - heading:
+            text: "Know your audience"
+          content:
+            html: "<p class='govuk-body'>This is the content for Know your audience.</p>"
+        - heading:
+            text: "How people read"
+          content:
+            html: "<p class='govuk-body'>This is the content for How people read.</p>"
   condensed_layout:
     description: |
       This is for when a smaller accordion is required. Since smaller screens trigger a single column layout, this modifier only makes the accordion smaller when viewed on large screens.

--- a/spec/components/accordion_spec.rb
+++ b/spec/components/accordion_spec.rb
@@ -13,18 +13,20 @@ describe "Accordion", type: :view do
   it "places the title and content correctly" do
     test_data = {
       id: "test-for-heading-and-content",
-      items: [{
-        heading: { text: "Heading 1" },
-        content: { html: "<p>Content 1.</p>" },
-      },
-              {
-                heading: { text: "Heading 2" },
-                content: { html: "<p>Content 2.</p>" },
-              },
-              {
-                heading: { text: "Heading 3" },
-                content: { html: "<p>Content 3.</p>" },
-              }],
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          content: { html: "<p>Content 1.</p>" },
+        },
+        {
+          heading: { text: "Heading 2" },
+          content: { html: "<p>Content 2.</p>" },
+        },
+        {
+          heading: { text: "Heading 3" },
+          content: { html: "<p>Content 3.</p>" },
+        },
+      ],
     }
 
     render_component(test_data)
@@ -42,16 +44,18 @@ describe "Accordion", type: :view do
   it "uses the correct id, and interpolates it correctly" do
     test_data = {
       id: "test-for-id",
-      items: [{
-        heading: { text: "Heading 1" },
-        summary: { text: "Summary 1." },
-        content: { html: "<p>Content 1.</p>" },
-      },
-              {
-                heading: { text: "Heading 2" },
-                summary: { text: "Summary 2." },
-                content: { html: "<p>Content 2.</p>" },
-              }],
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          summary: { text: "Summary 1." },
+          content: { html: "<p>Content 1.</p>" },
+        },
+        {
+          heading: { text: "Heading 2" },
+          summary: { text: "Summary 2." },
+          content: { html: "<p>Content 2.</p>" },
+        },
+      ],
     }
 
     render_component(test_data)
@@ -64,11 +68,13 @@ describe "Accordion", type: :view do
 
   it "an id is created when no id is set" do
     test_data = {
-      items: [{
-        heading: { text: "Heading 1" },
-        summary: { text: "Summary 1." },
-        content: { html: "<p>Content 1.</p>" },
-      }],
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          summary: { text: "Summary 1." },
+          content: { html: "<p>Content 1.</p>" },
+        },
+      ],
     }
 
     render_component(test_data)
@@ -86,11 +92,13 @@ describe "Accordion", type: :view do
     test_data = {
       id: "heading-level-change",
       heading_level: 5,
-      items: [{
-        heading: { text: "Heading 1" },
-        summary: { text: "Summary 1." },
-        content: { html: "<p>Content 1.</p>" },
-      }],
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          summary: { text: "Summary 1." },
+          content: { html: "<p>Content 1.</p>" },
+        },
+      ],
     }
     render_component(test_data)
     assert_select "h5", count: 1
@@ -98,11 +106,13 @@ describe "Accordion", type: :view do
 
   it "sets a default margin bottom" do
     test_data = {
-      items: [{
-        heading: { text: "Heading 1" },
-        summary: { text: "Summary 1." },
-        content: { html: "<p>Content 1.</p>" },
-      }],
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          summary: { text: "Summary 1." },
+          content: { html: "<p>Content 1.</p>" },
+        },
+      ],
     }
 
     render_component(test_data)
@@ -112,11 +122,13 @@ describe "Accordion", type: :view do
   it "sets a custom margin bottom" do
     test_data = {
       margin_bottom: 0,
-      items: [{
-        heading: { text: "Heading 1" },
-        summary: { text: "Summary 1." },
-        content: { html: "<p>Content 1.</p>" },
-      }],
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          summary: { text: "Summary 1." },
+          content: { html: "<p>Content 1.</p>" },
+        },
+      ],
     }
 
     render_component(test_data)
@@ -126,11 +138,13 @@ describe "Accordion", type: :view do
   it "default heading level is used when heading_level is not set" do
     test_data = {
       id: "heading-level-default",
-      items: [{
-        heading: { text: "Heading 1" },
-        summary: { text: "Summary 1." },
-        content: { html: "<p>Content 1.</p>" },
-      }],
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          summary: { text: "Summary 1." },
+          content: { html: "<p>Content 1.</p>" },
+        },
+      ],
     }
 
     render_component(test_data)
@@ -140,16 +154,18 @@ describe "Accordion", type: :view do
   it "data attribute is present when required" do
     test_data = {
       id: "test-for-data-attributes",
-      items: [{
-        heading: { text: "Heading 1" },
-        content: { html: "<p>Content 1.</p>" },
-        data_attributes: { gtm: "google-tag-manager" },
-      },
-              {
-                heading: { text: "Heading 2" },
-                content: { html: "<p>Content 2.</p>" },
-                data_attributes: { gtm: "google-tag-manager" },
-              }],
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          content: { html: "<p>Content 1.</p>" },
+          data_attributes: { gtm: "google-tag-manager" },
+        },
+        {
+          heading: { text: "Heading 2" },
+          content: { html: "<p>Content 2.</p>" },
+          data_attributes: { gtm: "google-tag-manager" },
+        },
+      ],
     }
 
     render_component(test_data)
@@ -161,14 +177,16 @@ describe "Accordion", type: :view do
   it '`data-module="gem-accordion"` attribute is present when no custom data attributes given' do
     test_data = {
       id: "test-for-module-data-attributes",
-      items: [{
-        heading: { text: "Heading 1" },
-        content: { html: "<p>Content 1.</p>" },
-      },
-              {
-                heading: { text: "Heading 2" },
-                content: { html: "<p>Content 2.</p>" },
-              }],
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          content: { html: "<p>Content 1.</p>" },
+        },
+        {
+          heading: { text: "Heading 2" },
+          content: { html: "<p>Content 2.</p>" },
+        },
+      ],
     }
     render_component(test_data)
     assert_select "[data-module='gem-accordion']", count: 1
@@ -180,20 +198,22 @@ describe "Accordion", type: :view do
       data_attributes: {
         accordion: "first",
       },
-      items: [{
-        data_attributes: {
-          gtm: "this-is-gtm",
+      items: [
+        {
+          data_attributes: {
+            gtm: "this-is-gtm",
+          },
+          heading: { text: "Heading 1" },
+          content: { html: "<p>Content 1.</p>" },
         },
-        heading: { text: "Heading 1" },
-        content: { html: "<p>Content 1.</p>" },
-      },
-              {
-                data_attributes: {
-                  gtm: "this-is-a-second-gtm",
-                },
-                heading: { text: "Heading 2" },
-                content: { html: "<p>Content 2.</p>" },
-              }],
+        {
+          data_attributes: {
+            gtm: "this-is-a-second-gtm",
+          },
+          heading: { text: "Heading 2" },
+          content: { html: "<p>Content 2.</p>" },
+        },
+      ],
     }
     render_component(test_data)
     assert_select "[data-module='gem-accordion']", count: 1
@@ -207,32 +227,59 @@ describe "Accordion", type: :view do
     test_data = {
       id: "condensed-layout",
       condensed: true,
-      items: [{
-        heading: { text: "Heading 1" },
-        summary: { text: "Summary 1." },
-        content: { html: "<p>Content 1.</p>" },
-        expanded: true,
-      },
-              {
-                heading: { text: "Heading 2" },
-                summary: { text: "Summary 2." },
-                content: { html: "<p>Content 2.</p>" },
-              }],
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          summary: { text: "Summary 1." },
+          content: { html: "<p>Content 1.</p>" },
+          expanded: true,
+        },
+        {
+          heading: { text: "Heading 2" },
+          summary: { text: "Summary 2." },
+          content: { html: "<p>Content 2.</p>" },
+        },
+      ],
     }
     render_component(test_data)
     assert_select ".gem-c-accordion__section.gem-c-accordion__section--expanded", count: 1
     assert_select ".gem-c-accordion__section", count: 2
   end
 
+  it "adds id to heading when attribute passed" do
+    test_data = {
+      id: "condensed-layout",
+      condensed: true,
+      items: [
+        {
+          heading: { text: "Heading 1", id: "heading-with-id" },
+          summary: { text: "Summary 1." },
+          content: { html: "<p>Content 1.</p>" },
+        },
+        {
+          heading: { text: "Heading 2" },
+          summary: { text: "Summary 2." },
+          content: { html: "<p>Content 2.</p>" },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select ".gem-c-accordion__section-heading", count: 2
+    assert_select ".gem-c-accordion__section-heading#heading-with-id", count: 1
+    assert_select ".gem-c-accordion__section-heading:not([id])", count: 1
+  end
+
   it "condensed class added correctly" do
     test_data = {
       id: "condensed-layout",
       condensed: true,
-      items: [{
-        heading: { text: "Heading 1" },
-        summary: { text: "Summary 1." },
-        content: { html: "<p>Content 1.</p>" },
-      }],
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          summary: { text: "Summary 1." },
+          content: { html: "<p>Content 1.</p>" },
+        },
+      ],
     }
     render_component(test_data)
     assert_select ".gem-c-accordion.gem-c-accordion--condensed", count: 1
@@ -241,11 +288,13 @@ describe "Accordion", type: :view do
   it "loop index starts at one, not zero (thanks Nunjucks.)" do
     test_data = {
       id: "thanks-nunjucks",
-      items: [{
-        heading: { text: "Heading 1" },
-        summary: { text: "Summary 1." },
-        content: { html: "<p>Content 1.</p>" },
-      }],
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          summary: { text: "Summary 1." },
+          content: { html: "<p>Content 1.</p>" },
+        },
+      ],
     }
 
     render_component(test_data)


### PR DESCRIPTION
## What
Applies an optional anchor navigation feature to accordions. This allows anchor links within accordions to:

- link to another accordion heading on the same page and automatically open that accordion
- link to an id anchor within an accordion on the same page and automatically open the containing accordion
- link to either of the above on different pages with the same setup (accordions with this feature flag) and open the associated accordion as above.

Additionally fixes a couple of typos in the accordions js and removes a line specifying data_attributes as `nil`. The latter is unnecessary and generates an extra `null` attribute on every item on the docs.

## Why
On manuals, there was previously a function to link between individual sections in manuals for ease of content. This was done by linking via an id anchor and the old bespoke manuals accordion js would work this out and open the accordion. This feature was overlooked in the recent update to manual accordions, leaving a lot of broken links and potentially confusing user journeys across manuals. There's a question to be answered about how accessible this functionality is, however for the moment this PR repairs the bug without having to undo the accordion changes and re-introducing a WCAG 2.3.4 failure.

No visual changes.
