### PR TITLE
Update share links to have new underline styles

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -22,7 +22,6 @@ $share-button-height: 32px;
 .gem-c-share-links__link {
   @include govuk-font(16, $weight: bold);
   margin-right: govuk-spacing(6);
-  text-decoration: none;
 
   @include govuk-template-link-focus-override;
 }

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -52,7 +52,7 @@
               'track-action': link[:icon],
               'track-options': track_options
             },
-            class: "govuk-link gem-c-share-links__link #{brand_helper.color_class}" do %>
+            class: "govuk-link govuk-link--no-underline gem-c-share-links__link #{brand_helper.color_class}" do %>
             <span class="gem-c-share-links__link-icon">
               <% if link[:icon] == 'facebook' %>
                 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" aria-hidden="true">


### PR DESCRIPTION
## What
Share Links have new Design System styles

## Why
Underline link styles have changed on the Design System adjusting Share Links gem.

## Visual Changes

<img width="1430" alt="Screenshot 2021-05-18 at 11 57 41" src="https://user-images.githubusercontent.com/71266765/118640046-72152100-b7d0-11eb-8002-9c9e0bfb0012.png">
<img width="1430" alt="Screenshot 2021-05-18 at 11 58 45" src="https://user-images.githubusercontent.com/71266765/118640034-704b5d80-b7d0-11eb-9362-07f4f0ff3491.png">
<img width="1430" alt="Screenshot 2021-05-18 at 11 58 30" src="https://user-images.githubusercontent.com/71266765/118640039-717c8a80-b7d0-11eb-92a5-e33db30f6d62.png">
<img width="1430" alt="Screenshot 2021-05-18 at 11 58 21" src="https://user-images.githubusercontent.com/71266765/118640042-717c8a80-b7d0-11eb-9b89-486aa16c5103.png">

