### PR TITLE
Add custom tracking action to Brexit superbreadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add custom tracking action to Brexit superbreadcrumbs ([PR #2118](https://github.com/alphagov/govuk_publishing_components/pull/2118))
+
 ## 24.13.2
 
 * Add alternate Brexit callout text ([PR #2115](https://github.com/alphagov/govuk_publishing_components/pull/2115))

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -11,6 +11,12 @@ module GovukPublishingComponents
         transition_period: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       }.freeze
 
+      BREXIT_TAXONS = {
+        brexit: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+        brexit_business: "634fd193-8039-4a70-a059-919c34ff4bfc",
+        brexit_citizen: "614b2e65-56ac-4f8d-bb9c-d1a14167ba25",
+      }.freeze
+
       # Returns the highest priority taxon that has a content_id matching those in PRIORITY_TAXONS
       def self.call(content_item, query_parameters = nil)
         new(content_item, query_parameters).breadcrumbs
@@ -35,7 +41,7 @@ module GovukPublishingComponents
           title: taxon["title"],
           path: taxon["base_path"],
           tracking_category: "breadcrumbClicked",
-          tracking_action: "superBreadcrumb",
+          tracking_action: tracking_action,
           tracking_label: content_item["base_path"],
           tracking_dimension_enabled: false,
         }
@@ -70,6 +76,14 @@ module GovukPublishingComponents
 
       def preferred_priority_taxon
         query_parameters["priority-taxon"] if query_parameters
+      end
+
+      def tracking_action
+        action = %w[superBreadcrumb]
+        action << "Brexitbusiness" if taxon["content_id"] == BREXIT_TAXONS[:brexit_business]
+        action << "Brexitcitizen" if taxon["content_id"] == BREXIT_TAXONS[:brexit_business]
+        action << "Brexitbusinessandcitizen" if taxon["content_id"] == BREXIT_TAXONS[:brexit]
+        action.join(" ")
       end
     end
   end


### PR DESCRIPTION
## What
If the priority taxon is Brexit we want the action to be "superBreadcrumb Brexitbusinessandcitizen". If the priority taxon is one of the Brexit subtaxons (business and citizen), we'd like it to be "superBreadcrumb Brexitbusiness" and "superBreadcrumb Brexitcitizen", respectively.

## Why
To prepare tracking and enable dashboard creation for the new Brexit pages.

[Trello card](https://trello.com/c/RqR5gkX2)

## Visual Changes
No visual changes

## Notes
Manually tested in `government-frontend`; found it challenging to figure out if and where a unit test might be added.