### PR TITLE
Version 24.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,16 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.13.4
 
 * Add tracking to government navigation ([PR #2127](https://github.com/alphagov/govuk_publishing_components/pull/2127))
 * Make jasmine tests pass in Internet Explorer ([PR #2090](https://github.com/alphagov/govuk_publishing_components/pull/2090))
+* Allow a custom link to be used on the header logo ([PR #2114](https://github.com/alphagov/govuk_publishing_components/pull/2114))
+* Add custom tracking action to Brexit superbreadcrumbs ([PR #2118](https://github.com/alphagov/govuk_publishing_components/pull/2118))
 
 ## 24.13.3
 
-* Add event tracking to header elements ([PR #2110](https://github.com/alphagov/govuk_publishing_components/pull/2110)) 
-
-## Unreleased
-* Allow a custom link to be used on the header logo ([PR #2114](https://github.com/alphagov/govuk_publishing_components/pull/2114))
-
-## Unreleased
-
-* Add custom tracking action to Brexit superbreadcrumbs ([PR #2118](https://github.com/alphagov/govuk_publishing_components/pull/2118))
+* Add event tracking to header elements ([PR #2110](https://github.com/alphagov/govuk_publishing_components/pull/2110))
 
 ## 24.13.2
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.13.3)
+    govuk_publishing_components (24.13.4)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.13.3".freeze
+  VERSION = "24.13.4".freeze
 end


### PR DESCRIPTION
## Includes

* Add tracking to government navigation ([PR #2127](https://github.com/alphagov/govuk_publishing_components/pull/2127))
* Make jasmine tests pass in Internet Explorer ([PR #2090](https://github.com/alphagov/govuk_publishing_components/pull/2090))
* Allow a custom link to be used on the header logo ([PR #2114](https://github.com/alphagov/govuk_publishing_components/pull/2114))
* Add custom tracking action to Brexit superbreadcrumbs ([PR #2118](https://github.com/alphagov/govuk_publishing_components/pull/2118))
