### PR TITLE
Fix new link styles on document list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix new link styles on document list ([PR #2211](https://github.com/alphagov/govuk_publishing_components/pull/2211))
 * Add Layout super navigation header component ([PR #2179](https://github.com/alphagov/govuk_publishing_components/pull/2179))
 
 ## 24.20.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -6,7 +6,6 @@
 }
 
 .gem-c-document-list__item {
-  overflow: hidden;
   margin-bottom: govuk-spacing(5);
   padding-top: govuk-spacing(2);
   border-top: 1px solid $govuk-border-colour;
@@ -16,11 +15,6 @@
 .gem-c-document-list__item-title {
   @include govuk-font($size: 19, $weight: bold);
   display: inline-block;
-}
-
-.gem-c-document-list__item-link {
-  @include govuk-link-common;
-  @include govuk-link-style-default;
 }
 
 .gem-c-document-list--no-underline {
@@ -156,18 +150,22 @@
 }
 
 .gem-c-document-list-child__link {
-  @include govuk-link-common;
-  @include govuk-link-style-default;
   text-decoration: none;
 
   &:hover {
     text-decoration: underline;
+    text-underline-offset: .1em;
+    @include govuk-link-hover-decoration;
+  }
+
+  &:focus {
+    text-decoration: none;
   }
 }
 
 .gem-c-document-list-child__description {
   @include govuk-text-colour;
-  margin-top: 0;
+  margin-top: govuk-spacing(1);
   margin-bottom: govuk-spacing(1);
 
   @include govuk-media-query($until: tablet) {

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -41,7 +41,7 @@
               item[:link][:text],
               item[:link][:path],
               data: item[:link][:data_attributes],
-              class: "#{item_classes} gem-c-document-list__item-link",
+              class: "#{item_classes} govuk-link",
               lang: item[:link][:locale].presence,
               rel: rel,
             )
@@ -65,7 +65,7 @@
 
         <% if item[:metadata] %>
           <ul class="gem-c-document-list__item-metadata">
-            <% item[:metadata].compact.each do |item_metadata_key, item_metadata_value| %> 
+            <% item[:metadata].compact.each do |item_metadata_key, item_metadata_value| %>
               <% if !item_metadata_key.to_s.eql?("locale") %>
                 <% lang = item[:metadata][:locale].present? && item[:metadata][:locale][item_metadata_key].present? ? item[:metadata][:locale][item_metadata_key] : nil %>
 
@@ -101,7 +101,7 @@
                       part[:link][:text],
                       part[:link][:path],
                       data: part[:link][:data_attributes],
-                      class: "gem-c-document-list-child__heading #{brand_helper.color_class} gem-c-document-list-child__link",
+                      class: "gem-c-document-list-child__heading #{brand_helper.color_class} govuk-link gem-c-document-list-child__link",
                     )
                   else
                     content_tag(

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -494,7 +494,7 @@ describe "Document list", type: :view do
       ],
     )
 
-    link = ".gem-c-document-list__item-link"
+    link = ".govuk-link"
 
     assert_select "#{link}[href=\"https://www.actionfraud.police.uk/contact-us\"][rel=\"external\"]", text: "Report Fraud"
     assert_select "#{link}[href=\"/contact-child-benefit-office\"]:not([rel])", text: "Child Benefit"


### PR DESCRIPTION
## What
The document list component was recently updated to use the new `govuk-frontend` link styles, but I spotted a couple of problems.

- fixes With only link variant, by removing overflow hidden (was clipping bottom border off focussed link)
- fixes With parts variant, by adding extra styles in and improving spacing beneath link (hover was wrong and hover + focus had a double underline)
- remove general link style in favour of using govuk-link class in template

## Why
Improving consistency for our link styles.

## Visual Changes
Before | After
------ | ------
![Screenshot 2021-07-14 at 12 01 10](https://user-images.githubusercontent.com/861310/125611677-04fce888-1854-4f3a-b71b-da292f13022e.png) | ![Screenshot 2021-07-14 at 12 01 35](https://user-images.githubusercontent.com/861310/125611690-033e5765-8a4e-4b8b-bffb-b656e3f2d0d3.png)
![Screenshot 2021-07-14 at 12 03 52](https://user-images.githubusercontent.com/861310/125611936-c299aebc-3b1c-4ac4-a125-18ed6867f487.png) | ![Screenshot 2021-07-14 at 12 03 59](https://user-images.githubusercontent.com/861310/125611953-839e4075-d596-40ed-9abb-a9a7d3be44a4.png)
