### PR TITLE
Version 25.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 25.1.0
 
 * Convert a tags to buttons on load in header-navigation js ([PR #2235](https://github.com/alphagov/govuk_publishing_components/pull/2235))
 * Allow label sizes for search component label ([PR #2236](https://github.com/alphagov/govuk_publishing_components/pull/2236)) MINOR

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (25.0.0)
+    govuk_publishing_components (25.1.0)
       govuk_app_config
       kramdown
       plek
@@ -98,7 +98,7 @@ GEM
     execjs (2.7.0)
     faker (2.17.0)
       i18n (>= 1.6, < 2)
-    faraday (1.5.1)
+    faraday (1.6.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -106,6 +106,7 @@ GEM
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
       faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
@@ -115,6 +116,7 @@ GEM
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
     ffi (1.15.0)
     gds-api-adapters (72.0.0)
       addressable
@@ -122,8 +124,8 @@ GEM
       null_logger
       plek (>= 1.9.0)
       rest-client (~> 2.0)
-    globalid (0.4.2)
-      activesupport (>= 4.2.0)
+    globalid (0.5.2)
+      activesupport (>= 5.0)
     govuk_app_config (4.0.0)
       logstasher (>= 1.2.2, < 2.2.0)
       sentry-rails (~> 4.5.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "25.0.0".freeze
+  VERSION = "25.1.0".freeze
 end


### PR DESCRIPTION
* Convert a tags to buttons on load in header-navigation js ([PR #2235](https://github.com/alphagov/govuk_publishing_components/pull/2235))
* Allow label sizes for search component label ([PR #2236](https://github.com/alphagov/govuk_publishing_components/pull/2236)) MINOR
* Update notice component to better match DS notification banner ([PR #2214](https://github.com/alphagov/govuk_publishing_components/pull/2214))
* Add option to nest context within the h1 for title component ([PR #2226](https://github.com/alphagov/govuk_publishing_components/pull/2226))