### PR TITLE
Update default footer links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 ## Unreleased
 
-* Remove Sass `extend` from title component ([PR #1994](https://github.com/alphagov/govuk_publishing_components/pull/1994))
+* Update default footer links ([PR #1989](https://github.com/alphagov/govuk_publishing_components/pull/1989)) PATCH
+* Remove Sass `extend` from title component ([PR #1994](https://github.com/alphagov/govuk_publishing_components/pull/1994)) PATCH
 
 ## 24.7.1
 

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -21,8 +21,13 @@
                 width_class = "govuk-grid-column-one-third"
               end
 
-              list_classes = %w( govuk-footer__list )
-              list_classes << "govuk-footer__list--columns-#{item[:columns]}" if item[:columns]
+              # If the list has multiple columns and there is only one link.
+              # This is to prevent a long link wrapping in a column, which
+              # leaves an obvious blank space to the right.
+              single_item_list = (( item[:columns] == 2 || item[:columns] == 3 ) && item[:items].length == 1 )
+
+              list_classes = %w[govuk-footer__list]
+              list_classes << "govuk-footer__list--columns-#{item[:columns]}" if item[:columns] unless single_item_list
             %>
             <div class="<%= width_class %>">
               <h2 class="govuk-footer__heading govuk-heading-m"><%= item[:title] %></h2>

--- a/lib/govuk_publishing_components/presenters/public_layout_helper.rb
+++ b/lib/govuk_publishing_components/presenters/public_layout_helper.rb
@@ -3,50 +3,34 @@ module GovukPublishingComponents
     class PublicLayoutHelper
       FOOTER_NAV = [
         {
-          title: "Prepare for Brexit",
+          title: "Coronavirus (COVID-19)",
           columns: 2,
           items: [
             {
-              href: "/business-uk-leaving-eu",
-              text: "Prepare your business or organisation for Brexit",
+              href: "/coronavirus",
+              text: "Coronavirus (COVID-19): guidance and support",
               attributes: {
                 data: {
                   track_category: "footerClicked",
-                  track_action: "brexitLinks",
-                  track_label: "Prepare your business or organisation for the UK leaving the EU",
+                  track_action: "coronavirusLinks",
+                  track_label: "Coronavirus (COVID-19): guidance and support",
                 },
               },
             },
+          ],
+        },
+        {
+          title: "Brexit",
+          columns: 1,
+          items: [
             {
-              href: "/prepare-eu-exit",
-              text: "Prepare for Brexit if you live in the UK",
+              href: "/transition",
+              text: "Check what you need to do",
               attributes: {
                 data: {
                   track_category: "footerClicked",
-                  track_action: "brexitLinks",
-                  track_label: "Prepare for Brexit if you live in the UK",
-                },
-              },
-            },
-            {
-              href: "/uk-nationals-living-eu",
-              text: "Living in Europe after Brexit",
-              attributes: {
-                data: {
-                  track_category: "footerClicked",
-                  track_action: "brexitLinks",
-                  track_label: "Living in Europe after Brexit",
-                },
-              },
-            },
-            {
-              href: "/staying-uk-eu-citizen",
-              text: "Continue to live in the UK after Brexit",
-              attributes: {
-                data: {
-                  track_category: "footerClicked",
-                  track_action: "brexitLinks",
-                  track_label: "Continue to live in the UK after Brexit",
+                  track_action: "transitionLinks",
+                  track_label: "Check what you need to do",
                 },
               },
             },

--- a/spec/components/layout_footer_spec.rb
+++ b/spec/components/layout_footer_spec.rb
@@ -12,12 +12,21 @@ describe "Layout footer", type: :view do
   end
 
   it "renders the footer with meta links" do
-    render_component(meta: { items: [{ href: "/help", text: "Help" }] })
+    render_component(
+      meta: {
+        items: [
+          {
+            href: "/help",
+            text: "Help",
+          },
+        ],
+      },
+    )
 
     assert_select ".govuk-footer__meta .govuk-footer__link[href='/help']", text: "Help"
   end
 
-  it "renders the footer with navigation" do
+  it "renders the footer with navigation with multiple links" do
     render_component(
       navigation: [
         {
@@ -28,6 +37,10 @@ describe "Layout footer", type: :view do
               href: "/browse/benefits",
               text: "Benefits",
             },
+            {
+              href: "/browse/births-deaths-marriages",
+              text: "Births, deaths, marriages and care",
+            },
           ],
         },
       ],
@@ -35,6 +48,27 @@ describe "Layout footer", type: :view do
 
     assert_select ".govuk-footer__navigation .govuk-footer__heading", text: "Services and information"
     assert_select ".govuk-footer__navigation .govuk-footer__list--columns-2 .govuk-footer__link[href='/browse/benefits']", text: "Benefits"
+  end
+
+  it "renders the footer with navigation with one link" do
+    render_component(
+      navigation: [
+        {
+          title: "Coronavirus (COVID-19)",
+          columns: 3,
+          items: [
+            {
+              href: "/coronavirus",
+              text: "Coronavirus (COVID-19): guidance and support",
+            },
+          ],
+        },
+      ],
+    )
+
+    assert_select ".govuk-footer__navigation .govuk-footer__list--columns-3", false
+    assert_select ".govuk-footer__navigation .govuk-footer__heading", text: "Coronavirus (COVID-19)"
+    assert_select ".govuk-footer__navigation .govuk-footer__link[href='/coronavirus']", text: "Coronavirus (COVID-19): guidance and support"
   end
 
   it "renders the footer with attributes" do


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Update the default footer links in the [public layout component][1] to the current set as used on www.gov.uk

Added a condition to stop a single link in a multiple-width column from wrapping.

## Why
<!-- What are the reasons behind this change being made? -->

The default links were out of date.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

Note - the colours of the live footer links are using the [older colour palette from `govuk_template`](https://github.com/alphagov/govuk_template/blob/134e8b910c5175d5f94b1f5c48fdc342bb5065c2/source/assets/stylesheets/_footer.scss#L17-L18), not the current more accessible colour palette from the [GOV.UK Design System](https://design-system.service.gov.uk/styles/colour/).

Before:

![image](https://user-images.githubusercontent.com/1732331/111980929-e435f600-8afe-11eb-972a-f19da1d30b87.png)

After:

![image](https://user-images.githubusercontent.com/1732331/111980868-cd8f9f00-8afe-11eb-8579-9874726d0448.png)

What's currently live on www.gov.uk:

![image](https://user-images.githubusercontent.com/1732331/111980999-f879f300-8afe-11eb-9660-d82b2b71bc02.png)

[1]: https://govuk-publis-update-foo-byame3.herokuapp.com/component-guide/layout_for_public
