### PR TITLE
Update notice component to not use `@extend`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ## Unreleased
 
 * Update documentation about component conventions and visual regression testing ([PR #2015](https://github.com/alphagov/govuk_publishing_components/pull/2015))
+* Remove `@extend` from notice component styles ([PR #2030])(https://github.com/alphagov/govuk_publishing_components/pull/2030)
+
 ## 24.9.4
 
 * Set up scroll tracking for the PCR test start page ([PR #2028](https://github.com/alphagov/govuk_publishing_components/pull/2028))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
@@ -6,7 +6,7 @@
   clear: both;
   border: $govuk-border-width solid govuk-colour("blue");
 
-  .govuk-govspeak, {
+  .govuk-govspeak {
     p:last-child {
       margin-bottom: 0;
     }
@@ -27,7 +27,9 @@
   }
 
   a {
-    @extend %govuk-link;
+    @include govuk-link-common;
+    @include govuk-link-style-default;
+    @include govuk-link-print-friendly;
   }
 }
 

--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -10,7 +10,7 @@
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
-  css_classes = %w(gem-c-notice)
+  css_classes = %w[gem-c-notice]
   css_classes << (shared_helper.get_margin_bottom)
 
   aria_attributes = aria_live ? {label: 'Notice', live: 'polite'} : {label: 'Notice'}


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Update notice component to not use `@extend` on links inside the component - swapped out `@extend`ing `govuk-link` for a lower-level `@include` of the govuk link styles for no visual difference.

## Why
<!-- What are the reasons behind this change being made? -->

Using `@extend` means that the `component_support` Sass file is required, can lead to accidental unnecessary CSS without realising it, and is incompatible with the `gem_layout` in Static.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
None.
