### PR TITLE
Change wording of report a problem button on feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change wording of report a problem button on feedback component ([PR #2021](https://github.com/alphagov/govuk_publishing_components/pull/2021))
+
 ## 24.9.2
 
 * Tidy up untranslated content and formatting on accordion docs ([PR #1958](https://github.com/alphagov/govuk_publishing_components/pull/1958)) PATCH

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -28,7 +28,7 @@
   </div>
   <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions">
     <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV-UK Open Form" aria-controls="something-is-wrong" aria-expanded="false">
-      <%= t("components.feedback.something_wrong", default: "There is something wrong with this page") %>
+      <%= t("components.feedback.something_wrong", default: "Report a problem with this page") %>
     </button>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,7 +50,7 @@ en:
       is_useful: "this page is useful"
       is_not_useful: "this page is not useful"
       thank_you_for_feedback: "Thank you for your feedback"
-      something_wrong: "There is something wrong with this page"
+      something_wrong: "Report a problem with this page"
       close: "Close"
       help_us_improve_govuk: "Help us improve GOV.UK"
       more_about_visit: "To help us improve GOV.UK, we’d like to know more about your visit today. We’ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don’t worry we won’t send you spam or share your email address with anyone."

--- a/spec/components/feedback_spec.rb
+++ b/spec/components/feedback_spec.rb
@@ -15,7 +15,7 @@ describe "Feedback", type: :view do
   it "asks the user if there is anything wrong with the page without javascript enabled" do
     render_component({})
 
-    assert_select ".gem-c-feedback .gem-c-feedback__prompt-link.js-something-is-wrong", text: "There is something wrong with this page"
+    assert_select ".gem-c-feedback .gem-c-feedback__prompt-link.js-something-is-wrong", text: "Report a problem with this page"
   end
 
   it "has required email survey signup form fields" do


### PR DESCRIPTION
## What
Updates wording of issue reporting button on feedback component from...

>There is something wrong with this page

to...

>Report a problem with this page

## Why
This is in response to feedback from the content community on the feedback component wording to clearly communicate what the button is for to users.

[Card](https://trello.com/c/rasDOIGP/583-update-wording-of-theres-something-wrong-with-this-page-button-to-match-keiths-suggestion)

## Visual Changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-04-20 at 10 16 51](https://user-images.githubusercontent.com/64783893/115371726-23209f80-a1c2-11eb-8b1e-e5fb81650b9f.png) | ![Screenshot 2021-04-20 at 10 17 11](https://user-images.githubusercontent.com/64783893/115371685-1ac86480-a1c2-11eb-9873-8e2f5d67e463.png) |
