### PR TITLE
Add lazy loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 # Unreleased
 
+* Add lazy loading to image card ([PR #2270](https://github.com/alphagov/govuk_publishing_components/pull/2270))
 * GOVUK.Modules.start can accept DOM elements ([PR #2260](https://github.com/alphagov/govuk_publishing_components/pull/2260))
 
 # 25.3.1

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -35,6 +35,15 @@ examples:
       image_alt: "some meaningful alt text please"
       heading_text: "I am not a heading"
       heading_level: 0
+  with_lazy_loading:
+    description: The image can have an attribute of lazy loading. Defaults to auto if not passed.
+    data:
+      href: "/really-not-a-page"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      image_alt: "some meaningful alt text please"
+      image_loading: "lazy"
+      heading_text: "I am not a heading"
+      heading_level: 0
   with_different_link_size:
     description: |
       Set a different font size for the link. Uses the [GOV.UK Frontend heading sizes](https://design-system.service.gov.uk/styles/typography/#headings) but defaults to 19px for legacy reasons. Valid options are `xl`, `l`, `m` and `s`.

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
       include ActionView::Helpers
       include ActionView::Context
 
-      attr_reader :href, :href_data_attributes, :extra_links, :large, :extra_links_no_indent, :heading_text, :metadata, :lang
+      attr_reader :href, :href_data_attributes, :extra_links, :large, :extra_links_no_indent, :heading_text, :metadata, :lang, :image_loading
 
       def initialize(local_assigns)
         @href = local_assigns[:href]
@@ -12,6 +12,7 @@ module GovukPublishingComponents
         @extra_links = local_assigns[:extra_links] || []
         @image_src = local_assigns[:image_src]
         @image_alt = local_assigns[:image_alt] || ""
+        @image_loading = local_assigns[:image_loading] || "auto"
         @context = local_assigns[:context]
         @description = local_assigns[:description]
         @large = local_assigns[:large]
@@ -35,7 +36,7 @@ module GovukPublishingComponents
       def image
         if @image_src
           content_tag(:figure, class: "gem-c-image-card__image-wrapper") do
-            image_tag(@image_src, class: "gem-c-image-card__image", alt: @image_alt)
+            image_tag(@image_src, class: "gem-c-image-card__image", alt: @image_alt, loading: @image_loading)
           end
         end
       end

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -123,4 +123,14 @@ describe "ImageCard", type: :view do
     render_component(href: "#", lang: "cy")
     assert_select ".gem-c-image-card[lang='cy']"
   end
+
+  it "applies lazy loading attribute when lazy is specified" do
+    render_component(href: "#", image_src: "/moo.jpg", image_alt: "some meaningful alt text", image_loading: "lazy")
+    assert_select ".gem-c-image-card__image[loading='lazy']"
+  end
+
+  it "checks image loading attribute is 'auto' when value 'image_loading' is not specified" do
+    render_component(href: "#", image_src: "/moo.jpg", image_alt: "some meaningful alt text")
+    assert_select ".gem-c-image-card__image[loading='auto']"
+  end
 end


### PR DESCRIPTION
## What

Adding lazy loading option to [image card](https://components.publishing.service.gov.uk/component-guide/image_card) providing a default to `auto`

## Why

As part of [this PR](https://github.com/alphagov/whitehall/pull/6236) realised that `loading="lazy"` was an attribute that exists on the image. [This had a measurable improvement on performance](https://github.com/alphagov/whitehall/pull/4979). 

In order to maintain use of this attribute _and_ use the [image card componen](https://components.publishing.service.gov.uk/component-guide/image_card)t adding the option to the gem

## Visual Changes
No visual changes, however visual representation of code update below:

![Screenshot 2021-08-17 at 11 29 37](https://user-images.githubusercontent.com/71266765/129710945-57b2532b-17bb-4dab-a162-2fec15ab1fe2.png)

---

![Screenshot 2021-08-17 at 11 29 18](https://user-images.githubusercontent.com/71266765/129710951-0c890804-f53f-4663-b6df-593502c06548.png)

## Anything else

Ref: https://web.dev/browser-level-image-lazy-loading/
[`auto`] has been added as the "default lazy-loading behaviour of the browser, which is the same as not including the attribute"

