### PR TITLE
Remove govuk-link class from headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove govuk-link class from headings ([PR #2020](https://github.com/alphagov/govuk_publishing_components/pull/2020))
 * Change wording of report a problem button on feedback component ([PR #2021](https://github.com/alphagov/govuk_publishing_components/pull/2021))
 
 ## 24.9.2

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -23,10 +23,11 @@
 
     <% links.each.with_index(1) do |link, index| %>
       <%
+        link_class = "govuk-link #{related_nav_helper.section_css_class("govuk-link gem-c-related-navigation__section-link", section_title, link: link, link_is_inline: (index >= section_link_limit))}"
         link_element = link_to(
           link[:text],
           link[:path],
-          class: related_nav_helper.section_css_class("gem-c-related-navigation__section-link", section_title, link: link, link_is_inline: (index >= section_link_limit)),
+          class: link_class,
           rel: link[:rel],
           lang: shared_helper.t_locale_check(link[:locale]),
           data: {

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -67,7 +67,6 @@ module GovukPublishingComponents
 
       def section_css_class(css_class, section_title, link: {}, link_is_inline: false)
         css_classes = [css_class]
-        css_classes << "govuk-link"
         css_classes << "#{css_class}--#{@context}" unless @context.nil?
         css_classes << "#{css_class}--inline" if link_is_inline
 


### PR DESCRIPTION
## What
Remove the `govuk-link` class from headings in the component. This was being inserted because of a recent change to stop using Sass's `extend` feature. Unfortunately in this case the method for generating classes that had been given the `govuk-link` class was being used for both links and headings, where inserting the `govuk-link` class by default wasn't correct.

## Why
Fixes https://github.com/alphagov/govuk_publishing_components/issues/2018

## Visual Changes
Fixes a very small visual bug with the headings, returning to the intended visual appearance. See the linked issue for details.
