### PR TITLE
Brexit child taxon superbreadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Remove hide-only option from contextual guidance ([PR #2126](https://github.com/alphagov/govuk_publishing_components/pull/2126))
 * Fix click tracking in government_navigation ([PR #2129](https://github.com/alphagov/govuk_publishing_components/pull/2129))
+* Add superbreadcrumb to content tagged to a Brexit child taxon ([PR #2123](https://github.com/alphagov/govuk_publishing_components/pull/2123))
 
 ## 24.13.4
 

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -35,7 +35,7 @@ module GovukPublishingComponents
       def breadcrumbs
         taxon && {
           title: taxon["title"],
-          path: taxon["base_path"],
+          path: breadcrumb_path,
           tracking_category: "breadcrumbClicked",
           tracking_action: tracking_action,
           tracking_label: content_item["base_path"],
@@ -95,6 +95,10 @@ module GovukPublishingComponents
       def tagged_to_both_brexit_child_taxons?
         t = priority_taxons.select { |taxon| brexit_child_taxon?(taxon) }
         t.uniq.count > 1
+      end
+
+      def breadcrumb_path
+        taxon.dig("details", "url_override").present? ? taxon.dig("details", "url_override") : taxon["base_path"]
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -8,13 +8,9 @@ module GovukPublishingComponents
         education_coronavirus: "272308f4-05c8-4d0d-abc7-b7c2e3ccd249",
         worker_coronavirus: "b7f57213-4b16-446d-8ded-81955d782680",
         business_coronavirus: "65666cdf-b177-4d79-9687-b9c32805e450",
-        transition_period: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
-      }.freeze
-
-      BREXIT_TAXONS = {
-        brexit: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
         brexit_business: "634fd193-8039-4a70-a059-919c34ff4bfc",
-        brexit_citizen: "614b2e65-56ac-4f8d-bb9c-d1a14167ba25",
+        brexit_individuals: "614b2e65-56ac-4f8d-bb9c-d1a14167ba25",
+        brexit_taxon: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       }.freeze
 
       # Returns the highest priority taxon that has a content_id matching those in PRIORITY_TAXONS
@@ -52,6 +48,8 @@ module GovukPublishingComponents
       def preferred_taxon
         if preferred_priority_taxon
           priority_taxons.find { |t| t["content_id"] == preferred_priority_taxon }
+        elsif tagged_to_both_brexit_child_taxons?
+          priority_taxons.find { |t| t["content_id"] == PRIORITY_TAXONS[:brexit_taxon] }
         end
       end
 
@@ -74,16 +72,29 @@ module GovukPublishingComponents
         PRIORITY_TAXONS.values.include?(taxon["content_id"])
       end
 
+      def brexit_child_taxon?(taxon)
+        brexit_child_taxons.include?(taxon["content_id"])
+      end
+
+      def brexit_child_taxons
+        [PRIORITY_TAXONS[:brexit_business], PRIORITY_TAXONS[:brexit_individuals]]
+      end
+
       def preferred_priority_taxon
         query_parameters["priority-taxon"] if query_parameters
       end
 
       def tracking_action
         action = %w[superBreadcrumb]
-        action << "Brexitbusiness" if taxon["content_id"] == BREXIT_TAXONS[:brexit_business]
-        action << "Brexitcitizen" if taxon["content_id"] == BREXIT_TAXONS[:brexit_business]
-        action << "Brexitbusinessandcitizen" if taxon["content_id"] == BREXIT_TAXONS[:brexit]
+        action << "Brexitbusiness" if taxon["content_id"] == PRIORITY_TAXONS[:brexit_business]
+        action << "Brexitcitizen" if taxon["content_id"] == PRIORITY_TAXONS[:brexit_individuals]
+        action << "Brexitbusinessandcitizen" if taxon["content_id"] == PRIORITY_TAXONS[:brexit_taxon]
         action.join(" ")
+      end
+
+      def tagged_to_both_brexit_child_taxons?
+        t = priority_taxons.select { |taxon| brexit_child_taxon?(taxon) }
+        t.uniq.count > 1
       end
     end
   end

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -28,6 +28,24 @@ describe "Contextual navigation" do
     and_i_see_the_brexit_call_to_action
   end
 
+  scenario "There is a page tagged to the brexit business child taxon" do
+    given_theres_a_page_tagged_to_the_brexit_business_taxon
+    and_i_visit_that_page
+    then_i_see_the_brexit_business_contextual_breadcrumbs
+  end
+
+  scenario "There is a page tagged to the brexit individuals child taxon" do
+    given_theres_a_page_tagged_to_the_brexit_individuals_taxon
+    and_i_visit_that_page
+    then_i_see_the_brexit_individuals_contextual_breadcrumbs
+  end
+
+  scenario "There is a page tagged to both brexit child taxons" do
+    given_theres_a_page_tagged_to_both_child_taxons
+    and_i_visit_that_page
+    and_i_see_the_brexit_contextual_breadcrumbs
+  end
+
   scenario "There's a step by step list" do
     given_theres_a_page_with_a_step_by_step
     and_i_visit_that_page
@@ -370,6 +388,26 @@ describe "Contextual navigation" do
     )
   end
 
+  def given_theres_a_page_tagged_to_the_brexit_business_taxon
+    tag_page_to_a_taxon(brexit_business_taxon)
+  end
+
+  def given_theres_a_page_tagged_to_the_brexit_individuals_taxon
+    tag_page_to_a_taxon(brexit_individuals_taxon)
+  end
+
+  def given_theres_a_page_tagged_to_both_child_taxons
+    tag_page_to_a_taxon(brexit_individuals_taxon, brexit_business_taxon)
+  end
+
+  def tag_page_to_a_taxon(*taxons)
+    content_store_has_random_item(
+      links: {
+        "taxons" => taxons,
+      },
+    )
+  end
+
   def given_there_is_a_non_step_by_step_parent_page
     @parent = not_step_by_step_content
   end
@@ -556,10 +594,21 @@ describe "Contextual navigation" do
     end
   end
 
-  def and_i_see_the_brexit_contextual_breadcrumbs
-    within ".gem-c-contextual-breadcrumbs" do
-      expect(page).to have_link(brexit_taxon["title"])
+  def and_i_see_the_brexit_contextual_breadcrumbs(taxon = nil)
+    title = taxon.nil? ? brexit_taxon["title"] : taxon["title"]
+
+    within ".gem-c-step-nav-header" do
+      expect(page).to have_content("Part of")
+      expect(page).to have_link(title)
     end
+  end
+
+  def then_i_see_the_brexit_business_contextual_breadcrumbs
+    and_i_see_the_brexit_contextual_breadcrumbs(brexit_business_taxon)
+  end
+
+  def then_i_see_the_brexit_individuals_contextual_breadcrumbs
+    and_i_see_the_brexit_contextual_breadcrumbs(brexit_individuals_taxon)
   end
 
   def and_i_see_the_brexit_call_to_action
@@ -676,6 +725,32 @@ describe "Contextual navigation" do
       "base_path" => "/brexit",
       "title" => "Brexit",
       "locale" => "en",
+    }
+  end
+
+  def brexit_business_taxon
+    {
+      "content_id" => "634fd193-8039-4a70-a059-919c34ff4bfc",
+      "api_path" => "/api/content/brexit/business-guidance",
+      "base_path" => "/brexit/business-guidance",
+      "title" => "Brexit: business guidance",
+      "locale" => "en",
+      "links" => {
+        "parent_taxons" => [brexit_taxon],
+      },
+    }
+  end
+
+  def brexit_individuals_taxon
+    {
+      "content_id" => "614b2e65-56ac-4f8d-bb9c-d1a14167ba25",
+      "api_path" => "/api/content/brexit/guidance-individuals",
+      "base_path" => "/brexit/guidance-individuals",
+      "title" => "Brexit: guidance for individuals",
+      "locale" => "en",
+      "links" => {
+        "parent_taxons" => [brexit_taxon],
+      },
     }
   end
 

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -21,11 +21,11 @@ describe "Contextual navigation" do
     and_i_see_the_coronavirus_contextual_breadcrumbs_for_workers
   end
 
-  scenario "There is a transition taxon" do
-    given_theres_a_page_with_transition_taxon
+  scenario "There is a brexit taxon" do
+    given_theres_a_page_with_brexit_taxon
     and_i_visit_that_page
-    and_i_see_the_transition_contextual_breadcrumbs
-    and_i_see_the_transition_call_to_action
+    and_i_see_the_brexit_contextual_breadcrumbs
+    and_i_see_the_brexit_call_to_action
   end
 
   scenario "There's a step by step list" do
@@ -33,7 +33,7 @@ describe "Contextual navigation" do
     and_i_visit_that_page
     then_i_see_the_step_by_step
     and_the_step_by_step_header
-    and_i_do_not_see_the_transition_call_to_action
+    and_i_do_not_see_the_brexit_call_to_action
   end
 
   scenario "There's more than one step by step" do
@@ -98,13 +98,13 @@ describe "Contextual navigation" do
     and_i_see_the_coronavirus_contextual_breadcrumbs_for_business
   end
 
-  scenario "A page is tagged to the transition taxon and a step_by_step" do
-    given_theres_a_page_with_transition_taxon_tagged_to_step_by_step
+  scenario "A page is tagged to the brexit taxon and a step_by_step" do
+    given_theres_a_page_with_brexit_taxon_tagged_to_step_by_step
     and_i_visit_that_page
     then_i_see_the_step_by_step
     and_the_step_by_step_header
-    and_i_do_not_see_the_transition_contextual_breadcrumbs
-    and_i_see_the_transition_call_to_action
+    and_i_do_not_see_the_brexit_contextual_breadcrumbs
+    and_i_see_the_brexit_call_to_action
   end
 
   scenario "It's a HTML Publication with a parent with breadcrumbs" do
@@ -351,13 +351,13 @@ describe "Contextual navigation" do
     )
   end
 
-  def given_theres_a_page_with_transition_taxon_tagged_to_step_by_step
-    given_theres_a_page_with_transition_taxon(part_of_step_navs: true)
+  def given_theres_a_page_with_brexit_taxon_tagged_to_step_by_step
+    given_theres_a_page_with_brexit_taxon(part_of_step_navs: true)
   end
 
-  def given_theres_a_page_with_transition_taxon(part_of_step_navs: nil)
+  def given_theres_a_page_with_brexit_taxon(part_of_step_navs: nil)
     live_taxon = taxon_item
-    live_taxon["links"]["parent_taxons"] = [transition_taxon]
+    live_taxon["links"]["parent_taxons"] = [brexit_taxon]
     links = { "taxons" => [live_taxon] }
 
     if part_of_step_navs == true
@@ -550,26 +550,26 @@ describe "Contextual navigation" do
     end
   end
 
-  def and_i_do_not_see_the_transition_contextual_breadcrumbs
+  def and_i_do_not_see_the_brexit_contextual_breadcrumbs
     within ".gem-c-contextual-breadcrumbs" do
-      expect(page).not_to have_link(transition_taxon["title"])
+      expect(page).not_to have_link(brexit_taxon["title"])
     end
   end
 
-  def and_i_see_the_transition_contextual_breadcrumbs
+  def and_i_see_the_brexit_contextual_breadcrumbs
     within ".gem-c-contextual-breadcrumbs" do
-      expect(page).to have_link(transition_taxon["title"])
+      expect(page).to have_link(brexit_taxon["title"])
     end
   end
 
-  def and_i_see_the_transition_call_to_action
+  def and_i_see_the_brexit_call_to_action
     within ".gem-c-contextual-sidebar" do
       expect(page).to have_selector(".gem-c-contextual-sidebar__brexit-cta")
       expect(page).to have_css(".gem-c-contextual-sidebar__brexit-heading", text: I18n.t("components.related_navigation.transition.title"))
     end
   end
 
-  def and_i_do_not_see_the_transition_call_to_action
+  def and_i_do_not_see_the_brexit_call_to_action
     within ".gem-c-contextual-sidebar" do
       expect(page).not_to have_selector(".gem-c-contextual-sidebar__brexit-cta")
     end
@@ -669,12 +669,12 @@ describe "Contextual navigation" do
     }
   end
 
-  def transition_taxon
+  def brexit_taxon
     {
       "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       "api_path" => "/api/content/brexit",
       "base_path" => "/brexit",
-      "title" => "Brexit Transition",
+      "title" => "Brexit",
       "locale" => "en",
     }
   end

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -25,11 +25,33 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
     }
   end
 
-  let(:transition_period_taxon) do
+  let(:brexit_taxon) do
     {
       "content_id" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       "base_path" => "/brexit",
-      "title" => "Transition",
+      "title" => "Brexit",
+    }
+  end
+
+  let(:brexit_business_taxon) do
+    {
+      "content_id" => "634fd193-8039-4a70-a059-919c34ff4bfc",
+      "base_path" => "/brexit/business-guidance",
+      "title" => "Brexit: business guidance",
+      "details" => {
+        "url_override" => "/guidance/brexit-guidance-for-businesses",
+      },
+    }
+  end
+
+  let(:brexit_individuals_taxon) do
+    {
+      "content_id" => "614b2e65-56ac-4f8d-bb9c-d1a14167ba25",
+      "base_path" => "/brexit/guidance-individuals",
+      "title" => "Brexit: guidance for individuals",
+      "details" => {
+        "url_override" => "/guidance/brexit-guidance-for-individuals",
+      },
     }
   end
 
@@ -68,11 +90,11 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
           end
         end
 
-        context "with transition taxon" do
-          let(:payload) { [transition_period_taxon] }
+        context "with brexit taxon" do
+          let(:payload) { [brexit_taxon] }
 
           it "returns the worker taxon" do
-            expect(subject.taxon).to eq(transition_period_taxon)
+            expect(subject.taxon).to eq(brexit_taxon)
           end
         end
 
@@ -81,6 +103,30 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
 
           it "returns the education taxon" do
             expect(subject.taxon).to eq(education_taxon)
+          end
+        end
+
+        context "with brexit_taxon taxon and brexit_individuals taxon" do
+          let(:payload) { [brexit_taxon, brexit_individuals_taxon] }
+
+          it "returns the brexit_individuals taxon" do
+            expect(subject.taxon).to eq(brexit_individuals_taxon)
+          end
+        end
+
+        context "with brexit_taxon taxon and brexit_business taxon" do
+          let(:payload) { [brexit_taxon, brexit_business_taxon] }
+
+          it "returns the brexit_business taxon" do
+            expect(subject.taxon).to eq(brexit_business_taxon)
+          end
+        end
+
+        context "with brexit_individuals taxon and brexit_business taxon" do
+          let(:payload) { [brexit_taxon, brexit_individuals_taxon, brexit_business_taxon] }
+
+          it "returns the brexit_taxon taxon" do
+            expect(subject.taxon).to eq(brexit_taxon)
           end
         end
 

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -167,6 +167,19 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
         it "returns the matching taxon" do
           expect(described_class.call(content)).to eq(breadcrumb_for(content, education_taxon))
         end
+
+        context "with a url_override field present" do
+          let(:content) { send(tagged_to_taxons, [brexit_individuals_taxon]) }
+          let(:url_override) { brexit_individuals_taxon["details"]["url_override"] }
+
+          it "it replaces the base path" do
+            breadcrumbs = breadcrumb_for(content, brexit_individuals_taxon)
+            breadcrumbs[:path] = url_override
+            breadcrumbs[:tracking_action] = "superBreadcrumb Brexitcitizen"
+
+            expect(described_class.call(content)).to eq(breadcrumbs)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## What
Add a super bread crumb to content tagged to the [brexit](https://content-tagger.publishing.service.gov.uk/taxons/634fd193-8039-4a70-a059-919c34ff4bfc) [child](https://content-tagger.publishing.service.gov.uk/taxons/614b2e65-56ac-4f8d-bb9c-d1a14167ba25) taxons.

## Why
We think it is more useful to direct users to either the Brexit business page, or the Brexit individuals page, rather than the Brexit landing page. 

## Visual Changes
 
- ### Tagged to Brexit parent taxon OR tagged to both child taxons

<img width="937" alt="Screenshot 2021-06-08 at 20 45 41" src="https://user-images.githubusercontent.com/17908089/121247740-819cfc80-c89a-11eb-9fb8-41207fa59f48.png">

- ### Tagged to Brexit: guidance for individuals

<img width="1032" alt="Screenshot 2021-06-08 at 20 43 06" src="https://user-images.githubusercontent.com/17908089/121247513-3f73bb00-c89a-11eb-868a-2e14efd0953f.png">

- ### Tagged to Brexit: guidance for businesses

<img width="1014" alt="Screenshot 2021-06-08 at 20 47 59" src="https://user-images.githubusercontent.com/17908089/121248052-dcceef00-c89a-11eb-8f36-eaeb734a464c.png">

