### PR TITLE
Version 25.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 25.0.0
 
 * BREAKING: Remove ability to link contextual text on titles ([PR #2192](https://github.com/alphagov/govuk_publishing_components/pull/2192))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (24.21.1)
+    govuk_publishing_components (25.0.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "24.21.1".freeze
+  VERSION = "25.0.0".freeze
 end


### PR DESCRIPTION
## 25.0.0

* **BREAKING:** Remove ability to link contextual text on titles ([PR #2192](https://github.com/alphagov/govuk_publishing_components/pull/2192))
* Delete empty print stylesheets ([PR #2225](https://github.com/alphagov/govuk_publishing_components/pull/2225))
* **BREAKING:** Remove `is_page_heading` parameter from radio component ([PR #2061](https://github.com/alphagov/govuk_publishing_components/pull/2061))
* Intervention: add tracking code and design tweaks ([PR #2224](https://github.com/alphagov/govuk_publishing_components/pull/2224))
* **BREAKING:** Remove deprecated `em()` Sass mixin ([PR #2220](https://github.com/alphagov/govuk_publishing_components/pull/2220))

  You must make the following changes when you migrate to this release:
  - Replace `em()` calls with `govuk-em()`


* **BREAKING:** Group tracking scripts in `govuk_publishing_components/analytics` ([PR #2117](https://github.com/alphagov/govuk_publishing_components/pull/2117))

  You must make the following changes when you migrate to this release:
  - Remove any direct reference to `govuk_publishing_components/lib/track-click` and make sure `govuk_publishing_components/analytics` is imported
