### PR TITLE
Reset margins for govspeak images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Create devolved nations component ([PR #2280](https://github.com/alphagov/govuk_publishing_components/pull/2280))
 * Fix document list children ([PR #2296](https://github.com/alphagov/govuk_publishing_components/pull/2296))
+* Reset margins for govspeak images ([PR #2297](https://github.com/alphagov/govuk_publishing_components/pull/2297))
 
 ## 26.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_images.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_images.scss
@@ -17,6 +17,7 @@
     clear: both;
     overflow: hidden;
     padding: govuk-spacing(2) 0 0;
+    margin: 0;
 
     img {
       display: inline;

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -824,3 +824,14 @@ examples:
           <a role="button" class="gem-c-button govuk-button" href="https://gov.uk/random">Button</a>
           <a class="gem-c-button govuk-button govuk-button--start" role="button" href="https://gov.uk/random"> Start button <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path></svg></a>
         </p>
+  image:
+    data:
+      block: |
+        <figure class="image embedded">
+          <div class="img">
+            <img src="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/40160/Picture2.jpg" alt="Open water with only mangrove stumps showing above the water. Credit: Blue Ventures-Garth Cripps">
+          </div>
+          <figcaption>
+            <p>Deforested area. Credit: Blue Ventures-Garth Cripps</p>
+          </figcaption>
+        </figure>


### PR DESCRIPTION
## What
Reset margins for govspeak images

## Why
govspeak images use a `<figure>` element without resetting the margin resulting in a shifted image


## Visual Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="979" alt="Screenshot 2021-09-07 at 17 33 03" src="https://user-images.githubusercontent.com/788096/132380910-18b9a952-8ca5-4bf4-ac40-1d29ec0d4a0d.png">


</td><td valign="top">

<img width="960" alt="Screenshot 2021-09-07 at 17 32 28" src="https://user-images.githubusercontent.com/788096/132380919-1ca6c01a-359f-474a-ad0d-fe5b015910b1.png">


</td></tr>
</table>

