### PR TITLE
Use url_override in breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Remove jQuery from the feedback component ([PR #2062](https://github.com/alphagov/govuk_publishing_components/pull/2062))
 * Remove `display: none` rules from component print stylesheets, and use the `govuk-!-display-none-print` class instead. ([PR #1561](https://github.com/alphagov/govuk_publishing_components/pull/1561))
 * Fix IE11 `initCustomEvent` error ([PR #2079](https://github.com/alphagov/govuk_publishing_components/pull/2079))
+* If present, use the url_override field in breadcrumbs ([PR #2093])(https://github.com/alphagov/govuk_publishing_components/pull/2093))
 
 ## 24.10.3
 

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_taxons.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_taxons.rb
@@ -14,7 +14,7 @@ module GovukPublishingComponents
         ordered_parents = all_parents.map.with_index do |parent, index|
           {
             title: parent.title,
-            url: parent.base_path,
+            url: parent.url_override.present? ? parent.url_override : parent.base_path,
             is_page_parent: index.zero?,
           }
         end
@@ -34,7 +34,6 @@ module GovukPublishingComponents
 
       def all_parents
         parents = []
-
         direct_parent = content_item.parent_taxon
         while direct_parent
           parents << direct_parent

--- a/lib/govuk_publishing_components/presenters/content_item.rb
+++ b/lib/govuk_publishing_components/presenters/content_item.rb
@@ -51,6 +51,10 @@ module GovukPublishingComponents
         content_store_response.fetch("base_path")
       end
 
+      def url_override
+        content_store_response.dig("details", "url_override")
+      end
+
       def description
         content_store_response.fetch("description", "")
       end

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_taxons_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_taxons_spec.rb
@@ -99,6 +99,34 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnT
           ],
         )
       end
+
+      context "when parent taxon has a url_override" do
+        it "uses the url_override value instead of the base_path" do
+          parent = {
+            "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+            "locale" => "en",
+            "title" => "A-parent",
+            "base_path" => "/a-parent",
+            "phase" => "live",
+            "links" => {
+              "parent_taxons" => [],
+            },
+            "details" => {
+              "url_override" => "/foo",
+            },
+          }
+
+          content_item = taxon_with_parent_taxons([parent])
+          breadcrumbs = breadcrumbs_for(content_item)
+
+          expect(breadcrumbs).to eq(
+            [
+              { title: "Home", url: "/", is_page_parent: false },
+              { title: "A-parent", url: "/foo", is_page_parent: true },
+            ],
+          )
+        end
+      end
     end
 
     context "with multiple parents" do


### PR DESCRIPTION
## What
- When a page is tagged to a taxon, use the url_override field of that taxon in the page breadcrumbs. If the taxon doesn't have a url_override set, then use the base_path as before. 

## Why
- We would like to be able to set a url_override field on taxons to customise the url of the page in content tagger. Related PR's are: https://github.com/alphagov/govuk-content-schemas/pull/1059 and https://github.com/alphagov/content-tagger/pull/1204


## Visual Changes
<img width="1489" alt="Screenshot 2021-05-24 at 12 21 17" src="https://user-images.githubusercontent.com/17908089/119341241-6ff90980-bc8b-11eb-988d-b358d309c298.png">
<img width="1536" alt="breadcrumbs" src="https://user-images.githubusercontent.com/17908089/119341245-7091a000-bc8b-11eb-8168-ae11ce8fa61e.png">

