### PR TITLE
Add hover style for govspeak mc button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+# Unreleased
+
+* Add hover style for govspeak mc button ([PR #2239](https://github.com/alphagov/govuk_publishing_components/pull/2239))
+
 ## 25.1.0
 
 * Convert a tags to buttons on load in header-navigation js ([PR #2235](https://github.com/alphagov/govuk_publishing_components/pull/2235))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -279,6 +279,11 @@
     padding: govuk-spacing(2);
     background-color: govuk-colour("white");
 
+    &:hover {
+      background-color: govuk-colour("light-grey");
+      color: $govuk-link-hover-colour;
+    }
+
     &:focus {
       @include govuk-focused-text;
       background-color: $govuk-focus-colour;


### PR DESCRIPTION
This fixes issue #2106 which highlights that govspeak charts buttons
(which function as a toggle between chart and table views) are missing a
relevant hover style.

Update the background and text colours on hover to match the hover state
of other similar button styles (for instance, the [print button](https://components.publishing.service.gov.uk/component-guide/print_link)).

## Hover before
https://user-images.githubusercontent.com/7116819/127658882-8017cf71-2a09-4b70-a35c-ab56d82cce4a.mov

## Hover after

https://user-images.githubusercontent.com/7116819/127658875-f1d834ad-4e0a-4c75-a667-47da43dc3bfd.mov


-----



Closes #2106 

-----

**NOTE:** several components contain a similar button style to this one, and they all have separate CSS to achieve more or less the same thing (a white background, grey border button with blue text). I raised an issue to investigate if these minor variations on the same theme can be consolidated #2238 