### PR TITLE
Update auditing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Unreleased
 
-* Update to component auditing. ([PR 1996](https://github.com/alphagov/govuk_publishing_components/pull/1996))
+* Update to component auditing. ([PR 1996](https://github.com/alphagov/govuk_publishing_components/pull/1996)) PATCH
 * Update default footer links ([PR #1989](https://github.com/alphagov/govuk_publishing_components/pull/1989)) PATCH
 * Remove Sass `extend` from title component ([PR #1994](https://github.com/alphagov/govuk_publishing_components/pull/1994)) PATCH
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update to component auditing. ([PR 1996](https://github.com/alphagov/govuk_publishing_components/pull/1996))
 * Update default footer links ([PR #1989](https://github.com/alphagov/govuk_publishing_components/pull/1989)) PATCH
 * Remove Sass `extend` from title component ([PR #1994](https://github.com/alphagov/govuk_publishing_components/pull/1994)) PATCH
 

--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -16,7 +16,6 @@ module GovukPublishingComponents
     def analyse_applications(path)
       results = []
       applications = %w[
-        calculators
         collections
         collections-publisher
         content-data-admin


### PR DESCRIPTION
## What
Calculators has now been retired.

Trello card: https://trello.com/c/4Sz5s78X/2400-epic-retire-the-calculators-app 

