### PR TITLE
Add meta tag to all content tagged to Brexit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix new link styles on document list ([PR #2211](https://github.com/alphagov/govuk_publishing_components/pull/2211))
+* Make sure custom dimension 112 is sent for all pages tagged to Brexit ([PR #2212](https://github.com/alphagov/govuk_publishing_components/pull/2212))
 
 ## 24.20.0
 

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -54,12 +54,12 @@ module GovukPublishingComponents
         }
       end
 
-      def brexit_audience
+      def brexit_audience(taxon)
         {
           PRIORITY_TAXONS[:brexit_business] => "Brexitbusiness",
           PRIORITY_TAXONS[:brexit_individuals] => "Brexitcitizen",
           PRIORITY_TAXONS[:brexit_taxon] => "Brexitbusinessandcitizen",
-        }[priority_taxon["content_id"]]
+        }[taxon["content_id"]]
       end
 
     private
@@ -113,7 +113,7 @@ module GovukPublishingComponents
 
       def tracking_action
         action = %w[superBreadcrumb]
-        action << brexit_audience
+        action << brexit_audience(priority_taxon)
         action.compact.join(" ")
       end
 

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -4,14 +4,17 @@ module GovukPublishingComponents
       # keys are labels, values are the content_ids for the matching taxons
       # Where multiple matching taxons are present, the top most one is the highest priority
       #   and the bottom one the lowest priority
-      PRIORITY_TAXONS = {
-        education_coronavirus: "272308f4-05c8-4d0d-abc7-b7c2e3ccd249",
-        worker_coronavirus: "b7f57213-4b16-446d-8ded-81955d782680",
-        business_coronavirus: "65666cdf-b177-4d79-9687-b9c32805e450",
+      BREXIT_TAXONS = {
         brexit_business: "634fd193-8039-4a70-a059-919c34ff4bfc",
         brexit_individuals: "614b2e65-56ac-4f8d-bb9c-d1a14167ba25",
         brexit_taxon: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       }.freeze
+
+      PRIORITY_TAXONS = {
+        education_coronavirus: "272308f4-05c8-4d0d-abc7-b7c2e3ccd249",
+        worker_coronavirus: "b7f57213-4b16-446d-8ded-81955d782680",
+        business_coronavirus: "65666cdf-b177-4d79-9687-b9c32805e450",
+      }.merge(BREXIT_TAXONS).freeze
 
       # Returns the highest priority taxon that has a content_id matching those in PRIORITY_TAXONS
       def self.call(content_item, query_parameters = nil)
@@ -29,6 +32,14 @@ module GovukPublishingComponents
         @priority_taxon ||= begin
           default_taxon = priority_taxons.min_by { |t| PRIORITY_TAXONS.values.index(t["content_id"]) }
           preferred_taxon || default_taxon
+        end
+      end
+
+      def priority_brexit_taxon
+        if tagged_to_both_brexit_child_taxons?
+          priority_brexit_taxons.find { |t| t["content_id"] == BREXIT_TAXONS[:brexit_taxon] }
+        else
+          priority_brexit_taxons.min_by { |t| BREXIT_TAXONS.values.index(t["content_id"]) }
         end
       end
 
@@ -70,6 +81,10 @@ module GovukPublishingComponents
         end
       end
 
+      def priority_brexit_taxons
+        priority_taxons.select { |t| priority_brexit_taxon?(t) }
+      end
+
       def taxon_tree(taxons)
         return [] if taxons.blank?
 
@@ -78,6 +93,10 @@ module GovukPublishingComponents
 
       def priority_taxon?(taxon)
         PRIORITY_TAXONS.values.include?(taxon["content_id"])
+      end
+
+      def priority_brexit_taxon?(taxon)
+        BREXIT_TAXONS.values.include?(taxon["content_id"])
       end
 
       def brexit_child_taxon?(taxon)

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -25,16 +25,16 @@ module GovukPublishingComponents
         @query_parameters = query_parameters
       end
 
-      def taxon
-        @taxon ||= begin
+      def priority_taxon
+        @priority_taxon ||= begin
           default_taxon = priority_taxons.min_by { |t| PRIORITY_TAXONS.values.index(t["content_id"]) }
           preferred_taxon || default_taxon
         end
       end
 
       def breadcrumbs
-        taxon && {
-          title: taxon["title"],
+        priority_taxon && {
+          title: priority_taxon["title"],
           path: breadcrumb_path,
           tracking_category: "breadcrumbClicked",
           tracking_action: tracking_action,
@@ -48,7 +48,7 @@ module GovukPublishingComponents
           PRIORITY_TAXONS[:brexit_business] => "Brexitbusiness",
           PRIORITY_TAXONS[:brexit_individuals] => "Brexitcitizen",
           PRIORITY_TAXONS[:brexit_taxon] => "Brexitbusinessandcitizen",
-        }[taxon["content_id"]]
+        }[priority_taxon["content_id"]]
       end
 
     private
@@ -104,7 +104,7 @@ module GovukPublishingComponents
       end
 
       def breadcrumb_path
-        taxon.dig("details", "url_override").present? ? taxon.dig("details", "url_override") : taxon["base_path"]
+        priority_taxon.dig("details", "url_override").present? ? priority_taxon.dig("details", "url_override") : priority_taxon["base_path"]
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -129,7 +129,7 @@ module GovukPublishingComponents
       end
 
       def tagged_to_priority_taxon?
-        priority_taxon_helper.taxon.present?
+        priority_taxon_helper.priority_taxon.present?
       end
 
       def priority_taxon_helper

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -123,8 +123,11 @@ module GovukPublishingComponents
         return meta_tags if taxons.blank?
         return meta_tags unless tagged_to_priority_taxon?
 
-        meta_tags[tag_key] = brexit_audience if brexit_audience.present?
+        taxon =
+          tag_key == "govuk:brexit-audience" ? priority_brexit_taxon : priority_taxon
 
+        brexit_audience = priority_taxon_helper.brexit_audience(taxon)
+        meta_tags[tag_key] = brexit_audience if brexit_audience.present?
         meta_tags
       end
 
@@ -136,8 +139,12 @@ module GovukPublishingComponents
         @priority_taxon_helper ||= ContentBreadcrumbsBasedOnPriority.new(content_item.deep_stringify_keys, request.query_parameters)
       end
 
-      def brexit_audience
-        priority_taxon_helper.brexit_audience
+      def priority_taxon
+        priority_taxon_helper.priority_taxon
+      end
+
+      def priority_brexit_taxon
+        priority_taxon_helper.priority_brexit_taxon
       end
 
       def has_content_history?

--- a/spec/components/contextual_breadcrumbs_spec.rb
+++ b/spec/components/contextual_breadcrumbs_spec.rb
@@ -42,11 +42,26 @@ describe "ContextualBreadcrumbs", type: :view do
     content_item
   end
 
+  def tag_to_priority_coronavirus(content_item)
+    content_item["links"]["taxons"][1]["title"] = "Coronavirus Education"
+    content_item["links"]["taxons"][1]["content_id"] = "272308f4-05c8-4d0d-abc7-b7c2e3ccd249"
+    content_item
+  end
+
   it "renders the brexit-superbreadcrumb meta tag on content tagged to brexit" do
     content_item = example_document_for("guide", "guide")
     content_item = tag_to_brexit(content_item)
     render_component(content_item: content_item)
     assert_select "meta[name='govuk:brexit-superbreadcrumb'][content='Brexitbusiness']"
+  end
+
+  it "does not render the brexit-superbreadcrumb meta tag on content tagged to brexit AND a priority coronavirus taxon" do
+    content_item = example_document_for("guide", "guide")
+    content_item = tag_to_brexit(content_item)
+    content_item["links"]["taxons"] << {}
+    content_item = tag_to_priority_coronavirus(content_item)
+    render_component(content_item: content_item)
+    assert_select "meta[name='govuk:brexit-superbreadcrumb'][content='Brexitbusiness']", count: 0
   end
 
   it "renders breadcrumbs that collapse on mobile by default" do

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -358,6 +358,50 @@ describe "Meta tags", type: :view do
     assert_meta_tag("govuk:brexit-audience", "Brexitbusiness")
   end
 
+  it "does not render the brexit audience metatag for content items tagged to brexit and a priority coronavirus taxon" do
+    content_item = {
+      links: {
+        taxons: [
+          {
+            title: "Brexit: business guidance",
+            content_id: "634fd193-8039-4a70-a059-919c34ff4bfc",
+            base_path: "/brexit/business-guidance",
+            document_type: "detailed_guide",
+            links: {
+              parent_taxons: [
+                {
+                  title: "Brexit",
+                  content_id: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+                  base_path: "/brexit",
+                  document_type: "taxon",
+                },
+              ],
+            },
+          },
+          {
+            title: "Work and financial support during coronavirus",
+            content_id: "b7f57213-4b16-446d-8ded-81955d782680",
+            base_path: "/coronavirus-taxon/work-and-financial-support",
+            document_type: "detailed_guide",
+            links: {
+              parent_taxons: [
+                {
+                  title: "Coronavirus (COVID-19)",
+                  content_id: "5b7b9532-a775-4bd2-a3aa-6ce380184b6c",
+                  base_path: "/coronavirus-taxon",
+                  document_type: "taxon",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+
+    render_component(content_item: example_document_for("detailed_guide", "detailed_guide").merge(content_item))
+    assert_no_meta_tag("govuk:brexit-audience")
+  end
+
   it "renders the has-content-history tag as true when the content has history" do
     content_item = {
       public_updated_at: Time.parse("2017-01-01"),

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -358,7 +358,7 @@ describe "Meta tags", type: :view do
     assert_meta_tag("govuk:brexit-audience", "Brexitbusiness")
   end
 
-  it "does not render the brexit audience metatag for content items tagged to brexit and a priority coronavirus taxon" do
+  it "renders the brexit audience metatag for content items tagged to brexit and a priority coronavirus taxon" do
     content_item = {
       links: {
         taxons: [
@@ -399,7 +399,7 @@ describe "Meta tags", type: :view do
     }
 
     render_component(content_item: example_document_for("detailed_guide", "detailed_guide").merge(content_item))
-    assert_no_meta_tag("govuk:brexit-audience")
+    assert_meta_tag("govuk:brexit-audience", "Brexitbusiness")
   end
 
   it "renders the has-content-history tag as true when the content has history" do

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -168,6 +168,25 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
         end
       end
 
+      describe "#priority_brexit_taxon" do
+        let(:brexit_taxons) { [brexit_taxon, brexit_business_taxon] }
+        let(:payload) { brexit_taxons }
+        let(:content) { directly_tagged_to_taxons(payload) }
+        subject { described_class.new(content) }
+
+        it "returns the highest priority brexit taxon" do
+          expect(subject.priority_brexit_taxon).to eq(brexit_business_taxon)
+        end
+
+        context "with brexit taxons and a coronavirus taxon" do
+          let(:payload) { brexit_taxons << education_taxon }
+
+          it "returns the brexit taxon" do
+            expect(subject.priority_brexit_taxon).to eq(brexit_business_taxon)
+          end
+        end
+      end
+
       describe ".call" do
         let(:content) { send(tagged_to_taxons, [education_taxon]) }
 

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -68,20 +68,20 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
 
   let(:payload) { [education_taxon] }
 
-  describe "#taxon" do
+  describe "#priority_taxon" do
     %w[directly_tagged_to_taxons indirectly_tagged_to_taxons].each do |tagged_to_taxons|
       context tagged_to_taxons do
         subject { described_class.new(send(tagged_to_taxons, payload)) }
 
         it "returns the matching taxon" do
-          expect(subject.taxon).to eq(education_taxon)
+          expect(subject.priority_taxon).to eq(education_taxon)
         end
 
         context "with business taxon" do
           let(:payload) { [business_taxon] }
 
           it "returns the business taxon" do
-            expect(subject.taxon).to eq(business_taxon)
+            expect(subject.priority_taxon).to eq(business_taxon)
           end
         end
 
@@ -89,7 +89,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
           let(:payload) { [worker_taxon] }
 
           it "returns the worker taxon" do
-            expect(subject.taxon).to eq(worker_taxon)
+            expect(subject.priority_taxon).to eq(worker_taxon)
           end
         end
 
@@ -97,7 +97,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
           let(:payload) { [brexit_taxon] }
 
           it "returns the brexit taxon" do
-            expect(subject.taxon).to eq(brexit_taxon)
+            expect(subject.priority_taxon).to eq(brexit_taxon)
             expect(subject.brexit_audience).to eq("Brexitbusinessandcitizen")
           end
         end
@@ -106,7 +106,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
           let(:payload) { [education_taxon, business_taxon] }
 
           it "returns the education taxon" do
-            expect(subject.taxon).to eq(education_taxon)
+            expect(subject.priority_taxon).to eq(education_taxon)
           end
         end
 
@@ -114,7 +114,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
           let(:payload) { [brexit_taxon, brexit_individuals_taxon] }
 
           it "returns the brexit_individuals taxon" do
-            expect(subject.taxon).to eq(brexit_individuals_taxon)
+            expect(subject.priority_taxon).to eq(brexit_individuals_taxon)
             expect(subject.brexit_audience).to eq("Brexitcitizen")
           end
         end
@@ -123,7 +123,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
           let(:payload) { [brexit_taxon, brexit_business_taxon] }
 
           it "returns the brexit_business taxon" do
-            expect(subject.taxon).to eq(brexit_business_taxon)
+            expect(subject.priority_taxon).to eq(brexit_business_taxon)
             expect(subject.brexit_audience).to eq("Brexitbusiness")
           end
         end
@@ -132,7 +132,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
           let(:payload) { [brexit_taxon, brexit_individuals_taxon, brexit_business_taxon] }
 
           it "returns the brexit_taxon taxon" do
-            expect(subject.taxon).to eq(brexit_taxon)
+            expect(subject.priority_taxon).to eq(brexit_taxon)
             expect(subject.brexit_audience).to eq("Brexitbusinessandcitizen")
           end
         end
@@ -141,7 +141,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
           let(:payload) { [] }
 
           it "returns nil" do
-            expect(subject.taxon).to be_nil
+            expect(subject.priority_taxon).to be_nil
           end
         end
 
@@ -153,7 +153,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
             content_item = send(tagged_to_taxons, payload)
             context_breadcrumb = described_class.new(content_item, query_parameters)
 
-            expect(context_breadcrumb.taxon).to eq(business_taxon)
+            expect(context_breadcrumb.priority_taxon).to eq(business_taxon)
           end
 
           it "returns the default taxon if not tagged to priority taxon" do
@@ -163,7 +163,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
             content_item = send(tagged_to_taxons, payload)
             context_breadcrumb = described_class.new(content_item, query_parameters)
 
-            expect(context_breadcrumb.taxon).to eq(education_taxon)
+            expect(context_breadcrumb.priority_taxon).to eq(education_taxon)
           end
         end
       end

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority_spec.rb
@@ -97,8 +97,11 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
           let(:payload) { [brexit_taxon] }
 
           it "returns the brexit taxon" do
-            expect(subject.priority_taxon).to eq(brexit_taxon)
-            expect(subject.brexit_audience).to eq("Brexitbusinessandcitizen")
+            priority_taxon = subject.priority_taxon
+            brexit_audience = subject.brexit_audience(priority_taxon)
+
+            expect(priority_taxon).to eq(brexit_taxon)
+            expect(brexit_audience).to eq("Brexitbusinessandcitizen")
           end
         end
 
@@ -114,8 +117,11 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
           let(:payload) { [brexit_taxon, brexit_individuals_taxon] }
 
           it "returns the brexit_individuals taxon" do
-            expect(subject.priority_taxon).to eq(brexit_individuals_taxon)
-            expect(subject.brexit_audience).to eq("Brexitcitizen")
+            priority_taxon = subject.priority_taxon
+            brexit_audience = subject.brexit_audience(priority_taxon)
+
+            expect(priority_taxon).to eq(brexit_individuals_taxon)
+            expect(brexit_audience).to eq("Brexitcitizen")
           end
         end
 
@@ -123,8 +129,11 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
           let(:payload) { [brexit_taxon, brexit_business_taxon] }
 
           it "returns the brexit_business taxon" do
-            expect(subject.priority_taxon).to eq(brexit_business_taxon)
-            expect(subject.brexit_audience).to eq("Brexitbusiness")
+            priority_taxon = subject.priority_taxon
+            brexit_audience = subject.brexit_audience(priority_taxon)
+
+            expect(priority_taxon).to eq(brexit_business_taxon)
+            expect(brexit_audience).to eq("Brexitbusiness")
           end
         end
 
@@ -132,8 +141,11 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnP
           let(:payload) { [brexit_taxon, brexit_individuals_taxon, brexit_business_taxon] }
 
           it "returns the brexit_taxon taxon" do
-            expect(subject.priority_taxon).to eq(brexit_taxon)
-            expect(subject.brexit_audience).to eq("Brexitbusinessandcitizen")
+            priority_taxon = subject.priority_taxon
+            brexit_audience = subject.brexit_audience(priority_taxon)
+
+            expect(priority_taxon).to eq(brexit_taxon)
+            expect(brexit_audience).to eq("Brexitbusinessandcitizen")
           end
         end
 


### PR DESCRIPTION
## What
Improve the tracking of pages tagged to a brexit priority taxon. 

## Why
If a page is tagged to a priority brexit taxon, we want it to contain a meta tag for the brexit audience type (`govuk:brexit-audience`), and send the value of that meta tag to GA as custom dimension 112. Currently this will not happen if the page is also tagged to a higher priority taxon (eg coronavirus child taxons).

## Source of bug
The [brexit_audience](https://github.com/alphagov/govuk_publishing_components/blob/bb7d37240a898b38ab3e70d669c6187459e9f3e1/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb#L46-L52) method is used by the meta_tag presenter to [decide](https://github.com/alphagov/govuk_publishing_components/blob/bb7d37240a898b38ab3e70d669c6187459e9f3e1/lib/govuk_publishing_components/presenters/meta_tags.rb#L126) if the meta tag should be added. And brexit_audience is calling `priority_taxon` which uses the order of taxons in the PRIORITY_TAXON hash. 

## Visual Changes
None

## Before (no brexit-audience meta tag is set)

<img width="1502" alt="Screenshot 2021-07-14 at 23 37 00" src="https://user-images.githubusercontent.com/17908089/125701734-1b6168d7-dde9-49e2-b570-e9f8a7f828d5.png">

## After (contains brexit-audience meta tag (Custom dimension 112)

<img width="1503" alt="Screenshot 2021-07-14 at 23 35 22" src="https://user-images.githubusercontent.com/17908089/125701624-947ba739-df42-401d-a4d0-fa1e0c4eb052.png">