### PR TITLE
Add scroll tracking to the brexit child taxon pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 ## Unreleased
 
 * Add tracking on search submit to public layout ([PR #2157](https://github.com/alphagov/govuk_publishing_components/pull/2157))
-*Turn off LUX's debug mode ([PR #2156](https://github.com/alphagov/govuk_publishing_components/pull/2156))
+* Turn off LUX's debug mode ([PR #2156](https://github.com/alphagov/govuk_publishing_components/pull/2156))
+* Add scroll tracking for the brexit child taxon pages ([PR #2155](https://github.com/alphagov/govuk_publishing_components/pull/2155))
 
 ## 24.15.2
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js
@@ -198,6 +198,20 @@
       ['Heading', 'Rules to follow'],
       ['Heading', 'Good to know'],
       ['Heading', 'Change your answers']
+    ],
+    '/guidance/brexit-guidance-for-businesses': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
+    ],
+    '/guidance/brexit-guidance-for-individuals-and-families': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
     ]
   }
 


### PR DESCRIPTION
## What
Add scroll tracking to the brexit child taxon pages. 

## Why
So we can measure user engagement with these pages.

## Visual Changes
None
