### PR TITLE
Rescope Brexit CTA to en/cy locale only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Rescope Brexit CTA to en/cy locale only ([PR #1984](https://github.com/alphagov/govuk_publishing_components/pull/1984))
+
 ## 24.6.1
 
 * Fix bug in summary list link text ([PR #1978](https://github.com/alphagov/govuk_publishing_components/pull/1978))

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -155,6 +155,7 @@ examples:
       content_item:
         title: "Transport news story"
         content_id: "3c402d90-fe77-49b9-a8aa-1800d4fc2b3d"
+        locale: "en"
         links:
           ordered_related_items:
           - title: Find an apprenticeship
@@ -180,6 +181,7 @@ examples:
       content_item:
         title: "30 creative teams awarded up to £100,000 each for Festival UK* 2022 R&D project"
         content_id: "c3752802-f091-43a9-ba90-33568fccf391"
+        locale: "en"
         links:
           ordered_related_items:
           - title: Find an apprenticeship
@@ -205,6 +207,7 @@ examples:
       content_item:
         title: "Local transport news story"
         content_id: "5c82db20-7631-11e4-a3cb-005056011aef"
+        locale: "en"
         links:
           ordered_related_items:
           - title: Find an apprenticeship

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -249,6 +249,10 @@ module GovukPublishingComponents
         false
       end
 
+      def brexit_cta_lang_allow_list?
+        %w[en cy].include?(content_item["locale"])
+      end
+
       def parent_taxon_include?(taxon, taxon_list)
         if taxon.present?
           if taxon.dig("links", "parent_taxons").to_a.any? { |taxon_item| taxon_list.include?(taxon_item["content_id"]) }
@@ -294,6 +298,7 @@ module GovukPublishingComponents
 
       def show_brexit_cta?
         brexit_cta_taxon_allow_list? &&
+          brexit_cta_lang_allow_list? &&
           step_by_step_count.zero? &&
           !brexit_cta_exception?
       end

--- a/spec/components/contextual_sidebar_spec.rb
+++ b/spec/components/contextual_sidebar_spec.rb
@@ -26,6 +26,7 @@ describe "Contextual sidebar", type: :view do
     content_item = {
       "title" => "Transport news story",
       "content_id" => "3c402d90-fe77-49b9-a8aa-1800d4fc2b3d",
+      "locale" => "en",
       "links" => {
         "taxons" => [
           {
@@ -52,6 +53,7 @@ describe "Contextual sidebar", type: :view do
     content_item = {
       "title" => "30 creative teams awarded up to £100,000 each for Festival UK* 2022 R&D project",
       "content_id" => "c3752802-f091-43a9-ba90-33568fccf391",
+      "locale" => "en",
       "links" => {
         "taxons" => [
           {
@@ -70,6 +72,7 @@ describe "Contextual sidebar", type: :view do
     content_item = {
       "title" => "Transport news story",
       "content_id" => "3c402d90-fe77-49b9-a8aa-1800d4fc2b3d",
+      "locale" => "en",
       "document_type" => "transaction",
       "links" => {
         "taxons" => [
@@ -89,6 +92,34 @@ describe "Contextual sidebar", type: :view do
     content_item = {
       "title" => "Local transport news story",
       "content_id" => "5c82db20-7631-11e4-a3cb-005056011aef",
+      "locale" => "en",
+      "links" => {
+        "taxons" => [
+          {
+            "content_id" => "3b4d6319-fcef-4637-b35a-e3df76321894",
+            "title" => "Local transport",
+            "phase" => "live",
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "content_id" => "a4038b29-b332-4f13-98b1-1c9709e216bc",
+                  "title" => "Transport",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    render_component(content_item: content_item)
+    assert_select ".gem-c-contextual-sidebar__brexit-cta", 0
+  end
+
+  it "does not render Brexit CTA when locale is not 'en' or 'cy'" do
+    content_item = {
+      "title" => "السعي إلى إتمام القضاء على برنامج الأسلحة الكيميائية السوري",
+      "content_id" => "9ec092af-0f53-4a82-b4b0-9d016162ba01",
+      "locale" => "ar",
       "links" => {
         "taxons" => [
           {


### PR DESCRIPTION
## What
Rescope Brexit CTA to `en`/`cy` locale only

## Why
We want to show the Brexit CTA on pages written in English or Welsh.

[Trello card](https://trello.com/c/lbZWSsY9)

## Visual Changes
[Example of a page affected by this change, rendered by `government-frontend`](https://www.gov.uk/government/speeches/pursuing-the-elimination-of-the-syrian-chemical-weapons-programme.ar)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![before](https://user-images.githubusercontent.com/788096/111641582-34f2d980-87f5-11eb-956e-504b79d99695.png)


</td><td valign="top">

![after](https://user-images.githubusercontent.com/788096/111641589-36bc9d00-87f5-11eb-84fc-5cbe45367f5e.png)


</td></tr>
</table>

