### PR TITLE
Add custom dimension to segment page views by Brexit audience type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update LUX to activate when usage cookies are accepted ([PR #2154](https://github.com/alphagov/govuk_publishing_components/pull/2154)) PATCH
+* Add custom dimension to the page view data for pages with the Brexit superbreadcrumb. And remove the CD from superbreadcrumb clicks.
 
 ## 24.18.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js
@@ -63,6 +63,7 @@
       'taxon-ids': { dimension: 59, defaultValue: 'other' },
       'content-has-history': { dimension: 39, defaultValue: 'false' },
       'publishing-application': { dimension: 89 },
+      'brexit-audience': { dimension: 111 },
       stepnavs: { dimension: 96 },
       'relevant-result-shown': { dimension: 83 },
       'spelling-suggestion': { dimension: 81 }

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -39,7 +39,8 @@ module GovukPublishingComponents
           tracking_category: "breadcrumbClicked",
           tracking_action: tracking_action,
           tracking_label: content_item["base_path"],
-        }.merge(custom_dimension_tracking)
+          tracking_dimension_enabled: false,
+        }
       end
 
     private
@@ -79,10 +80,6 @@ module GovukPublishingComponents
         [PRIORITY_TAXONS[:brexit_business], PRIORITY_TAXONS[:brexit_individuals]]
       end
 
-      def brexit_taxons
-        brexit_child_taxons << PRIORITY_TAXONS[:brexit_taxon]
-      end
-
       def preferred_priority_taxon
         query_parameters["priority-taxon"] if query_parameters
       end
@@ -91,16 +88,6 @@ module GovukPublishingComponents
         action = %w[superBreadcrumb]
         action << page_name_for_tracking
         action.compact.join(" ")
-      end
-
-      def custom_dimension_tracking
-        tracking = { tracking_dimension_enabled: false }
-        if brexit_taxons.include?(taxon["content_id"])
-          tracking[:tracking_dimension_enabled] = true
-          tracking[:tracking_dimension] = page_name_for_tracking
-          tracking[:tracking_dimension_index] = 111
-        end
-        tracking
       end
 
       def page_name_for_tracking

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -43,6 +43,14 @@ module GovukPublishingComponents
         }
       end
 
+      def brexit_audience
+        {
+          PRIORITY_TAXONS[:brexit_business] => "Brexitbusiness",
+          PRIORITY_TAXONS[:brexit_individuals] => "Brexitcitizen",
+          PRIORITY_TAXONS[:brexit_taxon] => "Brexitbusinessandcitizen",
+        }[taxon["content_id"]]
+      end
+
     private
 
       def preferred_taxon
@@ -88,14 +96,6 @@ module GovukPublishingComponents
         action = %w[superBreadcrumb]
         action << brexit_audience
         action.compact.join(" ")
-      end
-
-      def brexit_audience
-        {
-          PRIORITY_TAXONS[:brexit_business] => "Brexitbusiness",
-          PRIORITY_TAXONS[:brexit_individuals] => "Brexitcitizen",
-          PRIORITY_TAXONS[:brexit_taxon] => "Brexitbusinessandcitizen",
-        }[taxon["content_id"]]
       end
 
       def tagged_to_both_brexit_child_taxons?

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -86,11 +86,11 @@ module GovukPublishingComponents
 
       def tracking_action
         action = %w[superBreadcrumb]
-        action << page_name_for_tracking
+        action << brexit_audience
         action.compact.join(" ")
       end
 
-      def page_name_for_tracking
+      def brexit_audience
         {
           PRIORITY_TAXONS[:brexit_business] => "Brexitbusiness",
           PRIORITY_TAXONS[:brexit_individuals] => "Brexitcitizen",

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -20,7 +20,8 @@ module GovukPublishingComponents
         meta_tags = add_organisation_tags(meta_tags)
         meta_tags = add_political_tags(meta_tags)
         meta_tags = add_taxonomy_tags(meta_tags)
-        add_step_by_step_tags(meta_tags)
+        meta_tags = add_step_by_step_tags(meta_tags)
+        add_brexit_tags(meta_tags)
       end
 
     private
@@ -109,6 +110,27 @@ module GovukPublishingComponents
         end
 
         meta_tags
+      end
+
+      def add_brexit_tags(meta_tags)
+        links = content_item[:links]
+        taxons = links[:taxons] unless links.nil?
+
+        return meta_tags if taxons.blank?
+        return meta_tags unless tagged_to_priority_taxon?
+
+        audience = priority_taxon_helper.brexit_audience
+        meta_tags["govuk:brexit-audience"] = audience if audience.present?
+
+        meta_tags
+      end
+
+      def tagged_to_priority_taxon?
+        priority_taxon_helper.taxon.present?
+      end
+
+      def priority_taxon_helper
+        @priority_taxon_helper ||= ContentBreadcrumbsBasedOnPriority.new(content_item.deep_stringify_keys, request.query_parameters)
       end
 
       def has_content_history?

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -330,6 +330,34 @@ describe "Meta tags", type: :view do
     assert_select "meta[name='govuk:taxon-ids']", 0
   end
 
+  it "renders the brexit audience metatag for content items tagged to brexit" do
+    content_item = {
+      links: {
+        taxons: [
+          {
+            title: "Brexit: business guidance",
+            content_id: "634fd193-8039-4a70-a059-919c34ff4bfc",
+            base_path: "/brexit/business-guidance",
+            document_type: "detailed_guide",
+            links: {
+              parent_taxons: [
+                {
+                  title: "Brexit",
+                  content_id: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+                  base_path: "/brexit",
+                  document_type: "taxon",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+
+    render_component(content_item: example_document_for("detailed_guide", "detailed_guide").merge(content_item))
+    assert_meta_tag("govuk:brexit-audience", "Brexitbusiness")
+  end
+
   it "renders the has-content-history tag as true when the content has history" do
     content_item = {
       public_updated_at: Time.parse("2017-01-01"),

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -96,8 +96,9 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
         context "with brexit taxon" do
           let(:payload) { [brexit_taxon] }
 
-          it "returns the worker taxon" do
+          it "returns the brexit taxon" do
             expect(subject.taxon).to eq(brexit_taxon)
+            expect(subject.brexit_audience).to eq("Brexitbusinessandcitizen")
           end
         end
 
@@ -109,11 +110,12 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
           end
         end
 
-        context "with brexit_taxon taxon and brexit_individuals taxon" do
+        context "with brexit_taxon and brexit_individuals taxon" do
           let(:payload) { [brexit_taxon, brexit_individuals_taxon] }
 
           it "returns the brexit_individuals taxon" do
             expect(subject.taxon).to eq(brexit_individuals_taxon)
+            expect(subject.brexit_audience).to eq("Brexitcitizen")
           end
         end
 
@@ -122,6 +124,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
 
           it "returns the brexit_business taxon" do
             expect(subject.taxon).to eq(brexit_business_taxon)
+            expect(subject.brexit_audience).to eq("Brexitbusiness")
           end
         end
 
@@ -130,6 +133,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
 
           it "returns the brexit_taxon taxon" do
             expect(subject.taxon).to eq(brexit_taxon)
+            expect(subject.brexit_audience).to eq("Brexitbusinessandcitizen")
           end
         end
 

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -183,21 +183,6 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
             expect(described_class.call(content)).to eq(breadcrumbs)
           end
         end
-
-        context "when page is tagged to a brexit taxon" do
-          let(:content) { send(tagged_to_taxons, [brexit_individuals_taxon]) }
-
-          it "adds custom dimension tracking" do
-            breadcrumbs = breadcrumb_for(content, brexit_individuals_taxon)
-
-            breadcrumbs[:path] = "/guidance/brexit-guidance-for-individuals"
-            breadcrumbs[:tracking_action] = "superBreadcrumb Brexitcitizen"
-            breadcrumbs[:tracking_dimension] = "Brexitcitizen"
-            breadcrumbs[:tracking_dimension_enabled] = true
-            breadcrumbs[:tracking_dimension_index] = 111
-            expect(described_class.call(content)).to eq(breadcrumbs)
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
## What
1. Remove custom dimension 111 from clicks to the Brexit superbreadcrumb
2. Add custom dimension 111 to the GA payload for page views when a page is displaying a brexit superbreadcrumb

## Why
Request from PA

## Visual Changes
No visual changes
