### PR TITLE
Add links to privacy and accessibility statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add links to privacy and accessibility statements in layout footer component  ([PR #2168](https://github.com/alphagov/govuk_publishing_components/pull/2168))
+
+
 ## 24.16.0
 
 * Allow custom font size on action links ([PR #2162](https://github.com/alphagov/govuk_publishing_components/pull/2162))

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -40,10 +40,14 @@ examples:
         items:
           - href: '/help'
             text: Help
+          - href: '/help/privacy-notice'
+            text: Privacy
           - href: '/help/cookies'
             text: Cookies
           - href: '/contact'
             text: Contact
+          - href: '/help/accessibility-statement'
+            text: Accessibility statement
           - href: '/help/terms-conditions'
             text: Terms and conditions
           - href: '/cymraeg'


### PR DESCRIPTION
## What
This adds links to the privacy statement and accessibility statement to the layout footer metadata.

## Why
These exist on the live site where the footer isn't presented by the public layout, presumably they were updated after this version was forked.

## Visual Changes
Before:
![image](https://user-images.githubusercontent.com/31649453/123659012-28394500-d82a-11eb-9177-eaf13bb3ba01.png)

After:
![image](https://user-images.githubusercontent.com/31649453/123659292-6cc4e080-d82a-11eb-869e-11ec09903eb7.png)
