### PR TITLE
Add scroll tracking to /guidance/import-and-export-goods-using-preference-agreements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Allow custom font size on action links ([PR #2162](https://github.com/alphagov/govuk_publishing_components/pull/2162))
+* Add scroll tracking to /guidance/import-and-export-goods-using-preference-agreements ([PR #2165](https://github.com/alphagov/govuk_publishing_components/pull/2165))
 
 ## 24.15.3
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js
@@ -212,6 +212,13 @@
       ['Percent', 60],
       ['Percent', 80],
       ['Percent', 100]
+    ],
+    '/guidance/import-and-export-goods-using-preference-agreements': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
     ]
   }
 


### PR DESCRIPTION
## What
Add scroll tracking to /guidance/import-and-export-goods-using-preference-agreements

## Why
To monitor user engagement.

## Visual Changes
None

Trello: https://trello.com/c/OD132cuZ/1610-add-scroll-depth-tracking-to-new-rules-of-origin-triage-page
