### PR TITLE
Remove `is_page_heading` parameter from radio component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 ## Unreleased
 
 * BREAKING: Remove ability to link contextual text on titles ([PR #2192](https://github.com/alphagov/govuk_publishing_components/pull/2192))
-
 * Delete empty print stylesheets ([PR #2225](https://github.com/alphagov/govuk_publishing_components/pull/2225))
+* BREAKING: Remove is_page_heading parameter from radio component ([PR #2061](https://github.com/alphagov/govuk_publishing_components/pull/2061))
+
 
 ## 24.21.1
 

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -11,14 +11,13 @@
   heading_size ||= nil
   small ||= false
   inline ||= false
-  is_page_heading ||= false
-  heading_level = is_page_heading ? 'h1' : shared_helper.get_heading_level
+  heading_level = shared_helper.get_heading_level
   heading_classes = %w(govuk-fieldset__heading)
   heading_classes << "gem-c-radio__heading-text" if heading_level == 'h1'
 
   if ['s', 'm', 'l', 'xl'].include?(heading_size)
     size = heading_size
-  elsif is_page_heading
+  elsif heading_level == 'h1'
     size = 'xl'
   else
     size = 'm'

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -107,17 +107,6 @@ examples:
         text: "Green"
       - value: "blue"
         text: "Blue"
-  with_page_heading:
-    description: This adds a H1 element containing the text supplied.
-    data:
-      name: "radio-group-heading"
-      heading: "Is it raining?"
-      is_page_heading: true
-      items:
-      - value: "yes"
-        text: "Yes"
-      - value: "no"
-        text: "No"
   with_page_header_and_caption:
     description: |
       If a caption text is provided with a page heading, it will be displayed above the heading.
@@ -127,7 +116,7 @@ examples:
       name: "radio-group-heading"
       heading: "Is it snowing?"
       heading_caption: "Question 3 of 9"
-      is_page_heading: true
+      heading_level: 1
       items:
         - value: "yes"
           text: "Yes"
@@ -137,7 +126,7 @@ examples:
     data:
       name: "radio-group-heading"
       heading: "Is it snowing?"
-      is_page_heading: true
+      heading_level: 1
       hint: "Sleet or hail doesn’t count."
       items:
       - value: "yes"
@@ -179,7 +168,7 @@ examples:
     data:
       name: "radio-group-description"
       heading: "What is your favourite colour?"
-      is_page_heading: true
+      heading_level: 1
       description: |
         Skittles consist of hard sugar shells imprinted with the letter "S".
         The interior consists mainly of sugar, corn syrup, and hydrogenated
@@ -196,7 +185,7 @@ examples:
     description: |
       This allows the size of the legend to be changed. Valid options are s, m, l, xl, defaulting to m if no option is passed.
 
-      If the is_page_heading option is true and heading_size is not set, the text size will be xl.
+      If heading_level is 1 and heading_size is not set, the text size will be xl.
     data:
       name: "radio-group-description"
       heading: "What is your favourite colour?"

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -138,7 +138,7 @@ describe "Radio", type: :view do
     render_component(
       name: "favourite-skittle",
       heading: "What is your favourite skittle?",
-      is_page_heading: true,
+      heading_level: 1,
       items: [
         { label: "Red", value: "red" },
         { label: "Blue", value: "blue" },
@@ -153,7 +153,7 @@ describe "Radio", type: :view do
       name: "favourite-skittle",
       heading: "What is your favourite skittle?",
       heading_caption: "Question 3 of 9",
-      is_page_heading: true,
+      heading_level: 1,
       items: [
         { label: "Red", value: "red" },
         { label: "Blue", value: "blue" },
@@ -184,7 +184,7 @@ describe "Radio", type: :view do
       heading: "What is your favourite skittle?",
       heading_caption: "Question 3 of 9",
       heading_size: "l",
-      is_page_heading: true,
+      heading_level: 1,
       items: [
         { label: "Red", value: "red" },
         { label: "Blue", value: "blue" },
@@ -200,7 +200,7 @@ describe "Radio", type: :view do
       name: "favourite-skittle",
       heading: "What is your favourite skittle?",
       heading_caption: "Question 3 of 9",
-      is_page_heading: true,
+      heading_level: 1,
       items: [
         { label: "Red", value: "red" },
         { label: "Blue", value: "blue" },


### PR DESCRIPTION
# What

This removes all mentions of the `is_page_heading` option from the radio component.


# Why
Recently, the ability to pass a custom heading level to the radio component was introduced: https://github.com/alphagov/govuk_publishing_components/pull/1951 

Since specifying a custom heading level is now an option, the `is_page_heading` parameter became redundant. This parameter simply dictates that the radio component legend heading should be a `h1` of size `xl` by default.
It is possible to achieve the same result using `heading_level` and/or `heading_size` instead.

Whenever we need this component to have a h1 in the future, we can simply use the `heading_level` option (in combination with `heading_size`, if necessary).

This issue is recorded here https://github.com/alphagov/govuk_publishing_components/issues/1953 

# Visual changes
There should be no visual changes as a result of this update, as work has already been done to update all references of the radio component to use `heading_level`/`heading_size` instead of `is_page_heading: true` –  for instance [here](https://github.com/alphagov/finder-frontend/pull/2503/files)

There are still some references to the `is_page_heading` option in some older, read-only repositories which are using older versions of the gem ([Example](https://github.com/alphagov/govuk-search-relevance-tool/blob/9874bfbfbd39ee2a4b7de8b64a436ffd0cde5098/app/views/brexit_checker/_question_single_choice.html.erb#L7)). In the hypothetical situation where one of these repos is unarchived and updated to the latest version of `govuk_publishing_components`, this would be a breaking change in those repos.
