### PR TITLE
Release 25.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-# Unreleased
+# 25.5.0
 
 * Restore underline on image card header link ([PR #2277](https://github.com/alphagov/govuk_publishing_components/pull/2277))
 * Fix `line-height` on step-by-step nav header ([PR #2273](https://github.com/alphagov/govuk_publishing_components/pull/2273))
 * Enable draft on public layout ([PR #2274](https://github.com/alphagov/govuk_publishing_components/pull/2274))
+* Bump `govuk-frontend` from 3.12.0 to 3.13.0 ([PR #2164](https://github.com/alphagov/govuk_publishing_components/pull/2164))
 
 # 25.4.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (25.4.0)
+    govuk_publishing_components (25.5.0)
       govuk_app_config
       kramdown
       plek
@@ -98,7 +98,7 @@ GEM
     execjs (2.7.0)
     faker (2.17.0)
       i18n (>= 1.6, < 2)
-    faraday (1.6.0)
+    faraday (1.7.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "25.4.0".freeze
+  VERSION = "25.5.0".freeze
 end


### PR DESCRIPTION
# 25.5.0

* Fix `line-height` on step-by-step nav header ([PR #2273](https://github.com/alphagov/govuk_publishing_components/pull/2273))
* Enable draft on public layout ([PR #2274](https://github.com/alphagov/govuk_publishing_components/pull/2274))
* Bump `govuk-frontend` from 3.12.0 to 3.13.0 ([PR #2164](https://github.com/alphagov/govuk_publishing_components/pull/2164))
* Restore underline on image card header link ([PR #2277](https://github.com/alphagov/govuk_publishing_components/pull/2277))