### PR TITLE
Set LUX sampling to 1%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 - Don't include changes that are purely internal. The CHANGELOG should be a
   useful summary for people upgrading their application, not a replication
   of the commit log.
-  
+
+## Unreleased
+
+ * Set LUX's sampling rate to 1% ([PR 2145](https://github.com/alphagov/govuk_publishing_components/pull/2145))
+
 ## 24.14.1
 
 * Fix wrong label value for event tracking on menu button ([PR #2139](https://github.com/alphagov/govuk_publishing_components/pull/2139))

--- a/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux.js
+++ b/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux.js
@@ -8,19 +8,32 @@
  */
 
 
-/* ! Remember to keep the settings at the end of this file when updating LUX.
+/* ! Remember to keep these settings at the end of this file when updating LUX:
  *
- * The settings are:
  *  * `LUX.customerid = 47044334` to let LUX know who this is
  *  * `LUX.beaconMode = "simple"` to fire the beacon as an image, which is now
  *    allowed by the content security policy.
  *  * `LUX.debug = false` turns debugging on and off. Left set to false - and
  *    kept in the file so it's easier to remember that this can be turned on.
+ *
+ * ! And the sample rate needs to be set inside the main function that's
+ *   assigned to `LUX`:
+
+*  * `LUX.samplerate = 1` to set sample rate to 1% of users.
  */
 
 var LUX_t_start = Date.now(),
     LUX = window.LUX || {};
 LUX = function() {
+    // -------------------------------------------------------------------------
+    // Settings
+    // -------------------------------------------------------------------------
+    // Set the sample rate to 1% to avoid all events being sent.
+    LUX.samplerate = 1
+    // -------------------------------------------------------------------------
+    /// End
+    // -------------------------------------------------------------------------
+
     var gaLog = [];
     dlog("lux.js evaluation start.");
     var version = "214",
@@ -829,6 +842,10 @@ LUX = function() {
 }();
 var LUX_t_end = Date.now();
 
+// -----------------------------------------------------------------------------
+// More settings
+// -----------------------------------------------------------------------------
+//
 // This ID usually appended to the end of the lux.js as a query string when
 // using the SpeedCurve hosted version - but we have to include it here as this
 // is self hosted.
@@ -842,3 +859,10 @@ LUX.beaconMode = "simple";
 // `LUX.getDebug()` in the browser's console will show the history of what's
 // happened.
 LUX.debug = false;
+
+// Forces sampling - useful for when used with `debug = true`
+// LUX.forceSample()
+
+// -----------------------------------------------------------------------------
+// End of more settings
+// -----------------------------------------------------------------------------

--- a/docs/real-user-metrics.md
+++ b/docs/real-user-metrics.md
@@ -40,7 +40,19 @@ Setting the beacon mode to `"simple"` turns the non-default image method on:
 LUX.beaconMode = 'simple'
 ```
 
-### Debug (bonus mode)
+### Sample rate
+
+LUX defaults to sending every event to Speedcurve - this can be changed by setting `LUX.samplerate` to a integer:
+
+```javascript
+LUX.samplerate = 1 // Whole number from 1 to 100.
+```
+
+This then only sends 1% of visits.
+
+**This must be set at the top of the main `LUX` function or it will default to 100% sample rate.**
+
+### Debugging (bonus mode)
 
 ```javascript
 LUX.debug = true
@@ -51,6 +63,12 @@ Usefully, running `LUX.getDebug()` in the browser's console will show the histor
 
 ```javascript
 LUX.getDebug()
+```
+
+Sampling can also be forced by placing `LUX.forceSample()` at the end of the file:
+
+```javascript
+LUX.forceSample()
 ```
 
 [Performance API]: https://developer.mozilla.org/en-US/docs/Web/API/Performance_API


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
LUX defaults to 100% of events being sent - setting this to 1% will reduce the number of events to the same level that has been set in Speedcurve's admin settings.

Issue on static - https://github.com/alphagov/static/issues/2516

## Why
<!-- What are the reasons behind this change being made? -->
Approximately 29 million events were sent over the course of one day, of which only only 1% were analysed. To avoid the unnecessary sending of events we can only send 1% of events and set Speedcurve to analyse them all.

## Changes
<!-- If the change results in visual changes, show a before and after -->

1. Got to https://govuk-publis-update-lux-j6z85j.herokuapp.com/public/
2. Accept all cookies
3. Open browser console, and type `LUX.getDebug()`

An array is returned, one of which shows the sampling rate of 1%, as shown in the screenshot below:
<img width="1000" alt="Screenshot 2021-06-17 at 12 58 04" src="https://user-images.githubusercontent.com/1732331/122397537-f7772700-cf70-11eb-9393-a6609137c8e0.png">

