### PR TITLE
Improve a11y of breadcrumbs

### DIFF
--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -16,17 +16,21 @@
   <%= raw JSON.pretty_generate(breadcrumb_presenter.structured_data) %>
 </script>
 
-<div class="<%= classes.join(" ") %>" data-module="gem-track-click">
+<nav class="<%= classes.join(" ") %>" data-module="gem-track-click" aria-label="Breadcrumb">
   <ol class="govuk-breadcrumbs__list">
     <% breadcrumbs.each_with_index do |crumb, index| %>
       <% breadcrumb = GovukPublishingComponents::Presenters::Breadcrumb.new(crumb, index) %>
         <li class="govuk-breadcrumbs__list-item">
         <% if breadcrumb.is_link? %>
+          <% if index == breadcrumbs.size - 1 %>
+            <% last_link = index ? "page" : "" %>
+          <% end %>
           <%= link_to(
             breadcrumb[:title],
             breadcrumb.path,
             data: breadcrumb.tracking_data(breadcrumbs.length),
             class: "govuk-breadcrumbs__link",
+            "aria-current": last_link,
           ) %>
         <% else %>
           <%= breadcrumb[:title] %>
@@ -34,4 +38,4 @@
         </li>
     <% end %>
   </ol>
-</div>
+</nav>


### PR DESCRIPTION
## What 

Adding `<nav>` element labeled `Breadcrumb` identifies the structure as a breadcrumb trail and makes it a navigation landmark so that it is easy to locate.

`aria-current` applied to the last link in the set to indicate that it represents the current page.

## Why

Improving a11y of breadcrumbs, best practice, related to 1.3.1

_Breadcrumbs are not labelled in any way, making it harder for screen reader users and users who change styles to understand what they are and harder for screen reader users to navigate to them_

## Visual Changes
No visual changes

## Anything else?

https://www.w3.org/TR/wai-aria-practices-1.1/examples/breadcrumb/index.html

Draft PR:
- [ ] CHANGELOG
- [ ] JAWS
- [ ] VoiceOver
- [ ] NVDA
- [ ] Dragon?