### PR TITLE
Release 24.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.9.0
 
 * Image card link size option ([PR #2007](https://github.com/alphagov/govuk_publishing_components/pull/2007))
 * Update success notice component ([PR #1929](https://github.com/alphagov/govuk_publishing_components/pull/1929))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.8.0)
+    govuk_publishing_components (24.9.0)
       govuk_app_config
       kramdown
       plek
@@ -154,7 +154,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    marcel (1.0.0)
+    marcel (1.0.1)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -283,7 +283,7 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-raven (3.1.1)
+    sentry-raven (3.1.2)
       faraday (>= 1.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.8.0".freeze
+  VERSION = "24.9.0".freeze
 end


### PR DESCRIPTION
* Image card link size option ([PR #2007](https://github.com/alphagov/govuk_publishing_components/pull/2007))
* Update success notice component ([PR #1929](https://github.com/alphagov/govuk_publishing_components/pull/1929))
* Tidy up success alert markup ([PR #2004](https://github.com/alphagov/govuk_publishing_components/pull/2004))
