### PR TITLE
Release v24.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.14.0
 
+* Add real user metrics using Speedcurve's LUX ([PR #2135](https://github.com/alphagov/govuk_publishing_components/pull/2135))
 * Fix header tracking labels ([PR #2136](https://github.com/alphagov/govuk_publishing_components/pull/2136))
 
 ## 24.13.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.13.5)
+    govuk_publishing_components (24.14.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.13.5".freeze
+  VERSION = "24.14.0".freeze
 end


### PR DESCRIPTION
Includes:

 - Add real user metrics using Speedcurve's LUX ([PR 2135](https://github.com/alphagov/govuk_publishing_components/pull/2135))
