### PR TITLE
Fix sticky hover on search button in navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-# Unreleased
+## Unreleased
 
 * Add big number component ([PR #2278](https://github.com/alphagov/govuk_publishing_components/pull/2278))
 * Add missing `govuk-template` class to public layout ([PR #2307](https://github.com/alphagov/govuk_publishing_components/pull/2307))
+* Fix sticky hover on search button in navigation header([PR #2304](https://github.com/alphagov/govuk_publishing_components/pull/2304))
 
 ## 27.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -431,6 +431,26 @@ $search-icon-size: 20px;
         content: " ";
       }
     }
+
+    // To avoid the 'sticky hover' problem, we need to stop the hover state on
+    // touch screen devices.
+    //
+    // One solution is to use `@media(hover: hover)`. This turns on the hover
+    // state only for devices that aren't touchscreen, but means that browsers
+    // that don't support this media query won't get a hover state at all.
+    //
+    // To get around this, we do the opposite - we turn off the hover state for
+    // for touchscreen devices.
+    @media (hover: none), (pointer: coarse) {
+      &:not(:focus):hover {
+        background-color: $govuk-link-colour;
+        color: govuk-colour("white");
+
+        &:after {
+          background-color: $govuk-link-colour;
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## What
Fixes the sticky hover state seen on touchscreen devices by unsetting hover states when a touchscreen device is being used.

Card: https://trello.com/c/fZ9bs2G0

## Why
A stick hover state is seen on some touchscreen devices - when a button is selected, the hover state is also triggered. This caused the search button in the navigation header to look hovered when the focus state moved on. Fixing this makes the interface easier to understand, as the states of the buttons are no longer muddled.

## Visual Changes

### Before

<img width="552" alt="Screenshot 2021-09-09 at 14 12 36" src="https://user-images.githubusercontent.com/1732331/132692280-371dccc2-1e4c-4429-aa7f-cd70de79c925.png">

### After

<img width="543" alt="Screenshot 2021-09-09 at 14 10 42" src="https://user-images.githubusercontent.com/1732331/132692303-0d730f13-d8bd-4337-997d-e25aca737026.png">
