### PR TITLE
Turn off LUX's debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+*Turn off LUX's debug mode ([PR #2156](https://github.com/alphagov/govuk_publishing_components/pull/2156))
+
 ## 24.15.2
 
 * Update LUX JavaScript from v214 to v216 ([PR #2152](https://github.com/alphagov/govuk_publishing_components/pull/2152))

--- a/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux.js
+++ b/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux.js
@@ -760,7 +760,6 @@ LUX = (function () {
                 (n = document.getElementsByTagName("body")).length) &&
               n[0].appendChild(t);
         })(e);
-        console.log(LUX.samplerate)
       new Image().src = e;
     }
     function ie(e) {
@@ -1014,7 +1013,7 @@ LUX.beaconMode = "simple";
 // Setting debug to `true` shows what happening as it happens. Running
 // `LUX.getDebug()` in the browser's console will show the history of what's
 // happened.
-LUX.debug = true;
+LUX.debug = false;
 
 // Forces sampling - useful for when used with `debug = true`
 // LUX.forceSample()


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Turns off LUX's debug mode and removes a `console.log`.
## Why
<!-- What are the reasons behind this change being made? -->
The logging serves no purpose on production as it logs into the browser console - it can be safely removed and turned off.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

None.
