### PR TITLE
Release 24.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.15.3
 
 * Add tracking on search submit to public layout ([PR #2157](https://github.com/alphagov/govuk_publishing_components/pull/2157))
 * Turn off LUX's debug mode ([PR #2156](https://github.com/alphagov/govuk_publishing_components/pull/2156))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.15.2)
+    govuk_publishing_components (24.15.3)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.15.2".freeze
+  VERSION = "24.15.3".freeze
 end


### PR DESCRIPTION
## Includes

* Add tracking on search submit to public layout ([PR #2157](https://github.com/alphagov/govuk_publishing_components/pull/2157))
* Turn off LUX's debug mode ([PR #2156](https://github.com/alphagov/govuk_publishing_components/pull/2156))
