### PR TITLE
Fix click tracking in government_navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Don't include changes that are purely internal. The CHANGELOG should be a
   useful summary for people upgrading their application, not a replication
   of the commit log.
+  
+## Unreleased
+
+* Fix click tracking in government_navigation ([PR #2129](https://github.com/alphagov/govuk_publishing_components/pull/2129))
 
 ## 24.13.4
 

--- a/app/views/govuk_publishing_components/components/_government_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_government_navigation.html.erb
@@ -3,7 +3,7 @@
 %>
 
 <nav id="proposition-menu" class="no-proposition-name gem-c-government-navigation" aria-label="Departments and policy navigation">
-  <ul id="proposition-links">
+  <ul id="proposition-links" data-module="gem-track-click">
     <li>
       <a class="<%= 'active' if active == 'departments' %> govuk-link govuk-link--no-underline govuk-link--inverse"
          data-track-category="headerClicked"


### PR DESCRIPTION
The data module wasn't set so the Javascript wasn't being applied from #2127