### PR TITLE
Amend layout_for_public component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Allow custom font size on action links ([PR #2162](https://github.com/alphagov/govuk_publishing_components/pull/2162))
 * Add scroll tracking to /guidance/import-and-export-goods-using-preference-agreements ([PR #2165](https://github.com/alphagov/govuk_publishing_components/pull/2165))
+* Amend layout_for_public component ([PR #2160](https://github.com/alphagov/govuk_publishing_components/pull/2160))
 
 ## 24.15.3
 

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -1,7 +1,9 @@
 <%
+  omit_feedback_form ||= false
   emergency_banner ||= nil
   full_width ||= false
   global_bar ||= nil
+  product_name ||= nil
   html_lang ||= "en"
   layout_helper = GovukPublishingComponents::Presenters::PublicLayoutHelper.new(local_assigns)
   logo_link ||= "/"
@@ -76,6 +78,7 @@
         search: show_search,
         logo_link: logo_link,
         navigation_items: navigation_items,
+        product_name: product_name,
 
         # The (blue) bottom border needs to be underneath the emergency banner -
         # so it has been turned off and added in manually.
@@ -104,9 +107,11 @@
       </main>
     </div>
 
-    <div class="govuk-width-container">
-      <%= render "govuk_publishing_components/components/feedback" %>
-    </div>
+    <% unless omit_feedback_form %>
+      <div class="govuk-width-container">
+        <%= render "govuk_publishing_components/components/feedback" %>
+      </div>
+    <% end %>
 
     <% unless local_assigns[:hide_footer_links] %>
       <%= render "govuk_publishing_components/components/layout_footer", {

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -27,6 +27,10 @@ examples:
     description: This allows the header to be omitted which is currently used when rendering CSV previews from Whitehall
     data:
       omit_header: true
+  omit_feedback:
+    description: This allows the feedback form to be omitted
+    data:
+      omit_feedback_form: true
   navigation:
     description: Passes the navigation through to the [header component](/component-guide/layout_header/).
     data:

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -47,6 +47,24 @@ describe "Layout for public", type: :view do
     assert_select ".gem-c-layout-for-public .gem-c-layout-header", false
   end
 
+  it "displays with a feedback component by default" do
+    render_component({})
+
+    assert_select ".gem-c-layout-for-public .gem-c-feedback", true
+  end
+
+  it "can omit the feedback component" do
+    render_component(omit_feedback_form: true)
+
+    assert_select ".gem-c-layout-for-public .gem-c-feedback", false
+  end
+
+  it "can add a product name in the header" do
+    render_component(product_name: "Account")
+
+    assert_select ".gem-c-layout-for-public .gem-c-header__product-name", text: "Account"
+  end
+
   it "can add a emergency banner" do
     render_component({
       emergency_banner: "<div id='test-emergency-banner'>This is an emergency banner test</div>",


### PR DESCRIPTION
Adjust `layout_for_public` component to accept an optional `product_name` parameter, as well as an option to hide the feedback component. 

Both of these features are needed for the account homepage which is being moved over from `govuk-account-manager-prototype` to `frontend`: https://github.com/alphagov/frontend/compare/msw/account-home-page.

The account manager uses a different site header from the rest of GOVUK. Some main differences are:

- the account related navigation links in the header
- the “Account” product name next to the home link/logo
- the home link directs the user back to the account homepage (as opposed to other pages on GOVUK where the home link will link back to the GOVUK homepage)
- account pages also don't use the side-wide feedback component

This was not an issue on `govuk-account-manager-prototype` as it has its own layout and does not use `static` or `slimmer`, so we simply called the components needed with the necessary parameters on our application file. 

The `frontend` app on the other hand does use `static`, and the default layout used is vastly different from the layout required by accounts pages. 
A possible solution to this problem is the introduction of a [special layout template for accounts](https://github.com/alphagov/static/pull/2527) in `static` which is to be requested only by the account controller. These changes are here to support the introduction of the new template.


-----
https://trello.com/c/lIDQNATi/813-implement-the-govuk-account-home-page