### PR TITLE
Switch from trackClick to gemTrackClick script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Switch from `trackClick` to `gemTrackClick` script ([PR #1944](https://github.com/alphagov/govuk_publishing_components/pull/1944))
 * Add spacing to cookie banner confirmation message ([PR #1936](https://github.com/alphagov/govuk_publishing_components/pull/1936))
 * Fix Sass warning for extending a compound selector ([PR #1933](https://github.com/alphagov/govuk_publishing_components/pull/1933))
 

--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -13,7 +13,7 @@
   <%= raw JSON.pretty_generate(breadcrumb_presenter.structured_data) %>
 </script>
 
-<div class="<%= classes %>" data-module="track-click">
+<div class="<%= classes %>" data-module="gem-track-click">
   <ol class="govuk-breadcrumbs__list">
     <% breadcrumbs.each_with_index do |crumb, index| %>
       <% breadcrumb = GovukPublishingComponents::Presenters::Breadcrumb.new(crumb, index) %>

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -15,7 +15,7 @@
     "aria-label": aria_label,
     role: "navigation",
     data: {
-      module: "track-click"
+      module: "gem-track-click"
     }
   ) do %>
     <%= content_tag(

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -14,7 +14,7 @@
   text = raw(text)
 
   cookie_preferences_href ||= "/help/cookies"
-  confirmation_message ||= raw("You can <a class='govuk-link' href='#{cookie_preferences_href}' data-module='track-click' data-track-category='cookieBanner' data-track-action='Cookie banner settings clicked from confirmation'>change your cookie settings</a> at any time.")
+  confirmation_message ||= raw("You can <a class='govuk-link' href='#{cookie_preferences_href}' data-module='gem-track-click' data-track-category='cookieBanner' data-track-action='Cookie banner settings clicked from confirmation'>change your cookie settings</a> at any time.")
   services_cookies ||= nil
   css_classes = %w(gem-c-cookie-banner govuk-clearfix)
   css_classes << "gem-c-cookie-banner--services" if services_cookies
@@ -35,12 +35,12 @@
             <%= render "govuk_publishing_components/components/button", {
               name: "cookies",
               text: services_cookies.dig(:yes, :text) || "Yes",
-              data_attributes: { module: "track-click", "accept-cookies": "true", }.merge(services_cookies.dig(:yes, :data_attributes) || {})
+              data_attributes: { module: "gem-track-click", "accept-cookies": "true", }.merge(services_cookies.dig(:yes, :data_attributes) || {})
             } %>
             <%= render "govuk_publishing_components/components/button", {
               name: "cookies",
               text: services_cookies.dig(:no, :text) || "No",
-              data_attributes: { module: "track-click", "reject-cookies": "true", }.merge(services_cookies.dig(:no, :data_attributes) || {})
+              data_attributes: { module: "gem-track-click", "reject-cookies": "true", }.merge(services_cookies.dig(:no, :data_attributes) || {})
             } %>
             <% if services_cookies[:cookie_preferences] %>
               <%= link_to services_cookies.dig(:cookie_preferences, :text), services_cookies.dig(:cookie_preferences, :href), class: "govuk-link" %>
@@ -52,7 +52,7 @@
                 name: "cookies",
                 text: "Accept additional cookies",
                 data_attributes: {
-                  module: "track-click",
+                  module: "gem-track-click",
                   "accept-cookies": "true",
                   "track-category": "cookieBanner",
                   "track-action": "Cookie banner accepted",
@@ -63,7 +63,7 @@
                 name: "cookies",
                 text: "Reject additional cookies",
                 data_attributes: {
-                  module: "track-click",
+                  module: "gem-track-click",
                   "reject-cookies": "true",
                   "track-category": "cookieBanner",
                   "track-action": "Cookie banner rejected",
@@ -77,7 +77,7 @@
   <div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1" hidden>
     <p class="gem-c-cookie-banner__confirmation-message" role="alert"><%= confirmation_message %></p>
     <div class="govuk-button-group">
-      <button class="gem-c-cookie-banner__hide-button govuk-button" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide this message</button>
+      <button class="gem-c-cookie-banner__hide-button govuk-button" data-hide-cookie-banner="true" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide this message</button>
     </div>
   </div>
 </div>

--- a/app/views/govuk_publishing_components/components/_highlight_boxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_highlight_boxes.html.erb
@@ -9,7 +9,7 @@
 %>
 <% if items.any? %>
   <% unless within_multitype_list %>
-    <ol class="gem-c-highlight-boxes" <%= "data-module=track-click" if highlight_boxes_helper.data_tracking? %>>
+    <ol class="gem-c-highlight-boxes" <%= "data-module=gem-track-click" if highlight_boxes_helper.data_tracking? %>>
   <% end %>
     <% items.each do |content_item| %>
       <li class="gem-c-highlight-boxes__item-wrapper <%= half_width_class %>">

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -9,7 +9,7 @@
 %>
 <% if card_helper.href || card_helper.extra_links.any? %>
   <div class="<%= classes %> <%= brand_helper.brand_class %>"
-    <%= "data-module=track-click" if card_helper.is_tracking? %>
+    <%= "data-module=gem-track-click" if card_helper.is_tracking? %>
     <%= "lang=#{card_helper.lang}" if card_helper.lang %>>
     <div class="gem-c-image-card__text-wrapper">
       <div class="gem-c-image-card__header-and-context-wrapper">

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -16,7 +16,7 @@
   classes << "gem-c-metadata--inverse" if inverse
 %>
 <%= content_tag :div, class: classes, data: { module: "gem-toggle" } do %>
-  <dl data-module="track-click">
+  <dl data-module="gem-track-click">
     <% if from.any? %>
       <dt class="gem-c-metadata__term"><%= t("govuk_component.metadata.from", default: "From") %>:</dt>
       <dd class="gem-c-metadata__definition">

--- a/app/views/govuk_publishing_components/components/_organisation_logo.html.erb
+++ b/app/views/govuk_publishing_components/components/_organisation_logo.html.erb
@@ -26,7 +26,7 @@
 %>
 <<%= wrapping_element %>
   class="<%= wrapper_classes.join(" ") %>"
-  <%= "data-module=track-click" if organisation[:data_attributes] %>
+  <%= "data-module=gem-track-click" if organisation[:data_attributes] %>
 >
   <% if organisation[:url] %>
     <%= link_to organisation[:url],

--- a/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
@@ -4,7 +4,7 @@
   role="navigation"
   aria-label="<%= t("govuk_component.previous_and_next_navigation.pagination", default: "Pagination") %>"
 >
-  <ul class="gem-c-pagination__list" data-module="track-click">
+  <ul class="gem-c-pagination__list" data-module="gem-track-click">
     <% if local_assigns.include?(:previous_page) %>
       <li class="gem-c-pagination__item gem-c-pagination__item--previous">
         <a href="<%= previous_page[:url] %>"

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -14,7 +14,7 @@
   classes << brand_helper.brand_class
 
   data_attributes ||= {}
-  data_attributes[:module] = 'track-click'
+  data_attributes[:module] = 'gem-track-click'
 %>
 <% if links.any? %>
   <%= tag.div(class: classes, data: data_attributes) do %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
@@ -28,7 +28,7 @@
     <%= raw JSON.pretty_generate(breadcrumb_presenter.structured_data) %>
   </script>
 
-  <h2 class="<%= classes %>" data-module="track-click">
+  <h2 class="<%= classes %>" data-module="gem-track-click">
     <span class="gem-c-step-nav-header__part-of">Part of</span>
     <% if path %>
       <a href="<%= path %>"

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -6,7 +6,7 @@
 <% if links.any? %>
   <div 
     class="gem-c-step-nav-related <%= "gem-c-step-nav-related--singular" if links.length == 1 %>" 
-    data-module="track-click">
+    data-module="gem-track-click">
     <h2 class="gem-c-step-nav-related__heading">
       <span class="gem-c-step-nav-related__pretitle"><%= pretitle %></span>
       <% if links.length == 1 && !always_display_as_list %>

--- a/app/views/govuk_publishing_components/components/_subscription_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription_links.html.erb
@@ -27,7 +27,7 @@
     <% end %>
     <ul
       class="gem-c-subscription-links__list<%= ' gem-c-subscription-links__list--small' if local_assigns[:small_form] == true %>"
-      <%= "data-module=track-click" if sl_helper.tracking_is_present? %>
+      <%= "data-module=gem-track-click" if sl_helper.tracking_is_present? %>
     >
       <% if sl_helper.email_signup_link.present? %>
         <li class="gem-c-subscription-links__list-item<%= ' gem-c-subscription-links__list-item--small' if local_assigns[:small_form] == true %>" >

--- a/app/views/govuk_publishing_components/components/_taxonomy_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_taxonomy_list.html.erb
@@ -9,7 +9,7 @@
   taxonomy_list_helper = GovukPublishingComponents::Presenters::TaxonomyListHelper.new(image_cards)
 %>
 <% if highlight_box || document_list || image_cards %>
-  <ul class="gem-c-taxonomy-list" data-module="track-click">
+  <ul class="gem-c-taxonomy-list" data-module="gem-track-click">
     <% if image_cards %>
       <% taxonomy_list_helper.image_card_data.each do |image_card| %>
         <li class="gem-c-taxonomy-list__item">

--- a/app/views/govuk_publishing_components/components/_translation_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_translation_nav.html.erb
@@ -7,7 +7,7 @@
   <nav role="navigation"
     class="gem-c-translation-nav <%= translation_helper.classes %> <%= brand_helper.brand_class %>"
     aria-label="<%= t("common.translations") %>"
-    <%= "data-module=\"track-click\"" if translation_helper.tracking_is_present? %>
+    <%= "data-module=\"gem-track-click\"" if translation_helper.tracking_is_present? %>
   >
     <ul class="gem-c-translation-nav__list">
       <% translation_helper.translations.each.with_index do |translation, i| %>

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
@@ -3,7 +3,7 @@
 <% link_path = t("components.related_navigation.transition.link_path") %>
 
 <% data_attributes = {
-  "module": "track-click",
+  "module": "gem-track-click",
   "track-category": "relatedLinkClicked",
   "track-action": "1.0 Transition",
   "track-label": link_path,

--- a/app/views/govuk_publishing_components/components/docs/inverse_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/inverse_header.yml
@@ -45,7 +45,7 @@ examples:
     data:
       padding_top: false
       block: |
-        <div class="gem-c-breadcrumbs " data-module="track-click">
+        <div class="gem-c-breadcrumbs " data-module="gem-track-click">
           <ol>
             <li class="">
                 <a data-track-category="breadcrumbClicked" data-track-action="1" data-track-label="/section" data-track-options="{&quot;dimension28&quot;:&quot;2&quot;,&quot;dimension29&quot;:&quot;Section&quot;}" class="gem-c-breadcrumbs--inverse" aria-current="false" href="/section">Section</a>

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -16,7 +16,7 @@
     %>
   <% end %>
 
-  <ul class="gem-c-related-navigation__link-list" data-module="track-click">
+  <ul class="gem-c-related-navigation__link-list" data-module="gem-track-click">
     <% constructed_link_array = [] %>
 
     <% section_link_limit = related_nav_helper.calculate_section_link_limit(links) %>

--- a/spec/components/breadcrumbs_spec.rb
+++ b/spec/components/breadcrumbs_spec.rb
@@ -60,7 +60,7 @@ describe "Breadcrumbs", type: :view do
       dimension29: "Section",
     }
 
-    assert_select '.gem-c-breadcrumbs[data-module="track-click"]', 1
+    assert_select '.gem-c-breadcrumbs[data-module="gem-track-click"]', 1
     assert_select '.govuk-breadcrumbs__list-item:first-child a[data-track-action="1"]', 1
     assert_select '.govuk-breadcrumbs__list-item:first-child a[data-track-label="/section"]', 1
     assert_select '.govuk-breadcrumbs__list-item:first-child a[data-track-category="breadcrumbClicked"]', 1
@@ -75,7 +75,7 @@ describe "Breadcrumbs", type: :view do
       dimension29: "Section",
     }
 
-    assert_select '.gem-c-breadcrumbs[data-module="track-click"]', 1
+    assert_select '.gem-c-breadcrumbs[data-module="gem-track-click"]', 1
 
     assert_select '.govuk-breadcrumbs__list-item:nth-child(1) a[data-track-action="1"]', 1
     assert_select '.govuk-breadcrumbs__list-item:nth-child(1) a[data-track-label="/section"]', 1

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -83,7 +83,7 @@ describe "Contents list", type: :view do
   it "renders data attributes for tracking" do
     render_component(contents: nested_contents_list)
 
-    assert_select ".gem-c-contents-list[data-module='track-click']"
+    assert_select ".gem-c-contents-list[data-module='gem-track-click']"
 
     assert_tracking_link("category", "contentsClicked", 6)
     assert_tracking_link("action", "content_item 1")

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -18,13 +18,13 @@ describe "Cookie banner", type: :view do
   it "renders a button for accepting cookies" do
     render_component({})
     assert_select ".govuk-button-group .gem-c-button", text: "Accept additional cookies"
-    assert_select '.govuk-button-group .gem-c-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner accepted"]'
+    assert_select '.govuk-button-group .gem-c-button[data-module=gem-track-click][data-track-category=cookieBanner][data-track-action="Cookie banner accepted"]'
   end
 
   it "renders a button for rejecting cookies" do
     render_component({})
     assert_select ".govuk-button-group .gem-c-button", text: "Reject additional cookies"
-    assert_select '.govuk-button-group .gem-c-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner rejected"]'
+    assert_select '.govuk-button-group .gem-c-button[data-module=gem-track-click][data-track-category=cookieBanner][data-track-action="Cookie banner rejected"]'
   end
 
   it "renders a link for viewing cookie settings" do
@@ -40,14 +40,14 @@ describe "Cookie banner", type: :view do
   it "renders a link to the settings page within the confirmation message" do
     render_component({})
     assert_select ".gem-c-cookie-banner__confirmation-message a", text: "change your cookie settings"
-    assert_select '.gem-c-cookie-banner__confirmation-message a[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner settings clicked from confirmation"]'
+    assert_select '.gem-c-cookie-banner__confirmation-message a[data-module=gem-track-click][data-track-category=cookieBanner][data-track-action="Cookie banner settings clicked from confirmation"]'
   end
 
   it "renders a hide link within the confirmation banner" do
     render_component({})
 
     assert_select ".gem-c-cookie-banner__confirmation .gem-c-cookie-banner__hide-button", text: "Hide this message"
-    assert_select '.gem-c-cookie-banner__hide-button[data-module=track-click][data-track-category=cookieBanner][data-track-action="Hide cookie banner"]'
+    assert_select '.gem-c-cookie-banner__hide-button[data-module=gem-track-click][data-track-category=cookieBanner][data-track-action="Hide cookie banner"]'
   end
 
   it "renders with custom content" do
@@ -78,7 +78,7 @@ describe "Cookie banner", type: :view do
 
     # Check that the confirmation message also includes the custom URL
     assert_select ".gem-c-cookie-banner__confirmation-message a[href='/cookies']", text: "change your cookie settings"
-    assert_select '.gem-c-cookie-banner__confirmation-message a[data-module=track-click][data-track-category=cookieBanner][data-track-action="Cookie banner settings clicked from confirmation"]'
+    assert_select '.gem-c-cookie-banner__confirmation-message a[data-module=gem-track-click][data-track-category=cookieBanner][data-track-action="Cookie banner settings clicked from confirmation"]'
   end
 
   it "renders the 'analytics only' version" do
@@ -106,8 +106,8 @@ describe "Cookie banner", type: :view do
     )
 
     assert_select ".gem-c-cookie-banner.gem-c-cookie-banner--services"
-    assert_select ".govuk-button-group button[data-module=track-click][data-track-category=cookieBanner][data-accept-cookies=true]", text: "Yes"
-    assert_select ".govuk-button-group button[data-module=track-click][data-track-category=cookieBanner][data-reject-cookies=true]", text: "No"
+    assert_select ".govuk-button-group button[data-module=gem-track-click][data-track-category=cookieBanner][data-accept-cookies=true]", text: "Yes"
+    assert_select ".govuk-button-group button[data-module=gem-track-click][data-track-category=cookieBanner][data-reject-cookies=true]", text: "No"
     assert_select ".govuk-button-group .govuk-link[href='/cookies']", text: "How we use cookies"
   end
 end

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -12,7 +12,7 @@ describe "ImageCard", type: :view do
   it "shows an image" do
     render_component(href: "#", image_src: "/moo.jpg", image_alt: "some meaningful alt text")
     assert_select ".gem-c-image-card .gem-c-image-card__image[src='/moo.jpg'][alt='some meaningful alt text']"
-    assert_select ".gem-c-image-card[data-module='track-click']", false
+    assert_select ".gem-c-image-card[data-module='gem-track-click']", false
   end
 
   it "shows heading text" do
@@ -89,13 +89,13 @@ describe "ImageCard", type: :view do
 
   it "applies tracking attributes" do
     render_component(href: "#", href_data_attributes: { track_category: "cat" }, heading_text: "test")
-    assert_select ".gem-c-image-card[data-module='track-click']"
+    assert_select ".gem-c-image-card[data-module='gem-track-click']"
     assert_select ".gem-c-image-card__title-link[data-track-category='cat']"
   end
 
   it "applies tracking attributes for extra links" do
     render_component(href: "#", extra_links: [{ href: "/", text: "1", data_attributes: { track_category: "cat" } }])
-    assert_select ".gem-c-image-card[data-module='track-click']"
+    assert_select ".gem-c-image-card[data-module='gem-track-click']"
     assert_select ".gem-c-image-card__list-item a[data-track-category='cat']"
   end
 

--- a/spec/components/organisation_logo_spec.rb
+++ b/spec/components/organisation_logo_spec.rb
@@ -55,7 +55,7 @@ describe "Organisation logo", type: :view do
 
     render_component(organisation: { url: "/some-link", data_attributes: data_attributes })
 
-    assert_select ".gem-c-organisation-logo[data-module='track-click']"
+    assert_select ".gem-c-organisation-logo[data-module='gem-track-click']"
     assert_select ".gem-c-organisation-logo a.gem-c-organisation-logo__container.gem-c-organisation-logo__link[data-track-category='someLinkClicked']"
     assert_select ".gem-c-organisation-logo a.gem-c-organisation-logo__container.gem-c-organisation-logo__link[data-track-action='1']"
     assert_select ".gem-c-organisation-logo a.gem-c-organisation-logo__container.gem-c-organisation-logo__link[data-track-label='/some-link']"

--- a/spec/components/related_navigation_spec.rb
+++ b/spec/components/related_navigation_spec.rb
@@ -201,7 +201,7 @@ describe "Related navigation", type: :view do
     )
     render_component(content_item: content_item)
 
-    assert_select ".gem-c-related-navigation__nav-section ul[data-module='track-click']"
+    assert_select ".gem-c-related-navigation__nav-section ul[data-module='gem-track-click']"
     assert_select ".gem-c-related-navigation__section-link[data-track-category='relatedLinkClicked']"
     assert_select ".gem-c-related-navigation__section-link[data-track-action='1.1 Explore the topic']"
     assert_select ".gem-c-related-navigation__section-link[data-track-label='/apprenticeships']"

--- a/spec/components/subscription_links_spec.rb
+++ b/spec/components/subscription_links_spec.rb
@@ -23,7 +23,7 @@ describe "subscription links", type: :view do
   it "renders both email signup and feed links" do
     render_component(email_signup_link: "email-signup", feed_link: "singapore.atom")
     assert_select ".gem-c-subscription-links[data-module='gem-toggle']", false
-    assert_select ".gem-c-subscription-links__list[data-module='track-click']", false
+    assert_select ".gem-c-subscription-links__list[data-module='gem-track-click']", false
     assert_select ".gem-c-subscription-links__item[href=\"email-signup\"]", text: "Get emails"
     assert_select ".gem-c-subscription-links__item[href=\"singapore.atom\"]", text: "Subscribe to feed"
   end
@@ -65,18 +65,18 @@ describe "subscription links", type: :view do
 
   it "adds tracking for email signup link" do
     render_component(email_signup_link: "email-signup", email_signup_link_data_attributes: { 'track_category': "test" })
-    assert_select ".gem-c-subscription-links__list[data-module=\"track-click\"] .gem-c-subscription-links__item[data-track-category=\"test\"]"
+    assert_select ".gem-c-subscription-links__list[data-module=\"gem-track-click\"] .gem-c-subscription-links__item[data-track-category=\"test\"]"
   end
 
   it "adds tracking for feed link" do
     render_component(feed_link: "feed", feed_link_data_attributes: { 'track_category': "test" })
-    assert_select ".gem-c-subscription-links__list[data-module=\"track-click\"] .gem-c-subscription-links__item[data-track-category=\"test\"]"
+    assert_select ".gem-c-subscription-links__list[data-module=\"gem-track-click\"] .gem-c-subscription-links__item[data-track-category=\"test\"]"
   end
 
   it "adds tracking for feed link when it is a toggle" do
     render_component(feed_link_box_value: "feed", feed_link_data_attributes: { 'track_category': "test" })
     assert_select ".gem-c-subscription-links[data-module=\"gem-toggle\"]"
-    assert_select ".gem-c-subscription-links__list[data-module=\"track-click\"] .gem-c-subscription-links__item[data-track-category=\"test\"]"
+    assert_select ".gem-c-subscription-links__list[data-module=\"gem-track-click\"] .gem-c-subscription-links__item[data-track-category=\"test\"]"
   end
 
   it "adds small form modifier to the list of links" do

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -28,16 +28,16 @@ describe('Cookie banner', function () {
             '</div>' +
           '</div>' +
           '<div class="govuk-button-group">' +
-            '<button class="gem-c-button govuk-button" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted" data-cookie-types="all" style="display: block;">Accept additional cookies</button>' +
-            '<button class="gem-c-button govuk-button" type="submit" data-module="track-click" data-reject-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner rejected" style="display: block;">Reject additional cookies</button>' +
+            '<button class="gem-c-button govuk-button" type="submit" data-module="gem-track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted" data-cookie-types="all" style="display: block;">Accept additional cookies</button>' +
+            '<button class="gem-c-button govuk-button" type="submit" data-module="gem-track-click" data-reject-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner rejected" style="display: block;">Reject additional cookies</button>' +
             '<a class="govuk-link" href="/help/cookies">View cookies</a>' +
           '</div>' +
         '</div>' +
       '</div>' +
       '<div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1" hidden="">' +
-        '<p class="gem-c-cookie-banner__confirmation-message" role="alert">You can <a class="govuk-link" href="/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.</p>' +
+        '<p class="gem-c-cookie-banner__confirmation-message" role="alert">You can <a class="govuk-link" href="/help/cookies" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.</p>' +
         '<div class="govuk-button-group">' +
-          '<button class="gem-c-cookie-banner__hide-button govuk-button" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide this message</button>' +
+          '<button class="gem-c-cookie-banner__hide-button govuk-button" data-hide-cookie-banner="true" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide this message</button>' +
         '</div>' +
       '</div>' +
     '</div>'


### PR DESCRIPTION
### What

Switch from using `trackClick` script from `static` to `gemTrackClick` script from this repo. They are virtually the same, the latter being [copied over from `static` to `govuk_publishing_components`](https://github.com/alphagov/govuk_publishing_components/pull/1751).

### Why

Part of [a bigger piece of work](https://github.com/alphagov/static/pull/2405) to reduce the size of assets served to users and keep our codebase to a minimum.

## Visual Changes
No visual changes
