### PR TITLE
Fix search button on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+# Unreleased
+
+* Fix search button on mobile ([PR #2259](https://github.com/alphagov/govuk_publishing_components/pull/2259))
+
+
 # 25.2.3
 
 * Fix final issues with tracking on super nav header ([PR #2256](https://github.com/alphagov/govuk_publishing_components/pull/2256))

--- a/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
@@ -1,11 +1,13 @@
-<button
+<a
   class="search-toggle js-header-toggle"
   data-search-toggle-for="search"
+  data-button-text="<%= t("components.layout_header.show_hide_button") %>"
   data-show-text="<%= t("components.layout_header.show_button") %>"
   data-hide-text="<%= t("components.layout_header.hide_button") %>"
+  href="/search"
 >
-  <%= t("components.layout_header.show_button") %>
-</button>
+  <%= t("components.layout_header.search_button") %>
+</a>
 <form
   action="/search"
   class="gem-c-layout-header__search-form govuk-clearfix"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,7 @@ en:
       search_button: Search GOV.UK
       show_button: Show search
       top_level: Top level
+      show_hide_button: Show or hide search
     layout_super_navigation_header:
       logo_link_title: Go to the GOV.UK homepage
       logo_text: GOV.UK

--- a/spec/dummy/app/views/layouts/dummy_public_layout_explore_header.html.erb
+++ b/spec/dummy/app/views/layouts/dummy_public_layout_explore_header.html.erb
@@ -2,7 +2,7 @@
     emergency_banner: '<div class="govuk-width-container"><p class="govuk-body">This is the emergency banner slot.</p></div>',
     global_bar: '<div class="govuk-width-container govuk-!-margin-top-2"><p class="govuk-body">This is the global bar slot.</p></div>',
     title: "Example public page",
-    show_explore_header: false,
+    show_explore_header: true,
 } do %>
   <%= yield %>
 <% end %>


### PR DESCRIPTION
## What
The markup for this button was updated in static [1] and in this repo's mockup markup [2][3], but not in the template itself.

[1] https://github.com/alphagov/static/blob/main/app/views/root/_base.html.erb#L18

[2] https://github.com/alphagov/govuk_publishing_components/blob/master/spec/javascripts/components/header-navigation-spec.js#L24-L26
[3] #2235

## Why
To fix an issue where, on mobile, the search input is not shown when clicking the magnifying glass icon.

## Visual Changes
No visual changes.

Preview the [public_layout component in isolation](https://govuk-publis-fix-search-nh7jfb.herokuapp.com/public) for manual testing.