### PR TITLE
Add missing `govuk-template` class to public layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 # Unreleased
 
 * Add big number component ([PR #2278](https://github.com/alphagov/govuk_publishing_components/pull/2278))
+* Add missing `govuk-template` class to public layout ([PR #2307](https://github.com/alphagov/govuk_publishing_components/pull/2307))
 
 ## 27.0.0
 

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -44,8 +44,8 @@
   body_css_classes << "draft" if draft_watermark
 -%>
 <!DOCTYPE html>
-  <!--[if lt IE 9]><html class="lte-ie8" lang="<%= html_lang %>"><![endif]-->
-  <!--[if gt IE 8]><!--><html lang="<%= html_lang %>"><!--<![endif]-->
+  <!--[if lt IE 9]><html class="lte-ie8 govuk-template" lang="<%= html_lang %>"><![endif]-->
+  <!--[if gt IE 8]><!--><html class="govuk-template" lang="<%= html_lang %>"><!--<![endif]-->
   <head>
     <meta charset="utf-8" />
     <title><%= title %></title>

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -5,6 +5,18 @@ describe "Layout for public", type: :view do
     "layout_for_public"
   end
 
+  it "renders html document with 'en' as default lang" do
+    render_component({})
+
+    assert_select "html.govuk-template[lang=en]"
+  end
+
+  it "renders html document with custom lang" do
+    render_component(html_lang: "cy")
+
+    assert_select "html.govuk-template[lang=cy]"
+  end
+
   it "adds a default <title> tag" do
     render_component({})
 


### PR DESCRIPTION
## What
Add missing [`govuk-template` class](https://design-system.service.gov.uk/styles/page-template/) to public layout. 

## Why
This class set the overall page background colour to the same colour as used by the footer to give the illusion of a long footer, prevents automatic text sizing, as we already cater for small devices and would like the browser to stay on 100% text zoom by default and Force the scrollbar to always display in IE, to prevent horizontal page jumps as content height changes.

## Visual Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1792" alt="Screenshot 2021-09-13 at 11 56 16" src="https://user-images.githubusercontent.com/788096/133071963-48a2e3aa-92af-474c-a62c-f8f017c477e4.png">


</td><td valign="top">

<img width="1792" alt="Screenshot 2021-09-13 at 11 56 01" src="https://user-images.githubusercontent.com/788096/133071967-11fc8d01-059f-4c0a-b38e-6b7b2f6dbf75.png">


</td></tr>
</table>
