### PR TITLE
Update accordion link hover to new styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add govuk-link classes to government navigation links ([PR #2081](https://github.com/alphagov/govuk_publishing_components/pull/2081))
 * Update share links to have new underline styles ([PR #2073](https://github.com/alphagov/govuk_publishing_components/pull/2073))
 * Add govuk-link-common mixin to govspeak links ([PR #2078](https://github.com/alphagov/govuk_publishing_components/pull/2078))
+* Update links styles for accordion component ([PR #2080](https://github.com/alphagov/govuk_publishing_components/pull/2080))
 
 ## 24.10.3
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
@@ -40,25 +40,11 @@ $gem-c-accordion-bottom-border-width: 1px;
     @include govuk-font($size: 16);
     @include govuk-link-common;
     @include govuk-link-style-default;
+
     // Remove default button focus outline in Firefox
     &::-moz-focus-inner {
       padding: 0;
       border: 0;
-    }
-  }
-
-  .gem-c-accordion__open-all:hover,
-  .gem-c-accordion__open-all-text:hover {
-    text-decoration: underline;
-    color: $govuk-link-colour;
-  }
-
-  // Focus state, also to change chervon icon to black
-  .gem-c-accordion__open-all:focus {
-    .gem-c-accordion__open-all-text,
-    .gem-c-accordion-nav__chevron {
-      color: $govuk-focus-text-colour;
-      text-decoration: none;
     }
   }
 
@@ -73,6 +59,7 @@ $gem-c-accordion-bottom-border-width: 1px;
     margin-left: govuk-em(5, 14);
     border: govuk-em(1, 14) solid;
     border-radius: govuk-em(100, 14);
+
     // Main icon size across views, yet keep responsive for zoom
     @include govuk-media-query($from: tablet) {
       width: govuk-em(20, 16);
@@ -94,6 +81,7 @@ $gem-c-accordion-bottom-border-width: 1px;
       transform: rotate(-45deg);
       left: govuk-em(6, 14);
       bottom: govuk-em(5, 14);
+
       @include govuk-media-query($from: tablet) {
         width: govuk-em(6, 16);
         height: govuk-em(6, 16);
@@ -102,6 +90,22 @@ $gem-c-accordion-bottom-border-width: 1px;
         left: govuk-em(6, 16);
         bottom: govuk-em(5, 16);
       }
+    }
+  }
+
+  .gem-c-accordion__open-all:hover,
+  .gem-c-accordion__section-button:hover {
+    .gem-c-accordion-nav__chevron {
+      color: $govuk-link-hover-colour;
+      text-decoration: none;
+    }
+  }
+
+  // Focus state, also to change chervon icon to black
+  .gem-c-accordion__open-all:focus {
+    .gem-c-accordion-nav__chevron {
+      color: $govuk-focus-text-colour;
+      text-decoration: none;
     }
   }
 
@@ -150,6 +154,10 @@ $gem-c-accordion-bottom-border-width: 1px;
     @include govuk-typography-common;
     width: 100%;
 
+    &:hover {
+      color: $govuk-link-hover-colour;
+    }
+
     &:active {
       z-index: 1;
       color: $govuk-link-active-colour;
@@ -163,26 +171,12 @@ $gem-c-accordion-bottom-border-width: 1px;
     }
   }
 
-  .gem-c-accordion__section-button:hover {
-    color: $govuk-link-colour;
-    // On hover, add underline to toggle link
-    .gem-c-accordion__toggle-text {
-      text-decoration: underline;
-      color: $govuk-link-colour;
-    }
-  }
-
   .gem-c-accordion__section-button:focus {
     @include govuk-focused-text;
     // Overwrite focus border to top
     box-shadow: 0 0, 0 -4px;
     border-top: 1px solid transparent;
 
-    // Focus state to change the toggle link within individual sections
-    .gem-c-accordion__toggle-text {
-      color: $govuk-focus-text-colour;
-      text-decoration: none;
-    }
     // Focus state to change chervon icon colour within individual sections
     .gem-c-accordion-nav__chevron {
       color: $govuk-text-colour;
@@ -225,16 +219,41 @@ $gem-c-accordion-bottom-border-width: 1px;
     }
   }
 
-  // Setting width of the text, so the icon doesn't shift (left / right) when toggled
   .gem-c-accordion__toggle-text {
-    min-width: govuk-em(40, 16);
     display: inline-block;
+    // Setting width of the text so the icon doesn't shift left or right when
+    // toggled:
+    min-width: govuk-em(40, 16);
+  }
+
+  // On hover add underline to toggle link only:
+  .gem-c-accordion__section-button:hover .gem-c-accordion__toggle-text {
+    color: $govuk-link-hover-colour;
+    @include govuk-link-decoration;
+    @include govuk-link-hover-decoration;
+  }
+
+  // Ensure the correct focus sstate text colour and no underline:
+  .gem-c-accordion__section-button:focus .gem-c-accordion__toggle-text {
+    color: $govuk-focus-text-colour;
+    text-decoration: none;
   }
 
   .gem-c-accordion__open-all-text {
     min-width: govuk-em(120, 16);
     display: inline-block;
     text-align: left;
+  }
+
+  .gem-c-accordion__open-all:hover {
+    .gem-c-accordion__open-all-text {
+      @include govuk-link-decoration;
+      @include govuk-link-hover-decoration;
+    }
+  }
+
+  .gem-c-accordion__open-all:focus .gem-c-accordion__open-all-text {
+    text-decoration: none;
   }
 
   // Change the summary subheading size.


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Update the accordion hover states so it uses the new hover states from [GOV.UK Frontend v3.12.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.12.0).

This couldn't be automatically updated alongside by bumping because the accordion needs the hover states on text within the button, this required a number of bespoke changes.

Slight tweak to hover of the 'Show all sections' link - the hover state visual change is now triggered by hovering the whole button, not just the text.

## Why
<!-- What are the reasons behind this change being made? -->

To bring the accordion component up to date, alongside all of the other components that can't be automatically updated.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

| State | Before | After | 
| - | - | - |
| Show all link hover | ![image](https://user-images.githubusercontent.com/1732331/118957485-7704dc80-b958-11eb-9b43-c071b438f035.png) | ![image](https://user-images.githubusercontent.com/1732331/118956737-c72f6f00-b957-11eb-94ea-f58a92b1bde9.png) |
| Show all link focus and hover | ![image](https://user-images.githubusercontent.com/1732331/118957571-8be17000-b958-11eb-968c-6660fd1a314b.png) | ![image](https://user-images.githubusercontent.com/1732331/118956846-e1694d00-b957-11eb-9623-f6f28678fb47.png) |
| Show section hover | ![image](https://user-images.githubusercontent.com/1732331/118957714-a61b4e00-b958-11eb-93f2-03b0a5f169a9.png) | ![image](https://user-images.githubusercontent.com/1732331/118957206-3ad17c00-b958-11eb-834b-49581d159c65.png) |
| Show section hover and focus | ![image](https://user-images.githubusercontent.com/1732331/118957771-b3383d00-b958-11eb-8997-323f4a678097.png) | ![image](https://user-images.githubusercontent.com/1732331/118957274-49b82e80-b958-11eb-883a-565577baa9ca.png) |



