### PR TITLE
Remove grid overrides in layout-header 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Tidy up untranslated content and formatting on accordion docs ([PR #1958](https://github.com/alphagov/govuk_publishing_components/pull/1958)) PATCH
 * Add visual regression testing tool Percy ([PR #1013](https://github.com/alphagov/govuk_publishing_components/pull/1013)) PATCH
 * Remove @extend from component Sass ([PR #2002](https://github.com/alphagov/govuk_publishing_components/pull/2002)) PATCH
+* Remove grid overrides in layout-header ([PR #2013](https://github.com/alphagov/govuk_publishing_components/pull/2013)) PATCH
 
 ## 24.9.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-header.scss
@@ -33,7 +33,7 @@
 .gem-c-layout-header--search-left {
   .gem-c-header__menu-button.govuk-header__menu-button {
     margin-top: - govuk-spacing(7);
-    left: 0;
+    left: govuk-spacing(3);
   }
 
   .gem-c-header__nav-wrapper {
@@ -75,16 +75,6 @@
       padding-left: govuk-spacing(6);
       padding-right: govuk-spacing(1);
     }
-  }
-}
-
-@include govuk-compatibility(govuk_template) {
-  .gem-c-layout-header__search.govuk-grid-column-one-third-from-desktop,
-  .gem-c-layout-header__logo.govuk-grid-column-one-third-from-desktop,
-  .gem-c-layout-header__search.govuk-grid-column-one-third,
-  .gem-c-layout-header__logo.govuk-grid-column-two-thirds {
-    padding-right: 0;
-    padding-left: 0;
   }
 }
 

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -18,12 +18,12 @@
 <header class="<%= header_classes.join(' ') %>"  role="banner" data-module="govuk-header">
   <div class="govuk-header__container <%= width_class %>">
     <% if search_left %>
-      <div class="govuk-grid-row govuk-!-margin-left-0 govuk-!-margin-right-0">
+      <div class="govuk-grid-row">
         <div class="gem-c-layout-header__logo govuk-grid-column-one-third-from-desktop">
           <%= render "govuk_publishing_components/components/layout_header/header_logo", environment: environment, product_name: product_name %>
         </div>
       </div>
-      <div class="govuk-grid-row govuk-!-margin-left-0 govuk-!-margin-right-0">
+      <div class="govuk-grid-row">
         <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop gem-c-layout-header__search">
           <%= render "govuk_publishing_components/components/layout_header/search" %>
         </div>


### PR DESCRIPTION
## What
Fix layout-header by removing overrides

## Why
The new layout header component is currently only used (via static) in [collections](https://www.gov.uk/transition) and [finder-frontend](https://www.gov.uk/transition-check/questions) – part of the Accounts journey. We currently have an issue with the alignment of this component with the main container and it seems like removing these overrides fixes the issue.

## Visual Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1174" alt="before" src="https://user-images.githubusercontent.com/788096/114543308-f19f5580-9c50-11eb-8662-3284f970f29e.png">


</td><td valign="top">

<img width="1172" alt="after" src="https://user-images.githubusercontent.com/788096/114543316-f3691900-9c50-11eb-80d1-e9dbc7ee491e.png">


</td></tr>
<tr><td valign="top">

<img width="394" alt="mobile-before-closed" src="https://user-images.githubusercontent.com/788096/114548526-cbc97f00-9c57-11eb-8f95-aeccfc54b3a5.png">


</td><td valign="top">

<img width="394" alt="mobile-after-closed" src="https://user-images.githubusercontent.com/788096/114548533-ce2bd900-9c57-11eb-9a81-41aa33b8e62b.png">


</td></tr>
<tr><td valign="top">

<img width="394" alt="mobile-before-open" src="https://user-images.githubusercontent.com/788096/114548638-f1ef1f00-9c57-11eb-8078-d8305d18642a.png">


</td><td valign="top">

<img width="394" alt="mobile-after-open" src="https://user-images.githubusercontent.com/788096/114548646-f3b8e280-9c57-11eb-85c1-68d11555ca32.png">


</td></tr>
</table>

