### PR TITLE
Add analytics tags to super navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 # Unreleased
 
+* Add analytics tags to super navigation header ([PR # 2244](https://github.com/alphagov/govuk_publishing_components/pull/2244))
 * Update copy for Explore Super Menu Header ([PR #2247](https://github.com/alphagov/govuk_publishing_components/pull/2247))
 * Add hover style for govspeak mc button ([PR #2239](https://github.com/alphagov/govuk_publishing_components/pull/2239))
 * Load Youtube video instantly when cookies are accepted ([PR #2241](https://github.com/alphagov/govuk_publishing_components/pull/2241))

--- a/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
@@ -41,10 +41,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   var toggle = function ($button, $menu) {
     var isOpen = $button.getAttribute('aria-expanded') === 'true'
+    var trackingLabel = $button.getAttribute('data-tracking-key')
     if (isOpen) {
       hide($button, $menu)
     } else {
       show($button, $menu)
+    }
+
+    // Fire analytics if analytics are available
+    if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent && trackingLabel) {
+      window.GOVUK.analytics.trackEvent('headerClicked', trackingLabel + (isOpen ? 'Closed' : 'Opened'), { label: 'none' })
     }
   }
 

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -21,8 +21,11 @@ show_navigation_menu_text = t("components.layout_super_navigation_header.menu_to
     <div class="gem-c-layout-super-navigation-header__header-logo">
       <a class="govuk-header__link govuk-header__link--homepage"
         data-module="gem-track-click"
-        data-track-action="homeHeader"
-        data-track-category="homeLinkClicked"
+        data-track-action="logoLink"
+        data-track-category="headerClicked"
+        data-track-label="<%= logo_link %>"
+        data-track-dimension="<%= logo_text %>"
+        data-track-dimension-index="29"
         href="<%= logo_link %>"
         id="logo"
         title="<%= logo_link_title %>">
@@ -68,6 +71,7 @@ show_navigation_menu_text = t("components.layout_super_navigation_header.menu_to
         data-text-for-show="<%= show_navigation_menu_text %>"
         data-toggle-desktop-group="hidden"
         data-toggle-mobile-group="top"
+        data-tracking-key="menu"
         hidden
         id="super-navigation-menu-toggle"
         type="button"
@@ -81,9 +85,9 @@ show_navigation_menu_text = t("components.layout_super_navigation_header.menu_to
             li_classes = %w[gem-c-layout-super-navigation-header__navigation-item]
             li_classes << "gem-c-layout-super-navigation-header__navigation-item--with-children" if has_children
             unique_id = SecureRandom.hex(4)
-
             show_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.show", :label => link[:label])
             hide_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.hide", :label => link[:label])
+            tracking_label = link[:label].downcase.gsub(/\s+/, "")
           %>
           <%= tag.li class: li_classes do %>
             <a class="gem-c-layout-super-navigation-header__navigation-item-link" href="<%= link[:href] %>">
@@ -99,6 +103,7 @@ show_navigation_menu_text = t("components.layout_super_navigation_header.menu_to
                 data-text-for-show="<%= show_menu_text %>"
                 data-toggle-desktop-group="top"
                 data-toggle-mobile-group="second"
+                data-tracking-key="<%= tracking_label %>"
                 hidden
                 id="super-navigation-menu__section-<%= unique_id %>-toggle"
                 type="button"
@@ -172,6 +177,7 @@ show_navigation_menu_text = t("components.layout_super_navigation_header.menu_to
         data-text-for-show="<%= show_search_menu_text %>"
         data-toggle-mobile-group="top"
         data-toggle-desktop-group="top"
+        data-tracking-key="search"
         hidden
         id="super-search-menu-toggle"
         type="button"
@@ -257,6 +263,13 @@ show_navigation_menu_text = t("components.layout_super_navigation_header.menu_to
                   label_size: "m",
                   label_text: search_text,
                   size: "large",
+                  data_attributes: {
+                    track_category: "headerClicked",
+                    track_action: "searchSubmitted",
+                    track_label: "/search/all",
+                    track_dimension: t("components.search_box.label"),
+                    track_dimension_index: 29,
+                  },
                 } %>
               </form>
             </div>
@@ -267,7 +280,14 @@ show_navigation_menu_text = t("components.layout_super_navigation_header.menu_to
               <ul class="govuk-list">
                 <% popular_links.each do | popular_link | %>
                   <li class="gem-c-layout-super-navigation-header__popular-item">
-                    <a class="govuk-link gem-c-layout-super-navigation-header__popular-link" href="<%= popular_link[:href] %>">
+                    <a class="govuk-link gem-c-layout-super-navigation-header__popular-link"
+                      href="<%= popular_link[:href] %>"
+                      data-module="gem-track-click"
+                      data-track-action="popularLink"
+                      data-track-category="headerClicked"
+                      data-track-label="<%= popular_link[:href] %>"
+                      data-track-dimension="<%= popular_link[:label] %>"
+                      data-track-dimension-index="29">
                       <%= popular_link[:label] %>
                     </a>
                   </li>

--- a/spec/javascripts/components/layout-super-navigation-header-spec.js
+++ b/spec/javascripts/components/layout-super-navigation-header-spec.js
@@ -31,6 +31,7 @@ describe('The super header navigation', function () {
           'data-text-for-show="Show navigation menu" ' +
           'data-toggle-desktop-group="hidden" ' +
           'data-toggle-mobile-group="top" ' +
+          'data-tracking-key="testing" ' +
           'hidden ' +
           'id="super-navigation-menu-toggle" ' +
           'type="button" ' +
@@ -663,6 +664,8 @@ describe('The super header navigation', function () {
 
     var $element = document.querySelector('[data-module="super-navigation-mega-menu"]')
     thisModule = new GOVUK.Modules.SuperNavigationMegaMenu($element)
+
+    spyOn(GOVUK.analytics, 'trackEvent')
   })
 
   afterEach(function () {
@@ -735,8 +738,14 @@ describe('The super header navigation', function () {
           expect($button).toHaveAttr('aria-label', hideLabel)
         })
 
-        it('updates the button’s visual state', function () {
-          expect($button).toHaveClass('gem-c-layout-super-navigation-header__open-button')
+        it('triggers the correct google analytics custom event', function () {
+          expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('headerClicked', 'testingOpened', {
+            label: 'none'
+          })
+        })
+
+        xit('updates the button’s state', function () {
+          expect($button).toHaveClass('govuk-header__menu-button--open')
         })
       })
 
@@ -769,12 +778,11 @@ describe('The super header navigation', function () {
           expect($button).toHaveAttr('aria-label', 'Show navigation menu')
         })
 
-        it('updates the button’s visual state', function () {
-          expect($button).toHaveClass('gem-c-layout-super-navigation-header__open-button')
-
+        it('triggers the correct google analytics custom event', function () {
           $button.click()
-
-          expect($button).not.toHaveClass('gem-c-layout-super-navigation-header__open-button')
+          expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('headerClicked', 'testingClosed', {
+            label: 'none'
+          })
         })
       })
 

--- a/spec/javascripts/components/layout-super-navigation-header-spec.js
+++ b/spec/javascripts/components/layout-super-navigation-header-spec.js
@@ -743,10 +743,6 @@ describe('The super header navigation', function () {
             label: 'none'
           })
         })
-
-        xit('updates the button’s state', function () {
-          expect($button).toHaveClass('govuk-header__menu-button--open')
-        })
       })
 
       describe('updates correctly when clicked twice', function () {


### PR DESCRIPTION
## What
Add new analytics tags for the super navigation header.

## Why
So that we can track user engagement with the new navigation header during the upcoming A/B test.

No visual changes.

[Card](https://trello.com/c/tzaEtEhO/320-implement-analytics-tracking-on-the-new-menu-bar-header)
