### PR TITLE
Add new analytics tags for the super navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+* Add new analytics tags for the super navigation header ([PR #2243](https://github.com/alphagov/govuk_publishing_components/pull/2243))
+
 ## 25.1.0
 
 * Convert a tags to buttons on load in header-navigation js ([PR #2235](https://github.com/alphagov/govuk_publishing_components/pull/2235))

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -13,8 +13,11 @@ search_text= t("components.layout_super_navigation_header.search_text")
     <div class="gem-c-layout-super-navigation-header__header-logo">
       <a class="govuk-header__link govuk-header__link--homepage"
         data-module="gem-track-click"
-        data-track-action="homeHeader"
-        data-track-category="homeLinkClicked"
+        data-track-action="logoLink"
+        data-track-category="headerClicked"
+        data-track-category="<%= logo_link %>"
+        data-track-dimension="<%= logo_text %>"
+        data-track-dimension-index="29"
         href="<%= logo_link %>"
         id="logo"
         title="<%= logo_link_title %>">
@@ -64,7 +67,14 @@ search_text= t("components.layout_super_navigation_header.search_text")
                   <ul class="govuk-list">
                     <% link[:menu_contents].each do | item | %>
                       <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
-                        <a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="<%= item[:href] %>">
+                        <a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link"
+                          href="<%= item[:href] %>"
+                          data-module="gem-track-click"
+                          data-track-action="<%= link[:label].downcase.gsub(/\s+/, "") %>Link"
+                          data-track-category="headerClicked"
+                          data-track-label="<%= item[:href] %>"
+                          data-track-dimension="<%= item[:label] %>"
+                          data-track-dimension-index="29">
                           <%= item[:label] %>
                         </a>
                         <%= tag.p item[:description], class: "govuk-body-s gem-c-layout-super-navigation-header__dropdown-list-item-description" if item[:description].present? %>
@@ -101,13 +111,27 @@ search_text= t("components.layout_super_navigation_header.search_text")
                 inline_label: false,
                 label_text: raw("<h2 class=\"govuk-heading-m\">#{search_text}</h2>"),
                 size: "large",
+                data_attributes: {
+                  track_category: "headerClicked",
+                  track_action: "searchSubmitted",
+                  track_label: "/search/all",
+                  track_dimension: t("components.search_box.label"),
+                  track_dimension_index: 29,
+                }
               } %>
             </form>
             <h2 class="govuk-heading-m"><%= popular_links_heading %></h2>
             <ul class="govuk-list">
               <% popular_links.each do | popular_link | %>
                 <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
-                  <a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link" href="<%= popular_link[:href] %>">
+                  <a class="govuk-link gem-c-layout-super-navigation-header__dropdown-list-item-link"
+                    href="<%= popular_link[:href] %>"
+                    data-module="gem-track-click"
+                    data-track-action="popularLink"
+                    data-track-category="headerClicked"
+                    data-track-label="<%= popular_link[:href] %>"
+                    data-track-dimension="<%= popular_link[:label] %>"
+                    data-track-dimension-index="29">
                     <%= popular_link[:label] %>
                   </a>
                 </li>


### PR DESCRIPTION
## What
Add new analytics tags for the super navigation header.

## Why
So that we can track user engagement with the new navigation header during the upcoming A/B test.

Note that the following tags have yet to be added as they are waiting on https://github.com/alphagov/govuk_publishing_components/pull/2223 to be finished so that they can be added into the js:

- `menuClosed`
- `menuOpened`
- `topicsClosed`
- `topicsOpened`
- `governmentactivityClosed`
- `governmentactivityOpened`
- `searchClosed`
- `searchOpened`

No visual changes.

[Card](https://trello.com/c/tzaEtEhO/320-implement-analytics-tracking-on-the-new-menu-bar-header)
