### PR TITLE
Expand trigger event script options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Expand trigger event script options ([PR #2199](https://github.com/alphagov/govuk_publishing_components/pull/2199))
+
 ## 24.19.0
 
 * Switch environment app helper to use GOVUK_ENVIRONMENT_NAME ([PR #2191](https://github.com/alphagov/govuk_publishing_components/pull/2191)) PATCH

--- a/app/assets/javascripts/govuk_publishing_components/lib/trigger-event.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/trigger-event.js
@@ -4,10 +4,16 @@
 
   window.GOVUK.triggerEvent = function (element, eventName, parameters) {
     var params = parameters || {}
-    params.bubbles = true
-    params.cancelable = true
     var event
     var keyCode = params.keyCode
+
+    if (!Object.prototype.hasOwnProperty.call(params, 'bubbles')) {
+      params.bubbles = true
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(params, 'cancelable')) {
+      params.cancelable = true
+    }
 
     if (typeof window.CustomEvent === 'function') {
       event = new window.CustomEvent(eventName, params)

--- a/app/assets/javascripts/govuk_publishing_components/lib/trigger-event.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/trigger-event.js
@@ -7,12 +7,17 @@
     params.bubbles = true
     params.cancelable = true
     var event
+    var keyCode = params.keyCode
 
     if (typeof window.CustomEvent === 'function') {
       event = new window.CustomEvent(eventName, params)
     } else {
       event = document.createEvent('CustomEvent')
       event.initCustomEvent(eventName, params.bubbles, params.cancelable, params.detail)
+    }
+
+    if (keyCode) {
+      event.keyCode = keyCode
     }
 
     element.dispatchEvent(event)

--- a/spec/javascripts/govuk_publishing_components/lib/trigger-event-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/trigger-event-spec.js
@@ -8,6 +8,9 @@ describe('The trigger event code', function () {
       if (((event || {}).detail || {}).test === true) {
         obj.secondCalledFunction()
       }
+      if (event.keyCode === 13) {
+        obj.secondCalledFunction()
+      }
     },
     secondCalledFunction: function () {}
   }
@@ -33,6 +36,13 @@ describe('The trigger event code', function () {
   it('creates and triggers a custom event with parameters', function () {
     element[0].addEventListener('click', obj.calledFunction)
     window.GOVUK.triggerEvent(element[0], 'click', { detail: { test: true } })
+    expect(obj.calledFunction).toHaveBeenCalled()
+    expect(obj.secondCalledFunction).toHaveBeenCalled()
+  })
+
+  it('creates and triggers a custom event with a keyCode', function () {
+    element[0].addEventListener('keyup', obj.calledFunction)
+    window.GOVUK.triggerEvent(element[0], 'keyup', { keyCode: 13 })
     expect(obj.calledFunction).toHaveBeenCalled()
     expect(obj.secondCalledFunction).toHaveBeenCalled()
   })

--- a/spec/javascripts/govuk_publishing_components/lib/trigger-event-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/trigger-event-spec.js
@@ -5,6 +5,12 @@ describe('The trigger event code', function () {
 
   var obj = {
     calledFunction: function (event) {
+      if (typeof event.cancelable !== 'boolean' || event.cancelable === true) {
+        event.preventDefault()
+      }
+      if (event.defaultPrevented) {
+        obj.secondCalledFunction()
+      }
       if (((event || {}).detail || {}).test === true) {
         obj.secondCalledFunction()
       }
@@ -30,7 +36,6 @@ describe('The trigger event code', function () {
     element[0].addEventListener('click', obj.calledFunction)
     window.GOVUK.triggerEvent(element[0], 'click')
     expect(obj.calledFunction).toHaveBeenCalled()
-    expect(obj.secondCalledFunction).not.toHaveBeenCalled()
   })
 
   it('creates and triggers a custom event with parameters', function () {
@@ -45,5 +50,43 @@ describe('The trigger event code', function () {
     window.GOVUK.triggerEvent(element[0], 'keyup', { keyCode: 13 })
     expect(obj.calledFunction).toHaveBeenCalled()
     expect(obj.secondCalledFunction).toHaveBeenCalled()
+  })
+
+  it('creates a custom event that bubbles by default', function () {
+    element = $('<div/>')
+    var child = $('<div/>')
+    element.append(child)
+    $('body').append(element)
+    element[0].addEventListener('click', obj.calledFunction)
+    window.GOVUK.triggerEvent(child[0], 'click')
+    expect(obj.calledFunction).toHaveBeenCalled()
+  })
+
+  it('creates a custom event that does not bubble', function () {
+    element = $('<div/>')
+    var child = $('<div/>')
+    element.append(child)
+    $('body').append(element)
+    element[0].addEventListener('click', obj.calledFunction)
+    window.GOVUK.triggerEvent(child[0], 'click', { bubbles: false })
+    expect(obj.calledFunction).not.toHaveBeenCalled()
+  })
+
+  it('creates a custom event that can be cancelled', function () {
+    element = $('<input type="text"/>')
+    $('body').append(element)
+    element[0].addEventListener('keypress', obj.calledFunction)
+    window.GOVUK.triggerEvent(element[0], 'keypress')
+    expect(obj.calledFunction).toHaveBeenCalled()
+    expect(obj.secondCalledFunction).toHaveBeenCalled()
+  })
+
+  it('creates a custom event that cannot be cancelled', function () {
+    element = $('<input type="text"/>')
+    $('body').append(element)
+    element[0].addEventListener('keypress', obj.calledFunction)
+    window.GOVUK.triggerEvent(element[0], 'keypress', { cancelable: false })
+    expect(obj.calledFunction).toHaveBeenCalled()
+    expect(obj.secondCalledFunction).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## What
Expands the trigger event script to allow the following:

- allow a keyCode to be passed (yes, this is deprecated, but it works right now)
- allow 'bubbles' and 'cancelable' to be set, previously defaulted to true

## Why
The first thing is needed for some tests in finder-frontend (e.g. https://github.com/alphagov/finder-frontend/blob/main/spec/javascripts/live_search_spec.js#L291). The second thing seems like a logical addition.

## Visual Changes
None.
