### PR TITLE
Update meta links in layout footer variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add margin bottom to radio component ([PR #2175](https://github.com/alphagov/govuk_publishing_components/pull/2175))
+* Add privacy and accessibility links to the layout footer ([PR #2177](https://github.com/alphagov/govuk_publishing_components/pull/2177))
 
 ## 24.17.0
 

--- a/app/views/govuk_publishing_components/components/docs/layout_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_footer.yml
@@ -109,10 +109,14 @@ examples:
         items:
           - href: '/help'
             text: Help
+          - href: '/help/privacy-notice'
+            text: Privacy
           - href: '/help/cookies'
             text: Cookies
           - href: '/contact'
             text: Contact
+          - href: '/help/accessibility-statement'
+            text: Accessibility statement
           - href: '/help/terms-conditions'
             text: Terms and conditions
           - href: '/cymraeg'
@@ -150,10 +154,14 @@ examples:
         items:
           - href: '/help'
             text: Help
+          - href: '/help/privacy-notice'
+            text: Privacy
           - href: '/help/cookies'
             text: Cookies
           - href: '/contact'
             text: Contact
+          - href: '/help/accessibility-statement'
+            text: Accessibility statement
           - href: '/help/terms-conditions'
             text: Terms and conditions
           - href: '/cymraeg'

--- a/lib/govuk_publishing_components/presenters/public_layout_helper.rb
+++ b/lib/govuk_publishing_components/presenters/public_layout_helper.rb
@@ -331,8 +331,16 @@ module GovukPublishingComponents
             text: "Help",
           },
           {
+            href: "/help/privacy-notice",
+            text: "Privacy",
+          },
+          {
             href: "/help/cookies",
             text: "Cookies",
+          },
+          {
+            href: "/help/accessibility-statement",
+            text: "Accessibility statement",
           },
           {
             href: "/contact",


### PR DESCRIPTION
## What
This updates the meta block on alternate variants of the footer to bring them in line with the change made in [PR #2165](https://github.com/alphagov/govuk_publishing_components/pull/2165)
