### PR TITLE
Show password fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Show password fixes ([PR #1947](https://github.com/alphagov/govuk_publishing_components/pull/1947))
 * Switch from `trackClick` to `gemTrackClick` script ([PR #1944](https://github.com/alphagov/govuk_publishing_components/pull/1944))
 * Add spacing to cookie banner confirmation message ([PR #1936](https://github.com/alphagov/govuk_publishing_components/pull/1936))
 * Fix Sass warning for extending a compound selector ([PR #1933](https://github.com/alphagov/govuk_publishing_components/pull/1933))

--- a/app/assets/javascripts/govuk_publishing_components/components/show-password.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/show-password.js
@@ -11,8 +11,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.revertToPasswordOnFormSubmit = this.revertToPasswordOnFormSubmit.bind(this)
     this.input.classList.add('gem-c-input--with-password')
 
-    this.showPasswordText = this.$module.getAttribute('data-show')
-    this.hidePasswordText = this.$module.getAttribute('data-hide')
+    this.showPasswordText = this.$module.getAttribute('data-show-text')
+    this.hidePasswordText = this.$module.getAttribute('data-hide-text')
+    this.showPasswordFullText = this.$module.getAttribute('data-show-full-text')
+    this.hidePasswordFullText = this.$module.getAttribute('data-hide-full-text')
     this.shownPassword = this.$module.getAttribute('data-announce-show')
     this.hiddenPassword = this.$module.getAttribute('data-announce-hide')
 
@@ -27,6 +29,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.showHide.className = 'gem-c-show-password__toggle'
     this.showHide.setAttribute('aria-controls', this.input.getAttribute('id'))
     this.showHide.setAttribute('type', 'button')
+    this.showHide.setAttribute('aria-label', this.showPasswordFullText)
     this.showHide.innerHTML = this.showPasswordText
     this.wrapper.insertBefore(this.showHide, this.input.nextSibling)
 
@@ -50,12 +53,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   ShowPassword.prototype.togglePassword = function (event) {
     event.preventDefault()
     this.showHide.innerHTML = this.showHide.innerHTML === this.showPasswordText ? this.hidePasswordText : this.showPasswordText
+    this.showHide.setAttribute('aria-label', this.showHide.getAttribute('aria-label') === this.showPasswordFullText ? this.hidePasswordFullText : this.showPasswordFullText)
     this.statusText.innerHTML = this.statusText.innerHTML === this.shownPassword ? this.hiddenPassword : this.shownPassword
     this.input.setAttribute('type', this.input.getAttribute('type') === 'text' ? 'password' : 'text')
   }
 
   ShowPassword.prototype.revertToPasswordOnFormSubmit = function (event) {
     this.showHide.innerHTML = this.showPasswordText
+    this.showHide.setAttribute('aria-label', this.showPasswordFullText)
     this.statusText.innerHTML = this.hiddenPassword
     this.input.setAttribute('type', 'password')
   }

--- a/app/views/govuk_publishing_components/components/_show_password.html.erb
+++ b/app/views/govuk_publishing_components/components/_show_password.html.erb
@@ -19,10 +19,10 @@
     data: {
       module: "show-password",
       disable_form_submit_check: disable_form_submit_check,
-      show: t('components.input.show'),
-      hide: t('components.input.hide'),
-      announce_show: t('components.input.announce_show'),
-      announce_hide: t('components.input.announce_hide')
+      show: t('components.show_password.show'),
+      hide: t('components.show_password.hide'),
+      announce_show: t('components.show_password.announce_show'),
+      announce_hide: t('components.show_password.announce_hide')
     } do %>
       <%= render "govuk_publishing_components/components/input", {
         label: label,

--- a/app/views/govuk_publishing_components/components/_show_password.html.erb
+++ b/app/views/govuk_publishing_components/components/_show_password.html.erb
@@ -19,8 +19,10 @@
     data: {
       module: "show-password",
       disable_form_submit_check: disable_form_submit_check,
-      show: t('components.show_password.show'),
-      hide: t('components.show_password.hide'),
+      show_text: t('components.show_password.show'),
+      hide_text: t('components.show_password.hide'),
+      show_full_text: t('components.show_password.show_password'),
+      hide_full_text: t('components.show_password.hide_password'),
       announce_show: t('components.show_password.announce_show'),
       announce_hide: t('components.show_password.announce_hide')
     } do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,6 +88,8 @@ en:
     show_password:
       show: Show
       hide: Hide
+      show_password: Show password
+      hide_password: Hide password
       announce_show: Your password is shown
       announce_hide: Your password is hidden
     print_link:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,11 +54,6 @@ en:
       what_wrong: "What went wrong?"
       send_me_survey: "Send me the survey"
       send: "Send"
-    input:
-      show: Show
-      hide: Hide
-      announce_show: Your password is shown
-      announce_hide: Your password is hidden
     organisation_schema:
       all_content_search_description: "Find all content from %{organisation}"
     radio:
@@ -90,6 +85,11 @@ en:
       policies: "Policies"
       statistical_data_sets: "Statistical data sets"
       topical_events: "Topical events"
+    show_password:
+      show: Show
+      hide: Hide
+      announce_show: Your password is shown
+      announce_hide: Your password is hidden
     print_link:
       text: "Print this page"
     skip_link:

--- a/spec/components/show_password_spec.rb
+++ b/spec/components/show_password_spec.rb
@@ -19,8 +19,10 @@ describe "Show password", type: :view do
     )
 
     assert_select(".gem-c-show-password[data-module='show-password']")
-    assert_select(".gem-c-show-password[data-show='Show']")
-    assert_select(".gem-c-show-password[data-hide='Hide']")
+    assert_select(".gem-c-show-password[data-show-text='Show']")
+    assert_select(".gem-c-show-password[data-hide-text='Hide']")
+    assert_select(".gem-c-show-password[data-show-full-text='Show password']")
+    assert_select(".gem-c-show-password[data-hide-full-text='Hide password']")
     assert_select(".gem-c-show-password[data-announce-show='Your password is shown']")
     assert_select(".gem-c-show-password[data-announce-hide='Your password is hidden']")
     assert_select(".gem-c-input[autocomplete='off']")

--- a/spec/javascripts/components/show-password-spec.js
+++ b/spec/javascripts/components/show-password-spec.js
@@ -7,7 +7,7 @@ describe('A show password component', function () {
   describe('in password reveal mode', function () {
     beforeEach(function () {
       element = $(
-        '<div class="gem-c-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show="Show" data-hide="Hide" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">' +
+        '<div class="gem-c-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="Show" data-hide-text="Hide" data-show-full-text="Show password" data-hide-full-text="Hide password" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">' +
           '<div class="govuk-form-group">' +
             '<label for="input" class="gem-c-label govuk-label">Please enter your password</label>' +
             '<input name="password" value="this is my password" class="gem-c-input govuk-input" id="input" type="password" autocomplete="off">' +
@@ -26,6 +26,7 @@ describe('A show password component', function () {
       expect(element.find('.gem-c-input.gem-c-input--with-password').length).toBe(1)
       expect(element.find('.gem-c-show-password__toggle').length).toBe(1)
       expect(element.find('.gem-c-show-password__toggle').text()).toBe('Show')
+      expect(element.find('.gem-c-show-password__toggle').attr('aria-label')).toBe('Show password')
       expect(element.find('.gem-c-show-password__toggle').attr('aria-controls')).toBe('input')
       expect(element.find('.gem-c-show-password__toggle').attr('type')).toBe('button')
       expect(element.find('.govuk-visually-hidden').length).toBe(1)
@@ -36,6 +37,7 @@ describe('A show password component', function () {
       element.find('.gem-c-show-password__toggle').trigger('click')
 
       expect(element.find('.gem-c-show-password__toggle').text()).toBe('Hide')
+      expect(element.find('.gem-c-show-password__toggle').attr('aria-label')).toBe('Hide password')
       expect(element.find('input[name="password"]').attr('type')).toBe('text')
       expect(element.find('.govuk-visually-hidden').text()).toBe('Your password is shown')
     })
@@ -45,6 +47,7 @@ describe('A show password component', function () {
       element.find('.gem-c-show-password__toggle').trigger('click')
 
       expect(element.find('.gem-c-show-password__toggle').text()).toBe('Show')
+      expect(element.find('.gem-c-show-password__toggle').attr('aria-label')).toBe('Show password')
       expect(element.find('input[name="password"]').attr('type')).toBe('password')
       expect(element.find('.govuk-visually-hidden').text()).toBe('Your password is hidden')
     })
@@ -54,7 +57,7 @@ describe('A show password component', function () {
     beforeEach(function () {
       element = $(
         '<form>' +
-          '<div class="gem-c-show-password" data-module="show-password" data-show="Show" data-hide="Hide" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">' +
+          '<div class="gem-c-show-password" data-module="show-password" data-show-text="Show" data-hide-text="Hide" data-show-full-text="Show password" data-hide-full-text="Hide password" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">' +
             '<div class="govuk-form-group">' +
               '<label for="input" class="gem-c-label govuk-label">Please enter your password</label>' +
               '<input name="password" value="this is my password" class="gem-c-input govuk-input" id="input" type="password" autocomplete="off">' +
@@ -81,6 +84,7 @@ describe('A show password component', function () {
 
       element.find('button[type="submit"]').click()
       expect(element.find('.gem-c-show-password__toggle').text()).toBe('Show')
+      expect(element.find('.gem-c-show-password__toggle').attr('aria-label')).toBe('Show password')
       expect(element.find('input[name="password"]').attr('type')).toBe('password')
       expect(element.find('.govuk-visually-hidden').text()).toBe('Your password is hidden')
     })
@@ -90,7 +94,7 @@ describe('A show password component', function () {
     beforeEach(function () {
       element = $(
         '<form>' +
-          '<div class="gem-c-show-password" data-module="show-password" data-disable-form-submit-check="true" data-show="Show" data-hide="Hide" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">' +
+          '<div class="gem-c-show-password" data-module="show-password" data-disable-form-submit-check="true" data-show-text="Show" data-hide-text="Hide" data-show-full-text="Show password" data-hide-full-text="Hide password" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">' +
             '<div class="govuk-form-group">' +
               '<label for="input" class="gem-c-label govuk-label">Please enter your password</label>' +
               '<input name="password" value="this is my password" class="gem-c-input govuk-input" id="input" type="password" autocomplete="off">' +
@@ -117,6 +121,7 @@ describe('A show password component', function () {
 
       element.find('button[type="submit"]').click()
       expect(element.find('.gem-c-show-password__toggle').text()).toBe('Hide')
+      expect(element.find('.gem-c-show-password__toggle').attr('aria-label')).toBe('Hide password')
       expect(element.find('input[name="password"]').attr('type')).toBe('text')
       expect(element.find('.govuk-visually-hidden').text()).toBe('Your password is shown')
     })


### PR DESCRIPTION
## What

- adds an aria-label to the 'show/hide' button so that assistive tech reads it as 'show/hide password', which makes more sense out of context

## Why

- an accessibility audit revealed that the button out of context ('Show') isn't descriptive enough for users of assistive technology, and should be 'show password' instead, but we don't want to change the design because that text is too long on mobile

## Visual changes

None.

![Screenshot 2021-02-22 at 16 03 25](https://user-images.githubusercontent.com/861310/108734615-8c1fca00-7527-11eb-840b-7035f302f7ea.png)


## Needlessly detailed further background reading

### Problem

Our password button says 'show' or 'hide', which has been highlighted as an accessibility fail because the button out of context doesn't make sense.

```
Non-Descriptive Labels (AA)
Labels did not sufficiently describe the topic or purpose of the content.
WCAG Reference:
2.4.6 Headings and Labels (Level AA)
```

The solution proposed by the audit is to add the word 'password' as a visually hidden field. Sighted users would still see the button as 'Show' but screen reader users would hear it as 'Show password'. **EDIT: we've chosen to go with a different solution due to all this stuff below here.**

This works in English but other languages may have problems, specifically:

- the word 'show' may be different by itself compared with when it is immediately followed by 'password'
- we can't be certain what order the words should appear in, 'show password' in other languages might translate as 'password show'
- 'show password' might be a single word in some languages?

Since this would be in a separate element we need to keep the words 'show' and 'password' separate in the translation file.

### Languages on GOV.UK

We should consider the impact this will have based on the languages it might be translated into. Starting with the totally unscientific approach, here are the largest translation files in government-frontend:

- en.yml English
- ar.yml Arabic
- ta.yml Tamil
- ru.yml Russian
- cy.yml Welsh
- be.yml Belarusian
- hr.yml Croatian
- mt.yml Maltese
- uk.yml Ukrainian
- sl.yml Slovenian
- gd.yml Gaelic

...but this text is used in elements like components and navigation, not published content.

As a more scientific approach (thanks @kevindew) this is a breakdown of what’s in Publishing API by locale:

```
irb(main):004:0> Edition.with_document.where(content_store: :live).group("documents.locale").order("COUNT(*) DESC").count
=> {"en"=>695250, "cy"=>7801, "ar"=>3619, "es-419"=>3450, "ru"=>1454, "hi"=>1286, "zh"=>1156, "ur"=>1071, "pt"=>1071, "fr"=>673, "ja"=>521, "es"=>448, "ro"=>369, "uk"=>343, "it"=>299, "pl"=>298, "zh-tw"=>290, "de"=>264, "lt"=>238, "ko"=>222, "th"=>205, "bg"=>195, "bn"=>193, "so"=>189, "he"=>185, "el"=>181, "cs"=>178, "lv"=>173, "uz"=>167, "vi"=>159, "sq"=>158, "tr"=>145, "id"=>114, "si"=>113, "ta"=>112, "sr"=>104, "fa"=>83, "pa"=>63, "hy"=>45, "be"=>38, "gu"=>35, "et"=>24, "hu"=>24, "nl"=>21, "kk"=>18, "dr"=>16, "az"=>15, "sk"=>13, "pa-ur"=>5, "hr"=>4, "sl"=>4, "da"=>4, "no"=>4, "ps"=>4, "sv"=>3, "mt"=>3, "fi"=>3, "is"=>3, "gd"=>2, "zh-hk"=>2}
```

Top results are:

- "en"=>695250 English
- "cy"=>7801 Welsh
- "ar"=>3619 Arabic
- "es-419"=>3450 Spanish
- "ru"=>1454 Russian
- "hi"=>1286 Hindi
- "zh"=>1156 Chinese
- "ur"=>1071 Urdu
- "pt"=>1071 Portuguese
- "fr"=>673 French

A few hits of Google Translate later...

(note that I've had to put some filler text into some of these columns because both my local editor and github automatically changes some of the non Roman character set words based on the words that follow them, so please ignore `AAAA` in the following table. I don't know why it's doing this, I suspect it's changing the word order because they're right to left languages)

Language | Password | Show | Show password | Hide | Hide password | Ordered like English
-------- | -------- | ---- | ------------- | ---- | ------------- | --------------------
English  | password | show | show password | hide | hide password | Yes
Welsh | cyfrinair | sioe | dangos cyfrinair | cuddio | cuddio cyfrinair | Yes
Arabic | كلمه السر | AAAA تبين | AAAA عرض كلمة المرور | AAAA إخفاء | AAAA اخفاء كلمة المرور | unsure
Spanish | contraseña | show | mostrar contraseña | esconder | Contraseña oculta | No
Russian | пароль | Показать | показать пароль | Спрятать | скрыть пароль | Yes
Hindi | पारण शब्द | प्रदर्शन | शो पासवर्ड | छिपाना | पासवर्ड छिपाएं | unsure
Chinese (simplified)| 密码 | 展示 | 显示密码 | 隐藏 | 隐藏密码 | Yes
Chinese (traditional) | 密碼 | 展示 | 顯示密碼 | 隱藏 | 隱藏密碼 | Yes
Urdu | پاس ورڈ | AAAA دکھائیں | AAAA پاسورڈ دکھاو | AAAA چھپائیں | AAAA پاس ورڈ چھپائیں | unsure
Portuguese | senha | mostrar | mostrar senha | ocultar | esconder a senha | Yes
French | le mot de passe | Afficher | montrer le mot de passe | cacher | masquer le mot de passe | Yes

### Observations

- I am in no way an authority on any language
- the Spanish for 'show' is 'show' unless it's in front of 'password' in which case it's 'mostrar'
- something similar appears to happen for 'show' in Chinese, and in French but also for 'hide'
- most of the languages appear to have 'password' unchanged at the end of the sentence for both, only Spanish changes the order for 'hide'

### Objective recap

- We want a button that says 'show' or 'hide' for sighted users.
- We want a button that says 'show password' or 'hide password' for screen reader users.
- We want the button to make sense.
- We don't want a button that says 'password' for sighted users.

### Solutions

`aria-label`, as suggested by the mighty @injms