### PR TITLE
Switch environment app helper to use GOVUK_ENVIRONMENT_NAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 - Don't include changes that are purely internal. The CHANGELOG should be a
   useful summary for people upgrading their application, not a replication
   of the commit log.
-
+  
 ## Unreleased
 
+* Switch environment app helper to use GOVUK_ENVIRONMENT_NAME ([PR #2191](https://github.com/alphagov/govuk_publishing_components/pull/2191)) PATCH
 * Fix misaligned crown in heading component properly ([PR #2206](https://github.com/alphagov/govuk_publishing_components/pull/2206)) PATCH
 
 ## 24.18.5

--- a/lib/govuk_publishing_components/app_helpers/environment.rb
+++ b/lib/govuk_publishing_components/app_helpers/environment.rb
@@ -1,19 +1,14 @@
 module GovukPublishingComponents
   module AppHelpers
     class Environment
-      GOVUK_ENVIRONMENTS = {
-        "production" => "production",
-        "staging" => "staging",
-        "integration-blue-aws" => "integration",
-      }.freeze
+      GOVUK_ENVIRONMENTS = %w[integration staging production].freeze
 
       # The "acceptance environment" we're in - not the same as Rails env.
-      #
-      # Can be "production", "staging", "integration", or "development"
+      # Can be "production", "staging", "integration", "development" or "example" (if running on Heroku)
       def self.current_acceptance_environment
         return "example" if ENV["HEROKU"]
 
-        GOVUK_ENVIRONMENTS.fetch(ENV["ERRBIT_ENVIRONMENT_NAME"], "development")
+        GOVUK_ENVIRONMENTS.include?(ENV["GOVUK_ENVIRONMENT_NAME"]) ? ENV["GOVUK_ENVIRONMENT_NAME"] : "development"
       end
     end
   end

--- a/spec/lib/govuk_publishing_components/app_helpers/environment_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/environment_spec.rb
@@ -7,16 +7,20 @@ RSpec.describe GovukPublishingComponents::AppHelpers::Environment do
       expect(environment_name_for("something-else")).to eql("development")
     end
 
-    it "returns integration as well" do
-      expect(environment_name_for("integration-blue-aws")).to eql("integration")
+    it "returns a listed environment when specified" do
+      expect(environment_name_for("integration")).to eql("integration")
+    end
+
+    it "returns example when the Heroku environment variable is set" do
+      expect(environment_name_for("heroku", environment_variable_name: "HEROKU")).to eql("example")
     end
   end
 
-  def environment_name_for(actual_environment_name)
-    previous = ENV["ERRBIT_ENVIRONMENT_NAME"]
-    ENV["ERRBIT_ENVIRONMENT_NAME"] = actual_environment_name
+  def environment_name_for(actual_environment_name, environment_variable_name: "GOVUK_ENVIRONMENT_NAME")
+    previous = ENV[environment_variable_name]
+    ENV[environment_variable_name] = actual_environment_name
     name = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment
-    ENV["ERRBIT_ENVIRONMENT_NAME"] = previous
+    ENV[environment_variable_name] = previous
     name
   end
 end


### PR DESCRIPTION
This PR switches the `Environment` app helper to use the `GOVUK_ENVIRONMENT_NAME` when getting the current environment for use in the layout header component. The reason for this change is that we're removing the `ERRBIT_ENVIRONMENT_NAME` environment variable in favour of `GOVUK_ENVIRONMENT_NAME`, with the former being an overhang from the days when GOV.UK used Errbit. The `GOVUK_ENVIRONMENTS` variable is refactored from a hash to an array, as we no longer have a weird edge case where the name of the integration environment is different to the acceptance environment that the method returns; there will be a performance impact with this as we're no longer doing a constant-time lookup, but given the number of environments this should be negligible.

It also refactors the associated tests and introduces coverage for the Heroku environment.

Trello: https://trello.com/c/0Z2F9lKU