### PR TITLE
Remove jQuery from the feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove jQuery from the feedback component ([PR #2062](https://github.com/alphagov/govuk_publishing_components/pull/2062))
 * Remove `display: none` rules from component print stylesheets, and use the `govuk-!-display-none-print` class instead. ([PR #1561](https://github.com/alphagov/govuk_publishing_components/pull/1561))
 * Fix IE11 `initCustomEvent` error ([PR #2079](https://github.com/alphagov/govuk_publishing_components/pull/2079))
 

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -1,5 +1,4 @@
-/* eslint-env jquery */
-
+/* global XMLHttpRequest, FormData */
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
@@ -11,53 +10,56 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.element = $element[0]
       this.somethingIsWrongForm = this.element.querySelector('#something-is-wrong')
       this.surveyForm = this.element.querySelector('#page-is-not-useful')
-      this.$prompt = $element.find('.js-prompt')
-      this.$fields = $element.find('.gem-c-feedback__form-field')
-      this.$forms = $element.find('.js-feedback-form')
-      this.$toggleForms = $element.find('.js-toggle-form')
-      this.$closeForms = $element.find('.js-close-form')
+      this.prompt = this.element.querySelector('.js-prompt')
+      this.forms = this.element.querySelectorAll('.js-feedback-form')
+      this.toggleForms = this.element.querySelectorAll('.js-toggle-form')
+      this.closeForms = this.element.querySelectorAll('.js-close-form')
       this.activeForm = false
-      this.$activeForm = false
-      this.$pageIsUsefulButton = $element.find('.js-page-is-useful')
-      this.$pageIsNotUsefulButton = $element.find('.js-page-is-not-useful')
-      this.$somethingIsWrongButton = $element.find('.js-something-is-wrong')
-      this.$promptQuestions = $element.find('.js-prompt-questions')
-      this.$promptSuccessMessage = $element.find('.js-prompt-success')
-      this.$somethingIsWrongForm = $(this.somethingIsWrongForm)
-      this.$surveyForm = $(this.surveyForm)
-      this.$surveyWrapper = $element.find('#survey-wrapper')
+      this.pageIsUsefulButton = this.element.querySelector('.js-page-is-useful')
+      this.pageIsNotUsefulButton = this.element.querySelector('.js-page-is-not-useful')
+      this.somethingIsWrongButton = this.element.querySelector('.js-something-is-wrong')
+      this.promptQuestions = this.element.querySelectorAll('.js-prompt-questions')
+      this.promptSuccessMessage = this.element.querySelector('.js-prompt-success')
+      this.surveyWrapper = this.element.querySelector('#survey-wrapper')
 
-      var that = this
+      var thisModule = this
       var jshiddenClass = 'js-hidden'
 
       setInitialAriaAttributes()
       setHiddenValues()
 
-      this.$toggleForms.on('click', function (e) {
-        e.preventDefault()
-        toggleForm($(e.target).attr('aria-controls'))
-        trackEvent(getTrackEventParams($(this)))
-        updateAriaAttributes($(this))
-      })
+      for (var j = 0; j < this.toggleForms.length; j++) {
+        this.toggleForms[j].addEventListener('click', function (e) {
+          e.preventDefault()
+          var el = e.target
+          toggleForm(el.getAttribute('aria-controls'))
+          trackEvent(getTrackEventParams(el))
+          updateAriaAttributes(el)
+        })
+      }
 
-      this.$closeForms.on('click', function (e) {
-        e.preventDefault()
-        toggleForm($(e.target).attr('aria-controls'))
-        trackEvent(getTrackEventParams($(this)))
-        setInitialAriaAttributes()
-        revealInitialPrompt()
-        var refocusClass = '.js-' + $(e.target).attr('aria-controls')
-        $element.find(refocusClass).focus()
-      })
+      for (var i = 0; i < this.closeForms.length; i++) {
+        this.closeForms[i].addEventListener('click', function (e) {
+          e.preventDefault()
+          var el = e.target
+          var formToToggle = el.getAttribute('aria-controls')
+          toggleForm(formToToggle)
+          trackEvent(getTrackEventParams(el))
+          setInitialAriaAttributes()
+          revealInitialPrompt()
+          var refocusClass = '.js-' + formToToggle
+          thisModule.element.querySelector(refocusClass).focus()
+        })
+      }
 
-      this.$pageIsUsefulButton.on('click', function (e) {
+      this.pageIsUsefulButton.addEventListener('click', function (e) {
         e.preventDefault()
-        trackEvent(getTrackEventParams(that.$pageIsUsefulButton))
+        trackEvent(getTrackEventParams(thisModule.pageIsUsefulButton))
         showFormSuccess()
         revealInitialPrompt()
       })
 
-      this.$pageIsNotUsefulButton.on('click', function (e) {
+      this.pageIsNotUsefulButton.addEventListener('click', function (e) {
         var gaClientId
         var dummyGaClientId = '111111111.1111111111'
         if (window.GOVUK.cookie('_ga') === null || window.GOVUK.cookie('_ga') === '') {
@@ -68,95 +70,129 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         setHiddenValuesNotUsefulForm(gaClientId)
       })
 
-      $element.find('form').on('submit', function (e) {
-        e.preventDefault()
-        var $form = $(this)
-        $.ajax({
-          type: 'POST',
-          url: $form.attr('action'),
-          dataType: 'json',
-          data: $form.serialize(),
-          beforeSend: disableSubmitFormButton($form),
-          timeout: 6000
-        }).done(function (xhr) {
-          trackEvent(getTrackEventParams($form))
-          showFormSuccess(xhr.message)
-          revealInitialPrompt()
-          setInitialAriaAttributes()
-          that.$activeForm.toggleClass(jshiddenClass)
-        }).fail(function (xhr) {
-          showError(xhr)
-          enableSubmitFormButton($form)
-        })
-      })
+      // much of the JS needed to support sending the form contents via this script is
+      // unsupported by IE, even IE11. This check causes IE to not intercept form submits
+      // and let them happen normally, which is handled already by the backend
+      if (typeof window.URLSearchParams === 'function') {
+        for (var f = 0; f < this.forms.length; f++) {
+          this.forms[f].addEventListener('submit', function (e) {
+            e.preventDefault()
+            var $form = e.target
+            var xhr = new XMLHttpRequest()
+            var url = $form.getAttribute('action')
+            var params = new FormData($form)
+            params = new URLSearchParams(params).toString()
+
+            xhr.open('POST', url, true)
+            xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded')
+
+            xhr.onreadystatechange = function () {
+              if (xhr.readyState === 4 && xhr.status === 200) {
+                trackEvent(getTrackEventParams($form))
+                showFormSuccess(xhr.message)
+                revealInitialPrompt()
+                setInitialAriaAttributes()
+                thisModule.activeForm.classList.toggle(jshiddenClass)
+              } else {
+                showError(xhr)
+                enableSubmitFormButton($form)
+              }
+            }
+
+            disableSubmitFormButton($form)
+            xhr.send(params)
+          })
+        }
+      }
 
       function disableSubmitFormButton ($form) {
-        $form.find('input[type="submit"]').prop('disabled', true)
+        var formButton = $form.querySelector('[type="submit"]')
+        formButton.setAttribute('disabled', true)
       }
 
       function enableSubmitFormButton ($form) {
-        $form.find('input[type="submit"]').removeAttr('disabled')
+        var formButton = $form.querySelector('[type="submit"]')
+        formButton.removeAttribute('disabled')
       }
 
       function setInitialAriaAttributes () {
-        that.$forms.attr('aria-hidden', true)
-        that.$pageIsNotUsefulButton.attr('aria-expanded', false)
-        that.$somethingIsWrongButton.attr('aria-expanded', false)
+        for (var i = 0; i < thisModule.forms.length; i++) {
+          thisModule.forms[i].setAttribute('aria-hidden', true)
+        }
+        thisModule.pageIsNotUsefulButton.setAttribute('aria-expanded', false)
+        thisModule.somethingIsWrongButton.setAttribute('aria-expanded', false)
       }
 
       function setHiddenValues () {
-        that.$somethingIsWrongForm.append('<input type="hidden" name="javascript_enabled" value="true"/>')
-        that.$somethingIsWrongForm.append($('<input type="hidden" name="referrer">').val(document.referrer || 'unknown'))
-        that.somethingIsWrongForm.invalidInfoError = [
-          '<h2>',
-          '  Sorry, we’re unable to send your message as you haven’t given us any information.',
-          '</h2>',
-          '<p>Please tell us what you were doing or what went wrong</p>'
+        var javascriptEnabled = document.createElement('input')
+        javascriptEnabled.setAttribute('type', 'hidden')
+        javascriptEnabled.setAttribute('name', 'javascript_enabled')
+        javascriptEnabled.setAttribute('value', true)
+        thisModule.somethingIsWrongForm.appendChild(javascriptEnabled)
+
+        var referrer = document.createElement('input')
+        referrer.setAttribute('type', 'hidden')
+        referrer.setAttribute('name', 'referrer')
+        referrer.setAttribute('value', document.referrer || 'unknown')
+        thisModule.somethingIsWrongForm.appendChild(referrer)
+        thisModule.somethingIsWrongForm.invalidInfoError = [
+          '<h2>Sorry, we’re unable to send your message as you haven’t given us any information.</h2>',
+          ' <p>Please tell us what you were doing or what went wrong</p>'
         ].join('')
       }
 
       function setHiddenValuesNotUsefulForm (gaClientId) {
         var currentPathName = window.location.pathname.replace(/[^\s=?&]+(?:@|%40)[^\s=?&]+/, '[email]')
         var finalPathName = encodeURI(currentPathName)
-        that.surveyForm.invalidInfoError = [
-          '<h2>',
-          '  Sorry, we’re unable to send your message as you haven’t given us a valid email address. ',
-          '</h2>',
-          '<p>Enter an email address in the correct format, like name@example.com</p>'
+        thisModule.surveyForm.invalidInfoError = [
+          '<h2>Sorry, we’re unable to send your message as you haven’t given us a valid email address.</h2>',
+          ' <p>Enter an email address in the correct format, like name@example.com</p>'
         ].join('')
         if (document.querySelectorAll('[name="email_survey_signup[ga_client_id]"]').length === 0) {
-          that.$surveyForm.append($('<input name="email_survey_signup[ga_client_id]" type="hidden">').val(gaClientId || '0'))
+          var hiddenInput = document.createElement('input')
+          hiddenInput.setAttribute('type', 'hidden')
+          hiddenInput.setAttribute('name', 'email_survey_signup[ga_client_id]')
+          hiddenInput.setAttribute('value', gaClientId || '0')
+          thisModule.surveyForm.appendChild(hiddenInput)
         }
 
         if (document.querySelectorAll('.gem-c-feedback__email-link#take-survey').length === 0) {
-          that.$surveyWrapper.append('<a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=' + finalPathName + '&amp;gcl=' + gaClientId + '" class="gem-c-feedback__email-link govuk-link" id="take-survey" target="_blank" rel="noopener noreferrer">Don’t have an email address?</a>')
+          var takeSurvey = document.createElement('a')
+          takeSurvey.setAttribute('href', 'https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=' + finalPathName + '&amp;gcl=' + gaClientId)
+          takeSurvey.setAttribute('class', 'gem-c-feedback__email-link govuk-link')
+          takeSurvey.setAttribute('id', 'take-survey')
+          takeSurvey.setAttribute('target', '_blank')
+          takeSurvey.setAttribute('rel', 'noopener noreferrer')
+          takeSurvey.innerHTML = 'Don’t have an email address?'
+          thisModule.surveyWrapper.appendChild(takeSurvey)
         }
       }
 
       function updateAriaAttributes (linkClicked) {
-        linkClicked.attr('aria-expanded', true)
-        $('#' + linkClicked.attr('aria-controls')).attr('aria-hidden', false)
+        linkClicked.setAttribute('aria-expanded', true)
+        var controls = linkClicked.getAttribute('aria-controls')
+        var ariaControls = document.querySelector('#' + controls)
+        ariaControls.setAttribute('aria-hidden', false)
       }
 
       function toggleForm (formId) {
-        that.activeForm = that.element.querySelector('#' + formId)
-        that.$activeForm = $(that.activeForm)
-        that.$activeForm.toggleClass(jshiddenClass)
-        that.$prompt.toggleClass(jshiddenClass)
+        thisModule.activeForm = thisModule.element.querySelector('#' + formId)
+        thisModule.activeForm.classList.toggle(jshiddenClass)
+        thisModule.prompt.classList.toggle(jshiddenClass)
 
-        var formIsVisible = !that.$activeForm.hasClass(jshiddenClass)
+        var formIsVisible = !thisModule.activeForm.classList.contains(jshiddenClass)
 
         if (formIsVisible) {
-          that.$activeForm.find('.gem-c-input').first().focus()
+          thisModule.activeForm.querySelector('.gem-c-input').focus()
         } else {
-          that.$activeForm = false
+          thisModule.activeForm = false
         }
       }
 
       function getTrackEventParams ($node) {
         return {
-          category: $node.data('track-category'),
-          action: $node.data('track-action')
+          category: $node.getAttribute('data-track-category'),
+          action: $node.getAttribute('data-track-action')
         }
       }
 
@@ -168,40 +204,42 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       function showError (error) {
         var genericError = [
-          '<h2>',
-          '  Sorry, we’re unable to receive your message right now. ',
-          '</h2>',
-          '<p>If the problem persists, we have other ways for you to provide',
+          '<h2>Sorry, we’re unable to receive your message right now.</h2>',
+          ' <p>If the problem persists, we have other ways for you to provide',
           ' feedback on the <a href="/contact/govuk">contact page</a>.</p>'
         ].join('')
         // if the response is not a 404 or 500, show the error message if it exists
         // otherwise show the generic message
-        if (typeof (error.responseJSON) !== 'undefined') {
-          error = typeof (error.responseJSON.message) === 'undefined' ? genericError : error.responseJSON.message
-
-          if (error === 'email survey sign up failure') {
+        if ('response' in error) {
+          if (typeof error.response === 'object' && error.response !== null) {
+            error = error.response.message === 'email survey sign up failure' ? genericError : error.response.message
+          } else {
             error = genericError
           }
         } else if (error.status === 422) {
           // there's clobbering by nginx on all 422 requests, which is why the response returns a rendered html page instead of the expected JSON
-          // this is a temporary workaround to ensure that are are displaying relevant error messages to the users
-          error = that.activeForm.invalidInfoError || genericError
+          // this is a temporary workaround to ensure that we are displaying relevant error messages to the users
+          error = thisModule.activeForm.invalidInfoError || genericError
         } else {
-          // for all other, show generic error
           error = genericError
         }
-        var $errors = that.$activeForm.find('.js-errors')
-        $errors.html(error).removeClass(jshiddenClass).focus()
+        var $errors = thisModule.activeForm.querySelector('.js-errors')
+        $errors.innerHTML = error
+        $errors.classList.remove(jshiddenClass)
+        $errors.focus()
       }
 
       function showFormSuccess () {
-        that.$promptQuestions.addClass(jshiddenClass)
-        that.$promptSuccessMessage.removeClass(jshiddenClass).focus()
+        for (var i = 0; i < thisModule.promptQuestions.length; i++) {
+          thisModule.promptQuestions[i].classList.add(jshiddenClass)
+        }
+        thisModule.promptSuccessMessage.classList.remove(jshiddenClass)
+        thisModule.promptSuccessMessage.focus()
       }
 
       function revealInitialPrompt () {
-        that.$prompt.removeClass(jshiddenClass)
-        that.$prompt.focus()
+        thisModule.prompt.classList.remove(jshiddenClass)
+        thisModule.prompt.focus()
       }
     }
   }

--- a/app/views/govuk_publishing_components/components/docs/feedback.yml
+++ b/app/views/govuk_publishing_components/components/docs/feedback.yml
@@ -2,6 +2,8 @@ name: Feedback
 description: Invites user feedback on the current page.
 body: |
   This component is designed to sit at the bottom of pages on GOV.UK to allow users to submit feedback on that page.
+
+  This component uses JavaScript for expanding and collapsing and also for submitting form responses. This code is not compatible with Internet Explorer, so IE11 and down do not use JavaScript to submit the forms, instead falling back to a normal form submission.
 accessibility_criteria: |
   Form elements in the component must:
 

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -9,19 +9,19 @@ describe('Feedback component', function () {
         '<h3 class="gem-c-feedback__is-useful-question">Is this page useful?</h3>' +
         '<ul class="gem-c-feedback__option-list">' +
           '<li class="gem-c-feedback__option-list-item gem-c-feedback__option-list-item--useful">' +
-              '<a class="gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick" aria-expanded="false" role="button" href="/contact/govuk">' +
-                  'Yes <span class="visually-hidden">this page is useful</span>' +
-              '</a>' +
+            '<button class="gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">' +
+                'Yes <span class="visually-hidden">this page is useful</span>' +
+            '</button>' +
           '</li>' +
           '<li class="gem-c-feedback__option-list-item gem-c-feedback__option-list-item--not-useful">' +
-            '<a class="gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false" role="button" href="/contact/govuk">' +
+            '<button class="gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">' +
               'No <span class="visually-hidden">this page is not useful</span>' +
-            '</a>' +
+            '</button>' +
           '</li>' +
           '<li class="gem-c-feedback__option-list-item gem-c-feedback__option-list-item--wrong">' +
-            '<a class="gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV.UK Open Form" aria-controls="something-is-wrong" aria-expanded="false" role="button" href="/contact/govuk">' +
+            '<button class="gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV.UK Open Form" aria-controls="something-is-wrong" aria-expanded="false">' +
               'Is there anything wrong with this page?' +
-            '</a>' +
+            '</button>' +
           '</li>' +
         '</ul>' +
       '</div>' +
@@ -31,8 +31,7 @@ describe('Feedback component', function () {
     '</div>' +
 
     '<form action="/contact/govuk/page_improvements" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="Onsite Feedback" data-track-action="GOV.UK Send Form">' +
-      '<a href="#" class="gem-c-feedback__close js-close-form" aria-controls="something-is-wrong" aria-expanded="true" data-track-category="Onsite Feedback" data-track-action="GOV.UK Close Form">Close</a>' +
-
+      '<button class="govuk-button govuk-button--secondary gem-c-feedback__close gem-c-feedback__js-show js-close-form" data-track-category="Onsite Feedback" data-track-action="GOV.UK Close Form" aria-controls="something-is-wrong">Close</button>' +
       '<div class="grid-row">' +
         '<div class="column-two-thirds" id="survey-wrapper">' +
           '<div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>' +
@@ -62,8 +61,7 @@ describe('Feedback component', function () {
     '</form>' +
 
     '<form action="/contact/govuk/email-survey-signup" id="page-is-not-useful" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="yesNoFeedbackForm" data-track-action="Send Form">' +
-      '<a href="#" class="gem-c-feedback__close js-close-form" aria-controls="page-is-not-useful" aria-expanded="true" data-track-category="yesNoFeedbackForm" data-track-action="ffFormClose">Close</a>' +
-
+      '<button class="govuk-button govuk-button--secondary gem-c-feedback__close js-close-form" data-track-category="yesNoFeedbackForm" data-track-action="ffFormClose" aria-controls="page-is-not-useful">Close</button>' +
       '<div class="grid-row">' +
         '<div class="column-two-thirds">' +
           '<div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>' +
@@ -124,8 +122,9 @@ describe('Feedback component', function () {
     expect($('.js-toggle-form[aria-controls="something-is-wrong"]').attr('aria-expanded')).toBe('false')
   })
 
-  // note that this test will always fail in the browser if you disable 'run tests in random order'
-  // because the page auto reloads so the referrer will be localhost
+  // note that this test will fail in the browser 'run tests in random order' is disabled
+  // or any link in the jasmine window is clicked e.g. a specific test suite
+  // because the referrer will be localhost, not 'unknown'
   it('should append a hidden "referrer" field to the form', function () {
     loadFeedbackComponent()
 
@@ -135,20 +134,20 @@ describe('Feedback component', function () {
   it('should append a hidden "ga_client_id" field to the form with the appropriate value', function () {
     loadFeedbackComponent()
     GOVUK.setCookie('_ga', 'GA1.3.512324446.1561716924', {})
-    $('.js-page-is-not-useful').click()
+    $('.js-page-is-not-useful')[0].click()
     expect($('#page-is-not-useful').find("[name='email_survey_signup[ga_client_id]']").val()).toBe('512324446.1561716924')
   })
 
   it('should append a hidden "ga_client_id" field to the from with a default value if no client id is present', function () {
     loadFeedbackComponent()
     GOVUK.setCookie('_ga', '', {})
-    $('.js-page-is-not-useful').click()
+    $('.js-page-is-not-useful')[0].click()
     expect($('#page-is-not-useful').find("[name='email_survey_signup[ga_client_id]']").val()).toBe('111111111.1111111111')
   })
 
   it('should append the "Don’t have an email address?" link at the bottom of the form', function () {
     loadFeedbackComponent()
-    $('.js-page-is-not-useful').click()
+    $('.js-page-is-not-useful')[0].click()
 
     expect($('#survey-wrapper').find('#take-survey').length).toBe(1)
   })
@@ -156,7 +155,7 @@ describe('Feedback component', function () {
   describe('clicking the "page was useful" link', function () {
     it('displays a success message', function () {
       loadFeedbackComponent()
-      $('a.js-page-is-useful').click()
+      $('.js-page-is-useful')[0].click()
 
       var $success = $('.js-prompt-success')
 
@@ -166,14 +165,14 @@ describe('Feedback component', function () {
 
     it('hides the question links', function () {
       loadFeedbackComponent()
-      $('a.js-page-is-useful').click()
+      $('.js-page-is-useful')[0].click()
 
       expect($('.js-prompt-questions')).toHaveClass('js-hidden')
     })
 
     it('triggers a Google Analytics event', function () {
       loadFeedbackComponent()
-      $('a.js-page-is-useful').click()
+      $('.js-page-is-useful')[0].click()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('yesNoFeedbackForm', 'ffYesClick')
     })
@@ -182,28 +181,28 @@ describe('Feedback component', function () {
   describe('clicking the "page was not useful" link', function () {
     it('shows the feedback form', function () {
       loadFeedbackComponent()
-      $('a.js-page-is-not-useful').click()
+      $('.js-page-is-not-useful')[0].click()
 
       expect($('.gem-c-feedback .js-feedback-form#page-is-not-useful')).not.toHaveClass('js-hidden')
     })
 
     it('hides the prompt', function () {
       loadFeedbackComponent()
-      $('a.js-page-is-not-useful').click()
+      $('.js-page-is-not-useful')[0].click()
 
       expect($('.gem-c-feedback .js-prompt')).toHaveClass('js-hidden')
     })
 
     it('conveys that the form is now visible', function () {
       loadFeedbackComponent()
-      $('a.js-page-is-not-useful').click()
+      $('.js-page-is-not-useful')[0].click()
 
       expect($('.js-feedback-form#page-is-not-useful').attr('aria-hidden')).toBe('false')
     })
 
     it('conveys that the form is now expanded', function () {
       loadFeedbackComponent()
-      $('a.js-page-is-not-useful').click()
+      $('.js-page-is-not-useful')[0].click()
 
       expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('true')
       expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false')
@@ -213,14 +212,14 @@ describe('Feedback component', function () {
       loadFeedbackComponent()
       var $input = $('#page-is-not-useful .gem-c-input')[0]
       spyOn($input, 'focus')
-      $('a.js-page-is-not-useful').click()
+      $('.js-page-is-not-useful')[0].click()
 
       expect($input.focus).toHaveBeenCalled()
     })
 
     it('triggers a Google Analytics event', function () {
       loadFeedbackComponent()
-      $('a.js-page-is-not-useful').click()
+      $('.js-page-is-not-useful')[0].click()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('yesNoFeedbackForm', 'ffNoClick')
     })
@@ -229,28 +228,28 @@ describe('Feedback component', function () {
   describe('Clicking the "is there anything wrong with this page" link', function () {
     it('shows the form', function () {
       loadFeedbackComponent()
-      $('a.js-something-is-wrong').click()
+      $('.js-something-is-wrong')[0].click()
 
       expect($('.gem-c-feedback .js-feedback-form#something-is-wrong')).not.toHaveClass('js-hidden')
     })
 
     it('hides the prompt', function () {
       loadFeedbackComponent()
-      $('a.js-something-is-wrong').click()
+      $('.js-something-is-wrong')[0].click()
 
       expect($('.gem-c-feedback .js-prompt')).toHaveClass('js-hidden')
     })
 
     it('conveys that the form is now visible', function () {
       loadFeedbackComponent()
-      $('a.js-something-is-wrong').click()
+      $('.js-something-is-wrong')[0].click()
 
       expect($('.js-feedback-form').attr('aria-hidden')).toBe('false')
     })
 
     it('conveys that the form is now expanded', function () {
       loadFeedbackComponent()
-      $('a.js-something-is-wrong').click()
+      $('.js-something-is-wrong')[0].click()
 
       expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false')
       expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('true')
@@ -260,14 +259,14 @@ describe('Feedback component', function () {
       loadFeedbackComponent()
       var $input = $('#something-is-wrong .gem-c-input')[0]
       spyOn($input, 'focus')
-      $('a.js-something-is-wrong').click()
+      $('.js-something-is-wrong')[0].click()
 
       expect($input.focus).toHaveBeenCalled()
     })
 
     it('triggers a Google Analytics event', function () {
       loadFeedbackComponent()
-      $('a.js-something-is-wrong').click()
+      $('.js-something-is-wrong')[0].click()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('Onsite Feedback', 'GOV.UK Open Form')
     })
@@ -276,8 +275,8 @@ describe('Feedback component', function () {
   describe('Clicking the close link in the "something is wrong" form', function () {
     beforeEach(function () {
       loadFeedbackComponent()
-      $('a.js-something-is-wrong').click()
-      $('#something-is-wrong a.js-close-form').click()
+      $('.js-something-is-wrong')[0].click()
+      $('#something-is-wrong .js-close-form')[0].click()
     })
 
     it('hides the form', function () {
@@ -303,7 +302,7 @@ describe('Feedback component', function () {
     })
 
     it('triggers a Google Analytics event', function () {
-      $('#something-is-wrong a.js-close-form').click()
+      $('#something-is-wrong .js-close-form')[0].click()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('Onsite Feedback', 'GOV.UK Close Form')
     })
@@ -312,8 +311,8 @@ describe('Feedback component', function () {
   describe('Clicking the close link in the "not useful" form', function () {
     beforeEach(function () {
       loadFeedbackComponent()
-      $('a.js-page-is-not-useful').click()
-      $('#page-is-not-useful a.js-close-form').click()
+      $('.js-page-is-not-useful')[0].click()
+      $('#page-is-not-useful .js-close-form')[0].click()
     })
 
     it('hides the form', function () {
@@ -339,428 +338,435 @@ describe('Feedback component', function () {
     })
 
     it('triggers a Google Analytics event', function () {
-      $('#page-is-not-useful a.js-close-form').click()
+      $('#page-is-not-useful .js-close-form')[0].click()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('yesNoFeedbackForm', 'ffFormClose')
     })
   })
 
-  describe('successfully submitting the "is there anything wrong with this page" form', function () {
-    beforeEach(function () {
-      jasmine.Ajax.install()
-    })
-
-    afterEach(function () {
-      jasmine.Ajax.uninstall()
-    })
-
-    it('triggers a Google Analytics event', function () {
-      loadFeedbackComponent()
-      fillAndSubmitSomethingIsWrongForm()
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 200,
-        contentType: 'text/plain',
-        responseText: '{ "message": "ok" }'
+  // this check prevents these tests being run if in IE11 or below
+  // because the JS doesn't work for form submissions on IE
+  if (typeof window.URLSearchParams === 'function') {
+    describe('successfully submitting the "is there anything wrong with this page" form', function () {
+      beforeEach(function () {
+        jasmine.Ajax.install()
       })
 
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('Onsite Feedback', 'GOV.UK Send Form')
-    })
-
-    it('submits the feedback to the feedback frontend', function () {
-      loadFeedbackComponent()
-      fillAndSubmitSomethingIsWrongForm()
-
-      var request = jasmine.Ajax.requests.mostRecent()
-      expect(request.url).toBe('/contact/govuk/page_improvements')
-      expect(request.method).toBe('POST')
-      expect(request.data()).toEqual({
-        url: ['http://example.com/path/to/page'],
-        what_doing: ['I was looking for some information about local government.'],
-        what_wrong: ['The background should be green.'],
-        referrer: ['unknown'],
-        javascript_enabled: ['true']
-      })
-    })
-
-    it('displays a success message', function () {
-      loadFeedbackComponent()
-      fillAndSubmitSomethingIsWrongForm()
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 200,
-        contentType: 'application/json',
-        responseText: '{}'
+      afterEach(function () {
+        jasmine.Ajax.uninstall()
       })
 
-      var $success = $('.js-prompt-success')
+      it('triggers a Google Analytics event', function () {
+        loadFeedbackComponent()
+        fillAndSubmitSomethingIsWrongForm()
 
-      expect($success).not.toHaveClass('js-hidden')
-      expect($success).toHaveText('Thanks for your feedback.')
-    })
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'text/plain',
+          responseText: '{ "message": "ok" }'
+        })
 
-    it('focusses the success message', function () {
-      loadFeedbackComponent()
-      fillAndSubmitSomethingIsWrongForm()
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 200,
-        contentType: 'application/json',
-        responseText: '{}'
+        expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('Onsite Feedback', 'GOV.UK Send Form')
       })
 
-      expect(document.activeElement).toBe($('.gem-c-feedback .js-prompt').get(0))
-    })
+      // note that this test will fail in the browser 'run tests in random order' is disabled
+      // or any link in the jasmine window is clicked e.g. a specific test suite
+      // because the referrer will be localhost, not 'unknown'
+      it('submits the feedback to the feedback frontend', function () {
+        loadFeedbackComponent()
+        fillAndSubmitSomethingIsWrongForm()
 
-    it('hides the form', function () {
-      loadFeedbackComponent()
-      fillAndSubmitSomethingIsWrongForm()
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 200,
-        contentType: 'application/json',
-        responseText: '{}'
+        var request = jasmine.Ajax.requests.mostRecent()
+        expect(request.url).toBe('/contact/govuk/page_improvements')
+        expect(request.method).toBe('POST')
+        expect(request.data()).toEqual({
+          url: ['http://example.com/path/to/page'],
+          what_doing: ['I was looking for some information about local government.'],
+          what_wrong: ['The background should be green.'],
+          referrer: ['unknown'],
+          javascript_enabled: ['true']
+        })
       })
 
-      expect($('#something-is-wrong')).toHaveClass('js-hidden')
-    })
+      it('displays a success message', function () {
+        loadFeedbackComponent()
+        fillAndSubmitSomethingIsWrongForm()
 
-    it('hides the links to show the feedback form', function () {
-      loadFeedbackComponent()
-      fillAndSubmitSomethingIsWrongForm()
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'application/json',
+          responseText: '{}'
+        })
 
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 200,
-        contentType: 'application/json',
-        responseText: '{}'
+        var $success = $('.js-prompt-success')
+
+        expect($success).not.toHaveClass('js-hidden')
+        expect($success).toHaveText('Thanks for your feedback.')
       })
 
-      expect($('.js-prompt-questions')).toHaveClass('js-hidden')
-    })
-  })
+      it('focusses the success message', function () {
+        loadFeedbackComponent()
+        fillAndSubmitSomethingIsWrongForm()
 
-  describe('successfully submitting the "page is not useful" form', function () {
-    beforeEach(function () {
-      jasmine.Ajax.install()
-    })
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'application/json',
+          responseText: '{}'
+        })
 
-    afterEach(function () {
-      jasmine.Ajax.uninstall()
-    })
-
-    it('triggers a Google Analytics event', function () {
-      loadFeedbackComponent()
-      fillAndSubmitPageIsNotUsefulForm()
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 200,
-        contentType: 'text/plain',
-        responseText: '{ "message": "ok" }'
+        expect(document.activeElement).toBe($('.gem-c-feedback .js-prompt').get(0))
       })
 
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('yesNoFeedbackForm', 'Send Form')
-    })
+      it('hides the form', function () {
+        loadFeedbackComponent()
+        fillAndSubmitSomethingIsWrongForm()
 
-    it('submits the feedback to the feedback frontend', function () {
-      GOVUK.setCookie('_ga', '', {})
-      loadFeedbackComponent()
-      fillAndSubmitPageIsNotUsefulForm()
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'application/json',
+          responseText: '{}'
+        })
 
-      var request = jasmine.Ajax.requests.mostRecent()
-      expect(request.url).toBe('/contact/govuk/email-survey-signup')
-      expect(request.method).toBe('POST')
-      expect(request.data()).toEqual({
-        'email_survey_signup[email_address]': ['test@test.com'],
-        'email_survey_signup[ga_client_id]': ['111111111.1111111111'],
-        'email_survey_signup[survey_source]': ['a_source'],
-        'email_survey_signup[survey_id]': ['an_id']
+        expect($('#something-is-wrong')).toHaveClass('js-hidden')
+      })
+
+      it('hides the links to show the feedback form', function () {
+        loadFeedbackComponent()
+        fillAndSubmitSomethingIsWrongForm()
+
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'application/json',
+          responseText: '{}'
+        })
+
+        expect($('.js-prompt-questions')).toHaveClass('js-hidden')
       })
     })
 
-    it('displays a success message', function () {
-      loadFeedbackComponent()
-      fillAndSubmitPageIsNotUsefulForm()
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 200,
-        contentType: 'application/json',
-        responseText: '{}'
+    describe('successfully submitting the "page is not useful" form', function () {
+      beforeEach(function () {
+        jasmine.Ajax.install()
       })
 
-      var $prompt = $('.js-prompt-success')
-
-      expect($prompt).not.toHaveClass('js-hidden')
-      expect($prompt).toHaveText('Thanks for your feedback.')
-    })
-
-    it('focusses the success message', function () {
-      loadFeedbackComponent()
-      fillAndSubmitPageIsNotUsefulForm()
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 200,
-        contentType: 'application/json',
-        responseText: '{}'
+      afterEach(function () {
+        jasmine.Ajax.uninstall()
       })
 
-      expect(document.activeElement).toBe($('.gem-c-feedback .js-prompt').get(0))
-    })
+      it('triggers a Google Analytics event', function () {
+        loadFeedbackComponent()
+        fillAndSubmitPageIsNotUsefulForm()
 
-    it('hides the form', function () {
-      loadFeedbackComponent()
-      fillAndSubmitPageIsNotUsefulForm()
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'text/plain',
+          responseText: '{ "message": "ok" }'
+        })
 
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 200,
-        contentType: 'application/json',
-        responseText: '{}'
+        expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('yesNoFeedbackForm', 'Send Form')
       })
 
-      expect($('.js-feedback-form')).toHaveClass('js-hidden')
-    })
+      it('submits the feedback to the feedback frontend', function () {
+        GOVUK.setCookie('_ga', '', {})
+        loadFeedbackComponent()
+        fillAndSubmitPageIsNotUsefulForm()
 
-    it('hides the links to show the feedback form', function () {
-      loadFeedbackComponent()
-      fillAndSubmitPageIsNotUsefulForm()
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 200,
-        contentType: 'application/json',
-        responseText: '{}'
+        var request = jasmine.Ajax.requests.mostRecent()
+        expect(request.url).toBe('/contact/govuk/email-survey-signup')
+        expect(request.method).toBe('POST')
+        expect(request.data()).toEqual({
+          'email_survey_signup[email_address]': ['test@test.com'],
+          'email_survey_signup[ga_client_id]': ['111111111.1111111111'],
+          'email_survey_signup[survey_source]': ['a_source'],
+          'email_survey_signup[survey_id]': ['an_id']
+        })
       })
 
-      expect($('.js-prompt-questions')).toHaveClass('js-hidden')
-    })
-  })
+      it('displays a success message', function () {
+        loadFeedbackComponent()
+        fillAndSubmitPageIsNotUsefulForm()
 
-  describe('submitting the "is something wrong with this page" form with invalid data', function () {
-    beforeEach(function () {
-      jasmine.Ajax.install()
-    })
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'application/json',
+          responseText: '{}'
+        })
 
-    afterEach(function () {
-      jasmine.Ajax.uninstall()
-    })
+        var $prompt = $('.js-prompt-success')
 
-    it('disables the submit button until the server responds', function () {
-      loadFeedbackComponent()
-      fillAndSubmitSomethingIsWrongForm()
-
-      expect($('.gem-c-feedback form [type=submit]')).toBeDisabled()
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 422,
-        contentType: 'application/json',
-        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+        expect($prompt).not.toHaveClass('js-hidden')
+        expect($prompt).toHaveText('Thanks for your feedback.')
       })
 
-      expect($('.gem-c-feedback form [type=submit]')).not.toBeDisabled()
-    })
+      it('focusses the success message', function () {
+        loadFeedbackComponent()
+        fillAndSubmitPageIsNotUsefulForm()
 
-    it('retains the feedback the user originally entered', function () {
-      loadFeedbackComponent()
-      fillAndSubmitSomethingIsWrongForm()
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'application/json',
+          responseText: '{}'
+        })
 
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 422,
-        contentType: 'application/json',
-        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+        expect(document.activeElement).toBe($('.gem-c-feedback .js-prompt').get(0))
       })
 
-      expect($('[name=what_doing]').val()).toEqual('I was looking for some information about local government.')
-      expect($('[name=what_wrong]').val()).toEqual('The background should be green.')
-    })
+      it('hides the form', function () {
+        loadFeedbackComponent()
+        fillAndSubmitPageIsNotUsefulForm()
 
-    it('displays a generic error if the field isn\'t a visible part of the form', function () {
-      loadFeedbackComponent()
-      fillAndSubmitSomethingIsWrongForm()
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'application/json',
+          responseText: '{}'
+        })
 
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 422,
-        contentType: 'application/json',
-        responseText: '{"errors": {"path": ["can\'t be blank"], "another": ["weird error"]}}'
+        expect($('.js-feedback-form')).toHaveClass('js-hidden')
       })
 
-      expect($('#something-is-wrong .js-errors').html()).toContainText(
-        'Sorry, we’re unable to receive your message right now. ' +
-        'If the problem persists, we have other ways for you to provide ' +
-        'feedback on the contact page.'
-      )
-    })
+      it('hides the links to show the feedback form', function () {
+        loadFeedbackComponent()
+        fillAndSubmitPageIsNotUsefulForm()
 
-    it('focusses the error message', function () {
-      loadFeedbackComponent()
-      var $input = $('#something-is-wrong .js-errors')[0]
-      spyOn($input, 'focus')
-      fillAndSubmitSomethingIsWrongForm()
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'application/json',
+          responseText: '{}'
+        })
 
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 422,
-        contentType: 'application/json',
-        responseText: '{}'
-      })
-
-      expect($input.focus).toHaveBeenCalled()
-    })
-  })
-
-  describe('Submitting the "page is not useful" form with invalid data', function () {
-    beforeEach(function () {
-      jasmine.Ajax.install()
-    })
-
-    afterEach(function () {
-      jasmine.Ajax.uninstall()
-    })
-
-    it('disables the submit button until the server responds', function () {
-      loadFeedbackComponent()
-      fillAndSubmitPageIsNotUsefulForm()
-
-      expect($('.gem-c-feedback form [type=submit]')).toBeDisabled()
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 422,
-        contentType: 'application/json',
-        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
-      })
-
-      expect($('.gem-c-feedback form [type=submit]')).not.toBeDisabled()
-    })
-
-    it('retains the feedback the user originally entered', function () {
-      loadFeedbackComponent()
-      fillAndSubmitPageIsNotUsefulForm()
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 422,
-        contentType: 'application/json',
-        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
-      })
-
-      expect($("[name='email_survey_signup[email_address]']").val()).toEqual('test@test.com')
-    })
-
-    it('displays a generic error if the field isn\'t a visible part of the form', function () {
-      loadFeedbackComponent()
-      fillAndSubmitPageIsNotUsefulForm()
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 422,
-        contentType: 'application/json',
-        responseText: '{"errors": {"path": ["can\'t be blank"], "another": ["weird error"]}}'
-      })
-
-      expect($('#page-is-not-useful .js-errors').html()).toContainText(
-        'Sorry, we’re unable to receive your message right now. ' +
-        'If the problem persists, we have other ways for you to provide ' +
-        'feedback on the contact page.'
-      )
-    })
-
-    it('focusses the generic error', function () {
-      loadFeedbackComponent()
-      var $input = $('#page-is-not-useful .js-errors')[0]
-      spyOn($input, 'focus')
-      fillAndSubmitPageIsNotUsefulForm()
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 422,
-        contentType: 'application/json',
-        responseText: '{"errors": {"path": ["can\'t be blank"], "description": ["can\'t be blank"]}}'
-      })
-
-      expect($input.focus).toHaveBeenCalled()
-    })
-  })
-
-  describe('submitting a form that fails because email_survey_signup[survey_source] is missing', function () {
-    beforeEach(function () {
-      jasmine.Ajax.install()
-
-      loadFeedbackComponent()
-      fillAndSubmitSomethingIsWrongForm()
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 422,
-        contentType: 'application/json',
-        responseText: '{"message":"email survey sign up failure","errors":{"survey_source":["can\'t be blank"]}}'
+        expect($('.js-prompt-questions')).toHaveClass('js-hidden')
       })
     })
 
-    afterEach(function () {
-      jasmine.Ajax.uninstall()
-    })
+    describe('submitting the "is something wrong with this page" form with invalid data', function () {
+      beforeEach(function () {
+        jasmine.Ajax.install()
+      })
 
-    it('displays the generic error message in place of the less helpful "email survey sign up failure"', function () {
-      expect($('.gem-c-feedback__error-summary').html()).toContainText(
-        'Sorry, we’re unable to receive your message right now. ' +
-        'If the problem persists, we have other ways for you to provide ' +
-        'feedback on the contact page.'
-      )
-      expect($('.gem-c-feedback__error-summary').html()).not.toContainText('email survey sign up failure')
-    })
-  })
+      afterEach(function () {
+        jasmine.Ajax.uninstall()
+      })
 
-  describe('submitting a form that fails for some reason', function () {
-    beforeEach(function () {
-      jasmine.Ajax.install()
+      it('disables the submit button until the server responds', function () {
+        loadFeedbackComponent()
+        fillAndSubmitSomethingIsWrongForm()
 
-      loadFeedbackComponent()
-      fillAndSubmitSomethingIsWrongForm()
+        expect($('.gem-c-feedback form [type=submit]')).toBeDisabled()
 
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 500,
-        contentType: 'text/plain',
-        responseText: ''
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 422,
+          contentType: 'application/json',
+          responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+        })
+
+        expect($('.gem-c-feedback form [type=submit]')).not.toBeDisabled()
+      })
+
+      it('retains the feedback the user originally entered', function () {
+        loadFeedbackComponent()
+        fillAndSubmitSomethingIsWrongForm()
+
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 422,
+          contentType: 'application/json',
+          responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+        })
+
+        expect($('[name=what_doing]').val()).toEqual('I was looking for some information about local government.')
+        expect($('[name=what_wrong]').val()).toEqual('The background should be green.')
+      })
+
+      it('displays a generic error if the field isn\'t a visible part of the form', function () {
+        loadFeedbackComponent()
+        fillAndSubmitSomethingIsWrongForm()
+
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 422,
+          contentType: 'application/json',
+          responseText: '{"errors": {"path": ["can\'t be blank"], "another": ["weird error"]}}'
+        })
+
+        expect($('#something-is-wrong .js-errors').html()).toContainText(
+          'Sorry, we’re unable to receive your message right now. ' +
+          'If the problem persists, we have other ways for you to provide ' +
+          'feedback on the contact page.'
+        )
+      })
+
+      it('focusses the error message', function () {
+        loadFeedbackComponent()
+        var $input = $('#something-is-wrong .js-errors')[0]
+        spyOn($input, 'focus')
+        fillAndSubmitSomethingIsWrongForm()
+
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 422,
+          contentType: 'application/json',
+          responseText: '{}'
+        })
+
+        expect($input.focus).toHaveBeenCalled()
       })
     })
 
-    afterEach(function () {
-      jasmine.Ajax.uninstall()
+    describe('Submitting the "page is not useful" form with invalid data', function () {
+      beforeEach(function () {
+        jasmine.Ajax.install()
+      })
+
+      afterEach(function () {
+        jasmine.Ajax.uninstall()
+      })
+
+      it('disables the submit button until the server responds', function () {
+        loadFeedbackComponent()
+        fillAndSubmitPageIsNotUsefulForm()
+
+        expect($('.gem-c-feedback form [type=submit]')).toBeDisabled()
+
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 422,
+          contentType: 'application/json',
+          responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+        })
+
+        expect($('.gem-c-feedback form [type=submit]')).not.toBeDisabled()
+      })
+
+      it('retains the feedback the user originally entered', function () {
+        loadFeedbackComponent()
+        fillAndSubmitPageIsNotUsefulForm()
+
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 422,
+          contentType: 'application/json',
+          responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+        })
+
+        expect($("[name='email_survey_signup[email_address]']").val()).toEqual('test@test.com')
+      })
+
+      it('displays a generic error if the field isn\'t a visible part of the form', function () {
+        loadFeedbackComponent()
+        fillAndSubmitPageIsNotUsefulForm()
+
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 422,
+          contentType: 'application/json',
+          responseText: '{"errors": {"path": ["can\'t be blank"], "another": ["weird error"]}}'
+        })
+
+        expect($('#page-is-not-useful .js-errors').html()).toContainText(
+          'Sorry, we’re unable to receive your message right now. ' +
+          'If the problem persists, we have other ways for you to provide ' +
+          'feedback on the contact page.'
+        )
+      })
+
+      it('focusses the generic error', function () {
+        loadFeedbackComponent()
+        var $input = $('#page-is-not-useful .js-errors')[0]
+        spyOn($input, 'focus')
+        fillAndSubmitPageIsNotUsefulForm()
+
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 422,
+          contentType: 'application/json',
+          responseText: '{"errors": {"path": ["can\'t be blank"], "description": ["can\'t be blank"]}}'
+        })
+
+        expect($input.focus).toHaveBeenCalled()
+      })
     })
 
-    it('displays a generic error message', function () {
-      expect($('.gem-c-feedback__error-summary').html()).toContainText(
-        'Sorry, we’re unable to receive your message right now. ' +
-        'If the problem persists, we have other ways for you to provide ' +
-        'feedback on the contact page.'
-      )
+    describe('submitting a form that fails because email_survey_signup[survey_source] is missing', function () {
+      beforeEach(function () {
+        jasmine.Ajax.install()
+
+        loadFeedbackComponent()
+        fillAndSubmitSomethingIsWrongForm()
+
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 422,
+          contentType: 'application/json',
+          responseText: '{"message":"email survey sign up failure","errors":{"survey_source":["can\'t be blank"]}}'
+        })
+      })
+
+      afterEach(function () {
+        jasmine.Ajax.uninstall()
+      })
+
+      it('displays the generic error message in place of the less helpful "email survey sign up failure"', function () {
+        expect($('.gem-c-feedback__error-summary').html()).toContainText(
+          'Sorry, we’re unable to receive your message right now. ' +
+          'If the problem persists, we have other ways for you to provide ' +
+          'feedback on the contact page.'
+        )
+        expect($('.gem-c-feedback__error-summary').html()).not.toContainText('email survey sign up failure')
+      })
     })
 
-    it('retains the feedback the user originally entered', function () {
-      expect($('[name=what_doing]').val()).toEqual('I was looking for some information about local government.')
-      expect($('[name=what_wrong]').val()).toEqual('The background should be green.')
+    describe('submitting a form that fails for some reason', function () {
+      beforeEach(function () {
+        jasmine.Ajax.install()
+
+        loadFeedbackComponent()
+        fillAndSubmitSomethingIsWrongForm()
+
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 500,
+          contentType: 'text/plain',
+          responseText: ''
+        })
+      })
+
+      afterEach(function () {
+        jasmine.Ajax.uninstall()
+      })
+
+      it('displays a generic error message', function () {
+        expect($('.gem-c-feedback__error-summary').html()).toContainText(
+          'Sorry, we’re unable to receive your message right now. ' +
+          'If the problem persists, we have other ways for you to provide ' +
+          'feedback on the contact page.'
+        )
+      })
+
+      it('retains the feedback the user originally entered', function () {
+        expect($('[name=what_doing]').val()).toEqual('I was looking for some information about local government.')
+        expect($('[name=what_wrong]').val()).toEqual('The background should be green.')
+      })
+
+      it('re-enables the submit button', function () {
+        expect($('.gem-c-feedback form [type=submit]')).not.toBeDisabled()
+      })
     })
 
-    it('re-enables the submit button', function () {
-      expect($('.gem-c-feedback form [type=submit]')).not.toBeDisabled()
-    })
-  })
+    describe('submitting a form that times out', function () {
+      beforeEach(function () {
+        jasmine.Ajax.install()
+        jasmine.clock().install()
 
-  describe('submitting a form that times out', function () {
-    beforeEach(function () {
-      jasmine.Ajax.install()
-      jasmine.clock().install()
+        loadFeedbackComponent()
+        fillAndSubmitSomethingIsWrongForm()
+        jasmine.Ajax.requests.mostRecent().responseTimeout()
+      })
 
-      loadFeedbackComponent()
-      fillAndSubmitSomethingIsWrongForm()
-      jasmine.Ajax.requests.mostRecent().responseTimeout()
-    })
+      afterEach(function () {
+        jasmine.Ajax.uninstall()
+        jasmine.clock().uninstall()
+      })
 
-    afterEach(function () {
-      jasmine.Ajax.uninstall()
-      jasmine.clock().uninstall()
+      it('displays a generic error message', function () {
+        expect($('.gem-c-feedback__error-summary').html()).toContainText(
+          'Sorry, we’re unable to receive your message right now. ' +
+          'If the problem persists, we have other ways for you to provide ' +
+          'feedback on the contact page.'
+        )
+      })
     })
-
-    it('displays a generic error message', function () {
-      expect($('.gem-c-feedback__error-summary').html()).toContainText(
-        'Sorry, we’re unable to receive your message right now. ' +
-        'If the problem persists, we have other ways for you to provide ' +
-        'feedback on the contact page.'
-      )
-    })
-  })
+  }
 
   function loadFeedbackComponent () {
     var feedback = new GOVUK.Modules.Feedback()
@@ -768,17 +774,17 @@ describe('Feedback component', function () {
   }
 
   function fillAndSubmitSomethingIsWrongForm () {
-    $('a.js-something-is-wrong').click()
+    $('.js-something-is-wrong')[0].click()
     var $form = $('.gem-c-feedback #something-is-wrong')
     $form.find('[name=what_doing]').val('I was looking for some information about local government.')
     $form.find('[name=what_wrong]').val('The background should be green.')
-    $form.find('[type=submit]').click()
+    $form.find('[type=submit]')[0].click()
   }
 
   function fillAndSubmitPageIsNotUsefulForm () {
-    $('a.js-page-is-not-useful').click()
+    $('.js-page-is-not-useful')[0].click()
     var $form = $('.gem-c-feedback #page-is-not-useful')
     $form.find('[name="email_survey_signup[email_address]"]').val('test@test.com')
-    $form.find('[type=submit]').click()
+    $form.find('[type=submit]')[0].click()
   }
 })


### PR DESCRIPTION
## What
Remove jQuery code from the feedback component's JavaScript, and replace with vanilla JS.

There are two things that might be a problem with this PR:

**Ajax**

Firstly, this component used jQuery's ajax functionality. We've only got a few scripts that do this, and there are a few options for what to replace it with (`XMLHttpRequest`, [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)). We should have a consistent approach for this.

I've chosen `XMLHttpRequest` because I'm more familiar with it, but `fetch` might be better. I don't want this conversation to block this PR - I think it's more important we remove jQuery, and if we have to, we can come back later and fix up the consistency (as I said, it's only a few scripts that do this).

**Internet Explorer**

Doing ajax requests and form serialisation is really hard in IE, particularly old IE but also even IE11. After going through numerous hoops and writing a lot of extra code I've finally come to the decision that the simplest option is to wrap the form submission JS in a check that excludes IE from using it. 

This means that IE users will still get the normal functionality of the feedback component, but when they submit a response to either of the two forms it will not be handled by JS and be passed as a normal form submission to the backend (which is what happens now if you have JS disabled in your browser).

Consequently, I've wrapped the tests that check form submission in the same if statement that the component code uses to check for IE11, as there's no point running those tests on IE11 (they immediately try to do a proper form submission and break the test suite).

I accept that this might be a bit more controversial so happy to discuss.

## Why
We're trying to remove our dependency on jQuery.

## Visual Changes
None.
