### PR TITLE
Resolve IE11 accordion gem doc duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 
+* Resolve IE11 accordion gem doc duplication ([PR #2036](https://github.com/alphagov/govuk_publishing_components/pull/2036))
 * Add data attributes to show password component ([PR #2025](https://github.com/alphagov/govuk_publishing_components/pull/2025))
 * Update documentation about component conventions and visual regression testing ([PR #2015](https://github.com/alphagov/govuk_publishing_components/pull/2015))
 * Remove `@extend` from notice component styles ([PR #2030](https://github.com/alphagov/govuk_publishing_components/pull/2030))

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -326,8 +326,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   // Adding an event listener to all anchor link a tags in an accordion is risky but we circumvent this risk partially by only being a layer of accordion behaviour instead of any sort of change to link behaviour
   GemAccordion.prototype.addEventListenersForAnchors = function () {
     var links = this.$module.querySelectorAll('.' + this.sectionInnerContent + ' a[href*="#"]')
-
-    links.forEach(function (link) {
+    nodeListForEach(links, function (link) {
       if (link.pathname === window.location.pathname) {
         link.addEventListener('click', this.openForAnchor.bind(this, link.hash.split('#')[1]))
       }


### PR DESCRIPTION
## What?

Updating to use polyfill version for `forEach` for IE11

## Why?

The Accordion on the gem docs was being visually duplicated.

## Visual Changes

Before
![image](https://user-images.githubusercontent.com/71266765/116299599-ce6abf00-a795-11eb-8c37-f663273598e3.png)

After 

![Screenshot 2021-04-28 at 09 03 02](https://user-images.githubusercontent.com/71266765/116368948-c300ad80-a800-11eb-8c2f-7011bc45c939.png)

## Anything else?

_"`querySelectorAll()` is a method which return a `NodeList`. And on [Internet Explorer](
https://caniuse.com/mdn-api_nodelist_foreach), `foreach()` only works on Array objects. (It works with NodeList with ES6, not supported by IE11)."_ [ref](https://stackoverflow.com/questions/55741747/javascript-foreach-loops-not-working-on-ie11)

[Related PR](https://github.com/alphagov/govuk_publishing_components/pull/1937)
