### PR TITLE
Update postcode regex for PII stripping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   of the commit log.
 
 
+## Unreleased
+
+* Update postcode regex for PII stripping
+
 ## 24.10.0
 
 * Resolve IE11 accordion gem doc duplication ([PR #2036](https://github.com/alphagov/govuk_publishing_components/pull/2036))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## Unreleased
 
-* Update postcode regex for PII stripping
+* Update postcode regex for PII stripping ([PR #2043](https://github.com/alphagov/govuk_publishing_components/pull/2043))
 
 ## 24.10.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/pii.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/pii.js
@@ -5,7 +5,7 @@
 
   var GOVUK = global.GOVUK || {}
   var EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
-  var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9](?!refund)[ABD-HJLNPQ-Z]{2,3}/gi
+  var POSTCODE_PATTERN = /\b[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9](?!refund)[ABD-HJLNPQ-Z]{2,3}\b/gi
   var DATE_PATTERN = /\d{4}(-?)\d{2}(-?)\d{2}/g
   var ESCAPE_REGEX_PATTERN = /[|\\{}()[\]^$+*?.]/g
 

--- a/spec/javascripts/govuk_publishing_components/analytics/pii.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/pii.spec.js
@@ -83,13 +83,15 @@ describe('GOVUK.PII', function () {
       var obj = {
         email: 'this is an@email.com address',
         postcode: 'this is a sw1a 1aa postcode',
-        date: 'this is a 2019-01-21 date'
+        date: 'this is a 2019-01-21 date',
+        uuid: 'd6c2de5d-ef90-45d1-82d4-5f2438369eea'
       }
 
       var strippedObj = {
         email: 'this is [email] address',
         postcode: 'this is a [postcode] postcode',
-        date: 'this is a [date] date'
+        date: 'this is a [date] date',
+        uuid: 'd6c2de5d-ef90-45d1-82d4-5f2438369eea'
       }
 
       obj = pii.stripPII(obj)
@@ -122,8 +124,14 @@ describe('GOVUK.PII', function () {
 
     it('observes the meta tag and strips out postcodes', function () {
       expect(pii.stripPostcodePII).toEqual(true)
-      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a long GL194LYX postcode, this is a 2019-01-21 date, this is a p800refund')
-      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a long [postcode] postcode, this is a 2019-01-21 date, this is a p800refund')
+      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a long GL194LYX postcode, this is a 2019-01-21 date, this is a d6c2de5d-ef90-45d1-82d4-5f2438369eea content ID, this is a p800refund')
+      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a long [postcode] postcode, this is a 2019-01-21 date, this is a d6c2de5d-ef90-45d1-82d4-5f2438369eea content ID, this is a p800refund')
+    })
+
+    it('doesn\'t strip out UUIDs in URLs', function () {
+      expect(pii.stripPostcodePII).toEqual(true)
+      var string = pii.stripPII('gov.uk/thing?postcode=sw1a1aa&uuid=d6c2de5d-ef90-45d1-82d4-5f2438369eea')
+      expect(string).toEqual('gov.uk/thing?postcode=[postcode]&uuid=d6c2de5d-ef90-45d1-82d4-5f2438369eea')
     })
   })
 
@@ -167,7 +175,7 @@ describe('GOVUK.PII', function () {
       pii = new GOVUK.Pii()
     })
 
-    it('observes the meta tag and strips out postcodes', function () {
+    it('observes the meta tag and strips out dates', function () {
       expect(pii.stripDatePII).toEqual(true)
       var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date')
       expect(string).toEqual('this is [email] address, this is a sw1a 1aa postcode, this is a [date] date')


### PR DESCRIPTION
## What

Fixing the postcode regex to not match UUIDs

## Why

The postcode regex that we use often matches UUIDs that are in page URL query strings. These UUIDs are used to show different types of navigation on a page, so are significant for analysis terms.

I've attempted to fix this by adding word boundaries around the regex. Matching a sequence of characters that look like postcode format in a longer string seems a bit eager.

The example provided by the performance analyst was:

https://www.gov.uk/search/services?parent=%2Ftransition&topic=d6c2de5d-ef90-45d1-82d4-5f2438369eea

is being stripped to:

https://www.gov.uk/search/services?parent=/transition&topic=[postcode]5d-ef90-45d1-82d4-5f2438369eea

which is not useful.

https://trello.com/c/fxEriQnM/1489-redact-pii-from-ga-in-a-less-aggressive-manner

## Visual Changes

None