### PR TITLE
Use current Rails version for configuration defaults

### DIFF
--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -24,5 +24,9 @@ module Dummy
     # -- all .rb files in that directory are automatically loaded.
     config.i18n.default_locale = :en
     config.i18n.fallbacks = [I18n.default_locale]
+
+    # Use current Rails version defaults, this isn't a normal app so we don't
+    # need to be delicate about upgrading.
+    config.load_defaults Rails::VERSION::STRING.to_f
   end
 end


### PR DESCRIPTION
This applies whatever the current Rails version config defaults to this
app. This has been done to bring the defaults up to date (6.1) in such
a way that we don't need to maintain this number.

The reason this has been applied is because we are experiencing a bug
with sentry-rails where a file is failing to load (stack trace below). I
discovered this seems to be an issue with the classic Rails autoloader
whilst it seems resolved with Zeitwerk.

Keeping the Rails defaults up-to-date also seems a logical step to
making testing with Rails versions more accurate.

Stack trace:

```
LoadError: No such file to load -- sentry/send_event_job.rb
  /Users/kevindew/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4/lib/active_support/dependencies.rb:332:in `require'
  /Users/kevindew/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4/lib/active_support/dependencies.rb:332:in `block in require'
  /Users/kevindew/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4/lib/active_support/dependencies.rb:299:in `load_dependency'
  /Users/kevindew/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4/lib/active_support/dependencies.rb:332:in `require'
  /Users/kevindew/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4/lib/active_support/dependencies.rb:424:in `block in require_or_load'
  /Users/kevindew/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-6.1.4/lib/active_support/dependencies.rb:39:in `block in load_interlock'
```