### PR TITLE
Update notice component to better match DS notification banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Convert a tags to buttons on load in header-navigation js ([PR #2235](https://github.com/alphagov/govuk_publishing_components/pull/2235))
 * Allow label sizes for search component label ([PR #2236](https://github.com/alphagov/govuk_publishing_components/pull/2236)) MINOR
+* Update notice component to better match DS notification banner ([PR #2214](https://github.com/alphagov/govuk_publishing_components/pull/2214))
 
 ## 25.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_notice.scss
@@ -1,10 +1,8 @@
-.gem-c-notice {
-  @include govuk-text-colour;
-  @include govuk-responsive-padding(4);
-  @include govuk-responsive-margin(8, "bottom");
+@import "govuk/components/notification-banner/notification-banner";
 
+.gem-c-notice {
+  @include govuk-responsive-margin(8, "bottom");
   clear: both;
-  border: $govuk-border-width solid govuk-colour("blue");
 
   .govuk-govspeak {
     p:last-child {
@@ -18,22 +16,9 @@
 }
 
 .gem-c-notice__title {
-  @include govuk-font(24, $weight: bold);
-  margin-top: 0;
-  @include govuk-responsive-margin(4, "bottom");
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-
   a {
     @include govuk-link-common;
     @include govuk-link-style-default;
     @include govuk-link-print-friendly;
   }
-}
-
-.gem-c-notice__description {
-  @include govuk-font(19);
-  margin: 0;
 }

--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -8,29 +8,35 @@
   local_assigns[:margin_bottom] ||= 8
   local_assigns[:margin_bottom] = 8 if local_assigns[:margin_bottom] > 9
 
+  banner_title ||= t("components.notice.banner_title")
+  banner_title_id ||= "govuk-notification-banner-title-#{SecureRandom.hex(4)}"
+  show_banner_title ||= false
+  heading_level = show_banner_title ? "h3" : "h2"
+
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
-  css_classes = %w[gem-c-notice]
+  css_classes = %w[govuk-notification-banner gem-c-notice]
   css_classes << (shared_helper.get_margin_bottom)
 
-  aria_attributes = aria_live ? {label: 'Notice', live: 'polite'} : {label: 'Notice'}
+  aria_attributes = {label: 'Notice'}
+  aria_attributes[:live] = 'polite' if aria_live
+  aria_attributes[:labelledby] = banner_title_id if show_banner_title
 
   description_present = description.present? || description_text.present? || description_govspeak.present?
 %>
 <% if title || description_present %>
   <%= tag.section class: css_classes, aria: aria_attributes, lang: lang, role: "region" do %>
-    <% if title %>
-      <% if description_present %>
-        <%= tag.h2 title, class: "gem-c-notice__title" %>
-      <% else %>
-        <%= tag.span title, class: "gem-c-notice__title" %>
-      <% end %>
+    <%= tag.div class: "govuk-notification-banner__header" do %>
+      <%= tag.h2 banner_title, class: "govuk-notification-banner__title", id: banner_title_id %>
+    <% end if show_banner_title %>
+    <%= tag.div class: "govuk-notification-banner__content" do %>
+      <%= content_tag(heading_level, title, class: "gem-c-notice__title govuk-notification-banner__heading") if description_present && title %>
+      <%= tag.span title, class: "gem-c-notice__title govuk-notification-banner__heading" if !description_present && title %>
+      <%= tag.p description_text, class: "gem-c-notice__description" if description_text %>
+
+      <%= description if description %>
+
+      <%= render 'govuk_publishing_components/components/govspeak', content: description_govspeak if description_govspeak %>
     <% end %>
-
-    <%= tag.p description_text, class: "gem-c-notice__description" if description_text %>
-
-    <%= description if description %>
-
-    <%= render 'govuk_publishing_components/components/govspeak', content: description_govspeak if description_govspeak %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/notice.yml
+++ b/app/views/govuk_publishing_components/components/docs/notice.yml
@@ -50,3 +50,18 @@ examples:
       title: 'This publication was withdrawn on 30 September 2015'
       description_govspeak: <p>This document is no longer current. We published a new version on 30 September 2015.</p>
       lang: 'en'
+  with_banner_title:
+    description: |
+      By default, the notice component renders with a banner title of "Important" if `show_banner_title` is `true`.
+    data:
+      title: 'This publication was withdrawn on 30 September 2015'
+      description_govspeak: <p>This document is no longer current. We published a new version on 30 September 2015.</p>
+      show_banner_title: true
+  with_custom_banner_title:
+    description: |
+      The default banner title can be overruled by specifying a `banner_title` option.
+    data:
+      title: 'This publication was withdrawn on 30 September 2015'
+      description_govspeak: <p>This document is no longer current. We published a new version on 30 September 2015.</p>
+      show_banner_title: true
+      banner_title: "Information"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,6 +183,8 @@ en:
       toggle_more: "+ %{number} more"
     modal_dialogue:
       close_modal: Close modal dialogue
+    notice:
+      banner_title: Important
     organisation_schema:
       all_content_search_description: Find all content from %{organisation}
     previous_and_next_navigation:

--- a/spec/components/notice_spec.rb
+++ b/spec/components/notice_spec.rb
@@ -86,4 +86,21 @@ describe "Notice", type: :view do
     render_component(title: "Your settings have been saved")
     assert_select ".gem-c-notice[lang=en]", false
   end
+
+  it "displays without a banner title by default" do
+    render_component(title: "Your settings have been saved")
+    assert_select ".gem-c-notice .govuk-notification-banner__title", false
+  end
+
+  it "displays with a banner title of 'Important' by default when show_banner_title is true" do
+    render_component(title: "Your settings have been saved", show_banner_title: true, description_text: "Duplicate, added in error")
+    assert_select ".gem-c-notice h2.govuk-notification-banner__title", text: "Important"
+    assert_select "h3.gem-c-notice__title", text: "Your settings have been saved"
+  end
+
+  it "can display with a custom banner title if required" do
+    render_component(title: "Your settings have been saved", show_banner_title: true, banner_title: "Notice", description_text: "Duplicate, added in error")
+    assert_select ".gem-c-notice h2.govuk-notification-banner__title", text: "Notice"
+    assert_select "h3.gem-c-notice__title", text: "Your settings have been saved"
+  end
 end


### PR DESCRIPTION
Between the [notice](https://components.publishing.service.gov.uk/component-guide/notice), [success](https://components.publishing.service.gov.uk/component-guide/success_alert) and [error alert](https://components.publishing.service.gov.uk/component-guide/error_alert) components, we've got a mix of styles and approaches. 
Ideally these would all be one component, with modifiers applied to generate variations. 
This is a step towards that goal.


The GOV.UK version of the notification component currently deviates from the Design System version. 
This adopts Design System classes and styles for this component, only keeping few CSS overrides that are necessary for our usage of this component. 

Instead of applying the "Important" banner style across the board, it has been suggested by the GOVUK design community to make it opt-in, so that it can be applied only where it suits the intent of the banner.

Additionally, the title text is customisable so any term can be used in case that the word "Important" doesn't quite fit with the information the notice is trying to convey.

-----

#2082 

Design System notification banner https://design-system.service.gov.uk/components/notification-banner/ 
GOV.UK notice component https://components.publishing.service.gov.uk/component-guide/notice