### PR TITLE
Add Welsh translations for topics, transition and tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add Welsh translations for topics, transition and tabs ([PR #2193](https://github.com/alphagov/govuk_publishing_components/pull/2193))
+
 ## 24.18.3
 
 * Use correct locale key for the character count component ([PR #2189](https://github.com/alphagov/govuk_publishing_components/pull/2189))

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -114,14 +114,14 @@ cy:
       related_guides:
       statistical_data_sets:
       topical_events:
-      topics:
+      topics: Archwilio’r pwnc
       transition:
+        link_path: "/brexit.cy"
+        link_text: Cael rhestr bersonol o gamau gweithredu
+        title: Brexit
         hub_page_link_path:
         hub_page_link_text:
-        hub_page_title:
-        link_path: "/brexit.cy"
-        link_text: Gwiriwch beth sydd angen i chi ei wneud
-        title: Brexit
+        hub_page_title: Gwiriwr Brexit
       world_locations:
     search_box:
       input_title:
@@ -154,4 +154,4 @@ cy:
       delete:
       edit:
     tabs:
-      contents:
+      contents: Cynnwys

--- a/spec/components/brexit_cta_spec.rb
+++ b/spec/components/brexit_cta_spec.rb
@@ -45,7 +45,7 @@ describe "BrexitCta", type: :view do
     welsh_content_items.each do |item|
       I18n.with_locale(:cy) { render_component({ content_item: item }) }
       assert_select ".gem-c-contextual-sidebar__brexit-heading", text: "Brexit"
-      assert_link_with_text_in(".gem-c-contextual-sidebar__brexit-text", "/brexit.cy", "Gwiriwch beth sydd angen i chi ei wneud")
+      assert_link_with_text_in(".gem-c-contextual-sidebar__brexit-text", "/brexit.cy", "Cael rhestr bersonol o gamau gweithredu")
     end
   end
 end


### PR DESCRIPTION
## What
As we prepare to launch the Brexit-related guidance in Welsh we received translations for a few components used on the page. We've also updated the key order for transition subitems to align it with the .en locale

## Why
For language consistency across the page.

## Visual Changes
No visual changes (aside from content being updated, of course)

[Trello card](https://trello.com/c/0chnMRTQ)