### PR TITLE
Release 24.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 24.11.1
+
+* Update shape of tracking link ([PR #2101](https://github.com/alphagov/govuk_publishing_components/pull/2101))
+
 ## 24.11.0
 
 * Add `[Withdrawn]` to the beginning of the `og:title` meta tag for withdrawn pages ([PR #2066](https://github.com/alphagov/govuk_publishing_components/pull/2066))
-* Update shape of tracking link ([PR #2101](https://github.com/alphagov/govuk_publishing_components/pull/2101))
 * Fix accordion anchor link navigation bug ([PR #2087](https://github.com/alphagov/govuk_publishing_components/pull/2087))
 * Remove jQuery from the feedback component ([PR #2062](https://github.com/alphagov/govuk_publishing_components/pull/2062))
 * Remove `display: none` rules from component print stylesheets, and use the `govuk-!-display-none-print` class instead. ([PR #1561](https://github.com/alphagov/govuk_publishing_components/pull/1561))
@@ -30,6 +33,7 @@
 * Update scroll tracker config entries ([PR #2052](https://github.com/alphagov/govuk_publishing_components/pull/2052))
 
 ## 24.10.1
+
 * Remove unused i18n keys ([PR #2038](https://github.com/alphagov/govuk_publishing_components/pull/2038))
 * Update postcode regex for PII stripping ([PR #2043](https://github.com/alphagov/govuk_publishing_components/pull/2043))
 * Add legacy `govspeak` class alongside gem-c-govspeak ([PR #2044](https://github.com/alphagov/govuk_publishing_components/pull/2044))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.11.0)
+    govuk_publishing_components (24.11.1)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.11.0".freeze
+  VERSION = "24.11.1".freeze
 end


### PR DESCRIPTION
Releasing fix 
- Update shape of tracking link ([PR #2101](https://github.com/alphagov/govuk_publishing_components/pull/2101))