### PR TITLE
Add Layout super navigation header component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add Layout super navigation header component ([PR #2179](https://github.com/alphagov/govuk_publishing_components/pull/2179))
+
 ## 24.20.0
 
 * Add inverse option for govspeak ([PR #2207](https://github.com/alphagov/govuk_publishing_components/pull/2207))

--- a/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
@@ -1,0 +1,71 @@
+//= require govuk/vendor/polyfills/Element/prototype/classList.js
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function SuperNavigationToggle ($module) {
+    this.$module = $module
+
+    this.showMenuText = $module.getAttribute('data-text-for-show-menu')
+    this.hideMenuText = $module.getAttribute('data-text-for-hide-menu')
+    this.buttonText = $module.getAttribute('data-text-for-button')
+
+    this.$button = this.setupButton($module)
+
+    this.$menu = document.getElementById(this.$button.getAttribute('aria-controls'))
+
+    this.syncStatus()
+  }
+
+  SuperNavigationToggle.prototype.setupButton = function (target) {
+    var menuHeading = target.getAttribute('aria-labelledby')
+    var adjacentTo = target.querySelector('#' + menuHeading)
+    var buttonText = document.createTextNode(this.buttonText)
+
+    var button = document.createElement('button')
+    button.type = 'button'
+    button.className = 'govuk-header__menu-button gem-c-layout-super-navigation-header__menu-button'
+    button.setAttribute('aria-controls', 'super-navigation-menu')
+    button.setAttribute('aria-label', this.showMenuText)
+    button.setAttribute('aria-expanded', false)
+
+    button.appendChild(buttonText)
+    adjacentTo.insertAdjacentElement('beforebegin', button)
+
+    return button
+  }
+
+  SuperNavigationToggle.prototype.syncStatus = function () {
+    this.status = this.$button.getAttribute('aria-expanded') === 'true' ? 'open' : 'closed'
+  }
+
+  SuperNavigationToggle.prototype.closeMenu = function () {
+    this.$menu.classList.remove('gem-c-layout-super-navigation-header__items--open')
+
+    this.$button.classList.remove('govuk-header__menu-button--open')
+    this.$button.setAttribute('aria-expanded', false)
+    this.$button.setAttribute('aria-label', this.showMenuText)
+  }
+
+  SuperNavigationToggle.prototype.openMenu = function () {
+    this.$menu.classList.add('gem-c-layout-super-navigation-header__items--open')
+
+    this.$button.classList.add('govuk-header__menu-button--open')
+    this.$button.setAttribute('aria-expanded', true)
+    this.$button.setAttribute('aria-label', this.hideMenuText)
+  }
+
+  SuperNavigationToggle.prototype.handleToggle = function () {
+    if (this.status === 'open') this.closeMenu()
+    if (this.status === 'closed') this.openMenu()
+
+    this.syncStatus()
+  }
+
+  SuperNavigationToggle.prototype.init = function () {
+    this.$button.addEventListener('click', this.handleToggle.bind(this))
+  }
+
+  Modules.SuperNavigationToggle = SuperNavigationToggle
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -49,6 +49,7 @@ $govuk-new-link-styles: true;
 @import "components/layout-for-admin";
 @import "components/layout-for-public";
 @import "components/layout-header";
+@import "components/layout-super-navigation-header";
 @import "components/lead-paragraph";
 @import "components/metadata";
 @import "components/modal-dialogue";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -8,6 +8,7 @@
 @import "components/print/contents-list";
 @import "components/print/govspeak-html-publication";
 @import "components/print/govspeak";
+@import "components/print/layout-super-navigation-header";
 @import "components/print/step-by-step-nav-header";
 @import "components/print/step-by-step-nav";
 @import "components/print/textarea";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -119,3 +119,7 @@ $search-icon-size: 20px;
 .js-enabled .gem-c-layout-super-navigation-header__items--open {
   display: block;
 }
+
+.gem-c-layout-super-navigation-header__dropdown-menu {
+  display: none;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -94,3 +94,28 @@ $search-icon-size: 20px;
     width: $search-icon-size;
   }
 }
+
+.gem-c-layout-super-navigation-header__menu-button {
+  @include govuk-font($size: 19, $weight: bold, $line-height: 20px);
+  border-left: 1px solid govuk-colour("mid-grey");
+  border-right: 1px solid govuk-colour("mid-grey");
+  padding: govuk-spacing(4);
+  top: 0;
+
+  &:focus {
+    border-left-color: $govuk-focus-colour;
+    border-right-color: $govuk-focus-colour;
+  }
+}
+
+.js-enabled .gem-c-layout-super-navigation-header__items {
+  display: none;
+
+  @include govuk-media-query($from: "desktop") {
+    display: block;
+  }
+}
+
+.js-enabled .gem-c-layout-super-navigation-header__items--open {
+  display: block;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -1,0 +1,96 @@
+$search-icon-size: 20px;
+
+.gem-c-layout-super-navigation-header {
+  background: govuk-colour("black");
+  position: relative;
+}
+
+.gem-c-layout-super-navigation-header__header-logo {
+  height: govuk-spacing(6);
+  padding-top: govuk-spacing(3);
+  padding-bottom: govuk-spacing(3);
+
+  @include govuk-media-query($from: "desktop") {
+    display: block;
+    float: left;
+  }
+}
+
+.gem-c-layout-super-navigation-header__content {
+  @include govuk-media-query($from: "desktop") {
+    display: block;
+    float: right;
+  }
+}
+
+.gem-c-layout-super-navigation-header__items {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 govuk-spacing(1) 0;
+
+  @include govuk-media-query($from: "desktop") {
+    padding: 0;
+  }
+}
+
+.gem-c-layout-super-navigation-header__item {
+  margin-right: 0;
+  padding: govuk-spacing(1) 0;
+
+  @include govuk-media-query($from: "desktop") {
+    float: left;
+    padding: 0;
+  }
+}
+
+.gem-c-layout-super-navigation-header__item-link {
+  display: block;
+  padding: govuk-spacing(3) 0;
+  position: relative;
+
+  @include govuk-media-query($from: "desktop") {
+    padding: govuk-spacing(4);
+    width: auto;
+  }
+
+  &:focus {
+    z-index: 1;
+  }
+}
+
+// Special search link
+.gem-c-layout-super-navigation-header__item--search {
+  border-bottom: 0;
+}
+
+.gem-c-layout-super-navigation-header__item-link--search {
+  @include govuk-media-query($from: "desktop") {
+    background-color: $govuk-link-colour;
+    display: inherit;
+    width: govuk-spacing(4);
+
+    &:hover {
+      background-color: $govuk-link-hover-colour;
+    }
+
+    &:focus {
+      background-color: $govuk-focus-colour;
+    }
+  }
+}
+
+.gem-c-layout-super-navigation-header__item-link-text--search {
+  @include govuk-media-query($from: "desktop") {
+    @include govuk-visually-hidden;
+  }
+}
+
+.gem-c-layout-super-navigation-header__item-link-icon--search {
+  display: none;
+
+  @include govuk-media-query($from: "desktop") {
+    display: block;
+    height: $search-icon-size;
+    width: $search-icon-size;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_layout-super-navigation-header.scss
@@ -1,0 +1,3 @@
+.gem-c-super-navigation-header a:after {
+  content: " ( " attr(href) " ) ";
+}

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -1,14 +1,15 @@
 <%
-  omit_feedback_form ||= false
   emergency_banner ||= nil
   full_width ||= false
   global_bar ||= nil
-  product_name ||= nil
   html_lang ||= "en"
   layout_helper = GovukPublishingComponents::Presenters::PublicLayoutHelper.new(local_assigns)
   logo_link ||= "/"
   navigation_items ||= []
+  omit_feedback_form ||= false
   omit_header ||= false
+  product_name ||= nil
+  show_explore_header ||= false
   show_search = local_assigns.include?(:show_search) ? local_assigns[:show_search] : true
   title ||= "GOV.UK - The best place to find government services and information"
 
@@ -75,16 +76,20 @@
     <%= render "govuk_publishing_components/components/cookie_banner" %>
 
     <% unless omit_header %>
-      <%= render "govuk_publishing_components/components/layout_header", {
-        search: show_search,
-        logo_link: logo_link,
-        navigation_items: navigation_items,
-        product_name: product_name,
+      <% if show_explore_header %>
+        <%= render "govuk_publishing_components/components/layout_super_navigation_header" %>
+      <% else %>
+        <%= render "govuk_publishing_components/components/layout_header", {
+          search: show_search,
+          logo_link: logo_link,
+          navigation_items: navigation_items,
+          product_name: product_name,
 
-        # The (blue) bottom border needs to be underneath the emergency banner -
-        # so it has been turned off and added in manually.
-        remove_bottom_border: true,
-      } %>
+          # The (blue) bottom border needs to be underneath the emergency banner -
+          # so it has been turned off and added in manually.
+          remove_bottom_border: true,
+        } %>
+      <% end %>
     <% end %>
 
     <%= raw(emergency_banner) %>

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -1,80 +1,13 @@
 <%
-  navigation_links = YAML::load("
-- label: Topics
-  href: /browse
-  description: Find information and services
-  link_sections:
-    - - label: Benefits
-        href: /browse/benefits
-      - label: Births, death, marriages and care
-        href: /browse/births-deaths-marriages
-      - label: Brexit
-        href: /brexit
-      - label: Business and self-employed
-        href: /browse/business
-      - label: Childcare and parenting
-        href: /browse/childcare-parenting
-      - label: Citizenship and living in the UK
-        href: /browse/citizenship
-      - label: Coronavirus (COVID‑19)
-        href: /coronavirus
-      - label: Crime, justice and the law
-        href: /browse/justice
-      - label: Disabled people
-        href: /browse/disabilities
-    - - label: Driving and transport
-        href: /browse/driving
-      - label: Education and learning
-        href: /browse/education
-      - label: Employing people
-        href: /browse/employing-people
-      - label: Environment and countryside
-        href: /browse/environment-countryside
-      - label: Housing and local services
-        href: /browse/housing-local-services
-      - label: Money and tax
-        href: /browse/tax
-      - label: Passports, travel and living abroad
-        href: /browse/abroad
-      - label: Visas and immigration
-        href: /browse/visas-immigration
-      - label: Working, jobs and pensions
-        href: /browse/working
-- label: Departments
-  href: /government/organisations
-- label: Government activity
-  href: /search/news-and-communications
-  description: Find out what the government is doing
-  link_sections:
-    - - label: News
-        href: /search/news-and-communications
-        description: News stories, speeches, letters and notices
-      - label: Guidance and regulation
-        href: /search/guidance-and-regulation
-        description: Detailed guidance, regulations and rules
-      - label: Research and statistics
-        href: /search/research-and-statistics
-        description: Reports, analysis and official statistics
-    - - label: Policy papers and consultation
-        href: /search/policy-papers-and-consultations
-        description: Consultations and strategy
-      - label: Transparency
-        href: /search/transparency-and-freedom-of-information-releases
-        description: Government data, freedom of information releases and corporate reports
-  footer_links:
-    - - label: How government works
-        href: /government/how-government-works
-    - - label: Get involved
-        href: /government/get-involved
-")
-
 logo_link = "https://www.gov.uk/"
-logo_link_title = "Go to the GOV.UK homepage"
-logo_text = "GOV.UK"
-navigation_menu_heading = "Navigation menu"
-search_text = "Search GOV.UK"
+logo_link_title = t("components.layout_super_navigation_header.logo_link_title")
+logo_text = t("components.layout_super_navigation_header.logo_text")
+navigation_links = t("components.layout_super_navigation_header.navigation_links")
+navigation_menu_heading = t("components.layout_super_navigation_header.navigation_menu_heading")
+popular_links = t("components.layout_super_navigation_header.popular_links")
+popular_links_heading = t("components.layout_super_navigation_header.popular_links_heading")
+search_text= t("components.layout_super_navigation_header.search_text")
 %>
-
 <header role="banner" class="gem-c-layout-super-navigation-header">
   <div class="gem-c-layout-super-navigation-header__container govuk-width-container govuk-clearfix">
     <div class="gem-c-layout-super-navigation-header__header-logo">
@@ -122,9 +55,36 @@ search_text = "Search GOV.UK"
       <ul id="super-navigation-menu" class="gem-c-layout-super-navigation-header__items">
         <% navigation_links.each do | link | %>
           <li class="govuk-header__navigation-item gem-c-layout-super-navigation-header__item">
-            <a class="govuk-header__link gem-c-layout-super-navigation-header__item-link" href="<%= link["href"] %>">
-              <%= link["label"] %>
+            <a class="govuk-header__link gem-c-layout-super-navigation-header__item-link" href="<%= link[:href] %>">
+              <%= link[:label] %>
             </a>
+            <% if link[:menu_contents].present? or link[:footer_links].present? %>
+              <div class="gem-c-layout-super-navigation-header__dropdown-menu">
+                <% if link[:menu_contents].present? %>
+                  <ul class="govuk-list">
+                    <% link[:menu_contents].each do | item | %>
+                      <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                        <a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="<%= item[:href] %>">
+                          <%= item[:label] %>
+                        </a>
+                        <%= tag.p item[:description], class: "govuk-body-s gem-c-layout-super-navigation-header__dropdown-list-item-description" if item[:description].present? %>
+                      </li>
+                    <% end %>
+                  </ul>
+                <% end %>
+                <% if link[:footer_links].present? %>
+                  <ul class="govuk-list">
+                    <% link[:footer_links].each do | item | %>
+                      <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                        <a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="<%= item[:href] %>">
+                          <%= item[:label] %>
+                        </a>
+                      </li>
+                    <% end %>
+                  </ul>
+                <% end %>
+              </div>
+            <% end %>
           </li>
         <% end %>
         <li class="govuk-header__navigation-item gem-c-layout-super-navigation-header__item gem-c-layout-super-navigation-header__item--search">
@@ -135,6 +95,25 @@ search_text = "Search GOV.UK"
               <line x1="15.8668" y1="16.3587" x2="25.4475" y2="25.9393" stroke="currentColor" stroke-width="3" />
             </svg>
           </a>
+          <div class="gem-c-layout-super-navigation-header__dropdown-menu">
+            <form id="search" action="/search" method="get" role="search" aria-label="Site-wide">
+              <%= render "govuk_publishing_components/components/search", {
+                inline_label: false,
+                label_text: raw("<h2 class=\"govuk-heading-m\">#{search_text}</h2>"),
+                size: "large",
+              } %>
+            </form>
+            <h2 class="govuk-heading-m"><%= popular_links_heading %></h2>
+            <ul class="govuk-list">
+              <% popular_links.each do | popular_link | %>
+                <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                  <a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="<%= popular_link[:href] %>">
+                    <%= popular_link[:label] %>
+                  </a>
+                </li>
+              <% end %>
+            </ul>
+          </div>
         </li>
       </ul>
     </nav>

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -1,0 +1,135 @@
+<%
+  navigation_links = YAML::load("
+- label: Topics
+  href: /browse
+  description: Find information and services
+  link_sections:
+    - - label: Benefits
+        href: /browse/benefits
+      - label: Births, death, marriages and care
+        href: /browse/births-deaths-marriages
+      - label: Brexit
+        href: /brexit
+      - label: Business and self-employed
+        href: /browse/business
+      - label: Childcare and parenting
+        href: /browse/childcare-parenting
+      - label: Citizenship and living in the UK
+        href: /browse/citizenship
+      - label: Coronavirus (COVID‑19)
+        href: /coronavirus
+      - label: Crime, justice and the law
+        href: /browse/justice
+      - label: Disabled people
+        href: /browse/disabilities
+    - - label: Driving and transport
+        href: /browse/driving
+      - label: Education and learning
+        href: /browse/education
+      - label: Employing people
+        href: /browse/employing-people
+      - label: Environment and countryside
+        href: /browse/environment-countryside
+      - label: Housing and local services
+        href: /browse/housing-local-services
+      - label: Money and tax
+        href: /browse/tax
+      - label: Passports, travel and living abroad
+        href: /browse/abroad
+      - label: Visas and immigration
+        href: /browse/visas-immigration
+      - label: Working, jobs and pensions
+        href: /browse/working
+- label: Departments
+  href: /government/organisations
+- label: Government activity
+  href: /search/news-and-communications
+  description: Find out what the government is doing
+  link_sections:
+    - - label: News
+        href: /search/news-and-communications
+        description: News stories, speeches, letters and notices
+      - label: Guidance and regulation
+        href: /search/guidance-and-regulation
+        description: Detailed guidance, regulations and rules
+      - label: Research and statistics
+        href: /search/research-and-statistics
+        description: Reports, analysis and official statistics
+    - - label: Policy papers and consultation
+        href: /search/policy-papers-and-consultations
+        description: Consultations and strategy
+      - label: Transparency
+        href: /search/transparency-and-freedom-of-information-releases
+        description: Government data, freedom of information releases and corporate reports
+  footer_links:
+    - - label: How government works
+        href: /government/how-government-works
+    - - label: Get involved
+        href: /government/get-involved
+")
+
+logo_link = "https://www.gov.uk/"
+logo_link_title = "Go to the GOV.UK homepage"
+logo_text = "GOV.UK"
+navigation_menu_heading = "Navigation menu"
+search_text = "Search GOV.UK"
+%>
+
+<header role="banner" class="gem-c-layout-super-navigation-header">
+  <div class="gem-c-layout-super-navigation-header__container govuk-width-container govuk-clearfix">
+    <div class="gem-c-layout-super-navigation-header__header-logo">
+      <a class="govuk-header__link govuk-header__link--homepage"
+        data-module="gem-track-click"
+        data-track-action="homeHeader"
+        data-track-category="homeLinkClicked"
+        href="<%= logo_link %>"
+        id="logo"
+        title="<%= logo_link_title %>">
+        <span class="govuk-header__logotype">
+          <svg aria-hidden="true"
+            class="govuk-header__logotype-crown gem-c-layout-super-navigation-header__logotype-crown"
+            focusable="false"
+            height="30"
+            viewBox="0 0 132 97"
+            xmlns="http://www.w3.org/2000/svg"
+            width="36">
+            <path fill="currentColor"
+              fill-rule="evenodd"
+              d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z">
+            </path>
+            <image class="govuk-header__logotype-crown-fallback-image"
+              height="30"
+              src="<%= asset_path('govuk-logotype-crown.png') %>"
+              width="36"
+              xlink:href="">
+            </image>
+          </svg>
+          <span class="govuk-header__logotype-text">
+            <%= logo_text %>
+          </span>
+        </span>
+      </a>
+    </div>
+    <nav class="gem-c-layout-super-navigation-header__content" aria-labelledby="navigation-menu-heading">
+      <h2 id="navigation-menu-heading" class="govuk-visually-hidden"><%= navigation_menu_heading %></h2>
+      <ul id="navigation" class="gem-c-layout-super-navigation-header__items">
+        <% navigation_links.each do | link | %>
+          <li class="govuk-header__navigation-item gem-c-layout-super-navigation-header__item">
+            <a class="govuk-header__link gem-c-layout-super-navigation-header__item-link" href="<%= link["href"] %>">
+              <%= link["label"] %>
+            </a>
+          </li>
+        <% end %>
+        <li class="govuk-header__navigation-item gem-c-layout-super-navigation-header__item gem-c-layout-super-navigation-header__item--search">
+          <a class="govuk-header__link gem-c-layout-super-navigation-header__item-link gem-c-layout-super-navigation-header__item-link--search" href="/search">
+            <span class="gem-c-layout-super-navigation-header__item-link-text--search"><%= search_text %></span>
+            <svg class="gem-c-layout-super-navigation-header__item-link-icon--search" width="27" height="27" viewBox="0 0 27 27" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <circle cx="10.0161" cy="10.0161" r="8.51613" stroke="currentColor" stroke-width="3" />
+              <line x1="15.8668" y1="16.3587" x2="25.4475" y2="25.9393" stroke="currentColor" stroke-width="3" />
+            </svg>
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -110,9 +110,16 @@ search_text = "Search GOV.UK"
         </span>
       </a>
     </div>
-    <nav class="gem-c-layout-super-navigation-header__content" aria-labelledby="navigation-menu-heading">
-      <h2 id="navigation-menu-heading" class="govuk-visually-hidden"><%= navigation_menu_heading %></h2>
-      <ul id="navigation" class="gem-c-layout-super-navigation-header__items">
+    <nav
+      aria-labelledby="super-navigation-menu-heading"
+      class="gem-c-layout-super-navigation-header__content"
+      data-module="super-navigation-toggle"
+      data-text-for-button="Menu"
+      data-text-for-show-menu="Show navigation menu"
+      data-text-for-hide-menu="Hide navigation menu"
+    >
+      <h2 id="super-navigation-menu-heading" class="govuk-visually-hidden"><%= navigation_menu_heading %></h2>
+      <ul id="super-navigation-menu" class="gem-c-layout-super-navigation-header__items">
         <% navigation_links.each do | link | %>
           <li class="govuk-header__navigation-item gem-c-layout-super-navigation-header__item">
             <a class="govuk-header__link gem-c-layout-super-navigation-header__item-link" href="<%= link["href"] %>">

--- a/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
@@ -1,0 +1,22 @@
+name: Layout super navigation header
+description: The super navigation header provides a consistent header across GOV.UK.
+body: |
+shared_accessibility_criteria:
+  - link
+accessibility_criteria: |
+  The component must:
+
+  * have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+
+  Images in the super navigation header must:
+
+  * be presentational when linked to from accompanying text (crown icon).
+
+  Landmarks and Roles in the super navigation header should:
+
+  * have a role of banner at the root of the component (<header>) (ARIA 1.1)
+accessibility_excluded_rules:
+  - landmark-banner-is-top-level # The header element can not be top level in the examples
+  - landmark-no-duplicate-banner # banners will be duplicated in component examples list
+examples:
+  default:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -79,6 +79,14 @@ ar:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -79,6 +79,14 @@ az:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -79,6 +79,14 @@ be:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -79,6 +79,14 @@ bg:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -79,6 +79,14 @@ bn:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -79,6 +79,14 @@ cs:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -79,6 +79,14 @@ cy:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -79,6 +79,14 @@ da:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -79,6 +79,14 @@ de:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -79,6 +79,14 @@ dr:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -79,6 +79,14 @@ el:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,91 @@ en:
       search_button: Search GOV.UK
       show_button: Show search
       top_level: Top level
+    layout_super_navigation_header:
+      logo_link_title: Go to the GOV.UK homepage
+      logo_text: GOV.UK
+      navigation_menu_heading: Navigation menu
+      search_text: Search GOV.UK
+      popular_links_heading: Popular on GOV.UK
+      popular_links:
+        - label: 'Coronavirus (COVID-19): rules'
+          href: /guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do
+        - label: 'Brexit: check what you need to do'
+          href: /brexit
+        - label: Sign in to your personal tax account
+          href: /personal-tax-account
+        - label: Find a job
+          href: /find-a-job
+        - label: Sign in to your Universal Credit account
+          href: /sign-in-universal-credit
+      navigation_links:
+        - label: Topics
+          href: /browse
+          description: Find information and services
+          show: true
+          menu_contents:
+            - label: Benefits
+              href: /browse/benefits
+            - label: Births, death, marriages and care
+              href: /browse/births-deaths-marriages
+            - label: Brexit
+              href: /brexit
+            - label: Business and self-employed
+              href: /browse/business
+            - label: Childcare and parenting
+              href: /browse/childcare-parenting
+            - label: Citizenship and living in the UK
+              href: /browse/citizenship
+            - label: Coronavirus (COVID‑19)
+              href: /coronavirus
+            - label: Crime, justice and the law
+              href: /browse/justice
+            - label: Disabled people
+              href: /browse/disabilities
+            - label: Driving and transport
+              href: /browse/driving
+            - label: Education and learning
+              href: /browse/education
+            - label: Employing people
+              href: /browse/employing-people
+            - label: Environment and countryside
+              href: /browse/environment-countryside
+            - label: Housing and local services
+              href: /browse/housing-local-services
+            - label: Money and tax
+              href: /browse/tax
+            - label: Passports, travel and living abroad
+              href: /browse/abroad
+            - label: Visas and immigration
+              href: /browse/visas-immigration
+            - label: Working, jobs and pensions
+              href: /browse/working
+        - label: Departments
+          href: /government/organisations
+        - label: Government activity
+          href: /search/news-and-communications
+          description: Find out what the government is doing
+          menu_contents:
+            - label: News
+              href: /search/news-and-communications
+              description: News stories, speeches, letters and notices
+            - label: Guidance and regulation
+              href: /search/guidance-and-regulation
+              description: Detailed guidance, regulations and rules
+            - label: Research and statistics
+              href: /search/research-and-statistics
+              description: Reports, analysis and official statistics
+            - label: Policy papers and consultation
+              href: /search/policy-papers-and-consultations
+              description: Consultations and strategy
+            - label: Transparency
+              href: /search/transparency-and-freedom-of-information-releases
+              description: Government data, freedom of information releases and corporate reports
+          footer_links:
+            - label: How government works
+              href: /government/how-government-works
+            - label: Get involved
+              href: /government/get-involved
     metadata:
       from: From
       history: History

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -79,6 +79,14 @@ es-419:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -79,6 +79,14 @@ es:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -79,6 +79,14 @@ et:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -79,6 +79,14 @@ fa:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -79,6 +79,14 @@ fi:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -79,6 +79,14 @@ fr:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -79,6 +79,14 @@ gd:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -79,6 +79,14 @@ gu:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -79,6 +79,14 @@ he:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -79,6 +79,14 @@ hi:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -79,6 +79,14 @@ hr:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -79,6 +79,14 @@ hu:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -79,6 +79,14 @@ hy:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -79,6 +79,14 @@ id:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -79,6 +79,14 @@ is:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -79,6 +79,14 @@ it:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -79,6 +79,14 @@ ja:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -79,6 +79,14 @@ ka:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -79,6 +79,14 @@ kk:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -79,6 +79,14 @@ ko:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -79,6 +79,14 @@ lt:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -79,6 +79,14 @@ lv:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -79,6 +79,14 @@ ms:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -79,6 +79,14 @@ mt:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -79,6 +79,14 @@ nl:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -79,6 +79,14 @@
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -79,6 +79,14 @@ pa-pk:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -79,6 +79,14 @@ pa:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -79,6 +79,14 @@ pl:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -79,6 +79,14 @@ ps:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -79,6 +79,14 @@ pt:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -79,6 +79,14 @@ ro:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -79,6 +79,14 @@ ru:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -79,6 +79,14 @@ si:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -79,6 +79,14 @@ sk:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -79,6 +79,14 @@ sl:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -79,6 +79,14 @@ so:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -79,6 +79,14 @@ sq:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -79,6 +79,14 @@ sr:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -79,6 +79,14 @@ sv:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -79,6 +79,14 @@ sw:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -79,6 +79,14 @@ ta:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -79,6 +79,14 @@ th:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -79,6 +79,14 @@ tk:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -79,6 +79,14 @@ tr:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -79,6 +79,14 @@ uk:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -79,6 +79,14 @@ ur:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -79,6 +79,14 @@ uz:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -79,6 +79,14 @@ vi:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -79,6 +79,14 @@ zh-hk:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -79,6 +79,14 @@ zh-tw:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -79,6 +79,14 @@ zh:
       search_button:
       show_button:
       top_level:
+    layout_super_navigation_header:
+      logo_link_title:
+      logo_text:
+      navigation_menu_heading:
+      search_text:
+      popular_links_heading:
+      popular_links:
+      navigation_links:
     metadata:
       from:
       history:

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -63,6 +63,7 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/layout-for-admin';
 @import 'govuk_publishing_components/components/layout-for-public';
 @import 'govuk_publishing_components/components/layout-header';
+@import 'govuk_publishing_components/components/layout-super-navigation-header';
 @import 'govuk_publishing_components/components/print-link';
 @import 'govuk_publishing_components/components/related-navigation';
 @import 'govuk_publishing_components/components/search';
@@ -80,6 +81,7 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/print/govspeak';
 @import 'govuk_publishing_components/components/print/layout-footer';
 @import 'govuk_publishing_components/components/print/layout-header';
+@import 'govuk_publishing_components/components/print/layout-super-navigation-header';
 @import 'govuk_publishing_components/components/print/search';
 @import 'govuk_publishing_components/components/print/skip-link';
 @import 'govuk_publishing_components/components/print/step-by-step-nav';
@@ -102,6 +104,7 @@ describe "Component guide index" do
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/layout-header
+//= require govuk_publishing_components/components/layout-super-navigation-header
 //= require govuk_publishing_components/components/print-link
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/tabs"

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe "Super navigation header", type: :view do
+  def component_name
+    "layout_super_navigation_header"
+  end
+
+  it "renders the super navigation header" do
+    render_component({})
+
+    assert_select ".gem-c-layout-super-navigation-header", count: 1
+  end
+
+  it "has a nav element that is labelled by a heading that exists" do
+    render_component({})
+
+    assert_select ".gem-c-layout-super-navigation-header__content[aria-labelledby]", count: 1
+
+    label = "##{assert_select('.gem-c-layout-super-navigation-header__content[aria-labelledby]').first['aria-labelledby']}"
+
+    assert_select label, count: 1
+  end
+
+  it "renders the menu list with links in it" do
+    render_component({})
+
+    assert_select ".gem-c-layout-super-navigation-header__items", count: 1
+    assert_select ".gem-c-layout-super-navigation-header__items .gem-c-layout-super-navigation-header__item", count: 4
+    assert_select ".gem-c-layout-super-navigation-header__items .gem-c-layout-super-navigation-header__item .gem-c-layout-super-navigation-header__item-link", count: 4
+  end
+
+  it "has only one search link in the menu" do
+    render_component({})
+
+    assert_select ".gem-c-layout-super-navigation-header__item--search", count: 1
+  end
+end

--- a/spec/javascripts/components/layout-super-navigation-header-spec.js
+++ b/spec/javascripts/components/layout-super-navigation-header-spec.js
@@ -53,6 +53,100 @@ describe('The super header navigation', function () {
                 '<a class="govuk-header__link gem-c-layout-super-navigation-header__item-link" href="/example-one">' +
                   'Example one' +
                 '</a>' +
+                '<div class="gem-c-layout-super-navigation-header__dropdown-menu">' +
+                  '<ul class="govuk-list">' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/benefits">' +
+                          'Benefits' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/births-deaths-marriages">' +
+                          'Births, death, marriages and care' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/brexit">' +
+                          'Brexit' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/business">' +
+                          'Business and self-employed' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/childcare-parenting">' +
+                          'Childcare and parenting' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/citizenship">' +
+                          'Citizenship and living in the UK' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/coronavirus">' +
+                          'Coronavirus (COVID‑19)' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/justice">' +
+                          'Crime, justice and the law' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/disabilities">' +
+                          'Disabled people' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/driving">' +
+                          'Driving and transport' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/education">' +
+                          'Education and learning' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/employing-people">' +
+                          'Employing people' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/environment-countryside">' +
+                          'Environment and countryside' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/housing-local-services">' +
+                          'Housing and local services' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/tax">' +
+                          'Money and tax' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/abroad">' +
+                          'Passports, travel and living abroad' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/visas-immigration">' +
+                          'Visas and immigration' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/browse/working">' +
+                          'Working, jobs and pensions' +
+                        '</a>' +
+                      '</li>' +
+                    '</ul>' +
+                '</div>' +
               '</li>' +
               '<li class="govuk-header__navigation-item gem-c-layout-super-navigation-header__item">' +
                 '<a class="govuk-header__link gem-c-layout-super-navigation-header__item-link" href="/example-two">' +
@@ -63,6 +157,52 @@ describe('The super header navigation', function () {
                 '<a class="govuk-header__link gem-c-layout-super-navigation-header__item-link" href="/example-three">' +
                   'Example three' +
                 '</a>' +
+                '<div class="gem-c-layout-super-navigation-header__dropdown-menu">' +
+                  '<ul class="govuk-list">' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/search/news-and-communications">' +
+                          'News' +
+                        '</a>' +
+                        '<p class="govuk-body-s gem-c-layout-super-navigation-header__dropdown-list-item-description">News stories, speeches, letters and notices</p>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/search/guidance-and-regulation">' +
+                          'Guidance and regulation' +
+                        '</a>' +
+                        '<p class="govuk-body-s gem-c-layout-super-navigation-header__dropdown-list-item-description">Detailed guidance, regulations and rules</p>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/search/research-and-statistics">' +
+                          'Research and statistics' +
+                        '</a>' +
+                        '<p class="govuk-body-s gem-c-layout-super-navigation-header__dropdown-list-item-description">Reports, analysis and official statistics</p>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/search/policy-papers-and-consultations">' +
+                          'Policy papers and consultation' +
+                        '</a>' +
+                        '<p class="govuk-body-s gem-c-layout-super-navigation-header__dropdown-list-item-description">Consultations and strategy</p>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/search/transparency-and-freedom-of-information-releases">' +
+                          'Transparency' +
+                        '</a>' +
+                        '<p class="govuk-body-s gem-c-layout-super-navigation-header__dropdown-list-item-description">Government data, freedom of information releases and corporate reports</p>' +
+                      '</li>' +
+                  '</ul>' +
+                  '<ul class="govuk-list">' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/government/how-government-works">' +
+                          'How government works' +
+                        '</a>' +
+                      '</li>' +
+                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                        '<a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="/government/get-involved">' +
+                          'Get involved' +
+                        '</a>' +
+                      '</li>' +
+                  '</ul>' +
+              '</div>' +
               '</li>' +
               '<li class="govuk-header__navigation-item gem-c-layout-super-navigation-header__item gem-c-layout-super-navigation-header__item--search">' +
                 '<a class="govuk-header__link gem-c-layout-super-navigation-header__item-link gem-c-layout-super-navigation-header__item-link--search" href="/search">' +

--- a/spec/javascripts/components/layout-super-navigation-header-spec.js
+++ b/spec/javascripts/components/layout-super-navigation-header-spec.js
@@ -1,0 +1,208 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+describe('The super header navigation', function () {
+  'use strict'
+
+  var container
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.className = 'js-enabled'
+    container.innerHTML =
+      '<header role="banner" class="gem-c-layout-super-navigation-header">' +
+        '<div class="gem-c-layout-super-navigation-header__container govuk-width-container govuk-clearfix">' +
+          '<div class="gem-c-layout-super-navigation-header__header-logo">' +
+            '<a href="https://www.gov.uk/"' +
+                'title="Go to the GOV.UK homepage"' +
+                'class="govuk-header__link govuk-header__link--homepage"' +
+                'id="logo"' +
+                'data-module="gem-track-click"' +
+                'data-track-category="homeLinkClicked"' +
+                'data-track-action="homeHeader">' +
+              '<span class="govuk-header__logotype">' +
+                '<svg aria-hidden="true"' +
+                      'focusable="false"' +
+                      'class="govuk-header__logotype-crown gem-c-layout-super-navigation-header__logotype-crown"' +
+                      'xmlns="http://www.w3.org/2000/svg"' +
+                      'viewBox="0 0 132 97"' +
+                      'height="30"' +
+                      'width="36">' +
+                  '<path fill="currentColor"' +
+                        'fill-rule="evenodd"' +
+                        'd="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z">' +
+                  '</path>' +
+                '</svg>' +
+                '<span class="govuk-header__logotype-text">' +
+                  'GOV.UK' +
+                '</span>' +
+              '</span>' +
+            '</a>' +
+          '</div>' +
+          '<nav ' +
+            'aria-labelledby="super-navigation-menu-heading" ' +
+            'class="gem-c-layout-super-navigation-header__content" ' +
+            'data-module="super-navigation-toggle" ' +
+            'data-text-for-button="Menu" ' +
+            'data-text-for-show-menu="Show navigation menu" ' +
+            'data-text-for-hide-menu="Hide navigation menu"' +
+          '>' +
+            '<h2 id="super-navigation-menu-heading" class="govuk-visually-hidden">Navigation menu</h2>' +
+            '<ul id="super-navigation-menu" class="gem-c-layout-super-navigation-header__items">' +
+              '<li class="govuk-header__navigation-item gem-c-layout-super-navigation-header__item">' +
+                '<a class="govuk-header__link gem-c-layout-super-navigation-header__item-link" href="/example-one">' +
+                  'Example one' +
+                '</a>' +
+              '</li>' +
+              '<li class="govuk-header__navigation-item gem-c-layout-super-navigation-header__item">' +
+                '<a class="govuk-header__link gem-c-layout-super-navigation-header__item-link" href="/example-two">' +
+                  'Example two' +
+                '</a>' +
+              '</li>' +
+              '<li class="govuk-header__navigation-item gem-c-layout-super-navigation-header__item">' +
+                '<a class="govuk-header__link gem-c-layout-super-navigation-header__item-link" href="/example-three">' +
+                  'Example three' +
+                '</a>' +
+              '</li>' +
+              '<li class="govuk-header__navigation-item gem-c-layout-super-navigation-header__item gem-c-layout-super-navigation-header__item--search">' +
+                '<a class="govuk-header__link gem-c-layout-super-navigation-header__item-link gem-c-layout-super-navigation-header__item-link--search" href="/search">' +
+                  '<span class="gem-c-layout-super-navigation-header__item-link-text--search">Search</span>' +
+                  '<svg class="gem-c-layout-super-navigation-header__item-link-icon--search" width="27" height="27" viewBox="0 0 27 27" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">' +
+                    '<circle cx="10.0161" cy="10.0161" r="8.51613" stroke="currentColor" stroke-width="3" />' +
+                    '<line x1="15.8668" y1="16.3587" x2="25.4475" y2="25.9393" stroke="currentColor" stroke-width="3" />' +
+                  '</svg>' +
+                '</a>' +
+              '</li>' +
+            '</ul>' +
+          '</nav>' +
+        '</div>' +
+      '</header>'
+
+    document.body.appendChild(container)
+
+    var $element = document.querySelector('[data-module="super-navigation-toggle"]')
+    new GOVUK.Modules.SuperNavigationToggle($element).init()
+  })
+
+  afterEach(function () {
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
+
+    document.body.removeChild(container)
+  })
+
+  describe('the Menu button', function () {
+    var $button
+
+    beforeEach(function () {
+      $button = document.querySelector('.gem-c-layout-super-navigation-header__menu-button')
+    })
+
+    it('is present', function () {
+      expect($button).toExist()
+    })
+
+    it('has the correct text', function () {
+      expect($button).toHaveText('Menu')
+    })
+
+    it('has the correct type', function () {
+      expect($button).toHaveAttr('type', 'button')
+    })
+
+    it('is correctly visible depending on the screen size', function () {
+      if (window.innerWidth >= 769) {
+        expect($button).toBeHidden()
+      } else {
+        expect($button).toBeVisible()
+      }
+    })
+
+    describe('with the correct ARIA attributes', function () {
+      it('has `aria-controls` set to "navigation"', function () {
+        expect($button).toHaveAttr('aria-controls', 'super-navigation-menu')
+      })
+
+      it('has `aria-label` set to "Show navigation menu"', function () {
+        expect($button).toHaveAttr('aria-label', 'Show navigation menu')
+      })
+
+      it('has `aria-expanded` set to false', function () {
+        expect($button).toHaveAttr('aria-expanded', 'false')
+      })
+    })
+  })
+
+  describe('clicking the "Menu" button once', function () {
+    var $button
+    var $menu
+
+    beforeEach(function () {
+      $button = document.querySelector('.gem-c-layout-super-navigation-header__menu-button')
+      $menu = document.querySelector('.gem-c-layout-super-navigation-header__items')
+
+      $button.click()
+    })
+
+    it('opens the menu', function () {
+      expect($menu).toHaveClass('gem-c-layout-super-navigation-header__items--open')
+    })
+
+    it('updates the button’s `aria-expanded` attribute to true', function () {
+      expect($button).toHaveAttr('aria-expanded', 'true')
+    })
+
+    it('updates the button’s `aria-label` to "Hide navigation menu"', function () {
+      expect($button).toHaveAttr('aria-label', 'Hide navigation menu')
+    })
+
+    it('updates button’s state', function () {
+      expect($button).toHaveClass('govuk-header__menu-button--open')
+    })
+  })
+
+  describe('clicking the "Menu" button twice', function () {
+    var $button
+    var $menu
+
+    beforeEach(function () {
+      $button = document.querySelector('.gem-c-layout-super-navigation-header__menu-button')
+      $menu = document.querySelector('.gem-c-layout-super-navigation-header__items')
+
+      $button.click()
+    })
+
+    it('opens and then closes the menu', function () {
+      expect($menu).toHaveClass('gem-c-layout-super-navigation-header__items--open')
+
+      $button.click()
+
+      expect($menu).not.toHaveClass('gem-c-layout-super-navigation-header__items--open')
+    })
+
+    it('sets the button’s `aria-expanded` attribute to true, then false', function () {
+      expect($button).toHaveAttr('aria-expanded', 'true')
+
+      $button.click()
+
+      expect($button).toHaveAttr('aria-expanded', 'false')
+    })
+
+    it('sets the button’s `aria-label` attribute to "Hide navigation menu", then "Show navigation menu"', function () {
+      expect($button).toHaveAttr('aria-label', 'Hide navigation menu')
+
+      $button.click()
+
+      expect($button).toHaveAttr('aria-label', 'Show navigation menu')
+    })
+
+    it('updates the button’s state', function () {
+      expect($button).toHaveClass('govuk-header__menu-button--open')
+
+      $button.click()
+
+      expect($button).not.toHaveClass('govuk-header__menu-button--open')
+    })
+  })
+})


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Adds the super navigation menu (better name suggestions welcome) as a component to the gem.

## Why
<!-- What are the reasons behind this change being made? -->
To enable the super navigation header to be used in the public layout component as part of an A/B test across GOV.UK.


## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

HTML only (no CSS, no JavaScript):
![image](https://user-images.githubusercontent.com/1732331/124758735-cb731400-df26-11eb-823a-a3534083b4de.png)

Small screen, only CSS:
<img width="496" alt="Screenshot 2021-07-06 at 16 38 06" src="https://user-images.githubusercontent.com/1732331/124628650-97d9b080-de78-11eb-9104-de75325f28e9.png">

Large screen, only CSS:
<img width="993" alt="Screenshot 2021-07-06 at 16 38 55" src="https://user-images.githubusercontent.com/1732331/124628751-b17af800-de78-11eb-847f-c82f81862eb5.png">

Small screen, CSS and JavaScript enabled (menu closed):
![image](https://user-images.githubusercontent.com/1732331/124628983-e424f080-de78-11eb-83e2-880a167e40c2.png)

Small screen, CSS and JavaScript enabled (menu opened):

![image](https://user-images.githubusercontent.com/1732331/124629043-f30ba300-de78-11eb-9ad8-a56ec5fce547.png)


Large screen, CSS and JavaScript enabled:
![image](https://user-images.githubusercontent.com/1732331/124628884-d1aab700-de78-11eb-977a-796a31e17a18.png)

