### PR TITLE
Remove unused i18n keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ doc
 tmp/failures.txt
 node_modules
 yarn-error.log
+coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Update documentation about component conventions and visual regression testing ([PR #2015](https://github.com/alphagov/govuk_publishing_components/pull/2015))
 * Remove `@extend` from notice component styles ([PR #2030](https://github.com/alphagov/govuk_publishing_components/pull/2030))
 * Swap out Sass `em()` function for `govuk-em()` ([PR #2034](https://github.com/alphagov/govuk_publishing_components/pull/2034))
+* Remove unused i18n keys ([PR #2038](https://github.com/alphagov/govuk_publishing_components/pull/2038))
 
 ## 24.9.4
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
+    i18n-coverage (0.2.0)
     jasmine (3.7.0)
       jasmine-core (~> 3.7.0)
       phantomjs
@@ -337,6 +338,7 @@ DEPENDENCIES
   govuk_publishing_components!
   govuk_schemas (~> 4.0)
   govuk_test (~> 2)
+  i18n-coverage
   jasmine (~> 3.7.0)
   jasmine_selenium_runner (~> 3.0.0)
   percy-capybara (~> 4.0, >= 4.0.2)

--- a/app/views/govuk_publishing_components/components/_government_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_government_navigation.html.erb
@@ -6,37 +6,37 @@
   <ul id="proposition-links">
     <li>
       <a class="<%= 'active' if active == 'departments' %>" href="/government/organisations">
-        <%= t("govuk_component.government_navigation.departments", default: "Departments") %>
+        <%= t("components.government_navigation.departments", default: "Departments") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'worldwide' %>" href="/government/world">
-        <%= t("govuk_component.government_navigation.worldwide", default: "Worldwide") %>
+        <%= t("components.government_navigation.worldwide", default: "Worldwide") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'how-government-works' %>" href="/government/how-government-works">
-        <%= t("govuk_component.government_navigation.how-government-works", default: "How government works") %>
+        <%= t("components.government_navigation.how-government-works", default: "How government works") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'get-involved' %>" href="/government/get-involved">
-        <%= t("govuk_component.government_navigation.get-involved", default: "Get involved") %>
+        <%= t("components.government_navigation.get-involved", default: "Get involved") %>
       </a>
     </li>
     <li class="clear-child">
       <a class="<%= 'active' if active == 'consultations' %>" href="<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>">
-        <%= t("govuk_component.government_navigation.consultations", default: "Consultations") %>
+        <%= t("components.government_navigation.consultations", default: "Consultations") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'statistics' %>" href="/search/research-and-statistics">
-        <%= t("govuk_component.government_navigation.statistics", default: "Statistics") %>
+        <%= t("components.government_navigation.statistics", default: "Statistics") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'announcements' %>" href="/news-and-communications">
-        <%= t("govuk_component.government_navigation.news_and_communications", default: "News and communications") %>
+        <%= t("components.government_navigation.news_and_communications", default: "News and communications") %>
       </a>
     </li>
   </ul>

--- a/app/views/govuk_publishing_components/components/_layout_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_header.html.erb
@@ -1,7 +1,7 @@
 <%
   environment ||= nil
   full_width ||= false
-  navigation_aria_label ||= "Top level"
+  navigation_aria_label ||= t("components.layout_header.top_level")
   navigation_items ||= []
   product_name ||= nil
   remove_bottom_border ||= false

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -18,34 +18,34 @@
 <%= content_tag :div, class: classes, data: { module: "gem-toggle" } do %>
   <dl data-module="gem-track-click">
     <% if from.any? %>
-      <dt class="gem-c-metadata__term"><%= t("govuk_component.metadata.from", default: "From") %>:</dt>
+      <dt class="gem-c-metadata__term"><%= t("components.metadata.from", default: "From") %>:</dt>
       <dd class="gem-c-metadata__definition">
         <%= render 'govuk_publishing_components/components/metadata/sentence', items: from, toggle_id: "from-#{SecureRandom.hex(4)}" %>
       </dd>
     <% end %>
     <% if part_of.any? %>
-      <dt class="gem-c-metadata__term"><%= t("govuk_component.metadata.part_of", default: "Part of") %>:</dt>
+      <dt class="gem-c-metadata__term"><%= t("components.metadata.part_of", default: "Part of") %>:</dt>
       <dd class="gem-c-metadata__definition">
         <%= render 'govuk_publishing_components/components/metadata/sentence', items: part_of, toggle_id: "part-of-#{SecureRandom.hex(4)}" %>
       </dd>
     <% end %>
     <% if local_assigns.include?(:history) %>
-      <dt class="gem-c-metadata__term"><%= t("govuk_component.metadata.history", default: "History") %>:</dt>
+      <dt class="gem-c-metadata__term"><%= t("components.metadata.history", default: "History") %>:</dt>
       <dd class="gem-c-metadata__definition"><%= history %></dd>
     <% end %>
     <% if local_assigns.include?(:first_published) && first_published %>
-      <dt class="gem-c-metadata__term"><%= t("govuk_component.metadata.published", default: "Published") %>:</dt>
+      <dt class="gem-c-metadata__term"><%= t("components.metadata.published", default: "Published") %>:</dt>
       <dd class="gem-c-metadata__definition"><%= first_published %></dd>
     <% end %>
     <% if local_assigns.include?(:last_updated) && last_updated %>
-      <dt class="gem-c-metadata__term"><%= t("govuk_component.metadata.last_updated", default: "Last updated") %>:</dt>
+      <dt class="gem-c-metadata__term"><%= t("components.metadata.last_updated", default: "Last updated") %>:</dt>
       <dd class="gem-c-metadata__definition">
         <%= last_updated %><% if local_assigns.include?(:see_updates_link) %>,
           <a href="#history" class="gem-c-metadata__definition-link"
                              data-track-category="content-history"
                              data-track-action="see-all-updates-link-clicked"
                              data-track-label="history">
-            <%= t("govuk_component.metadata.see_all_updates", default: "see all updates") %>
+            <%= t("components.metadata.see_all_updates", default: "see all updates") %>
           </a>
         <% end %>
       </dd>

--- a/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
@@ -2,7 +2,7 @@
 <nav
   class="gem-c-pagination"
   role="navigation"
-  aria-label="<%= t("govuk_component.previous_and_next_navigation.pagination", default: "Pagination") %>"
+  aria-label="<%= t("components.previous_and_next_navigation.pagination", default: "Pagination") %>"
 >
   <ul class="gem-c-pagination__list" data-module="gem-track-click">
     <% if local_assigns.include?(:previous_page) %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
@@ -22,10 +22,10 @@
     class="gem-c-step-nav js-hidden <% unless small %>gem-c-step-nav--large<% end %>"
     <%= "data-remember" if remember_last_step %>
     <%= "data-id=#{tracking_id}" if tracking_id %>
-    data-show-text="<%= t("govuk_component.step_by_step_nav.show", default: "show") %>"
-    data-hide-text="<%= t("govuk_component.step_by_step_nav.hide", default: "hide") %>"
-    data-show-all-text="<%= t("govuk_component.step_by_step_nav.show_all", default: "Show all steps") %>"
-    data-hide-all-text="<%= t("govuk_component.step_by_step_nav.hide_all", default: "Hide all steps") %>"
+    data-show-text="<%= t("components.step_by_step_nav.show", default: "show") %>"
+    data-hide-text="<%= t("components.step_by_step_nav.hide", default: "hide") %>"
+    data-show-all-text="<%= t("components.step_by_step_nav.show_all", default: "Show all steps") %>"
+    data-hide-all-text="<%= t("components.step_by_step_nav.hide_all", default: "Hide all steps") %>"
   >
     <ol class="gem-c-step-nav__steps">
       <% steps.each_with_index do |step, step_index| %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -1,6 +1,6 @@
 <%
   links ||= []
-  pretitle ||= t("govuk_component.step_by_step_nav_related.part_of", default: "Part of")
+  pretitle ||= t("components.step_by_step_nav_related.part_of", default: "Part of")
   always_display_as_list ||= false
 %>
 <% if links.any? %>

--- a/app/views/govuk_publishing_components/components/_subscription_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription_links.html.erb
@@ -23,7 +23,7 @@
 <% if sl_helper.component_data_is_valid? %>
   <%= tag.section class: css_classes, data: data do %>
     <% unless hide_heading %>
-      <h2 class="gem-c-subscription-links__hidden-header visuallyhidden"><%= t("govuk_component.subscription_links.subscriptions", default: "Subscriptions") %></h2>
+      <h2 class="gem-c-subscription-links__hidden-header visuallyhidden"><%= t("components.subscription_links.subscriptions", default: "Subscriptions") %></h2>
     <% end %>
     <ul
       class="gem-c-subscription-links__list<%= ' gem-c-subscription-links__list--small' if local_assigns[:small_form] == true %>"

--- a/app/views/govuk_publishing_components/components/_success_alert.html.erb
+++ b/app/views/govuk_publishing_components/components/_success_alert.html.erb
@@ -13,7 +13,7 @@
     module: "initial-focus",
   } do %>
   <div class="govuk-notification-banner__header">
-    <%= tag.h2 t("govuk_component.success_alert.success", default: "Success"), class: "govuk-notification-banner__title", id: title_id %>
+    <%= tag.h2 t("components.success_alert.success", default: "Success"), class: "govuk-notification-banner__title", id: title_id %>
   </div>
   <div class="govuk-notification-banner__content">
     <% if description.present? %>

--- a/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
@@ -7,7 +7,7 @@
     class="govuk-header__menu-button govuk-js-header-toggle gem-c-header__menu-button"
     type="button"
   >
-    Menu
+    <%= t("components.layout_header.menu") %>
   </button>
   <%= tag.nav class: "gem-c-header__nav", aria: { label: navigation_aria_label } do %>
     <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end">

--- a/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
+++ b/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
@@ -13,8 +13,8 @@
        class="gem-c-metadata__definition-link"
        data-controls="toggle-<%= toggle_id %>"
        data-expanded="false"
-       data-toggled-text="<%= t("govuk_component.metadata.toggle_less", default: "Show fewer") %>">
-        <%= t("govuk_component.metadata.toggle_more", number: remaining.length, default: "+ #{remaining.length} more") %>
+       data-toggled-text="<%= t("components.metadata.toggle_less", default: "Show fewer") %>">
+        <%= t("components.metadata.toggle_more", number: remaining.length, default: "+ #{remaining.length} more") %>
     </a>
   </div>
   <span id="toggle-<%= toggle_id %>" class="gem-c-metadata__toggle-items js-hidden"><%= remaining.to_sentence.html_safe %></span>

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -54,8 +54,8 @@
           class="gem-c-related-navigation__toggle"
           data-controls="toggle_<%= section_title %>"
           data-expanded="false"
-          data-toggled-text="<%= t("govuk_component.metadata.toggle_less", default: "Show fewer") %>">
-          <%= t("govuk_component.metadata.toggle_more",
+          data-toggled-text="<%= t("components.metadata.toggle_less", default: "Show fewer") %>">
+          <%= t("components.metadata.toggle_more",
                 number: related_nav_helper.remaining_link_count(links),
                 default: "+ #{related_nav_helper.remaining_link_count(links)} more") %>
         </a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,7 +65,6 @@ en:
       show_button: "Show search"
       hide_button: "Hide search"
       top_level: "Top level"
-      nav_items_aria_label: "Show or hide Top Level Navigation"
       menu: "Menu"
     organisation_schema:
       all_content_search_description: "Find all content from %{organisation}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,8 +44,8 @@ en:
       contents: "Contents"
     feedback:
       is_this_page_useful: "Is this page useful?"
-      yes: "Yes"
-      no: "No"
+      "yes": "Yes"
+      "no": "No"
       maybe: "Maybe"
       is_useful: "this page is useful"
       is_not_useful: "this page is not useful"

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "gds-api-adapters"
   s.add_development_dependency "govuk_schemas", "~> 4.0"
   s.add_development_dependency "govuk_test", "~> 2"
+  s.add_development_dependency "i18n-coverage"
   s.add_development_dependency "jasmine", "~> 3.7.0"
   s.add_development_dependency "jasmine_selenium_runner", "~> 3.0.0"
   s.add_development_dependency "percy-capybara", "~> 4.0", ">= 4.0.2"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,11 @@ require_relative "support/components_helper"
 require "gds_api/test_helpers/content_store"
 require "faker"
 
+require "i18n/coverage"
+require "i18n/coverage/printers/file_printer"
+I18n::Coverage.config.printer = I18n::Coverage::Printers::FilePrinter
+I18n::Coverage.start
+
 WebMock.disable_net_connect!(allow_localhost: true)
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,12 @@ require_relative "support/components_helper"
 require "gds_api/test_helpers/content_store"
 require "faker"
 
-require "i18n/coverage"
-require "i18n/coverage/printers/file_printer"
-I18n::Coverage.config.printer = I18n::Coverage::Printers::FilePrinter
-I18n::Coverage.start
+if ENV["USE_I18N_COVERAGE"]
+  require "i18n/coverage"
+  require "i18n/coverage/printers/file_printer"
+  I18n::Coverage.config.printer = I18n::Coverage::Printers::FilePrinter
+  I18n::Coverage.start
+end
 
 WebMock.disable_net_connect!(allow_localhost: true)
 


### PR DESCRIPTION
## What
This PR adds the [i18n-coverage gem](https://github.com/hiptest/i18n-coverage) to monitor untested i18n keys. I've then removed used the coverage reports to identify and remove unused keys. See commits for details.

## Why
Trello: https://trello.com/c/Z3Pitrfg/2454-identify-and-remove-unused-keys-in-locale-files-5

## Visual Changes
N/A