### PR TITLE
Bump version to 24.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.13.1
 
 * Rename /transition to /brexit ([PR #2112](https://github.com/alphagov/govuk_publishing_components/pull/2112))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.13.0)
+    govuk_publishing_components (24.13.1)
       govuk_app_config
       kramdown
       plek
@@ -151,7 +151,7 @@ GEM
       selenium-webdriver (~> 3.8)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    kgio (2.11.3)
+    kgio (2.11.4)
     kramdown (2.3.1)
       rexml
     link_header (0.0.8)
@@ -224,7 +224,7 @@ GEM
       rake (>= 0.8.7)
       thor (~> 1.0)
     rainbow (3.0.0)
-    raindrops (0.19.1)
+    raindrops (0.19.2)
     rake (13.0.3)
     regexp_parser (2.1.1)
     request_store (1.5.0)
@@ -324,7 +324,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.7.3)
+    websocket-driver (0.7.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.13.0".freeze
+  VERSION = "24.13.1".freeze
 end


### PR DESCRIPTION
Updates Brexit links in various places, and fixes scroll tracking on /brexit
