### PR TITLE
Fix GOV.UK Frontend deprecation warning for component-guide print stylesheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix GOV.UK Frontend deprecation warning for component-guide print stylesheet ([PR #1961](https://github.com/alphagov/govuk_publishing_components/pull/1961))
+
 ## 24.4.1
 
 * Fix tracking in `details.js` ([PR #1962](https://github.com/alphagov/govuk_publishing_components/pull/1962))

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -1,7 +1,7 @@
 // This is the file that the application needs to include in order to use
 // the components.
 
-@import "components/helpers/govuk-frontend-settings";
+@import "govuk_frontend_support";
 
 @import "components/print/accordion";
 @import "components/print/attachment";


### PR DESCRIPTION
This file imports "govuk/base" which is required to resolve a GOV.UK Frontend warning. This is attempt 2 following https://github.com/alphagov/govuk_publishing_components/pull/1934, this tries to be a more modest fix.

Before:

```
I, [2021-03-08T10:25:39.692458 #79055]  INFO -- : Writing /Users/kevindew/govuk/govuk_publishing_components/spec/dummy/public/assets/component_guide/visual-regression-7a6fbecb638d5f96b24d97212b0044b0b3d9e195c0ea5543612dba4347f5ec2e.js.gz
WARNING: Importing items from the core layer without first importing `base` is deprecated, and will no longer work as of GOV.UK Frontend v4.0.
         on line 2:3 of node_modules/govuk-frontend/govuk/core/_links.scss
         from line 1:9 of node_modules/govuk-frontend/govuk/core/_all.scss
         from line 4:9 of app/assets/stylesheets/govuk_publishing_components/component_support.scss
         from line 5:9 of app/assets/stylesheets/govuk_publishing_components/components/print/_accordion.scss
         from line 6:9 of app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
         from line 1:9 of app/assets/stylesheets/component_guide/print.scss

I, [2021-03-08T10:25:41.428470 #79055]  INFO -- : Writing /Users/kevindew/govuk/govuk_publishing_components/spec/dummy/public/assets/component_guide/print-a0002005ec52f551aa28aa9e421e2cd6d1ab9c8cc06f4c1b7b50abd92dada192.css
I, [2021-03-08T10:25:41.428689 #79055]  INFO -- : Writing /Users/kevindew/govuk/govuk_publishing_components/spec/dummy/public/assets/component_guide/print-a0002005ec52f551aa28aa9e421e2cd6d1ab9c8cc06f4c1b7b50abd92dada192.css.gz
```

After:

```
I, [2021-03-08T10:26:16.011247 #79155]  INFO -- : Writing /Users/kevindew/govuk/govuk_publishing_components/spec/dummy/public/assets/component_guide/visual-regression-7a6fbecb638d5f96b24d97212b0044b0b3d9e195c0ea5543612dba4347f5ec2e.js.gz
I, [2021-03-08T10:26:17.598856 #79155]  INFO -- : Writing /Users/kevindew/govuk/govuk_publishing_components/spec/dummy/public/assets/component_guide/print-a0002005ec52f551aa28aa9e421e2cd6d1ab9c8cc06f4c1b7b50abd92dada192.css
I, [2021-03-08T10:26:17.599218 #79155]  INFO -- : Writing /Users/kevindew/govuk/govuk_publishing_components/spec/dummy/public/assets/component_guide/print-a0002005ec52f551aa28aa9e421e2cd6d1ab9c8cc06f4c1b7b50abd92dada192.css.gz
```
