### PR TITLE
Release 24.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.7.0
 
 * Add GOVUK Frontend Details module to GOVUK Modules and amend modules.js start function ([PR #1985](https://github.com/alphagov/govuk_publishing_components/pull/1985))
 * Rescope Brexit CTA to en/cy locale only ([PR #1984](https://github.com/alphagov/govuk_publishing_components/pull/1984))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.6.1)
+    govuk_publishing_components (24.7.0)
       govuk_app_config
       kramdown
       plek
@@ -143,7 +143,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     kgio (2.11.3)
-    kramdown (2.3.0)
+    kramdown (2.3.1)
       rexml
     link_header (0.0.8)
     logstasher (2.1.5)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.6.1".freeze
+  VERSION = "24.7.0".freeze
 end


### PR DESCRIPTION
* Add GOVUK Frontend Details module to GOVUK Modules and amend `modules.js` start function ([PR #1985](https://github.com/alphagov/govuk_publishing_components/pull/1985))
* Rescope Brexit CTA to en/cy locale only ([PR #1984](https://github.com/alphagov/govuk_publishing_components/pull/1984))
* Add JavaScript tests for accordion component ([PR #1977](https://github.com/alphagov/govuk_publishing_components/pull/1977))
* Fix search component label background ([PR #1983](https://github.com/alphagov/govuk_publishing_components/pull/1983))
* Allow emergency banner and global bar in public layout component ([PR #1978](https://github.com/alphagov/govuk_publishing_components/pull/1915))
