### PR TITLE
Add tracking to government navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add tracking to government navigation ([PR #2127](https://github.com/alphagov/govuk_publishing_components/pull/2127))
 * Make jasmine tests pass in Internet Explorer ([PR #2090](https://github.com/alphagov/govuk_publishing_components/pull/2090))
 
 ## 24.13.3

--- a/app/views/govuk_publishing_components/components/_government_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_government_navigation.html.erb
@@ -5,37 +5,79 @@
 <nav id="proposition-menu" class="no-proposition-name gem-c-government-navigation" aria-label="Departments and policy navigation">
   <ul id="proposition-links">
     <li>
-      <a class="<%= 'active' if active == 'departments' %> govuk-link govuk-link--no-underline govuk-link--inverse" href="/government/organisations">
+      <a class="<%= 'active' if active == 'departments' %> govuk-link govuk-link--no-underline govuk-link--inverse"
+         data-track-category="headerClicked"
+         data-track-action="departmentsLink"
+         data-track-label="/government/organisations"
+         data-track-dimension="<%= t("components.government_navigation.departments") %>"
+         data-track-dimension-index="29"
+         href="/government/organisations">
         <%= t("components.government_navigation.departments") %>
       </a>
     </li>
     <li>
-      <a class="<%= 'active' if active == 'worldwide' %> govuk-link govuk-link--no-underline govuk-link--inverse" href="/government/world">
+      <a class="<%= 'active' if active == 'worldwide' %> govuk-link govuk-link--no-underline govuk-link--inverse"
+         data-track-category="headerClicked"
+         data-track-action="worldwideLink"
+         data-track-label="/world"
+         data-track-dimension="<%= t("components.government_navigation.worldwide") %>"
+         data-track-dimension-index="29"
+         href="/world">
         <%= t("components.government_navigation.worldwide") %>
       </a>
     </li>
     <li>
-      <a class="<%= 'active' if active == 'how-government-works' %> govuk-link govuk-link--no-underline govuk-link--inverse" href="/government/how-government-works">
+      <a class="<%= 'active' if active == 'how-government-works' %> govuk-link govuk-link--no-underline govuk-link--inverse"
+         data-track-category="headerClicked"
+         data-track-action="governmentactivityLink"
+         data-track-label="/government/how-government-works"
+         data-track-dimension="<%= t("components.government_navigation.how-government-works") %>"
+         data-track-dimension-index="29"
+         href="/government/how-government-works">
         <%= t("components.government_navigation.how-government-works") %>
       </a>
     </li>
     <li>
-      <a class="<%= 'active' if active == 'get-involved' %> govuk-link govuk-link--no-underline govuk-link--inverse" href="/government/get-involved">
+      <a class="<%= 'active' if active == 'get-involved' %> govuk-link govuk-link--no-underline govuk-link--inverse"
+         data-track-category="headerClicked"
+         data-track-action="governmentactivityLink"
+         data-track-label="/government/get-involved"
+         data-track-dimension="<%= t("components.government_navigation.get-involved") %>"
+         data-track-dimension-index="29"
+         href="/government/get-involved">
         <%= t("components.government_navigation.get-involved") %>
       </a>
     </li>
     <li class="clear-child">
-      <a class="<%= 'active' if active == 'consultations' %> govuk-link govuk-link--no-underline govuk-link--inverse" href="<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>">
+      <a class="<%= 'active' if active == 'consultations' %> govuk-link govuk-link--no-underline govuk-link--inverse"
+         data-track-category="headerClicked"
+         data-track-action="governmentactivityLink"
+         data-track-label="/government/get-involved"
+         data-track-dimension="<%= t("components.government_navigation.consultations") %>"
+         data-track-dimension-index="29"
+         href="<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>">
         <%= t("components.government_navigation.consultations") %>
       </a>
     </li>
     <li>
-      <a class="<%= 'active' if active == 'statistics' %> govuk-link govuk-link--no-underline govuk-link--inverse" href="/search/research-and-statistics">
+      <a class="<%= 'active' if active == 'statistics' %> govuk-link govuk-link--no-underline govuk-link--inverse"
+         data-track-category="headerClicked"
+         data-track-action="governmentactivityLink"
+         data-track-label="/government/research-and-statistics"
+         data-track-dimension="<%= t("components.government_navigation.statistics") %>"
+         data-track-dimension-index="29"
+      href="/search/research-and-statistics">
         <%= t("components.government_navigation.statistics") %>
       </a>
     </li>
     <li>
-      <a class="<%= 'active' if active == 'announcements' %> govuk-link govuk-link--no-underline govuk-link--inverse" href="/news-and-communications">
+      <a class="<%= 'active' if active == 'announcements' %> govuk-link govuk-link--no-underline govuk-link--inverse"
+         data-track-category="headerClicked"
+         data-track-action="governmentactivityLink"
+         data-track-label="/search/news-and-communications"
+         data-track-dimension="<%= t("components.government_navigation.news_and_communications") %>"
+         data-track-dimension-index="29"
+         href="/search/news-and-communications">
         <%= t("components.government_navigation.news_and_communications") %>
       </a>
     </li>

--- a/spec/components/government_navigation_spec.rb
+++ b/spec/components/government_navigation_spec.rb
@@ -10,7 +10,7 @@ describe "Government navigation", type: :view do
 
     assert_select "\#proposition-links li a", text: "Departments"
     assert_link_with_text("/government/organisations", "Departments")
-    assert_link_with_text("/news-and-communications", "News and communications")
+    assert_link_with_text("/search/news-and-communications", "News and communications")
     assert_link_with_text("/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&amp;content_store_document_type[]=closed_consultations", "Consultations")
     assert_link_with_text("/search/research-and-statistics", "Statistics")
   end


### PR DESCRIPTION
## What

Add tracking data attributes to elements in the government_navigation menu header (which mirrors what is in [Whitehall](https://github.com/alphagov/whitehall/pull/6129)).

## Why

As part of gathering some baseline data ahead of updating the header design.

## Visual changes?

None

[Trello](https://trello.com/c/CwPwNE60/321-implement-analytics-tracking-on-the-existing-headers)