### PR TITLE
Normalize locale files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,12 +134,23 @@ GEM
       selenium-webdriver (>= 3.142)
       webdrivers (>= 4)
     hashdiff (1.0.1)
+    highline (2.0.3)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     i18n-coverage (0.2.0)
+    i18n-tasks (0.9.34)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     jasmine (3.7.0)
       jasmine-core (~> 3.7.0)
       phantomjs
@@ -217,6 +228,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.1.3.2)
       actionpack (= 6.1.3.2)
       activesupport (= 6.1.3.2)
@@ -303,6 +317,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
+    terminal-table (3.0.1)
+      unicode-display_width (>= 1.1.1, < 3)
     thor (1.1.0)
     tilt (2.0.10)
     tzinfo (2.0.4)
@@ -343,6 +359,7 @@ DEPENDENCIES
   govuk_schemas (~> 4.0)
   govuk_test (~> 2)
   i18n-coverage
+  i18n-tasks
   jasmine (~> 3.7.0)
   jasmine_selenium_runner (~> 3.0.0)
   percy-capybara (~> 4.0, >= 4.0.2)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,4 @@
+data:
+  yaml:
+    write:
+      line_width: -1

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,20 +12,14 @@ en:
     article_schema:
       scoped_search_description: Search within %{title}
     attachment:
-      opendocument_html: This file is in an <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation'
-        target=%{target} class='govuk-link'>OpenDocument</a> format
+      opendocument_html: This file is in an <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation' target=%{target} class='govuk-link'>OpenDocument</a> format
       order_a_copy: Order a copy
       page:
         one: 1 page
-        other: '%{count} pages'
+        other: "%{count} pages"
       reference: 'Ref: %{reference}'
       request_format_cta: Request an accessible format.
-      request_format_details_html: If you use assistive technology (such as a screen
-        reader) and need a version of this document in a more accessible format, please
-        email <a href='mailto:%{alternative_format_contact_email}' target='_blank'
-        class='govuk-link'>%{alternative_format_contact_email}</a>. Please tell us
-        what format you need. It will help us if you say what assistive technology
-        you use.
+      request_format_details_html: If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email <a href='mailto:%{alternative_format_contact_email}' target='_blank' class='govuk-link'>%{alternative_format_contact_email}</a>. Please tell us what format you need. It will help us if you say what assistive technology you use.
       request_format_text: This file may not be suitable for users of assistive technology.
     back_link:
       back: Back
@@ -44,28 +38,24 @@ en:
       buttons:
         accept_cookies: Accept additional cookies
         reject_cookies: Reject additional cookies
-      hide: Hide this message
-      text:
-        - We use some essential cookies to make this website work.
-        - We’d like to set additional cookies to understand how you use GOV.UK, remember your settings and improve government services.
-        - We also use cookies set by other sites to help us deliver content from their services.
       confirmation_message: You can %{link} at any time.
       confirmation_message_link: change your cookie settings
+      hide: Hide this message
+      text:
+      - We use some essential cookies to make this website work.
+      - We’d like to set additional cookies to understand how you use GOV.UK, remember your settings and improve government services.
+      - We also use cookies set by other sites to help us deliver content from their services.
       title: Cookies on GOV.UK
     feedback:
       close: Close
-      dont_include_personal_info: Don’t include personal or financial information
-        like your National Insurance number or credit card details.
+      dont_include_personal_info: Don’t include personal or financial information like your National Insurance number or credit card details.
       email_address: Email address
       help_us_improve_govuk: Help us improve GOV.UK
       is_not_useful: this page is not useful
       is_this_page_useful: Is this page useful?
       is_useful: this page is useful
       maybe: Maybe
-      more_about_visit: To help us improve GOV.UK, we’d like to know more about your
-        visit today. We’ll send you a link to a feedback form. It will take only 2
-        minutes to fill in. Don’t worry we won’t send you spam or share your email
-        address with anyone.
+      more_about_visit: To help us improve GOV.UK, we’d like to know more about your visit today. We’ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don’t worry we won’t send you spam or share your email address with anyone.
       'no': 'No'
       send: Send
       send_me_survey: Send me the survey

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "govuk_schemas", "~> 4.0"
   s.add_development_dependency "govuk_test", "~> 2"
   s.add_development_dependency "i18n-coverage"
+  s.add_development_dependency "i18n-tasks"
   s.add_development_dependency "jasmine", "~> 3.7.0"
   s.add_development_dependency "jasmine_selenium_runner", "~> 3.0.0"
   s.add_development_dependency "percy-capybara", "~> 4.0", ">= 4.0.2"


### PR DESCRIPTION
## What
- Add `i18n-tasks` as a development dependency.  This will allow us to more easily normalize the locale files (i.e. sorts into alphabetical order and adjusts syntax).
- Normalizes the locale files.

## Why
This will allow us to keep locale files consistently formatted across all GOV.UK applications.

## Visual Changes
None

[Trello card](https://trello.com/c/kB1a8jJE)