### PR TITLE
Version 24.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 24.20.0
 
 * Add inverse option for govspeak ([PR #2207](https://github.com/alphagov/govuk_publishing_components/pull/2207))
 * Expand trigger event script options ([PR #2199](https://github.com/alphagov/govuk_publishing_components/pull/2199))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.19.0)
+    govuk_publishing_components (24.20.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.19.0".freeze
+  VERSION = "24.20.0".freeze
 end


### PR DESCRIPTION
* Add inverse option for govspeak ([PR #2207](https://github.com/alphagov/govuk_publishing_components/pull/2207))
* Expand trigger event script options ([PR #2199](https://github.com/alphagov/govuk_publishing_components/pull/2199))
