### PR TITLE
Update success alert docs to include links guidance

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/success_alert.yml
+++ b/app/views/govuk_publishing_components/components/docs/success_alert.yml
@@ -24,6 +24,11 @@ examples:
     data:
       message: Message to alert the user to a successful action goes here
       title_id: my-custom-success-id
+  with_styled_link:
+    description: If you need to include a link in your success alert, you need to specify the `govuk-link` and `govuk-notification-banner__link` classes on that link element. This is in line with Design System guidance that the colour of the link in success notification banners can look jarring if any links are a different colour to the principal colour used by the success banner.
+    data:
+      message: Message to alert the user to a successful action goes here
+      description: <p class="govuk-body">A further description with <a href="/a-cool-page" class="govuk-link govuk-notification-banner__link">a link</a></p>
   long_example:
     data:
       message: |


### PR DESCRIPTION
## What
Adds some guidance to the success alert documentation for if you're using links in your success alert content.

## Why
To comply with Design System guidance on this topic. More info here https://github.com/alphagov/govuk_publishing_components/issues/2008

No visual changes.
