### PR TITLE
Rename "extra links" within image_card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* **BREAKING:** Rename extra_links to extra_details (image card) ([PR #2300](https://github.com/alphagov/govuk_publishing_components/pull/2300))
 * Create devolved nations component ([PR #2280](https://github.com/alphagov/govuk_publishing_components/pull/2280))
 * Fix document list children ([PR #2296](https://github.com/alphagov/govuk_publishing_components/pull/2296))
 * Reset margins for govspeak images ([PR #2297](https://github.com/alphagov/govuk_publishing_components/pull/2297))

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -23,7 +23,7 @@
   extra_link_classes << brand_helper.color_class
 
 %>
-<% if card_helper.href || card_helper.extra_links.any? %>
+<% if card_helper.href || card_helper.extra_details.any? %>
   <div class="<%= classes %> <%= brand_helper.brand_class %>"
     <%= "data-module=gem-track-click" if card_helper.is_tracking? %>
     <%= "lang=#{card_helper.lang}" if card_helper.lang %>>
@@ -44,9 +44,9 @@
         <%= card_helper.context %>
       </div>
       <%= card_helper.description %>
-      <% if card_helper.extra_links.any? %>
-        <ul class="gem-c-image-card__list <%= "gem-c-image-card__list--indented" if not card_helper.extra_links_no_indent %>">
-          <% card_helper.extra_links.each do |link| %>
+      <% if card_helper.extra_details.any? %>
+        <ul class="gem-c-image-card__list <%= "gem-c-image-card__list--indented" if not card_helper.extra_details_no_indent %>">
+          <% card_helper.extra_details.each do |link| %>
             <li class="gem-c-image-card__list-item <%= "gem-c-image-card__list-item--text" if not link[:href].present? %>">
               <% if link[:href].present? %>
                 <%= link_to link[:text], link[:href],

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -66,14 +66,14 @@ examples:
         text: "Press release"
       heading_text: "Government does things"
       description: "Following a thorough review of existing procedure, a government body has today announced that further work is necessary."
-  with_extra_links:
+  with_extra_details:
     data:
       href: "/a-page-no-just-kidding"
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
       image_alt: "some meaningful alt text please"
       heading_text: "Some more links"
       description: "Greater transparency across government is at the heart of our commitment to let you hold politicians and public bodies to account."
-      extra_links: [
+      extra_details: [
         {
           text: "Single departmental plans",
           href: "/1"
@@ -87,7 +87,7 @@ examples:
           href: "/3"
         },
       ]
-  extra_links_without_indent:
+  extra_details_without_indent:
     description: Don't indent the extra links. Used for links to people pages.
     data:
       href: "/government/people/"
@@ -96,21 +96,21 @@ examples:
       context:
         text: "The Rt Hon"
       heading_text: "John Whiskers MP"
-      extra_links: [
+      extra_details: [
         {
           text: "Minister for Cats",
           href: "/government/ministers/"
         }
       ]
-      extra_links_no_indent: true
-  extra_links_with_no_links:
-    description: If `extra_links` are passed to the component without `href` attributes, they are displayed as a simple text list.
+      extra_details_no_indent: true
+  extra_details_with_no_links:
+    description: If `extra_details` are passed to the component without `href` attributes, they are displayed as a simple text list.
     data:
       href: "/government/people/"
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
       image_alt: "some meaningful alt text please"
       heading_text: "John Whiskers MP"
-      extra_links: [
+      extra_details: [
         {
           text: "Conservative 2010 to 2016",
         },
@@ -118,14 +118,14 @@ examples:
           text: "Labour 2007 to 2010",
         }
       ]
-      extra_links_no_indent: true
-  extra_links_with_no_main_link:
+      extra_details_no_indent: true
+  extra_details_with_no_main_link:
     description: If extra links are included, the main link is not needed. Note that in this configuration the image is not a link as no link has been supplied.
     data:
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
       image_alt: "some meaningful alt text please"
       heading_text: "John Whiskers MP"
-      extra_links: [
+      extra_details: [
         {
           text: "Minister for Cats",
           href: "/government/ministers/"
@@ -145,7 +145,7 @@ examples:
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
       image_alt: "some meaningful alt text please"
       description: Here are some links to more information about the thing you are reading about.
-      extra_links: [
+      extra_details: [
         {
           text: "More information",
           href: "/1"
@@ -174,7 +174,7 @@ examples:
       image_alt: "some meaningful alt text please"
       heading_text: "Something relating to this"
       description: "Public reform committee consultation vote department interior minister referendum."
-      extra_links: [
+      extra_details: [
         {
           text: "Something",
           href: "/1"
@@ -210,7 +210,7 @@ examples:
       image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
       image_alt: "some meaningful alt text please"
       heading_text: "A link with tracking"
-      extra_links: [
+      extra_details: [
         {
           text: "Another link with tracking",
           href: "/1",
@@ -235,13 +235,13 @@ examples:
         text: "The Rt Hon"
       heading_text: "John Whiskers MP"
       metadata: "Unpaid"
-      extra_links: [
+      extra_details: [
         {
           text: "Minister for Cats",
           href: "/government/ministers/"
         }
       ]
-      extra_links_no_indent: true
+      extra_details_no_indent: true
   with_lang:
     description: |
       Pass through an appropriate `lang` to set a HTML lang attribute for the component.

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -4,12 +4,12 @@ module GovukPublishingComponents
       include ActionView::Helpers
       include ActionView::Context
 
-      attr_reader :href, :href_data_attributes, :extra_links, :large, :extra_links_no_indent, :heading_text, :metadata, :lang, :image_loading
+      attr_reader :href, :href_data_attributes, :extra_details, :large, :extra_details_no_indent, :heading_text, :metadata, :lang, :image_loading
 
       def initialize(local_assigns)
         @href = local_assigns[:href]
         @href_data_attributes = local_assigns[:href_data_attributes]
-        @extra_links = local_assigns[:extra_links] || []
+        @extra_details = local_assigns[:extra_details] || []
         @image_src = local_assigns[:image_src]
         @image_alt = local_assigns[:image_alt] || ""
         @image_loading = local_assigns[:image_loading] || "auto"
@@ -17,7 +17,7 @@ module GovukPublishingComponents
         @description = local_assigns[:description]
         @large = local_assigns[:large]
         @heading_text = local_assigns[:heading_text]
-        @extra_links_no_indent = local_assigns[:extra_links_no_indent]
+        @extra_details_no_indent = local_assigns[:extra_details_no_indent]
         @metadata = local_assigns[:metadata]
         @lang = local_assigns[:lang]
       end
@@ -25,8 +25,8 @@ module GovukPublishingComponents
       def is_tracking?
         return true if @href_data_attributes
 
-        if @extra_links
-          @extra_links.each do |link|
+        if @extra_details
+          @extra_details.each do |link|
             return true if link[:data_attributes]
           end
         end

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -68,38 +68,38 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card .gem-c-image-card__context span[aria-hidden=true]", text: "—"
   end
 
-  it "renders extra links" do
-    render_component(href: "#", extra_links: [{ href: "/1", text: "link1" }, { href: "/2", text: "link2" }])
+  it "renders extra details" do
+    render_component(href: "#", extra_details: [{ href: "/1", text: "link1" }, { href: "/2", text: "link2" }])
     assert_select ".gem-c-image-card__list .gem-c-image-card__list-item a[href='/1']", text: "link1"
     assert_select ".gem-c-image-card__list .gem-c-image-card__list-item a[href='/2']", text: "link2"
   end
 
-  it "renders extra links without indent" do
-    render_component(href: "#", extra_links: [{ href: "/1", text: "link1" }], extra_links_no_indent: true)
+  it "renders extra details without indent" do
+    render_component(href: "#", extra_details: [{ href: "/1", text: "link1" }], extra_details_no_indent: true)
     assert_select ".gem-c-image-card__list"
     assert_select ".gem-c-image-card__list.gem-c-image-card__list--indented", false
   end
 
-  it "renders extra links without links and just as a text list" do
-    render_component(href: "#", extra_links: [{ text: "text1" }], extra_links_no_indent: true)
+  it "renders extra details without links and just as a text list" do
+    render_component(href: "#", extra_details: [{ text: "text1" }], extra_details_no_indent: true)
     assert_select ".gem-c-image-card__list"
     assert_select ".gem-c-image-card__list-item.gem-c-image-card__list-item--text"
   end
 
-  it "renders extra links without a main link" do
-    render_component(extra_links: [{ href: "/1", text: "link1" }])
+  it "renders extra details without a main link" do
+    render_component(extra_details: [{ href: "/1", text: "link1" }])
     assert_select ".gem-c-image-card__title a", false
   end
 
   it "applies branding" do
-    render_component(href: "#", heading_text: "test", extra_links: [{ href: "/1", text: "link1" }], brand: "attorney-generals-office")
+    render_component(href: "#", heading_text: "test", extra_details: [{ href: "/1", text: "link1" }], brand: "attorney-generals-office")
     assert_select ".gem-c-image-card.brand--attorney-generals-office"
     assert_select ".gem-c-image-card__title-link.brand__color"
     assert_select ".gem-c-image-card__list-item .brand__color"
   end
 
   it "labels a no-image version" do
-    render_component(href: "#", heading_text: "test", extra_links: [{ href: "/1", text: "link1" }], brand: "attorney-generals-office")
+    render_component(href: "#", heading_text: "test", extra_details: [{ href: "/1", text: "link1" }], brand: "attorney-generals-office")
     assert_select ".gem-c-image-card--no-image"
   end
 
@@ -114,8 +114,8 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card__title-link[data-track-category='cat']"
   end
 
-  it "applies tracking attributes for extra links" do
-    render_component(href: "#", extra_links: [{ href: "/", text: "1", data_attributes: { track_category: "cat" } }])
+  it "applies tracking attributes for extra details" do
+    render_component(href: "#", extra_details: [{ href: "/", text: "1", data_attributes: { track_category: "cat" } }])
     assert_select ".gem-c-image-card[data-module='gem-track-click']"
     assert_select ".gem-c-image-card__list-item a[data-track-category='cat']"
   end


### PR DESCRIPTION
## What

Resolves #2295 

## Why

An additional - no link option was added to `extra_links` within [image card](https://components.publishing.service.gov.uk/component-guide/image_card) making it confusing in terms of the naming, consider `extra_links_no_links` this has been updated to `list` so it makes more sense - `extra_list_no_links`

## Visual Changes

None

## Anything else 

Breaking change - impacting `collections` - [linked PR](https://github.com/alphagov/collections/pull/2524)