### PR TITLE
Convert Brexit CTA into a standard link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Remove govuk-link class from headings ([PR #2020](https://github.com/alphagov/govuk_publishing_components/pull/2020))
 * Change wording of report a problem button on feedback component ([PR #2021](https://github.com/alphagov/govuk_publishing_components/pull/2021))
 * Remove traffic light indicators from Brexit nav ([#PR2024](https://github.com/alphagov/govuk_publishing_components/pull/2024))
+* Convert Brexit CTA into a standard link ([#PR2026](https://github.com/alphagov/govuk_publishing_components/pull/2026))
 
 ## 24.9.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -1,5 +1,4 @@
 $transition-campaign-red: #ff003b;
-$transition-campaign-dark-blue: #1e1348;
 
 .gem-c-contextual-sidebar__brexit-related-links {
   border-top: 2px solid $govuk-brand-colour;
@@ -24,21 +23,9 @@ $transition-campaign-dark-blue: #1e1348;
 
   .gem-c-contextual-sidebar__brexit-text {
     @include govuk-font(16);
-
-    margin-top: 0;
     margin-bottom: govuk-spacing(1);
-    text-decoration: underline;
-
     @include govuk-media-query($from: tablet) {
       margin-bottom: govuk-spacing(2);
     }
-  }
-}
-
-.gem-c-contextual-sidebar__brexit-cta:focus {
-  box-shadow: 0 $govuk-focus-width $govuk-focus-text-colour;
-
-  .gem-c-contextual-sidebar__brexit-text {
-    text-decoration: none;
   }
 }

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_brexit_cta.html.erb
@@ -11,11 +11,13 @@
   "track-dimension-index": "29",
 } %>
 
-<%= link_to link_path,
-    class: "govuk-link gem-c-contextual-sidebar__brexit-cta",
-    data: data_attributes,
-    aria: { label: "#{t("components.related_navigation.transition.aria_label")}" },
-    lang: shared_helper.t_locale("components.related_navigation.transition.title") do %>
-  <h2 class="gem-c-contextual-sidebar__brexit-heading govuk-heading-s"><%= t("components.related_navigation.transition.title") %></h2>
-  <p class="gem-c-contextual-sidebar__brexit-text"><%= link_text %></p>
+<%= tag.div class: "gem-c-contextual-sidebar__brexit-cta" do %>
+  <%= tag.h2 t("components.related_navigation.transition.title"), class: "gem-c-contextual-sidebar__brexit-heading govuk-heading-s" %>
+  <%= tag.p class: "gem-c-contextual-sidebar__brexit-text govuk-body" do %>
+    <%= link_to link_text,
+      link_path,
+      class: "govuk-link",
+      data: data_attributes,
+      lang: shared_helper.t_locale("components.related_navigation.transition.title") %>
+  <% end %>
 <% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -13,4 +13,3 @@ cy:
         title: "Brexit"
         link_path: "/transition.cy"
         link_text: "Gwiriwch beth sydd angen i chi ei wneud"
-        aria_label: "Brexit. Gwiriwch beth sydd angen i chi ei wneud."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,7 +88,6 @@ en:
         title: "Brexit"
         link_path: "/transition"
         link_text: "Check what you need to do"
-        aria_label: "Brexit. Check what you need to do."
     related_footer_navigation:
       collections: "Collections"
       policies: "Policies"


### PR DESCRIPTION
## What
Convert Brexit CTA into a standard link. Follow up on #2024.

## Why
Now that we don't have any additional graphics that need to be incorporated in this navigation element, we can convert it into a standard navigation link, similar to the other ones in the contextual sidebar.

## Visual Changes
No visual changes except for focus state – see below

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="300" alt="before" src="https://user-images.githubusercontent.com/788096/115673006-0c09bb00-a344-11eb-8baa-b6a28174b8ba.png">


</td><td valign="top">

<img width="300" alt="after" src="https://user-images.githubusercontent.com/788096/115673021-0dd37e80-a344-11eb-8399-d349c74a1f53.png">


</td></tr>
</table>

[Trello card](https://trello.com/c/vNhkoqGr)