### PR TITLE
Change tracking on details component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## 24.18.4
 
+* Change tracking on details component ([PR #2195](https://github.com/alphagov/govuk_publishing_components/pull/2195))
 * Add Welsh translations for topics, transition and tabs ([PR #2193](https://github.com/alphagov/govuk_publishing_components/pull/2193))
 * Add custom dimension for pages displaying the Brexit superbreadcrumb ([PR #2197](https://github.com/alphagov/govuk_publishing_components/pull/2197))
 

--- a/app/assets/javascripts/govuk_publishing_components/components/details.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/details.js
@@ -7,24 +7,26 @@ window.GOVUK.Modules.GovukDetails = window.GOVUKFrontend;
 (function (Modules) {
   function GemDetails ($module) {
     this.$module = $module
-    this.customTrackLabel = this.$module.getAttribute('data-track-label')
+    this.$summary = this.$module.querySelector('.govuk-details__summary')
+
+    this.customTrackLabel = this.$summary.getAttribute('data-track-label')
     this.detailsClick = this.$module.querySelector('[data-details-track-click]')
   }
 
   GemDetails.prototype.init = function () {
     if (this.customTrackLabel) { // If a custom label has been provided, we can simply call the tracking module
       var trackDetails = new window.GOVUK.Modules.GemTrackClick()
-      trackDetails.start($(this.$module))
+      trackDetails.start($(this.$summary))
     } else if (this.detailsClick) { // If no custom label is set, we use the open/close status as the label
       this.detailsClick.addEventListener('click', function (event) {
-        this.trackDefault(this.$module)
+        this.trackDefault(this.$summary)
       }.bind(this))
     }
   }
 
   GemDetails.prototype.trackDefault = function (element) {
     if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
-      var componentStatus = (element.getAttribute('open') == null) ? 'open' : 'closed'
+      var componentStatus = (this.$module.getAttribute('open') == null) ? 'open' : 'closed'
       var trackCategory = element.getAttribute('data-track-category')
       var trackAction = element.getAttribute('data-track-action')
       var trackOptions = element.getAttribute('data-track-options')

--- a/app/views/govuk_publishing_components/components/_details.html.erb
+++ b/app/views/govuk_publishing_components/components/_details.html.erb
@@ -6,15 +6,18 @@
   css_classes = %w(gem-c-details govuk-details)
   css_classes << (shared_helper.get_margin_bottom)
 
+  details_data_attributes = {}
+  details_data_attributes[:module] = 'govuk-details gem-details'
+
   data_attributes ||= {}
-  data_attributes[:module] = 'govuk-details gem-details'
+  data_attributes[:details_track_click] = ''
 %>
-<%= tag.details class: css_classes, data: data_attributes, open: open do %>
-  <summary class="govuk-details__summary" data-details-track-click>
+<%= tag.details class: css_classes, data: details_data_attributes, open: open do %>
+  <%= tag.summary class: "govuk-details__summary", data: data_attributes do %>
     <span class="govuk-details__summary-text">
       <%= title %>
     </span>
-  </summary>
+  <% end %>
   <div class="govuk-details__text">
     <%= yield %>
   </div>

--- a/app/views/govuk_publishing_components/components/docs/details.yml
+++ b/app/views/govuk_publishing_components/components/docs/details.yml
@@ -22,7 +22,7 @@ examples:
       block: |
         We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
   with_data_attributes:
-    description: Can be used for tracking. By default, `track-label` is set to the status ("open" or "closed") unless a track_label is passed into the component.
+    description: Can be used for tracking. Tracking is applied to the summary element when the details element is opened and closed. By default, `track-label` is set to the status ("open" or "closed") unless a track_label is passed into the component.
     data:
       title: Help with nationality
       data_attributes:

--- a/spec/components/details_spec.rb
+++ b/spec/components/details_spec.rb
@@ -42,9 +42,9 @@ describe "Details", type: :view do
       },
     )
 
-    assert_select '.govuk-details[data-track-category="track-category"]'
-    assert_select '.govuk-details[data-track-action="track-action"]'
-    assert_select '.govuk-details[data-track-label="track-label"]'
+    assert_select '.govuk-details .govuk-details__summary[data-track-category="track-category"]'
+    assert_select '.govuk-details .govuk-details__summary[data-track-action="track-action"]'
+    assert_select '.govuk-details .govuk-details__summary[data-track-label="track-label"]'
   end
 
   it "defaults to the initial bottom margin if an incorrect value is passed" do

--- a/spec/javascripts/components/details-spec.js
+++ b/spec/javascripts/components/details-spec.js
@@ -14,8 +14,8 @@ describe('Details component', function () {
     spyOn(GOVUK.Modules, 'GemTrackClick').and.callFake(function () { this.start = function () {} })
 
     FIXTURE =
-      '<details class="gem-c-details govuk-details govuk-!-margin-bottom-3" data-track-category="track-category" data-track-action="track-action" data-track-label="track-label" data-module="gem-details">' +
-        '<summary class="govuk-details__summary" data-details-track-click="">' +
+      '<details class="gem-c-details govuk-details" data-module="gem-details">' +
+        '<summary class="govuk-details__summary" data-track-category="track-category" data-track-action="track-action" data-track-label="track-label" data-details-track-click="">' +
         '<span>Toggle text</span>' +
         '</summary>' +
       '</details>'
@@ -39,9 +39,9 @@ describe('Details component', function () {
   })
 
   it('does not fire an event if track category and track action are not present', function () {
-    $('.gem-c-details').attr('data-track-action', null)
-    $('.gem-c-details').attr('data-track-category', null)
-    $('.gem-c-details').attr('data-track-label', null)
+    $('.gem-c-details .govuk-details__summary').attr('data-track-action', null)
+    $('.gem-c-details .govuk-details__summary').attr('data-track-category', null)
+    $('.gem-c-details .govuk-details__summary').attr('data-track-label', null)
 
     loadDetailsComponent()
 
@@ -51,7 +51,7 @@ describe('Details component', function () {
   })
 
   it('tracks open state by default if no track label provided', function () {
-    $('.gem-c-details').attr('data-track-label', null)
+    $('.gem-c-details .govuk-details__summary').attr('data-track-label', null)
     loadDetailsComponent()
 
     $('.govuk-details__summary').click()
@@ -60,7 +60,7 @@ describe('Details component', function () {
   })
 
   it('tracks closed state by default if no track label provided', function () {
-    $('.gem-c-details').attr('data-track-label', null)
+    $('.gem-c-details .govuk-details__summary').attr('data-track-label', null)
     $('.gem-c-details').attr('open', true)
     loadDetailsComponent()
 
@@ -70,10 +70,10 @@ describe('Details component', function () {
   })
 
   it('allows custom track options', function () {
-    $('.gem-c-details').attr('data-track-action', 'track-action')
-    $('.gem-c-details').attr('data-track-category', 'track-category')
-    $('.gem-c-details').attr('data-track-options', '{"value":"track-value"}')
-    $('.gem-c-details').attr('data-track-label', null)
+    $('.gem-c-details .govuk-details__summary').attr('data-track-action', 'track-action')
+    $('.gem-c-details .govuk-details__summary').attr('data-track-category', 'track-category')
+    $('.gem-c-details .govuk-details__summary').attr('data-track-options', '{"value":"track-value"}')
+    $('.gem-c-details .govuk-details__summary').attr('data-track-label', null)
 
     loadDetailsComponent()
 


### PR DESCRIPTION
## What
- move the tracking attributes onto the summary element rather than the whole component
- this prevents collisions from occurring if we want to track links or other elements that appear inside the details element, using the gem-track-click script

## Why
I recently needed to track radio buttons inside a details component and the tracking was either not firing or firing twice, the second track being from the details component. This is partly because the `gem-track-click` tracking script attempts to traverse up the DOM if it can't find what it's trying to track, which was then colliding with the tracking on the details component... it was all very confusing. 

The solution is to move the tracking from the details component to the summary element within, which is actually the thing being tracked anyway.

## Visual Changes
None.
