### PR TITLE
Hide print link component from print version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Hide print link component from print version ([PR #2063](https://github.com/alphagov/govuk_publishing_components/pull/2063))
+
 ## 24.10.3
 
 * Remove phase banner restrictions ([PR #2057](https://github.com/alphagov/govuk_publishing_components/pull/2057))

--- a/app/views/govuk_publishing_components/components/_print_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_print_link.html.erb
@@ -13,7 +13,7 @@
     margin_bottom: margin_bottom
   })
 
-  wrapper_classes = %w(gem-c-print-link)
+  wrapper_classes = %w(gem-c-print-link govuk-!-display-none-print)
   wrapper_classes << "gem-c-print-link--show-without-js" unless require_js
   wrapper_classes << (shared_helper.get_margin_top)
   wrapper_classes << (shared_helper.get_margin_bottom)


### PR DESCRIPTION
It does not make sense for the print link to be visible in the printed document. 
This adds a [design system override class](https://design-system.service.gov.uk/styles/layout/#override-how-elements-display) to hide it on the printed version of the page.

Fixes https://github.com/alphagov/govuk_publishing_components/issues/1770
