### PR TITLE
Remove hide-only option from contextual guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 - Don't include changes that are purely internal. The CHANGELOG should be a
   useful summary for people upgrading their application, not a replication
   of the commit log.
-  
+
 ## Unreleased
 
+* Remove hide-only option from contextual guidance ([PR #2126](https://github.com/alphagov/govuk_publishing_components/pull/2126))
 * Fix click tracking in government_navigation ([PR #2129](https://github.com/alphagov/govuk_publishing_components/pull/2129))
 
 ## 24.13.4

--- a/app/assets/javascripts/govuk_publishing_components/components/contextual-guidance.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/contextual-guidance.js
@@ -15,9 +15,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   ContextualGuidance.prototype.handleFocus = function (event) {
     this.hideAllGuidance()
-    if (!event.target.getAttribute('data-contextual-guidance-hide-only')) {
-      this.$guidance.style.display = 'block'
-    }
+    this.$guidance.style.display = 'block'
   }
 
   ContextualGuidance.prototype.hideAllGuidance = function () {

--- a/spec/javascripts/components/contextual-guidance-spec.js
+++ b/spec/javascripts/components/contextual-guidance-spec.js
@@ -29,27 +29,14 @@ describe('Contextual guidance component', function () {
             '<p>The summary should explain the main point of the story. It is the first line of the story so don’t repeat it in the body and end with a full stop.</p>' +
           '</div>' +
         '</div>' +
-      '</div>' +
-
-      '<div id="document-description-guidance" class="gem-c-contextual-guidance" data-module="contextual-guidance">' +
-        '<textarea id="document-description" class="gem-c-textarea govuk-textarea" data-contextual-guidance-hide-only="true"></textarea>' +
-
-        '<div class="gem-c-contextual-guidance__wrapper" for="document-description">' +
-          '<div class="gem-c-contextual-guidance__guidance">' +
-            '<h2 class="govuk-heading-s">Summary</h2>' +
-            '<p>The description should describe the story.</p>' +
-          '</div>' +
-        '</div>' +
       '</div>'
 
     document.body.classList.add('js-enabled')
     document.body.appendChild(container)
     var titleContextualGuidance = document.getElementById('document-title-guidance')
     var summaryContextualGuidance = document.getElementById('document-summary-guidance')
-    var descriptionContextualGuidance = document.getElementById('document-description-guidance')
     new GOVUK.Modules.ContextualGuidance().start($(titleContextualGuidance))
     new GOVUK.Modules.ContextualGuidance().start($(summaryContextualGuidance))
-    new GOVUK.Modules.ContextualGuidance().start($(descriptionContextualGuidance))
   })
 
   afterEach(function () {
@@ -80,19 +67,5 @@ describe('Contextual guidance component', function () {
 
     expect(titleGuidance.style.display).toEqual('none')
     expect(summaryGuidance.style.display).toEqual('block')
-  })
-
-  it('should not show associated guidance on focus if the hide-only attribute is present', function () {
-    var description = document.getElementById('document-description')
-    var descriptionGuidance = document.querySelector('#document-description-guidance .gem-c-contextual-guidance__wrapper')
-
-    var titleGuidance = document.querySelector('#document-title-guidance .gem-c-contextual-guidance__wrapper')
-    var summaryGuidance = document.querySelector('#document-summary-guidance .gem-c-contextual-guidance__wrapper')
-
-    description.dispatchEvent(new window.Event('focus'))
-
-    expect(titleGuidance.style.display).toEqual('none')
-    expect(summaryGuidance.style.display).toEqual('none')
-    expect(descriptionGuidance.style.display).toEqual('none')
   })
 })


### PR DESCRIPTION
## What / why
As discussed in https://github.com/alphagov/govuk_publishing_components/pull/2090#discussion_r647559873, the contextual guidance component contained an option that wasn't documented, or tested (until very recently, in the same PR) or used. The option allowed contextual guidance to be permanently hidden.

This PR removes that option.

## Visual Changes
None.
