### PR TITLE
Keep print button styles in line with other buttons

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_print-link.scss
@@ -20,6 +20,7 @@ $gem-c-print-link-background-height: 18px;
   background: image-url("govuk_publishing_components/icon-print.png") no-repeat govuk-spacing(2) 50%;
   background-size: $gem-c-print-link-background-width $gem-c-print-link-background-height;
   padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) (govuk-spacing(4) + $gem-c-print-link-background-width);
+  text-decoration: none;
 
   @include govuk-device-pixel-ratio($ratio: 2) {
     background-image: image-url("govuk_publishing_components/icon-print-2x.png");
@@ -32,7 +33,6 @@ $gem-c-print-link-background-height: 18px;
 
 .gem-c-print-link__link {
   box-shadow: inset 0 0 0 1px $govuk-border-colour;
-  text-decoration: none;
 
   &:focus {
     border: 0;


### PR DESCRIPTION
## What
Keep print button styles in line with other buttons

## Why
In https://github.com/alphagov/govuk_publishing_components/pull/1735 we tried to bring the print button in line with other button elements, so we're removing the underline for this component on any states and regardless of the element used (button or anchor).

## Visual Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="960" alt="Screenshot 2021-05-18 at 12 33 15" src="https://user-images.githubusercontent.com/788096/118644222-7c85e980-b7d5-11eb-80dc-cd84e622ae36.png">

<img width="959" alt="Screenshot 2021-05-18 at 12 37 53" src="https://user-images.githubusercontent.com/788096/118644771-0fbf1f00-b7d6-11eb-8296-9106224b6267.png">

<img width="959" alt="Screenshot 2021-05-18 at 12 38 17" src="https://user-images.githubusercontent.com/788096/118644897-2ebdb100-b7d6-11eb-8911-b8df7162a1e3.png">


</td><td valign="top">

<img width="960" alt="Screenshot 2021-05-18 at 12 33 36" src="https://user-images.githubusercontent.com/788096/118644230-7e4fad00-b7d5-11eb-8c75-ade22abec884.png">

<img width="959" alt="Screenshot 2021-05-18 at 12 38 13" src="https://user-images.githubusercontent.com/788096/118644783-13eb3c80-b7d6-11eb-862a-b83d2a4ef76f.png">

<img width="959" alt="Screenshot 2021-05-18 at 12 38 26" src="https://user-images.githubusercontent.com/788096/118644908-31b8a180-b7d6-11eb-82e5-032425e2f245.png">


</td></tr>
</table>

