### PR TITLE
Intervention component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Switch environment app helper to use GOVUK_ENVIRONMENT_NAME ([PR #2191](https://github.com/alphagov/govuk_publishing_components/pull/2191)) PATCH
+* Add intervention component ([PR #2196](https://github.com/alphagov/govuk_publishing_components/pull/2196))
 * Fix misaligned crown in heading component properly ([PR #2206](https://github.com/alphagov/govuk_publishing_components/pull/2206)) PATCH
 
 ## 24.18.5

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -42,6 +42,7 @@ $govuk-new-link-styles: true;
 @import "components/image-card";
 @import "components/input";
 @import "components/inset-text";
+@import "components/intervention";
 @import "components/inverse-header";
 @import "components/label";
 @import "components/layout-footer";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_intervention.scss
@@ -1,0 +1,16 @@
+.gem-c-intervention {
+  @include govuk-text-colour;
+  @include govuk-responsive-padding(4);
+  @include govuk-responsive-margin(4, "bottom");
+  background-color: govuk-colour("light-grey", $legacy: "grey-4");
+}
+
+.gem-c-intervention__title {
+  @include govuk-font(24, $weight: bold);
+  margin-top: 0;
+  @include govuk-responsive-margin(4, "bottom");
+}
+
+.gem-c-intervention__paragraph {
+  @include govuk-font(19);
+}

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -105,5 +105,5 @@
 </ul>
 
 <div class="component-markdown">
-  <p class="govuk-body">If you cannot find a suitable component consider extending an existing component or <a href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/develop-component.md">creating a new one</a>.</p>
+  <p class="govuk-body">If you cannot find a suitable component consider extending an existing component or <a href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/generate-a-new-component.md">creating a new one</a>.</p>
 </div>

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -1,0 +1,15 @@
+<%= tag.section class: "gem-c-intervention", role: "region" do %>
+  <h2 class="gem-c-intervention__title">
+    <a class="govuk-link" href="/next-steps-for-your-business">
+      <%= t("components.intervention.title") %>
+    </a>
+  </h2>
+
+  <p class="gem-c-intervention__paragraph">
+    <%= t("components.intervention.description") %>
+  </p>
+
+  <p class="gem-c-intervention__paragraph">
+    <%= t("components.intervention.dismiss_html") %>
+  </p>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/intervention.yml
+++ b/app/views/govuk_publishing_components/components/docs/intervention.yml
@@ -1,0 +1,24 @@
+name: Intervention
+description: An area that contains personalised content to the user
+body: |
+  The intervention is used to show personalised content. For instance, if the user has visited multiple
+  pages in the same area of the site, we might want let them know that there are other pages on GOV.UK
+  that would be useful to them. This component would be used to add this personalised content and would
+  indicate to the user that this is not normally part of the page, but has been added for them specifically.
+
+  Right now the contents of the component are static, as the MVP of personalised content is only for Start a Business.
+  Since many pages will use this component with the same text, we hard-code it here for now.
+
+  The dismiss link will reload the page but the `hide-intervention` query string parameter will cause the
+  backed not to show the intervention again. Some progressive enhancement will be added in later to avoid
+  reloading the page if JavaScript is available.
+accessibility_criteria: |
+  The intervention component must:
+
+  - have a border colour contrast ratio of more than 4.5:1 with its background to be visually distinct
+
+  - always render headings with associated description content, so there are no isolated heading elements inside the component
+shared_accessibility_criteria:
+  - link
+examples:
+  default:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,10 @@ en:
       news_and_communications: News and communications
       statistics: Statistics
       worldwide: Worldwide
+    intervention:
+      title: Check the next steps for your limited company
+      description: You might be interested in this because you’ve been browsing guidance relevant to starting a limited company.
+      dismiss_html: <a class="govuk-link" href="?hide-intervention=true">Hide this suggestion</a> if it’s not relevant to you
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated

--- a/spec/components/intervention_spec.rb
+++ b/spec/components/intervention_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe "Intervention", type: :view do
+  def component_name
+    "intervention"
+  end
+
+  it "renders the component" do
+    render_component({})
+    assert_select ".gem-c-intervention__title", text: "Check the next steps for your limited company"
+    assert_select ".gem-c-intervention__paragraph", text: "You might be interested in this because you’ve been browsing guidance relevant to starting a limited company."
+    assert_select ".gem-c-intervention__paragraph", text: "Hide this suggestion if it’s not relevant to you"
+  end
+end


### PR DESCRIPTION
## What

A new component called "intervention" which will be used for showing personalised content (based on previous browsing). The component's content is hardcoded for now, as this is an MVP which will be used only in the Start a Business area of gov.uk 

## Why

The data labs' Personalisation Without an Account project includes showing users recommended content, based on their behaviour on www.gov.uk

## Visual Changes

Visual design for new component
![sab](https://user-images.githubusercontent.com/69542/124769905-c7002880-df31-11eb-8e28-f2d36d568d38.png)

