### PR TITLE
Fix global banner wrapper in public layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Create devolved nations component ([PR #2280](https://github.com/alphagov/govuk_publishing_components/pull/2280))
 * Fix document list children ([PR #2296](https://github.com/alphagov/govuk_publishing_components/pull/2296))
 * Reset margins for govspeak images ([PR #2297](https://github.com/alphagov/govuk_publishing_components/pull/2297))
+* Fix global banner wrapper in public layout ([PR #2294](https://github.com/alphagov/govuk_publishing_components/pull/2294))
 
 ## 26.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
@@ -9,6 +9,7 @@
 
 .js-enabled .gem-c-layout-for-public__global-banner-wrapper {
   margin-top: - govuk-spacing(2);
+  min-height: govuk-spacing(2);
   position: relative;
 }
 


### PR DESCRIPTION
## What
Fix global banner wrapper in public layout

## Why
The `global-banner-wrapper` element is rendered whether or not there is an active global banner as it's a slot for other elements such as the survey banner. When there is no content in this container, because of the negative margin-top it pulls the element below (often the back link or the breadcrumbs) higher up than it should be. By setting a `min-height` we make sure no layout alteration happen in this scenario, while it scales up when content is presented within the container.

## Visual Changes

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1045" alt="Screenshot 2021-09-07 at 10 32 36" src="https://user-images.githubusercontent.com/788096/132322869-ae0bbfe2-ec24-43c1-818c-cc9a0182697e.png">


</td><td valign="top">

<img width="1045" alt="Screenshot 2021-09-07 at 10 32 59" src="https://user-images.githubusercontent.com/788096/132322883-37bab2bd-ce8c-4da1-94bd-1e47db8e0d17.png">


</td></tr>
</table>
