### PR TITLE
Load Youtube video instantly when cookies are accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 # Unreleased
 
 * Add hover style for govspeak mc button ([PR #2239](https://github.com/alphagov/govuk_publishing_components/pull/2239))
+* Load Youtube video instantly when cookies are accepted ([PR #2241](https://github.com/alphagov/govuk_publishing_components/pull/2241))
 
 ## 25.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/youtube-link-enhancement.js
@@ -9,9 +9,15 @@
 
   YoutubeLinkEnhancement.prototype.init = function () {
     if (!this.campaignCookiesAllowed()) {
+      this.startModule = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.startModule)
       return
     }
+    this.startModule()
+  }
 
+  YoutubeLinkEnhancement.prototype.startModule = function () {
+    window.removeEventListener('cookie-consent', this.startModule)
     var $youtubeLinks = this.$element.querySelectorAll('a[href*="youtube.com"], a[href*="youtu.be"]')
 
     if ($youtubeLinks.length > 0) {


### PR DESCRIPTION
`YoutubeLinkEnhancement` checks if the user has accepted all cookies, and progressively enhances a youtube link into an embedded video if that condition is met.
This check occurs when the module is initialised on page load.

Therefore, if a user who has not yet accepted cookies lands on a page containing a YouTube video, then clicks "Accept cookies" in the cookie banner in order to watch said video, they would have to refresh the page in order for the video to load.
This is not ideal and can lead to confusion or frustration.

This introduces an additional check for the case in which cookies have not been accepted on initialisation, which listens for the `'cookie-consent'` event ([first introduced not too long ago](https://github.com/alphagov/govuk_publishing_components/commit/777a381d2ccb67f0a7e78ebf659be806d8d6442d)) and re-initialises the `YoutubeLinkEnhancement` functionality if the event is detected.
As a result, the video should load as soon as the user has accepted cookies, and not on the next page load.

