### PR TITLE
Adding ID to list item

### DIFF
--- a/app/views/govuk_publishing_components/components/_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_list.html.erb
@@ -2,6 +2,8 @@
   aria_label ||= nil
   extra_spacing ||= nil
   id ||= nil
+  id_li ||= nil
+  list_id ||= false
   items ||= []
   list_type ||= "unordered"
   visible_counters ||= nil
@@ -10,6 +12,9 @@
   classes << "govuk-list--bullet" if visible_counters && list_type === "unordered"
   classes << "govuk-list--number" if visible_counters && list_type === "number"
   classes << "govuk-list--spaced" if extra_spacing
+
+  # Default list ID is "list-item-[]" unless a custom ID is defined.
+  list_id = list_id & id_li.present? ? id_li : "list-item-#{SecureRandom.hex(4)}"
 
   # Default list type is unordered list.
   list_tag = "ul"
@@ -20,7 +25,9 @@
 <% if items.any? %>
   <%= content_tag list_tag, class: classes, id: id, "aria-label": aria_label do %>
     <% items.each do |item| %>
-      <li><%= raw(item) %></li>
+      <%= tag.li(id: list_id) do %>
+        <%= raw(item) %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/fieldset.yml
+++ b/app/views/govuk_publishing_components/components/docs/fieldset.yml
@@ -28,6 +28,17 @@ examples:
 
           <input type="radio" id="passport-no" name="default">
           <label for="passport-no">No</label>
+  with_id_list_attribute:
+    data:
+      legend_text: 'Do you have a passport?'
+      id: passports
+      block: |
+        <!-- Use the radio component, this is hardcoded only for this example -->
+          <input type="radio" id="passport-yes" name="default">
+          <label for="passport-yes">Yes</label>
+
+          <input type="radio" id="passport-no" name="default">
+          <label for="passport-no">No</label>
   with_heading:
     description: Make the legend different sizes. Valid options are 's', 'm', 'l' and 'xl'.
     data:

--- a/app/views/govuk_publishing_components/components/docs/list.yml
+++ b/app/views/govuk_publishing_components/components/docs/list.yml
@@ -62,3 +62,16 @@ examples:
     data:
       id: 'super-fantastic-chocolate-list'
       <<: *default-example-data
+  with_id_list_attribute:
+    description: |
+      Sets the `id` on the `li` element.
+    data:
+      list_id: true
+      <<: *default-example-data
+  with_id_list_attribute_custom:
+    description: |
+      Sets the `id` on the `li` element with custom ID
+    data:
+      list_id: true
+      id_li: default-id-xxxx
+      <<: *default-example-data

--- a/spec/components/list_spec.rb
+++ b/spec/components/list_spec.rb
@@ -77,7 +77,7 @@ describe "List", type: :view do
     assert_select "ul.govuk-list--spaced li:nth-child(2)", text: "Another test item"
   end
 
-  it "adds an `id` correctly" do
+  it "adds an outer `id` correctly" do
     render_component(
       id: "this-is-a-test-id",
       items: ["Test item", "Another test item"],
@@ -85,6 +85,27 @@ describe "List", type: :view do
 
     assert_select "ul#this-is-a-test-id li", text: "Test item"
     assert_select "ul#this-is-a-test-id li:nth-child(2)", text: "Another test item"
+  end
+
+  it "adds a generated `id` on the inner list element correctly" do
+    render_component(
+      list_id: true,
+      items: ["Test item", "Another test item"],
+    )
+
+    assert_select "ul li[id]", text: "Test item"
+    assert_select "ul li[id]:nth-child(2)", text: "Another test item"
+  end
+
+  it "adds an custom `id` on the inner list element correctly" do
+    render_component(
+      list_id: true,
+      id_li: "this-is-a-test-id",
+      items: ["Test item", "Another test item"],
+    )
+
+    assert_select "ul li#this-is-a-test-id", text: "Test item"
+    assert_select "ul li#this-is-a-test-id:nth-child(2)", text: "Another test item"
   end
 
   it "adds markup within the list items" do


### PR DESCRIPTION
## What?

Extending the list component to allow a user to pass an ID to a list item, should no custom ID be provide one will be generated.

## Why?

Whilst [converting](https://github.com/alphagov/whitehall/pull/6091) an element to use the [list component](http://localhost:3212/component-guide/list) (on Whitehall) this resulted in a testing error due to a missing ID. Current iteration of this gem component does not provide an option to generate an ID or provide a custom one. 

This extension aims to resolve this and provide these options for future list component use.

## Visual Changes
None however screenshots for Context attached

![Screenshot 2021-05-11 at 13 54 35](https://user-images.githubusercontent.com/71266765/117818457-88672e00-b260-11eb-8113-444d28275917.png)

![Screenshot 2021-05-11 at 13 54 45](https://user-images.githubusercontent.com/71266765/117818449-869d6a80-b260-11eb-8dee-ededfaac7712.png)

## Anything else?

Raising a draft for feedback if _should_ do this.
 