### PR TITLE
Add scroll tracking for brexit child taxon pages in welsh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add scroll tracking to welsh brexit child taxon pages ([PR #2201](https://github.com/alphagov/govuk_publishing_components/pull/2201))
+
 ## 24.18.4
 
 * Add Welsh translations for topics, transition and tabs ([PR #2193](https://github.com/alphagov/govuk_publishing_components/pull/2193))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js
@@ -206,7 +206,21 @@
       ['Percent', 80],
       ['Percent', 100]
     ],
+    '/guidance/brexit-guidance-for-businesses.cy': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
+    ],
     '/guidance/brexit-guidance-for-individuals-and-families': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
+    ],
+    '/guidance/brexit-guidance-for-individuals-and-families.cy': [
       ['Percent', 20],
       ['Percent', 40],
       ['Percent', 60],


### PR DESCRIPTION
## What
Add scroll tracking to the welsh versions of the brexit child taxon pages.

## Why
Request from PA

## Visual Changes
None
