### PR TITLE
Use correct locale key for character count component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use correct locale key for the character count component ([PR #2189](https://github.com/alphagov/govuk_publishing_components/pull/2189))
+
 ## 24.18.2
 
 * Fix misaligned crown in heading component ([PR #2134](https://github.com/alphagov/govuk_publishing_components/pull/2134)) PATCH

--- a/app/views/govuk_publishing_components/components/_character_count.html.erb
+++ b/app/views/govuk_publishing_components/components/_character_count.html.erb
@@ -18,7 +18,7 @@
     <%= render "govuk_publishing_components/components/textarea", { id: id, character_count: true }.merge(textarea.symbolize_keys) %>
 
     <span id="<%= id %>-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
-      <%= t("components.character_count", number: maxlength || maxwords, type: maxwords ? t("components.character_count.type.words") : t("components.character_count.type.characters")) %>
+      <%= t("components.character_count.body", number: maxlength || maxwords, type: maxwords ? t("components.character_count.type.words") : t("components.character_count.type.characters")) %>
     </span>
   <% end %>
 <% end %>


### PR DESCRIPTION
## What
Changes the locale key used in the character count component to use the correct one.

## Why
This wrong key was used in a51250be8.

## Visual Changes
We are currently presenting `{:body=>"You can enter up to %{number} %{type}", :type=>{:characters=>"characters", :words=>"words"}}` when it should say `You can enter up to n [characters|words]`.
