### PR TITLE
Restore underline on image card header link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 # Unreleased
 
+* Restore underline on image card header link ([PR #2277](https://github.com/alphagov/govuk_publishing_components/pull/2277))
 * Fix `line-height` on step-by-step nav header ([PR #2273](https://github.com/alphagov/govuk_publishing_components/pull/2273))
 * Enable draft on public layout ([PR #2274](https://github.com/alphagov/govuk_publishing_components/pull/2274))
 

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -14,7 +14,6 @@
   heading_link_classes = %w[
     gem-c-image-card__title-link
     govuk-link
-    govuk-link--no-underline
   ] 
   heading_link_classes << brand_helper.color_class
   extra_link_classes = %w[


### PR DESCRIPTION
## What

Adding underline to links within [image card](https://components.publishing.service.gov.uk/component-guide/image_card) headings

## Why

As the image card heading, in this context, is linked this restores the underline as this offers more affordance this is a link than just colour alone meeting [WCAG 1.4.1](https://www.w3.org/TR/WCAG20-TECHS/F73.html)

> Link underlines or some other non-color visual distinction are required (when the links are discernible to those with color vision).

## Visual Changes

![image-card-link](https://user-images.githubusercontent.com/71266765/130228969-9bbc1de4-424b-42fc-afa6-7063b2b13b96.jpg)

## Anything else?

[Prompted from work on this PR](https://github.com/alphagov/whitehall/pull/6243) it was noticeable that in situ that links are absent from these linked headlines on the image card.
