### PR TITLE
Add govuk-link-common mixin to govspeak links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 * Remove direct anchor styling on inverse header component ([PR #2084](https://github.com/alphagov/govuk_publishing_components/pull/2084))
 * Update action link, contents list and image card components to use new link styles ([PR #2071](https://github.com/alphagov/govuk_publishing_components/pull/2071))
 * Add govuk-link classes to government navigation links ([PR #2081](https://github.com/alphagov/govuk_publishing_components/pull/2081))
+* Update share links to have new underline styles ([PR #2073](https://github.com/alphagov/govuk_publishing_components/pull/2073))
+* Add govuk-link-common mixin to govspeak links ([PR #2078](https://github.com/alphagov/govuk_publishing_components/pull/2078))
 
 ## 24.10.3
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -75,6 +75,7 @@
   // Links
 
   a {
+    @include govuk-link-common;
     @include govuk-link-style-default;
 
     &:focus {


### PR DESCRIPTION
## What
Update the [govspeak component](https://components.publishing.service.gov.uk/component-guide/govspeak) to use the latest link styles from the latest govuk frontend release.

## Why
Part of ongoing work by the govuk frontend community to ensure that all components are using new link styles from govuk frontend so that users can reap the benefits of them.

This PR also includes a separate changelog line for https://github.com/alphagov/govuk_publishing_components/pull/2073 as that PR should've included a changelog line but it got missed before merge. 

## Visual Changes (hover state)
| Before | After |
| --- | --- |
| ![Screenshot 2021-05-19 at 11 32 20](https://user-images.githubusercontent.com/64783893/118799553-c2ef4d00-b896-11eb-91d9-1459b47446ec.png) | ![Screenshot 2021-05-19 at 11 32 28](https://user-images.githubusercontent.com/64783893/118799576-c97dc480-b896-11eb-81b5-99018ea30a36.png) |

