### PR TITLE
Release v24.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.15.1
 
 * Added tracking for the header menu toggle ([PR 2143](https://github.com/alphagov/govuk_publishing_components/pull/2143))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.15.0)
+    govuk_publishing_components (24.15.1)
       govuk_app_config
       kramdown
       plek
@@ -120,7 +120,7 @@ GEM
       rest-client (~> 2.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk_app_config (3.2.0)
+    govuk_app_config (3.1.1)
       logstasher (>= 1.2.2, < 2.2.0)
       sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.5.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.15.0".freeze
+  VERSION = "24.15.1".freeze
 end


### PR DESCRIPTION
Includes:

* Added tracking for the header menu toggle ([PR #2143](https://github.com/alphagov/govuk_publishing_components/pull/2143))
