### PR TITLE
Add default aria label for navigation items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add spacing to cookie banner confirmation message ([PR #1936](https://github.com/alphagov/govuk_publishing_components/pull/1936))
 * Fix Sass warning for extending a compound selector ([PR #1933](https://github.com/alphagov/govuk_publishing_components/pull/1933))
+* Add default aria label for navigation items (PR [#1946](https://github.com/alphagov/govuk_publishing_components/pull/1946))
 
 ## 24.3.0
 

--- a/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
@@ -1,3 +1,5 @@
+<% navigation_aria_label ||= "Top level" %>
+
 <% if navigation_items.any? %>
   <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
   <%= tag.nav class: "gem-c-header__nav", aria: { label: navigation_aria_label } do %>


### PR DESCRIPTION
## What
Adds a default value for `navigation_aria_label` to the `navigation_items` sub-component.

## Why
Currently, `navigation_aria_label` is passed directly to `navigation_items` without any defaulting under the assumption that it's only used by `layout_header`. This however breaks [anything that's only using the separately exposed navigation_items](https://github.com/alphagov/datagovuk_find/blob/24a0ef70958720370a42e7daa7c7b1437fc4dada/app/views/layouts/_proposition_header.html.erb). Adding a default here allows the sub-component to render without needed to pass a custom aria label if it isn't required.

No visual changes.
