### PR TITLE
Update link styles for show password component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove `display: none` rules from component print stylesheets, and use the `govuk-!-display-none-print` class instead. ([PR #1561](https://github.com/alphagov/govuk_publishing_components/pull/1561))
+* Update link styles for show password component ([PR #2074](https://github.com/alphagov/govuk_publishing_components/pull/2074))
 
 ## 24.10.3
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_show-password.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_show-password.scss
@@ -49,6 +49,7 @@
 
   &:hover {
     color: $govuk-link-hover-colour;
+    @include govuk-link-hover-decoration;
   }
 
   &:focus {


### PR DESCRIPTION
## What
Update the button styling for the [show password component](https://components.publishing.service.gov.uk/component-guide/show_password) to use the latest link styles on the button text.

## Why
Part of ongoing work by the govuk frontend community to use the latest link styles from the design system. The show password component uses text styling within it's main button that simulates the style of a link so we're applying the link styles here for consistency.

## Visual Changes (hover state)
| Before | After |
| --- | --- |
| ![Screenshot 2021-05-18 at 15 22 32](https://user-images.githubusercontent.com/64783893/118668697-042b2280-b7ed-11eb-9db1-c23b7d382a51.png) | ![Screenshot 2021-05-18 at 15 22 58](https://user-images.githubusercontent.com/64783893/118668734-0ab99a00-b7ed-11eb-9547-d293df7415ee.png) |
