### PR TITLE
Remove direct anchor styling on inverse header component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Update link styles for show password component ([PR #2074](https://github.com/alphagov/govuk_publishing_components/pull/2074))
 * Update link styles for subscription links ([PR #2075](https://github.com/alphagov/govuk_publishing_components/pull/2075))
 * Update inset text block example ([PR #2085](https://github.com/alphagov/govuk_publishing_components/pull/2085))
+* Remove direct anchor styling on inverse header component ([PR #2084](https://github.com/alphagov/govuk_publishing_components/pull/2084))
 
 ## 24.10.3
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_inverse-header.scss
@@ -7,10 +7,6 @@
   box-sizing: border-box;
 }
 
-.gem-c-inverse-header a {
-  color: govuk-colour("white");
-}
-
 .gem-c-inverse-header .gem-c-inverse-header__supplement,
 .gem-c-inverse-header .publication-header__last-changed {
   // This publication-header class is injected on publication pages, really

--- a/app/views/govuk_publishing_components/components/docs/inverse_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/inverse_header.yml
@@ -3,6 +3,8 @@ description: A wrapper to contain header content in white text
 body: |
   This component can be passed a block of template code and will wrap it in a blue header. This is as light-touch as possible and doesn't attempt to deal with the margins and paddings of its content. White text is enforced on content and would need to be overriden where unwanted. Implemented to accomodate topic and list page headings and breadcrumbs but unopinionated about its contents.
 
+  If passing links to the block make sure to add [the inverse modifier](https://design-system.service.gov.uk/styles/typography/#links-on-dark-backgrounds).
+
 accessibility_criteria: |
   The component must:
 
@@ -16,7 +18,7 @@ examples:
     data:
       block: |
         <div class="gem-c-title gem-c-title--inverse">
-          <h1 class="gem-c-title__text ">
+          <h1 class="gem-c-title__text govuk-heading-l">
             Education, Training and Skills
           </h1>
         </div>
@@ -26,7 +28,7 @@ examples:
       full_width: true
       block: |
         <div class="gem-c-title gem-c-title--inverse">
-          <h1 class="gem-c-title__text ">
+          <h1 class="gem-c-title__text govuk-heading-l">
             Education, Training and Skills
           </h1>
         </div>
@@ -35,8 +37,8 @@ examples:
     data:
       block: |
         <div class="gem-c-title gem-c-title--inverse gem-c-title--bottom-margin">
-          <p class="gem-c-title__context">Notice</p>
-          <h1 class="gem-c-title__text">
+          <p class="gem-c-title__context govuk-caption-m">Notice</p>
+          <h1 class="gem-c-title__text govuk-heading-l">
             LN5 0AT, Jackson Homes (Scopwick) Ltd: environmental permit application
           </h1>
         </div>
@@ -45,21 +47,22 @@ examples:
     data:
       padding_top: false
       block: |
-        <div class="gem-c-breadcrumbs " data-module="gem-track-click">
-          <ol>
-            <li class="">
-                <a data-track-category="breadcrumbClicked" data-track-action="1" data-track-label="/section" data-track-options="{&quot;dimension28&quot;:&quot;2&quot;,&quot;dimension29&quot;:&quot;Section&quot;}" class="gem-c-breadcrumbs--inverse" aria-current="false" href="/section">Section</a>
+        <div class="gem-c-breadcrumbs govuk-breadcrumbs govuk-breadcrumbs--collapse-on-mobile gem-c-breadcrumbs--inverse">
+          <ol class="govuk-breadcrumbs__list">
+            <li class="govuk-breadcrumbs__list-item">
+              <a href="/section" class="govuk-breadcrumbs__link">Section</a>
             </li>
-            <li class="">
-                <a data-track-category="breadcrumbClicked" data-track-action="2" data-track-label="#content" data-track-options="{&quot;dimension28&quot;:&quot;2&quot;,&quot;dimension29&quot;:&quot;Education of disadvantaged children&quot;}" class="gem-c-breadcrumbs--inverse gem-c-breadcrumbs--current " aria-current="page" href="#content">Education of disadvantaged children</a>
+            <li class="govuk-breadcrumbs__list-item">
+              <a href="/section/sub-section" class="govuk-breadcrumbs__link">Education of disadvantaged children</a>
             </li>
           </ol>
         </div>
-        <div class="gem-c-title gem-c-title--inverse">
-          <h1 class="gem-c-title__text ">
-            Education, Training and Skills
-          </h1>
-        </div>
         <p class="gem-c-lead-paragraph gem-c-lead-paragraph--inverse">
           Schools and academies, further and higher education, apprenticeships and other skills training, student funding, early years.
+        </p>
+  with_link:
+    data:
+      block: |
+        <p class="gem-c-lead-paragraph gem-c-lead-paragraph--inverse">
+          Schools and academies, further and higher education, apprenticeships and <a href="#other-skills" class="govuk-link govuk-link--inverse">other skills</a> training, student funding, early years.
         </p>


### PR DESCRIPTION
## What
Removed direct styling on any anchors within the block (as it can cause style leakage) and improve examples to give us a bit more confidence when reviewing the component.

## Why
Reviewing the inverse header for new link styles in the component guide and in apps.

## Visual Changes

### Component Guide
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_3212_component-guide_inverse_header (1)](https://user-images.githubusercontent.com/788096/118987866-927fdf80-b978-11eb-969f-a5e354e2424e.png)

</td><td valign="top">

![localhost_3212_component-guide_inverse_header](https://user-images.githubusercontent.com/788096/118987846-8bf16800-b978-11eb-8a97-53c9f1531243.png)

</td></tr>
</table>

### Collections

<table>
<tr><th>Default</th><th>Hover</th></tr>
<tr><td valign="top">

<img width="1023" alt=":education:funding-and-finance-for-students-link" src="https://user-images.githubusercontent.com/788096/118988077-c4914180-b978-11eb-902d-ca9a28da1dd0.png">


</td><td valign="top">

<img width="1024" alt=":education:funding-and-finance-for-students-hover" src="https://user-images.githubusercontent.com/788096/118988080-c65b0500-b978-11eb-966a-5ae09189f061.png">


</td></tr>
</table>

### Finder frontend

<table>
<tr><th>Default</th><th>Hover</th></tr>
<tr><td valign="top">

<img width="1023" alt=":search:services?parent=%2Feducation topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0-link" src="https://user-images.githubusercontent.com/788096/118988089-c824c880-b978-11eb-89ee-8007d217bb26.png">


</td><td valign="top">

<img width="1024" alt=":search:services?parent=%2Feducation topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0-hover" src="https://user-images.githubusercontent.com/788096/118988097-cb1fb900-b978-11eb-9e18-f93de5e67d15.png">


</td></tr>
</table>
