### PR TITLE
Fix IE11 initCustomEvent error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove `display: none` rules from component print stylesheets, and use the `govuk-!-display-none-print` class instead. ([PR #1561](https://github.com/alphagov/govuk_publishing_components/pull/1561))
+* Fix IE11 `initCustomEvent` error ([PR #2079](https://github.com/alphagov/govuk_publishing_components/pull/2079))
 
 ## 24.10.3
 

--- a/app/assets/javascripts/govuk_publishing_components/components/reorderable-list.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/reorderable-list.js
@@ -98,7 +98,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       event = new window.CustomEvent(eventName, params)
     } else {
       event = document.createEvent('CustomEvent')
-      event.initCustomEvent(eventName, params.bubbles, params.cancelable)
+      event.initCustomEvent(eventName, params.bubbles, params.cancelable, null)
     }
 
     element.dispatchEvent(event)

--- a/app/assets/javascripts/govuk_publishing_components/lib/trigger-event.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/trigger-event.js
@@ -10,7 +10,7 @@
       event = new window.CustomEvent(eventName, params)
     } else {
       event = document.createEvent('CustomEvent')
-      event.initCustomEvent(eventName, params.bubbles, params.cancelable)
+      event.initCustomEvent(eventName, params.bubbles, params.cancelable, null)
     }
 
     element.dispatchEvent(event)


### PR DESCRIPTION
Some work was done to allow cookie dependent modules to start immediately when the user consents to cookies. https://github.com/alphagov/govuk_publishing_components/pull/2041 
To make this possible, some functionality was introduced to trigger a custom cookie consent event when consent is given. It seems like some of the code that was introduced causes a JS error on IE11 specifically. 
![image](https://user-images.githubusercontent.com/7116819/118842403-137ba000-b8c1-11eb-978c-0acee5e30582.png)

The error appears to be related to the `initCustomEvent` method. Namely, it seems like IE11 does not like when this method is called with less than the required 4 arguments, and consequently throws an error.
This passes `null` as a 4th argument, which should appease IE11 without causing issues in other browsers.
