### PR TITLE
Allow the public layout to render without the footer navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fix new link styles on document list ([PR #2211](https://github.com/alphagov/govuk_publishing_components/pull/2211))
 * Make sure custom dimension 112 is sent for all pages tagged to Brexit ([PR #2212](https://github.com/alphagov/govuk_publishing_components/pull/2212))
+* Allow the public layout to render without the footer navigation ([PR #2218](https://github.com/alphagov/govuk_publishing_components/pull/2218))
 
 ## 24.20.0
 

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -7,6 +7,7 @@
   logo_link ||= "/"
   navigation_items ||= []
   omit_feedback_form ||= false
+  omit_footer_navigation ||= false
   omit_header ||= false
   product_name ||= nil
   show_explore_header ||= false
@@ -122,7 +123,7 @@
     <% unless local_assigns[:hide_footer_links] %>
       <%= render "govuk_publishing_components/components/layout_footer", {
         with_border: true,
-        navigation: layout_helper.footer_navigation,
+        navigation: omit_footer_navigation ? nil : layout_helper.footer_navigation,
         meta: layout_helper.footer_meta,
       } %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -31,6 +31,10 @@ examples:
     description: This allows the feedback form to be omitted
     data:
       omit_feedback_form: true
+  omit_footer_navigation:
+    description: This allows the footer navigation to be omitted
+    data:
+      omit_footer_navigation: true
   navigation:
     description: Passes the navigation through to the [header component](/component-guide/layout_header/).
     data:

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -59,6 +59,20 @@ describe "Layout for public", type: :view do
     assert_select ".gem-c-layout-for-public .gem-c-feedback", false
   end
 
+  it "can omit the footer navigation" do
+    render_component(omit_footer_navigation: true)
+
+    assert_select ".gem-c-layout-for-public .govuk-footer__navigation", false
+    assert_select ".gem-c-layout-for-public .govuk-footer__section-break", false
+  end
+
+  it "does not omit the footer navigation if `omit_footer_navigation` is `false`" do
+    render_component(omit_footer_navigation: false)
+
+    assert_select ".gem-c-layout-for-public .govuk-footer__navigation", true
+    assert_select ".gem-c-layout-for-public .govuk-footer__section-break", true
+  end
+
   it "can add a product name in the header" do
     render_component(product_name: "Account")
 


### PR DESCRIPTION
## What
Add `omit_footer_navigation` to `layout_for_public`.

## Why
This feature is required to update `service-manual-frontend` (https://www.gov.uk/service-manual) to the new layout.

## Visual Changes
👉 [Preview the component with this flag on](https://govuk-publis-gem-layout-jaztpm.herokuapp.com/component-guide/layout_for_public/omit_footer_navigation/preview)
