### PR TITLE
Fix arrow size on Brexit variation of action link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add scroll tracking to welsh brexit child taxon pages ([PR #2201](https://github.com/alphagov/govuk_publishing_components/pull/2201))
+* Fix arrow size on Brexit variation of action link ([PR #2203](https://github.com/alphagov/govuk_publishing_components/pull/2203))
 
 ## 24.18.4
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -151,11 +151,11 @@
 
   &:before {
     height: 30px;
-    width: 35px;
+    width: 30px;
     background-image: image-url("govuk_publishing_components/action-link-arrow--brexit.svg");
     background-repeat: no-repeat;
-    background-size: 25px auto;
-    background-position: 0 0;
+    background-size: 18px auto;
+    background-position: 0 2px;
   }
 
   @include govuk-media-query($until: tablet) {
@@ -166,7 +166,9 @@
     margin-bottom: govuk-spacing(2);
 
     &:before {
+      width: 35px;
       background-position: 0 4px;
+      background-size: 25px auto;
     }
   }
 }


### PR DESCRIPTION

## What
Adjust the size and positioning of the Brexit variation of action link

## Why
We'd like the Brexit arrow to scale down (along with the text) on narrow screens

## Visual Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="395" alt="Screenshot 2021-07-09 at 12 53 48" src="https://user-images.githubusercontent.com/788096/125074086-bb893a80-e0b4-11eb-93f5-dab40faaff70.png">


</td><td valign="top">

<img width="395" alt="Screenshot 2021-07-09 at 12 50 12" src="https://user-images.githubusercontent.com/788096/125074092-bd52fe00-e0b4-11eb-8266-60edffe97dad.png">


</td></tr>
</table>

