### PR TITLE
Add single page notification component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Bump `govuk-frontend` from 3.13.0 to 3.14.0 ([PR #2334](https://github.com/alphagov/govuk_publishing_components/pull/2334 ))
+* Add single page notification component ([PR #2293](https://github.com/alphagov/govuk_publishing_components/pull/2293))
 * Update the design of the mobile menu button on the super navigation ([PR #2382](https://github.com/alphagov/govuk_publishing_components/pull/2382))
 * Update positioning and border colour on super navigation search button ([PR #2413](https://github.com/alphagov/govuk_publishing_components/pull/2413))
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -68,6 +68,7 @@ $govuk-new-link-styles: true;
 @import "components/select";
 @import "components/share-links";
 @import "components/show-password";
+@import "components/single-page-notification-button";
 @import "components/skip-link";
 @import "components/step-by-step-nav-header";
 @import "components/step-by-step-nav-related";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
@@ -1,0 +1,32 @@
+.gem-c-single-page-notification-button__submit {
+  position: relative;
+  padding: govuk-spacing(2);
+  text-decoration: none;
+  margin: govuk-spacing(0);
+  box-shadow: inset 0 0 0 1px transparent;
+  border: 1px solid $govuk-border-colour;
+  color: $govuk-link-colour;
+  cursor: pointer;
+  background: none;
+
+  &:active {
+    top: 2px;
+  }
+
+  &:focus {
+    @include govuk-focused-text;
+    background-color: $govuk-focus-colour;
+    border-color: transparent;
+    box-shadow: 0 $govuk-focus-width $govuk-text-colour;
+  }
+
+  &:hover {
+    background-color: govuk-colour("light-grey");
+  }
+}
+
+.gem-c-single-page-notification-button__icon {
+  color: govuk-colour("black");
+  vertical-align: top;
+  margin-right: govuk-spacing(1);
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
@@ -1,17 +1,10 @@
 .gem-c-single-page-notification-button__submit {
-  position: relative;
   padding: govuk-spacing(2);
-  text-decoration: none;
   margin: govuk-spacing(0);
-  box-shadow: inset 0 0 0 1px transparent;
   border: 1px solid $govuk-border-colour;
   color: $govuk-link-colour;
   cursor: pointer;
   background: none;
-
-  &:active {
-    top: 2px;
-  }
 
   &:focus {
     @include govuk-focused-text;
@@ -22,6 +15,11 @@
 
   &:hover {
     background-color: govuk-colour("light-grey");
+    color: $govuk-link-hover-colour;
+
+    &:focus {
+      color: $govuk-text-colour;
+    }
   }
 }
 

--- a/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
@@ -8,7 +8,7 @@
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   wrapper_classes = %w(gem-c-single-page-notification-button govuk-!-display-none-print)
-  wrapper_classes << (shared_helper.get_margin_bottom)
+  wrapper_classes << shared_helper.get_margin_bottom
   classes = "govuk-body-s gem-c-single-page-notification-button__submit"
 %>
 <% button_text = capture do %>

--- a/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
@@ -1,29 +1,21 @@
 <%
   page ||= ''
   data_attributes ||= {}
-  margin_top ||= 3
   base_path ||= nil
-  margin_bottom ||= 3
+  local_assigns[:margin_bottom] ||= 3
   already_subscribed ||= false
   text ||= already_subscribed ? t('components.single_page_notification_button.unsubscribe_text') : t('components.single_page_notification_button.subscribe_text')
 
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({
-    margin_top: margin_top,
-    margin_bottom: margin_bottom
-  })
-
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   wrapper_classes = %w(gem-c-single-page-notification-button govuk-!-display-none-print)
-  wrapper_classes << (shared_helper.get_margin_top)
   wrapper_classes << (shared_helper.get_margin_bottom)
-  classes = %w[govuk-link govuk-body-s]
-  classes << "gem-c-single-page-notification-button__submit govuk-link--no-visited-state"
-  data_attributes[:module] = "single-page-notification-button"
+  classes = "govuk-body-s gem-c-single-page-notification-button__submit"
 %>
 <% button_text = capture do %>
   <svg class="gem-c-single-page-notification-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 459.334 459.334"><path fill="currentColor" d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"/></svg><%= text %>
 <% end %>
 <%= tag.form class: wrapper_classes, action: "/email/subscriptions/single-page/new", method: "POST", data: data_attributes do %>
-  <%= hidden_field_tag "base_path", base_path  %>
+  <input type="hidden" name="base_path" value="<%= base_path %>">
   <%= content_tag(:button, button_text, {
     class: classes,
     type: "submit",

--- a/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
@@ -1,0 +1,31 @@
+<%
+  page ||= ''
+  data_attributes ||= {}
+  margin_top ||= 3
+  base_path ||= nil
+  margin_bottom ||= 3
+  already_subscribed ||= false
+  text ||= already_subscribed ? t('components.single_page_notification_button.unsubscribe_text') : t('components.single_page_notification_button.subscribe_text')
+
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({
+    margin_top: margin_top,
+    margin_bottom: margin_bottom
+  })
+
+  wrapper_classes = %w(gem-c-single-page-notification-button govuk-!-display-none-print)
+  wrapper_classes << (shared_helper.get_margin_top)
+  wrapper_classes << (shared_helper.get_margin_bottom)
+  classes = %w[govuk-link govuk-body-s]
+  classes << "gem-c-single-page-notification-button__submit govuk-link--no-visited-state"
+  data_attributes[:module] = "single-page-notification-button"
+%>
+<% button_text = capture do %>
+  <svg class="gem-c-single-page-notification-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 459.334 459.334"><path fill="currentColor" d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"/></svg><%= text %>
+<% end %>
+<%= tag.form class: wrapper_classes, action: "/email/subscriptions/single-page/new", method: "POST", data: data_attributes do %>
+  <%= hidden_field_tag "base_path", base_path  %>
+  <%= content_tag(:button, button_text, {
+    class: classes,
+    type: "submit",
+  }) %>
+<% end if base_path.presence %>

--- a/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
+++ b/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
@@ -24,3 +24,9 @@ examples:
       base_path: '/current-page-path'
       data_attributes:
         category: fancyButtons
+  with_margin_bottom:
+    description: |
+      The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a margin bottom of 15px.
+    data:
+      base_path: '/current-page-path'
+      margin_bottom: 5

--- a/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
+++ b/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
@@ -1,0 +1,22 @@
+name: Single page notification button
+description: A link that subscribes the user to email notifications to a page
+body: |
+  By default, the component displays with the "Get emails about this page" state. The component does not render without the `base_path` parameter.
+
+  The `base_path` is necessary for [checking if an email subscription is active on page load](https://github.com/alphagov/account-api/blob/main/docs/api.md#get-apipersonalisationcheck-email-subscriptiontopic_slug) and the creation/deletion of an email notification subscription.
+
+  When the button is clicked, the `base_path` is submitted to an endpoint which proceeds to check the user's authentication status and whether they are already subscribed to the page or not. Depending on these factors, they will be routed accordingly.
+accessibility_criteria: |
+  - The bell icon must be presentational and ignored by screen readers.
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    description: By default this component prompts the user to subscribe to email notifications to this page. The component uses JavaScript to check if the user has already subscribed to email notifications on the current page. If yes, the state of the component updates accordingly.
+    data:
+      base_path: '/current-page-path'
+  already_subscribed:
+    description: If the user has already subscribed to email notifications about the current page, display the "Stop getting emails about this page" state.
+    data:
+      base_path: '/current-page-path'
+      already_subscribed: true

--- a/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
+++ b/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
@@ -1,5 +1,5 @@
 name: Single page notification button
-description: A link that subscribes the user to email notifications to a page
+description: A button that subscribes the user to email notifications to a page
 body: |
   By default, the component displays with the "Get emails about this page" state. The component does not render without the `base_path` parameter.
 
@@ -8,11 +8,9 @@ body: |
   When the button is clicked, the `base_path` is submitted to an endpoint which proceeds to check the user's authentication status and whether they are already subscribed to the page or not. Depending on these factors, they will be routed accordingly.
 accessibility_criteria: |
   - The bell icon must be presentational and ignored by screen readers.
-shared_accessibility_criteria:
-  - link
 examples:
   default:
-    description: By default this component prompts the user to subscribe to email notifications to this page. The component uses JavaScript to check if the user has already subscribed to email notifications on the current page. If yes, the state of the component updates accordingly.
+    description: By default this component prompts the user to subscribe to email notifications to this page.
     data:
       base_path: '/current-page-path'
   already_subscribed:
@@ -20,3 +18,9 @@ examples:
     data:
       base_path: '/current-page-path'
       already_subscribed: true
+  with_data_attributes:
+    description: The component accepts data attributes (for example, for analytics)
+    data:
+      base_path: '/current-page-path'
+      data_attributes:
+        category: fancyButtons

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,6 +258,9 @@ en:
       hide_password: Hide password
       show: Show
       show_password: Show password
+    single_page_notification_button:
+      subscribe_text: Get emails about this page
+      unsubscribe_text: Stop getting emails about this page
     skip_link:
       text: Skip to main content
     step_by_step_nav:

--- a/spec/components/single_page_notification_button_spec.rb
+++ b/spec/components/single_page_notification_button_spec.rb
@@ -30,4 +30,14 @@ describe "Single page notification button", type: :view do
     render_component({ base_path: "/the-current-page", data_attributes: { action: "kaboom!" } })
     assert_select ".gem-c-single-page-notification-button[data-action='kaboom!']"
   end
+
+  it "sets a default bottom margin" do
+    render_component({ base_path: "/the-current-page" })
+    assert_select '.gem-c-single-page-notification-button.govuk-\!-margin-bottom-3'
+  end
+
+  it "adds bottom margin if margin_bottom is specified" do
+    render_component({ base_path: "/the-current-page", margin_bottom: 9 })
+    assert_select '.gem-c-single-page-notification-button.govuk-\!-margin-bottom-9'
+  end
 end

--- a/spec/components/single_page_notification_button_spec.rb
+++ b/spec/components/single_page_notification_button_spec.rb
@@ -25,4 +25,9 @@ describe "Single page notification button", type: :view do
     render_component({ base_path: "/the-current-page", already_subscribed: true })
     assert_select ".gem-c-single-page-notification-button", text: "Stop getting emails about this page"
   end
+
+  it "has data attributes if data_attributes is specified" do
+    render_component({ base_path: "/the-current-page", data_attributes: { action: "kaboom!" } })
+    assert_select ".gem-c-single-page-notification-button[data-action='kaboom!']"
+  end
 end

--- a/spec/components/single_page_notification_button_spec.rb
+++ b/spec/components/single_page_notification_button_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe "Single page notification button", type: :view do
+  def component_name
+    "single_page_notification_button"
+  end
+
+  it "does not render without a base path" do
+    assert_empty render_component({})
+  end
+
+  it "renders with the correct markup if base path is present" do
+    render_component({ base_path: "/the-current-page" })
+    assert_select "form.gem-c-single-page-notification-button"
+    assert_select "input[type='hidden']", value: "/the-current-page"
+    assert_select ".gem-c-single-page-notification-button button.gem-c-single-page-notification-button__submit[type='submit']"
+  end
+
+  it "shows 'Get emails about this page' by default" do
+    render_component({ base_path: "/the-current-page" })
+    assert_select ".gem-c-single-page-notification-button", text: "Get emails about this page"
+  end
+
+  it "shows 'Stop getting emails about this page' if already_subscribed is true" do
+    render_component({ base_path: "/the-current-page", already_subscribed: true })
+    assert_select ".gem-c-single-page-notification-button", text: "Stop getting emails about this page"
+  end
+end


### PR DESCRIPTION
Create the button component for [single page notifications](https://www.figma.com/file/9RzsNFl3iYBXM5QfKO2HkE/Detailed-notifications-%2B-account?node-id=40%3A5830).

The intention is to attach this button to the metadata block component (only the [variation with a link to see all updates](https://components.publishing.service.gov.uk/component-guide/metadata/updated_with_links_to_see_details/preview)) and [published dates](https://government-frontend.herokuapp.com/component-guide/published-dates) component (again, only the variation that has a list of updates).

The button comes with two states:
- the default state (user is either logged out, or is logged in and does not already receive email notifications for the current page)
- the "subscribed" state (user is logged in and has email notifications active for the current page)

<img width="517" alt="Screenshot 2021-11-05 at 15 48 40" src="https://user-images.githubusercontent.com/7116819/140540217-102abca4-5a74-470f-a3ed-a85849851c54.png">

Clicking the button will trigger a POST request which sends the `base_path` (mandatory parameter without which the component will not render) to a `/email/subscriptions/single-page/new` endpoint. This will check the user's authentication status and whether they are already subscribed to the page or not. Depending on these factors, they will be routed accordingly.

-----

The next step for this component is to add JS which will call a `/api/personalisation/check-email-subscription` endpoint on page load. 
There will be a check to determine if the current user is authenticated and has already saved this page; if yes, `account-api` will serve the button HTML (the "subscribed" variation of it) from the `/api/personalisation/check-email-subscription` endpoint. The button will always fall back to the unauthenticated/unsubscribed state, with the other state being shown as an enhancement.

-----

https://trello.com/c/oOpGMmxF