### PR TITLE
Add margin bottom to radio component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add margin bottom to radio component ([PR #2175](https://github.com/alphagov/govuk_publishing_components/pull/2175))
+
 ## 24.17.0
 
 * Allow multiple JavaScript modules on a certain element ([PR #2170](https://github.com/alphagov/govuk_publishing_components/pull/2170))

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -1,4 +1,5 @@
 <%
+  local_assigns[:margin_bottom] ||= 6
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   id ||= nil
   id_prefix ||= "radio-#{SecureRandom.hex(4)}"
@@ -27,6 +28,7 @@
   hint ||= nil
   error_message ||= nil
   error_items ||= []
+  margin_bottom = margin_bottom ||= 6
 
   has_error = error_message || error_items.any?
   hint_id = "hint-#{SecureRandom.hex(4)}" if hint
@@ -34,6 +36,7 @@
 
   form_group_css_classes = %w(govuk-form-group)
   form_group_css_classes << "govuk-form-group--error" if has_error
+  form_group_css_classes << shared_helper.get_margin_bottom
 
   radio_classes = %w(govuk-radios)
   radio_classes << "govuk-radios--small" if small

--- a/app/views/govuk_publishing_components/components/docs/radio.yml
+++ b/app/views/govuk_publishing_components/components/docs/radio.yml
@@ -65,6 +65,16 @@ examples:
         text: "Use GOV.UK Verify"
         hint_text: "You'll have an account if you've already proved your identity with a certified company, such as the Post Office."
         bold: true
+  with_bottom_margin:
+    description: "The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to a margin bottom of 30px (6)."
+    data:
+      name: "radio-group"
+      margin_bottom: 9
+      items:
+      - value: "government-gateway"
+        text: "Use Government Gateway"
+      - value: "govuk-verify"
+        text: "Use GOV.UK Verify"
   with_hint_on_form_group:
     data:
       name: "radio-group-error"

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -288,11 +288,37 @@ Code can be called and referred to in the template as follows:
 
 ### Shared helper
 
-There is also a [shared helper](https://github.com/alphagov/govuk_publishing_components/blob/master/lib/govuk_publishing_components/presenters/shared_helper.rb) that can provide common functionality to all components. This includes a margin bottom option and a heading level option. See components that use the shared helper for [examples of usage](https://github.com/alphagov/govuk_publishing_components/blob/master/app/views/govuk_publishing_components/components/_heading.html.erb).
+There is a [shared helper](https://github.com/alphagov/govuk_publishing_components/blob/master/lib/govuk_publishing_components/presenters/shared_helper.rb) that can provide common functionality to all components. This includes:
+
+- set margin bottom and top
+- set heading level and heading font size
+- allow JavaScript classes to be added that begin with `js-` but reject any others
+- translation helpers
+
+The following is an example of how to use the shared helper to set margin bottom on a component.
+
+Add the shared helper to the component template:
 
 ```erb
 shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 ```
+
+Call the shared helper to provide a margin bottom class:
+
+```erb
+classes << shared_helper.get_margin_bottom
+```
+
+The component will accept a number for `margin_bottom` from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to a margin bottom of 15px (3). If you require a different default value, change the code as shown.
+
+```erb
+local_assigns[:margin_bottom] ||= 0 # this will be the default
+shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+```
+
+Tests should be added to the component to check that the default margin bottom is correct and that the expected given margin bottom is set. The shared helper has its own tests to check that it returns the correct values.
+
+See components that use the shared helper for further examples of usage, including the accordion, attachment, button, heading, radio, and others.
 
 ## Passing HTML to a component
 

--- a/spec/components/radio_spec.rb
+++ b/spec/components/radio_spec.rb
@@ -91,6 +91,35 @@ describe "Radio", type: :view do
     assert_select ".govuk-radios.govuk-radios--inline"
   end
 
+  it "renders radios with the correct default margin bottom" do
+    render_component(
+      name: "radio-group-one-item",
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway",
+        },
+      ],
+    )
+
+    assert_select '.govuk-form-group.govuk-\!-margin-bottom-6'
+  end
+
+  it "renders radios with a given margin bottom" do
+    render_component(
+      name: "radio-group-one-item",
+      margin_bottom: 9,
+      items: [
+        {
+          value: "government-gateway",
+          text: "Use Government Gateway",
+        },
+      ],
+    )
+
+    assert_select '.govuk-form-group.govuk-\!-margin-bottom-9'
+  end
+
   it "renders radio-group with a legend" do
     render_component(
       name: "favourite-smartie",


### PR DESCRIPTION
## What
Adds the margin_bottom option to the radio component, using the shared helper.

Also expands the documentation for the shared helper, because I had to look through code to remember how to do this.

## Why
Need this option for the radio component on the coronavirus landing page.

## Visual Changes

![Screenshot 2021-07-01 at 09 08 37](https://user-images.githubusercontent.com/861310/124089595-f0a9e300-da4b-11eb-96e8-a180cf52608e.png)

Trello card: https://trello.com/c/eE62ythU/447-coronavirus-timeline-frontend
