### PR TITLE
Release 24.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,15 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.17.0
 
+* Allow multiple JavaScript modules on a certain element ([PR #2170](https://github.com/alphagov/govuk_publishing_components/pull/2170))
 * Add Brexit variation to action links ([PR #2172](https://github.com/alphagov/govuk_publishing_components/pull/2172))
 * Add faux `require_tree` for Govspeak and polyfills ([PR #2173](https://github.com/alphagov/govuk_publishing_components/pull/2173))
 
 ## 24.16.1
 
-* Add links to privacy and accessibility statements in layout footer component  ([PR #2168](https://github.com/alphagov/govuk_publishing_components/pull/2168))
+* Add links to privacy and accessibility statements in layout footer component ([PR #2168](https://github.com/alphagov/govuk_publishing_components/pull/2168))
 
 ## 24.16.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.16.1)
+    govuk_publishing_components (24.17.0)
       govuk_app_config
       kramdown
       plek
@@ -98,7 +98,7 @@ GEM
     execjs (2.7.0)
     faker (2.17.0)
       i18n (>= 1.6, < 2)
-    faraday (1.4.2)
+    faraday (1.4.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.16.1".freeze
+  VERSION = "24.17.0".freeze
 end


### PR DESCRIPTION
## 24.17.0

* Allow multiple JavaScript modules on a certain element ([PR #2170](https://github.com/alphagov/govuk_publishing_components/pull/2170))
* Add Brexit variation to action links ([PR #2172](https://github.com/alphagov/govuk_publishing_components/pull/2172))
* Add faux `require_tree` for Govspeak and polyfills ([PR #2173](https://github.com/alphagov/govuk_publishing_components/pull/2173))
