### PR TITLE
🚧  [DO NOT MERGE] Add account layout wrapper component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add account layout wrapper component ([PR #2245](https://github.com/alphagov/govuk_publishing_components/pull/2245))
+
 ## 25.1.0
 
 * Convert a tags to buttons on load in header-navigation js ([PR #2235](https://github.com/alphagov/govuk_publishing_components/pull/2235))

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -12,6 +12,7 @@ $govuk-new-link-styles: true;
 
 // components
 @import "components/accordion";
+@import "components/account-layout";
 @import "components/action-link";
 @import "components/attachment";
 @import "components/attachment-link";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_account-layout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_account-layout.scss
@@ -1,0 +1,57 @@
+.account .gem-c-layout-for-public__global-banner-wrapper {
+  // TODO: this is a localised fix for the issue described here https://github.com/alphagov/govuk_publishing_components/issues/2159
+  // this rule should be removed if/when the bug is fixed
+  margin-top: 0;
+}
+
+.gem-c-account-layout-menu {
+  margin: 0 0 govuk-spacing(6) 0;
+  padding: 0;
+
+  @include govuk-media-query($from: desktop) {
+    margin-right: govuk-spacing(4);
+  }
+}
+
+// Used to determine width of blue location indicator in navigation mention
+$_current-indicator-width: 4px;
+
+.gem-c-account-layout-menu__item {
+  list-style-type: none;
+  padding: 12px 0;
+
+  @include govuk-media-query($from: tablet) {
+    margin: 0 0 govuk-spacing(4);
+    padding: govuk-spacing(1) 0;
+  }
+}
+
+.gem-c-account-layout-menu__item--current {
+  margin-left: -(govuk-spacing(2) + $_current-indicator-width);
+  padding-left: govuk-spacing(2);
+  border-left: $_current-indicator-width solid govuk-colour("blue");
+
+  .gem-c-account-layout-menu__link {
+    text-decoration: none;
+  }
+}
+
+.gem-c-account-layout-menu__link {
+  @include govuk-font(19, $weight: "bold");
+
+  &:not(:focus):hover {
+    color: $govuk-link-colour;
+  }
+}
+
+.gem-c-account-layout-feedback-footer {
+  margin-bottom: govuk-spacing(4);
+  padding: govuk-spacing(3);
+  background: govuk-colour("light-grey");
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(6);
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(8);
+  }
+}

--- a/app/views/govuk_publishing_components/components/_account_layout.html.erb
+++ b/app/views/govuk_publishing_components/components/_account_layout.html.erb
@@ -1,0 +1,45 @@
+<%
+  location ||= nil
+  hide_feedback_footer ||= false
+  hide_account_navigation ||= false
+  hide_phase_banner ||= false
+%>
+<% message = capture do %>
+  <%= t("components.account_layout.feedback.banners.phase_intro") %>
+  <a class="govuk-link" href=<%= "#{Plek.find('account-manager')}/feedback" %>><%= t("components.account_layout.feedback.banners.phase_link") %></a>
+  <%= t("components.account_layout.feedback.banners.phase_outro") %>
+<% end %>
+
+<div class="gem-c-account-layout">
+  <%= render "govuk_publishing_components/components/phase_banner", {
+    phase: "alpha",
+    message: message
+  } unless hide_phase_banner %>
+
+  <div class="govuk-grid-row govuk-main-wrapper">
+    <%= tag.div(class: 'govuk-grid-column-one-third') do %>
+      <%= render "govuk_publishing_components/components/account_layout/account-navigation", { page_is: location } %>
+    <% end unless hide_account_navigation %>
+
+    <div class="govuk-grid-column-two-thirds">
+      <%= before_main if local_assigns.include?(:before_main) %>
+      <main role="main" id="content">
+        <%= yield %>
+      </main>
+    </div>
+  </div>
+  <%= tag.div(class: "gem-c-account-layout-feedback-footer") do %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("components.account_layout.feedback.banners.title"),
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+
+    <p class="govuk-body govuk-!-margin-bottom-0">
+      <%= t("components.account_layout.feedback.banners.footer_intro") %>
+      <a href="<%= "#{Plek.find('account-manager')}/feedback" %>" class="govuk-link"><%= t("components.account_layout.feedback.banners.footer_link") %></a>
+      <%= t("components.account_layout.feedback.banners.footer_outro") %>
+    </p>
+  <% end unless hide_feedback_footer %>
+</div>

--- a/app/views/govuk_publishing_components/components/account_layout/_account-navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/account_layout/_account-navigation.html.erb
@@ -1,0 +1,30 @@
+<% page_is ||= nil %>
+
+<nav aria-label="Account management" class="gem-c-account-layout-nav">
+  <ul class="gem-c-account-layout-menu">
+    <li class="gem-c-account-layout-menu__item <%= "gem-c-account-layout-menu__item--current" if page_is == "your-account" %>">
+      <%= link_to(
+        t("components.account_layout.navigation.menu_bar.account.link_text"),
+        "#{Plek.find('account-manager')}",
+        class: 'gem-c-account-layout-menu__link govuk-link govuk-link--no-visited-state',
+        'aria-current': page_is == "your-account" ? "page" : nil,
+      ) %>
+    </li>
+    <li class="gem-c-account-layout-menu__item <%= "gem-c-account-layout-menu__item--current" if page_is == "manage" %>">
+      <%= link_to(
+        t("components.account_layout.navigation.menu_bar.manage.link_text"),
+        "#{Plek.find('account-manager')}/account/manage",
+        class: 'gem-c-account-layout-menu__link govuk-link govuk-link--no-visited-state',
+        'aria-current': page_is == "manage" ? "page" : nil,
+      ) %>
+    </li>
+    <li class="gem-c-account-layout-menu__item <%= "gem-c-account-layout-menu__item--current" if page_is == "security" %>">
+      <%= link_to(
+        t("components.account_layout.navigation.menu_bar.security.link_text"),
+        "#{Plek.find('account-manager')}/account/security",
+        class: 'gem-c-account-layout-menu__link govuk-link govuk-link--no-visited-state',
+        'aria-current': page_is == "security" ? "page" : nil,
+      ) %>
+    </li>
+  </ul>
+</nav>

--- a/app/views/govuk_publishing_components/components/docs/account_layout.yml
+++ b/app/views/govuk_publishing_components/components/docs/account_layout.yml
@@ -1,0 +1,50 @@
+name: Account layout
+description: |
+  A content wrapper for GOVUK Account pages.
+
+  This wrapper has no control over markup, which is passed in to the component pre-generated.
+  The component adds page furniture (e.g. a phase banner, account navigation, feedback prompt) before and after the content that is passed into the component.
+accessibility_criteria: |
+  - Headings must be part of a correct heading structure for the page
+  - If a page includes more than one navigation landmark, each should have a unique label
+  - The current item in the navigation landmark must be correctly indicated with the `aria-current` attribute
+shared_accessibility_criteria:
+  - link
+accessibility_excluded_rules:
+  - duplicate-id # IDs will be duplicated in component examples list
+  - landmark-main-is-top-level # The main element can not be top level in the examples
+  - landmark-no-duplicate-main # The main element has to be duplicated in the examples
+  - landmark-unique # aria-label attributes will be duplicated in component examples list
+display_html: true
+examples:
+  default:
+    data:
+      block: |
+        <h2 class="govuk-heading-l">This is a title</h2>
+        <p class="govuk-body">This is some body text with <a href="https://example.com">a link</a>.</p>
+  without_feedback_footer:
+    data:
+      hide_feedback_footer: true
+      block: |
+        <h2 class="govuk-heading-l">This is a title</h2>
+        <p class="govuk-body">This is some body text with <a href="https://example.com">a link</a>.</p>
+  with_current_account_navigation:
+    description: "Valid options are currently `your-account`, `manage`, and `security`"
+    data:
+      location: "manage"
+      block: |
+        <h2 class="govuk-heading-l">This is a title</h2>
+        <p class="govuk-body">This is some body text with <a href="https://example.com">a link</a>.</p>
+  without_account_navigation:
+    data:
+      hide_account_navigation: true
+      block: |
+        <h2 class="govuk-heading-l">This is a title</h2>
+        <p class="govuk-body">This is some body text with <a href="https://example.com">a link</a>.</p>
+  with_content_before_main:
+    data:
+      before_main: |
+        <a href="#" class="govuk-link govuk-body">I am a navigational element that should not be part of `main`</a>
+      block: |
+        <h1 class="govuk-heading-l">This is a title</h1>
+        <p class="govuk-body">This is some content inside main with <a href="https://example.com">a link</a>.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,26 @@ en:
       show: Show
       show_all: Show all sections
       this_section_visually_hidden: " this section"
+    account_layout:
+      feedback:
+        banners:
+          footer_intro: We’re trialling GOV.UK accounts.
+          footer_link: Give feedback
+          footer_outro: on your experience so we can make them better.
+          phase_intro: We’re trialling GOV.UK accounts - your
+          phase_link: feedback
+          phase_outro: will help us improve them.
+          title: Help improve GOV.UK accounts
+      navigation:
+        destroy_user_session: Sign out
+        menu_bar:
+          account:
+            link_text: Your account
+          manage:
+            link_text: Manage your account
+          security:
+            link_text: Security and privacy
+        user_root_path: Account
     article_schema:
       scoped_search_description: Search within %{title}
     attachment:

--- a/spec/components/account_layout_spec.rb
+++ b/spec/components/account_layout_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+describe "Account layout", type: :view do
+  def component_name
+    "account_layout"
+  end
+
+  it "accepts a block" do
+    render "govuk_publishing_components/components/#{component_name}" do
+      "content-via-block"
+    end
+    expect(rendered).to include("content-via-block")
+  end
+
+  it "renders content in an account layout wrapper" do
+    render "govuk_publishing_components/components/#{component_name}" do
+      "<h1>content</h1>".html_safe
+    end
+
+    assert_select ".gem-c-account-layout h1", text: "content"
+  end
+
+  it "renders with a phase banner by default" do
+    render_component({})
+
+    assert_select ".gem-c-account-layout .gem-c-phase-banner"
+  end
+
+  it "renders with an account nav by default" do
+    render_component({})
+
+    assert_select ".gem-c-account-layout .gem-c-account-layout-nav"
+  end
+
+  it "renders with a feedback prompt by default" do
+    render_component({})
+
+    assert_select ".gem-c-account-layout .gem-c-account-layout-feedback-footer h2", text: "Help improve GOV.UK accounts"
+  end
+
+  it "can render without an account nav" do
+    render_component(hide_account_navigation: true)
+
+    # both the nav and its .govuk-grid-column-one-third container should not be present
+    assert_select ".gem-c-account-layout .govuk-main-wrapper > .govuk-grid-column-one-third", false
+    assert_select ".gem-c-account-layout .gem-c-account-layout-nav", false
+  end
+
+  it "can render without a phase banner" do
+    render_component(hide_phase_banner: true)
+
+    assert_select ".gem-c-account-layout .gem-c-phase-banner", false
+  end
+
+  it "can render without a feedback prompt" do
+    render_component(hide_feedback_footer: true)
+
+    assert_select ".gem-c-account-layout .gem-c-account-layout-feedback-footer", false
+  end
+
+  it "does not indicate an active navigation item by default" do
+    render_component({})
+
+    assert_select ".gem-c-account-layout-nav li.gem-c-account-layout-menu__item.gem-c-account-layout-menu__item--current a[aria-current=page]", false
+  end
+
+  it "indicates the active navigation item if the location parameter is passed" do
+    render_component(location: "manage")
+
+    assert_select ".gem-c-account-layout-nav li.gem-c-account-layout-menu__item.gem-c-account-layout-menu__item--current a[aria-current=page]", text: "Manage your account"
+  end
+
+  it "can render with additional navigational content before the <main> landmark" do
+    render "govuk_publishing_components/components/#{component_name}", before_main: "<a id='testing' href>before</a>".html_safe do
+      "<h1>content</h1>".html_safe
+    end
+
+    assert_select "a#testing + main"
+    assert_select "a#testing", text: "before"
+  end
+end


### PR DESCRIPTION
**Please ignore this PR for now** – exploring `layout_for_public` based alternative as suggested by @alex-ju 

-----

Some account-related components, contents, and CSS are repeated across different apps on GOVUK.

The first instance of this was when we [relocated the account homepage from the govuk-account-manager-app to the frontend app](https://github.com/alphagov/frontend/pull/2841), which meant that some of the page furniture and content was duplicated between those apps.

More recently, the accounts team are working towards the goal of single page notifications which will enable users who have linked their email notifications address and their GOVUK account email address to manage their email subscriptions through their account. 

Part of this work is making the email management pages (rendered by `email-alert-frontend`) look the same as the account manager when the user is authenticated with a linked account. Preview:

<img width="1337" alt="Screenshot 2021-08-05 at 18 02 13" src="https://user-images.githubusercontent.com/7116819/128391228-45a523fb-343b-4eeb-898d-8ce78f508dc0.png">

That would make it three separate apps where page furniture and content are repeated to achieve the same layout.

The purpose of this PR is to nip this issue in the bud by creating an account layout/wrapper component which can be shared between different apps. 
This will mean that the content, the CSS, the markup for all the different building blocks that make up the account layout will live in the gem which should help us prevent inconsistencies between different applications using this layout.

Example of usage: https://github.com/alphagov/email-alert-frontend/pull/1106/files?diff=split&w=1#diff-f43fe075643e681b2c01c2f853bb0c4299d135b47fcbd4da96890d521c49e3eb

https://trello.com/c/F0ZDY0RC

