### PR TITLE
Bump gem to 24.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.4.0
 
 * Add border option to breadcrumb ([PR #1952](https://github.com/alphagov/govuk_publishing_components/pull/1952)) MINOR
 * Add custom heading level option to radio component ([PR #1951](https://github.com/alphagov/govuk_publishing_components/pull/1951))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.3.1)
+    govuk_publishing_components (24.4.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.3.1".freeze
+  VERSION = "24.4.0".freeze
 end


### PR DESCRIPTION
Includes:

* Add border option to breadcrumb ([PR #1952](https://github.com/alphagov/govuk_publishing_components/pull/1952)) MINOR
* Add custom heading level option to radio component ([PR #1951](https://github.com/alphagov/govuk_publishing_components/pull/1951))