### PR TITLE
Release v24.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
   
-## Unreleased
+## 24.14.1
 
 * Fix wrong label value for event tracking on menu button ([PR #2139](https://github.com/alphagov/govuk_publishing_components/pull/2139))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.14.0)
+    govuk_publishing_components (24.14.1)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.14.0".freeze
+  VERSION = "24.14.1".freeze
 end


### PR DESCRIPTION
Includes:

* Fix wrong label value for event tracking on menu button ([PR #2139](https://github.com/alphagov/govuk_publishing_components/pull/2139))
