### PR TITLE
Reset organisation logo margin

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -3,6 +3,9 @@
   font-size: 13px;
   font-weight: 400;
   line-height: 1.35;
+  // When this is a heading the margin needs to be set to stop it from
+  // inheriting the browser's default margin:
+  margin: 0;
 
   @include govuk-media-query($from: tablet) {
     font-size: 18px;

--- a/app/views/govuk_publishing_components/components/_organisation_logo.html.erb
+++ b/app/views/govuk_publishing_components/components/_organisation_logo.html.erb
@@ -6,16 +6,13 @@
   heading_level ||= false
   inline ||= false
 
-  # Check if `heading_level` is a number; if so, check if it's an appropriate
-  # number.
-  use_heading = heading_level.is_a?(Integer) ?
-                  (heading_level >= 1 && heading_level <= 6) :
-                  false
+  # Check if `heading_level` is an appropriate number:
+  use_heading = [*1..6].include?(heading_level)
 
-  # Set the wrapping element to be a heading or a `div`
-  wrapping_element = use_heading ? "h#{heading_level}" : "div"
+  # Set the wrapping element to be a heading or a `div`:
+  wrapping_element = (use_heading ? "h#{heading_level}" : "div").to_sym
 
-  wrapper_classes = %w(gem-c-organisation-logo)
+  wrapper_classes = %w[gem-c-organisation-logo]
   wrapper_classes << brand_helper.brand_class
 
   container_classes = [
@@ -24,10 +21,13 @@
   ]
   container_classes << "gem-c-organisation-logo__container--inline" if inline
 %>
-<<%= wrapping_element %>
-  class="<%= wrapper_classes.join(" ") %>"
-  <%= "data-module=gem-track-click" if organisation[:data_attributes] %>
->
+
+<%= content_tag(wrapping_element, {
+    class: wrapper_classes,
+    data: {
+      module: ("gem-track-click" if organisation[:data_attributes])
+    }
+  }) do %>
   <% if organisation[:url] %>
     <%= link_to organisation[:url],
       class: container_classes.join(" "),
@@ -39,4 +39,4 @@
       <%= logo_helper.logo_content %>
     </div>
   <% end %>
-</<%= wrapping_element %>>
+<% end %>


### PR DESCRIPTION
Setting the organisation's margin to zero as the component inherited the browser's default margins when used as a heading.

Also tidied up the component template to use `content_tag` instead of interpolating the tags, and added a nicer way of checking for an appropriate heading level.

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

 - Set the organisation logo component's margins to zero
 - Swapped to using `content_tag` instead of interpolating the element type
 - Switched to a nice and more readable way of checking that the heading level is appropriate

## Why
<!-- What are the reasons behind this change being made? -->

If used as a heading the organisation logo would inherit the default margin set by the browser - setting it to zero avoids this inheritance.

Previously the outer element was either a `div` or heading element - and this was interpolated (for example `<<% element_type %>>` and `</<% element_type %>>`) - using `content_tag` instead makes this component more readable.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
None.
