### PR TITLE
Add [Withdrawn] to the og:title tag of withdrawn content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## 24.10.3
 
 * Remove phase banner restrictions ([PR #2057](https://github.com/alphagov/govuk_publishing_components/pull/2057))
+* Add `[Withdrawn]` to the beginning of the `og:title` meta tag for withdrawn pages ([PR #2066](https://github.com/alphagov/govuk_publishing_components/pull/2066))
 
 ## 24.10.2
 

--- a/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
@@ -17,7 +17,7 @@
 <meta property="og:site_name" content="GOV.UK" />
 <meta property="og:type" content="article" />
 <meta property="og:url" content="<%= page.canonical_url %>" />
-<meta property="og:title" content="<%= page.title %>" />
+<meta property="og:title" content="<% if page.withdrawn? %>[Withdrawn] <% end %><%= page.title %>" />
 <meta property="og:description" content="<%= strip_tags(page.description) %>" />
 
 <% if page.has_image? %>

--- a/lib/govuk_publishing_components/presenters/machine_readable/page.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/page.rb
@@ -66,6 +66,10 @@ module GovukPublishingComponents
       def requested_path
         local_assigns[:request_path]
       end
+
+      def withdrawn?
+        content_item["withdrawn_notice"].present?
+      end
     end
   end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

For content that has been withdrawn, prefixes the `og:title` tag with '[Withdrawn]'.

https://trello.com/c/7OxshPDC/2498-2-add-withdrawn-to-ogtitle-tag


## Why
<!-- What are the reasons behind this change being made? -->

> The prefix is currently added to the title metatag, but not og:title. The latter is used when content is shared on social media etc, so in those cases it's not clear to users that content has been withdrawn.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
