### PR TITLE
Remove references to visual regression JavaScript

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,7 +5,6 @@ Rails.application.config.assets.precompile += %w[
   component_guide/accessibility-test.js
   component_guide/application.js
   component_guide/filter-components.js
-  component_guide/visual-regression.js
   component_guide/print.css
   govuk_publishing_components/rum-loader.js
   govuk_publishing_components/vendor/lux/lux-reporter.js

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -22,7 +22,6 @@ src_files:
   - assets/govuk_publishing_components/analytics.js
 
   # Use some of the assets from the component guide for testing
-  - assets/component_guide/visual-regression.js
   - assets/component_guide/accessibility-test.js
   - assets/component_guide/filter-components.js
 


### PR DESCRIPTION


## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

The visual regression testing JavaScript was removed in #2033 - these references to the deleted file were missed. This fixes that omission.

## Why
<!-- What are the reasons behind this change being made? -->

It was a bit annoying as this caused 404 errors to be noted in the console when running Jasmine in the browser.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
None.
