### PR TITLE
Rework accordion anchor link nav to allow for colon anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Summary list changes ([PR #1971](https://github.com/alphagov/govuk_publishing_components/pull/1971))
+* Rework accordion anchor link nav to allow for colon anchors ([PR #1974](https://github.com/alphagov/govuk_publishing_components/pull/1974))
 
 ## 24.5.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -293,8 +293,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   // Navigate to and open accordions with anchored content on page load if a hash is present
   GemAccordion.prototype.openByAnchorOnLoad = function () {
-    if (window.location.hash && this.$module.querySelector(window.location.hash)) {
-      this.openForAnchor(window.location.hash)
+    var splitHash = window.location.hash.split('#')[1]
+
+    if (window.location.hash && document.getElementById(splitHash)) {
+      this.openForAnchor(splitHash)
     }
   }
 
@@ -305,20 +307,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     links.forEach(function (link) {
       if (link.pathname === window.location.pathname) {
-        link.addEventListener('click', this.openForAnchor.bind(this, link.hash))
+        link.addEventListener('click', this.openForAnchor.bind(this, link.hash.split('#')[1]))
       }
     }.bind(this))
   }
 
   // Find the parent accordion section for the given id and open it
   GemAccordion.prototype.openForAnchor = function (hash) {
-    var target = document.querySelector(hash)
+    var target = document.getElementById(hash)
     var section = this.getContainingSection(target)
 
     this.setExpanded(true, section)
   }
 
-  // Loop through the given ids ancestors until the parent section class is found
+  // Loop through the given id's ancestors until the parent section class is found
   GemAccordion.prototype.getContainingSection = function (target) {
     while (!target.classList.contains(this.sectionClass)) {
       target = target.parentElement


### PR DESCRIPTION
## What
Rework the anchor link navigation functionality of the accordion component to remove the hash from the id when navigating and use `getElementById` instead of `querySelector ` when searching for those anchor ids.

## Why
There is a pre-existing feature in manuals frontend that allows for the navigation between footnotes. These anchor links are marked up using the format of `fnref:[footnote number]`. [Example of this in use](https://www.gov.uk/guidance/drivers-hours-goods-vehicles/1-eu-and-aetr-rules-on-drivers-hours). `querySelector` doesn't like that colon in id queries because it [interferes with existing CSS syntax](https://bugzilla.mozilla.org/show_bug.cgi?id=883044). This change allows it to work and fixes this bug in manuals frontend.

No visual changes

[Card](https://trello.com/c/pdwRd2nA/683-fix-footnotes-on-manuals-accordions)
