### PR TITLE
Release v24.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.18.1
 
 * Update LUX to activate when usage cookies are accepted ([PR #2154](https://github.com/alphagov/govuk_publishing_components/pull/2154)) PATCH
 * Add custom dimension to the page view data for pages with the Brexit superbreadcrumb. And remove the CD from superbreadcrumb clicks.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.18.0)
+    govuk_publishing_components (24.18.1)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.18.0".freeze
+  VERSION = "24.18.1".freeze
 end


### PR DESCRIPTION
Includes:

 * Update LUX to activate when usage cookies are accepted (#2154)
 * Add custom dimension to segment page views by Brexit audience type (#2186)
