### PR TITLE
Fix document list children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Create devolved nations component ([PR #2280](https://github.com/alphagov/govuk_publishing_components/pull/2280))
+* Fix document list children ([PR #2296](https://github.com/alphagov/govuk_publishing_components/pull/2296))
 
 ## 26.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -107,6 +107,8 @@
 
 .gem-c-document-list__children {
   margin-bottom: 0;
+  padding-left: 0;
+  list-style-type: none;
 
   @include govuk-media-query($from: desktop) {
     margin-left: govuk-spacing(4);

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -92,7 +92,7 @@
         <% end %>
 
         <% if item[:parts] && item[:parts].any? %>
-          <ul class="gem-c-document-list__children govuk-list">
+          <ul class="gem-c-document-list__children">
             <% item[:parts].each do |part| %>
               <li class="gem-c-document-list-child">
                 <%=


### PR DESCRIPTION

## What
Remove class composition in favour of attribute declaration on `gem-c-document-list__children` elements.

## Why
Class composition (in this case `gem-c-document-list__children`  with `govuk-list`) means that when we have the same attribute (let's say `margin-top`) the order of precedence is dictated by where these class definitions are presented in the compiled CSS files – known as document order. Document order makes styling flakey as when swapping a component in or out or changing the order of SCSS imports we may end up with different styling. This happened in https://github.com/alphagov/finder-frontend/pull/2616 when switching to the new `gem_layout` where the document-list SCSS import is followed by [error-summary](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/components/_error-summary.scss), which [includes the basic list styles](https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/components/error-summary/_index.scss#L1) making `govuk-list` styles to override definitions in `gem-c-document-list__children`.

## Visual Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="665" alt="Screenshot 2021-09-07 at 12 19 05" src="https://user-images.githubusercontent.com/788096/132336566-d7c61301-1596-418a-b449-bef4581f4286.png">


</td><td valign="top">

<img width="665" alt="Screenshot 2021-09-07 at 12 20 59" src="https://user-images.githubusercontent.com/788096/132336569-b1d7926d-ce71-42a3-ba8c-4ea3153be8c6.png">


</td></tr>
</table>

