### PR TITLE
Add option to nest context within the h1 for title component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Convert a tags to buttons on load in header-navigation js ([PR #2235](https://github.com/alphagov/govuk_publishing_components/pull/2235))
 * Allow label sizes for search component label ([PR #2236](https://github.com/alphagov/govuk_publishing_components/pull/2236)) MINOR
 * Update notice component to better match DS notification banner ([PR #2214](https://github.com/alphagov/govuk_publishing_components/pull/2214))
+* Add option to nest context within the h1 for title component ([PR #2226](https://github.com/alphagov/govuk_publishing_components/pull/2226))
 
 ## 25.0.0
 

--- a/app/views/govuk_publishing_components/components/_title.html.erb
+++ b/app/views/govuk_publishing_components/components/_title.html.erb
@@ -3,6 +3,7 @@
 
   context ||= false
   context_locale ||= false
+  context_inside ||= false
 
   inverse ||= false
   local_assigns[:margin_top] ||= 8
@@ -18,13 +19,22 @@
   heading_classes = %w[gem-c-title__text]
   heading_classes << (average_title_length.present? ? 'govuk-heading-l' : 'govuk-heading-xl')
 %>
+
+<% @context_block = capture do %>
+  <span class="govuk-caption-xl gem-c-title__context" <%= "lang=#{context_locale}" if context_locale.present? %>>
+    <%= context %>
+  </span>
+<% end %>
+
 <%= content_tag(:div, class: classes) do %>
-  <% if context %>
-    <span class="govuk-caption-xl gem-c-title__context" <%= "lang=#{context_locale}" if context_locale.present? %>>
-      <%= context %>
-    </span>
+  <% if context && !context_inside %>
+    <%= @context_block %>
   <% end %>
+  
   <h1 class="<%= heading_classes.join(" ") %>">
+    <% if context && context_inside %>
+      <%= @context_block %>
+    <% end %>
     <%= title %>
   </h1>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/title.yml
+++ b/app/views/govuk_publishing_components/components/docs/title.yml
@@ -24,6 +24,13 @@ examples:
     data:
       context: Publication
       title: My page title
+  with_context_inside:
+    description: |
+      If the context should be considered part of the page heading, you can nest the context within the <code><h1></code>.
+    data:
+      context: Publication
+      title: My page title
+      context_inside: true
   with_context_language_labelled:
     description: |
       Sometimes this component appears on a page that has been translated. The title will naturally be supplied in the required language but the context string may fall back to the default. In these instances we need to label the language so the page remains semantic and screenreaders can handle the switch.

--- a/spec/components/title_spec.rb
+++ b/spec/components/title_spec.rb
@@ -18,7 +18,22 @@ describe "Title", type: :view do
 
   it "title context appears" do
     render_component(title: "Hello World", context: "Format")
-    assert_select ".govuk-caption-xl", text: "Format"
+    assert_select ".gem-c-title > .gem-c-title__context", text: "Format"
+  end
+
+  it "renders no title context inside" do
+    render_component(title: "Hello World", context: "Format")
+    assert_select ".gem-c-title__text > .gem-c-title__context", false, text: "Format"
+  end
+
+  it "title context appears inside" do
+    render_component(title: "Hello World", context: "Format", context_inside: true)
+    assert_select ".gem-c-title__text > .gem-c-title__context", text: "Format"
+  end
+
+  it "renders no title context adjacent to title" do
+    render_component(title: "Hello World", context: "Format", context_inside: true)
+    assert_select ".gem-c-title > .gem-c-title__context", false, text: "Format"
   end
 
   it "applies context language if supplied to a context string" do
@@ -27,7 +42,7 @@ describe "Title", type: :view do
   end
 
   it "applies title length if supplied" do
-    render_component(title: "Hello World", context: "format", average_title_length: "long")
+    render_component(title: "Hello World", average_title_length: "long")
     assert_select ".gem-c-title .govuk-heading-l", text: "Hello World"
   end
 


### PR DESCRIPTION
## What
Move the caption inside of the h1.

## Why
Currently, the context is missed when page titles are read by screen readers. This way when users navigate through headings with a screenreader will hear the title with context announced.

No visual changes.

https://trello.com/c/gPFqiwZa/799-update-headings-for-smart-answers-outcome
