### PR TITLE
Fix navigation header layout error that occurs when resizing browser window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,46 +7,50 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-# 25.5.0
+## Unreleased
+
+* Fix navigation header layout error that occurs when resizing browser window ([PR #2281](https://github.com/alphagov/govuk_publishing_components/pull/2281))
+
+## 25.5.0
 
 * Restore underline on image card header link ([PR #2277](https://github.com/alphagov/govuk_publishing_components/pull/2277))
 * Fix `line-height` on step-by-step nav header ([PR #2273](https://github.com/alphagov/govuk_publishing_components/pull/2273))
 * Enable draft on public layout ([PR #2274](https://github.com/alphagov/govuk_publishing_components/pull/2274))
 * Bump `govuk-frontend` from 3.12.0 to 3.13.0 ([PR #2164](https://github.com/alphagov/govuk_publishing_components/pull/2164))
 
-# 25.4.0
+## 25.4.0
 
 * Add lazy loading to image card ([PR #2270](https://github.com/alphagov/govuk_publishing_components/pull/2270))
 * GOVUK.Modules.start can accept DOM elements ([PR #2260](https://github.com/alphagov/govuk_publishing_components/pull/2260))
 
-# 25.3.1
+## 25.3.1
 
 * Fix track click link tracking ([PR #2265](https://github.com/alphagov/govuk_publishing_components/pull/2265))
 * Add language tag for Welsh link in public layout template ([PR #2258](https://github.com/alphagov/govuk_publishing_components/pull/2258))
 * Revert "Fix cookie banner issue (IE10)" ([PR #2267](https://github.com/alphagov/govuk_publishing_components/pull/2267))
 
-# 25.3.0
+## 25.3.0
 
 * Extend track click script ([PR #2263](https://github.com/alphagov/govuk_publishing_components/pull/2263))
 * Fix cookie banner issue (IE10) ([PR #2231](https://github.com/alphagov/govuk_publishing_components/pull/2231))
 * Extend layout for public with account components ([PR #2255](https://github.com/alphagov/govuk_publishing_components/pull/2255))
 * Update search toggle tracking ([PR #2262](https://github.com/alphagov/govuk_publishing_components/pull/2262))
 
-# 25.2.3
+## 25.2.3
 
 * Fix final issues with tracking on super nav header ([PR #2256](https://github.com/alphagov/govuk_publishing_components/pull/2256))
 
-# 25.2.2
+## 25.2.2
 
 * Fix typo in tracking module on super navigation header ([PR #2253](https://github.com/alphagov/govuk_publishing_components/pull/2253))
 
-# 25.2.1
+## 25.2.1
 
 * Add link tracking to super navigation header ([PR #2249](https://github.com/alphagov/govuk_publishing_components/pull/2249))
 * Fix typos in super navigation link tracking ([PR #2251](https://github.com/alphagov/govuk_publishing_components/pull/2251))
 * Update super navigation styles to avoid `govuk-layout` clashes ([PR #2250](https://github.com/alphagov/govuk_publishing_components/pull/2250))
 
-# 25.2.0
+## 25.2.0
 
 * Add analytics tags to super navigation header ([PR #2244](https://github.com/alphagov/govuk_publishing_components/pull/2244))
 * Update copy for Explore Super Menu Header ([PR #2247](https://github.com/alphagov/govuk_publishing_components/pull/2247))

--- a/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
@@ -155,10 +155,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       this.$module.style.marginBottom = '0'
-
-      window.removeEventListener('resize', this.resizeHandler, { passive: true })
-
-      this.lastWindowSize = this.windowSize()
     }
 
     // Hide the navigation toggle button and show the navigation submenu:
@@ -166,10 +162,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.$navigationToggle.setAttribute('hidden', 'hidden')
       this.$navigationMenu.removeAttribute('hidden')
 
-      window.addEventListener('resize', this.resizeHandler, { passive: true })
-
-      this.lastWindowSize = this.windowSize()
+      this.resizeHandler()
     }
+
+    this.lastWindowSize = this.windowSize()
   }
 
   SuperNavigationMegaMenu.prototype.buttonHandler = function (event) {


### PR DESCRIPTION
## What
Removes the window resize listener inside the `updateStates` function, which itself was used with a window resize or matchMedia listener.

## Why
When moving from mobile to desktop view, and resizing the window to exactly 769 pixels wide the layout was broken. This was because the listener to change the layouts was added at this breakpoint, but the function wouldn't be fired until the _next_ resize event one pixel later.

Since this was a `resize` listener being fired by another resize or matchMedia listener it could be removed and replaced with firing the function.

Example of the visual glitch:

<img width="66%" alt="Screenshot 2021-08-23 at 14 15 28" src="https://user-images.githubusercontent.com/1732331/130453654-526ae2ff-9e67-4250-9bbc-da457729d98c.png">


## Visual Changes

Before at 769 pixels wide:

<img width="765" alt="Screenshot 2021-08-23 at 14 14 28" src="https://user-images.githubusercontent.com/1732331/130453532-572b473e-4abb-4f80-b0b2-f1aa27b33118.png">


After at 769 pixels wide:

![image](https://user-images.githubusercontent.com/1732331/130453029-76f3672b-908b-4899-8f78-6c2f59f23d2e.png)
