### PR TITLE
Add language tag for Welsh link in public layout template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 # Unreleased
 
 * Fix track click link tracking ([PR #2265](https://github.com/alphagov/govuk_publishing_components/pull/2265))
+* Add language tag for Welsh link in public layout template ([PR #2258](https://github.com/alphagov/govuk_publishing_components/pull/2258))
 
 # 25.3.0
 

--- a/lib/govuk_publishing_components/presenters/public_layout_helper.rb
+++ b/lib/govuk_publishing_components/presenters/public_layout_helper.rb
@@ -353,6 +353,9 @@ module GovukPublishingComponents
           {
             href: "/cymraeg",
             text: "Rhestr o Wasanaethau Cymraeg",
+            attributes: {
+              lang: "cy",
+            },
           },
           {
             href: "/government/organisations/government-digital-service",


### PR DESCRIPTION
## What
Add language tag for Welsh link in public layout template -

```
<li class="govuk-footer__inline-list-item">
  <a class="govuk-footer__link" lang="cy" href="/cymraeg">Rhestr o Wasanaethau Cymraeg</a>
</li>
```
## Why
Fail of WCAG SC 3.1.2