### PR TITLE
Rename /transition to /brexit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Rename /transition to /brexit ([PR #2112](https://github.com/alphagov/govuk_publishing_components/pull/2112))
+
 ## 24.13.0
 
 * Update link styles for show password component ([PR #2074](https://github.com/alphagov/govuk_publishing_components/pull/2074))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js
@@ -6,7 +6,7 @@
   window.GOVUK = window.GOVUK || {}
 
   var CONFIG = {
-    '/transition': [
+    '/brexit': [
       ['Percent', 20],
       ['Percent', 40],
       ['Percent', 60],

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -116,7 +116,7 @@ cy:
       topical_events:
       topics:
       transition:
-        link_path: "/transition.cy"
+        link_path: "/brexit.cy"
         link_text: Gwiriwch beth sydd angen i chi ei wneud
         title: Brexit
       world_locations:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,7 +129,7 @@ en:
       topical_events: Topical event
       topics: Explore the topic
       transition:
-        link_path: "/transition"
+        link_path: "/brexit"
         link_text: Check what you need to do
         title: Brexit
       world_locations: World locations

--- a/lib/govuk_publishing_components/presenters/public_layout_helper.rb
+++ b/lib/govuk_publishing_components/presenters/public_layout_helper.rb
@@ -24,7 +24,7 @@ module GovukPublishingComponents
           columns: 1,
           items: [
             {
-              href: "/transition",
+              href: "/brexit",
               text: "Check what you need to do",
               attributes: {
                 data: {

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -672,8 +672,8 @@ describe "Contextual navigation" do
   def transition_taxon
     {
       "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
-      "api_path" => "/api/content/transition",
-      "base_path" => "/transition",
+      "api_path" => "/api/content/brexit",
+      "base_path" => "/brexit",
       "title" => "Brexit Transition",
       "locale" => "en",
     }

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
   let(:transition_period_taxon) do
     {
       "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
-      "base_path" => "/transition",
+      "base_path" => "/brexit",
       "title" => "Transition",
     }
   end


### PR DESCRIPTION
We renamed the taxon today to reflect the language that people use. There is a redirect in place so the links will all still work, but the scroll tracking is currently broken because it's fixed to the URL not the content ID.

https://trello.com/c/wxR5o06H/1539-implement-brexit-landing-page-url-change
