### PR TITLE
Add a Custom dimension to Brexit super breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add a custom dimension to clicks on super breadcrumbs tagged to a brexit taxon ([PR #2149](https://github.com/alphagov/govuk_publishing_components/pull/2149))
+
 ## 24.15.1
 
 * Added tracking for the header menu toggle ([PR 2143](https://github.com/alphagov/govuk_publishing_components/pull/2143))

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -39,8 +39,7 @@ module GovukPublishingComponents
           tracking_category: "breadcrumbClicked",
           tracking_action: tracking_action,
           tracking_label: content_item["base_path"],
-          tracking_dimension_enabled: false,
-        }
+        }.merge(custom_dimension_tracking)
       end
 
     private
@@ -80,6 +79,10 @@ module GovukPublishingComponents
         [PRIORITY_TAXONS[:brexit_business], PRIORITY_TAXONS[:brexit_individuals]]
       end
 
+      def brexit_taxons
+        brexit_child_taxons << PRIORITY_TAXONS[:brexit_taxon]
+      end
+
       def preferred_priority_taxon
         query_parameters["priority-taxon"] if query_parameters
       end
@@ -90,6 +93,16 @@ module GovukPublishingComponents
         action << "Brexitcitizen" if taxon["content_id"] == PRIORITY_TAXONS[:brexit_individuals]
         action << "Brexitbusinessandcitizen" if taxon["content_id"] == PRIORITY_TAXONS[:brexit_taxon]
         action.join(" ")
+      end
+
+      def custom_dimension_tracking
+        tracking = { tracking_dimension_enabled: false }
+        if brexit_taxons.include?(taxon["content_id"])
+          tracking[:tracking_dimension_enabled] = true
+          tracking[:tracking_dimension] = "customTrackingDimension"
+          tracking[:tracking_dimension_index] = 111
+        end
+        tracking
       end
 
       def tagged_to_both_brexit_child_taxons?

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -89,20 +89,26 @@ module GovukPublishingComponents
 
       def tracking_action
         action = %w[superBreadcrumb]
-        action << "Brexitbusiness" if taxon["content_id"] == PRIORITY_TAXONS[:brexit_business]
-        action << "Brexitcitizen" if taxon["content_id"] == PRIORITY_TAXONS[:brexit_individuals]
-        action << "Brexitbusinessandcitizen" if taxon["content_id"] == PRIORITY_TAXONS[:brexit_taxon]
-        action.join(" ")
+        action << page_name_for_tracking
+        action.compact.join(" ")
       end
 
       def custom_dimension_tracking
         tracking = { tracking_dimension_enabled: false }
         if brexit_taxons.include?(taxon["content_id"])
           tracking[:tracking_dimension_enabled] = true
-          tracking[:tracking_dimension] = "customTrackingDimension"
+          tracking[:tracking_dimension] = page_name_for_tracking
           tracking[:tracking_dimension_index] = 111
         end
         tracking
+      end
+
+      def page_name_for_tracking
+        {
+          PRIORITY_TAXONS[:brexit_business] => "Brexitbusiness",
+          PRIORITY_TAXONS[:brexit_individuals] => "Brexitcitizen",
+          PRIORITY_TAXONS[:brexit_taxon] => "Brexitbusinessandcitizen",
+        }[taxon["content_id"]]
       end
 
       def tagged_to_both_brexit_child_taxons?

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
 
             breadcrumbs[:path] = "/guidance/brexit-guidance-for-individuals"
             breadcrumbs[:tracking_action] = "superBreadcrumb Brexitcitizen"
-            breadcrumbs[:tracking_dimension] = "customTrackingDimension"
+            breadcrumbs[:tracking_dimension] = "Brexitcitizen"
             breadcrumbs[:tracking_dimension_enabled] = true
             breadcrumbs[:tracking_dimension_index] = 111
             expect(described_class.call(content)).to eq(breadcrumbs)

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -180,6 +180,12 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
             expect(described_class.call(content)).to eq(breadcrumbs)
           end
         end
+
+        context "when page is tagged to a brexit taxon" do
+          it "adds custom dimension tracking" do
+
+          end
+        end
       end
     end
   end

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
       "content_id" => "b7f57213-4b16-446d-8ded-81955d782680",
       "base_path" => "/coronavirus-taxon/work-and-financial-support",
       "title" => "Work and financial support during coronavirus",
+      "details" => {
+        "url_override" => "/guidance/brexit-guidance-for-individuals",
+      },
     }
   end
 
@@ -169,21 +172,30 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
         end
 
         context "with a url_override field present" do
-          let(:content) { send(tagged_to_taxons, [brexit_individuals_taxon]) }
-          let(:url_override) { brexit_individuals_taxon["details"]["url_override"] }
+          let(:content) { send(tagged_to_taxons, [worker_taxon]) }
+          let(:url_override) { worker_taxon["details"]["url_override"] }
 
           it "it replaces the base path" do
-            breadcrumbs = breadcrumb_for(content, brexit_individuals_taxon)
+            breadcrumbs = breadcrumb_for(content, worker_taxon)
             breadcrumbs[:path] = url_override
-            breadcrumbs[:tracking_action] = "superBreadcrumb Brexitcitizen"
+            breadcrumbs[:tracking_action] = "superBreadcrumb"
 
             expect(described_class.call(content)).to eq(breadcrumbs)
           end
         end
 
         context "when page is tagged to a brexit taxon" do
-          it "adds custom dimension tracking" do
+          let(:content) { send(tagged_to_taxons, [brexit_individuals_taxon]) }
 
+          it "adds custom dimension tracking" do
+            breadcrumbs = breadcrumb_for(content, brexit_individuals_taxon)
+
+            breadcrumbs[:path] = "/guidance/brexit-guidance-for-individuals"
+            breadcrumbs[:tracking_action] = "superBreadcrumb Brexitcitizen"
+            breadcrumbs[:tracking_dimension] = "customTrackingDimension"
+            breadcrumbs[:tracking_dimension_enabled] = true
+            breadcrumbs[:tracking_dimension_index] = 111
+            expect(described_class.call(content)).to eq(breadcrumbs)
           end
         end
       end


### PR DESCRIPTION
## What

We want to add a custom dimension to the data sent to GA when a user clicks a superbreadcrumb for one of the brexit taxon pages.

## Why
To make it easier to analyse the data.

## Visual Changes
None

Trello: https://trello.com/c/v6Qc6Erc/1582-capture-the-audience-type-on-brexit-pages-as-a-custom-dimension-in-ga