### PR TITLE
Release 25.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 25.7.0
 
 * Add text list to image card ([PR #2286](https://github.com/alphagov/govuk_publishing_components/pull/2286))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (25.6.0)
+    govuk_publishing_components (25.7.0)
       govuk_app_config
       kramdown
       plek

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "25.6.0".freeze
+  VERSION = "25.7.0".freeze
 end


### PR DESCRIPTION
Includes:

* Add text list to image card ([PR #2286](https://github.com/alphagov/govuk_publishing_components/pull/2286))