### PR TITLE
Allow multiple JavaScript modules on a certain element

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/button.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/button.js
@@ -2,4 +2,4 @@
 // = require govuk/components/button/button.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
-window.GOVUK.Modules.Button = window.GOVUKFrontend
+window.GOVUK.Modules.GovukButton = window.GOVUKFrontend

--- a/app/assets/javascripts/govuk_publishing_components/components/character-count.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/character-count.js
@@ -2,4 +2,4 @@
 // = require govuk/components/character-count/character-count.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
-window.GOVUK.Modules.CharacterCount = window.GOVUKFrontend
+window.GOVUK.Modules.GovukCharacterCount = window.GOVUKFrontend

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -3,17 +3,17 @@
 // = require govuk/components/checkboxes/checkboxes.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
-window.GOVUK.Modules.Checkboxes = window.GOVUKFrontend;
+window.GOVUK.Modules.GovukCheckboxes = window.GOVUKFrontend;
 
 (function (Modules) {
-  function GovukCheckboxes ($module) {
+  function GemCheckboxes ($module) {
     this.$module = $module
     this.$checkboxes = this.$module.querySelectorAll('input[type=checkbox]')
     this.$nestedCheckboxes = this.$module.querySelectorAll('[data-nested=true] input[type=checkbox]')
     this.$exclusiveCheckboxes = this.$module.querySelectorAll('[data-exclusive=true] input[type=checkbox]')
   }
 
-  GovukCheckboxes.prototype.init = function () {
+  GemCheckboxes.prototype.init = function () {
     this.applyAriaControlsAttributes(this.$module)
 
     for (var i = 0; i < this.$checkboxes.length; i++) {
@@ -29,7 +29,7 @@ window.GOVUK.Modules.Checkboxes = window.GOVUKFrontend;
     }
   }
 
-  GovukCheckboxes.prototype.handleCheckboxChange = function (event) {
+  GemCheckboxes.prototype.handleCheckboxChange = function (event) {
     if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
       // Where checkboxes are manipulated externally in finders, `suppressAnalytics`
       // is passed to prevent duplicate GA events.
@@ -58,7 +58,7 @@ window.GOVUK.Modules.Checkboxes = window.GOVUKFrontend;
     }
   }
 
-  GovukCheckboxes.prototype.handleNestedCheckboxChange = function (event) {
+  GemCheckboxes.prototype.handleNestedCheckboxChange = function (event) {
     var $checkbox = event.target
     var $isNested = $checkbox.closest('.govuk-checkboxes--nested')
     var $hasNested = this.$module.querySelector('.govuk-checkboxes--nested[data-parent=' + $checkbox.id + ']')
@@ -70,7 +70,7 @@ window.GOVUK.Modules.Checkboxes = window.GOVUKFrontend;
     }
   }
 
-  GovukCheckboxes.prototype.toggleNestedCheckboxes = function ($scope, $checkbox) {
+  GemCheckboxes.prototype.toggleNestedCheckboxes = function ($scope, $checkbox) {
     var $nestedCheckboxes = $scope.querySelectorAll('input[type=checkbox]')
     if ($checkbox.checked) {
       for (var i = 0; i < $nestedCheckboxes.length; i++) {
@@ -83,7 +83,7 @@ window.GOVUK.Modules.Checkboxes = window.GOVUKFrontend;
     }
   }
 
-  GovukCheckboxes.prototype.toggleParentCheckbox = function ($scope, $checkbox) {
+  GemCheckboxes.prototype.toggleParentCheckbox = function ($scope, $checkbox) {
     var $inputs = $scope.querySelectorAll('input')
     var $checkedInputs = $scope.querySelectorAll('input:checked')
     var parentId = $scope.getAttribute('data-parent')
@@ -96,7 +96,7 @@ window.GOVUK.Modules.Checkboxes = window.GOVUKFrontend;
     }
   }
 
-  GovukCheckboxes.prototype.handleExclusiveCheckboxChange = function (event) {
+  GemCheckboxes.prototype.handleExclusiveCheckboxChange = function (event) {
     var $currentCheckbox = event.target
     var $checkboxes = $currentCheckbox.closest('.govuk-checkboxes')
     var $exclusiveOption = $checkboxes.querySelector('input[type=checkbox][data-exclusive]')
@@ -113,7 +113,7 @@ window.GOVUK.Modules.Checkboxes = window.GOVUKFrontend;
     }
   }
 
-  GovukCheckboxes.prototype.applyAriaControlsAttributes = function ($scope) {
+  GemCheckboxes.prototype.applyAriaControlsAttributes = function ($scope) {
     var $inputs = $scope.querySelectorAll('[data-controls]')
 
     for (var i = 0; i < $inputs.length; i++) {
@@ -121,5 +121,5 @@ window.GOVUK.Modules.Checkboxes = window.GOVUKFrontend;
     }
   }
 
-  Modules.GovukCheckboxes = GovukCheckboxes
+  Modules.GemCheckboxes = GemCheckboxes
 })(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/components/details.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/details.js
@@ -2,16 +2,16 @@
 // = require govuk/components/details/details.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
-window.GOVUK.Modules.Details = window.GOVUKFrontend;
+window.GOVUK.Modules.GovukDetails = window.GOVUKFrontend;
 
 (function (Modules) {
-  function GovukDetails ($module) {
+  function GemDetails ($module) {
     this.$module = $module
     this.customTrackLabel = this.$module.getAttribute('data-track-label')
     this.detailsClick = this.$module.querySelector('[data-details-track-click]')
   }
 
-  GovukDetails.prototype.init = function () {
+  GemDetails.prototype.init = function () {
     if (this.customTrackLabel) { // If a custom label has been provided, we can simply call the tracking module
       var trackDetails = new window.GOVUK.Modules.GemTrackClick()
       trackDetails.start($(this.$module))
@@ -22,7 +22,7 @@ window.GOVUK.Modules.Details = window.GOVUKFrontend;
     }
   }
 
-  GovukDetails.prototype.trackDefault = function (element) {
+  GemDetails.prototype.trackDefault = function (element) {
     if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
       var componentStatus = (element.getAttribute('open') == null) ? 'open' : 'closed'
       var trackCategory = element.getAttribute('data-track-category')
@@ -45,5 +45,5 @@ window.GOVUK.Modules.Details = window.GOVUKFrontend;
     }
   }
 
-  Modules.GovukDetails = GovukDetails
+  Modules.GemDetails = GemDetails
 })(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/components/error-summary.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/error-summary.js
@@ -2,4 +2,4 @@
 // = require govuk/components/error-summary/error-summary.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
-window.GOVUK.Modules.ErrorSummary = window.GOVUKFrontend
+window.GOVUK.Modules.GovukErrorSummary = window.GOVUKFrontend

--- a/app/assets/javascripts/govuk_publishing_components/components/layout-header.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/layout-header.js
@@ -2,4 +2,4 @@
 // = require govuk/components/header/header.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
-window.GOVUK.Modules.Header = window.GOVUKFrontend
+window.GOVUK.Modules.GovukHeader = window.GOVUKFrontend

--- a/app/assets/javascripts/govuk_publishing_components/components/radio.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/radio.js
@@ -2,4 +2,4 @@
 // = require govuk/components/radios/radios.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
-window.GOVUK.Modules.Radios = window.GOVUKFrontend
+window.GOVUK.Modules.GovukRadios = window.GOVUKFrontend

--- a/app/assets/javascripts/govuk_publishing_components/components/tabs.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/tabs.js
@@ -2,4 +2,4 @@
 // = require govuk/components/tabs/tabs.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
-window.GOVUK.Modules.Tabs = window.GOVUKFrontend
+window.GOVUK.Modules.GovukTabs = window.GOVUKFrontend

--- a/app/assets/javascripts/govuk_publishing_components/modules.js
+++ b/app/assets/javascripts/govuk_publishing_components/modules.js
@@ -30,7 +30,6 @@
         var element = $(modules[i])
         var moduleName = camelCaseAndCapitalise(element.data('module'))
         var started = element.data('module-started')
-        var frontendModuleName = moduleName.replace('Govuk', '')
 
         if ( // GOV.UK Publishing & Legacy Modules
           typeof GOVUK.Modules[moduleName] === 'function' &&
@@ -43,11 +42,11 @@
         }
 
         if ( // GOV.UK Frontend Modules
-          typeof GOVUK.Modules[frontendModuleName] === 'function' &&
-          GOVUK.Modules[frontendModuleName].prototype.init &&
+          typeof GOVUK.Modules[moduleName] === 'function' &&
+          GOVUK.Modules[moduleName].prototype.init &&
           !started
         ) {
-          module = new GOVUK.Modules[frontendModuleName](element[0]).init()
+          module = new GOVUK.Modules[moduleName](element[0]).init()
           element.data('module-started', true)
         }
       }

--- a/app/assets/javascripts/govuk_publishing_components/modules.js
+++ b/app/assets/javascripts/govuk_publishing_components/modules.js
@@ -26,28 +26,32 @@
       var modules = this.find(container)
 
       for (var i = 0, l = modules.length; i < l; i++) {
-        var module
         var element = $(modules[i])
-        var moduleName = camelCaseAndCapitalise(element.data('module'))
-        var started = element.data('module-started')
+        var moduleNames = element.data('module').split(' ')
 
-        if ( // GOV.UK Publishing & Legacy Modules
-          typeof GOVUK.Modules[moduleName] === 'function' &&
-          !GOVUK.Modules[moduleName].prototype.init &&
-          !started
-        ) {
-          module = new GOVUK.Modules[moduleName]()
-          module.start(element)
-          element.data('module-started', true)
-        }
+        for (var j = 0, k = moduleNames.length; j < k; j++) {
+          var module
+          var moduleName = camelCaseAndCapitalise(moduleNames[j])
+          var started = element.data(moduleNames[j] + '-module-started')
 
-        if ( // GOV.UK Frontend Modules
-          typeof GOVUK.Modules[moduleName] === 'function' &&
-          GOVUK.Modules[moduleName].prototype.init &&
-          !started
-        ) {
-          module = new GOVUK.Modules[moduleName](element[0]).init()
-          element.data('module-started', true)
+          if ( // GOV.UK Publishing & Legacy Modules
+            typeof GOVUK.Modules[moduleName] === 'function' &&
+            !GOVUK.Modules[moduleName].prototype.init &&
+            !started
+          ) {
+            module = new GOVUK.Modules[moduleName]()
+            module.start(element)
+            element.data(moduleNames[j] + '-module-started', true)
+          }
+
+          if ( // GOV.UK Frontend Modules
+            typeof GOVUK.Modules[moduleName] === 'function' &&
+            GOVUK.Modules[moduleName].prototype.init &&
+            !started
+          ) {
+            module = new GOVUK.Modules[moduleName](element[0]).init()
+            element.data(moduleNames[j] + '-module-started', true)
+          }
         }
       }
 

--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -4,7 +4,7 @@
   id = cb_helper.id
 %>
 
-<%= tag.div id: id, class: cb_helper.css_classes, data: { module: "govuk-checkboxes" } do %>
+<%= tag.div id: id, class: cb_helper.css_classes, data: { module: "gem-checkboxes" } do %>
   <% if cb_helper.should_have_fieldset %>
     <% if cb_helper.heading_markup %>
       <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": cb_helper.fieldset_describedby do %>
@@ -23,7 +23,7 @@
         <% end %>
 
         <%= tag.ul class: cb_helper.list_classes, data: {
-          module: ('checkboxes' if cb_helper.has_conditional),
+          module: ('govuk-checkboxes' if cb_helper.has_conditional),
           nested: ('true' if cb_helper.has_nested),
           exclusive: ('true' if cb_helper.has_exclusive)
         } do %>

--- a/app/views/govuk_publishing_components/components/_details.html.erb
+++ b/app/views/govuk_publishing_components/components/_details.html.erb
@@ -7,7 +7,7 @@
   css_classes << (shared_helper.get_margin_bottom)
 
   data_attributes ||= {}
-  data_attributes[:module] = 'govuk-details'
+  data_attributes[:module] = 'govuk-details gem-details'
 %>
 <%= tag.details class: css_classes, data: data_attributes, open: open do %>
   <summary class="govuk-details__summary" data-details-track-click>

--- a/spec/javascripts/components/checkboxes-spec.js
+++ b/spec/javascripts/components/checkboxes-spec.js
@@ -3,11 +3,11 @@
 
 describe('Checkboxes component', function () {
   function loadCheckboxesComponent () {
-    new GOVUK.Modules.GovukCheckboxes($('.gem-c-checkboxes')[0]).init()
+    new GOVUK.Modules.GemCheckboxes($('.gem-c-checkboxes')[0]).init()
   }
 
   var FIXTURE =
-  '<div id="checkboxes-1ac8e5cf" class="gem-c-checkboxes govuk-form-group " data-module="govuk-checkboxes">' +
+  '<div id="checkboxes-1ac8e5cf" class="gem-c-checkboxes govuk-form-group " data-module="gem-checkboxes">' +
      '<fieldset class="govuk-fieldset" aria-describedby="checkboxes-1ac8e5cf-hint ">' +
         '<legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">' +
            '<h1 class="govuk-fieldset__heading">What is your favourite colour?</h1>' +

--- a/spec/javascripts/components/details-spec.js
+++ b/spec/javascripts/components/details-spec.js
@@ -5,8 +5,8 @@ describe('Details component', function () {
   var FIXTURE
 
   function loadDetailsComponent () {
-    var element = document.querySelector('[data-module="govuk-details"]')
-    new GOVUK.Modules.GovukDetails(element).init()
+    var element = document.querySelector('[data-module="gem-details"]')
+    new GOVUK.Modules.GemDetails(element).init()
   }
 
   beforeEach(function () {
@@ -14,7 +14,7 @@ describe('Details component', function () {
     spyOn(GOVUK.Modules, 'GemTrackClick').and.callFake(function () { this.start = function () {} })
 
     FIXTURE =
-      '<details class="gem-c-details govuk-details govuk-!-margin-bottom-3" data-track-category="track-category" data-track-action="track-action" data-track-label="track-label" data-module="govuk-details">' +
+      '<details class="gem-c-details govuk-details govuk-!-margin-bottom-3" data-track-category="track-category" data-track-action="track-action" data-track-label="track-label" data-module="gem-details">' +
         '<summary class="govuk-details__summary" data-details-track-click="">' +
         '<span>Toggle text</span>' +
         '</summary>' +

--- a/spec/javascripts/govuk_publishing_components/modules.spec.js
+++ b/spec/javascripts/govuk_publishing_components/modules.spec.js
@@ -62,11 +62,13 @@ describe('GOVUK Modules', function () {
     var callbackLegacyModule
     var callbackGovukModule
     var callbackFrontendModule
+    var callbackGemFrontendModule
 
     beforeEach(function () {
       callbackLegacyModule = jasmine.createSpy()
       callbackGovukModule = jasmine.createSpy()
       callbackFrontendModule = jasmine.createSpy()
+      callbackGemFrontendModule = jasmine.createSpy()
 
       // GOV.UK Frontend Toolkit Modules
       GOVUK.Modules.LegacyTestAlertModule = function () {
@@ -91,6 +93,15 @@ describe('GOVUK Modules', function () {
         callbackFrontendModule(this.element)
       }
       GOVUK.Modules.TestAlertFrontendModule = TestAlertFrontendModule
+
+      // GOV.UK Gem Frontend Modules
+      function GemTestAlertFrontendModule (element) {
+        this.element = element
+      }
+      GemTestAlertFrontendModule.prototype.init = function () {
+        callbackGemFrontendModule(this.element)
+      }
+      GOVUK.Modules.GemTestAlertFrontendModule = GemTestAlertFrontendModule
 
       // GOV.UK Publishing Module with a GOVUK Frontend counterpart
       function GovukTestAlertPublishingAndFrontendModule () { }
@@ -129,6 +140,7 @@ describe('GOVUK Modules', function () {
       delete GOVUK.Modules.LegacyTestAlertModule
       delete GOVUK.Modules.GovukTestAlertModule
       delete GOVUK.Modules.TestAlertFrontendModule
+      delete GOVUK.Modules.GemTestAlertFrontendModule
       delete GOVUK.Modules.GovukTestAlertPublishingAndFrontendModule
       delete GOVUK.Modules.TestAlertPublishingAndFrontendModule
       delete GOVUK.Modules.TestCookieDependencyModule
@@ -182,7 +194,19 @@ describe('GOVUK Modules', function () {
       GOVUK.modules.start()
       expect(callbackLegacyModule.calls.count()).toBe(3)
       expect(callbackGovukModule.calls.count()).toBe(2)
-      expect(callbackFrontendModule.calls.count()).toBe(2)
+      expect(callbackFrontendModule.calls.count()).toBe(1)
+      modules.remove()
+    })
+
+    it('starts multiple modules on a single element', function () {
+      var modules = $(
+        '<div data-module="test-alert-frontend-module gem-test-alert-frontend-module"></div>'
+      )
+
+      $('body').append(modules)
+      GOVUK.modules.start()
+      expect(callbackGemFrontendModule.calls.count()).toBe(1)
+      expect(callbackFrontendModule.calls.count()).toBe(1)
       modules.remove()
     })
 


### PR DESCRIPTION
## What
Allow multiple JavaScript modules on a certain element.

## Why
To allow components using scripts from both `govuk-frontend` and `govuk_publishing_components` to work as intended. This fixes a bug where the checkboxes and details components only load the `govuk-frontend` scripts as a result of [converging to a single module system](https://github.com/alphagov/govuk_publishing_components/pull/2095).

This PR proposes a uniform notation between the `data-module` values (e.g. "govuk-checkboxes" or "gem-checkboxes") and the JavaScript module names (`GovukCheckboxes` and `GemCheckboxes`) with the possibility to apply multiple modules on a certain element. This makes the modules system a bit less 'magical' in the sense that its behaviour is more predictable instead of trying to automatically initialise multiple modules based on a single `data-module` declaration.

## Visual Changes
No visual changes.
