### PR TITLE
Release 24.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.9.1
 
 * Change to the exceptions list for Brexit branding ([PR #2011](https://github.com/alphagov/govuk_publishing_components/pull/2011))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.9.0)
+    govuk_publishing_components (24.9.1)
       govuk_app_config
       kramdown
       plek
@@ -381,9 +381,6 @@ DEPENDENCIES
   uglifier (>= 4.1.0)
   webmock (~> 3.8.3)
   yard
-
-RUBY VERSION
-   ruby 2.6.6p146
 
 BUNDLED WITH
    1.17.3

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.9.0".freeze
+  VERSION = "24.9.1".freeze
 end


### PR DESCRIPTION
Includes:

* Change to the exceptions list for Brexit branding #2011 
