### PR TITLE
Add data attributes to show password component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 
+* Add data attributes to show password component ([PR #2025](https://github.com/alphagov/govuk_publishing_components/pull/2025))
 * Update documentation about component conventions and visual regression testing ([PR #2015](https://github.com/alphagov/govuk_publishing_components/pull/2015))
 * Remove `@extend` from notice component styles ([PR #2030])(https://github.com/alphagov/govuk_publishing_components/pull/2030)
 

--- a/app/assets/javascripts/govuk_publishing_components/components/show-password.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/show-password.js
@@ -41,6 +41,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.wrapper.insertBefore(this.statusText, this.showHide.nextSibling)
 
     this.showHide.addEventListener('click', this.$module.togglePassword)
+    this.moveDataAttributesToButton()
 
     this.parentForm = this.input.form
     var disableFormSubmitCheck = this.$module.getAttribute('data-disable-form-submit-check')
@@ -63,6 +64,17 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.showHide.setAttribute('aria-label', this.showPasswordFullText)
     this.statusText.innerHTML = this.hiddenPassword
     this.input.setAttribute('type', 'password')
+  }
+
+  ShowPassword.prototype.moveDataAttributesToButton = function () {
+    var attrs = this.input.attributes
+    for (var i = attrs.length; i >= 0; i--) {
+      var attr = attrs[i]
+      if (attr && /^data-button/.test(attr.name)) {
+        this.showHide.setAttribute(attr.name.replace('-button', ''), attr.value)
+        this.input.removeAttribute(attr.name)
+      }
+    }
   }
 
   Modules.ShowPassword = ShowPassword

--- a/app/views/govuk_publishing_components/components/_show_password.html.erb
+++ b/app/views/govuk_publishing_components/components/_show_password.html.erb
@@ -9,6 +9,7 @@
   hint ||= nil
   error_message ||= nil
   error_items ||= nil
+  data ||= nil
 
   if !label
     raise ArgumentError, "This component requires a label"
@@ -37,6 +38,7 @@
         error_items: error_items,
         type: "password",
         autocomplete: autocomplete,
+        data: data,
       } %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/show_password.yml
+++ b/app/views/govuk_publishing_components/components/docs/show_password.yml
@@ -79,3 +79,13 @@ examples:
       error_items:
       - text: Look I keep telling you
       - text: This isn't your password
+  with_data_attributes:
+    description: Data attributes can be passed to add to the input element. If the data attribute starts with `data-button-` this attribute will be applied to the show/hide button, instead of the input. Note that if JS is disabled, all attributes are added to the input.
+    data:
+      label:
+        text: Your password
+      data:
+        example_1: value
+        example_2: thing
+        button_example_1: wotsit
+        button_example_2: doodad

--- a/spec/components/show_password_spec.rb
+++ b/spec/components/show_password_spec.rb
@@ -50,4 +50,18 @@ describe "Show password", type: :view do
 
     assert_select(".gem-c-input[autocomplete='off']")
   end
+
+  it "renders with data attributes" do
+    render_component(
+      label: {
+        text: "Your password",
+      },
+      data: {
+        track_action: "action",
+        track_label: "label",
+      },
+    )
+
+    assert_select(".gem-c-input[data-track-action='action'][data-track-label='label']")
+  end
 end

--- a/spec/javascripts/components/show-password-spec.js
+++ b/spec/javascripts/components/show-password-spec.js
@@ -126,4 +126,32 @@ describe('A show password component', function () {
       expect(element.find('.govuk-visually-hidden').text()).toBe('Your password is shown')
     })
   })
+
+  describe('with data attributes', function () {
+    beforeEach(function () {
+      element = $(
+        '<div class="gem-c-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="Show" data-hide-text="Hide" data-show-full-text="Show password" data-hide-full-text="Hide password" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">' +
+          '<div class="govuk-form-group">' +
+            '<label for="input" class="gem-c-label govuk-label">Please enter your password</label>' +
+            '<input name="password" value="this is my password" class="gem-c-input govuk-input" id="input" type="password" autocomplete="off" data-normal-attribute-one="one" data-normal-attribute-two="two" data-button-moving-attribute-one="button-one" data-button-moving-attribute-two="button-two">' +
+          '</div>' +
+        '</div>'
+      )
+      new GOVUK.Modules.ShowPassword().start(element)
+    })
+
+    afterEach(function () {
+      element.remove()
+    })
+
+    it('applies data attributes to the button correctly', function () {
+      expect(element.find('input').attr('data-normal-attribute-one')).toBe('one')
+      expect(element.find('input').attr('data-normal-attribute-two')).toBe('two')
+      expect(element.find('input')[0].hasAttribute('data-button-moving-attribute-one')).toBe(false)
+      expect(element.find('input')[0].hasAttribute('data-button-moving-attribute-two')).toBe(false)
+
+      expect(element.find('button').attr('data-moving-attribute-one')).toBe('button-one')
+      expect(element.find('button').attr('data-moving-attribute-two')).toBe('button-two')
+    })
+  })
 })


### PR DESCRIPTION
## What
Allow data attributes to be passed to the show password component. This basically passes them to the input component, which the show password component wraps (interestingly the ability to pass data attributes to the input component doesn't appear to be documented, but you can do it, leading to a possible discussion about components not only wrapping other components but relying on aspects of their API).

However, the complexity is that I don't want data attributes on the input, I want them on the show/hide button. This is generated by JS, so I've added a bit to the script to check for any data attributes that start with `data-button-` and move them onto the button. It's a bit convoluted, but it works, and I'm not sure how else to do it without hard coding something.

## Why
We want to add tracking to the show/hide button, so we can see how many people are using it. This will be done by wrapping the component in an element with the `gem-track-click` data-module, then passing relevant attributes to the component.

## Visual Changes
None.

Trello card: https://trello.com/c/HRCea3NT/721-add-tracking-to-the-show-password-component