### PR TITLE
Release 24.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.16.0
 
 * Allow custom font size on action links ([PR #2162](https://github.com/alphagov/govuk_publishing_components/pull/2162))
 * Add scroll tracking to /guidance/import-and-export-goods-using-preference-agreements ([PR #2165](https://github.com/alphagov/govuk_publishing_components/pull/2165))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.15.3)
+    govuk_publishing_components (24.16.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.15.3".freeze
+  VERSION = "24.16.0".freeze
 end


### PR DESCRIPTION
### Includes

* Allow custom font size on action links ([PR #2162](https://github.com/alphagov/govuk_publishing_components/pull/2162))
* Add scroll tracking to /guidance/import-and-export-goods-using-preference-agreements ([PR #2165](https://github.com/alphagov/govuk_publishing_components/pull/2165))
* Amend layout_for_public component ([PR #2160](https://github.com/alphagov/govuk_publishing_components/pull/2160))
