### PR TITLE
Enable draft on public layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 # Unreleased
 
 * Fix `line-height` on step-by-step nav header ([PR #2273](https://github.com/alphagov/govuk_publishing_components/pull/2273))
+* Enable draft on public layout ([PR #2274](https://github.com/alphagov/govuk_publishing_components/pull/2274))
 
 # 25.4.0
 

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -11,6 +11,7 @@
   omit_header ||= false
   product_name ||= nil
   show_explore_header ||= false
+  draft_watermark ||= false
   show_search = local_assigns.include?(:show_search) ? local_assigns[:show_search] : true
   title ||= "GOV.UK - The best place to find government services and information"
 
@@ -39,6 +40,8 @@
 # when a) there's content for the emergency or global banner *and* b) when using
 # the contrained width layout.
   blue_bar_dedupe = !full_width && global_bar.present?
+  body_css_classes = %w(gem-c-layout-for-public govuk-template__body)
+  body_css_classes << "draft" if draft_watermark
 -%>
 <!DOCTYPE html>
   <!--[if lt IE 9]><html class="lte-ie8" lang="<%= html_lang %>"><![endif]-->
@@ -72,7 +75,7 @@
 
     <%= yield :head %>
   </head>
-  <body class="gem-c-layout-for-public govuk-template__body">
+  <%= tag.body class: body_css_classes do %>
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
@@ -147,5 +150,5 @@
       } %>
     <% end %>
     <%= javascript_include_tag 'application' %>
-  </body>
+  <% end %>
 </html>

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -255,4 +255,10 @@ describe "Layout for public", type: :view do
 
     assert_select ".gem-c-cookie-banner__message .govuk-cookie-banner__heading", text: "Can we use cookies to collect information about how you use GOV.UK?"
   end
+
+  it "displays as draft watermark" do
+    render_component({ draft_watermark: true })
+
+    assert_select ".gem-c-layout-for-public.govuk-template__body.draft"
+  end
 end


### PR DESCRIPTION
## What
Add a `draft_watermark` option to the `layout_for_public` component.

## Why
[A `draft` class](https://github.com/alphagov/static/blob/main/app/views/root/_base.html.erb#L8) is used to apply a watermark when previewing documents in publishing application. [A smokey test is currently failing](https://deploy.integration.publishing.service.gov.uk/job/Smokey/32866/console) as this class is missing in applications using the new `gem_layout`.

The class, styling, and the associated asset should all be brought in line with our current conventions, but this will require a breaking change as we have [many instances](https://github.com/search?q=org%3Aalphagov+body.draft&type=code) where this `.draft` class is checked to exists.

## Visual Changes
No visual changes at the component level.

[Trello card](https://trello.com/c/EljDIthN/1201-smokey-failing-on-integration)