### PR TITLE
Update search toggle tracking

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/header-navigation.js
@@ -47,16 +47,17 @@
         var isSearchToggle = sourceClass.match('search-toggle')
         var showText = this.getAttribute('data-show-text') || 'Show search'
         var hideText = this.getAttribute('data-hide-text') || 'Hide search'
+        var buttonName = this.getAttribute('data-button-name') || 'menu'
 
         if (targetClass.indexOf('js-visible') !== -1) {
           target.setAttribute('class', targetClass.replace(/(^|\s)js-visible(\s|$)/, ''))
           if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
-            window.GOVUK.analytics.trackEvent('headerClicked', 'menuClosed', { label: 'none' })
+            window.GOVUK.analytics.trackEvent('headerClicked', buttonName + 'Closed', { label: 'none' })
           }
         } else {
           target.setAttribute('class', targetClass + ' js-visible')
           if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
-            window.GOVUK.analytics.trackEvent('headerClicked', 'menuOpened', { label: 'none' })
+            window.GOVUK.analytics.trackEvent('headerClicked', buttonName + 'Opened', { label: 'none' })
           }
         }
         if (sourceClass.indexOf('js-visible') !== -1) {
@@ -84,13 +85,14 @@
     var element = $menuToggleButtons[j]
 
     element.addEventListener('click', function (event) {
+      var buttonName = event.target.getAttribute('data-button-name') || 'menu'
       var expanded = event.target.getAttribute('aria-expanded')
 
       if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
         if (expanded === 'true') {
-          window.GOVUK.analytics.trackEvent('headerClicked', 'menuClosed', { label: 'none' })
+          window.GOVUK.analytics.trackEvent('headerClicked', buttonName + 'Closed', { label: 'none' })
         } else {
-          window.GOVUK.analytics.trackEvent('headerClicked', 'menuOpened', { label: 'none' })
+          window.GOVUK.analytics.trackEvent('headerClicked', buttonName + 'Opened', { label: 'none' })
         }
       }
     })

--- a/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_navigation_items.html.erb
@@ -6,6 +6,7 @@
     aria-label="Show or hide Top Level Navigation"
     class="govuk-header__menu-button govuk-js-header-toggle gem-c-header__menu-button govuk-!-display-none-print"
     type="button"
+    data-button-name="menu"
   >
     <%= t("components.layout_header.menu") %>
   </button>

--- a/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_header/_search.html.erb
@@ -1,6 +1,7 @@
 <button
   class="search-toggle js-header-toggle"
   data-search-toggle-for="search"
+  data-button-name="search"
   data-show-text="<%= t("components.layout_header.show_button") %>"
   data-hide-text="<%= t("components.layout_header.hide_button") %>"
 >


### PR DESCRIPTION


## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Updates the event being fired by the search toggle from `menuOpened` and `menuClosed` to `searchOpened` and `searchClosed`.

It'd be nice to have a more elegant way of doing this, but this fixes a problem that needs to be fixed quickly.

## Why
<!-- What are the reasons behind this change being made? -->
This will differentiate the events being fired by the menu and the search toggles to allow for more accurate analysis of users interactions.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
None.
