### PR TITLE
New link styles for step by step nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Update links styles for accordion component ([PR #2080](https://github.com/alphagov/govuk_publishing_components/pull/2080))
 * New link styles for prev next navigation ([PR #2088](https://github.com/alphagov/govuk_publishing_components/pull/2088))
 * Update organisation logos hover state ([PR #2089](https://github.com/alphagov/govuk_publishing_components/pull/2089))
+* New link styles for step by step nav ([PR #2092](https://github.com/alphagov/govuk_publishing_components/pull/2092))
 
 ## 24.10.3
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
@@ -36,7 +36,7 @@ $gem-c-accordion-bottom-border-width: 1px;
     -webkit-appearance: none;
     cursor: pointer;
     margin-bottom: govuk-spacing(4);
-    padding: 0 govuk-spacing(1) govuk-spacing(1) 0;
+    padding: 0 govuk-spacing(1) govuk-spacing(2) 0;
     @include govuk-font($size: 16);
     @include govuk-link-common;
     @include govuk-link-style-default;
@@ -250,10 +250,6 @@ $gem-c-accordion-bottom-border-width: 1px;
       @include govuk-link-decoration;
       @include govuk-link-hover-decoration;
     }
-  }
-
-  .gem-c-accordion__open-all:focus .gem-c-accordion__open-all-text {
-    text-decoration: none;
   }
 
   // Change the summary subheading size.

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -113,10 +113,11 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
   position: relative;
   z-index: 1; // this and relative position stops focus outline underlap with border of accordion
   margin: .5em 0 1.5em;
-  padding: 0 0 govuk-spacing(1);
+  padding: 0 0 govuk-spacing(2);
 
   &:hover .gem-c-step-nav__button-text {
-    text-decoration: underline;
+    @include govuk-link-decoration;
+    @include govuk-link-hover-decoration;
   }
 
   .gem-c-step-nav--large & {
@@ -338,7 +339,8 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
     }
 
     .gem-c-step-nav__button-text {
-      text-decoration: underline;
+      @include govuk-link-decoration;
+      @include govuk-link-hover-decoration;
     }
   }
 }


### PR DESCRIPTION
## What
Apples the latest link styles from govuk frontend to the [step by step navigation component](https://components.publishing.service.gov.uk/component-guide/step_by_step_nav).

## Why
Part of ongoing work by the govuk frontend community to ensure that we are using the new link styles from the latest release of govuk frontend.

This change also includes a minor tweak to the "show all" button on this component and the accordion component focus states so that the thick underline from the new hover state doesn't interfere visually with the small focus state.

## Visual Changes
| State | Before | After |
| --- | --- | --- |
| All sections button hover | ![Screenshot 2021-05-24 at 11 50 04](https://user-images.githubusercontent.com/64783893/119337707-0ecf3700-bc87-11eb-908a-be82340c6806.png) | ![Screenshot 2021-05-24 at 11 50 20](https://user-images.githubusercontent.com/64783893/119337727-168edb80-bc87-11eb-8927-948cf14878ff.png) |
| Single section button hover | ![Screenshot 2021-05-24 at 11 50 26](https://user-images.githubusercontent.com/64783893/119337763-1e4e8000-bc87-11eb-86dd-d57ca634b408.png) | ![Screenshot 2021-05-24 at 11 50 33](https://user-images.githubusercontent.com/64783893/119337798-25758e00-bc87-11eb-81f8-82cf2ed794eb.png) |
| All sections button focus and hover | ![Screenshot 2021-05-24 at 11 50 52](https://user-images.githubusercontent.com/64783893/119337830-2c9c9c00-bc87-11eb-8920-00ceb8107a81.png) | ![Screenshot 2021-05-26 at 17 27 36](https://user-images.githubusercontent.com/64783893/119697047-b72bf980-be47-11eb-974a-16ce3f24dbcd.png) |
| Links default | ![Screenshot 2021-05-24 at 15 54 04](https://user-images.githubusercontent.com/64783893/119527054-de1afa80-bd77-11eb-9038-32d23878481a.png) | ![Screenshot 2021-05-24 at 15 54 11](https://user-images.githubusercontent.com/64783893/119527078-e410db80-bd77-11eb-865b-1df71cc3055e.png) |
| Links standard link hover | ![Screenshot 2021-05-24 at 15 54 18](https://user-images.githubusercontent.com/64783893/119527128-f2f78e00-bd77-11eb-8262-6ddf0246fe57.png) | ![Screenshot 2021-05-24 at 15 54 26](https://user-images.githubusercontent.com/64783893/119527161-fa1e9c00-bd77-11eb-91a0-c2a789e6b339.png) |
| Links active link hover | ![Screenshot 2021-05-24 at 15 54 34](https://user-images.githubusercontent.com/64783893/119527228-0acf1200-bd78-11eb-83b7-ab075bc72eab.png) | ![Screenshot 2021-05-24 at 15 54 46](https://user-images.githubusercontent.com/64783893/119527264-10c4f300-bd78-11eb-9fd6-b93da0e07f6f.png) |
