### PR TITLE
Add bottom border option to breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add border option to breadcrumb ([PR #1952])(https://github.com/alphagov/govuk_publishing_components/pull/1952) MINOR
+
 ## 24.3.1
 
 * Show password fixes ([PR #1947](https://github.com/alphagov/govuk_publishing_components/pull/1947))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_breadcrumbs.scss
@@ -21,6 +21,17 @@
   border-color: govuk-colour("white");
 }
 
+.gem-c-breadcrumbs--border-bottom {
+  border-bottom: 1px solid $govuk-border-colour;
+  padding-bottom: govuk-spacing(1);
+
+  &.govuk-breadcrumbs--collapse-on-mobile {
+    @include govuk-media-query($until: tablet) {
+      padding-bottom: 0;
+    }
+  }
+}
+
 .govuk-breadcrumbs--collapse-on-mobile {
   @include govuk-media-query($until: tablet) {
     .govuk-breadcrumbs__list-item {

--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -1,19 +1,22 @@
 <%
+  border ||= false
   breadcrumbs ||= []
-  inverse ||= false
   collapse_on_mobile ||= false
+  inverse ||= false
+
   breadcrumb_presenter = GovukPublishingComponents::Presenters::Breadcrumbs.new(breadcrumbs)
 
-  classes = "gem-c-breadcrumbs govuk-breadcrumbs"
-  classes << " govuk-breadcrumbs--collapse-on-mobile" if collapse_on_mobile
-  classes << " gem-c-breadcrumbs--inverse" if inverse
+  classes = %w[gem-c-breadcrumbs govuk-breadcrumbs]
+  classes << "govuk-breadcrumbs--collapse-on-mobile" if collapse_on_mobile
+  classes << "gem-c-breadcrumbs--inverse" if inverse
+  classes << "gem-c-breadcrumbs--border-bottom" if border == "bottom"
 %>
 
 <script type="application/ld+json">
   <%= raw JSON.pretty_generate(breadcrumb_presenter.structured_data) %>
 </script>
 
-<div class="<%= classes %>" data-module="gem-track-click">
+<div class="<%= classes.join(" ") %>" data-module="gem-track-click">
   <ol class="govuk-breadcrumbs__list">
     <% breadcrumbs.each_with_index do |crumb, index| %>
       <% breadcrumb = GovukPublishingComponents::Presenters::Breadcrumb.new(crumb, index) %>

--- a/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
@@ -97,3 +97,25 @@ examples:
         url: '/browse/abroad'
       - title: 'Travel abroad'
         url: '/browse/abroad/travel-abroad'
+  with_border:
+    description: "Set a border below the breadcrumb. Off by default."
+    data:
+      border: "bottom"
+      breadcrumbs:
+      - title: "Section"
+        url: "/section"
+      - title: "Sub-section"
+        url: "/section/sub-section"
+      - title: "Sub-sub-section"
+        url: "/section/sub-section/sub-section"
+  with_border_and_collapse_on_mobile:
+    data:
+      border: "bottom"
+      collapse_on_mobile: true
+      breadcrumbs:
+      - title: "Section"
+        url: "/section"
+      - title: "Sub-section"
+        url: "/section/sub-section"
+      - title: "Sub-sub-section"
+        url: "/section/sub-section/sub-section"

--- a/spec/components/breadcrumbs_spec.rb
+++ b/spec/components/breadcrumbs_spec.rb
@@ -156,4 +156,19 @@ describe "Breadcrumbs", type: :view do
 
     assert_select(".gem-c-breadcrumbs.govuk-breadcrumbs.govuk-breadcrumbs--collapse-on-mobile")
   end
+
+  it "has a border when passed a border parameter" do
+    render_component(
+      border: "bottom",
+      breadcrumbs: [
+        { title: "Home", url: "/" },
+        { title: "Section", url: "/section" },
+        { title: "Sub-section", url: "/sub-section" },
+        { title: "Sub-sub-section", url: "/sub-sub-section" },
+        { title: "Sub-sub-sub-section", url: "/sub-sub-sub-section" },
+      ],
+    )
+
+    assert_select(".gem-c-breadcrumbs.govuk-breadcrumbs.gem-c-breadcrumbs--border-bottom")
+  end
 end


### PR DESCRIPTION
## What
Adds a parameter so a border can be added to the bottom of a breadcrumb.

## Why
<!-- What are the reasons behind this change being made? -->
This is needed so this component can be used in alphagov/manuals-frontend.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
Desktop:

![image](https://user-images.githubusercontent.com/1732331/109535408-732d9080-7ab4-11eb-8644-4563da2654c9.png)


Mobile:
<img src="https://user-images.githubusercontent.com/1732331/109535391-6ad55580-7ab4-11eb-8d17-abe692432574.png" width="50%">