### PR TITLE
Trigger feature flag for new link styles on govuk-link

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -1,6 +1,9 @@
 // This is the file that the application needs to include in order to use
 // the components.
 
+// feature flag for accessible link styles
+$govuk-new-link-styles: true;
+
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/component_support";
 


### PR DESCRIPTION
## What
Set the feature flag for applying the new `govuk-link` styles (`$govuk-new-link-styles`) to `true`, thus setting the new link styles on our components by default.

## Why
This change has come from the [latest release of GOV.UK frontend](https://github.com/alphagov/govuk-frontend/releases). This change has been extensively researched and will have a positive impact on link visibility across govuk.

## Visual Changes
coming soon...
