### PR TITLE
Add smart_answer to the document types excluded from Brexit navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix click tracking in government_navigation ([PR #2129](https://github.com/alphagov/govuk_publishing_components/pull/2129))
 * Add superbreadcrumb to content tagged to a Brexit child taxon ([PR #2123](https://github.com/alphagov/govuk_publishing_components/pull/2123))
 * Use the `init` API to initialise component modules ([PR #2095](https://github.com/alphagov/govuk_publishing_components/pull/2095))
+* Add smart_answer to the document types excluded from Brexit navigation ([PR #2133](https://github.com/alphagov/govuk_publishing_components/pull/2133))
 
 ## 24.13.4
 

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -194,6 +194,7 @@ module GovukPublishingComponents
           maib_report
           raib_report
           simple_smart_answer
+          smart_answer
           transaction
         ]
       end


### PR DESCRIPTION
Will exclude [more pages with start buttons on](https://www.gov.uk/api/content/find-coronavirus-support) from having navigation on that might interrupt their service journey.

Until recently, smart_answers used transactions as their start pages, which is why they haven't been included previously.

https://trello.com/c/A7LMRDFc/1579-stop-brexit-sidebar-navigation-from-appearing-on-smart-answers