### PR TITLE
Add spacing to header menu

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -54,7 +54,6 @@
   .gem-c-header__content {
     position: relative;
     width: 100%;
-    padding-bottom: govuk-spacing(2);
   }
 
   @include govuk-media-query($from: desktop) {
@@ -103,8 +102,9 @@
 }
 
 .gem-c-header__content.govuk-header__content {
-  width: auto;
   padding-left: 0;
+  padding-bottom: govuk-spacing(2);
+  width: auto;
 
   @include govuk-media-query($from: desktop) {
     float: right;


### PR DESCRIPTION

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
The menu appeared differently on smaller screens when using with left side search and when used on it's own without search - this tweak makes sure that the spacing is the same for both of these uses of the menu.

## Why
<!-- What are the reasons behind this change being made? -->

So that the menu is consistent.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

Menu when used with left side search:

![image](https://user-images.githubusercontent.com/1732331/111477851-7026d700-8727-11eb-9253-c943eb5c16e9.png)


Before:
![image](https://user-images.githubusercontent.com/1732331/111477646-3d7cde80-8727-11eb-9cb7-673bb2863243.png)

After: 
![image](https://user-images.githubusercontent.com/1732331/111477695-4a013700-8727-11eb-96cd-053d32b1d4e2.png)
