### PR TITLE
Add GOVUK Frontend Details module to GOVUK Modules and amend modules.js `start` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add GOVUK Frontend Details module to GOVUK Modules and amend modules.js start function ([PR #1985](https://github.com/alphagov/govuk_publishing_components/pull/1985))
 * Rescope Brexit CTA to en/cy locale only ([PR #1984](https://github.com/alphagov/govuk_publishing_components/pull/1984))
 * Add js tests for accordion component ([PR #1977](https://github.com/alphagov/govuk_publishing_components/pull/1977))
 * Fix search component label background ([PR #1983](https://github.com/alphagov/govuk_publishing_components/pull/1983))

--- a/app/assets/javascripts/govuk_publishing_components/components/details.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/details.js
@@ -1,7 +1,8 @@
 /* eslint-env jquery */
 // = require govuk/components/details/details.js
 window.GOVUK = window.GOVUK || {}
-window.GOVUK.Modules = window.GOVUK.Modules || {};
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+window.GOVUK.Modules.Details = window.GOVUKFrontend;
 
 (function (Modules) {
   function GovukDetails () { }

--- a/app/assets/javascripts/govuk_publishing_components/modules.js
+++ b/app/assets/javascripts/govuk_publishing_components/modules.js
@@ -40,7 +40,9 @@
           module = new GOVUK.Modules[moduleName]()
           module.start(element)
           element.data('module-started', true)
-        } else if ( // GOV.UK Frontend Modules
+        }
+
+        if ( // GOV.UK Frontend Modules
           typeof GOVUK.Modules[frontendModuleName] === 'function' &&
           GOVUK.Modules[frontendModuleName].prototype.init &&
           !started

--- a/spec/javascripts/govuk_publishing_components/modules.spec.js
+++ b/spec/javascripts/govuk_publishing_components/modules.spec.js
@@ -84,13 +84,29 @@ describe('GOVUK Modules', function () {
       GOVUK.Modules.GovukTestAlertModule = GovukTestAlertModule
 
       // GOV.UK Frontend Modules
-      function TestAlertModule (element) {
+      function TestAlertFrontendModule (element) {
         this.element = element
       }
-      TestAlertModule.prototype.init = function () {
+      TestAlertFrontendModule.prototype.init = function () {
         callbackFrontendModule(this.element)
       }
-      GOVUK.Modules.TestAlertModule = TestAlertModule
+      GOVUK.Modules.TestAlertFrontendModule = TestAlertFrontendModule
+
+      // GOV.UK Publishing Module with a GOVUK Frontend counterpart
+      function GovukTestAlertPublishingAndFrontendModule () { }
+      GovukTestAlertPublishingAndFrontendModule.prototype.start = function (element) {
+        callbackGovukModule(element)
+      }
+      GOVUK.Modules.GovukTestAlertPublishingAndFrontendModule = GovukTestAlertPublishingAndFrontendModule
+
+      // GOV.UK Frontend Module with a GOVUK Publishing Module counterpart
+      function TestAlertPublishingAndFrontendModule (element) {
+        this.element = element
+      }
+      TestAlertPublishingAndFrontendModule.prototype.init = function () {
+        callbackFrontendModule(this.element)
+      }
+      GOVUK.Modules.TestAlertPublishingAndFrontendModule = TestAlertPublishingAndFrontendModule
 
       container = $('<div></div>')
     })
@@ -98,7 +114,9 @@ describe('GOVUK Modules', function () {
     afterEach(function () {
       delete GOVUK.Modules.LegacyTestAlertModule
       delete GOVUK.Modules.GovukTestAlertModule
-      delete GOVUK.Modules.TestAlertModule
+      delete GOVUK.Modules.TestAlertFrontendModule
+      delete GOVUK.Modules.GovukTestAlertPublishingAndFrontendModule
+      delete GOVUK.Modules.TestAlertPublishingAndFrontendModule
 
       container.remove()
     })
@@ -106,8 +124,9 @@ describe('GOVUK Modules', function () {
     it('starts modules within a container', function () {
       var legacyModule = $('<div data-module="legacy-test-alert-module"></div>')
       var publishingModule = $('<div data-module="govuk-test-alert-module"></div>')
-      var frontendModule = $('<div data-module="test-alert-module"></div>')
-      container.append(legacyModule).append(publishingModule).append(frontendModule)
+      var frontendModule = $('<div data-module="test-alert-frontend-module"></div>')
+      var publishingAndFrontendModule = $('<div data-module="govuk-test-alert-publishing-and-frontend-module"></div>')
+      container.append(legacyModule).append(publishingModule).append(frontendModule).append(publishingAndFrontendModule)
 
       GOVUK.modules.start(container)
       expect(callbackLegacyModule).toHaveBeenCalled()
@@ -140,14 +159,15 @@ describe('GOVUK Modules', function () {
         '<strong data-module="legacy-test-alert-module"></strong>' +
         '<span data-module="legacy-test-alert-module"></span>' +
         '<div data-module="govuk-test-alert-module"></div>' +
-        '<div data-module="test-alert-module"></div>'
+        '<div data-module="govuk-test-alert-publishing-and-frontend-module"></div>' +
+        '<div data-module="test-alert-frontend-module"></div>'
       )
 
       $('body').append(modules)
       GOVUK.modules.start()
       expect(callbackLegacyModule.calls.count()).toBe(3)
-      expect(callbackGovukModule.calls.count()).toBe(1)
-      expect(callbackFrontendModule.calls.count()).toBe(1)
+      expect(callbackGovukModule.calls.count()).toBe(2)
+      expect(callbackFrontendModule.calls.count()).toBe(2)
       modules.remove()
     })
   })


### PR DESCRIPTION
# What
- Amend JS modules initialiser code to account for the case where a GOVUK JS module has a GOVUK Frontend counterpart module which also needs to be initialised
- Add GOVUK Frontend's Details JS module to our own GOVUK Modules object so that the module can be initialised with the other modules

# Why
As part of the Accounts team's DAC report it was flagged that the `details` element was not functional in Internet Explorer and assistive tech was not able to interact with this component as expected.

Some investigation revealed that:
1. this is well known issue where all versions of Internet Explorer and Edge (pre-chromium) don't fully support details/summary: https://caniuse.com/details

2. on the Design System's version of the details component, the issue would not occur, which would suggest that our components gem version is not properly importing the fix from GOVUK Frontend.

After some digging I realised that while we are requiring `govuk-frontend`'s `details.js` script in our own component javascript, it is never initialised, therefore we were not applying their polyfill for IE.

These changes add GOVUK Frontend's Details JS module to our own GOVUK Modules object so that the module can be initialised with the other modules, which should automatically resolve our IE issue.

This also changes the GOVUK modules start function. The way the module start function works currently is that it will either init a GOV.UK Publishing & Legacy Module, or if that doesn't exist, it will init the GOV.UK Frontend equivalent if it exists.
This does not work well in situations where we need both, for instance in the case of the `details` component, where we have a `GovukDetails.js `, but also a `Details.js` (from GOV.UK Frontend) which both need to run for the details component to work correctly.




## Visual Changes

### Before – details component does nothing on IE

https://user-images.githubusercontent.com/7116819/111684484-ac892e80-881e-11eb-848b-2048adde7d77.mov


### After – details component works as expected on IE

https://user-images.githubusercontent.com/7116819/111684469-a85d1100-881e-11eb-9d1e-8f8960bd3519.mov



<!-- If the change results in visual changes, show a before and after -->


https://trello.com/c/lNkwruEi/647-fix-accessibility-issues-raised-by-dac
