### PR TITLE
Swap `sanitize` for `raw` in list component

### DIFF
--- a/app/views/govuk_publishing_components/components/_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_list.html.erb
@@ -1,12 +1,12 @@
 <%
-  id ||= nil
+  aria_label ||= nil
   extra_spacing ||= nil
+  id ||= nil
+  items ||= []
   list_type ||= "unordered"
   visible_counters ||= nil
-  items ||= []
-  aria_label ||= nil
 
-  classes = %w(gem-c-list govuk-list)
+  classes = %w[gem-c-list govuk-list]
   classes << "govuk-list--bullet" if visible_counters && list_type === "unordered"
   classes << "govuk-list--number" if visible_counters && list_type === "number"
   classes << "govuk-list--spaced" if extra_spacing
@@ -20,7 +20,7 @@
 <% if items.any? %>
   <%= content_tag list_tag, class: classes, id: id, "aria-label": aria_label do %>
     <% items.each do |item| %>
-      <li><%= sanitize(item) %></li>
+      <li><%= raw(item) %></li>
     <% end %>
   <% end %>
 <% end %>

--- a/spec/components/list_spec.rb
+++ b/spec/components/list_spec.rb
@@ -87,7 +87,7 @@ describe "List", type: :view do
     assert_select "ul#this-is-a-test-id li:nth-child(2)", text: "Another test item"
   end
 
-  it "adds links within a list" do
+  it "adds markup within the list items" do
     render_component(
       items: [
         "<a href='https://example.com/'>Test item</a>",
@@ -97,5 +97,25 @@ describe "List", type: :view do
 
     assert_select "ul.govuk-list li a", text: "Test item"
     assert_select "ul.govuk-list li:nth-child(2) a", text: "Another test item"
+  end
+
+  it "keeps attributes intact when given markup" do
+    render_component(
+      items: [
+        "<a
+          href='https://example.com/'
+          data-module='gem-track-click'
+          data-track-category='category'
+          data-track-action='action'
+          data-track-label='Test item'
+        >Test item</a>",
+        "<a href='https://example.com/'>Another test item</a>",
+      ],
+    )
+
+    assert_select "ul.govuk-list li a[data-module='gem-track-click']"
+    assert_select "ul.govuk-list li a[data-track-category='category']"
+    assert_select "ul.govuk-list li a[data-track-action='action']"
+    assert_select "ul.govuk-list li a[data-track-label='Test item']"
   end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

The list component used the `sanitize` method. This has been swapped for the `raw` method. 

Tests to ensure that attributes on markup passed into component are unaltered have been added.

## Why
<!-- What are the reasons behind this change being made? -->

The sanitize method strips out elements and attributes that are not in an allowlist from a string, and then allows the string to be added as markup rather than being added as a string. This could strip out `data-` and other useful attributes given to the list component.

 The `raw` method doesn't alter the markup - so any string passed into the component will be used verbatim. Since the strings being given to the list component come from within an application, we can presume these to be trustworthy.


## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

None.
