### PR TITLE
Fix issue where priority_brexit_taxon is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix issue metatag component error when priority_brexit_taxon isn't available. ([PR #2227](https://github.com/alphagov/govuk_publishing_components/pull/2227))
+
 ## 24.21.0
 
 * Add scroll tracking to travel advice pages ([PR #2217](https://github.com/alphagov/govuk_publishing_components/pull/2217))

--- a/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
+++ b/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_priority.rb
@@ -55,6 +55,8 @@ module GovukPublishingComponents
       end
 
       def brexit_audience(taxon)
+        return nil unless taxon
+
         {
           PRIORITY_TAXONS[:brexit_business] => "Brexitbusiness",
           PRIORITY_TAXONS[:brexit_individuals] => "Brexitcitizen",


### PR DESCRIPTION
This prevents an error from being thrown when `priority_brexit_taxon` is nil because there isn't relevant taxon tagged to the content item