### PR TITLE
Remove Sass `extend` from title component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove Sass `extend` from title component ([PR #1994](https://github.com/alphagov/govuk_publishing_components/pull/1994))
+
 ## 24.7.1
 
 * Add placeholder locale files to standardise apps. ([PR #1992](https://github.com/alphagov/govuk_publishing_components/pull/1992))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
@@ -26,10 +26,5 @@
 }
 
 .gem-c-title__text {
-  @extend %govuk-heading-xl;
   margin: 0;
-}
-
-.gem-c-title__text--long {
-  @extend %govuk-heading-l;
 }

--- a/app/views/govuk_publishing_components/components/_title.html.erb
+++ b/app/views/govuk_publishing_components/components/_title.html.erb
@@ -1,5 +1,6 @@
 <%
   average_title_length ||= false
+
   context ||= false
   context_locale ||= false
   context_text = context.is_a?(Hash) ? context[:text] : context
@@ -12,10 +13,13 @@
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
-  classes = %w(gem-c-title)
+  classes = %w[gem-c-title]
   classes << "gem-c-title--inverse" if inverse
   classes << (shared_helper.get_margin_top)
   classes << (shared_helper.get_margin_bottom)
+
+  heading_classes = %w[gem-c-title__text]
+  heading_classes << (average_title_length.present? ? 'govuk-heading-l' : 'govuk-heading-xl')
 %>
 <%= content_tag(:div, class: classes) do %>
   <% if context %>
@@ -23,7 +27,7 @@
       <%= context_href ? link_to(context_text, context_href, class: 'gem-c-title__context-link govuk-link', data: context_data) : context_text %>
     </span>
   <% end %>
-  <h1 class="gem-c-title__text <% if average_title_length %>gem-c-title__text--<%= average_title_length %><% end %>">
+  <h1 class="<%= heading_classes.join(" ") %>">
     <%= title %>
   </h1>
 <% end %>

--- a/spec/components/title_spec.rb
+++ b/spec/components/title_spec.rb
@@ -33,7 +33,7 @@ describe "Title", type: :view do
 
   it "applies title length if supplied" do
     render_component(title: "Hello World", context: "format", average_title_length: "long")
-    assert_select ".gem-c-title .gem-c-title__text--long", text: "Hello World"
+    assert_select ".gem-c-title .govuk-heading-l", text: "Hello World"
   end
 
   it "applies the inverse flag if supplied" do


### PR DESCRIPTION
## What

Instead of extending `govuk-heading-xl` in the Sass, this change updates the title component to use the `.govuk-heading-xl` in the markup. This allows importing of just the title component without any unnecessary styles.


<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->
Extending `%govuk-heading-l` forced the typography `core/typography` Sass from GOV.UK Frontend to be included - this caused unnecessary CSS to be included in the compiled stylesheet.

Removing the use of `extend` gives us a smaller stylesheet - for example, we can only import the `govuk_frontend_support` (which provides mixins, variables, and other, uh, _things_ for subsequent stylesheets but compiles to no CSS) and the title component stylesheet. 

For example:

```css
@import "govuk_publishing_components/component_support";
@import "govuk_publishing_components/components/title";
```

gives a stylesheet that is 155KB in size.

With the changes, `govuk_frontend_support` can be used:
```css
@import "govuk_publishing_components/govuk_frontend_support";
@import "govuk_publishing_components/components/title";
```

This results in a stylesheet that's 1.3KB in size.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

None.

[1]: https://github.com/alphagov/govuk-frontend/blob/c4fbe3dc7ff67741f7a07a2fe70ee9cd91b94cfe/src/govuk/core/_typography.scss#L11-L23 