### PR TITLE
Add tracking on search submit to public layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add tracking on search submit to public layout ([PR #2157](https://github.com/alphagov/govuk_publishing_components/pull/2157))
 *Turn off LUX's debug mode ([PR #2156](https://github.com/alphagov/govuk_publishing_components/pull/2156))
 
 ## 24.15.2

--- a/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
@@ -18,5 +18,10 @@
     id: "site-search-text",
     margin_bottom: 0,
     no_border: true,
+    data_attributes: {
+      track_category: "headerClicked",
+      track_action: "searchSubmitted",
+      track_label: "none",
+    },
   } %>
 </form>


### PR DESCRIPTION
## What
Previous data tracking events added to the search button weren't included in the new public layout template as they didn't need to until frontend applications began using the newer template in production. Well they do now!

## Why

This is part of work to baseline data of usage of navigation elements before a redesign.

![Screenshot 2021-06-22 at 13 15 23](https://user-images.githubusercontent.com/424772/122922819-ee64cc00-d35b-11eb-944b-dc5453518915.png)


## Visual Changes
None
