### PR TITLE
Extend track click script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 # Unreleased
 
+* Extend track click script ([PR #2263](https://github.com/alphagov/govuk_publishing_components/pull/2263))
 * Fix cookie banner issue (IE10) ([PR #2231](https://github.com/alphagov/govuk_publishing_components/pull/2231))
 
 # 25.2.3

--- a/app/assets/javascripts/govuk_publishing_components/analytics/track-click.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/track-click.js
@@ -9,11 +9,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   GemTrackClick.prototype.start = function ($module) {
     this.$module = $module[0]
     this.$module.handleClick = this.handleClick.bind(this)
+    var trackLinksOnly = this.$module.hasAttribute('data-track-links-only')
 
     var that = this
     // add a listener to the whole element
     this.$module.addEventListener('click', function (e) {
-      that.$module.handleClick(e.target)
+      if (!trackLinksOnly) {
+        that.$module.handleClick(e.target)
+      } else if (trackLinksOnly && e.target.tagName === 'A') {
+        that.$module.handleClick(e.target)
+      }
     })
   }
 
@@ -36,7 +41,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var dimensionIndex = target.getAttribute('data-track-dimension-index')
       var extraOptions = target.getAttribute('data-track-options')
 
-      options.label = label ? label : linkText
+      options.label = label || linkText
 
       if (value) {
         options.value = value

--- a/app/assets/javascripts/govuk_publishing_components/analytics/track-click.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/track-click.js
@@ -19,9 +19,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   GemTrackClick.prototype.handleClick = function (target) {
     var options = { transport: 'beacon' }
+    var linkText
 
     // if clicked element hasn't got the right attributes, look for a parent that matches
     if (!target.hasAttribute('data-track-category') && !target.hasAttribute('data-track-action')) {
+      linkText = target.textContent || target.innerText
       target = target.closest('[data-track-category][data-track-action]')
     }
 
@@ -34,9 +36,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var dimensionIndex = target.getAttribute('data-track-dimension-index')
       var extraOptions = target.getAttribute('data-track-options')
 
-      if (label) {
-        options.label = label
-      }
+      options.label = label ? label : linkText
 
       if (value) {
         options.value = value

--- a/spec/javascripts/govuk_publishing_components/analytics/track-click.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/track-click.spec.js
@@ -124,6 +124,28 @@ describe('A click tracker', function () {
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat2', 'action2', { label: 'label2', transport: 'beacon' })
   })
 
+  it('tracks all links in a trackable container and uses the link text as the label if no label is specified', function () {
+    element = $(
+      '<div data-module="gem-track-click" data-track-category="cat1" data-track-action="action1">' +
+        '<a class="first" href="#">Link 1</a>' +
+        '<a class="second" href="#" ' +
+          'data-track-category="cat2"' +
+          'data-track-action="action2"' +
+          'data-track-label="label2">' +
+          'Link 2' +
+        '</a>' +
+      '</div>'
+    )
+
+    new GOVUK.Modules.GemTrackClick().start(element)
+
+    element.find('a.first')[0].click()
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat1', 'action1', { label: 'Link 1', transport: 'beacon' })
+
+    element.find('a.second')[0].click()
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat2', 'action2', { label: 'label2', transport: 'beacon' })
+  })
+
   it('tracks a click correctly when event target is a child element of trackable element', function () {
     element = $(
       '<div data-module="gem-track-click">' +

--- a/spec/javascripts/govuk_publishing_components/analytics/track-click.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/track-click.spec.js
@@ -146,6 +146,32 @@ describe('A click tracker', function () {
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat2', 'action2', { label: 'label2', transport: 'beacon' })
   })
 
+  it('tracks only clicks on links when configured', function () {
+    element = $(
+      '<div data-module="gem-track-click" data-track-category="cat1" data-track-action="action1" data-track-links-only>' +
+        '<a class="first" href="#">Link 1</a>' +
+        '<a class="second" href="#" ' +
+          'data-track-category="cat2"' +
+          'data-track-action="action2"' +
+          'data-track-label="label2">' +
+          'Link 2' +
+        '</a>' +
+        '<span class="nothing"></span>' +
+      '</div>'
+    )
+
+    new GOVUK.Modules.GemTrackClick().start(element)
+
+    element.find('.nothing')[0].click()
+    expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
+
+    element.find('a.first')[0].click()
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat1', 'action1', { label: 'Link 1', transport: 'beacon' })
+
+    element.find('a.second')[0].click()
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat2', 'action2', { label: 'label2', transport: 'beacon' })
+  })
+
   it('tracks a click correctly when event target is a child element of trackable element', function () {
     element = $(
       '<div data-module="gem-track-click">' +


### PR DESCRIPTION
## What

Modify `GemTrackClick` so that if no `data-track-label` attribute is provided, the text of the link clicked will be used.

- this will allow tracking to be added to a wrapping element containing links managed outside of an editable template

## Why
We want to add tracking to links within an element where the content is managed outside of the template (e.g. a YML file) and the content is subject to change, without having to keep ensuring the links have the right data attributes. This allows us to add the module, action and event attributes to the parent, and the script will automatically use the text of the clicked link as the label.

## Visual Changes
None.

Trello card: https://trello.com/c/Q6kr2nFK/551-add-ga-tracking-codes-to-fcdo-call-out-box-of-covid-info
