### PR TITLE
Update header tracking to cover for menu and search button toggles

### DIFF
--- a/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
@@ -18,5 +18,10 @@
     id: "site-search-text",
     margin_bottom: 0,
     no_border: true,
+    data_attributes: {
+      track_category: "headerClicked",
+      track_action: "searchSubmitted",
+      track_label: "none",
+    },
   } %>
 </form>


### PR DESCRIPTION
It wasn't clear that the toggle was affecting both buttons, and previously the GA values were the same for both when they should be distinct.

## What
Fixes to header menu tracking events.

## Why
As part of gathering some baseline data ahead of updating the header design.

[Trello](https://trello.com/c/CwPwNE60/321-implement-analytics-tracking-on-the-existing-headers)

## Visual Changes
None