### PR TITLE
Add event tracking to search elements in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Don't include changes that are purely internal. The CHANGELOG should be a
   useful summary for people upgrading their application, not a replication
   of the commit log.
+  
+## Unreleased
+
+* Add event tracking to header elements ([#2110](https://github.com/alphagov/govuk_publishing_components/pull/2110) 
 
 ## 24.13.2
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
@@ -21,8 +21,14 @@
 
         if (targetClass.indexOf('js-visible') !== -1) {
           target.setAttribute('class', targetClass.replace(/(^|\s)js-visible(\s|$)/, ''))
+          if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+            window.GOVUK.analytics.trackEvent('headerClicked', 'searchClosed', { label: 'none' } )
+          }
         } else {
           target.setAttribute('class', targetClass + ' js-visible')
+          if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+            window.GOVUK.analytics.trackEvent('headerClicked', 'searchOpened', { label: 'none' } )
+          }
         }
         if (sourceClass.indexOf('js-visible') !== -1) {
           this.setAttribute('class', sourceClass.replace(/(^|\s)js-visible(\s|$)/, ''))

--- a/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
@@ -22,12 +22,12 @@
         if (targetClass.indexOf('js-visible') !== -1) {
           target.setAttribute('class', targetClass.replace(/(^|\s)js-visible(\s|$)/, ''))
           if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
-            window.GOVUK.analytics.trackEvent('headerClicked', 'searchClosed', { label: 'none' } )
+            window.GOVUK.analytics.trackEvent('headerClicked', 'searchClosed', { label: 'none' })
           }
         } else {
           target.setAttribute('class', targetClass + ' js-visible')
           if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
-            window.GOVUK.analytics.trackEvent('headerClicked', 'searchOpened', { label: 'none' } )
+            window.GOVUK.analytics.trackEvent('headerClicked', 'searchOpened', { label: 'none' })
           }
         }
         if (sourceClass.indexOf('js-visible') !== -1) {

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -10,6 +10,9 @@
   size ||= ""
   value ||= ""
 
+  data_attributes ||= {}
+  data_attributes[:module] = 'gem-track-click'
+
   classes = %w[gem-c-search govuk-!-display-none-print]
   classes << (shared_helper.get_margin_top)
   classes << (shared_helper.get_margin_bottom) if local_assigns[:margin_bottom]
@@ -40,9 +43,9 @@
       value: value,
     ) %>
     <div class="gem-c-search__item gem-c-search__submit-wrapper">
-      <button class="gem-c-search__submit" type="submit">
+      <%= tag.button class: "gem-c-search__submit", type: "submit", data: data_attributes do %>
         <%= button_text %>
-      </button>
+      <% end %>
     </div>
   </div>
 </div>

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -85,4 +85,19 @@ describe "Search", type: :view do
     render_component(button_text: "Search please")
     assert_select ".gem-c-search__submit", text: "Search please"
   end
+
+  it "applies data attributes when provided" do
+    render_component(
+      button_text: "Some test text",
+      data_attributes: {
+        track_category: "track-category",
+        track_action: "track-action",
+        track_label: "track-label",
+      },
+    )
+
+    assert_select '.gem-c-search__submit[data-track-category="track-category"]'
+    assert_select '.gem-c-search__submit[data-track-action="track-action"]'
+    assert_select '.gem-c-search__submit[data-track-label="track-label"]'
+  end
 end


### PR DESCRIPTION
## What
Adds click track events on the open/close of the search box in mobile view and the submit button.

## Why
As part of gathering some baseline data ahead of updating the header design.

## Visual Changes
None

[Trello](https://trello.com/c/CwPwNE60/321-implement-analytics-tracking-on-the-existing-headers)
