### PR TITLE
Fix search component label background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Rescope Brexit CTA to en/cy locale only ([PR #1984](https://github.com/alphagov/govuk_publishing_components/pull/1984))
 * Add js tests for accordion component ([PR #1977](https://github.com/alphagov/govuk_publishing_components/pull/1977))
+* Fix search component label background ([PR #1983](https://github.com/alphagov/govuk_publishing_components/pull/1983))
 
 ## 24.6.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -9,7 +9,6 @@ $large-input-size: 50px;
 .gem-c-search__label {
   @include govuk-font($size: 19, $line-height: $input-size);
   display: block;
-  background: govuk-colour("white");
   color: $govuk-text-colour;
 
   h1 {
@@ -25,6 +24,7 @@ $large-input-size: 50px;
     padding-left: govuk-spacing(3);
     z-index: 1;
     color: $govuk-secondary-text-colour;
+    background: govuk-colour("white");
   }
 
   // match label colour with the label component colour
@@ -144,6 +144,10 @@ $large-input-size: 50px;
 }
 
 .gem-c-search--on-govuk-blue {
+  .gem-c-search__label {
+    color: govuk-colour("white");
+  }
+
   .gem-c-search__input {
     border-width: 0;
 
@@ -191,8 +195,18 @@ $large-input-size: 50px;
 }
 
 .gem-c-search--no-border {
+  .gem-c-search__label {
+    color: govuk-colour("white");
+  }
+
   .gem-c-search__input[type="search"] {
     border: 0;
+  }
+
+  .js-enabled & {
+    .gem-c-search__label {
+      color: $govuk-secondary-text-colour;
+    }
   }
 }
 


### PR DESCRIPTION
## What

Change the search component's label so that it looks less broken. This is surprisingly complex. There are several variants to consider:

- default behaviour
- on a blue background
- without a border, typically on a black background (referred to in the code as on a white background, confusingly)

For each variant of the component, we have to consider the following conditions.

- JS enabled: the label overlays the input, disappearing when clicked
- JS disabled: the label appears prior to the input (this is where the problem is)
- linearized: the label appears prior to the input, but JS may be enabled or disabled

The linearized state was highlighted in a past accessibility audit as not being displayed properly. A fix was applied. To see this page state, choose `Linearize Page` in the miscellaneous tab of web developer toolbar.

![Screenshot 2021-03-18 at 12 43 55](https://user-images.githubusercontent.com/861310/111628144-cbb89980-87e7-11eb-84d3-8a7871f8122c.png)


## Why
Fixes https://github.com/alphagov/govuk_publishing_components/issues/1824

## Visual Changes

This change fixes the appearance of the component when JS is disabled on a blue background. It shouldn't change the behaviour of anything else. Note that if JS is enabled and the page is linearized, it still looks broken as reported in https://github.com/alphagov/govuk_publishing_components/issues/1824 but I don't think there's anything that can be done about that - there's no way to detect if a user has enabled this feature.

Before | After
------ | ------
![Screenshot 2021-03-18 at 12 50 16](https://user-images.githubusercontent.com/861310/111628841-8ea0d700-87e8-11eb-824a-a246b269deac.png) | ![Screenshot 2021-03-18 at 12 50 33](https://user-images.githubusercontent.com/861310/111628857-9496b800-87e8-11eb-88c3-3503e8282efa.png)
