### PR TITLE
Fix final issues with tracking on super nav header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+# Unreleased
+
+* Fix final issues with tracking on super nav header ([PR #2256](https://github.com/alphagov/govuk_publishing_components/pull/2256))
+
 # 25.2.2
 
 * Fix typo in tracking module on super navigation header ([PR #2253](https://github.com/alphagov/govuk_publishing_components/pull/2253))

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -90,9 +90,17 @@ show_navigation_menu_text = t("components.layout_super_navigation_header.menu_to
             tracking_label = link[:label].downcase.gsub(/\s+/, "")
           %>
           <%= tag.li class: li_classes do %>
-            <a class="gem-c-layout-super-navigation-header__navigation-item-link" href="<%= link[:href] %>">
-              <%= link[:label] %>
-            </a>
+            <%= link_to link[:label], link[:href], {
+              class: "gem-c-layout-super-navigation-header__navigation-item-link",
+              data: {
+                module: "gem-track-click",
+                track_action: "#{tracking_label}Link",
+                track_category: "headerClicked",
+                track_label: link[:href],
+                track_dimension: link[:label],
+                track_dimension_index: "29",
+              }
+            } %>
             <% if has_children %>
               <button
                 aria-controls="super-navigation-menu__section-<%= unique_id %>"

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -168,7 +168,7 @@ show_navigation_menu_text = t("components.layout_super_navigation_header.menu_to
                                     data: {
                                       module: "gem-track-click",
                                       track_action: "#{tracking_label}Link",
-                                      track_cateogry: "headerClicked",
+                                      track_category: "headerClicked",
                                       track_label: item[:href],
                                       track_dimension: item[:label],
                                       track_dimension_index: "29",


### PR DESCRIPTION
## What
Add tracking to section heading links when there aren't any section children, thus the link is displayed by default, and fix a typo.

## Why
To make tracking work for govuk explore.

No visual changes.
