### PR TITLE
Fix component preview

### DIFF
--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -148,7 +148,7 @@ $gem-guide-border-width: 1px;
 
 .component-guide-preview--simple {
   border: 0;
-  padding: 0;
+  padding: govuk-spacing(2);
 
   &:before {
     display: none;


### PR DESCRIPTION
## What
Adds some padding to the simple component preview, to make component previewing on 'preview' and 'preview all' screens better.

## Why
I started work on a problem with the search component and found that on the 'preview all' screen the component on a dark background doesn't show the dark/blue background. Turns out that's because on those screens there's no padding, and the component completely covered the dark/blue background.

## Visual Changes

Yes, it indents the previews a little bit, but it does that on the main page already and I think being able to see the preview properly in context is worth it.

Before | After
------ | ------
![Screenshot 2021-03-18 at 11 11 13](https://user-images.githubusercontent.com/861310/111618349-2ba94300-87dc-11eb-8a70-c52053b17558.png) | ![Screenshot 2021-03-18 at 11 11 20](https://user-images.githubusercontent.com/861310/111618362-31068d80-87dc-11eb-8873-924d628b1864.png)

