### PR TITLE
Update action link, contents list and image card components to use new link styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Update link styles for subscription links ([PR #2075](https://github.com/alphagov/govuk_publishing_components/pull/2075))
 * Update inset text block example ([PR #2085](https://github.com/alphagov/govuk_publishing_components/pull/2085))
 * Remove direct anchor styling on inverse header component ([PR #2084](https://github.com/alphagov/govuk_publishing_components/pull/2084))
+* Update action link, contents list and image card components to use new link styles ([PR #2071](https://github.com/alphagov/govuk_publishing_components/pull/2071))
 
 ## 24.10.3
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -32,10 +32,6 @@
 .gem-c-action-link__link {
   color: inherit;
 
-  &:hover {
-    text-decoration: underline;
-  }
-
   &:focus {
     text-decoration: none;
     color: $govuk-focus-text-colour;
@@ -106,10 +102,6 @@
     background-size: 25px auto;
     background-position: 0 2px;
   }
-
-  .gem-c-action-link__link {
-    text-decoration: none;
-  }
 }
 
 .gem-c-action-link--simple-light {
@@ -121,10 +113,6 @@
     background-repeat: no-repeat;
     background-size: 25px auto;
     background-position: 0 2px;
-  }
-
-  .gem-c-action-link__link {
-    text-decoration: none;
   }
 }
 
@@ -150,10 +138,6 @@
     background-size: 25px auto;
     background-position: 0 2px;
   }
-
-  .gem-c-action-link__link {
-    text-decoration: none;
-  }
 }
 
 .gem-c-action-link--transparent-icon {
@@ -176,25 +160,6 @@
 
 .gem-c-action-link--light-text {
   color: govuk-colour("white");
-
-  .gem-c-action-link__link,
-  .gem-c-action-link__subtext-link {
-    text-decoration: underline;
-
-    &:link,
-    &:visited {
-      color: govuk-colour("white");
-    }
-
-    &:hover {
-      color: $gem-hover-dark-background;
-    }
-
-    &:focus {
-      text-decoration: none;
-      color: $govuk-focus-text-colour;
-    }
-  }
 
   .gem-c-action-link__subtext {
     &:before {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
@@ -25,19 +25,6 @@
   list-style-type: none;
 }
 
-.gem-c-contents-list--no-underline {
-  .gem-c-contents-list__link {
-    text-decoration: none;
-
-    &:hover,
-    &:active {
-      text-decoration: underline;
-    }
-
-    @include govuk-template-link-focus-override;
-  }
-}
-
 .gem-c-contents-list__link {
   .gem-c-contents-list__list-item--parent > & {
     font-weight: bold;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -63,12 +63,6 @@
 }
 
 .gem-c-image-card__title-link {
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
-
   &:focus {
     text-decoration: none;
   }

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -32,6 +32,7 @@
 
   link_classes = %w(govuk-link gem-c-action-link__link)
   link_classes << shared_helper.classes if classes
+  link_classes << "govuk-link--inverse" if light_text
 %>
 <% if text.present? %>
   <div class="<%= css_classes.join(' ') %>">
@@ -55,7 +56,7 @@
         <span class="gem-c-action-link__subtext-wrapper">
           <% if subtext_href %>
             <%= content_tag(:span, subtext, class: "gem-c-action-link__subtext") do %>
-              <%= link_to subtext, subtext_href, class: "gem-c-action-link__subtext-link govuk-link", data: data %>
+              <%= link_to subtext, subtext_href, class: link_classes, data: data %>
             <% end %>
           <% else %>
             <%= content_tag(:span, subtext, class: "gem-c-action-link__subtext") %>

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -1,12 +1,19 @@
 <%-
   cl_helper = GovukPublishingComponents::Presenters::ContentsListHelper.new(local_assigns)
+  underline_links ||= false
   aria_label ||= t("components.contents_list.contents")
   format_numbers ||= false
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
   title_fallback = t("components.contents_list.contents", locale: I18n.locale, fallback: false, default: "en")
-  classes = cl_helper.classes
+  classes = %w[gem-c-contents-list]
   classes << brand_helper.brand_class
+  link_classes = %w[
+    gem-c-contents-list__link
+    govuk-link
+  ]
+  link_classes << brand_helper.color_class
+  link_classes << "govuk-link--no-underline" unless underline_links
 -%>
 <% if cl_helper.contents.any? %>
   <%= content_tag(
@@ -31,7 +38,7 @@
         <li class="<%= cl_helper.list_item_classes(contents_item, false) %>" <%= "aria-current=true" if contents_item[:active] %>>
           <% link_text = format_numbers ? cl_helper.wrap_numbers_with_spans(contents_item[:text]) : contents_item[:text] %>
           <%= link_to_if !contents_item[:active], link_text, contents_item[:href],
-            class: "gem-c-contents-list__link govuk-link #{brand_helper.color_class}",
+            class:  link_classes,
             data: {
               track_category: 'contentsClicked',
               track_action: "content_item #{position}",
@@ -47,7 +54,7 @@
               <% contents_item[:items].each.with_index(1) do |nested_contents_item, nested_position| %>
                 <li class="<%= cl_helper.list_item_classes(nested_contents_item, true) %>" <%= "aria-current=true" if nested_contents_item[:active] %>>
                   <%= link_to_if !nested_contents_item[:active], nested_contents_item[:text], nested_contents_item[:href],
-                    class: "gem-c-contents-list__link govuk-link #{brand_helper.color_class}",
+                    class: link_classes,
                     data: {
                       track_category: 'contentsClicked',
                       track_action: "nested_content_item #{position}:#{nested_position}",

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -10,6 +10,19 @@
   font_size ||= card_helper.large ? 'm' : 's'
   heading_class = %w[gem-c-image-card__title]
   heading_class << shared_helper.get_heading_size(font_size, 's')
+
+  heading_link_classes = %w[
+    gem-c-image-card__title-link
+    govuk-link
+    govuk-link--no-underline
+  ] 
+  heading_link_classes << brand_helper.color_class
+  extra_link_classes = %w[
+    gem-c-image-card__list-item-link
+    govuk-link
+  ]
+  extra_link_classes << brand_helper.color_class
+
 %>
 <% if card_helper.href || card_helper.extra_links.any? %>
   <div class="<%= classes %> <%= brand_helper.brand_class %>"
@@ -21,7 +34,7 @@
           <%= content_tag(shared_helper.get_heading_level, class: heading_class) do %>
             <% if card_helper.href %>
               <%= link_to card_helper.heading_text, card_helper.href,
-                class: "gem-c-image-card__title-link govuk-link #{brand_helper.color_class}",
+                class: heading_link_classes,
                 data: card_helper.href_data_attributes
               %>
             <% else %>
@@ -37,7 +50,7 @@
           <% card_helper.extra_links.each do |link| %>
             <li class="gem-c-image-card__list-item">
               <%= link_to link[:text], link[:href],
-                class: "gem-c-image-card__list-item-link govuk-link #{brand_helper.color_class}",
+                class: extra_link_classes,
                 data: link[:data_attributes]
               %>
             </li>

--- a/lib/govuk_publishing_components/presenters/contents_list_helper.rb
+++ b/lib/govuk_publishing_components/presenters/contents_list_helper.rb
@@ -11,9 +11,6 @@ module GovukPublishingComponents
         @contents = options[:contents] || []
         @nested = @contents.any? { |c| c[:items] && c[:items].any? }
         @format_numbers = options[:format_numbers]
-
-        @classes = %w[gem-c-contents-list]
-        @classes << " gem-c-contents-list--no-underline" unless options[:underline_links]
       end
 
       def list_item_classes(list_item, nested)

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -42,15 +42,15 @@ describe "Contents list", type: :view do
 
   it "renders a list of contents links" do
     render_component(contents: contents_list)
-    assert_select ".gem-c-contents-list.gem-c-contents-list--no-underline"
-    assert_select ".gem-c-contents-list__link[href='/one']", text: "1. One"
-    assert_select ".gem-c-contents-list__link[href='/two']", text: "2. Two"
+    assert_select ".gem-c-contents-list"
+    assert_select ".gem-c-contents-list__link.govuk-link--no-underline[href='/one']", text: "1. One"
+    assert_select ".gem-c-contents-list__link.govuk-link--no-underline[href='/two']", text: "2. Two"
   end
 
   it "renders with the underline option" do
     render_component(contents: contents_list, underline_links: true)
     assert_select ".gem-c-contents-list"
-    assert_select ".gem-c-contents-list.gem-c-contents-list--no-underline", false
+    assert_select ".gem-c-contents-list .govuk-link--no-underline", false
   end
 
   it "renders text only when link is active" do


### PR DESCRIPTION
## What
Update the [action link](https://components.publishing.service.gov.uk/component-guide/action_link), [contents list](https://components.publishing.service.gov.uk/component-guide/contents_list) and [image card](https://components.publishing.service.gov.uk/component-guide/image_card) components so that they are using the new link styles.

Additionally adds underlines to links that previously didn't have underlines on the action link component.

## Why
Part of work by the govuk frontend community to update our gem to use new link styles from GOV.UK frontend.

Action link underlines are being applied because this ensures consistency, whether the text is in front of a light background, or even a dark background.

[Card for action links underlines](https://trello.com/c/GroJtbez/725-add-underline-throughout-all-action-links-jazzy-arrows)

## Visual changes (hover state)
| Before | After |
| --- | --- |
| ![Screenshot 2021-05-18 at 15 28 48](https://user-images.githubusercontent.com/64783893/118680215-75230800-b7f6-11eb-9a0b-ffe09eccf262.png) | ![Screenshot 2021-05-18 at 15 29 14](https://user-images.githubusercontent.com/64783893/118680187-6d636380-b7f6-11eb-8592-2c0073b4b461.png) |
| ![Screenshot 2021-05-18 at 15 29 26](https://user-images.githubusercontent.com/64783893/118680311-89670500-b7f6-11eb-9e97-9203d6ef23e0.png) | ![Screenshot 2021-05-18 at 15 29 57](https://user-images.githubusercontent.com/64783893/118680350-8ec44f80-b7f6-11eb-8edb-6f2325ffcfae.png) |
| ![Screenshot 2021-05-18 at 15 29 41](https://user-images.githubusercontent.com/64783893/118680393-997ee480-b7f6-11eb-8806-be2dc60c7d2d.png) | ![Screenshot 2021-05-18 at 15 30 11](https://user-images.githubusercontent.com/64783893/118680422-a0a5f280-b7f6-11eb-9e9a-694dc1ff7fa3.png) |
| ![Screenshot 2021-05-18 at 16 28 48](https://user-images.githubusercontent.com/64783893/118680536-bca99400-b7f6-11eb-80e4-fabff73750f5.png) | ![Screenshot 2021-05-18 at 16 29 00](https://user-images.githubusercontent.com/64783893/118680560-c29f7500-b7f6-11eb-913d-035196642f3e.png) |
| ![Screenshot 2021-05-18 at 16 29 09](https://user-images.githubusercontent.com/64783893/118680624-cf23cd80-b7f6-11eb-9bfd-7fad4cb41dec.png) | ![Screenshot 2021-05-18 at 16 29 29](https://user-images.githubusercontent.com/64783893/118680662-d64adb80-b7f6-11eb-8eac-6c82e160853a.png) |

