### PR TITLE
Define available locales

### DIFF
--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -24,6 +24,72 @@ module Dummy
     # -- all .rb files in that directory are automatically loaded.
     config.i18n.default_locale = :en
     config.i18n.fallbacks = [I18n.default_locale]
+    config.i18n.available_locales = %i[
+      ar
+      az
+      be
+      bg
+      bn
+      cs
+      cy
+      da
+      de
+      dr
+      el
+      en
+      es-419
+      es
+      et
+      fa
+      fi
+      fr
+      gd
+      gu
+      he
+      hi
+      hr
+      hu
+      hy
+      id
+      is
+      it
+      ja
+      ka
+      kk
+      ko
+      lt
+      lv
+      ms
+      mt
+      nl
+      no
+      pa-pk
+      pa
+      pl
+      ps
+      pt
+      ro
+      ru
+      si
+      sk
+      sl
+      so
+      sq
+      sr
+      sv
+      sw
+      ta
+      th
+      tk
+      tr
+      uk
+      ur
+      uz
+      vi
+      zh-hk
+      zh-tw
+      zh
+    ]
 
     # Use current Rails version defaults, this isn't a normal app so we don't
     # need to be delicate about upgrading.


### PR DESCRIPTION
Defines the locales actually in use, in the application. This has been
done as a prerequisite for the Rails Translation Manager changes [1].

[1]: https://github.com/alphagov/rails_translation_manager/pull/12

Trello:
https://trello.com/c/Ma1ygjNc/2567-add-automated-tests-to-check-translations-5

