### PR TITLE
Release v25.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-# Unreleased
+# 25.3.0
 
 * Extend track click script ([PR #2263](https://github.com/alphagov/govuk_publishing_components/pull/2263))
 * Fix cookie banner issue (IE10) ([PR #2231](https://github.com/alphagov/govuk_publishing_components/pull/2231))
 * Extend layout for public with account components ([PR #2255](https://github.com/alphagov/govuk_publishing_components/pull/2255))
+* Update search toggle tracking ([PR #2262](https://github.com/alphagov/govuk_publishing_components/pull/2262))
 
 # 25.2.3
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (25.2.3)
+    govuk_publishing_components (25.3.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "25.2.3".freeze
+  VERSION = "25.3.0".freeze
 end


### PR DESCRIPTION
Includes:

* Extend track click script (https://github.com/alphagov/govuk_publishing_components/pull/2263)
* Fix cookie banner issue (IE10) (https://github.com/alphagov/govuk_publishing_components/pull/2231)
* Extend layout for public with account components (https://github.com/alphagov/govuk_publishing_components/pull/2255)
* Update search toggle tracking (https://github.com/alphagov/govuk_publishing_components/pull/2262)
