### PR TITLE
Update organisation logos hover state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add govuk-link-common mixin to govspeak links ([PR #2078](https://github.com/alphagov/govuk_publishing_components/pull/2078))
 * Update links styles for accordion component ([PR #2080](https://github.com/alphagov/govuk_publishing_components/pull/2080))
 * New link styles for prev next navigation ([PR #2088](https://github.com/alphagov/govuk_publishing_components/pull/2088))
+* Update organisation logos hover state ([PR #2089](https://github.com/alphagov/govuk_publishing_components/pull/2089))
 
 ## 24.10.3
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -1,12 +1,11 @@
 // Default logo corresponds with the "medium stacked" Whitehall equivalent
 .gem-c-organisation-logo {
   font-size: 13px;
-  line-height: (15 / 13);
   font-weight: 400;
+  line-height: 1.35;
 
   @include govuk-media-query($from: tablet) {
     font-size: 18px;
-    line-height: 20px;
   }
 }
 
@@ -62,7 +61,12 @@
   font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
 
   &:hover {
-    text-decoration: underline;
+    color: $govuk-link-hover-colour;
+  }
+
+  &:active {
+    color: govuk-colour("black");
+    @include govuk-link-hover-decoration;
   }
 
   &:focus {


### PR DESCRIPTION
## What
Update the hover state for the [organisation logo component](https://components.publishing.service.gov.uk/component-guide/organisation_logo)

## Why
Part of ongoing work by the govuk frontend community to implement the new link styles from the latest release of govuk frontend.

This additionally applies a minor redesign to the component's states based on design work by the govuk accessibility team to improve consistency o link behaviour across govuk. [Card](https://trello.com/c/djz1Sxy3/740-update-organisation-component-to-be-consistent-throughout-govuk-and-remove-any-style-overrides).

## Visual Changes
| State | Before | After |
| --- | --- | --- |
| default | ![Screenshot 2021-05-21 at 11 07 13](https://user-images.githubusercontent.com/64783893/119122758-c6b1d980-ba26-11eb-8518-4fa4538be0bf.png) | ![Screenshot 2021-05-25 at 15 13 53](https://user-images.githubusercontent.com/64783893/119513134-dbb2a380-bd6b-11eb-8a53-8365245c6d9b.png) |
| hover | ![Screenshot 2021-05-21 at 11 20 47](https://user-images.githubusercontent.com/64783893/119122828-dcbf9a00-ba26-11eb-86c1-20473efe908d.png) | ![Screenshot 2021-05-25 at 15 11 08](https://user-images.githubusercontent.com/64783893/119513191-e705cf00-bd6b-11eb-86b5-a43532202694.png) |
| active | ![Screenshot 2021-05-21 at 11 21 28](https://user-images.githubusercontent.com/64783893/119122894-ee08a680-ba26-11eb-97af-22c34509ab78.png) | ![Screenshot 2021-05-25 at 15 11 45](https://user-images.githubusercontent.com/64783893/119513226-ef5e0a00-bd6b-11eb-882f-bc36f4912bba.png) |
| focus | ![Screenshot 2021-05-21 at 11 21 53](https://user-images.githubusercontent.com/64783893/119122954-fe208600-ba26-11eb-9607-cfb56eb2e26d.png) | ![Screenshot 2021-05-25 at 15 15 06](https://user-images.githubusercontent.com/64783893/119513323-07358e00-bd6c-11eb-8d06-dfdbc9992c2e.png) |



