### PR TITLE
Remove ability to link context text on titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* BREAKING: Remove ability to link contextual text on titles ([PR #2192](https://github.com/alphagov/govuk_publishing_components/pull/2192))
+
 * Delete empty print stylesheets ([PR #2225](https://github.com/alphagov/govuk_publishing_components/pull/2225))
 
 ## 24.21.1
@@ -18,7 +20,7 @@
 ## 24.21.0
 
 * Add scroll tracking to travel advice pages ([PR #2217](https://github.com/alphagov/govuk_publishing_components/pull/2217))
-* Fix new link styles on document list ([PR #2211](https://github.com/alphagov/govuk_publishing_components/pull/2211))
+
 * Make sure custom dimension 112 is sent for all pages tagged to Brexit ([PR #2212](https://github.com/alphagov/govuk_publishing_components/pull/2212))
 * Allow the public layout to render without the footer navigation ([PR #2218](https://github.com/alphagov/govuk_publishing_components/pull/2218))
 

--- a/app/views/govuk_publishing_components/components/_title.html.erb
+++ b/app/views/govuk_publishing_components/components/_title.html.erb
@@ -3,9 +3,6 @@
 
   context ||= false
   context_locale ||= false
-  context_text = context.is_a?(Hash) ? context[:text] : context
-  context_href = context.is_a?(Hash) ? context[:href] : false
-  context_data = context.is_a?(Hash) ? context[:data] : false
 
   inverse ||= false
   local_assigns[:margin_top] ||= 8
@@ -24,7 +21,7 @@
 <%= content_tag(:div, class: classes) do %>
   <% if context %>
     <span class="govuk-caption-xl gem-c-title__context" <%= "lang=#{context_locale}" if context_locale.present? %>>
-      <%= context_href ? link_to(context_text, context_href, class: 'gem-c-title__context-link govuk-link', data: context_data) : context_text %>
+      <%= context %>
     </span>
   <% end %>
   <h1 class="<%= heading_classes.join(" ") %>">

--- a/app/views/govuk_publishing_components/components/docs/title.yml
+++ b/app/views/govuk_publishing_components/components/docs/title.yml
@@ -33,18 +33,6 @@ examples:
       context: Publication
       context_locale: en
       title: My page title
-  with_context_link:
-    description: |
-      It’s unclear if links in the context of a title are useful and are being clicked by users. Data attributes are included to track this behaviour.
-
-      Context links are used on [topic pages](https://www.gov.uk/topic/business-tax/vat) where there is also a breadcrumb.
-    data:
-      context:
-        text: Publication
-        href: '/link'
-        data:
-          some_tracking_parameter: 'tracking-param'
-      title: My page title
   long_title_with_context:
     data:
       context: Publication

--- a/spec/components/title_spec.rb
+++ b/spec/components/title_spec.rb
@@ -21,11 +21,6 @@ describe "Title", type: :view do
     assert_select ".govuk-caption-xl", text: "Format"
   end
 
-  it "title context link appears" do
-    render_component(title: "Hello World", context: { text: "Format", href: "/format", data: { tracking: true } })
-    assert_select ".gem-c-title__context-link[href='/format'][data-tracking]", text: "Format"
-  end
-
   it "applies context language if supplied to a context string" do
     render_component(title: "Bonjour Monde", context: "hello", context_locale: "en")
     assert_select ".govuk-caption-xl[lang='en']"
@@ -82,7 +77,7 @@ describe "Title", type: :view do
   end
 
   it "applies context language if supplied to a context link" do
-    render_component(title: "Bonjour", context: { text: "Format", href: "/format" }, context_locale: "en")
+    render_component(title: "Bonjour", context: "Format", context_locale: "en")
     assert_select ".govuk-caption-xl[lang='en']"
   end
 end


### PR DESCRIPTION
## What
This removes the ability to add a link to the contextual text that sometimes appears above a title. 

## Why
In many cases where this was used there were already breadcrumbs serving the same purpose and meaning duplicate links. Additionally, the link was not obvious unless hovered meaning there was no realistic was for most users to know it was there. 

## Visual Changes

THIS IS A BREAKING CHANGE. If an app updates to this version with attempts to link the context then the context hash will be exposed:

![Screenshot 2021-07-06 at 15 02 58](https://user-images.githubusercontent.com/31649453/124622577-24817000-de73-11eb-99fa-6d49a6bb92cf.png)

The following PRs cover removing all the examples I'm aware of and this version of the components should not be used until they are merged:
https://github.com/alphagov/government-frontend/pull/2117
https://github.com/alphagov/whitehall/pull/6120
https://github.com/alphagov/collections/pull/2463

