### PR TITLE
Extend modules start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Extend modules start ([PR #2010](https://github.com/alphagov/govuk_publishing_components/pull/2010))
+
 ## 24.9.0
 
 * Image card link size option ([PR #2007](https://github.com/alphagov/govuk_publishing_components/pull/2007))

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -88,6 +88,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (window.GOVUK.globalBarInit) {
       window.GOVUK.globalBarInit.init()
     }
+    window.GOVUK.modules.start()
   }
 
   CookieBanner.prototype.rejectCookieConsent = function () {

--- a/app/assets/javascripts/govuk_publishing_components/modules.js
+++ b/app/assets/javascripts/govuk_publishing_components/modules.js
@@ -35,20 +35,24 @@
         if ( // GOV.UK Publishing & Legacy Modules
           typeof GOVUK.Modules[moduleName] === 'function' &&
           !GOVUK.Modules[moduleName].prototype.init &&
-          !started
+          (!started || started === 'delay')
         ) {
           module = new GOVUK.Modules[moduleName]()
           module.start(element)
-          element.data('module-started', true)
+          if (started !== 'delay') {
+            element.data('module-started', true)
+          }
         }
 
         if ( // GOV.UK Frontend Modules
           typeof GOVUK.Modules[frontendModuleName] === 'function' &&
           GOVUK.Modules[frontendModuleName].prototype.init &&
-          !started
+          (!started || started === 'delay')
         ) {
           module = new GOVUK.Modules[frontendModuleName](element[0]).init()
-          element.data('module-started', true)
+          if (started !== 'delay') {
+            element.data('module-started', true)
+          }
         }
       }
 

--- a/docs/javascript-modules.md
+++ b/docs/javascript-modules.md
@@ -29,12 +29,32 @@ module = new GOVUK.Modules[type]()
 module.start(element)
 ```
 
-Running `GOVUK.modules.start()` multiple times will have no additional affect. When a module is started a flag is set on the element using the data attribute `module-started`. `data-module-started` is a reserved attribute. It can however be called with an element as the first argument, to allow modules to be started in dynamically loaded content:
+Running `GOVUK.modules.start()` multiple times will have no additional affect for most modules. When a module is started a flag is set on the element using the data attribute `module-started`. `data-module-started` is a reserved attribute. It can however be called with an element as the first argument, to allow modules to be started in dynamically loaded content:
 
 ```javascript
 var $container = $('.dynamic-content')
 GOVUK.modules.start($container)
 ```
+
+### Modules and cookie consent
+
+Some modules might rely on cookie consent being granted before doing anything. If a user consents to cookies on a page with such a module, that module should be started without the user having to reload the page.
+
+Modules that check for cookie consent in their `start` method can be loaded in this way by setting the `data-module-started` attribute in their template to `delay`. When cookies are accepted, the cookie banner calls `GOVUK.modules.start()`, which will start delayed modules a second time. The flow for this process looks like this:
+
+** Without cookie consent **
+
+- page loads, `GOVUK.modules.start()` is called normally
+- delayed modules are started, find that cookie consent has not been given, and do nothing
+- user consents to cookies
+- the cookie banner calls `GOVUK.modules.start()` for a second time
+- all existing normal modules on the page are not started, because they have `data-module-started` set to `true`
+- delayed modules are started a second time, find that cookie consent has been given, and execute
+
+** With cookie consent **
+
+- page loads, `GOVUK.modules.start()` is called normally
+- delayed modules are started, find that cookie consent has been given, and execute as normal
 
 ### Module structure
 

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -14,7 +14,7 @@ describe('Cookie banner', function () {
     container = document.createElement('div')
 
     container.innerHTML =
-    '<div id="global-cookie-message" class="gem-c-cookie-banner govuk-clearfix" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet="" style="display: block;">' +
+    '<div id="global-cookie-message" class="gem-c-cookie-banner govuk-clearfix" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet="">' +
       '<div class="govuk-cookie-banner js-banner-wrapper" role="region" aria-label="Cookies on GOV.UK">' +
         '<div class="gem-c-cookie-banner__message govuk-cookie-banner__message govuk-width-container govuk-body">' +
           '<div class="govuk-grid-row">' +
@@ -28,8 +28,8 @@ describe('Cookie banner', function () {
             '</div>' +
           '</div>' +
           '<div class="govuk-button-group">' +
-            '<button class="gem-c-button govuk-button" type="submit" data-module="gem-track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted" data-cookie-types="all" style="display: block;">Accept additional cookies</button>' +
-            '<button class="gem-c-button govuk-button" type="submit" data-module="gem-track-click" data-reject-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner rejected" style="display: block;">Reject additional cookies</button>' +
+            '<button class="gem-c-button govuk-button" type="submit" data-module="gem-track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted" data-cookie-types="all">Accept additional cookies</button>' +
+            '<button class="gem-c-button govuk-button" type="submit" data-module="gem-track-click" data-reject-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner rejected">Reject additional cookies</button>' +
             '<a class="govuk-link" href="/help/cookies">View cookies</a>' +
           '</div>' +
         '</div>' +
@@ -161,6 +161,10 @@ describe('Cookie banner', function () {
   it('shows a confirmation message when cookies have been accepted', function () {
     var element = document.querySelector('[data-module="cookie-banner"]')
     new GOVUK.Modules.CookieBanner().start($(element))
+    // this is normally set by GOVUK.modules.start but not here as module is called directly
+    // need to set manually as the click below calls GOVUK.modules start and it'll get confused otherwise
+    // essentially this simulates real world use of our modules code
+    $(element).attr('data-module-started', true)
 
     var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
     var mainCookieBanner = document.querySelector('.gem-c-cookie-banner__message')

--- a/spec/javascripts/govuk_publishing_components/modules.spec.js
+++ b/spec/javascripts/govuk_publishing_components/modules.spec.js
@@ -143,6 +143,15 @@ describe('GOVUK Modules', function () {
       expect(callbackLegacyModule.calls.count()).toBe(1)
     })
 
+    it('starts modules that are delayed', function () {
+      var module = $('<div data-module="legacy-test-alert-module" data-module-started="delay"></div>')
+      container.append(module)
+
+      GOVUK.modules.start(module)
+      GOVUK.modules.start(module)
+      expect(callbackLegacyModule.calls.count()).toBe(2)
+    })
+
     it('passes the HTML element to the module’s start method', function () {
       var module = $('<div data-module="legacy-test-alert-module"></div>')
       container.append(module)


### PR DESCRIPTION
## What

Allow cookie consent dependent modules to be initialised immediately when the user consents to cookies, so the page doesn't have to be reloaded first.

- update the cookie banner to call `GOVUK.modules.start()` when cookies are accepted
- extend the `modules.start` function to check the `data-module-started` for a specific value, `delay`
- this allows cookie consent dependent modules to exist on a page and be initialised when the user clicks to accept cookies, without the page needing to be reloaded
- assumes that modules that do this check for cookie consent first before doing anything
- update documentation to explain this
- modify cookie banner test slightly to more accurately simulate running this in a real world environment

See the updated doc file in this PR for more details of how this works in practice.

## Why
We have a new feature on the bank holidays page where users can save their location, but this is done with cookies and so we don't show this feature unless cookies are accepted. Currently if you accept cookies on that page the feature doesn't appear until the page is reloaded.

This feature is an experiment, so it may not be continued, but I suspect that as we move towards a more personalised GOV.UK we will increasingly need the ability to initialise code like this on a page only after cookie consent is given.

## Visual Changes
None.

Trello card: https://trello.com/c/QweAgiPc/693-bank-holidays-experiment-things-to-clean-up
