### PR TITLE
Fix typos in super navigation link tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 # Unreleased
 
 * Add link tracking to super navigation header ([PR #2249](https://github.com/alphagov/govuk_publishing_components/pull/2249))
+* Fix typos in super navigation link tracking ([PR #2251](https://github.com/alphagov/govuk_publishing_components/pull/2251))
 
 # 25.2.0
 

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -137,9 +137,9 @@ show_navigation_menu_text = t("components.layout_super_navigation_header.menu_to
                                 <%= link_to item[:label], item[:href], {
                                   class: link_classes,
                                   data: {
-                                    module: "gem-track-lick",
+                                    module: "gem-track-click",
                                     track_action: "#{tracking_label}Link",
-                                    track_cateogry: "headerClicked",
+                                    track_category: "headerClicked",
                                     track_label: item[:href],
                                     track_dimension: item[:label],
                                     track_dimension_index: "29",
@@ -168,7 +168,7 @@ show_navigation_menu_text = t("components.layout_super_navigation_header.menu_to
                                     data: {
                                       module: "gem-track-lick",
                                       track_action: "#{tracking_label}Link",
-                                      track_cateogry: "footerClicked",
+                                      track_cateogry: "headerClicked",
                                       track_label: item[:href],
                                       track_dimension: item[:label],
                                       track_dimension_index: "29",


### PR DESCRIPTION
## What
Fix a couple of typos and incorrect tracking attributes in the super navigation tracking.

## Why
Missed during prior review.

No visual changes.
