### PR TITLE
Fix accordion anchor link navigation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix accordion anchor link navigation bug ([PR #2087](https://github.com/alphagov/govuk_publishing_components/pull/2087))
 * Remove jQuery from the feedback component ([PR #2062](https://github.com/alphagov/govuk_publishing_components/pull/2062))
 * Remove `display: none` rules from component print stylesheets, and use the `govuk-!-display-none-print` class instead. ([PR #1561](https://github.com/alphagov/govuk_publishing_components/pull/1561))
 * Fix IE11 `initCustomEvent` error ([PR #2079](https://github.com/alphagov/govuk_publishing_components/pull/2079))

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -47,7 +47,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.initSectionHeaders()
 
     // Feature flag for anchor tag navigation used on manuals
-    if (this.$module.getAttribute('data-anchor-navigation')) {
+    if (this.$module.getAttribute('data-anchor-navigation') === 'true') {
       this.openByAnchorOnLoad()
       this.addEventListenersForAnchors()
     }


### PR DESCRIPTION
## What
If the URL of a page with an accordion on it has a location hash in the URL that doesn't match an actual accordion section, an error can occur as described in issue https://github.com/alphagov/govuk_publishing_components/issues/2086

This partly fixes this problem by checking for an actual value for the `data-anchor-navigation` attribute, however this might not be a solution to the whole problem.

## Why
Noticed in the component auditing pages (locally) the accordion was breaking if tabs were changed and the page reloaded.

## Visual Changes
None.
