### PR TITLE
Release 27.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.2.0
 
 * Add new scroll tracking ([PR #2305](https://github.com/alphagov/govuk_publishing_components/pull/2305))
 * Update crown fallback image ([PR #2313](https://github.com/alphagov/govuk_publishing_components/pull/2313)) PATCH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.1.0)
+    govuk_publishing_components (27.2.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.1.0".freeze
+  VERSION = "27.2.0".freeze
 end


### PR DESCRIPTION
* Add new scroll tracking ([PR #2305](https://github.com/alphagov/govuk_publishing_components/pull/2305))
* Update crown fallback image ([PR #2313](https://github.com/alphagov/govuk_publishing_components/pull/2313)) PATCH
* Remove heading and use strong in step nav header ([PR #2311](https://github.com/alphagov/govuk_publishing_components/pull/2311))