### PR TITLE
Use the`init` API to initialise modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Remove hide-only option from contextual guidance ([PR #2126](https://github.com/alphagov/govuk_publishing_components/pull/2126))
 * Fix click tracking in government_navigation ([PR #2129](https://github.com/alphagov/govuk_publishing_components/pull/2129))
 * Add superbreadcrumb to content tagged to a Brexit child taxon ([PR #2123](https://github.com/alphagov/govuk_publishing_components/pull/2123))
+* Use the `init` API to initialise component modules ([PR #2095](https://github.com/alphagov/govuk_publishing_components/pull/2095))
 
 ## 24.13.4
 

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -7,15 +7,12 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function GemAccordion () { }
-
-  GemAccordion.prototype.start = function ($module) {
-    this.$module = $module[0]
+  function GemAccordion ($module) {
+    this.$module = $module
     this.sectionClass = 'gem-c-accordion__section'
     this.moduleId = this.$module.getAttribute('id')
     this.sections = this.$module.querySelectorAll('.' + this.sectionClass)
     this.openAllButton = ''
-    this.browserSupportsSessionStorage = helper.checkForSessionStorage()
     this.controlsClass = 'gem-c-accordion__controls'
     this.openAllClass = 'gem-c-accordion__open-all'
     this.openAllTextClass = 'gem-c-accordion__open-all-text'
@@ -39,6 +36,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.actions.showAllText = this.$module.getAttribute('data-show-all-text')
     this.$module.actions.hideAllText = this.$module.getAttribute('data-hide-all-text')
     this.$module.actions.thisSectionVisuallyHidden = this.$module.getAttribute('data-this-section-visually-hidden')
+  }
+
+  GemAccordion.prototype.init = function () {
+    this.browserSupportsSessionStorage = helper.checkForSessionStorage()
 
     // Indicate that JavaScript has worked
     this.$module.classList.add('gem-c-accordion--active')

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -6,14 +6,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
 window.GOVUK.Modules.Checkboxes = window.GOVUKFrontend;
 
 (function (Modules) {
-  function GovukCheckboxes () { }
-
-  GovukCheckboxes.prototype.start = function ($module) {
-    this.$module = $module[0]
+  function GovukCheckboxes ($module) {
+    this.$module = $module
     this.$checkboxes = this.$module.querySelectorAll('input[type=checkbox]')
     this.$nestedCheckboxes = this.$module.querySelectorAll('[data-nested=true] input[type=checkbox]')
     this.$exclusiveCheckboxes = this.$module.querySelectorAll('[data-exclusive=true] input[type=checkbox]')
+  }
 
+  GovukCheckboxes.prototype.init = function () {
     this.applyAriaControlsAttributes(this.$module)
 
     for (var i = 0; i < this.$checkboxes.length; i++) {

--- a/app/assets/javascripts/govuk_publishing_components/components/contextual-guidance.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/contextual-guidance.js
@@ -2,13 +2,14 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function ContextualGuidance () { }
-
-  ContextualGuidance.prototype.start = function ($module) {
-    this.$module = $module[0]
+  function ContextualGuidance ($module) {
+    this.$module = $module
     this.$guidance = this.$module.querySelector('.gem-c-contextual-guidance__wrapper')
     this.$inputId = this.$guidance.getAttribute('for')
     this.$input = this.$module.querySelector('#' + this.$inputId)
+  }
+
+  ContextualGuidance.prototype.init = function () {
     if (!this.$input) return
     this.$input.addEventListener('focus', this.handleFocus.bind(this))
   }

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -2,18 +2,18 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function CookieBanner () { }
+  function CookieBanner ($module) {
+    this.$module = $module
+    this.$module.cookieBanner = document.querySelector('.gem-c-cookie-banner')
+    this.$module.cookieBannerConfirmationMessage = this.$module.querySelector('.gem-c-cookie-banner__confirmation')
+    this.$module.cookieBannerConfirmationMessageText = this.$module.querySelector('.gem-c-cookie-banner__confirmation-message')
+  }
 
-  CookieBanner.prototype.start = function ($module) {
-    this.$module = $module[0]
+  CookieBanner.prototype.init = function () {
     this.$module.hideCookieMessage = this.hideCookieMessage.bind(this)
     this.$module.showConfirmationMessage = this.showConfirmationMessage.bind(this)
     this.$module.setCookieConsent = this.setCookieConsent.bind(this)
     this.$module.rejectCookieConsent = this.rejectCookieConsent.bind(this)
-
-    this.$module.cookieBanner = document.querySelector('.gem-c-cookie-banner')
-    this.$module.cookieBannerConfirmationMessage = this.$module.querySelector('.gem-c-cookie-banner__confirmation')
-    this.$module.cookieBannerConfirmationMessageText = this.$module.querySelector('.gem-c-cookie-banner__confirmation-message')
     this.setupCookieMessage()
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/components/copy-to-clipboard.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/copy-to-clipboard.js
@@ -2,23 +2,24 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function CopyToClipboard () { }
+  function CopyToClipboard ($module) {
+    this.$module = $module
+    this.$input = this.$module.querySelector('.gem-c-input')
+    this.$copyButton = this.$module.querySelector('.gem-c-button')
+  }
 
-  CopyToClipboard.prototype.start = function ($module) {
-    this.$module = $module[0]
+  CopyToClipboard.prototype.init = function () {
+    if (!this.$input || !this.$copyButton) return
 
-    var input = this.$module.querySelector('.gem-c-input')
-    var copyButton = this.$module.querySelector('.gem-c-button')
+    this.$input.addEventListener('click', function () {
+      this.$input.select()
+    }.bind(this))
 
-    input.addEventListener('click', function () {
-      input.select()
-    })
-
-    copyButton.addEventListener('click', function (event) {
+    this.$copyButton.addEventListener('click', function (event) {
       event.preventDefault()
-      input.select()
+      this.$input.select()
       document.execCommand('copy')
-    })
+    }.bind(this))
   }
 
   Modules.CopyToClipboard = CopyToClipboard

--- a/app/assets/javascripts/govuk_publishing_components/components/details.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/details.js
@@ -5,26 +5,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
 window.GOVUK.Modules.Details = window.GOVUKFrontend;
 
 (function (Modules) {
-  function GovukDetails () { }
+  function GovukDetails ($module) {
+    this.$module = $module
+    this.customTrackLabel = this.$module.getAttribute('data-track-label')
+    this.detailsClick = this.$module.querySelector('[data-details-track-click]')
+  }
 
-  GovukDetails.prototype.start = function ($module) {
-    this.$module = $module[0]
-
-    var customTrackLabel = this.$module.getAttribute('data-track-label')
-
-    // If a custom label has been provided, we can simply call the tracking module
-    if (customTrackLabel) {
+  GovukDetails.prototype.init = function () {
+    if (this.customTrackLabel) { // If a custom label has been provided, we can simply call the tracking module
       var trackDetails = new window.GOVUK.Modules.GemTrackClick()
-      trackDetails.start($module)
-    } else {
-      // If no custom label is set, we use the open/close status as the label
-      var detailsClick = this.$module.querySelector('[data-details-track-click]')
-
-      if (detailsClick) {
-        detailsClick.addEventListener('click', function (event) {
-          this.trackDefault(this.$module)
-        }.bind(this))
-      }
+      trackDetails.start($(this.$module))
+    } else if (this.detailsClick) { // If no custom label is set, we use the open/close status as the label
+      this.detailsClick.addEventListener('click', function (event) {
+        this.trackDefault(this.$module)
+      }.bind(this))
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -3,244 +3,242 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  'use strict'
+  function Feedback ($module) {
+    this.$module = $module
+    this.somethingIsWrongForm = this.$module.querySelector('#something-is-wrong')
+    this.surveyForm = this.$module.querySelector('#page-is-not-useful')
+    this.prompt = this.$module.querySelector('.js-prompt')
+    this.forms = this.$module.querySelectorAll('.js-feedback-form')
+    this.toggleForms = this.$module.querySelectorAll('.js-toggle-form')
+    this.closeForms = this.$module.querySelectorAll('.js-close-form')
+    this.activeForm = false
+    this.pageIsUsefulButton = this.$module.querySelector('.js-page-is-useful')
+    this.pageIsNotUsefulButton = this.$module.querySelector('.js-page-is-not-useful')
+    this.somethingIsWrongButton = this.$module.querySelector('.js-something-is-wrong')
+    this.promptQuestions = this.$module.querySelectorAll('.js-prompt-questions')
+    this.promptSuccessMessage = this.$module.querySelector('.js-prompt-success')
+    this.surveyWrapper = this.$module.querySelector('#survey-wrapper')
+    this.jshiddenClass = 'js-hidden'
+  }
 
-  Modules.Feedback = function () {
-    this.start = function ($element) {
-      this.element = $element[0]
-      this.somethingIsWrongForm = this.element.querySelector('#something-is-wrong')
-      this.surveyForm = this.element.querySelector('#page-is-not-useful')
-      this.prompt = this.element.querySelector('.js-prompt')
-      this.forms = this.element.querySelectorAll('.js-feedback-form')
-      this.toggleForms = this.element.querySelectorAll('.js-toggle-form')
-      this.closeForms = this.element.querySelectorAll('.js-close-form')
-      this.activeForm = false
-      this.pageIsUsefulButton = this.element.querySelector('.js-page-is-useful')
-      this.pageIsNotUsefulButton = this.element.querySelector('.js-page-is-not-useful')
-      this.somethingIsWrongButton = this.element.querySelector('.js-something-is-wrong')
-      this.promptQuestions = this.element.querySelectorAll('.js-prompt-questions')
-      this.promptSuccessMessage = this.element.querySelector('.js-prompt-success')
-      this.surveyWrapper = this.element.querySelector('#survey-wrapper')
+  Feedback.prototype.init = function () {
+    this.setInitialAriaAttributes()
+    this.setHiddenValues()
 
-      var thisModule = this
-      var jshiddenClass = 'js-hidden'
-
-      setInitialAriaAttributes()
-      setHiddenValues()
-
-      for (var j = 0; j < this.toggleForms.length; j++) {
-        this.toggleForms[j].addEventListener('click', function (e) {
-          e.preventDefault()
-          var el = e.target
-          toggleForm(el.getAttribute('aria-controls'))
-          trackEvent(getTrackEventParams(el))
-          updateAriaAttributes(el)
-        })
-      }
-
-      for (var i = 0; i < this.closeForms.length; i++) {
-        this.closeForms[i].addEventListener('click', function (e) {
-          e.preventDefault()
-          var el = e.target
-          var formToToggle = el.getAttribute('aria-controls')
-          toggleForm(formToToggle)
-          trackEvent(getTrackEventParams(el))
-          setInitialAriaAttributes()
-          revealInitialPrompt()
-          var refocusClass = '.js-' + formToToggle
-          thisModule.element.querySelector(refocusClass).focus()
-        })
-      }
-
-      this.pageIsUsefulButton.addEventListener('click', function (e) {
+    for (var j = 0; j < this.toggleForms.length; j++) {
+      this.toggleForms[j].addEventListener('click', function (e) {
         e.preventDefault()
-        trackEvent(getTrackEventParams(thisModule.pageIsUsefulButton))
-        showFormSuccess()
-        revealInitialPrompt()
-      })
+        var el = e.target
+        this.toggleForm(el.getAttribute('aria-controls'))
+        this.trackEvent(this.getTrackEventParams(el))
+        this.updateAriaAttributes(el)
+      }.bind(this))
+    }
 
-      this.pageIsNotUsefulButton.addEventListener('click', function (e) {
-        var gaClientId
-        var dummyGaClientId = '111111111.1111111111'
-        if (window.GOVUK.cookie('_ga') === null || window.GOVUK.cookie('_ga') === '') {
-          gaClientId = dummyGaClientId
-        } else {
-          gaClientId = window.GOVUK.cookie('_ga').split('.').slice(-2).join('.')
-        }
-        setHiddenValuesNotUsefulForm(gaClientId)
-      })
+    for (var i = 0; i < this.closeForms.length; i++) {
+      this.closeForms[i].addEventListener('click', function (e) {
+        e.preventDefault()
+        var el = e.target
+        var formToToggle = el.getAttribute('aria-controls')
+        this.toggleForm(formToToggle)
+        this.trackEvent(this.getTrackEventParams(el))
+        this.setInitialAriaAttributes()
+        this.revealInitialPrompt()
+        var refocusClass = '.js-' + formToToggle
+        this.$module.querySelector(refocusClass).focus()
+      }.bind(this))
+    }
 
-      // much of the JS needed to support sending the form contents via this script is
-      // unsupported by IE, even IE11. This check causes IE to not intercept form submits
-      // and let them happen normally, which is handled already by the backend
-      if (typeof window.URLSearchParams === 'function') {
-        for (var f = 0; f < this.forms.length; f++) {
-          this.forms[f].addEventListener('submit', function (e) {
-            e.preventDefault()
-            var $form = e.target
-            var xhr = new XMLHttpRequest()
-            var url = $form.getAttribute('action')
-            var params = new FormData($form)
-            params = new URLSearchParams(params).toString()
+    this.pageIsUsefulButton.addEventListener('click', function (e) {
+      e.preventDefault()
+      this.trackEvent(this.getTrackEventParams(this.pageIsUsefulButton))
+      this.showFormSuccess()
+      this.revealInitialPrompt()
+    }.bind(this))
 
-            xhr.open('POST', url, true)
-            xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded')
+    this.pageIsNotUsefulButton.addEventListener('click', function (e) {
+      var gaClientId
+      var dummyGaClientId = '111111111.1111111111'
+      if (window.GOVUK.cookie('_ga') === null || window.GOVUK.cookie('_ga') === '') {
+        gaClientId = dummyGaClientId
+      } else {
+        gaClientId = window.GOVUK.cookie('_ga').split('.').slice(-2).join('.')
+      }
+      this.setHiddenValuesNotUsefulForm(gaClientId)
+    }.bind(this))
 
-            xhr.onreadystatechange = function () {
-              if (xhr.readyState === 4 && xhr.status === 200) {
-                trackEvent(getTrackEventParams($form))
-                showFormSuccess(xhr.message)
-                revealInitialPrompt()
-                setInitialAriaAttributes()
-                thisModule.activeForm.classList.toggle(jshiddenClass)
-              } else {
-                showError(xhr)
-                enableSubmitFormButton($form)
-              }
+    // much of the JS needed to support sending the form contents via this script is
+    // unsupported by IE, even IE11. This check causes IE to not intercept form submits
+    // and let them happen normally, which is handled already by the backend
+    if (typeof window.URLSearchParams === 'function') {
+      for (var f = 0; f < this.forms.length; f++) {
+        this.forms[f].addEventListener('submit', function (e) {
+          e.preventDefault()
+          var $form = e.target
+          var xhr = new XMLHttpRequest()
+          var url = $form.getAttribute('action')
+          var params = new FormData($form)
+          params = new URLSearchParams(params).toString()
+
+          xhr.open('POST', url, true)
+          xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded')
+
+          xhr.onreadystatechange = function () {
+            if (xhr.readyState === 4 && xhr.status === 200) {
+              this.trackEvent(this.getTrackEventParams($form))
+              this.showFormSuccess(xhr.message)
+              this.revealInitialPrompt()
+              this.setInitialAriaAttributes()
+              this.activeForm.classList.toggle(this.jshiddenClass)
+            } else {
+              this.showError(xhr)
+              this.enableSubmitFormButton($form)
             }
+          }.bind(this)
 
-            disableSubmitFormButton($form)
-            xhr.send(params)
-          })
-        }
-      }
-
-      function disableSubmitFormButton ($form) {
-        var formButton = $form.querySelector('[type="submit"]')
-        formButton.setAttribute('disabled', true)
-      }
-
-      function enableSubmitFormButton ($form) {
-        var formButton = $form.querySelector('[type="submit"]')
-        formButton.removeAttribute('disabled')
-      }
-
-      function setInitialAriaAttributes () {
-        for (var i = 0; i < thisModule.forms.length; i++) {
-          thisModule.forms[i].setAttribute('aria-hidden', true)
-        }
-        thisModule.pageIsNotUsefulButton.setAttribute('aria-expanded', false)
-        thisModule.somethingIsWrongButton.setAttribute('aria-expanded', false)
-      }
-
-      function setHiddenValues () {
-        var javascriptEnabled = document.createElement('input')
-        javascriptEnabled.setAttribute('type', 'hidden')
-        javascriptEnabled.setAttribute('name', 'javascript_enabled')
-        javascriptEnabled.setAttribute('value', true)
-        thisModule.somethingIsWrongForm.appendChild(javascriptEnabled)
-
-        var referrer = document.createElement('input')
-        referrer.setAttribute('type', 'hidden')
-        referrer.setAttribute('name', 'referrer')
-        referrer.setAttribute('value', document.referrer || 'unknown')
-        thisModule.somethingIsWrongForm.appendChild(referrer)
-        thisModule.somethingIsWrongForm.invalidInfoError = [
-          '<h2>Sorry, we’re unable to send your message as you haven’t given us any information.</h2>',
-          ' <p>Please tell us what you were doing or what went wrong</p>'
-        ].join('')
-      }
-
-      function setHiddenValuesNotUsefulForm (gaClientId) {
-        var currentPathName = window.location.pathname.replace(/[^\s=?&]+(?:@|%40)[^\s=?&]+/, '[email]')
-        var finalPathName = encodeURI(currentPathName)
-        thisModule.surveyForm.invalidInfoError = [
-          '<h2>Sorry, we’re unable to send your message as you haven’t given us a valid email address.</h2>',
-          ' <p>Enter an email address in the correct format, like name@example.com</p>'
-        ].join('')
-        if (document.querySelectorAll('[name="email_survey_signup[ga_client_id]"]').length === 0) {
-          var hiddenInput = document.createElement('input')
-          hiddenInput.setAttribute('type', 'hidden')
-          hiddenInput.setAttribute('name', 'email_survey_signup[ga_client_id]')
-          hiddenInput.setAttribute('value', gaClientId || '0')
-          thisModule.surveyForm.appendChild(hiddenInput)
-        }
-
-        if (document.querySelectorAll('.gem-c-feedback__email-link#take-survey').length === 0) {
-          var takeSurvey = document.createElement('a')
-          takeSurvey.setAttribute('href', 'https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=' + finalPathName + '&amp;gcl=' + gaClientId)
-          takeSurvey.setAttribute('class', 'gem-c-feedback__email-link govuk-link')
-          takeSurvey.setAttribute('id', 'take-survey')
-          takeSurvey.setAttribute('target', '_blank')
-          takeSurvey.setAttribute('rel', 'noopener noreferrer')
-          takeSurvey.innerHTML = 'Don’t have an email address?'
-          thisModule.surveyWrapper.appendChild(takeSurvey)
-        }
-      }
-
-      function updateAriaAttributes (linkClicked) {
-        linkClicked.setAttribute('aria-expanded', true)
-        var controls = linkClicked.getAttribute('aria-controls')
-        var ariaControls = document.querySelector('#' + controls)
-        ariaControls.setAttribute('aria-hidden', false)
-      }
-
-      function toggleForm (formId) {
-        thisModule.activeForm = thisModule.element.querySelector('#' + formId)
-        thisModule.activeForm.classList.toggle(jshiddenClass)
-        thisModule.prompt.classList.toggle(jshiddenClass)
-
-        var formIsVisible = !thisModule.activeForm.classList.contains(jshiddenClass)
-
-        if (formIsVisible) {
-          thisModule.activeForm.querySelector('.gem-c-input').focus()
-        } else {
-          thisModule.activeForm = false
-        }
-      }
-
-      function getTrackEventParams ($node) {
-        return {
-          category: $node.getAttribute('data-track-category'),
-          action: $node.getAttribute('data-track-action')
-        }
-      }
-
-      function trackEvent (trackEventParams) {
-        if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
-          window.GOVUK.analytics.trackEvent(trackEventParams.category, trackEventParams.action)
-        }
-      }
-
-      function showError (error) {
-        var genericError = [
-          '<h2>Sorry, we’re unable to receive your message right now.</h2>',
-          ' <p>If the problem persists, we have other ways for you to provide',
-          ' feedback on the <a href="/contact/govuk">contact page</a>.</p>'
-        ].join('')
-        // if the response is not a 404 or 500, show the error message if it exists
-        // otherwise show the generic message
-        if ('response' in error) {
-          if (typeof error.response === 'object' && error.response !== null) {
-            error = error.response.message === 'email survey sign up failure' ? genericError : error.response.message
-          } else {
-            error = genericError
-          }
-        } else if (error.status === 422) {
-          // there's clobbering by nginx on all 422 requests, which is why the response returns a rendered html page instead of the expected JSON
-          // this is a temporary workaround to ensure that we are displaying relevant error messages to the users
-          error = thisModule.activeForm.invalidInfoError || genericError
-        } else {
-          error = genericError
-        }
-        var $errors = thisModule.activeForm.querySelector('.js-errors')
-        $errors.innerHTML = error
-        $errors.classList.remove(jshiddenClass)
-        $errors.focus()
-      }
-
-      function showFormSuccess () {
-        for (var i = 0; i < thisModule.promptQuestions.length; i++) {
-          thisModule.promptQuestions[i].classList.add(jshiddenClass)
-        }
-        thisModule.promptSuccessMessage.classList.remove(jshiddenClass)
-        thisModule.promptSuccessMessage.focus()
-      }
-
-      function revealInitialPrompt () {
-        thisModule.prompt.classList.remove(jshiddenClass)
-        thisModule.prompt.focus()
+          this.disableSubmitFormButton($form)
+          xhr.send(params)
+        }.bind(this))
       }
     }
   }
+
+  Feedback.prototype.disableSubmitFormButton = function ($form) {
+    var formButton = $form.querySelector('[type="submit"]')
+    formButton.setAttribute('disabled', true)
+  }
+
+  Feedback.prototype.enableSubmitFormButton = function ($form) {
+    var formButton = $form.querySelector('[type="submit"]')
+    formButton.removeAttribute('disabled')
+  }
+
+  Feedback.prototype.setInitialAriaAttributes = function () {
+    for (var i = 0; i < this.forms.length; i++) {
+      this.forms[i].setAttribute('aria-hidden', true)
+    }
+    this.pageIsNotUsefulButton.setAttribute('aria-expanded', false)
+    this.somethingIsWrongButton.setAttribute('aria-expanded', false)
+  }
+
+  Feedback.prototype.setHiddenValues = function () {
+    var javascriptEnabled = document.createElement('input')
+    javascriptEnabled.setAttribute('type', 'hidden')
+    javascriptEnabled.setAttribute('name', 'javascript_enabled')
+    javascriptEnabled.setAttribute('value', true)
+    this.somethingIsWrongForm.appendChild(javascriptEnabled)
+
+    var referrer = document.createElement('input')
+    referrer.setAttribute('type', 'hidden')
+    referrer.setAttribute('name', 'referrer')
+    referrer.setAttribute('value', document.referrer || 'unknown')
+    this.somethingIsWrongForm.appendChild(referrer)
+    this.somethingIsWrongForm.invalidInfoError = [
+      '<h2>Sorry, we’re unable to send your message as you haven’t given us any information.</h2>',
+      ' <p>Please tell us what you were doing or what went wrong</p>'
+    ].join('')
+  }
+
+  Feedback.prototype.setHiddenValuesNotUsefulForm = function (gaClientId) {
+    var currentPathName = window.location.pathname.replace(/[^\s=?&]+(?:@|%40)[^\s=?&]+/, '[email]')
+    var finalPathName = encodeURI(currentPathName)
+    this.surveyForm.invalidInfoError = [
+      '<h2>Sorry, we’re unable to send your message as you haven’t given us a valid email address.</h2>',
+      ' <p>Enter an email address in the correct format, like name@example.com</p>'
+    ].join('')
+    if (document.querySelectorAll('[name="email_survey_signup[ga_client_id]"]').length === 0) {
+      var hiddenInput = document.createElement('input')
+      hiddenInput.setAttribute('type', 'hidden')
+      hiddenInput.setAttribute('name', 'email_survey_signup[ga_client_id]')
+      hiddenInput.setAttribute('value', gaClientId || '0')
+      this.surveyForm.appendChild(hiddenInput)
+    }
+
+    if (document.querySelectorAll('.gem-c-feedback__email-link#take-survey').length === 0) {
+      var takeSurvey = document.createElement('a')
+      takeSurvey.setAttribute('href', 'https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=' + finalPathName + '&amp;gcl=' + gaClientId)
+      takeSurvey.setAttribute('class', 'gem-c-feedback__email-link govuk-link')
+      takeSurvey.setAttribute('id', 'take-survey')
+      takeSurvey.setAttribute('target', '_blank')
+      takeSurvey.setAttribute('rel', 'noopener noreferrer')
+      takeSurvey.innerHTML = 'Don’t have an email address?'
+      this.surveyWrapper.appendChild(takeSurvey)
+    }
+  }
+
+  Feedback.prototype.updateAriaAttributes = function (linkClicked) {
+    linkClicked.setAttribute('aria-expanded', true)
+    var controls = linkClicked.getAttribute('aria-controls')
+    var ariaControls = document.querySelector('#' + controls)
+    ariaControls.setAttribute('aria-hidden', false)
+  }
+
+  Feedback.prototype.toggleForm = function (formId) {
+    this.activeForm = this.$module.querySelector('#' + formId)
+    this.activeForm.classList.toggle(this.jshiddenClass)
+    this.prompt.classList.toggle(this.jshiddenClass)
+
+    var formIsVisible = !this.activeForm.classList.contains(this.jshiddenClass)
+
+    if (formIsVisible) {
+      this.activeForm.querySelector('.gem-c-input').focus()
+    } else {
+      this.activeForm = false
+    }
+  }
+
+  Feedback.prototype.getTrackEventParams = function ($node) {
+    return {
+      category: $node.getAttribute('data-track-category'),
+      action: $node.getAttribute('data-track-action')
+    }
+  }
+
+  Feedback.prototype.trackEvent = function (trackEventParams) {
+    if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+      window.GOVUK.analytics.trackEvent(trackEventParams.category, trackEventParams.action)
+    }
+  }
+
+  Feedback.prototype.showError = function (error) {
+    var genericError = [
+      '<h2>Sorry, we’re unable to receive your message right now.</h2>',
+      ' <p>If the problem persists, we have other ways for you to provide',
+      ' feedback on the <a href="/contact/govuk">contact page</a>.</p>'
+    ].join('')
+    // if the response is not a 404 or 500, show the error message if it exists
+    // otherwise show the generic message
+    if ('response' in error) {
+      if (typeof error.response === 'object' && error.response !== null) {
+        error = error.response.message === 'email survey sign up failure' ? genericError : error.response.message
+      } else {
+        error = genericError
+      }
+    } else if (error.status === 422) {
+      // there's clobbering by nginx on all 422 requests, which is why the response returns a rendered html page instead of the expected JSON
+      // this is a temporary workaround to ensure that we are displaying relevant error messages to the users
+      error = this.activeForm.invalidInfoError || genericError
+    } else {
+      error = genericError
+    }
+    var $errors = this.activeForm.querySelector('.js-errors')
+    $errors.innerHTML = error
+    $errors.classList.remove(this.jshiddenClass)
+    $errors.focus()
+  }
+
+  Feedback.prototype.showFormSuccess = function () {
+    for (var i = 0; i < this.promptQuestions.length; i++) {
+      this.promptQuestions[i].classList.add(this.jshiddenClass)
+    }
+    this.promptSuccessMessage.classList.remove(this.jshiddenClass)
+    this.promptSuccessMessage.focus()
+  }
+
+  Feedback.prototype.revealInitialPrompt = function () {
+    this.prompt.classList.remove(this.jshiddenClass)
+    this.prompt.focus()
+  }
+
+  Modules.Feedback = Feedback
 })(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/components/govspeak.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/govspeak.js
@@ -2,11 +2,11 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function Govspeak () { }
+  function Govspeak ($module) {
+    this.$module = $module
+  }
 
-  Govspeak.prototype.start = function ($module) {
-    this.$module = $module[0]
-
+  Govspeak.prototype.init = function () {
     if (this.$module.className.indexOf('disable-youtube') === -1) {
       this.embedYoutube()
     }

--- a/app/assets/javascripts/govuk_publishing_components/components/modal-dialogue.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/modal-dialogue.js
@@ -2,14 +2,16 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function ModalDialogue () { }
-
-  ModalDialogue.prototype.start = function ($module) {
-    this.$module = $module[0]
+  function ModalDialogue ($module) {
+    this.$module = $module
     this.$dialogBox = this.$module.querySelector('.gem-c-modal-dialogue__box')
     this.$closeButton = this.$module.querySelector('.gem-c-modal-dialogue__close-button')
     this.$html = document.querySelector('html')
     this.$body = document.querySelector('body')
+  }
+
+  ModalDialogue.prototype.init = function () {
+    if (!this.$dialogBox || !this.$closeButton) return
 
     this.$module.resize = this.handleResize.bind(this)
     this.$module.open = this.handleOpen.bind(this)

--- a/app/assets/javascripts/govuk_publishing_components/components/print-link.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/print-link.js
@@ -2,10 +2,11 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function PrintLink () { }
+  function PrintLink ($module) {
+    this.$module = $module
+  }
 
-  PrintLink.prototype.start = function ($module) {
-    this.$module = $module[0]
+  PrintLink.prototype.init = function () {
     this.$module.addEventListener('click', function () {
       window.print()
     })

--- a/app/assets/javascripts/govuk_publishing_components/components/reorderable-list.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/reorderable-list.js
@@ -3,13 +3,13 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function ReorderableList () { }
-
-  ReorderableList.prototype.start = function ($module) {
-    this.$module = $module[0]
+  function ReorderableList ($module) {
+    this.$module = $module
     this.$upButtons = this.$module.querySelectorAll('.js-reorderable-list-up')
     this.$downButtons = this.$module.querySelectorAll('.js-reorderable-list-down')
+  }
 
+  ReorderableList.prototype.init = function () {
     this.sortable = window.Sortable.create(this.$module, { // eslint-disable-line new-cap
       chosenClass: 'gem-c-reorderable-list__item--chosen',
       dragClass: 'gem-c-reorderable-list__item--drag',

--- a/app/assets/javascripts/govuk_publishing_components/components/show-password.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/show-password.js
@@ -2,11 +2,12 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function ShowPassword () { }
-
-  ShowPassword.prototype.start = function ($module) {
-    this.$module = $module[0]
+  function ShowPassword ($module) {
+    this.$module = $module
     this.input = this.$module.querySelector('.gem-c-input')
+  }
+
+  ShowPassword.prototype.init = function () {
     this.$module.togglePassword = this.togglePassword.bind(this)
     this.$module.revertToPasswordOnFormSubmit = this.revertToPasswordOnFormSubmit.bind(this)
     this.input.classList.add('gem-c-input--with-password')

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -6,10 +6,8 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function Gemstepnav () { }
-
-  Gemstepnav.prototype.start = function ($module) {
-    this.$module = $module[0]
+  function Gemstepnav ($module) {
+    this.$module = $module
     this.$module.actions = {} // stores text for JS appended elements 'show' and 'hide' on steps, and 'show/hide all' button
     this.$module.rememberShownStep = false
     this.$module.stepNavSize = false
@@ -18,7 +16,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.activeStepClass = 'gem-c-step-nav__step--active'
     this.$module.activeLinkHref = '#content'
     this.$module.uniqueId = false
+  }
 
+  Gemstepnav.prototype.init = function () {
     // Indicate that js has worked
     this.$module.classList.add('gem-c-step-nav--active')
 

--- a/docs/javascript-modules.md
+++ b/docs/javascript-modules.md
@@ -22,11 +22,11 @@ $(document).ready(function(){
 
 This will attempt to find and start all modules in the page. For the example above it will look for a module at `GOVUK.Modules.SomeModule`. Note the value of the data attribute has been converted to _PascalCase_.
 
-The module will be instantiated and then its `start` method called. The HTML element with the `data-module` attribute is passed as the first argument to the module. This limits modules to acting only within their containing elements.
+The module will be instantiated and then its `init` or `start` method called. The HTML element with the `data-module` attribute is passed as the first argument to the module. This limits modules to acting only within their containing elements.
 
 ```javascript
-module = new GOVUK.Modules[type]()
-module.start(element)
+module = new GOVUK.Modules.SomeModule(element)
+module.init()
 ```
 
 Running `GOVUK.modules.start()` multiple times will have no additional affect. When a module is started a flag is set on the element using the data attribute `module-started`. `data-module-started` is a reserved attribute. It can however be called with an element as the first argument, to allow modules to be started in dynamically loaded content:
@@ -43,8 +43,8 @@ Some modules might need cookie consent before doing anything. If a user consents
 This can be achieved by structuring a module to listen for the `cookie-consent` event. This event is fired by the cookie banner when the user consents to cookies.
 
 ```javascript
-AnExampleModule.prototype.start = function ($module) {
-  this.$module = $module[0]
+AnExampleModule.prototype.init = function ($module) {
+  this.$module = $module
   var consentCookie = window.GOVUK.getConsentCookie()
 
   if (consentCookie && consentCookie.settings) {
@@ -76,9 +76,11 @@ The simplest module looks like:
 (function(Modules) {
   'use strict'
 
-  function SomeModule () {}
-  SomeModule.prototype.start = function($element) {
-    // module code
+  function SomeModule ($element) {
+    // variables and attributes
+  }
+  SomeModule.prototype.init = function() {
+    // function calls and event bindings
   }
   Modules.SomeModule = SomeModule
 })(window.GOVUK.Modules)

--- a/spec/javascripts/components/accordion-spec.js
+++ b/spec/javascripts/components/accordion-spec.js
@@ -49,7 +49,7 @@ describe('An accordion component', function () {
     container.querySelector('.gem-c-accordion').setAttribute('data-locale', JSON.stringify(localeData))
 
     element = document.getElementById('default-id')
-    new GOVUK.Modules.GemAccordion().start($(element))
+    new GOVUK.Modules.GemAccordion(element).init()
   })
 
   afterEach(function () {

--- a/spec/javascripts/components/checkboxes-spec.js
+++ b/spec/javascripts/components/checkboxes-spec.js
@@ -3,8 +3,7 @@
 
 describe('Checkboxes component', function () {
   function loadCheckboxesComponent () {
-    var checkboxes = new GOVUK.Modules.GovukCheckboxes()
-    checkboxes.start($('.gem-c-checkboxes'))
+    new GOVUK.Modules.GovukCheckboxes($('.gem-c-checkboxes')[0]).init()
   }
 
   var FIXTURE =

--- a/spec/javascripts/components/contextual-guidance-spec.js
+++ b/spec/javascripts/components/contextual-guidance-spec.js
@@ -35,8 +35,8 @@ describe('Contextual guidance component', function () {
     document.body.appendChild(container)
     var titleContextualGuidance = document.getElementById('document-title-guidance')
     var summaryContextualGuidance = document.getElementById('document-summary-guidance')
-    new GOVUK.Modules.ContextualGuidance().start($(titleContextualGuidance))
-    new GOVUK.Modules.ContextualGuidance().start($(summaryContextualGuidance))
+    new GOVUK.Modules.ContextualGuidance(titleContextualGuidance).init()
+    new GOVUK.Modules.ContextualGuidance(summaryContextualGuidance).init()
   })
 
   afterEach(function () {

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -58,7 +58,7 @@ describe('Cookie banner', function () {
 
   it('should show the cookie banner', function () {
     var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner().start($(element))
+    new GOVUK.Modules.CookieBanner(element).init()
 
     var cookieBannerMain = document.querySelector('.js-banner-wrapper')
     var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
@@ -72,8 +72,7 @@ describe('Cookie banner', function () {
     GOVUK.setDefaultConsentCookie() // Set default cookies, which are set whether there is any interaction or not.
 
     var element = document.querySelector('[data-module="cookie-banner"]')
-
-    new GOVUK.Modules.CookieBanner().start($(element))
+    new GOVUK.Modules.CookieBanner(element).init()
 
     var cookieBannerMain = document.querySelector('.js-banner-wrapper')
     var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
@@ -87,15 +86,14 @@ describe('Cookie banner', function () {
     GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
 
     var element = document.querySelector('[data-module="cookie-banner"]')
-
-    new GOVUK.Modules.CookieBanner().start($(element))
+    new GOVUK.Modules.CookieBanner(element).init()
 
     expect(element).toBeHidden()
   })
 
   it('sets a default consent cookie', function () {
     var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner().start($(element))
+    new GOVUK.Modules.CookieBanner(element).init()
 
     expect(GOVUK.getCookie('cookies_preferences_set')).toEqual(null)
     expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
@@ -106,7 +104,7 @@ describe('Cookie banner', function () {
     spyOn(GOVUK, 'deleteUnconsentedCookies').and.callThrough()
 
     var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner().start($(element))
+    new GOVUK.Modules.CookieBanner(element).init()
 
     expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
     expect(GOVUK.deleteUnconsentedCookies).toHaveBeenCalled()
@@ -118,7 +116,7 @@ describe('Cookie banner', function () {
     spyOn(GOVUK, 'setCookie').and.callThrough()
 
     var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner().start($(element))
+    new GOVUK.Modules.CookieBanner(element).init()
 
     // Manually reset the consent cookie so we can check the accept button works as intended
     expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
@@ -143,7 +141,7 @@ describe('Cookie banner', function () {
     spyOn(GOVUK, 'setCookie').and.callThrough()
 
     var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner().start($(element))
+    new GOVUK.Modules.CookieBanner(element).init()
 
     // Manually reset the consent cookie so we can check the accept button works as intended
     expect(GOVUK.getCookie('cookies_policy')).toEqual(DEFAULT_COOKIE_CONSENT)
@@ -160,7 +158,7 @@ describe('Cookie banner', function () {
 
   it('shows a confirmation message when cookies have been accepted', function () {
     var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner().start($(element))
+    new GOVUK.Modules.CookieBanner(element).init()
 
     var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
     var mainCookieBanner = document.querySelector('.gem-c-cookie-banner__message')
@@ -179,7 +177,7 @@ describe('Cookie banner', function () {
     spyOn(GOVUK, 'setCookie').and.callThrough()
 
     var element = document.querySelector('[data-module="cookie-banner"]')
-    new GOVUK.Modules.CookieBanner().start($(element))
+    new GOVUK.Modules.CookieBanner(element).init()
 
     var link = document.querySelector('button[data-hide-cookie-banner="true"]')
     link.dispatchEvent(new window.Event('click'))
@@ -202,7 +200,7 @@ describe('Cookie banner', function () {
 
     it('should hide the cookie banner', function () {
       var element = document.querySelector('[data-module="cookie-banner"]')
-      new GOVUK.Modules.CookieBanner().start($(element))
+      new GOVUK.Modules.CookieBanner(element).init()
       expect(element).toBeHidden()
     })
   })

--- a/spec/javascripts/components/copy-to-clipboard-spec.js
+++ b/spec/javascripts/components/copy-to-clipboard-spec.js
@@ -7,8 +7,8 @@ describe('Copy to clipboard component', function () {
   var FIXTURE
 
   function loadCopyToClipboard () {
-    var copyToClipboard = new GOVUK.Modules.CopyToClipboard()
-    copyToClipboard.start($('[data-module=copy-to-clipboard]'))
+    var element = document.querySelector('[data-module=copy-to-clipboard]')
+    new GOVUK.Modules.CopyToClipboard(element).init()
   }
 
   beforeEach(function () {
@@ -25,7 +25,8 @@ describe('Copy to clipboard component', function () {
 
     loadCopyToClipboard()
 
-    $('.govuk-button').trigger('click')
+    var copyButton = document.querySelector('button')
+    window.GOVUK.triggerEvent(copyButton, 'click')
 
     expect(document.execCommand).toHaveBeenCalledWith('copy')
   })

--- a/spec/javascripts/components/details-spec.js
+++ b/spec/javascripts/components/details-spec.js
@@ -5,8 +5,8 @@ describe('Details component', function () {
   var FIXTURE
 
   function loadDetailsComponent () {
-    var details = new GOVUK.Modules.GovukDetails()
-    details.start($('.gem-c-details'))
+    var element = document.querySelector('[data-module="govuk-details"]')
+    new GOVUK.Modules.GovukDetails(element).init()
   }
 
   beforeEach(function () {

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -769,8 +769,7 @@ describe('Feedback component', function () {
   }
 
   function loadFeedbackComponent () {
-    var feedback = new GOVUK.Modules.Feedback()
-    feedback.start($('.gem-c-feedback'))
+    new GOVUK.Modules.Feedback($('.gem-c-feedback')[0]).init()
   }
 
   function fillAndSubmitSomethingIsWrongForm () {

--- a/spec/javascripts/components/govspeak-spec.js
+++ b/spec/javascripts/components/govspeak-spec.js
@@ -2,15 +2,13 @@
 /* global GOVUK */
 
 describe('Govspeak', function () {
-  var govspeakModule = new GOVUK.Modules.Govspeak()
+  var container
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
 
   describe('youtube enhancement', function () {
-    var container
-
-    afterEach(function () {
-      document.body.removeChild(container)
-    })
-
     it('embeds youtube videos', function () {
       container = document.createElement('div')
       container.innerHTML =
@@ -19,8 +17,8 @@ describe('Govspeak', function () {
         '<div>'
       document.body.appendChild(container)
 
-      var element = document.querySelector('.gem-c-govspeak')
-      new GOVUK.Modules.Govspeak().start($(element))
+      var element = document.querySelector('[data-module="govspeak"]')
+      new GOVUK.Modules.Govspeak(element).init()
 
       expect(document.querySelectorAll('.gem-c-govspeak__youtube-video').length).toBe(1)
     })
@@ -33,8 +31,8 @@ describe('Govspeak', function () {
         '<div>'
       document.body.appendChild(container)
 
-      var element = document.querySelector('.gem-c-govspeak')
-      new GOVUK.Modules.Govspeak().start($(element))
+      var element = document.querySelector('[data-module="govspeak"]')
+      new GOVUK.Modules.Govspeak(element).init()
 
       expect(document.querySelectorAll('.gem-c-govspeak__youtube-video').length).toBe(0)
     })
@@ -42,7 +40,8 @@ describe('Govspeak', function () {
 
   describe('barchart enhancement', function () {
     it('embeds barcharts', function () {
-      var $element = $(
+      container = document.createElement('div')
+      container.innerHTML =
         '<div id="govspeak-barchart" class="gem-c-govspeak govuk-govspeak" data-module="govspeak">' +
           '<table class="js-barchart-table mc-auto-outdent">' +
             '<tbody>' +
@@ -52,9 +51,12 @@ describe('Govspeak', function () {
             '</tbody>' +
           '</table>' +
         '<div>'
-      )
-      govspeakModule.start($element)
-      expect($element.find('.mc-chart').length).toBe(1)
+      document.body.appendChild(container)
+
+      var element = document.querySelector('[data-module="govspeak"]')
+      new GOVUK.Modules.Govspeak(element).init()
+
+      expect(document.querySelectorAll('.mc-chart').length).toBe(1)
     })
   })
 })

--- a/spec/javascripts/components/modal-dialogue-spec.js
+++ b/spec/javascripts/components/modal-dialogue-spec.js
@@ -32,7 +32,7 @@ describe('Modal dialogue component', function () {
 
     document.body.appendChild(container)
     var element = document.querySelector('[data-module="modal-dialogue"]')
-    new GOVUK.Modules.ModalDialogue().start($(element))
+    new GOVUK.Modules.ModalDialogue(element).init()
   })
 
   afterEach(function () {

--- a/spec/javascripts/components/print-link-spec.js
+++ b/spec/javascripts/components/print-link-spec.js
@@ -2,13 +2,28 @@
 /* global GOVUK */
 
 describe('Print link', function () {
+  'use strict'
+
+  var container
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML = '<button class="gem-c-print-link__button govuk-link" data-module="print-link">Print this page</button>'
+
+    document.body.appendChild(container)
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
   it('calls the DOM print API when clicked', function () {
     spyOn(window, 'print')
-    var element = $('<button class="gem-c-print-link__button govuk-link">Print this page</button>')
 
-    new GOVUK.Modules.PrintLink().start(element)
+    var element = document.querySelector('[data-module="print-link"]')
+    new GOVUK.Modules.PrintLink(element).init()
 
-    element.trigger('click')
+    element.dispatchEvent(new window.Event('click'))
 
     expect(window.print).toHaveBeenCalled()
   })

--- a/spec/javascripts/components/reorderable-list-spec.js
+++ b/spec/javascripts/components/reorderable-list-spec.js
@@ -53,9 +53,9 @@ describe('Reorderable list component', function () {
 
     beforeEach(function () {
       window.matchMedia = mockMatchMedia
-      reorderableList = new GOVUK.Modules.ReorderableList()
+      reorderableList = new GOVUK.Modules.ReorderableList(element)
       spyOn(reorderableList, 'setupResponsiveChecks')
-      reorderableList.start($(element))
+      reorderableList.init()
     })
 
     afterEach(function () {
@@ -86,7 +86,7 @@ describe('Reorderable list component', function () {
 
     beforeEach(function () {
       window.matchMedia = mockMatchMedia
-      reorderableList = new GOVUK.Modules.ReorderableList()
+      reorderableList = new GOVUK.Modules.ReorderableList(element)
     })
 
     afterEach(function () {
@@ -95,7 +95,7 @@ describe('Reorderable list component', function () {
 
     it('should setup responsive checks', function () {
       spyOn(reorderableList, 'setupResponsiveChecks')
-      reorderableList.start($(element))
+      reorderableList.init()
 
       expect(reorderableList.setupResponsiveChecks).toHaveBeenCalled()
     })
@@ -117,9 +117,9 @@ describe('Reorderable list component', function () {
     var reorderableList
     var sortable
     beforeEach(function () {
-      reorderableList = new GOVUK.Modules.ReorderableList()
-      reorderableList.start($(element))
-      spyOnEvent($(element), 'reorder-drag')
+      reorderableList = new GOVUK.Modules.ReorderableList(element)
+      reorderableList.init()
+      spyOnEvent(element, 'reorder-drag')
       sortable = reorderableList.sortable
       sortable.sort(sortable.toArray().reverse())
       sortable.options.onSort() // not triggered by 'sort'
@@ -140,7 +140,7 @@ describe('Reorderable list component', function () {
     })
 
     it('should trigger a reorder-drag event', function () {
-      expect('reorder-drag').toHaveBeenTriggeredOn($(element))
+      expect('reorder-drag').toHaveBeenTriggeredOn(element)
     })
   })
 
@@ -148,8 +148,8 @@ describe('Reorderable list component', function () {
     var reorderableList
     var firstItemDownButton
     beforeEach(function () {
-      reorderableList = new GOVUK.Modules.ReorderableList()
-      reorderableList.start($(element))
+      reorderableList = new GOVUK.Modules.ReorderableList(element)
+      reorderableList.init()
       firstItemDownButton = document.querySelector('li:nth-child(1) .js-reorderable-list-down')
       spyOnEvent(firstItemDownButton, 'reorder-move-down')
       firstItemDownButton.click()
@@ -178,8 +178,8 @@ describe('Reorderable list component', function () {
     var reorderableList
     var secondItemUpButton
     beforeEach(function () {
-      reorderableList = new GOVUK.Modules.ReorderableList()
-      reorderableList.start($(element))
+      reorderableList = new GOVUK.Modules.ReorderableList(element)
+      reorderableList.init()
       secondItemUpButton = document.querySelector('li:nth-child(2) .js-reorderable-list-up')
       spyOnEvent(secondItemUpButton, 'reorder-move-up')
       secondItemUpButton.click()

--- a/spec/javascripts/components/show-password-spec.js
+++ b/spec/javascripts/components/show-password-spec.js
@@ -14,7 +14,7 @@ describe('A show password component', function () {
           '</div>' +
         '</div>'
       )
-      new GOVUK.Modules.ShowPassword().start(element)
+      new GOVUK.Modules.ShowPassword(element[0]).init()
     })
 
     afterEach(function () {
@@ -67,7 +67,7 @@ describe('A show password component', function () {
         '</form>'
       )
       $('body').append(element)
-      new GOVUK.Modules.ShowPassword().start(element.find('.gem-c-show-password'))
+      new GOVUK.Modules.ShowPassword(element.find('.gem-c-show-password')[0]).init()
       $('body').on('submit', function (e) {
         e.preventDefault()
       })
@@ -104,7 +104,7 @@ describe('A show password component', function () {
         '</form>'
       )
       $('body').append(element)
-      new GOVUK.Modules.ShowPassword().start(element.find('.gem-c-show-password'))
+      new GOVUK.Modules.ShowPassword(element.find('.gem-c-show-password')[0]).init()
       $('body').on('submit', function (e) {
         e.preventDefault()
       })
@@ -137,7 +137,7 @@ describe('A show password component', function () {
           '</div>' +
         '</div>'
       )
-      new GOVUK.Modules.ShowPassword().start(element)
+      new GOVUK.Modules.ShowPassword(element[0]).init()
     })
 
     afterEach(function () {

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -120,7 +120,7 @@ describe('A stepnav module', function () {
 
   beforeEach(function () {
     $element = $(html)
-    new GOVUK.Modules.Gemstepnav().start($element)
+    new GOVUK.Modules.Gemstepnav($element[0]).init()
     expectedstepnavStepCount = $element.find('.gem-c-step-nav__step').length
     expectedstepnavContentCount = $element.find('.gem-c-step-nav__step').first().find('.js-link').length
     expectedstepnavLinkCount = $element.find('.gem-c-step-nav__list-item').length
@@ -378,7 +378,7 @@ describe('A stepnav module', function () {
       $element = $(html)
       $element.attr('data-remember', true)
       $element.addClass('gem-c-step-nav--large')
-      new GOVUK.Modules.Gemstepnav().start($element)
+      new GOVUK.Modules.Gemstepnav($element[0]).init()
     })
 
     afterEach(function () {
@@ -426,7 +426,7 @@ describe('A stepnav module', function () {
       $element.attr('data-remember', true)
       $element.addClass('gem-c-step-nav--large')
       window.sessionStorage.setItem('unique-id', '["topic-step-one","topic-step-three"]')
-      new GOVUK.Modules.Gemstepnav().start($element)
+      new GOVUK.Modules.Gemstepnav($element[0]).init()
     })
 
     afterEach(function () {
@@ -465,7 +465,7 @@ describe('A stepnav module', function () {
       $element.attr('data-remember', true)
       $element.addClass('gem-c-step-nav--large')
       window.sessionStorage.setItem('unique-id', '["topic-step-one","topic-step-two","topic-step-three"]')
-      new GOVUK.Modules.Gemstepnav().start($element)
+      new GOVUK.Modules.Gemstepnav($element[0]).init()
     })
 
     afterEach(function () {
@@ -483,7 +483,7 @@ describe('A stepnav module', function () {
       $element = $(html)
       $element.attr('data-remember', true)
       window.sessionStorage.setItem('unique-id', '["topic-step-one","topic-step-two","topic-step-three"]')
-      new GOVUK.Modules.Gemstepnav().start($element)
+      new GOVUK.Modules.Gemstepnav($element[0]).init()
     })
 
     afterEach(function () {
@@ -508,7 +508,7 @@ describe('A stepnav module', function () {
     beforeEach(function () {
       $element = $(html)
       $element.find('#topic-step-two').attr('data-show', '')
-      new GOVUK.Modules.Gemstepnav().start($element)
+      new GOVUK.Modules.Gemstepnav($element[0]).init()
     })
 
     it('shows the step it\'s supposed to', function () {
@@ -529,7 +529,7 @@ describe('A stepnav module', function () {
     beforeEach(function () {
       $element = $(html)
       $element.addClass('gem-c-step-nav--large')
-      new GOVUK.Modules.Gemstepnav().start($element)
+      new GOVUK.Modules.Gemstepnav($element[0]).init()
     })
 
     it('triggers a google analytics custom event when clicking on the title on a big stepnav', function () {
@@ -679,7 +679,7 @@ describe('A stepnav module', function () {
     beforeEach(function () {
       $element = $(html)
       $element.find('.js-will-be-an-active-link').addClass('gem-c-step-nav__list-item--active')
-      new GOVUK.Modules.Gemstepnav().start($element)
+      new GOVUK.Modules.Gemstepnav($element[0]).init()
     })
 
     afterEach(function () {
@@ -738,7 +738,7 @@ describe('A stepnav module', function () {
       $element = $(html)
       $element.find('.js-will-be-an-active-link').addClass('gem-c-step-nav__list-item--active')
       window.sessionStorage.setItem('govuk-step-nav-active-link_unique-id', '3.5')
-      new GOVUK.Modules.Gemstepnav().start($element)
+      new GOVUK.Modules.Gemstepnav($element[0]).init()
     })
 
     afterEach(function () {
@@ -761,7 +761,7 @@ describe('A stepnav module', function () {
       $element = $(html)
       $element.find('.js-will-be-an-active-link').addClass('gem-c-step-nav__list-item--active')
       window.sessionStorage.setItem('govuk-step-nav-active-link_unique-id', 'definitelynotvalid')
-      new GOVUK.Modules.Gemstepnav().start($element)
+      new GOVUK.Modules.Gemstepnav($element[0]).init()
     })
 
     afterEach(function () {
@@ -780,7 +780,7 @@ describe('A stepnav module', function () {
       $element = $(html)
       $element.find('.js-will-be-an-active-link').addClass('gem-c-step-nav__list-item--active')
       $element.find('.gem-c-step-nav__step').removeClass('gem-c-step-nav__step--active')
-      new GOVUK.Modules.Gemstepnav().start($element)
+      new GOVUK.Modules.Gemstepnav($element[0]).init()
     })
 
     afterEach(function () {
@@ -798,7 +798,7 @@ describe('A stepnav module', function () {
     beforeEach(function () {
       $element = $(html)
       $element.removeAttr('data-id')
-      new GOVUK.Modules.Gemstepnav().start($element)
+      new GOVUK.Modules.Gemstepnav($element[0]).init()
     })
 
     it('triggers a google analytics custom event on show all', function () {


### PR DESCRIPTION
## What
Use the `init` API to initialise modules.

## Why

- To converge to a single JavaScript pattern across GDS (aligning the current scripts with the ones we currently have in `govuk-frontend`)
- To be able to port components upstream (in `govuk-frontend`) without needing to refactor the code
- To initialise [JavaScript modules without requiring jQuery](https://trello.com/c/sghHecNi/91-remove-jquery-dependency)

## Modules in GOV.UK
JavaScript modules in GOV.UK are actually design patterns for keeping pieces of code independent of other components. We currently have 3 design patterns for writing JavaScript in GOV.UK applications.

### GOV.UK Frontend Toolkit Modules
Mostly found in legacy scripts, either migrated from Toolkit, Elements, or written in the same era.
```
GOVUK.Modules.TestModule = function () {
  var that = this
  that.start = function ($element) {
    //
  }
}
```

### GOV.UK Publishing Modules
Found across GOV.UK applications, on relatively new scripts (~2-3 years old). Similar to the `govuk-frontend` approach described below, it relies on the classic prototype pattern but with a `start` function that takes a jQuery object that initialises on.
```
function TestModule () { }
TestModule.prototype.start = function ($element) {
  //
}
```

### GOV.UK Frontend Modules
Used in `govuk-frontend` scripts. Relies on the classic prototype pattern with an  `init` function. The element passed to the constructor function is a standard HTMLElement.
```
function TestModule (element) {
  this.element = element
}
TestModule.prototype.init = function () {
  //
}
```
