### PR TITLE
Update inset text block example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Remove `display: none` rules from component print stylesheets, and use the `govuk-!-display-none-print` class instead. ([PR #1561](https://github.com/alphagov/govuk_publishing_components/pull/1561))
 * Update link styles for show password component ([PR #2074](https://github.com/alphagov/govuk_publishing_components/pull/2074))
 * Update link styles for subscription links ([PR #2075](https://github.com/alphagov/govuk_publishing_components/pull/2075))
+* Update inset text block example ([PR #2085](https://github.com/alphagov/govuk_publishing_components/pull/2085))
 
 ## 24.10.3
 

--- a/app/views/govuk_publishing_components/components/docs/inset_text.yml
+++ b/app/views/govuk_publishing_components/components/docs/inset_text.yml
@@ -15,6 +15,6 @@ examples:
     data:
       block: |
         <div>
-          <h2 id='heading'>To publish this step by step you need to</h2>
-          <a href='/foo'>Check for broken links</a>
+          <h2 class="govuk-heading-m" id='heading'>To publish this step by step you need to</h2>
+          <a class="govuk-link" href='/foo'>Check for broken links</a>
         </div>


### PR DESCRIPTION
## What
Use realistic/suggested markup when passing a block to the inset text component

## Why
Reviewing the inset text for new link styles

## Visual Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="960" alt="Screenshot 2021-05-20 at 14 48 37" src="https://user-images.githubusercontent.com/788096/118990094-7ed57880-b97a-11eb-8834-46ec6573937c.png">


</td><td valign="top">

<img width="960" alt="Screenshot 2021-05-20 at 14 48 16" src="https://user-images.githubusercontent.com/788096/118990110-8137d280-b97a-11eb-9b8c-fe84b69b8821.png">


</td></tr>
</table>

