### PR TITLE
Add missing layout_header documentation

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -105,7 +105,10 @@ examples:
   with_search_bar:
     data:
       search: true
-
+  with_custom_logo_link:
+    description: The header logo links to root by default. This option allows us to override that in certain instances.
+    data:
+      logo_link: "/account/home"
 accessibility_criteria: |
   The component must:
 


### PR DESCRIPTION
The option to override the default layout header logo link was introduced some time back, but it was not documented in the component guide.


