### PR TITLE
Fix `line-height` on step-by-step nav header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+# Unreleased
+
+* Fix `line-height` on step-by-step nav header ([PR #2273](https://github.com/alphagov/govuk_publishing_components/pull/2273))
+
 # 25.4.0
 
 * Add lazy loading to image card ([PR #2270](https://github.com/alphagov/govuk_publishing_components/pull/2270))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav-header.scss
@@ -1,5 +1,7 @@
 .gem-c-step-nav-header {
+  @include govuk-font(24, $weight: bold);
   @include govuk-text-colour;
+
   position: relative;
   padding: 10px;
   background: govuk-colour("light-grey", $legacy: "grey-4");
@@ -14,8 +16,4 @@
 .gem-c-step-nav-header__part-of {
   @include govuk-font(19, $weight: bold);
   display: block;
-}
-
-.gem-c-step-nav-header__title {
-  @include govuk-font(24, $weight: bold, $line-height: 1);
 }


### PR DESCRIPTION
## What
Applying a custom `line-height` on a `<span>` doesn't have any effect, as it's an inline element. We are setting the property on the parent `<h2>` element instead, as it's a block element.

## Why
This fixes a reported issue on mobile where the browser default `<h2>` `line-height` is inherited by the `<span>` element.

## Visual Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![components publishing service gov uk_component-guide_step_by_step_nav_header_with_a_long_text_preview](https://user-images.githubusercontent.com/788096/130081247-e06804d9-0084-4fc4-a8bd-802fa975c373.png)


</td><td valign="top">

![localhost_3212_component-guide_step_by_step_nav_header_with_a_long_text_preview](https://user-images.githubusercontent.com/788096/130081282-ed597356-ef96-4e0d-983d-e19696843935.png)


</td></tr>
<tr><td valign="top">

![components publishing service gov uk_component-guide_step_by_step_nav_header_with_a_long_text_preview (1)](https://user-images.githubusercontent.com/788096/130081315-fd8f0224-9479-4d40-8a1e-a9306c78f80f.png)


</td><td valign="top">

![components publishing service gov uk_component-guide_step_by_step_nav_header_with_a_long_text_preview (1)](https://user-images.githubusercontent.com/788096/130081315-fd8f0224-9479-4d40-8a1e-a9306c78f80f.png)


</td></tr>

</table>

