### PR TITLE
Added tracking for the header menu toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Added tracking for the header menu toggle ([PR 2143](https://github.com/alphagov/govuk_publishing_components/pull/2143))
+
 ## 24.15.0
 
  * Set LUX's sampling rate to 1% ([PR 2145](https://github.com/alphagov/govuk_publishing_components/pull/2145))

--- a/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
@@ -47,3 +47,23 @@
     }
   }
 }).call(this)
+
+;(function () {
+  var $menuToggleButtons = document.querySelectorAll('.govuk-js-header-toggle')
+
+  for (var j = 0; j < $menuToggleButtons.length; j++) {
+    var element = $menuToggleButtons[j]
+
+    element.addEventListener('click', function (event) {
+      var expanded = event.target.getAttribute('aria-expanded')
+
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        if (expanded === 'true') {
+          window.GOVUK.analytics.trackEvent('headerClicked', 'menuClosed', { label: 'none' })
+        } else {
+          window.GOVUK.analytics.trackEvent('headerClicked', 'menuOpened', { label: 'none' })
+        }
+      }
+    })
+  }
+})()

--- a/spec/javascripts/components/header-navigation-spec.js
+++ b/spec/javascripts/components/header-navigation-spec.js
@@ -1,0 +1,110 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+describe('The header navigation', function () {
+  'use strict'
+
+  var element
+
+  afterEach(function () {
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
+  })
+
+  describe('when clicking the', function () {
+    beforeEach(function () {
+      spyOn(GOVUK.analytics, 'trackEvent')
+
+      var html =
+        '<header class="gem-c-layout-header govuk-header gem-c-layout-header--search-left" role="banner" data-module="govuk-header">' +
+          '<div class="govuk-header__container govuk-width-container">' +
+            '<div class="govuk-grid-row">' +
+              '<div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop gem-c-layout-header__search">' +
+                '<button class="search-toggle js-header-toggle" data-search-toggle-for="search" data-show-text="Show search" data-hide-text="Hide search">' +
+                  'Show search' +
+                '</button>' +
+                '<form action="/search" class="gem-c-layout-header__search-form govuk-clearfix" id="search" method="get" role="search">' +
+                  '<div class="gem-c-search govuk-!-display-none-print  govuk-!-margin-bottom-0 gem-c-search--no-border gem-c-search--on-white" data-module="gem-toggle-input-class-on-focus">' +
+                    '<label for="site-search-text" class="gem-c-search__label">' +
+                      'Search on GOV.UK' +
+                    '</label>' +
+                    '<div class="gem-c-search__item-wrapper">' +
+                      '<input class="gem-c-search__item gem-c-search__input js-class-toggle" id="site-search-text" name="q" title="Search" type="search" value="">' +
+                      '<div class="gem-c-search__item gem-c-search__submit-wrapper">' +
+                        '<button class="gem-c-search__submit" type="submit" data-module="gem-track-click">' +
+                          'Search GOV.UK' +
+                        '</button>' +
+                      '</div>' +
+                    '</div>' +
+                  '</div>' +
+                '</form>' +
+              '</div>' +
+              '<div class="govuk-header__content gem-c-header__content govuk-grid-column-full">' +
+                '<button aria-controls="navigation" aria-label="Show or hide Top Level Navigation" class="govuk-header__menu-button govuk-js-header-toggle gem-c-header__menu-button govuk-!-display-none-print" type="button" aria-expanded="false">' +
+                  'Menu' +
+                '</button>' +
+                '<nav class="gem-c-header__nav" aria-label="Top level">' +
+                  '<ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end">' +
+                    '<li class="govuk-header__navigation-item">' +
+                      '<a class="govuk-header__link" href="item-1">Departments</a>' +
+                    '</li>' +
+                  '</ul>' +
+                '</nav>' +
+              '</div>' +
+            '</div>' +
+          '</div>' +
+        '</header>'
+      element = $(html)
+    })
+
+    // These tests are skipped as there I can't find a way to make them work.
+    // The IIFE in `header-navigation.js` runs before the HTML fixture is
+    // available - it then can't find the appropriate element to attach an
+    // event listener to. This means that clicking the button in the fixture
+    // doesn't do anything and the test fails. I can't see a way of making this
+    // work without completely rewriting the JavaScript to use the
+    // `GOVUK.Modules` system - which I unfortunately don't have time for.
+    // I'm leaving the tests here in case of later inspiration.
+
+    xit('menu opened', function () {
+      element.find('.govuk-js-header-toggle')[0].click()
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('headerClicked', 'menuOpened', Object({ label: 'none' }))
+    })
+
+    xit('menu closed', function () {
+      element.find('.govuk-js-header-toggle')[0].click()
+      element.find('.govuk-js-header-toggle')[0].click()
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('headerClicked', 'menuClosed', Object({ label: 'none' }))
+    })
+
+    xit('search opened', function () {
+      element.find('.search-toggle')[0].click()
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('headerClicked', 'searchOpened', Object({ label: 'none' }))
+    })
+
+    xit('search closed', function () {
+      element.find('.search-toggle')[0].click()
+      element.find('.search-toggle')[0].click()
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('headerClicked', 'searchClosed', Object({ label: 'none' }))
+    })
+
+    xit('search opened and then the menu opened', function () {
+      element.find('.govuk-js-header-toggle')[0].click()
+      element.find('.search-toggle')[0].click()
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('headerClicked', 'searchOpened', Object({ label: 'none' }))
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('headerClicked', 'searchOpened', Object({ label: 'none' }))
+    })
+
+    xit('search opened and then the menu opened, then both closed', function () {
+      element.find('.govuk-js-header-toggle')[0].click()
+      element.find('.search-toggle')[0].click()
+      element.find('.govuk-js-header-toggle')[0].click()
+      element.find('.search-toggle')[0].click()
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('headerClicked', 'searchClosed', Object({ label: 'none' }))
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('headerClicked', 'searchClosed', Object({ label: 'none' }))
+    })
+  })
+})


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

There is already tracking in place to see how users use the search toggle - this adds tracking for the menu toggle.

Since the functionality for the toggling of the menu comes from GOV.UK Frontend, this needed to be a separate event listener added to specifically send events to analytics.

This can be removed when the AB test has been completed.

The tests proved impossible to get passing without a substantial rewrite of the header navigation JavaScript itself - the tests have been added but skipped in case inspiration strikes at a later date.

## Why
<!-- What are the reasons behind this change being made? -->

To enable analysis of how users use the menu and the search on smaller screens.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

None