### PR TITLE
Release v25.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-# Unreleased
+# 25.4.0
 
 * Add lazy loading to image card ([PR #2270](https://github.com/alphagov/govuk_publishing_components/pull/2270))
 * GOVUK.Modules.start can accept DOM elements ([PR #2260](https://github.com/alphagov/govuk_publishing_components/pull/2260))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (25.3.1)
+    govuk_publishing_components (25.4.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "25.3.1".freeze
+  VERSION = "25.4.0".freeze
 end


### PR DESCRIPTION
This release includes:

* Add lazy loading to image card ([#2270](https://github.com/alphagov/govuk_publishing_components/pull/2270))
* GOVUK.Modules.start can accept DOM elements ([#2260](https://github.com/alphagov/govuk_publishing_components/pull/2260))
