### PR TITLE
Version 24.10.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.10.2
 
 * Allow modules to start after cookie consent ([PR #2041](https://github.com/alphagov/govuk_publishing_components/pull/2041))
 * Fix travel advice pages to use parent breadcrumbs ([PR #2050](https://github.com/alphagov/govuk_publishing_components/pull/2050))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.10.1)
+    govuk_publishing_components (24.10.2)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.10.1".freeze
+  VERSION = "24.10.2".freeze
 end


### PR DESCRIPTION
* Allow modules to start after cookie consent ([PR #2041](https://github.com/alphagov/govuk_publishing_components/pull/2041))
* Fix travel advice pages to use parent breadcrumbs ([PR #2050](https://github.com/alphagov/govuk_publishing_components/pull/2050))
* Refactor heading logic in radio component ([PR #2051](https://github.com/alphagov/govuk_publishing_components/pull/2051))
* Update design of metadata component ([PR #2046](https://github.com/alphagov/govuk_publishing_components/pull/2046))
* Update scroll tracker config entries ([PR #2052](https://github.com/alphagov/govuk_publishing_components/pull/2052))
