### PR TITLE
Release 27.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.0.0
 
 * **BREAKING:** Rename extra_links to extra_details (image card) ([PR #2300](https://github.com/alphagov/govuk_publishing_components/pull/2300))
 * Create devolved nations component ([PR #2280](https://github.com/alphagov/govuk_publishing_components/pull/2280))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (26.0.0)
+    govuk_publishing_components (27.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "26.0.0".freeze
+  VERSION = "27.0.0".freeze
 end


### PR DESCRIPTION
* **BREAKING:** Rename extra_links to extra_details (image card) ([PR #2300](https://github.com/alphagov/govuk_publishing_components/pull/2300))
* Create devolved nations component ([PR #2280](https://github.com/alphagov/govuk_publishing_components/pull/2280))
* Fix document list children ([PR #2296](https://github.com/alphagov/govuk_publishing_components/pull/2296))
* Reset margins for govspeak images ([PR #2297](https://github.com/alphagov/govuk_publishing_components/pull/2297))
* Fix global banner wrapper in public layout ([PR #2294](https://github.com/alphagov/govuk_publishing_components/pull/2294))