### PR TITLE
Allow label sizes in search component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Convert a tags to buttons on load in header-navigation js ([PR #2235](https://github.com/alphagov/govuk_publishing_components/pull/2235))
+* Allow label sizes for search component label ([PR #2236](https://github.com/alphagov/govuk_publishing_components/pull/2236)) MINOR
 
 ## 25.0.0
 

--- a/app/views/govuk_publishing_components/components/_fieldset.html.erb
+++ b/app/views/govuk_publishing_components/components/_fieldset.html.erb
@@ -5,7 +5,7 @@
   describedby ||= nil
   role ||= nil
   heading_level ||= nil
-  heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
+  heading_size = false unless shared_helper.valid_heading_size?(heading_size)
   error_message ||= nil
   error_id ||= nil
   id ||= nil

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -23,7 +23,7 @@
   hint_id = "hint-#{SecureRandom.hex(4)}"
   error_id = "error-#{SecureRandom.hex(4)}"
   search_icon ||= nil
-  heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
+  heading_size = false unless shared_helper.valid_heading_size?(heading_size)
   heading_level ||= nil
   prefix ||= nil
   suffix ||= nil

--- a/app/views/govuk_publishing_components/components/_label.html.erb
+++ b/app/views/govuk_publishing_components/components/_label.html.erb
@@ -1,16 +1,16 @@
 <%
-  hint_text ||= ''
+  hint_text ||= ""
   is_radio_label ||= false
   bold ||= false
-  heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
+  heading_size = false unless ["s", "m", "l", "xl"].include?(heading_size)
   is_page_heading ||= false
 
-  css_classes = %w( gem-c-label govuk-label )
+  css_classes = %w[gem-c-label govuk-label]
   css_classes << "govuk-label--s" if bold
   css_classes << "govuk-radios__label" if is_radio_label
   css_classes << "govuk-label--#{heading_size}" if heading_size
 
-  hint_text_css_classes = %w( govuk-hint )
+  hint_text_css_classes = %w[govuk-hint]
   hint_text_css_classes << "govuk-radios__hint" if is_radio_label
 %>
 

--- a/app/views/govuk_publishing_components/components/_label.html.erb
+++ b/app/views/govuk_publishing_components/components/_label.html.erb
@@ -1,8 +1,10 @@
 <%
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+
   hint_text ||= ""
   is_radio_label ||= false
   bold ||= false
-  heading_size = false unless ["s", "m", "l", "xl"].include?(heading_size)
+  heading_size = false unless shared_helper.valid_heading_size?(heading_size)
   is_page_heading ||= false
 
   css_classes = %w[gem-c-label govuk-label]

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -15,12 +15,12 @@
   heading_classes = %w(govuk-fieldset__heading)
   heading_classes << "gem-c-radio__heading-text" if heading_level == 'h1'
 
-  if ['s', 'm', 'l', 'xl'].include?(heading_size)
+  if (shared_helper.valid_heading_size?(heading_size))
     size = heading_size
-  elsif heading_level == 'h1'
-    size = 'xl'
+  elsif heading_level == "h1"
+    size = "xl"
   else
-    size = 'm'
+    size = "m"
   end
 
   description ||= nil

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -4,6 +4,7 @@
   aria_controls ||= nil
   button_text ||= t("components.search_box.search_button")
   id ||= "search-main-" + SecureRandom.hex(4)
+  label_size ||= nil
   label_text ||= t("components.search_box.label")
   name ||= "q"
   no_border ||= false
@@ -12,6 +13,13 @@
 
   data_attributes ||= {}
   data_attributes[:module] = 'gem-track-click'
+
+  label_classes = []
+  if (["xl", "l", "m", "s"].include?(label_size))
+    label_classes << "govuk-label govuk-label--#{label_size}"
+  else
+    label_classes << "gem-c-search__label"
+  end
 
   classes = %w[gem-c-search govuk-!-display-none-print]
   classes << (shared_helper.get_margin_top)
@@ -23,13 +31,13 @@
   else
     classes << "gem-c-search--on-white"
   end
-  classes << "gem-c-search--separate-label" if local_assigns.include?(:inline_label)
+  classes << "gem-c-search--separate-label" if local_assigns.include?(:inline_label) or local_assigns.include?(:label_size)
 %>
 
 <div class="<%= classes.join(" ") %>" data-module="gem-toggle-input-class-on-focus">
-  <label for="<%= id %>" class="gem-c-search__label">
+  <%= tag.label({ for: id, class: label_classes }) do %>
     <%= label_text %>
-  </label>
+  <% end %>
   <div class="gem-c-search__item-wrapper">
     <%= tag.input(
       aria: {

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -15,7 +15,7 @@
   data_attributes[:module] = 'gem-track-click'
 
   label_classes = []
-  if (["xl", "l", "m", "s"].include?(label_size))
+  if (shared_helper.valid_heading_size?(label_size))
     label_classes << "govuk-label govuk-label--#{label_size}"
   else
     label_classes << "gem-c-search__label"

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -1,11 +1,13 @@
 <%
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+
   options ||= []
   id ||= false
   label ||= false
   full_width ||= false
   name ||= id
   is_page_heading ||= false
-  heading_size = false unless ['s', 'm', 'l', 'xl'].include?(heading_size)
+  heading_size = false unless shared_helper.valid_heading_size?(heading_size)
   error_message ||= nil
   error_id ||= nil
 

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -1,7 +1,7 @@
 <%
   local_assigns[:heading_level] ||= 3
-  heading_size = 'm' unless ['s', 'm', 'l', 'xl'].include?(heading_size)
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  heading_size = "m" unless shared_helper.valid_heading_size?(heading_size)
 
   id ||= nil
   title ||= nil

--- a/app/views/govuk_publishing_components/components/docs/search.yml
+++ b/app/views/govuk_publishing_components/components/docs/search.yml
@@ -64,3 +64,8 @@ examples:
       This is visually hidden text -- to check for changes use a screen reader or inspect the button element.
     data:
       button_text: "Search absolutely everywhere"
+  with_set_label_size:
+    description: |
+      Allows the label text size to be set to `xl`, `l`, `m`, or `s`. If this is set, then `inline_label` is automatically set to `false`.
+    data:
+      label_size: "xl"

--- a/lib/govuk_publishing_components/presenters/shared_helper.rb
+++ b/lib/govuk_publishing_components/presenters/shared_helper.rb
@@ -31,10 +31,14 @@ module GovukPublishingComponents
         "span"
       end
 
+      def valid_heading_size?(size)
+        %w[xl l m s].include?(size)
+      end
+
       def get_heading_size(option, fallback)
         govuk_class = "govuk-heading-"
 
-        if %w[xl l m s].include? option
+        if valid_heading_size?(option)
           "#{govuk_class}#{option}"
         else
           "#{govuk_class}#{fallback}"

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -100,4 +100,22 @@ describe "Search", type: :view do
     assert_select '.gem-c-search__submit[data-track-action="track-action"]'
     assert_select '.gem-c-search__submit[data-track-label="track-label"]'
   end
+
+  it "renders the correct label size" do
+    render_component(label_size: "xl")
+    assert_select ".govuk-label.govuk-label--xl", text: "Search on GOV.UK"
+    assert_no_selector ".gem-c-search__label"
+  end
+
+  it "renders the default label when given an incorrect t-shirt size" do
+    render_component(label_size: "super-massive-size")
+    assert_no_selector ".govuk-label"
+    assert_select ".gem-c-search__label", text: "Search on GOV.UK"
+  end
+
+  it "renders the default label when given no label size" do
+    render_component({})
+    assert_no_selector ".govuk-label"
+    assert_select ".gem-c-search__label", text: "Search on GOV.UK"
+  end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

The search component doesn't allow for the text size of the label to be adjusted. This allows the `label_size` parameter that will alter the label tet size, as long as it's set to `xl`, `l`, `m`, or `s`.

This doesn't override the current default - if no label size is given, then this
component's label will be the same as before.

Setting `label_size` forces `inline_label` to be `false`.

## Why
<!-- What are the reasons behind this change being made? -->
The explore header needed a differently sized label.

There was a requirement to set the text size of the label - but without overriding the current default.


## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

No changes to existing versions.

`xl` version:
![image](https://user-images.githubusercontent.com/1732331/127358596-b3f92b4d-b078-4853-bd92-f5a0ef06af94.png)

`l` version:
![image](https://user-images.githubusercontent.com/1732331/127358639-95001553-cd83-444e-b894-c070f38cd2de.png)

`m` version:
![image](https://user-images.githubusercontent.com/1732331/127358677-eee39370-4be4-4c03-907a-cf8f7612b469.png)

`s` version:
![image](https://user-images.githubusercontent.com/1732331/127358720-f15fc173-180f-4690-a2ac-000e32304bb5.png)

