### PR TITLE
Fix tracking in details.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix tracking in `details.js` ([PR #1962](https://github.com/alphagov/govuk_publishing_components/pull/1962))
+
 ## 24.4.0
 
 * Add border option to breadcrumb ([PR #1952](https://github.com/alphagov/govuk_publishing_components/pull/1952)) MINOR

--- a/app/assets/javascripts/govuk_publishing_components/components/details.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/details.js
@@ -13,7 +13,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     // If a custom label has been provided, we can simply call the tracking module
     if (customTrackLabel) {
-      var trackDetails = new window.GOVUK.Modules.TrackClick()
+      var trackDetails = new window.GOVUK.Modules.GemTrackClick()
       trackDetails.start($module)
     } else {
       // If no custom label is set, we use the open/close status as the label

--- a/spec/javascripts/components/details-spec.js
+++ b/spec/javascripts/components/details-spec.js
@@ -4,13 +4,6 @@
 describe('Details component', function () {
   var FIXTURE
 
-  var callback = jasmine.createSpy()
-  GOVUK.Modules.TrackClick = function () {
-    this.start = function () {
-      callback()
-    }
-  }
-
   function loadDetailsComponent () {
     var details = new GOVUK.Modules.GovukDetails()
     details.start($('.gem-c-details'))
@@ -18,6 +11,7 @@ describe('Details component', function () {
 
   beforeEach(function () {
     spyOn(GOVUK.analytics, 'trackEvent')
+    spyOn(GOVUK.Modules, 'GemTrackClick').and.callFake(function () { this.start = function () {} })
 
     FIXTURE =
       '<details class="gem-c-details govuk-details govuk-!-margin-bottom-3" data-track-category="track-category" data-track-action="track-action" data-track-label="track-label" data-module="govuk-details">' +
@@ -41,7 +35,7 @@ describe('Details component', function () {
     $('.govuk-details__summary').click()
 
     expect(GOVUK.analytics.trackEvent.calls.count()).toEqual(0)
-    expect(callback).toHaveBeenCalled()
+    expect(GOVUK.Modules.GemTrackClick.calls.count()).toEqual(1)
   })
 
   it('does not fire an event if track category and track action are not present', function () {


### PR DESCRIPTION
## What
Fix tracking in `details.js`

## Why
`TrackClick` (provided by static) was recently replaced with `GemTrackClick` (provided by govuk_publishing_components) after the analytics scripts have been ported from static to govuk_publishing_components. This instance has been missed at that point, which causes JS to crash on certain pages across GOV.UK.

## Visual Changes
This issues has been reported by @ChrisBAshton as the JS crash stopped the video render script in [`government-frontend`](https://www.integration.publishing.service.gov.uk/government/publications/uk-points-based-immigration-system-employer-information)
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1440" alt="Screenshot 2021-03-08 at 13 03 10" src="https://user-images.githubusercontent.com/788096/110325036-bdf85c80-800e-11eb-844e-577696903b6c.png">


</td><td valign="top">

<img width="1440" alt="Screenshot 2021-03-08 at 13 03 29" src="https://user-images.githubusercontent.com/788096/110325044-bfc22000-800e-11eb-864f-d3e8310e385e.png">


</td></tr>
</table>

