### PR TITLE
Fix bug in summary list link text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix bug in summary list link text ([PR #1978](https://github.com/alphagov/govuk_publishing_components/pull/1978))
+
 ## 24.6.0
 
 * Remove title attribute from summary list ([PR #1973](https://github.com/alphagov/govuk_publishing_components/pull/1973))

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -81,7 +81,7 @@
                 <%= link_to item[:edit].fetch(:href),
                             class: "govuk-link",
                             data: item[:edit].fetch(:data_attributes, {}) do %>
-                  <%= edit_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" unless edit[:link_text_no_enhance] -%>
+                  <%= edit_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" unless item[:edit][:link_text_no_enhance] -%>
                 <% end %>
               <% end %>
             <% end %>
@@ -94,7 +94,7 @@
                 <%= link_to item[:delete].fetch(:href),
                             class: "govuk-link gem-link--destructive",
                             data: item[:delete].fetch(:data_attributes, {}) do %>
-                  <%= delete_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" unless delete[:link_text_no_enhance] -%>
+                  <%= delete_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" unless item[:delete][:link_text_no_enhance] -%>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/views/govuk_publishing_components/components/docs/summary_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/summary_list.yml
@@ -73,7 +73,24 @@ examples:
 
       To override this behaviour, use `link_text_no_enhance` on the link in question, as shown. This will remove the visually hidden text, allowing you to add your own. The component will render a `span` element with a class of `govuk-visually-hidden` included in a passed [capture block](https://apidock.com/rails/ActionView/Helpers/CaptureHelper/capture) as the `link_text` parameter.
     data:
-      <<: *default-example-data
+      title: "Title, summary and body"
+      items:
+      - field: "Title"
+        value: "Rural conservation techniques"
+        edit:
+          href: "edit-title"
+          text: "Edit"
+          data_attributes:
+            gtm: "edit-title"
+      - field: "Body"
+        value: "Following the land use committee change to overreaching rural byelaws in 2009, further policies were adopted."
+        edit:
+          href: "edit-body"
+          link_text: "Edit"
+        delete:
+          href: "delete-body"
+          link_text: "Remove"
+          link_text_no_enhance: true
       edit:
         href: "edit-title-summary-body"
         link_text: Edit this document <span class="govuk-visually-hidden">my hidden text for screenreaders</span>

--- a/spec/components/summary_list_spec.rb
+++ b/spec/components/summary_list_spec.rb
@@ -249,35 +249,48 @@ describe "Summary list", type: :view do
 
   it "renders all links without visually hidden extra text if specified" do
     render_component(
-      title: "Title",
+      title: "Something",
       edit: {
-        href: "edit-title",
+        href: "edit-something",
         link_text_no_enhance: true,
       },
       delete: {
-        href: "delete-title",
+        href: "delete-something",
         link_text_no_enhance: true,
       },
       items: [
         {
-          field: "Title",
+          field: "Item 1",
           value: "Ethical standards for public service providers",
           edit: {
-            href: "#edit-title",
+            href: "#edit-item-1-title",
             link_text_no_enhance: true,
           },
           delete: {
-            href: "#delete-title",
+            href: "#delete-item-1-title",
             link_text_no_enhance: true,
+          },
+        },
+        {
+          field: "Item 2",
+          value: "Ethical standards for janitorial staff",
+          edit: {
+            href: "#edit-item-2-title",
+          },
+          delete: {
+            href: "#delete-item-2-title",
           },
         },
       ],
     )
-    assert_select 'ul.govuk-summary-list__actions-list .govuk-summary-list__actions-list-item .govuk-link[href="edit-title"]', text: "Change"
-    assert_select 'ul.govuk-summary-list__actions-list .govuk-summary-list__actions-list-item .govuk-link[href="delete-title"]', text: "Delete"
+    assert_select '.govuk-summary-list__actions-list .govuk-link[href="edit-something"]', text: "Change"
+    assert_select '.govuk-summary-list__actions-list .govuk-link[href="delete-something"]', text: "Delete"
 
-    assert_select '.govuk-summary-list__actions-list-item .govuk-link[href="#edit-title"]', text: "Change"
-    assert_select '.govuk-summary-list__actions-list-item .govuk-link.gem-link--destructive[href="#delete-title"]', text: "Delete"
+    assert_select '.govuk-summary-list__row .govuk-summary-list__actions .govuk-link[href="#edit-item-1-title"]', text: "Change"
+    assert_select '.govuk-summary-list__row .govuk-summary-list__actions .govuk-link.gem-link--destructive[href="#delete-item-1-title"]', text: "Delete"
+
+    assert_select '.govuk-summary-list__row .govuk-summary-list__actions .govuk-link[href="#edit-item-2-title"]', text: "Change Item 2"
+    assert_select '.govuk-summary-list__row .govuk-summary-list__actions .govuk-link.gem-link--destructive[href="#delete-item-2-title"]', text: "Delete Item 2"
   end
 
   it "renders the wider dt layout" do


### PR DESCRIPTION
## What
- `link_text_no_enhance` for row links was being checked against the overall links for the component, so passing the parameter for the row when not passing it for the overall links had no effect
- tests were not specific enough to spot this
- now corrected

## Why
It weren't working.

## Visual Changes
None.

