### PR TITLE
Tidy up success alert markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update success notice component ([PR #1929](https://github.com/alphagov/govuk_publishing_components/pull/1929))
+* Tidy up success alert markup ([PR #2004](https://github.com/alphagov/govuk_publishing_components/pull/2004))
 
 ## 24.8.0
 

--- a/app/views/govuk_publishing_components/components/_success_alert.html.erb
+++ b/app/views/govuk_publishing_components/components/_success_alert.html.erb
@@ -1,23 +1,24 @@
-<% description ||= nil %>
+<%
+  description ||= nil
+  title_id ||= "govuk-notification-banner-title-#{SecureRandom.hex(4)}"
+%>
 
 <%= tag.div class: "gem-c-success-alert govuk-notification-banner govuk-notification-banner--success",
   role: "alert",
   tabindex: "-1",
   aria: {
-    labelledby: "govuk-notification-banner-title",
+    labelledby: title_id,
   },
   data: {
     module: "initial-focus",
   } do %>
   <div class="govuk-notification-banner__header">
-    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-      <%= t("govuk_component.success_alert.success", default: "Success") %>
-    </h2>
+    <%= tag.h2 t("govuk_component.success_alert.success", default: "Success"), class: "govuk-notification-banner__title", id: title_id %>
   </div>
   <div class="govuk-notification-banner__content">
     <% if description.present? %>
       <%= tag.h3 message, class: "govuk-notification-banner__heading" %>
-      <%= tag.div description %>
+      <%= description %>
     <% else %>
       <%= tag.p message, class: "govuk-body gem-c-success-alert__message" %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/success_alert.yml
+++ b/app/views/govuk_publishing_components/components/docs/success_alert.yml
@@ -12,9 +12,18 @@ examples:
     data:
       message: Message to alert the user to a successful action goes here
   with_message_and_description:
+    description: Descriptions can be passed as plain text but it is strongly recommended that you pass these as html, cleaned using `raw` or `sanitize`.
     data:
       message: Message to alert the user to a successful action goes here
-      description: A further description
+      description: <p class="govuk-body">A further description</p>
+  with_custom_title_id:
+    description: |
+      This is for the heading element at the head of the component (reading "Success" by default) where the id is used by an `aria-labelledby` on screen reader focus of the element.
+
+      Please ensure that this id is unique across the view you are building.
+    data:
+      message: Message to alert the user to a successful action goes here
+      title_id: my-custom-success-id
   long_example:
     data:
       message: |

--- a/spec/components/success_alert_spec.rb
+++ b/spec/components/success_alert_spec.rb
@@ -11,9 +11,16 @@ describe "Success Alert", type: :view do
   end
 
   it "allows a block to be given for description" do
-    render_component(message: "Foo", description: "Bar")
+    render_component(message: "Foo", description: raw("<p class=\"govuk-body\">Bar</p>"))
 
     assert_select ".govuk-notification-banner__heading", text: "Foo"
-    assert_select ".govuk-notification-banner__content div", text: "Bar"
+    assert_select ".govuk-notification-banner__content .govuk-body", text: "Bar"
+  end
+
+  it "allows the block to be given a custom component label id" do
+    render_component(message: "Foo", title_id: "Bar")
+
+    assert_select ".gem-c-success-alert", aria: { labelledby: "Bar" }
+    assert_select ".govuk-notification-banner__title", id: "Bar"
   end
 end


### PR DESCRIPTION
## What
- Adds a hashed ID to the success alert heading ID
- Add the option to set a custom ID for the title and the `aria-labelledby`
- Removes an unnecessary `div` from the success alert markup
- Adds some guidance advising devs to pass sanitised/raw'd markup to the `description` attribute

## Why
In response to comments made by Alex post-merge on https://github.com/alphagov/govuk_publishing_components/pull/1929

No visual changes
