### PR TITLE
New link styles for prev next navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Update share links to have new underline styles ([PR #2073](https://github.com/alphagov/govuk_publishing_components/pull/2073))
 * Add govuk-link-common mixin to govspeak links ([PR #2078](https://github.com/alphagov/govuk_publishing_components/pull/2078))
 * Update links styles for accordion component ([PR #2080](https://github.com/alphagov/govuk_publishing_components/pull/2080))
+* New link styles for prev next navigation ([PR #2088](https://github.com/alphagov/govuk_publishing_components/pull/2088))
 
 ## 24.10.3
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
@@ -31,6 +31,16 @@
   &:hover,
   &:active {
     background-color: govuk-colour("light-grey", $legacy: "grey-4");
+
+    // Add govuk-link hover decoration to title if no label present
+    .gem-c-pagination__link-text--decorated {
+      @include govuk-link-decoration;
+    }
+
+    .gem-c-pagination__link-label,
+    .gem-c-pagination__link-text--decorated {
+      @include govuk-link-hover-decoration;
+    }
   }
 
   &:focus {
@@ -73,8 +83,8 @@
 .gem-c-pagination__link-label {
   display: inline-block;
   margin-top: .1em;
-  text-decoration: underline;
   margin-left: govuk-spacing(5);
+  @include govuk-link-decoration;
 
   @include govuk-media-query($from: tablet) {
     margin-left: govuk-spacing(6);

--- a/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
@@ -6,6 +6,10 @@
 >
   <ul class="gem-c-pagination__list" data-module="gem-track-click">
     <% if local_assigns.include?(:previous_page) %>
+      <%
+        link_text_classes = %w[gem-c-pagination__link-text]
+        link_text_classes << "gem-c-pagination__link-text--decorated" unless previous_page[:label].present?
+      %>
       <li class="gem-c-pagination__item gem-c-pagination__item--previous">
         <a href="<%= previous_page[:url] %>"
           class="govuk-link gem-c-pagination__link"
@@ -20,9 +24,7 @@
             <svg class="gem-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
               <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"/>
             </svg>
-            <span class="gem-c-pagination__link-text">
-              <%= previous_page[:title] %>
-            </span>
+            <%= tag.span(previous_page[:title], class: link_text_classes) %>
           </span>
           <% if previous_page[:label].present? %>
             <span class="gem-c-pagination__link-divider visually-hidden">:</span>
@@ -32,6 +34,10 @@
       </li>
     <% end %>
     <% if local_assigns.include?(:next_page) %>
+      <%
+        link_text_classes = %w[gem-c-pagination__link-text]
+        link_text_classes << "gem-c-pagination__link-text--decorated" unless next_page[:label].present?
+      %>
       <li class="gem-c-pagination__item gem-c-pagination__item--next">
         <a href="<%= next_page[:url] %>"
           class="govuk-link gem-c-pagination__link"
@@ -46,9 +52,7 @@
             <svg class="gem-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
               <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"/>
             </svg>
-            <span class="gem-c-pagination__link-text">
-              <%= next_page[:title] %>
-            </span>
+            <%= tag.span(next_page[:title], class: link_text_classes) %>
           </span>
           <% if next_page[:label].present? %>
             <span class="gem-c-pagination__link-divider visually-hidden">:</span>


### PR DESCRIPTION
## What
Amends the hover state for the [previous and next navigation component](https://components.publishing.service.gov.uk/component-guide/previous_and_next_navigation), specifically applies the new `govuk-link` hover decoration to the label element and to the title element when a label isn't present.

## Why
Part of ongoing work by the govuk frontend community to ensure we are using the new link styles from the latest govuk frontend release.

This change specifically is an accessibility enhancement as, besides the slight background change, there is no clear indicator that the state of the component has changed.

## Visual Changes (hover state)
| State | Before | After |
| --- | --- | --- |
| With label | ![Screenshot 2021-05-20 at 17 55 46](https://user-images.githubusercontent.com/64783893/119019803-7b9bb600-b995-11eb-9f32-b18fc679bb9d.png) | ![Screenshot 2021-05-20 at 17 55 56](https://user-images.githubusercontent.com/64783893/119019836-82c2c400-b995-11eb-9959-b43e50ac7260.png) |
| Without label | ![Screenshot 2021-05-20 at 17 56 07](https://user-images.githubusercontent.com/64783893/119019879-8b1aff00-b995-11eb-8000-f40f2dbe57a3.png) | ![Screenshot 2021-05-20 at 17 56 16](https://user-images.githubusercontent.com/64783893/119019903-90784980-b995-11eb-9dc4-2a02089798c6.png) |




