### PR TITLE
Move hardcoded strings to locale files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Move all hardcoded text from components into locale files ([PR #2100](https://github.com/alphagov/govuk_publishing_components/pull/2100))
+
 ## 24.11.1
 
 * Update shape of tracking link ([PR #2101](https://github.com/alphagov/govuk_publishing_components/pull/2101))

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -27,7 +27,7 @@
 
   if attachment.number_of_pages
     attributes << tag.span(
-      pluralize(attachment.number_of_pages, "page"),
+      t("components.attachment.page", count: attachment.number_of_pages),
       class: "gem-c-attachment__attribute",
     )
   end
@@ -59,7 +59,7 @@
     <% end %>
 
     <% if attachment.reference.present? %>
-      <%= tag.p "Ref: #{attachment.reference}", class: "gem-c-attachment__metadata gem-c-attachment__metadata--compact" %>
+      <%= tag.p t("components.attachment.reference", reference: attachment.reference), class: "gem-c-attachment__metadata gem-c-attachment__metadata--compact" %>
     <% end %>
 
     <% if attachment.unnumbered_reference.present? %>
@@ -71,7 +71,7 @@
     <% end %>
 
     <% if attachment.is_official_document && !hide_order_copy_link %>
-      <%= tag.p link_to("Order a copy", "https://www.gov.uk/guidance/how-to-buy-printed-copies-of-official-documents", class: "govuk-link govuk-link--no-visited-state", target: "_blank"),
+      <%= tag.p link_to(t("components.attachment.order_a_copy"), "https://www.gov.uk/guidance/how-to-buy-printed-copies-of-official-documents", class: "govuk-link govuk-link--no-visited-state", target: "_blank"),
         class: "gem-c-attachment__metadata" %>
     <% end %>
 

--- a/app/views/govuk_publishing_components/components/_attachment_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment_link.html.erb
@@ -24,7 +24,7 @@
 
   if attachment.number_of_pages
     attributes << tag.span(
-      pluralize(attachment.number_of_pages, "page"),
+      I18n.t("components.attachment.page", count: attachment.number_of_pages),
       class: "gem-c-attachment-link__attribute",
     )
   end

--- a/app/views/govuk_publishing_components/components/_character_count.html.erb
+++ b/app/views/govuk_publishing_components/components/_character_count.html.erb
@@ -18,7 +18,7 @@
     <%= render "govuk_publishing_components/components/textarea", { id: id, character_count: true }.merge(textarea.symbolize_keys) %>
 
     <span id="<%= id %>-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
-      You can enter up to <%= maxlength || maxwords %> <%= maxwords ? 'words' : 'characters' %>
+      <%= t("components.character_count", number: maxlength || maxwords, type: maxwords ? t("components.character_count.type.words") : t("components.character_count.type.characters")) %>
     </span>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -18,7 +18,7 @@
   <% if navigation.content_tagged_to_other_step_by_steps? %>
     <%# Rendering step by step related items because there are a few but not too many of them %>
     <%= render 'govuk_publishing_components/components/step_by_step_nav_related', {
-      pretitle: "Also part of",
+      pretitle: t("components.contextual_sidebar.pretitle"),
       links: navigation.step_nav_helper.also_part_of_step_nav,
       always_display_as_list: true
     } %>

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -1,7 +1,7 @@
 <%
   id ||= 'global-cookie-message'
-  title ||= "Cookies on GOV.UK"
-  text ||= ["We use some essential cookies to make this website work.", "We’d like to set additional cookies to understand how you use GOV.UK, remember your settings and improve government services.", "We also use cookies set by other sites to help us deliver content from their services."]
+  title ||= t("components.cookie_banner.title")
+  text ||= t("components.cookie_banner.text")
   if text.kind_of?(Array)
     newtext = ""
     text.each do |t|
@@ -14,7 +14,17 @@
   text = raw(text)
 
   cookie_preferences_href ||= "/help/cookies"
-  confirmation_message ||= raw("You can <a class='govuk-link' href='#{cookie_preferences_href}' data-module='gem-track-click' data-track-category='cookieBanner' data-track-action='Cookie banner settings clicked from confirmation'>change your cookie settings</a> at any time.")
+  confirmation_message ||= raw(t("components.cookie_banner.confirmation_message",
+                                link: link_to(
+                                  t("components.cookie_banner.confirmation_message_link"),
+                                  cookie_preferences_href,
+                                  class: "govuk-link",
+                                  data: {
+                                    module: "gem-track-click",
+                                    'track-category': "cookieBanner",
+                                    'track-action': "Cookie banner settings clicked from confirmation",
+                                  },
+                                )))
   services_cookies ||= nil
   css_classes = %w(gem-c-cookie-banner govuk-clearfix)
   css_classes << "gem-c-cookie-banner--services" if services_cookies
@@ -50,7 +60,7 @@
           <div class="govuk-button-group">
             <%= render "govuk_publishing_components/components/button", {
                 name: "cookies",
-                text: "Accept additional cookies",
+                text: t("components.cookie_banner.buttons.accept_cookies"),
                 data_attributes: {
                   module: "gem-track-click",
                   "accept-cookies": "true",
@@ -61,7 +71,7 @@
             } %>
             <%= render "govuk_publishing_components/components/button", {
                 name: "cookies",
-                text: "Reject additional cookies",
+                text: t("components.cookie_banner.buttons.reject_cookies"),
                 data_attributes: {
                   module: "gem-track-click",
                   "reject-cookies": "true",
@@ -77,7 +87,7 @@
   <div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1" hidden>
     <p class="gem-c-cookie-banner__confirmation-message" role="alert"><%= confirmation_message %></p>
     <div class="govuk-button-group">
-      <button class="gem-c-cookie-banner__hide-button govuk-button" data-hide-cookie-banner="true" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide this message</button>
+      <button class="gem-c-cookie-banner__hide-button govuk-button" data-hide-cookie-banner="true" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner"><%= t("components.cookie_banner.hide") %></button>
     </div>
   </div>
 </div>

--- a/app/views/govuk_publishing_components/components/_government_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_government_navigation.html.erb
@@ -6,37 +6,37 @@
   <ul id="proposition-links">
     <li>
       <a class="<%= 'active' if active == 'departments' %>" href="/government/organisations">
-        <%= t("components.government_navigation.departments", default: "Departments") %>
+        <%= t("components.government_navigation.departments") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'worldwide' %>" href="/government/world">
-        <%= t("components.government_navigation.worldwide", default: "Worldwide") %>
+        <%= t("components.government_navigation.worldwide") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'how-government-works' %>" href="/government/how-government-works">
-        <%= t("components.government_navigation.how-government-works", default: "How government works") %>
+        <%= t("components.government_navigation.how-government-works") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'get-involved' %>" href="/government/get-involved">
-        <%= t("components.government_navigation.get-involved", default: "Get involved") %>
+        <%= t("components.government_navigation.get-involved") %>
       </a>
     </li>
     <li class="clear-child">
       <a class="<%= 'active' if active == 'consultations' %>" href="<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>">
-        <%= t("components.government_navigation.consultations", default: "Consultations") %>
+        <%= t("components.government_navigation.consultations") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'statistics' %>" href="/search/research-and-statistics">
-        <%= t("components.government_navigation.statistics", default: "Statistics") %>
+        <%= t("components.government_navigation.statistics") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'announcements' %>" href="/news-and-communications">
-        <%= t("components.government_navigation.news_and_communications", default: "News and communications") %>
+        <%= t("components.government_navigation.news_and_communications") %>
       </a>
     </li>
   </ul>

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -59,7 +59,7 @@
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         <% if meta.any? %>
-          <h2 class="govuk-visually-hidden">Support links</h2>
+          <h2 class="govuk-visually-hidden"><%= t("components.layout_footer.support_links") %></h2>
           <ul class="govuk-footer__inline-list govuk-!-display-none-print">
             <% meta[:items].each do |item| %>
               <li class="govuk-footer__inline-list-item">
@@ -79,16 +79,11 @@
           />
         </svg>
         <span class="govuk-footer__licence-description">
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
+          <%= t("components.layout_footer.licence_html") %>
         </span>
       </div>
       <div class="govuk-footer__meta-item">
-        <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
+        <%= t("components.layout_footer.copyright_html") %>
       </div>
     </div>
   </div>

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -18,27 +18,27 @@
 <%= content_tag :div, class: classes, data: { module: "gem-toggle" } do %>
   <dl data-module="gem-track-click">
     <% if from.any? %>
-      <dt class="gem-c-metadata__term"><%= t("components.metadata.from", default: "From") %>:</dt>
+      <dt class="gem-c-metadata__term"><%= t("components.metadata.from") %>:</dt>
       <dd class="gem-c-metadata__definition">
         <%= render 'govuk_publishing_components/components/metadata/sentence', items: from, toggle_id: "from-#{SecureRandom.hex(4)}" %>
       </dd>
     <% end %>
     <% if part_of.any? %>
-      <dt class="gem-c-metadata__term"><%= t("components.metadata.part_of", default: "Part of") %>:</dt>
+      <dt class="gem-c-metadata__term"><%= t("components.metadata.part_of") %>:</dt>
       <dd class="gem-c-metadata__definition">
         <%= render 'govuk_publishing_components/components/metadata/sentence', items: part_of, toggle_id: "part-of-#{SecureRandom.hex(4)}" %>
       </dd>
     <% end %>
     <% if local_assigns.include?(:history) %>
-      <dt class="gem-c-metadata__term"><%= t("components.metadata.history", default: "History") %>:</dt>
+      <dt class="gem-c-metadata__term"><%= t("components.metadata.history") %>:</dt>
       <dd class="gem-c-metadata__definition"><%= history %></dd>
     <% end %>
     <% if local_assigns.include?(:first_published) && first_published %>
-      <dt class="gem-c-metadata__term"><%= t("components.metadata.published", default: "Published") %></dt>
+      <dt class="gem-c-metadata__term"><%= t("components.metadata.published") %></dt>
       <dd class="gem-c-metadata__definition"><%= first_published %></dd>
     <% end %>
     <% if local_assigns.include?(:last_updated) && last_updated %>
-      <dt class="gem-c-metadata__term"><%= t("components.metadata.last_updated", default: "Last updated") %></dt>
+      <dt class="gem-c-metadata__term"><%= t("components.metadata.last_updated") %></dt>
       <dd class="gem-c-metadata__definition">
         <%= last_updated %>
         <% if local_assigns.include?(:see_updates_link) %>
@@ -46,7 +46,7 @@
                              data-track-category="content-history"
                              data-track-action="see-all-updates-link-clicked"
                              data-track-label="history">
-            <%= t("components.metadata.see_all_updates", default: "see all updates") %>
+            <%= t("components.metadata.see_all_updates") %>
           </a>
         <% end %>
       </dd>

--- a/app/views/govuk_publishing_components/components/_modal_dialogue.html.erb
+++ b/app/views/govuk_publishing_components/components/_modal_dialogue.html.erb
@@ -18,6 +18,6 @@
       </svg>
     <% end %>
     <%= tag.div yield, class: "gem-c-modal-dialogue__content" %>
-    <%= tag.button "×", class: "gem-c-modal-dialogue__close-button", aria: { label: "Close modal dialogue" } %>
+    <%= tag.button "×", class: "gem-c-modal-dialogue__close-button", aria: { label: t("components.modal_dialogue.close_modal") } %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
@@ -2,7 +2,7 @@
 <nav
   class="gem-c-pagination"
   role="navigation"
-  aria-label="<%= t("components.previous_and_next_navigation.pagination", default: "Pagination") %>"
+  aria-label="<%= t("components.previous_and_next_navigation.pagination") %>"
 >
   <ul class="gem-c-pagination__list" data-module="gem-track-click">
     <% if local_assigns.include?(:previous_page) %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
@@ -22,10 +22,10 @@
     class="gem-c-step-nav js-hidden <% if small %>govuk-!-display-none-print<% end %> <% unless small %>gem-c-step-nav--large<% end %>"
     <%= "data-remember" if remember_last_step %>
     <%= "data-id=#{tracking_id}" if tracking_id %>
-    data-show-text="<%= t("components.step_by_step_nav.show", default: "show") %>"
-    data-hide-text="<%= t("components.step_by_step_nav.hide", default: "hide") %>"
-    data-show-all-text="<%= t("components.step_by_step_nav.show_all", default: "Show all steps") %>"
-    data-hide-all-text="<%= t("components.step_by_step_nav.hide_all", default: "Hide all steps") %>"
+    data-show-text="<%= t("components.step_by_step_nav.show") %>"
+    data-hide-text="<%= t("components.step_by_step_nav.hide") %>"
+    data-show-all-text="<%= t("components.step_by_step_nav.show_all") %>"
+    data-hide-all-text="<%= t("components.step_by_step_nav.hide_all") %>"
   >
     <ol class="gem-c-step-nav__steps">
       <% steps.each_with_index do |step, step_index| %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -1,6 +1,6 @@
 <%
   links ||= []
-  pretitle ||= t("components.step_by_step_nav_related.part_of", default: "Part of")
+  pretitle ||= t("components.step_by_step_nav_related.part_of")
   always_display_as_list ||= false
 %>
 <% if links.any? %>

--- a/app/views/govuk_publishing_components/components/_subscription_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription_links.html.erb
@@ -23,7 +23,7 @@
 <% if sl_helper.component_data_is_valid? %>
   <%= tag.section class: css_classes, data: data do %>
     <% unless hide_heading %>
-      <h2 class="gem-c-subscription-links__hidden-header visuallyhidden"><%= t("components.subscription_links.subscriptions", default: "Subscriptions") %></h2>
+      <h2 class="gem-c-subscription-links__hidden-header visuallyhidden"><%= t("components.subscription_links.subscriptions") %></h2>
     <% end %>
     <ul
       class="gem-c-subscription-links__list<%= ' gem-c-subscription-links__list--small' if local_assigns[:small_form] == true %>"

--- a/app/views/govuk_publishing_components/components/_subscription_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription_links.html.erb
@@ -70,7 +70,7 @@
         <div lang="en">
           <%= render "govuk_publishing_components/components/input", {
             label: {
-              text: "Copy and paste this URL into your feed reader"
+              text: t("components.subscription_links.feed_link_label"),
             },
             name: "feed-reader-box",
             value: feed_link_box_value

--- a/app/views/govuk_publishing_components/components/_success_alert.html.erb
+++ b/app/views/govuk_publishing_components/components/_success_alert.html.erb
@@ -13,7 +13,7 @@
     module: "initial-focus",
   } do %>
   <div class="govuk-notification-banner__header">
-    <%= tag.h2 t("components.success_alert.success", default: "Success"), class: "govuk-notification-banner__title", id: title_id %>
+    <%= tag.h2 t("components.success_alert.success"), class: "govuk-notification-banner__title", id: title_id %>
   </div>
   <div class="govuk-notification-banner__content">
     <% if description.present? %>

--- a/app/views/govuk_publishing_components/components/_tabs.html.erb
+++ b/app/views/govuk_publishing_components/components/_tabs.html.erb
@@ -8,7 +8,7 @@
 <% if tabs.count > 1 %>
   <div class="govuk-tabs gem-c-tabs" data-module="govuk-tabs">
     <h2 class="govuk-tabs__title">
-      Contents
+      <%= t("components.tabs.contents") %>
     </h2>
     <ul class="govuk-tabs__list">
       <% tabs.each do |tab| %>

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -10,7 +10,7 @@
     data-track-action="GOV.UK Close Form"
     aria-controls="something-is-wrong"
     aria-expanded="true">
-    <%= t("components.feedback.close", default: "Close") %>
+    <%= t("components.feedback.close") %>
   </button>
 
   <div class="govuk-grid-row">
@@ -19,12 +19,12 @@
 
       <input type="hidden" name="url" value="<%= url_without_pii %>">
 
-      <h3 class="gem-c-feedback__form-heading"><%= t("components.feedback.help_us_improve_govuk", default: "Help us improve GOV.UK") %></h3>
-      <p id="feedback_explanation" class="gem-c-feedback__form-paragraph"><%= t("components.feedback.dont_include_personal_info", default: "Don’t include personal or financial information like your National Insurance number or credit card details.") %></p>
+      <h3 class="gem-c-feedback__form-heading"><%= t("components.feedback.help_us_improve_govuk") %></h3>
+      <p id="feedback_explanation" class="gem-c-feedback__form-paragraph"><%= t("components.feedback.dont_include_personal_info") %></p>
 
       <%= render "govuk_publishing_components/components/input", {
         label: {
-          text: t("components.feedback.what_doing", default: "What were you doing?")
+          text: t("components.feedback.what_doing")
         },
         name: "what_doing",
         describedby: "feedback_explanation"
@@ -32,13 +32,13 @@
 
       <%= render "govuk_publishing_components/components/input", {
         label: {
-          text: t("components.feedback.what_wrong", default: "What went wrong?")
+          text: t("components.feedback.what_wrong")
         },
         name: "what_wrong"
       } %>
 
       <%= render "govuk_publishing_components/components/button", {
-        text: t("components.feedback.send", default: "Send")
+        text: t("components.feedback.send")
       } %>
     </div>
   </div>

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -10,7 +10,7 @@
     data-track-action="ffFormClose"
     aria-controls="page-is-not-useful"
     aria-expanded="true">
-    <%= t("components.feedback.close", default: "Close") %>
+    <%= t("components.feedback.close") %>
   </button>
 
   <div class="govuk-grid-row">
@@ -20,12 +20,12 @@
       <input name="email_survey_signup[survey_id]" type="hidden" value="footer_satisfaction_survey">
       <input name="email_survey_signup[survey_source]" type="hidden" value="<%= path_without_pii %>">
 
-      <h3 class="gem-c-feedback__form-heading"><%= t("components.feedback.help_us_improve_govuk", default: "Help us improve GOV.UK") %></h3>
-      <p id="survey_explanation" class="gem-c-feedback__form-paragraph"><%= t("components.feedback.more_about_visit", default: "To help us improve GOV.UK, we’d like to know more about your visit today. We’ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don’t worry we won’t send you spam or share your email address with anyone.") %></p>
+      <h3 class="gem-c-feedback__form-heading"><%= t("components.feedback.help_us_improve_govuk") %></h3>
+      <p id="survey_explanation" class="gem-c-feedback__form-paragraph"><%= t("components.feedback.more_about_visit") %></p>
 
       <%= render "govuk_publishing_components/components/input", {
         label: {
-          text: t("components.feedback.email_address", default: "Email address")
+          text: t("components.feedback.email_address")
         },
         name: "email_survey_signup[email_address]",
         type: "email",
@@ -34,7 +34,7 @@
       } %>
 
        <%= render "govuk_publishing_components/components/button", {
-        text: t("components.feedback.send_me_survey", default: "Send me the survey"),
+        text: t("components.feedback.send_me_survey"),
       } %>
     </div>
   </div>

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -4,31 +4,31 @@
 
 <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
   <div class="gem-c-feedback__prompt-questions js-prompt-questions">
-    <h2 class="gem-c-feedback__prompt-question"><%= t("components.feedback.is_this_page_useful", default: "Is this page useful?") %></h2>
+    <h2 class="gem-c-feedback__prompt-question"><%= t("components.feedback.is_this_page_useful") %></h2>
     <!-- Maybe button exists only to try and capture clicks by bots -->
     <button data-track-category="yesNoFeedbackForm" data-track-action="ffMaybeClick" aria-expanded="false" style="display: none" hidden="hidden" aria-hidden="true">
-      <%= t("components.feedback.maybe", default: "Maybe") %>
+      <%= t("components.feedback.maybe") %>
     </button>
     
     <ul class="gem-c-feedback__option-list">
       <li class="gem-c-feedback__option-list-item">
         <button class="govuk-button gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">
-          <%= t("components.feedback.yes", default: "Yes") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_useful", default: "this page is useful") %></span>
+          <%= t("components.feedback.yes") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_useful") %></span>
         </button>
       </li>
       <li class="gem-c-feedback__option-list-item">
         <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">
-          <%= t("components.feedback.no", default: "No") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_not_useful", default: "this page is not useful") %></span>
+          <%= t("components.feedback.no") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_not_useful") %></span>
         </button>
       </li>
     </ul>
   </div>
   <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-success js-prompt-success js-hidden" role="alert">
-    <%= t("components.feedback.thank_you_for_feedback", default: "Thank you for your feedback") %>
+    <%= t("components.feedback.thank_you_for_feedback") %>
   </div>
   <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions">
     <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV-UK Open Form" aria-controls="something-is-wrong" aria-expanded="false">
-      <%= t("components.feedback.something_wrong", default: "Report a problem with this page") %>
+      <%= t("components.feedback.something_wrong") %>
     </button>
   </div>
 </div>

--- a/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
+++ b/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
@@ -13,8 +13,8 @@
        class="gem-c-metadata__definition-link govuk-!-display-none-print"
        data-controls="toggle-<%= toggle_id %>"
        data-expanded="false"
-       data-toggled-text="<%= t("components.metadata.toggle_less", default: "Show fewer") %>">
-        <%= t("components.metadata.toggle_more", number: remaining.length, default: "+ #{remaining.length} more") %>
+       data-toggled-text="<%= t("components.metadata.toggle_less") %>">
+        <%= t("components.metadata.toggle_more", number: remaining.length) %>
     </a>
   </div>
   <span id="toggle-<%= toggle_id %>" class="gem-c-metadata__toggle-items js-hidden"><%= remaining.to_sentence.html_safe %></span>

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -54,7 +54,7 @@
           class="gem-c-related-navigation__toggle"
           data-controls="toggle_<%= section_title %>"
           data-expanded="false"
-          data-toggled-text="<%= t("components.metadata.toggle_less", default: "Show fewer") %>">
+          data-toggled-text="<%= t("components.metadata.toggle_less") %>">
           <%= t("components.metadata.toggle_more",
                 number: related_nav_helper.remaining_link_count(links),
                 default: "+ #{related_nav_helper.remaining_link_count(links)} more") %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -13,15 +13,36 @@ ar:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ ar:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ ar:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ ar:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ ar:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -13,15 +13,36 @@ az:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ az:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ az:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ az:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ az:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -13,15 +13,36 @@ be:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ be:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ be:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ be:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ be:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -13,15 +13,36 @@ bg:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ bg:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ bg:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ bg:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ bg:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -13,15 +13,36 @@ bn:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ bn:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ bn:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ bn:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ bn:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -13,15 +13,36 @@ cs:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ cs:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ cs:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ cs:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ cs:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -13,15 +13,36 @@ cy:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back: Yn ôl
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents: Cynnwys
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ cy:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ cy:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ cy:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ cy:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -13,15 +13,36 @@ da:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ da:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ da:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ da:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ da:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -13,15 +13,36 @@ de:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ de:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ de:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ de:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ de:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -13,15 +13,36 @@ dr:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ dr:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ dr:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ dr:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ dr:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -13,15 +13,36 @@ el:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ el:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ el:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ el:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ el:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,18 @@ en:
       contents: Contents
     contextual_sidebar:
       pretitle: Also part of
+    cookie_banner:
+      buttons:
+        accept_cookies: Accept additional cookies
+        reject_cookies: Reject additional cookies
+      hide: Hide this message
+      text:
+        - We use some essential cookies to make this website work.
+        - We’d like to set additional cookies to understand how you use GOV.UK, remember your settings and improve government services.
+        - We also use cookies set by other sites to help us deliver content from their services.
+      confirmation_message: You can %{link} at any time.
+      confirmation_message_link: change your cookie settings
+      title: Cookies on GOV.UK
     feedback:
       close: Close
       dont_include_personal_info: Don’t include personal or financial information

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -155,6 +155,7 @@ en:
       part_of: Part of
     subscription_links:
       email_signup_link_text: Get emails
+      feed_link_label: Copy and paste this URL into your feed reader
       feed_link_text: Subscribe to feed
       subscriptions: Subscriptions
     success_alert:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,11 @@ en:
     attachment:
       opendocument_html: This file is in an <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation'
         target=%{target} class='govuk-link'>OpenDocument</a> format
+      order_a_copy: Order a copy
+      page:
+        one: 1 page
+        other: '%{count} pages'
+      reference: 'Ref: %{reference}'
       request_format_cta: Request an accessible format.
       request_format_details_html: If you use assistive technology (such as a screen
         reader) and need a version of this document in a more accessible format, please

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,3 +163,5 @@ en:
     summary_list:
       delete: Delete
       edit: Change
+    tabs:
+      contents: Contents

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,10 @@ en:
       news_and_communications: News and communications
       statistics: Statistics
       worldwide: Worldwide
+    layout_footer:
+      copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
+      licence_html: All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+      support_links: Support links
     layout_header:
       hide_button: Hide search
       menu: Menu

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,6 +101,8 @@ en:
       see_all_updates: See all updates
       toggle_less: Show fewer
       toggle_more: "+ %{number} more"
+    modal_dialogue:
+      close_modal: Close modal dialogue
     organisation_schema:
       all_content_search_description: Find all content from %{organisation}
     previous_and_next_navigation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,8 @@ en:
       or: or
     contents_list:
       contents: Contents
+    contextual_sidebar:
+      pretitle: Also part of
     feedback:
       close: Close
       dont_include_personal_info: Don’t include personal or financial information

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,11 @@ en:
       request_format_text: This file may not be suitable for users of assistive technology.
     back_link:
       back: Back
+    character_count:
+      body: You can enter up to %{number} %{type}
+      type:
+        characters: characters
+        words: words
     checkboxes:
       or: or
     contents_list:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,13 +51,13 @@ en:
       what_wrong: What went wrong?
       'yes': 'Yes'
     government_navigation:
-      consultations:
-      departments:
-      get-involved:
-      how-government-works:
-      news_and_communications:
-      statistics:
-      worldwide:
+      consultations: Consultations
+      departments: Departments
+      get-involved: Get involved
+      how-government-works: How government works
+      news_and_communications: News and communications
+      statistics: Statistics
+      worldwide: Worldwide
     layout_header:
       hide_button: Hide search
       menu: Menu
@@ -76,7 +76,7 @@ en:
     organisation_schema:
       all_content_search_description: Find all content from %{organisation}
     previous_and_next_navigation:
-      pagination:
+      pagination: Pagination
     print_link:
       text: Print this page
     radio:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -13,15 +13,36 @@ es-419:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ es-419:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ es-419:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ es-419:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ es-419:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -13,15 +13,36 @@ es:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ es:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ es:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ es:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ es:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -13,15 +13,36 @@ et:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents: Sisukord
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ et:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ et:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ et:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ et:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -13,15 +13,36 @@ fa:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ fa:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ fa:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ fa:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ fa:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -13,15 +13,36 @@ fi:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ fi:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ fi:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ fi:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ fi:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -13,15 +13,36 @@ fr:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents: Contenu
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ fr:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ fr:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ fr:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ fr:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -13,15 +13,36 @@ gd:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ gd:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ gd:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ gd:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ gd:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -13,15 +13,36 @@ gu:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ gu:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ gu:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ gu:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ gu:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -13,15 +13,36 @@ he:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ he:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ he:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ he:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ he:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -13,15 +13,36 @@ hi:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ hi:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ hi:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ hi:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ hi:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -13,15 +13,36 @@ hr:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ hr:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ hr:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ hr:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ hr:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -13,15 +13,36 @@ hu:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ hu:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ hu:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ hu:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ hu:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -13,15 +13,36 @@ hy:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ hy:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ hy:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ hy:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ hy:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -13,15 +13,36 @@ id:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ id:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ id:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ id:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ id:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -13,15 +13,36 @@ is:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ is:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ is:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ is:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ is:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -13,15 +13,36 @@ it:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ it:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ it:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ it:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ it:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,15 +13,36 @@ ja:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ ja:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ ja:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ ja:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ ja:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -13,15 +13,36 @@ ka:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ ka:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ ka:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ ka:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ ka:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -13,15 +13,36 @@ kk:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ kk:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ kk:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ kk:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ kk:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -13,15 +13,36 @@ ko:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ ko:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ ko:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ ko:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ ko:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -13,15 +13,36 @@ lt:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ lt:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ lt:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ lt:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ lt:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -13,15 +13,36 @@ lv:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ lv:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ lv:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ lv:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ lv:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -13,15 +13,36 @@ ms:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ ms:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ ms:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ ms:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ ms:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -13,15 +13,36 @@ mt:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ mt:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ mt:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ mt:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ mt:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -13,15 +13,36 @@ nl:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ nl:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ nl:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ nl:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ nl:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -13,15 +13,36 @@
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -13,15 +13,36 @@ pa-pk:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ pa-pk:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ pa-pk:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ pa-pk:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ pa-pk:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -13,15 +13,36 @@ pa:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ pa:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ pa:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ pa:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ pa:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -13,15 +13,36 @@ pl:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ pl:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ pl:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ pl:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ pl:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -13,15 +13,36 @@ ps:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ ps:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ ps:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ ps:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ ps:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -13,15 +13,36 @@ pt:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ pt:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ pt:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ pt:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ pt:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -13,15 +13,36 @@ ro:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ ro:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ ro:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ ro:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ ro:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -13,15 +13,36 @@ ru:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ ru:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ ru:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ ru:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ ru:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -13,15 +13,36 @@ si:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ si:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ si:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ si:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ si:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -13,15 +13,36 @@ sk:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ sk:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ sk:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ sk:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ sk:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -13,15 +13,36 @@ sl:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ sl:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ sl:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ sl:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ sl:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -13,15 +13,36 @@ so:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ so:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ so:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ so:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ so:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -13,15 +13,36 @@ sq:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ sq:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ sq:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ sq:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ sq:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -13,15 +13,36 @@ sr:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ sr:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ sr:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ sr:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ sr:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -13,15 +13,36 @@ sv:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ sv:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ sv:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ sv:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ sv:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -13,15 +13,36 @@ sw:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ sw:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ sw:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ sw:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ sw:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -13,15 +13,36 @@ ta:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ ta:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ ta:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ ta:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ ta:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -13,15 +13,36 @@ th:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ th:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ th:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ th:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ th:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -13,15 +13,36 @@ tk:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ tk:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ tk:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ tk:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ tk:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -13,15 +13,36 @@ tr:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ tr:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ tr:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ tr:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ tr:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -13,15 +13,36 @@ uk:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ uk:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ uk:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ uk:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ uk:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -13,15 +13,36 @@ ur:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ ur:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ ur:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ ur:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ ur:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -13,15 +13,36 @@ uz:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ uz:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ uz:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ uz:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ uz:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -13,15 +13,36 @@ vi:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ vi:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ vi:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ vi:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ vi:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -13,15 +13,36 @@ zh-hk:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ zh-hk:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ zh-hk:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ zh-hk:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ zh-hk:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -13,15 +13,36 @@ zh-tw:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ zh-tw:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ zh-tw:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ zh-tw:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ zh-tw:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -13,15 +13,36 @@ zh:
       scoped_search_description:
     attachment:
       opendocument_html:
+      order_a_copy:
+      page:
+        one:
+        other:
+      reference:
       request_format_cta:
       request_format_details_html:
       request_format_text:
     back_link:
       back:
+    character_count:
+      body:
+      type:
+        characters:
+        words:
     checkboxes:
       or:
     contents_list:
       contents:
+    contextual_sidebar:
+      pretitle:
+    cookie_banner:
+      buttons:
+        accept_cookies:
+        reject_cookies:
+      confirmation_message:
+      confirmation_message_link:
+      hide:
+      text:
+      title:
     feedback:
       close:
       dont_include_personal_info:
@@ -48,6 +69,10 @@ zh:
       news_and_communications:
       statistics:
       worldwide:
+    layout_footer:
+      copyright_html:
+      licence_html:
+      support_links:
     layout_header:
       hide_button:
       menu:
@@ -63,6 +88,8 @@ zh:
       see_all_updates:
       toggle_less:
       toggle_more:
+    modal_dialogue:
+      close_modal:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:
@@ -115,6 +142,7 @@ zh:
       part_of:
     subscription_links:
       email_signup_link_text:
+      feed_link_label:
       feed_link_text:
       subscriptions:
     success_alert:
@@ -122,3 +150,5 @@ zh:
     summary_list:
       delete:
       edit:
+    tabs:
+      contents:


### PR DESCRIPTION
## What

Moves all hardcoded English strings from components to the English locale file and adds placeholder keys for these in all other languages.

I haven't done anything with the component guide, as this is not offered in any other languages.

## Why

This will allow us to gain visibility of content that needs to be translated in order to fully support non-English content on GOV.UK.

## Visual Changes

None.

[Trello card](https://trello.com/c/jEj62y5d)