### PR TITLE
Update custom dimension tracking for brexit superbreadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add Welsh translations for topics, transition and tabs ([PR #2193](https://github.com/alphagov/govuk_publishing_components/pull/2193))
+* Add custom dimension for pages displaying the Brexit superbreadcrumb ([PR #2197](https://github.com/alphagov/govuk_publishing_components/pull/2197))
 
 ## 24.18.3
 
@@ -22,7 +23,7 @@
 ## 24.18.1
 
 * Update LUX to activate when usage cookies are accepted ([PR #2154](https://github.com/alphagov/govuk_publishing_components/pull/2154)) PATCH
-* Add custom dimension to the page view data for pages with the Brexit superbreadcrumb. And remove the custom dimension from superbreadcrumb clicks. ([PR #2186](https://github.com/alphagov/govuk_publishing_components/pull/2186))
+* Add custom dimension to the page view data for pages tagged to brexit taxons. And remove the custom dimension from superbreadcrumb clicks. ([PR #2186](https://github.com/alphagov/govuk_publishing_components/pull/2186))
 
 ## 24.18.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js
@@ -64,6 +64,7 @@
       'content-has-history': { dimension: 39, defaultValue: 'false' },
       'publishing-application': { dimension: 89 },
       'brexit-audience': { dimension: 112 },
+      'brexit-superbreadcrumb': { dimension: 111 },
       stepnavs: { dimension: 96 },
       'relevant-result-shown': { dimension: 83 },
       'spelling-suggestion': { dimension: 81 }

--- a/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js
@@ -63,7 +63,7 @@
       'taxon-ids': { dimension: 59, defaultValue: 'other' },
       'content-has-history': { dimension: 39, defaultValue: 'false' },
       'publishing-application': { dimension: 89 },
-      'brexit-audience': { dimension: 111 },
+      'brexit-audience': { dimension: 112 },
       stepnavs: { dimension: 96 },
       'relevant-result-shown': { dimension: 83 },
       'spelling-suggestion': { dimension: 81 }

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -12,9 +12,9 @@
                inverse: inverse,
                collapse_on_mobile: collapse_on_mobile %>
   <% end %>
-
-  <%= render(
-        'govuk_publishing_components/components/step_by_step_nav_header', breadcrumb_selector.priority_breadcrumbs
-      ) if breadcrumb_selector.priority_breadcrumbs
-  %>
+  <% if breadcrumb_selector.priority_breadcrumbs %>
+    <%= render 'govuk_publishing_components/components/step_by_step_nav_header', breadcrumb_selector.priority_breadcrumbs %>
+    <% meta_tag = GovukPublishingComponents::Presenters::MetaTags.new(content_item, local_assigns, request).brexit_priority_breadcrumb_tag %>
+    <meta name="<%= meta_tag.keys.first %>" content="<%= meta_tag.values.first %>">
+  <% end %>
 </div>

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -21,7 +21,11 @@ module GovukPublishingComponents
         meta_tags = add_political_tags(meta_tags)
         meta_tags = add_taxonomy_tags(meta_tags)
         meta_tags = add_step_by_step_tags(meta_tags)
-        add_brexit_tags(meta_tags)
+        add_brexit_tags("govuk:brexit-audience", meta_tags)
+      end
+
+      def brexit_priority_breadcrumb_tag
+        add_brexit_tags("govuk:brexit-superbreadcrumb")
       end
 
     private
@@ -112,14 +116,14 @@ module GovukPublishingComponents
         meta_tags
       end
 
-      def add_brexit_tags(meta_tags)
+      def add_brexit_tags(tag_key, meta_tags = {})
         links = content_item[:links]
         taxons = links[:taxons] unless links.nil?
 
         return meta_tags if taxons.blank?
         return meta_tags unless tagged_to_priority_taxon?
 
-        meta_tags["govuk:brexit-audience"] = brexit_audience if brexit_audience.present?
+        meta_tags[tag_key] = brexit_audience if brexit_audience.present?
 
         meta_tags
       end

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -119,8 +119,7 @@ module GovukPublishingComponents
         return meta_tags if taxons.blank?
         return meta_tags unless tagged_to_priority_taxon?
 
-        audience = priority_taxon_helper.brexit_audience
-        meta_tags["govuk:brexit-audience"] = audience if audience.present?
+        meta_tags["govuk:brexit-audience"] = brexit_audience if brexit_audience.present?
 
         meta_tags
       end
@@ -131,6 +130,10 @@ module GovukPublishingComponents
 
       def priority_taxon_helper
         @priority_taxon_helper ||= ContentBreadcrumbsBasedOnPriority.new(content_item.deep_stringify_keys, request.query_parameters)
+      end
+
+      def brexit_audience
+        priority_taxon_helper.brexit_audience
       end
 
       def has_content_history?

--- a/spec/components/contextual_breadcrumbs_spec.rb
+++ b/spec/components/contextual_breadcrumbs_spec.rb
@@ -36,6 +36,19 @@ describe "ContextualBreadcrumbs", type: :view do
     content_item
   end
 
+  def tag_to_brexit(content_item)
+    content_item["links"]["taxons"][0]["title"] = "Brexit: business guidance"
+    content_item["links"]["taxons"][0]["content_id"] = "634fd193-8039-4a70-a059-919c34ff4bfc"
+    content_item
+  end
+
+  it "renders the brexit-superbreadcrumb meta tag on content tagged to brexit" do
+    content_item = example_document_for("guide", "guide")
+    content_item = tag_to_brexit(content_item)
+    render_component(content_item: content_item)
+    assert_select "meta[name='govuk:brexit-superbreadcrumb'][content='Brexitbusiness']"
+  end
+
   it "renders breadcrumbs that collapse on mobile by default" do
     content_item = example_document_for("guide", "guide")
     content_item = remove_mainstream_browse(content_item)


### PR DESCRIPTION
## What
- Update CD 111 to track the audience on page views of all pages tagged to a brexit (priority) taxon. 
- Add CD 112 to track the audience on page views for pages tagged to a brexit (priority) taxon AND showing the brexit superbreadcrumb.

## Why
Request from PA

## Visual Changes
None

## Meta tags for pages with brexit superbreadcrumb

- both brexit-superbreadcrumb and brexit-audience are set. 

<img width="1522" alt="Screenshot 2021-07-07 at 16 49 13" src="https://user-images.githubusercontent.com/17908089/124790834-6b3e9b00-df43-11eb-82ff-93e9e3e4c00b.png">

## Met tags for pages tagged to a brexit priority taxon without a superbreadcrumb

- only the brexit-audience is set.

<img width="1512" alt="Screenshot 2021-07-07 at 16 52 22" src="https://user-images.githubusercontent.com/17908089/124791366-e6a04c80-df43-11eb-849c-9c24b8a50441.png">
