### PR TITLE
Implements scroll tracking for the covid pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix cookie banner preview in the component guide ([PR #1935](https://github.com/alphagov/govuk_publishing_components/pull/1935))
+* Implements scroll tracking for the covid pages ([PR #1942](https://github.com/alphagov/govuk_publishing_components/pull/1942))
 
 ## 24.2.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js
@@ -405,6 +405,34 @@
     ],
     '/eubusiness': [
       ['Heading', 'Additional help and support']
+    ],
+    '/coronavirus': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
+    ],
+    '/coronavirus/education-and-childcare': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
+    ],
+    '/coronavirus/worker-support': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
+    ],
+    '/coronavirus/business-support': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
     ]
   }
 


### PR DESCRIPTION
## What

Implement scroll tracking to coronavirus landing pages.

We will use the percentage format to track.

```
'/coronavirus': [
      ['Percent', 20],
      ['Percent', 40],
      ['Percent', 60],
      ['Percent', 80],
      ['Percent', 100]
    ],
```

All code changes sit here: https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js

## Why

We want to understand how far down the page users are going so we know that users are getting the relevant information.

https://trello.com/c/VRNHtbkc/162-scroll-tracking-on-landing-page