### PR TITLE
Add a new cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add cookie ([PR #1999](https://github.com/alphagov/govuk_publishing_components/pull/1999)) PATCH
 * Change button margin option ([PR #1998](https://github.com/alphagov/govuk_publishing_components/pull/1998)) MINOR
 * Add auditing to applications ([PR #1949](https://github.com/alphagov/govuk_publishing_components/pull/1949)) PATCH
 * Update auditing ([PR #1996](https://github.com/alphagov/govuk_publishing_components/pull/1996)) PATCH

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -25,6 +25,7 @@
     govuk_browser_upgrade_dismisssed: 'settings',
     govuk_not_first_visit: 'settings',
     analytics_next_page_call: 'usage',
+    user_nation: 'settings',
     _ga: 'usage',
     _gid: 'usage',
     _gat: 'usage',


### PR DESCRIPTION
## What / why

Add a new cookie into the list of allowed cookies. This is being used for a personalisation experiment and is likely to be temporary.

## Visual Changes
None.

Trello card: https://trello.com/c/qm6BnJiO/680-public-holidays-location-experiment-fe

