### PR TITLE
Remove traffic light indicators from Brexit nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Remove govuk-link class from headings ([PR #2020](https://github.com/alphagov/govuk_publishing_components/pull/2020))
 * Change wording of report a problem button on feedback component ([PR #2021](https://github.com/alphagov/govuk_publishing_components/pull/2021))
+* Remove traffic light indicators from Brexit nav ([#PR2024](https://github.com/alphagov/govuk_publishing_components/pull/2024))
 
 ## 24.9.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -42,27 +42,3 @@ $transition-campaign-dark-blue: #1e1348;
     text-decoration: none;
   }
 }
-
-.gem-c-contextual-sidebar__take-action-traffic-lights {
-  text-align: left;
-  margin-bottom: govuk-spacing(2);
-}
-
-.gem-c-contextual-sidebar__take-action-traffic-lights > li {
-  white-space: nowrap;
-  display: inline;
-  margin-right: 7px;
-  margin-bottom: govuk-spacing(1);
-}
-
-.gem-c-contextual-sidebar__take-action-traffic-lists-icon {
-  vertical-align: middle;
-  margin-top: -2px;
-  width: 22px;
-  margin-right: 2px;
-}
-
-.gem-c-contextual-sidebar__take-action-traffic-lists-text {
-  @include govuk-font($size: 19, $weight: bold, $line-height: 2);
-  vertical-align: middle;
-}

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
@@ -14,28 +14,8 @@
 <%= link_to link_path,
     class: "govuk-link gem-c-contextual-sidebar__brexit-cta",
     data: data_attributes,
-    aria: { label: "#{t("components.related_navigation.take_action_list.aria_label")} #{link_text}" },
+    aria: { label: "#{t("components.related_navigation.transition.aria_label")}" },
     lang: shared_helper.t_locale("components.related_navigation.transition.title") do %>
   <h2 class="gem-c-contextual-sidebar__brexit-heading govuk-heading-s"><%= t("components.related_navigation.transition.title") %></h2>
-  <ul class="govuk-list gem-c-contextual-sidebar__take-action-traffic-lights">
-    <li>
-      <%= image_tag 'govuk_publishing_components/take-action-red.svg', class: "gem-c-contextual-sidebar__take-action-traffic-lists-icon", alt: "" %>
-      <span class="gem-c-contextual-sidebar__take-action-traffic-lists-text">
-        <%= t("components.related_navigation.take_action_list.red") %>
-      </span>
-    </li>
-    <li>
-      <%= image_tag 'govuk_publishing_components/take-action-amber.svg', class: "gem-c-contextual-sidebar__take-action-traffic-lists-icon", alt: "" %>
-      <span class="gem-c-contextual-sidebar__take-action-traffic-lists-text">
-        <%= t("components.related_navigation.take_action_list.amber") %>
-      </span>
-    </li>
-    <li>
-      <%= image_tag 'govuk_publishing_components/take-action-green.svg', class: "gem-c-contextual-sidebar__take-action-traffic-lists-icon", alt: "" %>
-      <span class="gem-c-contextual-sidebar__take-action-traffic-lists-text">
-        <%= t("components.related_navigation.take_action_list.green") %>
-      </span>
-    </li>
-  </ul>
   <p class="gem-c-contextual-sidebar__brexit-text"><%= link_text %></p>
 <% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -13,8 +13,4 @@ cy:
         title: "Brexit"
         link_path: "/transition.cy"
         link_text: "Gwiriwch beth sydd angen i chi ei wneud"
-      take_action_list:
-        red: Gwiriwch
-        amber: Newidiwch
-        green: Ewch
-        aria_label: Ymgyrch slogan Brexit, Gwiriwch, Newidiwch, Ewch.
+        aria_label: "Brexit. Gwiriwch beth sydd angen i chi ei wneud."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,11 +88,7 @@ en:
         title: "Brexit"
         link_path: "/transition"
         link_text: "Check what you need to do"
-      take_action_list:
-        red: "Check"
-        amber: "Change"
-        green: "Go"
-        aria_label: "Brexit campaign slogan, Check, Change, Go."
+        aria_label: "Brexit. Check what you need to do."
     related_footer_navigation:
       collections: "Collections"
       policies: "Policies"


### PR DESCRIPTION
## What
Removing the Check, Change, Go traffic light section of the Brexit navigation.

<img width="311" src="https://user-images.githubusercontent.com/773037/115528880-54fd3900-a28a-11eb-9dbf-94344c227cc7.png">

## Why
We're removing this to avoid overlap with the new rules around Coronavirus travel which also uses a red, amber, green style. 

https://trello.com/c/vNhkoqGr/1462-remove-the-check-change-go-visual-in-the-brexit-sidebar-navigation-to-avoid-confusion-with-upcoming-rag-guidance

## Visual Changes

- [example page on review app](https://government-f-test-brexi-phy2vc.herokuapp.com/guidance/free-courses-for-jobs)
- [current page on GOV.UK](https://www.gov.uk/guidance/free-courses-for-jobs)

### Before 

#### Mobile
<img width="400" src="https://user-images.githubusercontent.com/773037/115529320-b6250c80-a28a-11eb-9332-a102cf20acdc.png">

#### Desktop
<img src="https://user-images.githubusercontent.com/773037/115529323-b6bda300-a28a-11eb-8a18-4c18859413a6.png">

### After

#### Mobile
<img width="400" src="https://user-images.githubusercontent.com/773037/115529317-b58c7600-a28a-11eb-84af-960933e5e841.png">

#### Desktop
<img src="https://user-images.githubusercontent.com/773037/115529297-b1605880-a28a-11eb-8507-6ba8f1e1b80c.png">

