### PR TITLE
Release 24.18.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.18.5
 
 * Add scroll tracking to welsh brexit child taxon pages ([PR #2201](https://github.com/alphagov/govuk_publishing_components/pull/2201))
 * Fix arrow size on Brexit variation of action link ([PR #2203](https://github.com/alphagov/govuk_publishing_components/pull/2203))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.18.4)
+    govuk_publishing_components (24.18.5)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.18.4".freeze
+  VERSION = "24.18.5".freeze
 end


### PR DESCRIPTION
## 24.18.5

* Add scroll tracking to Welsh Brexit child taxon pages ([PR #2201](https://github.com/alphagov/govuk_publishing_components/pull/2201))
* Fix arrow size on Brexit variation of action link ([PR #2203](https://github.com/alphagov/govuk_publishing_components/pull/2203))
