### PR TITLE
Allow default header navigation on public layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow default header navigation on public layout ([PR #2292](https://github.com/alphagov/govuk_publishing_components/pull/2292))
+
 ## 26.0.0
 
 * **BREAKING:** Add a dependency on govuk_personalisation, and use it to generate account URLs in the account layout ([PR #2289](https://github.com/alphagov/govuk_publishing_components/pull/2289))

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -20,6 +20,11 @@
   omit_account_feedback_footer ||= false
   omit_account_navigation ||= false
   omit_account_phase_banner ||= false
+  show_default_header_navigation_items ||= false
+  search_left ||= false
+
+  navigation_items = layout_helper.header_navigation if show_default_header_navigation_items
+  search_left = true if show_default_header_navigation_items
 
 # This is a hack - but it's the only way I can find to not have two blue bars on
 # constrained width layouts.
@@ -93,6 +98,7 @@
           search: show_search,
           logo_link: logo_link,
           navigation_items: navigation_items,
+          search_left: search_left,
           product_name: product_name,
 
           # The (blue) bottom border needs to be underneath the emergency banner -

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -48,6 +48,10 @@ examples:
       - text: Hidden on desktop
         href: "item-3"
         show_only_in_collapsed_menu: true
+  navigation_default:
+    description: Passes the default navigation through to the [header component](/component-guide/layout_header/).
+    data:
+      show_default_header_navigation_items: true
   with_global_banner:
     description: This allows the HTML for the global banner to be added to the page. This is only the slot for the global banner - the markup for the banner needs to be passed in.
     data:

--- a/lib/govuk_publishing_components/presenters/public_layout_helper.rb
+++ b/lib/govuk_publishing_components/presenters/public_layout_helper.rb
@@ -1,6 +1,86 @@
 module GovukPublishingComponents
   module Presenters
     class PublicLayoutHelper
+      HEADER_NAV = [
+        {
+          href: "/government/organisations",
+          text: "Departments",
+          data: {
+            track_category: "headerClicked",
+            track_action: "departmentsLink",
+            track_label: "/government/organisations",
+            track_dimension: "Departments",
+            track_dimension_index: "29",
+          },
+        },
+        {
+          href: "/world",
+          text: "Worldwide",
+          data: {
+            track_category: "headerClicked",
+            track_action: "worldwideLink",
+            track_label: "/world",
+            track_dimension: "Worldwide",
+            track_dimension_index: "29",
+          },
+        },
+        {
+          href: "/government/how-government-works",
+          text: "How government works",
+          data: {
+            track_category: "headerClicked",
+            track_action: "governmentactivityLink",
+            track_label: "/government/how-government-works",
+            track_dimension: "How government works",
+            track_dimension_index: "29",
+          },
+        },
+        {
+          href: "/government/get-involved",
+          text: "Get involved",
+          data: {
+            track_category: "headerClicked",
+            track_action: "governmentactivityLink",
+            track_label: "/government/get-involved",
+            track_dimension: "Get involved",
+            track_dimension_index: "29",
+          },
+        },
+        {
+          href: CGI.escapeHTML("/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations"),
+          text: "Consultations",
+          data: {
+            track_category: "headerClicked",
+            track_action: "governmentactivityLink",
+            track_label: CGI.escapeHTML("/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations"),
+            track_dimension: "Consultations",
+            track_dimension_index: "29",
+          },
+        },
+        {
+          href: "/search/research-and-statistics",
+          text: "Statistics",
+          data: {
+            track_category: "headerClicked",
+            track_action: "governmentactivityLink",
+            track_label: "/search/research-and-statistics",
+            track_dimension: "Statistics",
+            track_dimension_index: "29",
+          },
+        },
+        {
+          href: "/search/news-and-communications",
+          text: "News and communications",
+          data: {
+            track_category: "headerClicked",
+            track_action: "governmentactivityLink",
+            track_label: "/search/news-and-communications",
+            track_dimension: "News and communications",
+            track_dimension_index: "29",
+          },
+        },
+      ].freeze
+
       FOOTER_NAV = [
         {
           title: "Coronavirus (COVID-19)",
@@ -364,9 +444,10 @@ module GovukPublishingComponents
         ],
       }.freeze
 
-      attr_reader :footer_navigation, :footer_meta, :cookie_banner_data
+      attr_reader :header_navigation, :footer_navigation, :footer_meta, :cookie_banner_data
 
       def initialize(local_assigns)
+        @header_navigation = local_assigns[:header_navigation] || HEADER_NAV
         @footer_navigation = local_assigns[:footer_navigation] || FOOTER_NAV
         @footer_meta = local_assigns[:footer_meta] || FOOTER_META
         @cookie_banner_data = local_assigns[:cookie_banner_data] || {}


### PR DESCRIPTION
## What
This PR updates `layout_for_public` to be able to render the default header navigation.

## Why
A set of applications [1][2][3] require a header navigation (sometimes referred to as 'proposition menu') which is only available in `govuk_template` at the moment. 

## Note
We expect the `layout_header `component to be replaced by the `layout_super_navigation_header` in future, so all this code will be removed, but in the meantime this work is required to be able to progress with removing the dependency on `govuk_template`.

[1] https://github.com/alphagov/whitehall/pull/6240
[2] https://github.com/alphagov/finder-frontend/pull/2616
[3] https://github.com/alphagov/government-frontend/pull/2206

## Visual Changes
[Preview `layout_for_public` with default navigation](https://govuk-publis-allow-defa-xbzgfn.herokuapp.com/component-guide/layout_for_public/navigation_default/preview)
