### PR TITLE
Change button margin option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Change button margin option ([PR #1998](https://github.com/alphagov/govuk_publishing_components/pull/1998)) MINOR
 * Add auditing to applications ([PR #1949](https://github.com/alphagov/govuk_publishing_components/pull/1949)) PATCH
 * Update auditing ([PR #1996](https://github.com/alphagov/govuk_publishing_components/pull/1996)) PATCH
 * Update default footer links ([PR #1989](https://github.com/alphagov/govuk_publishing_components/pull/1989)) PATCH

--- a/app/views/govuk_publishing_components/components/docs/button.yml
+++ b/app/views/govuk_publishing_components/components/docs/button.yml
@@ -66,18 +66,19 @@ examples:
       href: "#"
       start: true
       info_text: "Sometimes you want to explain where a user is going to."
+  with_margin_bottom:
+    description: "The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having no margin bottom."
+    data:
+      text: "Submit"
+      margin_bottom: 6
   start_now_button_with_info_text_and_margin_bottom:
+    description: "When the component requires margin bottom and has info text, the margin is applied to the info text."
     data:
       text: "Start now"
       href: "#"
       start: true
       info_text: "Sometimes you want to explain where a user is going to and have a margin bottom"
-      margin_bottom: true
-  with_margin_bottom:
-    description: "Sometimes it's useful to break up a page, for example if a button is at the bottom of a page."
-    data:
-      text: "Submit"
-      margin_bottom: true
+      margin_bottom: 6
   extreme_text:
     data:
       text: "I'm a button with lots of text to test how the component scales at extremes."

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -31,7 +31,8 @@ module GovukPublishingComponents
         @info_text = local_assigns[:info_text]
         @info_text_classes = %w[gem-c-button__info-text]
         if local_assigns[:margin_bottom]
-          @info_text_classes << "gem-c-button__info-text--bottom-margin"
+          margin_class = get_margin_bottom(local_assigns[:margin_bottom], true)
+          @info_text_classes << margin_class
         end
         @rel = local_assigns[:rel]
         @data_attributes = local_assigns[:data_attributes]
@@ -81,10 +82,20 @@ module GovukPublishingComponents
         css_classes << "gem-c-button--secondary-quiet" if secondary_quiet
         css_classes << "govuk-button--secondary" if secondary_solid
         css_classes << "govuk-button--warning" if destructive
-        css_classes << "gem-c-button--bottom-margin" if margin_bottom && !info_text
+        if margin_bottom && !info_text
+          margin_class = get_margin_bottom(margin_bottom, false)
+          css_classes << margin_class
+        end
         css_classes << "gem-c-button--inline" if inline_layout
         css_classes << classes if classes
         css_classes.join(" ")
+      end
+
+      def get_margin_bottom(margin, info_text)
+        legacy_class = "gem-c-button--bottom-margin"
+        legacy_class = "gem-c-button__info-text--bottom-margin" if info_text
+
+        [*0..9].include?(margin) ? "govuk-!-margin-bottom-#{margin}" : legacy_class
       end
     end
   end

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -91,6 +91,15 @@ describe "Button", type: :view do
     assert_select ".gem-c-button__info-text.gem-c-button__info-text--bottom-margin", text: "Information text"
   end
 
+  it "renders info text with variable margin bottom" do
+    render_component(text: "Start now", info_text: "Information text", margin_bottom: 6)
+
+    assert_select ".gem-c-button--bottom-margin", count: 0
+
+    assert_select ".govuk-button", text: "Start now"
+    assert_select '.gem-c-button__info-text.govuk-\!-margin-bottom-6', text: "Information text"
+  end
+
   it "renders rel attribute correctly" do
     render_component(text: "Start now", rel: "nofollow")
     assert_select ".govuk-button[rel='nofollow']", text: "Start now"
@@ -112,6 +121,11 @@ describe "Button", type: :view do
 
     render_component(text: "Submit", margin_bottom: true)
     assert_select ".govuk-button.gem-c-button--bottom-margin", text: "Submit"
+  end
+
+  it "renders a variable margin bottom correctly" do
+    render_component(text: "Submit", margin_bottom: 6)
+    assert_select '.govuk-button.govuk-\!-margin-bottom-6', text: "Submit"
   end
 
   it "renders data attributes correctly for buttons" do


### PR DESCRIPTION
## What

Change the `margin_bottom` option for the button component

- now accepts govuk-spacing scale value for variable margin
- also still accepts former option of `true` to add a custom margin class, so this isn't a breaking change
- will remove the 'true' option later

I wanted to use the `shared_helper` for this, but the button component has its own helper and I couldn't figure out how to call the one from the other. Instead, I've semi-replicated the code from the shared helper into the button, which probably works better for now as we need to preserve the existing 'true' option anyway, for backwards compatibility.

Note that this change also applies to the info text. When the button is given a margin, it's applied to the button. When info text is present, that margin is applied to the info text instead, otherwise it would look wrong.

## Why

I need different margin below the component than the only option that was available. Also making the component API consistent is good.

## Visual Changes
None. Well, you can set a custom margin on the button.

Trello card: https://trello.com/c/qm6BnJiO/680-public-holidays-location-experiment-fe
