### PR TITLE
Make jasmine tests pass in Internet Explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@
 - Don't include changes that are purely internal. The CHANGELOG should be a
   useful summary for people upgrading their application, not a replication
   of the commit log.
-  
+
+## Unreleased
+
+* Make jasmine tests pass in Internet Explorer ([PR #2090](https://github.com/alphagov/govuk_publishing_components/pull/2090))
+
 ## 24.13.3
 
-* Add event tracking to header elements ([#2110](https://github.com/alphagov/govuk_publishing_components/pull/2110)) 
+* Add event tracking to header elements ([PR #2110](https://github.com/alphagov/govuk_publishing_components/pull/2110)) 
 
 ## Unreleased
 * Allow a custom link to be used on the header logo ([PR #2114](https://github.com/alphagov/govuk_publishing_components/pull/2114))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/analytics.js
@@ -41,7 +41,9 @@
     // we ignore the possibility of there being campaign variables in the
     // anchor because we wouldn't know how to detect and parse them if they
     // were present
-    return this.pii.stripPIIFromString(location.href.substring(location.origin.length).split('#')[0])
+    // IE can't access window.location.origin, so we have to do this slightly complex thing
+    var root = location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '')
+    return this.pii.stripPIIFromString(location.href.substring(root.length).split('#')[0])
   }
 
   Analytics.prototype.trackPageview = function (path, title, options) {

--- a/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js
@@ -33,6 +33,8 @@
 
     if (window.devicePixelRatio) {
       customDimensions.dimension11 = window.devicePixelRatio
+    } else {
+      customDimensions.dimension11 = window.screen.deviceXDPI / window.screen.logicalXDPI
     }
 
     return customDimensions

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -33,7 +33,9 @@ window.GOVUK.Modules.Checkboxes = window.GOVUKFrontend;
     if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
       // Where checkboxes are manipulated externally in finders, `suppressAnalytics`
       // is passed to prevent duplicate GA events.
-      if (!event.detail || (event.detail && event.detail.suppressAnalytics !== true)) {
+      // use Oliver Steele's Nested Object Access Pattern https://hackernoon.com/accessing-nested-objects-in-javascript-f02f1bd6387f
+      var allowAnalytics = ((event || {}).detail || {}).suppressAnalytics !== true
+      if (allowAnalytics) {
         var $checkbox = event.target
         var category = $checkbox.getAttribute('data-track-category')
         if (category) {
@@ -100,11 +102,11 @@ window.GOVUK.Modules.Checkboxes = window.GOVUKFrontend;
     var $exclusiveOption = $checkboxes.querySelector('input[type=checkbox][data-exclusive]')
     var $nonExclusiveOptions = $checkboxes.querySelectorAll('input[type=checkbox]:not([data-exclusive])')
 
-    if ($currentCheckbox.dataset.exclusive === 'true' && $currentCheckbox.checked === true) {
+    if ($currentCheckbox.getAttribute('data-exclusive') === 'true' && $currentCheckbox.checked === true) {
       for (var i = 0; i < $nonExclusiveOptions.length; i++) {
         $nonExclusiveOptions[i].checked = false
       }
-    } else if ($currentCheckbox.dataset.exclusive !== 'true' && $currentCheckbox.checked === true) {
+    } else if ($currentCheckbox.getAttribute('data-exclusive') !== 'true' && $currentCheckbox.checked === true) {
       if ($exclusiveOption) {
         $exclusiveOption.checked = false
       }

--- a/app/assets/javascripts/govuk_publishing_components/components/contextual-guidance.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/contextual-guidance.js
@@ -15,7 +15,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   ContextualGuidance.prototype.handleFocus = function (event) {
     this.hideAllGuidance()
-    if (!event.target.dataset.contextualGuidanceHideOnly) {
+    if (!event.target.getAttribute('data-contextual-guidance-hide-only')) {
       this.$guidance.style.display = 'block'
     }
   }

--- a/app/assets/javascripts/govuk_publishing_components/components/reorderable-list.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/reorderable-list.js
@@ -26,14 +26,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
 
     var boundOnClickUpButton = this.onClickUpButton.bind(this)
-    this.$upButtons.forEach(function (button) {
-      button.addEventListener('click', boundOnClickUpButton)
-    })
+    for (var u = 0; u < this.$upButtons.length; u++) {
+      this.$upButtons[u].addEventListener('click', boundOnClickUpButton)
+    }
 
     var boundOnClickDownButton = this.onClickDownButton.bind(this)
-    this.$downButtons.forEach(function (button) {
-      button.addEventListener('click', boundOnClickDownButton)
-    })
+    for (var d = 0; d < this.$downButtons.length; d++) {
+      this.$downButtons[d].addEventListener('click', boundOnClickDownButton)
+    }
   }
 
   ReorderableList.prototype.setupResponsiveChecks = function () {
@@ -85,9 +85,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   ReorderableList.prototype.updateOrderIndexes = function () {
     var $orderInputs = this.$module.querySelectorAll('.gem-c-reorderable-list__actions input')
-    $orderInputs.forEach(function (input, index) {
-      input.setAttribute('value', index + 1)
-    })
+    for (var i = 0; i < $orderInputs.length; i++) {
+      $orderInputs[i].setAttribute('value', i + 1)
+    }
   }
 
   ReorderableList.prototype.triggerEvent = function (element, eventName) {

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
@@ -462,11 +462,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var allCharts = document.querySelectorAll('table.js-barchart-table')
     var id = null
 
-    allCharts.forEach(function (chart, i) {
-      if (chart === module) {
+    for (var i = 0; i < allCharts.length; i++) {
+      if (allCharts[i] === module) {
         id = i
       }
-    })
+    }
 
     return id
   }

--- a/app/assets/javascripts/govuk_publishing_components/lib/trigger-event.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/trigger-event.js
@@ -2,15 +2,17 @@
   'use strict'
   window.GOVUK = window.GOVUK || {}
 
-  window.GOVUK.triggerEvent = function (element, eventName) {
-    var params = { bubbles: true, cancelable: true }
+  window.GOVUK.triggerEvent = function (element, eventName, parameters) {
+    var params = parameters || {}
+    params.bubbles = true
+    params.cancelable = true
     var event
 
     if (typeof window.CustomEvent === 'function') {
       event = new window.CustomEvent(eventName, params)
     } else {
       event = document.createEvent('CustomEvent')
-      event.initCustomEvent(eventName, params.bubbles, params.cancelable, null)
+      event.initCustomEvent(eventName, params.bubbles, params.cancelable, params.detail)
     }
 
     element.dispatchEvent(event)

--- a/spec/javascripts/components/accordion-spec.js
+++ b/spec/javascripts/components/accordion-spec.js
@@ -103,18 +103,21 @@ describe('An accordion component', function () {
       topLevelControl.click()
       expect(topLevelControl.innerText).toEqual('Hide all sections')
 
-      element.querySelectorAll('.gem-c-accordion__section').forEach(function (section) {
+      var sections = element.querySelectorAll('.gem-c-accordion__section')
+      for (var s = 0; s < sections.length; s++) {
+        var section = sections[s]
         expect(section).toHaveClass('gem-c-accordion__section--expanded')
         expect(section.querySelector('.gem-c-accordion__toggle-text').innerText).toEqual('Hide')
-      })
+      }
 
       topLevelControl.click()
       expect(topLevelControl.innerText).toEqual('Show all sections')
 
-      element.querySelectorAll('.gem-c-accordion__section').forEach(function (section) {
+      for (var q = 0; q < sections.length; q++) {
+        section = sections[q]
         expect(section).not.toHaveClass('gem-c-accordion__section--expanded')
         expect(section.querySelector('.gem-c-accordion__toggle-text').innerText).toEqual('Show')
-      })
+      }
     })
   })
 
@@ -141,10 +144,12 @@ describe('An accordion component', function () {
     it('sets lang attributes if locale attribute is present', function () {
       expect(element.querySelector('.gem-c-accordion__open-all-text').lang).toEqual('sa')
 
-      element.querySelectorAll('.gem-c-accordion__section-button').forEach(function (control) {
+      var buttons = element.querySelectorAll('.gem-c-accordion__section-button')
+      for (var b = 0; b < buttons.length; b++) {
+        var control = buttons[b]
         expect(control.querySelector('.gem-c-accordion__toggle-text').lang).toEqual('st')
         expect(control.querySelectorAll('.govuk-visually-hidden')[1].lang).toEqual('vh')
-      })
+      }
     })
 
     it('resets lang attributes upon button click if the locales for hide text is different', function () {
@@ -154,9 +159,10 @@ describe('An accordion component', function () {
 
       expect(topLevelControlText.lang).toEqual('ha')
 
-      element.querySelectorAll('.gem-c-accordion__section-button').forEach(function (control) {
-        expect(control.querySelector('.gem-c-accordion__toggle-text').lang).toEqual('ht')
-      })
+      var buttons = element.querySelectorAll('.gem-c-accordion__section-button')
+      for (var b = 0; b < buttons.length; b++) {
+        expect(buttons[b].querySelector('.gem-c-accordion__toggle-text').lang).toEqual('ht')
+      }
     })
   })
 })

--- a/spec/javascripts/components/checkboxes-spec.js
+++ b/spec/javascripts/components/checkboxes-spec.js
@@ -148,22 +148,19 @@ describe('Checkboxes component', function () {
   describe('controlling Google analytics track event when a checkbox is changed', function () {
     it('fires a Google analytics event if suppressAnalytics not passed to the change event', function () {
       var $checkbox = $checkboxesWrapper.find(":input[value='blue']")
-      var fakeOnChangeEvent = new window.CustomEvent('change')
-      $checkbox[0].dispatchEvent(fakeOnChangeEvent)
+      window.GOVUK.triggerEvent($checkbox[0], 'change')
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalled()
     })
 
     it('fires a Google analytics event if suppressAnalytics is set to false and passed to the change event', function () {
       var $checkbox = $checkboxesWrapper.find(":input[value='blue']")
-      var fakeOnChangeEvent = new window.CustomEvent('change', { detail: { suppressAnalytics: false } })
-      $checkbox[0].dispatchEvent(fakeOnChangeEvent)
+      window.GOVUK.triggerEvent($checkbox[0], 'change', { detail: { suppressAnalytics: false } })
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalled()
     })
 
     it('does not fire a Google analytics event if suppressAnalytics is passed to the change event', function () {
       var $checkbox = $checkboxesWrapper.find(":input[value='blue']")
-      var fakeOnChangeEvent = new window.CustomEvent('change', { detail: { suppressAnalytics: true } })
-      $checkbox[0].dispatchEvent(fakeOnChangeEvent)
+      window.GOVUK.triggerEvent($checkbox[0], 'change', { detail: { suppressAnalytics: true } })
       expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
     })
   })

--- a/spec/javascripts/components/contextual-guidance-spec.js
+++ b/spec/javascripts/components/contextual-guidance-spec.js
@@ -29,14 +29,27 @@ describe('Contextual guidance component', function () {
             '<p>The summary should explain the main point of the story. It is the first line of the story so don’t repeat it in the body and end with a full stop.</p>' +
           '</div>' +
         '</div>' +
+      '</div>' +
+
+      '<div id="document-description-guidance" class="gem-c-contextual-guidance" data-module="contextual-guidance">' +
+        '<textarea id="document-description" class="gem-c-textarea govuk-textarea" data-contextual-guidance-hide-only="true"></textarea>' +
+
+        '<div class="gem-c-contextual-guidance__wrapper" for="document-description">' +
+          '<div class="gem-c-contextual-guidance__guidance">' +
+            '<h2 class="govuk-heading-s">Summary</h2>' +
+            '<p>The description should describe the story.</p>' +
+          '</div>' +
+        '</div>' +
       '</div>'
 
     document.body.classList.add('js-enabled')
     document.body.appendChild(container)
     var titleContextualGuidance = document.getElementById('document-title-guidance')
     var summaryContextualGuidance = document.getElementById('document-summary-guidance')
+    var descriptionContextualGuidance = document.getElementById('document-description-guidance')
     new GOVUK.Modules.ContextualGuidance().start($(titleContextualGuidance))
     new GOVUK.Modules.ContextualGuidance().start($(summaryContextualGuidance))
+    new GOVUK.Modules.ContextualGuidance().start($(descriptionContextualGuidance))
   })
 
   afterEach(function () {
@@ -67,5 +80,19 @@ describe('Contextual guidance component', function () {
 
     expect(titleGuidance.style.display).toEqual('none')
     expect(summaryGuidance.style.display).toEqual('block')
+  })
+
+  it('should not show associated guidance on focus if the hide-only attribute is present', function () {
+    var description = document.getElementById('document-description')
+    var descriptionGuidance = document.querySelector('#document-description-guidance .gem-c-contextual-guidance__wrapper')
+
+    var titleGuidance = document.querySelector('#document-title-guidance .gem-c-contextual-guidance__wrapper')
+    var summaryGuidance = document.querySelector('#document-summary-guidance .gem-c-contextual-guidance__wrapper')
+
+    description.dispatchEvent(new window.Event('focus'))
+
+    expect(titleGuidance.style.display).toEqual('none')
+    expect(summaryGuidance.style.display).toEqual('none')
+    expect(descriptionGuidance.style.display).toEqual('none')
   })
 })

--- a/spec/javascripts/components/modal-dialogue-spec.js
+++ b/spec/javascripts/components/modal-dialogue-spec.js
@@ -5,7 +5,7 @@ function keyPress (element, key) {
   var event = document.createEvent('Event')
   event.keyCode = key // Deprecated, prefer .key instead
   event.key = key
-  event.initEvent('keydown')
+  event.initEvent('keydown', true, false)
   element.dispatchEvent(event)
 }
 

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -96,6 +96,28 @@ describe('A stepnav module', function () {
   var expectedstepnavContentCount = 0
   var expectedstepnavLinkCount = 0
 
+  beforeAll(function () {
+    var store = {}
+    var mock = (function () {
+      return {
+        getItem: function (key) {
+          return store[key] || null
+        },
+        setItem: function (key, value) {
+          store[key] = value + ''
+          return store[key]
+        },
+        removeItem: function (key) {
+          delete store[key]
+        },
+        clear: function () {
+          store = {}
+        }
+      }
+    })()
+    Object.defineProperty(window, 'sessionStorage', { value: mock, configurable: true, enumerable: true, writable: true })
+  })
+
   beforeEach(function () {
     $element = $(html)
     new GOVUK.Modules.Gemstepnav().start($element)
@@ -400,19 +422,6 @@ describe('A stepnav module', function () {
 
   describe('when open steps have been remembered', function () {
     beforeEach(function () {
-      var store = {}
-
-      spyOn(window.sessionStorage, 'getItem').and.callFake(function (key) {
-        return store[key]
-      })
-      spyOn(window.sessionStorage, 'setItem').and.callFake(function (key, value) {
-        store[key] = value + ''
-        return store[key]
-      })
-      spyOn(window.sessionStorage, 'removeItem').and.callFake(function () {
-        store = {}
-      })
-
       $element = $(html)
       $element.attr('data-remember', true)
       $element.addClass('gem-c-step-nav--large')
@@ -452,19 +461,6 @@ describe('A stepnav module', function () {
 
   describe('when all steps have been opened and remembered', function () {
     beforeEach(function () {
-      var store = {}
-
-      spyOn(window.sessionStorage, 'getItem').and.callFake(function (key) {
-        return store[key]
-      })
-      spyOn(window.sessionStorage, 'setItem').and.callFake(function (key, value) {
-        store[key] = value + ''
-        return store[key]
-      })
-      spyOn(window.sessionStorage, 'removeItem').and.callFake(function () {
-        store = {}
-      })
-
       $element = $(html)
       $element.attr('data-remember', true)
       $element.addClass('gem-c-step-nav--large')
@@ -484,19 +480,6 @@ describe('A stepnav module', function () {
 
   describe('when the remember open steps option is applied to a small step nav', function () {
     beforeEach(function () {
-      var store = {}
-
-      spyOn(window.sessionStorage, 'getItem').and.callFake(function (key) {
-        return store[key]
-      })
-      spyOn(window.sessionStorage, 'setItem').and.callFake(function (key, value) {
-        store[key] = value + ''
-        return store[key]
-      })
-      spyOn(window.sessionStorage, 'removeItem').and.callFake(function () {
-        store = {}
-      })
-
       $element = $(html)
       $element.attr('data-remember', true)
       window.sessionStorage.setItem('unique-id', '["topic-step-one","topic-step-two","topic-step-three"]')
@@ -752,19 +735,6 @@ describe('A stepnav module', function () {
 
   describe('in a double dot situation where a clicked link is already stored on page load', function () {
     beforeEach(function () {
-      var store = {}
-
-      spyOn(window.sessionStorage, 'getItem').and.callFake(function (key) {
-        return store[key]
-      })
-      spyOn(window.sessionStorage, 'setItem').and.callFake(function (key, value) {
-        store[key] = value + ''
-        return store[key]
-      })
-      spyOn(window.sessionStorage, 'clear').and.callFake(function () {
-        store = {}
-      })
-
       $element = $(html)
       $element.find('.js-will-be-an-active-link').addClass('gem-c-step-nav__list-item--active')
       window.sessionStorage.setItem('govuk-step-nav-active-link_unique-id', '3.5')
@@ -788,19 +758,6 @@ describe('A stepnav module', function () {
   // i.e. it doesn't fail to find the stored link and remove the active styling from everything
   describe('in a double dot situation where a clicked link that is not highlighted is already stored on page load', function () {
     beforeEach(function () {
-      var store = {}
-
-      spyOn(window.sessionStorage, 'getItem').and.callFake(function (key) {
-        return store[key]
-      })
-      spyOn(window.sessionStorage, 'setItem').and.callFake(function (key, value) {
-        store[key] = value + ''
-        return store[key]
-      })
-      spyOn(window.sessionStorage, 'clear').and.callFake(function () {
-        store = {}
-      })
-
       $element = $(html)
       $element.find('.js-will-be-an-active-link').addClass('gem-c-step-nav__list-item--active')
       window.sessionStorage.setItem('govuk-step-nav-active-link_unique-id', 'definitelynotvalid')

--- a/spec/javascripts/govuk_publishing_components/analytics/analytics.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/analytics.spec.js
@@ -48,6 +48,8 @@ describe('GOVUK.Analytics', function () {
   describe('extracting the default path for a page view', function () {
     it('returns a path extracted from the location', function () {
       var location = {
+        protocol: 'https:',
+        hostname: 'govuk-frontend-toolkit.example.com',
         href: 'https://govuk-frontend-toolkit.example.com/a/path',
         origin: 'https://govuk-frontend-toolkit.example.com'
       }
@@ -56,6 +58,8 @@ describe('GOVUK.Analytics', function () {
 
     it('includes the querystring in the path extracted from the location', function () {
       var location = {
+        protocol: 'https:',
+        hostname: 'govuk-frontend-toolkit.example.com',
         href: 'https://govuk-frontend-toolkit.example.com/a/path?with=a&query=string',
         origin: 'https://govuk-frontend-toolkit.example.com'
       }
@@ -64,6 +68,8 @@ describe('GOVUK.Analytics', function () {
 
     it('removes any anchor from the path extracted from the location', function () {
       var location = {
+        protocol: 'https:',
+        hostname: 'govuk-frontend-toolkit.example.com',
         href: 'https://govuk-frontend-toolkit.example.com/a/path#with-an-anchor',
         origin: 'https://govuk-frontend-toolkit.example.com'
       }

--- a/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/cookie-functions-spec.js
@@ -81,10 +81,7 @@ describe('Cookie helper functions', function () {
       var date = new Date()
       date.setTime(date.valueOf() + (365 * 24 * 60 * 60 * 1000))
 
-      document.cookie = 'analytics_next_page_call=test' +
-        ';expires=' + date.toUTCString() +
-        ';domain=' + window.location.hostname +
-        ';path=/'
+      GOVUK.setCookie('analytics_next_page_call', 'test', { expires: date.toUTCString(), domain: window.location.hostname, path: '/' })
 
       expect(GOVUK.getCookie('analytics_next_page_call')).toBe('test')
 

--- a/spec/javascripts/govuk_publishing_components/lib/trigger-event-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/trigger-event-spec.js
@@ -1,0 +1,39 @@
+/* eslint-env jasmine, jquery */
+
+describe('The trigger event code', function () {
+  var element
+
+  var obj = {
+    calledFunction: function (event) {
+      if (((event || {}).detail || {}).test === true) {
+        obj.secondCalledFunction()
+      }
+    },
+    secondCalledFunction: function () {}
+  }
+
+  beforeEach(function () {
+    element = $('<div/>')
+    $('body').append(element)
+    spyOn(obj, 'calledFunction').and.callThrough()
+    spyOn(obj, 'secondCalledFunction').and.callThrough()
+  })
+
+  afterEach(function () {
+    element.remove()
+  })
+
+  it('creates and triggers a custom event', function () {
+    element[0].addEventListener('click', obj.calledFunction)
+    window.GOVUK.triggerEvent(element[0], 'click')
+    expect(obj.calledFunction).toHaveBeenCalled()
+    expect(obj.secondCalledFunction).not.toHaveBeenCalled()
+  })
+
+  it('creates and triggers a custom event with parameters', function () {
+    element[0].addEventListener('click', obj.calledFunction)
+    window.GOVUK.triggerEvent(element[0], 'click', { detail: { test: true } })
+    expect(obj.calledFunction).toHaveBeenCalled()
+    expect(obj.secondCalledFunction).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What
Make (most of) our jasmine tests for JavaScript pass in Internet Explorer, currently aiming at IE10+.

## Why
We're removing jQuery across GOV.UK and we need confidence that the replacement code will work in all the browsers we support, especially when JS often has different ways (new/old) of doing the same thing. It would be good to be able to run our tests in all browsers and know they should pass.

Currently there are 188 failing tests. This PR fixes all but 13 of them, so there's still some work to do, but the changes are getting too big to review and I want to get some of these fixes out pronto.

<img width="841" alt="Screenshot 2021-05-25 at 10 12 37" src="https://user-images.githubusercontent.com/861310/119472081-d0e31900-bd41-11eb-87ac-b39866e02414.png">


A lot of the failing tests seem to be due to syntax issues within the tests themselves, rather than our actual JS, so adding a few lines to replace a `forEach` loop with a `for` loop doesn't feel like much of a price to pay for working tests.

## Visual Changes
None.

Bonus side effects:

- magna charta graphs (govspeak) now appear to work in IE10
- analytics code (cookie banner) is quite broken in IE10, this change might fix some of that: https://github.com/alphagov/govuk_publishing_components/issues/2103

Trello card: https://trello.com/c/CAkmuuTK/424-make-js-tests-pass-in-all-browsers