### PR TITLE
Update publishing docs

### DIFF
--- a/docs/publishing-to-rubygems.md
+++ b/docs/publishing-to-rubygems.md
@@ -19,15 +19,13 @@ Before publishing a new version [check the open and approved pull requests](http
 
 4. Update [`lib/govuk_publishing_components/version.rb`](/lib/govuk_publishing_components/version.rb) version with the new version number.
 
-5. Run `bundle install && yarn install` to ensure you have the latest dependencies installed.
-
-6. Commit changes. These should include updates in the following files:
+5. Commit changes. These should include updates in the following files:
   - [`CHANGELOG.md`](/CHANGELOG.md)
   - [`lib/govuk_publishing_components/version.rb`](/lib/govuk_publishing_components/version.rb)
   - [`Gemfile.lock`](/Gemfile.lock)
 
-7. Create a pull request and copy the changelog text for the current version in the pull request description.
+6. Create a pull request and copy the changelog text for the current version in the pull request description.
 
-8. Once the pull request is approved, merge to master. This action will trigger the CI to publish the new version to RubyGems. A [dependabot](https://github.com/dependabot) pull request will automatically be raised in frontend applications.
+7. Once the pull request is approved, merge to master. This action will trigger the CI to publish the new version to RubyGems. A [dependabot](https://github.com/dependabot) pull request will automatically be raised in frontend applications.
 
 See an [example pull request](https://github.com/alphagov/govuk_publishing_components/pull/873/files) for publishing a new version to RubyGems.


### PR DESCRIPTION
## What
Update the guidance for creating a new version of the gem.

## Why
The line I've deleted encouraged readers to upgrade all the packages in the `Gemfile.lock` when versioning the gem, which would introduce potential further changes to that file. If upgraded packages are required, they should be included in the PRs that introduce the change that depends on them, or be handled by dependabot. The only purpose of a PR to version the gem should be to version the gem.

## Visual Changes
None.