### PR TITLE
Set up scroll tracking for the PCR test start page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Set up scroll tracking for the PCR test start page ([PR #2028](https://github.com/alphagov/govuk_publishing_components/pull/2028))
+
 ## 24.9.3
 
 * Remove govuk-link class from headings ([PR #2020](https://github.com/alphagov/govuk_publishing_components/pull/2020))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js
@@ -433,6 +433,13 @@
       ['Percent', 60],
       ['Percent', 80],
       ['Percent', 100]
+    ],
+    '/get-coronavirus-test': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
     ]
   }
 


### PR DESCRIPTION
**What:**

Set up scroll tracking on the PCR test start page. https://www.gov.uk/get-coronavirus-test

We would be interested in understanding how far users scroll down the page by %

How far do users scroll?
How many users scroll to the green button?
How many read the content underneath the green button?

We're interested in whether the large amount of guidance on the page is confusing people and causing them to miss the green button, which is towards the bottom of the page. We're also interested in how many people read the information below the green button. 

**Why:**

So that we understand how the start page is currently performing, and decide what iteration or future research is needed,

**Who to work with:**

Rob and Harriet are gathering insights for the PCR start page
Ronan and Hannah are responsible for the content on the page
We need a dev to help us set up scroll tracking

**Timeline:**

As soon as we can

https://trello.com/c/8QiFq55T/358-set-up-scroll-tracking-for-the-pcr-test-start-page