### PR TITLE
Delete empty print stylesheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Delete empty print stylesheets ([PR #2225](https://github.com/alphagov/govuk_publishing_components/pull/2225))
+
 ## 24.21.1
 
 * Fix issue where metatag component throws an error when priority_brexit_taxon isn't available. ([PR #2227](https://github.com/alphagov/govuk_publishing_components/pull/2227))

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_attachment.scss
@@ -1,2 +1,0 @@
-//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
-// https://github.com/alphagov/government-frontend/blob/7a0b068a0faa1da07f58acf0b1d3a0aa3e1daf56/app/assets/stylesheets/print.scss#L2

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_back-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_back-link.scss
@@ -1,2 +1,0 @@
-//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
-// https://github.com/alphagov/govuk-account-manager-prototype/blob/7858b55afcddc2f855d909abd051838d95f21f13/app/assets/stylesheets/print.scss#L2

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_feedback.scss
@@ -1,2 +1,0 @@
-//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
-// https://github.com/alphagov/government-frontend/blob/7a0b068a0faa1da07f58acf0b1d3a0aa3e1daf56/app/assets/stylesheets/print.scss#L6

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_layout-footer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_layout-footer.scss
@@ -1,2 +1,0 @@
-//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
-// https://github.com/alphagov/govuk-account-manager-prototype/blob/7858b55afcddc2f855d909abd051838d95f21f13/app/assets/stylesheets/print.scss#L5

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_layout-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_layout-header.scss
@@ -1,2 +1,0 @@
-//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
-// https://github.com/alphagov/govuk-account-manager-prototype/blob/7858b55afcddc2f855d909abd051838d95f21f13/app/assets/stylesheets/print.scss#L6

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_metadata.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_metadata.scss
@@ -1,2 +1,0 @@
-//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
-// https://github.com/alphagov/manuals-frontend/blob/466b4c7a6507a3d76818e26612f174616f5cdf94/app/assets/stylesheets/print.scss#L15

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_search.scss
@@ -1,2 +1,0 @@
-//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
-// https://github.com/alphagov/govuk-account-manager-prototype/blob/7858b55afcddc2f855d909abd051838d95f21f13/app/assets/stylesheets/print.scss#L7

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_share-links.scss
@@ -1,2 +1,0 @@
-//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
-// https://github.com/alphagov/collections/blob/fc9db4ef6d87ad52d0ac795d1dd05d5fa116dde1/app/assets/stylesheets/print.scss#L9

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_skip-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_skip-link.scss
@@ -1,2 +1,0 @@
-//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
-// https://github.com/alphagov/govuk-account-manager-prototype/blob/7858b55afcddc2f855d909abd051838d95f21f13/app/assets/stylesheets/print.scss#L8

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_subscription-links.scss
@@ -1,2 +1,0 @@
-//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
-// https://github.com/alphagov/frontend/blob/34e84c7d6dc22bd4b06ce4c18a3d00b29fdcee83/app/assets/stylesheets/print.scss#L12

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_translation-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_translation-nav.scss
@@ -1,2 +1,0 @@
-//  Left this as an empty file as opposed to deleting it because it is @imported in application print stylesheets for example here:
-// https://github.com/alphagov/government-frontend/blob/7a0b068a0faa1da07f58acf0b1d3a0aa3e1daf56/app/assets/stylesheets/print.scss#L16

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -75,15 +75,9 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/title';"
 
     expected_print_sass = "@import 'govuk_publishing_components/govuk_frontend_support';
-@import 'govuk_publishing_components/components/print/back-link';
 @import 'govuk_publishing_components/components/print/button';
-@import 'govuk_publishing_components/components/print/feedback';
 @import 'govuk_publishing_components/components/print/govspeak';
-@import 'govuk_publishing_components/components/print/layout-footer';
-@import 'govuk_publishing_components/components/print/layout-header';
 @import 'govuk_publishing_components/components/print/layout-super-navigation-header';
-@import 'govuk_publishing_components/components/print/search';
-@import 'govuk_publishing_components/components/print/skip-link';
 @import 'govuk_publishing_components/components/print/step-by-step-nav';
 @import 'govuk_publishing_components/components/print/step-by-step-nav-header';
 @import 'govuk_publishing_components/components/print/title';"


### PR DESCRIPTION
Not long ago, there was some refactoring to remove `display: none` rules from component stylesheets in favour of using the `govuk-!-display-none-print` class instead: alphagov/govuk_publishing_components#1561

As a consequence of that refactoring process, some of the component print stylesheets which previously used to contain CSS are now empty files  ([Example](https://github.com/alphagov/govuk_publishing_components/blob/9213c4fc722900eda91c722cbb1af69ecacdafb7/app/assets/stylesheets/govuk_publishing_components/components/print/_back-link.scss)). These empty files could not be removed immediately as they were referenced in many applications' print stylesheets  ([Example](https://github.com/alphagov/govuk-account-manager-prototype/blob/7858b55afcddc2f855d909abd051838d95f21f13/app/assets/stylesheets/print.scss#L2))

~**Step 1** in the process of deleting these empty files is to hunt down references of these files in application print stylesheets and remove them. This step will be finalised once all the PRs linked to [this issue](https://github.com/alphagov/govuk_publishing_components/issues/2065) have been completed.~ **Done**

**Step 2** is removing these files from the components gem altogether, which is what this PR is doing. This step can only be completed once we have completed step 1.


