### PR TITLE
Add a dependency on govuk_personalisation, and use it to generate account URLs in the account layout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
   - dependency-name: gds-sso
   - dependency-name: govspeak
   - dependency-name: govuk_app_config
+  - dependency-name: govuk_personalisation
   - dependency-name: govuk_publishing_components
   - dependency-name: govuk_schemas
   - dependency-name: govuk_sidekiq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* **BREAKING:** Add a dependency on govuk_personalisation, and use it to generate account URLs in the account layout ([PR #2289](https://github.com/alphagov/govuk_publishing_components/pull/2289))
+
+  You must make the following changes when you migrate to this release:
+  - Upgrade to Rails 6
+
 ## 25.7.0
 
 * Add text list to image card ([PR #2286](https://github.com/alphagov/govuk_publishing_components/pull/2286))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,9 +3,10 @@ PATH
   specs:
     govuk_publishing_components (25.7.0)
       govuk_app_config
+      govuk_personalisation (>= 0.7.0)
       kramdown
       plek
-      rails (>= 5.0.0.1)
+      rails (>= 6)
       rouge
       sprockets (< 4)
 
@@ -98,7 +99,7 @@ GEM
     execjs (2.7.0)
     faker (2.17.0)
       i18n (>= 1.6, < 2)
-    faraday (1.7.0)
+    faraday (1.7.1)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -132,6 +133,9 @@ GEM
       sentry-ruby (~> 4.5.0)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
+    govuk_personalisation (0.7.0)
+      plek (>= 1.9.0)
+      rails (~> 6)
     govuk_schemas (4.3.0)
       json-schema (~> 2.8.0)
     govuk_test (2.3.0)

--- a/app/views/govuk_publishing_components/components/layout_for_public/_account-feedback-footer.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_for_public/_account-feedback-footer.html.erb
@@ -9,7 +9,7 @@
 
     <p class="govuk-body govuk-!-margin-bottom-0">
       <%= t("components.layout_for_public.account_layout.feedback.banners.footer_intro") %>
-      <a href="<%= "#{Plek.find('account-manager')}/feedback" %>" class="govuk-link">
+      <a href="<%= GovukPersonalisation::Urls.feedback %>" class="govuk-link">
         <%= t("components.layout_for_public.account_layout.feedback.banners.footer_link") %>
       </a>
       <%= t("components.layout_for_public.account_layout.feedback.banners.footer_outro") %>

--- a/app/views/govuk_publishing_components/components/layout_for_public/_account-layout.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_for_public/_account-layout.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-width-container">
   <% message = capture do %>
     <%= t("components.layout_for_public.account_layout.feedback.banners.phase_intro") %>
-    <a class="govuk-link" href=<%= "#{Plek.find('account-manager')}/feedback" %>>
+    <a class="govuk-link" href=<%= GovukPersonalisation::Urls.feedback %>>
       <%= t("components.layout_for_public.account_layout.feedback.banners.phase_link") %>
     </a>
     <%= t("components.layout_for_public.account_layout.feedback.banners.phase_outro") %>

--- a/app/views/govuk_publishing_components/components/layout_for_public/_account-navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_for_public/_account-navigation.html.erb
@@ -5,7 +5,7 @@
     <li class="gem-c-layout-for-public-account-menu__item <%= "gem-c-layout-for-public-account-menu__item--current" if page_is == "your-account" %>">
       <%= link_to(
         t("components.layout_for_public.account_layout.navigation.menu_bar.account.link_text"),
-        "#{Plek.find('account-manager')}",
+        GovukPersonalisation::Urls.your_account,
         class: 'gem-c-layout-for-public-account-menu__link govuk-link govuk-link--no-visited-state',
         'aria-current': page_is == "your-account" ? "page" : nil,
       ) %>
@@ -13,7 +13,7 @@
     <li class="gem-c-layout-for-public-account-menu__item <%= "gem-c-layout-for-public-account-menu__item--current" if page_is == "manage" %>">
       <%= link_to(
         t("components.layout_for_public.account_layout.navigation.menu_bar.manage.link_text"),
-        "#{Plek.find('account-manager')}/account/manage",
+        GovukPersonalisation::Urls.manage,
         class: 'gem-c-layout-for-public-account-menu__link govuk-link govuk-link--no-visited-state',
         'aria-current': page_is == "manage" ? "page" : nil,
       ) %>
@@ -21,7 +21,7 @@
     <li class="gem-c-layout-for-public-account-menu__item <%= "gem-c-layout-for-public-account-menu__item--current" if page_is == "security" %>">
       <%= link_to(
         t("components.layout_for_public.account_layout.navigation.menu_bar.security.link_text"),
-        "#{Plek.find('account-manager')}/account/security",
+        GovukPersonalisation::Urls.security,
         class: 'gem-c-layout-for-public-account-menu__link govuk-link govuk-link--no-visited-state',
         'aria-current': page_is == "security" ? "page" : nil,
       ) %>

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -17,9 +17,10 @@ Gem::Specification.new do |s|
   s.files = Dir["{node_modules/govuk-frontend,node_modules/axe-core,node_modules/jquery,node_modules/sortablejs,app,config,db,lib}/**/*", "LICENCE.md", "README.md"]
 
   s.add_dependency "govuk_app_config"
+  s.add_dependency "govuk_personalisation", ">= 0.7.0"
   s.add_dependency "kramdown"
   s.add_dependency "plek"
-  s.add_dependency "rails", ">= 5.0.0.1"
+  s.add_dependency "rails", ">= 6"
   s.add_dependency "rouge"
   s.add_dependency "sprockets", "< 4"
 

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -1,6 +1,7 @@
 require "active_support"
 require "action_controller"
 require "action_view"
+require "govuk_personalisation"
 require "govuk_publishing_components/config"
 require "govuk_publishing_components/engine"
 require "govuk_publishing_components/presenters/shared_helper"


### PR DESCRIPTION
## What
Change the account parts of the public layout component to use [the `GovukPersonalisation::Urls` module](https://www.rubydoc.info/gems/govuk_personalisation/0.7.0/GovukPersonalisation/Urls), which we have introduced as a consistent way to link to account-related pages across apps.

This is a breaking change, because it introduces a dependency on [the govuk_personalisation gem](https://rubygems.org/gems/govuk_personalisation), which has a dependency on `rails ~> 6`, whereas govuk_publishing_components currently has a dependency on `rails >= 5.0.0.1`, so any Rails 5 users will need to upgrade to Rails 6.  This shouldn't be a problem for GOV.UK, as we are already using Rails 6 for everything.

## Why
We currently link to account-related URLs in a few apps, and have adopted different practices in different places:

- In some places we use hard-coded paths on GOV.UK ([eg, static](https://github.com/alphagov/static/blob/9b0caaa6de54a0e3624f29520e97fec5a4fe29d2/app/views/root/_gem_base.html.erb#L47))
- In some places, we use environment variables with a full URI ([eg, email-alert-frontend](https://github.com/alphagov/email-alert-frontend/blob/88458caef82beb1b0b04b04cc46e0bdf7264fc35/app/controllers/subscriptions_management_controller.rb#L102))
- In some places, we use hard-coded paths on the Account Manager domain ([eg, govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/blob/3406c13d2564dbbde03e6b5ed3fc97842819c327/app/views/govuk_publishing_components/components/layout_for_public/_account-layout.html.erb#L4))

So we introduced the `GovukPersonalisation::Urls` module to give a Plek-like approach to finding URLs:

- For things on GOV.UK, it'll generate a URL relative to the website root (or the specific frontend app when running in development mode)
- For things off GOV.UK, it'll generate a URL relative to the Account Manager
- For both, an environment variable can be set to override the URL

So we will make our URL generation logic consistent, and also be able to support the migration to Digital Identity away from the Account Manager by overriding URLs in Puppet.

## Visual Changes
None.

---

[Trello card](https://trello.com/c/ZvDGaba4/958-use-di-auth-in-integration-give-feedback-on-their-documentation)
