### PR TITLE
Add big number component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+# Unreleased
+
+* Add big number component ([PR #2278](https://github.com/alphagov/govuk_publishing_components/pull/2278))
+
 ## 27.0.0
 
 * **BREAKING:** Rename extra_links to extra_details (image card) ([PR #2300](https://github.com/alphagov/govuk_publishing_components/pull/2300))

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -16,6 +16,7 @@ $govuk-new-link-styles: true;
 @import "components/attachment";
 @import "components/attachment-link";
 @import "components/back-link";
+@import "components/big-number";
 @import "components/breadcrumbs";
 @import "components/button";
 @import "components/character-count";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
@@ -1,0 +1,41 @@
+.gem-c-big-number {
+  margin-bottom: govuk-spacing(3);
+}
+
+.gem-c-big-number__value {
+  @include govuk-font($size: 80, $weight: bold);
+}
+
+.gem-c-big-number__label {
+  @include govuk-font($size: 16, $weight: bold, $line-height: 2);
+
+  // This pseudo element is to bypass an issue with NVDA where block level elements are dictated separately.
+  // What's happening here is that the label and the number technically have an inline relationship but appear to have a block relationship thanks to this element
+  &:before {
+    content: "";
+    display: block;
+  }
+}
+
+.gem-c-big-number__link {
+  display: inline-block;
+  text-decoration: none;
+
+  // Add govuk-link hover decoration to main value if no label present but a href attribute is
+  .gem-c-big-number__value--decorated {
+    @include govuk-link-decoration;
+    @include govuk-link-style-no-underline;
+  }
+
+  .gem-c-big-number__label {
+    @include govuk-link-decoration;
+  }
+
+  &:hover,
+  &:active {
+    .gem-c-big-number__label,
+    .gem-c-big-number__value--decorated {
+      @include govuk-link-hover-decoration;
+    }
+  }
+}

--- a/app/views/govuk_publishing_components/components/_big_number.html.erb
+++ b/app/views/govuk_publishing_components/components/_big_number.html.erb
@@ -1,0 +1,35 @@
+<%
+  href ||= nil
+  number ||= nil
+  label ||= nil
+  href ||= nil
+  data_attributes ||= nil
+  classes = ["gem-c-big-number__value"]
+  
+  if label.nil? && href
+    classes << "gem-c-big-number__value--decorated"
+  end
+%>
+<% if number %>
+  <% big_number_value = capture do %>
+    <%= tag.span class: classes do %>
+      <%= number %>
+    <% end %>
+
+    <% unless label.nil? %>
+      <% # add a virtual space here to handle screen readers printing dictations without a space between the number and the label %>
+      <span class="govuk-visually-hidden">&nbsp;</span>
+      <span class="gem-c-big-number__label">
+        <%= label %>
+      </span>
+    <% end %>
+  <% end %>
+  
+  <%= tag.div class: "gem-c-big-number" do %>
+    <% unless href.nil? %>
+      <%= link_to big_number_value, href, class: "govuk-link gem-c-big-number__link", data: data_attributes %>
+    <% else %>
+      <%= big_number_value %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/big_number.yml
+++ b/app/views/govuk_publishing_components/components/docs/big_number.yml
@@ -1,0 +1,50 @@
+name: Big number
+description: A big number, with a label if needed, for visualising quantitative values such as the number of government departments or historical prime ministers.
+body: |
+  This component requires at least a non-falsey `number` attribute value passed to it, otherwise it will not render.
+accessibility_criteria: |
+  This component must:
+
+  - communicate number value and label (if present) in a single dictation when read with a screen reader
+  - convey the meaning of the number shown
+shared_accessibility_criteria:
+- link
+examples:
+  default:
+    data:
+      number: 119
+  with_labels:
+    description: Labels for numbers are given inline styling but stacked using pseudo elements with display block. This is to bypass an issue with NVDA where block level elements are dictated separately.
+    data:
+      number: 119
+      label: Open consultations
+  passing_extra_symbols:
+    description: "In some cases, we want to communicate more than just the flat numeric value eg: 400+, 90%, -20, 1M etc. This is why we allow values to be passed as flat strings."
+    data:
+      number: "400+"
+      label: Other agencies and public bodies
+  with_link:
+    data:
+      number: 23
+      label: Ministerial departments
+      href: "/government/organisations#ministerial_departments"
+  with_link_but_no_label:
+    description: Numbers that are links are underlined unless a label is provided, in which case the label is given the underline.
+    data:
+      number: 23
+      href: "/government/organisations#ministerial_departments"
+  with_data_attributes:
+    description: |
+      These data attributes will only be present if a `href` attribute is present.
+      
+      This will also not automatically apply a `gem-track-click` module attribute if the data attributes pertain to click tracking. Remember to apply this outside the component call in a surrounding element, if using.
+    data:
+      number: 23
+      label: Ministerial departments
+      href: "/government/organisations#ministerial_departments"
+      data_attributes:
+        track-category: homepageClicked
+        track-action: departmentsLink
+        track-label: "/government/organisations#ministerial_departments"
+        track-dimension: 23 Ministerial departments
+        track-dimension-index: 29

--- a/spec/components/big_number_spec.rb
+++ b/spec/components/big_number_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+describe "Big number", type: :view do
+  def component_name
+    "big_number"
+  end
+
+  it "renders nothing when nothing is passed to it" do
+    assert_empty render_component({})
+    assert_empty render_component(number: false)
+  end
+
+  it "renders a number value" do
+    render_component(number: 500)
+
+    assert_select ".gem-c-big-number", count: 1
+  end
+
+  it "renders a number label if a label attribute is present" do
+    render_component({
+      number: 500,
+      label: "test runs",
+    })
+
+    assert_select ".gem-c-big-number__label", text: "test runs"
+  end
+
+  it "wraps a number item in a link if a href attribute is present" do
+    render_component({
+      number: 500,
+      label: "test runs",
+      href: "/tests",
+    })
+
+    assert_select "a.gem-c-big-number__link", count: 1, href: "/tests"
+  end
+
+  it "includes the number decorator class link if a href attribute is present but a label is not present" do
+    render_component({
+      number: 500,
+      href: "/tests",
+    })
+
+    assert_select ".gem-c-big-number__value.gem-c-big-number__value--decorated"
+  end
+
+  # The space mentioned in the below test is to handle screen readers printing dictations without a space between the number and the label
+  # We don't want this to get removed accidentally, hence the following test
+  it "ensures that a visually hidden space is included for screen readers when a label is present" do
+    render_component({
+      number: 500,
+      label: "test runs",
+    })
+
+    assert_select ".govuk-visually-hidden", count: 1
+  end
+end


### PR DESCRIPTION
## What
Adds the big number component to the component library

## Why
We have a couple of fragmented instances of this pattern across govuk which meets our criteria for componentisation.

You can read more on the reasoning, along with a spec for the API and the markup in the comments, here: https://github.com/alphagov/govuk_publishing_components/issues/2221

## Visual Changes (from bespoke examples on production)
| Link | Before | After |
| --- | --- | --- |
| https://www.gov.uk/ | ![Screenshot 2021-08-20 at 16 23 15](https://user-images.githubusercontent.com/64783893/130258213-36fd46b5-a214-46d4-b3d0-b3188866d95d.png) | ![Screenshot 2021-08-20 at 16 23 26](https://user-images.githubusercontent.com/64783893/130258234-5ed38a24-dbf8-407a-80b9-4d04588c2b24.png) |