### PR TITLE
Add faux `require_tree` for Govspeak and polyfills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add Brexit variation to action links ([PR #2172](https://github.com/alphagov/govuk_publishing_components/pull/2172))
+* Add faux `require_tree` for Govspeak and polyfills ([PR #2173](https://github.com/alphagov/govuk_publishing_components/pull/2173))
 
 ## 24.16.1
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/all.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/all.js
@@ -1,0 +1,1 @@
+// = require_tree ./

--- a/app/assets/javascripts/govuk_publishing_components/vendor/polyfills/all.js
+++ b/app/assets/javascripts/govuk_publishing_components/vendor/polyfills/all.js
@@ -1,0 +1,1 @@
+// = require_tree ./


### PR DESCRIPTION

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

This pull request adds a `all.js` file in each folder that uses `require_tree` for the govspeak and polyfill folders.

## Why
<!-- What are the reasons behind this change being made? -->
A recent change meant that `include` was needed for individual JavaScript files in the [polyfill][1] and [govspeak][2] folders - this was to avoid Static _and_ frontend applications from loading the same JavaScript file twice on the same page.

But this means that any additions to these folders will be left out and have to manually added to each of the frontend applications again. Unfortunately `require_tree` is only available for local files - so the frontend applications can not `require_tree` for folders in the gem.

Adding `require_tree` in a file means that this can be used in each frontend application, doesn't need manually updating, and ensures that any additions to each folder is not forgotten.

[1]: https://github.com/alphagov/frontend/blob/b9c48fb1dc04901ba7f8ae92076d2dfeb1c4240e/app/assets/javascripts/application.js#L4-L6
[2]: https://github.com/alphagov/frontend/blob/b9c48fb1dc04901ba7f8ae92076d2dfeb1c4240e/app/assets/javascripts/application.js#L21-L23
## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
None.
