### PR TITLE
Fix link formatting in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,7 +241,7 @@
 * Remove jQuery from the feedback component ([PR #2062](https://github.com/alphagov/govuk_publishing_components/pull/2062))
 * Remove `display: none` rules from component print stylesheets, and use the `govuk-!-display-none-print` class instead. ([PR #1561](https://github.com/alphagov/govuk_publishing_components/pull/1561))
 * Fix IE11 `initCustomEvent` error ([PR #2079](https://github.com/alphagov/govuk_publishing_components/pull/2079))
-* If present, use the url_override field in breadcrumbs ([PR #2093])(https://github.com/alphagov/govuk_publishing_components/pull/2093))
+* If present, use the url_override field in breadcrumbs ([PR #2093](https://github.com/alphagov/govuk_publishing_components/pull/2093))
 
 ## 24.10.3
 


### PR DESCRIPTION
The last link under version **24.11.0** doesn't look right: https://github.com/alphagov/govuk_publishing_components/blob/master/CHANGELOG.md#24110
