### PR TITLE
Release 24.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.18.0
 
 * Add margin bottom to radio component ([PR #2175](https://github.com/alphagov/govuk_publishing_components/pull/2175))
 * Add privacy and accessibility links to the layout footer ([PR #2177](https://github.com/alphagov/govuk_publishing_components/pull/2177))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.17.0)
+    govuk_publishing_components (24.18.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.17.0".freeze
+  VERSION = "24.18.0".freeze
 end


### PR DESCRIPTION
## 24.18.0

* Add margin bottom to radio component ([PR #2175](https://github.com/alphagov/govuk_publishing_components/pull/2175))
* Add privacy and accessibility links to the layout footer ([PR #2177](https://github.com/alphagov/govuk_publishing_components/pull/2177))
