### PR TITLE
Fix navigation header search toggle focus hover states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix navigation header layout error that occurs when resizing browser window ([PR #2281](https://github.com/alphagov/govuk_publishing_components/pull/2281))
+* Fix navigation header search toggle focus hover states ([PR #2284](https://github.com/alphagov/govuk_publishing_components/pull/2284))
 
 ## 25.5.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -396,16 +396,23 @@ $search-icon-size: 20px;
   position: absolute;
   right: (0 - govuk-spacing(3));
 
-  &.gem-c-layout-super-navigation-header__open-button {
-    border-top-color: govuk-colour("black");
+  &:after {
+    background-color: $govuk-link-colour;
+    content: " ";
+    left: 0;
+    right: 0;
+  }
+
+  &:not(.gem-c-layout-super-navigation-header__open-button):focus {
+    &:hover,
+    &:after {
+      background-color: $govuk-focus-colour;
+      border-top-color: $govuk-focus-colour;
+    }
   }
 
   @include govuk-media-query($from: 360px) {
     right: 0;
-  }
-
-  &:focus:hover {
-    border-top-color: govuk-colour("black");
   }
 
   @include govuk-media-query($from: "desktop") {
@@ -417,23 +424,9 @@ $search-icon-size: 20px;
     position: relative;
     float: right;
 
-    &:not(.gem-c-layout-super-navigation-header__open-button):hover {
-      background: govuk-colour("black");
-      color: govuk-colour("mid-grey");
-
-      &:after {
-        content: " ";
-        left: 0;
-        right: 0;
-      }
-    }
-
-    &:focus:hover:after,
-    &:after {
-      content: none;
-    }
-
     &.gem-c-layout-super-navigation-header__open-button {
+      border-top-color: govuk-colour("black");
+
       &:hover:after {
         content: " ";
       }


### PR DESCRIPTION
## What
Removed the search toggle button hover state when the button was focussed.

## Why
The hover state differed between the navigation toggle buttons and the search toggle buttons - this is now consistent in that there is now no visual change when a focussed element is hovered.

## Visual Changes
Before - search toggle focussed and hovered:

![image](https://user-images.githubusercontent.com/1732331/130626487-db463567-1482-4dcf-ba74-dab3dbbbdc6b.png)


After - search toggle focussed and hovered:

![image](https://user-images.githubusercontent.com/1732331/130626390-54969ea1-8e79-4060-b9f3-74a2fbb9347d.png)
