### PR TITLE
Add govuk-link classes to government navigation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Update inset text block example ([PR #2085](https://github.com/alphagov/govuk_publishing_components/pull/2085))
 * Remove direct anchor styling on inverse header component ([PR #2084](https://github.com/alphagov/govuk_publishing_components/pull/2084))
 * Update action link, contents list and image card components to use new link styles ([PR #2071](https://github.com/alphagov/govuk_publishing_components/pull/2071))
+* Add govuk-link classes to government navigation links ([PR #2081](https://github.com/alphagov/govuk_publishing_components/pull/2081))
 
 ## 24.10.3
 

--- a/app/views/govuk_publishing_components/components/_government_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_government_navigation.html.erb
@@ -5,37 +5,37 @@
 <nav id="proposition-menu" class="no-proposition-name gem-c-government-navigation" aria-label="Departments and policy navigation">
   <ul id="proposition-links">
     <li>
-      <a class="<%= 'active' if active == 'departments' %>" href="/government/organisations">
+      <a class="<%= 'active' if active == 'departments' %> govuk-link govuk-link--no-underline govuk-link--inverse" href="/government/organisations">
         <%= t("components.government_navigation.departments", default: "Departments") %>
       </a>
     </li>
     <li>
-      <a class="<%= 'active' if active == 'worldwide' %>" href="/government/world">
+      <a class="<%= 'active' if active == 'worldwide' %> govuk-link govuk-link--no-underline govuk-link--inverse" href="/government/world">
         <%= t("components.government_navigation.worldwide", default: "Worldwide") %>
       </a>
     </li>
     <li>
-      <a class="<%= 'active' if active == 'how-government-works' %>" href="/government/how-government-works">
+      <a class="<%= 'active' if active == 'how-government-works' %> govuk-link govuk-link--no-underline govuk-link--inverse" href="/government/how-government-works">
         <%= t("components.government_navigation.how-government-works", default: "How government works") %>
       </a>
     </li>
     <li>
-      <a class="<%= 'active' if active == 'get-involved' %>" href="/government/get-involved">
+      <a class="<%= 'active' if active == 'get-involved' %> govuk-link govuk-link--no-underline govuk-link--inverse" href="/government/get-involved">
         <%= t("components.government_navigation.get-involved", default: "Get involved") %>
       </a>
     </li>
     <li class="clear-child">
-      <a class="<%= 'active' if active == 'consultations' %>" href="<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>">
+      <a class="<%= 'active' if active == 'consultations' %> govuk-link govuk-link--no-underline govuk-link--inverse" href="<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>">
         <%= t("components.government_navigation.consultations", default: "Consultations") %>
       </a>
     </li>
     <li>
-      <a class="<%= 'active' if active == 'statistics' %>" href="/search/research-and-statistics">
+      <a class="<%= 'active' if active == 'statistics' %> govuk-link govuk-link--no-underline govuk-link--inverse" href="/search/research-and-statistics">
         <%= t("components.government_navigation.statistics", default: "Statistics") %>
       </a>
     </li>
     <li>
-      <a class="<%= 'active' if active == 'announcements' %>" href="/news-and-communications">
+      <a class="<%= 'active' if active == 'announcements' %> govuk-link govuk-link--no-underline govuk-link--inverse" href="/news-and-communications">
         <%= t("components.government_navigation.news_and_communications", default: "News and communications") %>
       </a>
     </li>

--- a/app/views/govuk_publishing_components/components/docs/government_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/government_navigation.yml
@@ -2,6 +2,8 @@ name: Government navigation
 description: Navigation placed in the header by Slimmer and used by pages which sit
   under the /government path. This is a markup only component and is not available
   for preview here. It can be passed a string to mark a link as being active.
+body: | 
+  Please note: because the markup on this component is currently tied to styles that aren't present in the components gem, they will appear "broken". This is because they are intended to be used in the [header component](/component-guide/layout_header/with_left_search_and_navigation) as white links against a black background. You can see a styled example of this component in use on the ['Counter-Fraud Standards and Profession' page](https://www.gov.uk/government/groups/counter-fraud-standards-and-profession).
 accessibility_criteria: |
   The government navigation component must:
 


### PR DESCRIPTION
## What
Adds the following classes to links on the [government navigation](https://components.publishing.service.gov.uk/component-guide/government_navigation) component. The classes it adds are:

- `govuk-link`
- `govuk-link--no-underline`
- `govuk-link--inverse`

## Why
Part of ongoing work by the govuk frontend community to ensure we are using the new link styles from the altest release of govuk frontend.

This is not a full implementation of the new link styles due to clashes with styles in the header from govuk-toolkit, our legacy implementation of what is now govuk frontend. There's no value in trying to fix this now as it would require either an update to the archived govuk-toolkit repo or a set of convoluted override styles between the gem and static. The decision to not implement this fully is further confounded by:

- Work by the govuk accessibility team to remove the static core layout, therefore the govuk-toolkit implementation
- Work by the govuk explore team which could make this component redundant

These classes at the very least mean that when these 2 workstreams are complete, we'll be using the correct classes and it does subtly apply a small portion of the new link styles (distance between the text and the underline on hover).

## Visual Changes (hover state)
| Before | After |
| --- | --- |
| ![Screenshot 2021-05-20 at 10 44 38](https://user-images.githubusercontent.com/64783893/118959573-5ccbfe00-b95a-11eb-821f-5779d7349556.png) | ![Screenshot 2021-05-20 at 10 44 45](https://user-images.githubusercontent.com/64783893/118959614-67869300-b95a-11eb-9499-264284b0cdff.png) |


