### PR TITLE
Add link tracking to super navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+# Unreleased
+
+* Add link tracking to super navigation header ([PR #2249](https://github.com/alphagov/govuk_publishing_components/pull/2249))
+
 # 25.2.0
 
 * Add analytics tags to super navigation header ([PR # 2244](https://github.com/alphagov/govuk_publishing_components/pull/2244))

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -134,7 +134,17 @@ show_navigation_menu_text = t("components.layout_super_navigation_header.menu_to
                                 link_classes << "gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" if has_description
                               %>
                               <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
-                                <%= link_to item[:label], item[:href], { class: link_classes } %>
+                                <%= link_to item[:label], item[:href], {
+                                  class: link_classes,
+                                  data: {
+                                    module: "gem-track-lick",
+                                    track_action: "#{tracking_label}Link",
+                                    track_cateogry: "headerClicked",
+                                    track_label: item[:href],
+                                    track_dimension: item[:label],
+                                    track_dimension_index: "29",
+                                  }
+                                } %>
                                 <%= tag.p item[:description], class: "govuk-body govuk-!-margin-0" if has_description %>
                               </li>
                             <% end %>
@@ -150,9 +160,20 @@ show_navigation_menu_text = t("components.layout_super_navigation_header.menu_to
                             <ul class="gem-c-layout-super-navigation-header__navigation-second-footer-list">
                               <% link[:footer_links].each do | item | %>
                                 <li class="gem-c-layout-super-navigation-header__navigation-second-footer-item">
-                                  <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-footer-link" href="<%= item[:href] %>">
-                                    <%= item[:label] %>
-                                  </a>
+                                  <%= link_to item[:label], item[:href], {
+                                    class: [
+                                      "govuk-link",
+                                      "gem-c-layout-super-navigation-header__navigation-second-footer-link",
+                                    ],
+                                    data: {
+                                      module: "gem-track-lick",
+                                      track_action: "#{tracking_label}Link",
+                                      track_cateogry: "footerClicked",
+                                      track_label: item[:href],
+                                      track_dimension: item[:label],
+                                      track_dimension_index: "29",
+                                    }
+                                  } %>
                                 </li>
                               <% end %>
                             </ul>


### PR DESCRIPTION
## What
Add tracking to links within sections on the super navigation header

## Why
To track user interaction for an upcoming A/B test by the govuk explore team.

No visual changes.

[Card](https://trello.com/c/tzaEtEhO/320-implement-analytics-tracking-on-the-new-menu-bar-header)
