### PR TITLE
Allow custom logo link in navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow custom logo link in navigation header ([PR #2320](https://github.com/alphagov/govuk_publishing_components/pull/2320)) MINOR
+
 ## 27.2.0
 
 * Add new scroll tracking ([PR #2305](https://github.com/alphagov/govuk_publishing_components/pull/2305))

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -87,7 +87,9 @@
 
     <% unless omit_header %>
       <% if show_explore_header %>
-        <%= render "govuk_publishing_components/components/layout_super_navigation_header" %>
+        <%= render "govuk_publishing_components/components/layout_super_navigation_header", {
+          logo_link: logo_link,
+        } %>
       <% else %>
         <%= render "govuk_publishing_components/components/layout_header", {
           search: show_search,

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -1,20 +1,19 @@
 <%
-logo_link = "https://www.gov.uk/"
-logo_link_title = t("components.layout_super_navigation_header.logo_link_title")
-logo_text = t("components.layout_super_navigation_header.logo_text")
-navigation_links = t("components.layout_super_navigation_header.navigation_links")
-navigation_menu_heading = t("components.layout_super_navigation_header.navigation_menu_heading")
-navigation_search_heading = t("components.layout_super_navigation_header.navigation_search_heading")
-navigation_search_subheading = t("components.layout_super_navigation_header.navigation_search_subheading")
-popular_links = t("components.layout_super_navigation_header.popular_links")
-popular_links_heading = t("components.layout_super_navigation_header.popular_links_heading")
-search_text = t("components.layout_super_navigation_header.search_text")
+  logo_link ||= "https://www.gov.uk/"
+  logo_link_title ||= t("components.layout_super_navigation_header.logo_link_title")
+  logo_text = t("components.layout_super_navigation_header.logo_text")
+  navigation_links = t("components.layout_super_navigation_header.navigation_links")
+  navigation_menu_heading = t("components.layout_super_navigation_header.navigation_menu_heading")
+  navigation_search_heading = t("components.layout_super_navigation_header.navigation_search_heading")
+  navigation_search_subheading = t("components.layout_super_navigation_header.navigation_search_subheading")
+  popular_links = t("components.layout_super_navigation_header.popular_links")
+  popular_links_heading = t("components.layout_super_navigation_header.popular_links_heading")
+  search_text = t("components.layout_super_navigation_header.search_text")
 
-hide_search_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.hide", :label => "search")
-show_search_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.show", :label => "search")
-hide_navigation_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.hide", :label => "navigation")
-show_navigation_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.show", :label => "navigation")
-
+  hide_search_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.hide", :label => "search")
+  show_search_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.show", :label => "search")
+  hide_navigation_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.hide", :label => "navigation")
+  show_navigation_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.show", :label => "navigation")
 %>
 <header role="banner" class="gem-c-layout-super-navigation-header">
   <div class="gem-c-layout-super-navigation-header__container govuk-width-container govuk-clearfix">

--- a/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
@@ -20,3 +20,8 @@ accessibility_excluded_rules:
   - landmark-no-duplicate-banner # banners will be duplicated in component examples list
 examples:
   default:
+  with_custom_logo_link:
+    description: The header logo links to root by default. This option allows us to override that in certain instances. Remember to change the title, as the default is "Go to the GOV.UK homepage".
+    data:
+      logo_link: "https://www.example.com"
+      logo_link_title: "Go to example"

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -85,4 +85,28 @@ describe "Super navigation header", type: :view do
 
     assert_select ".gem-c-layout-super-navigation-header__search-item", count: 1
   end
+
+  it "has the correct default crown logo link" do
+    render_component({})
+
+    assert_select "a.govuk-header__link--homepage[href='https://www.gov.uk/']", count: 1
+  end
+
+  it "allows a custom crown logo link" do
+    render_component({
+      logo_link: "https://www.example.com/",
+    })
+
+    assert_select "a.govuk-header__link--homepage[href='https://www.example.com/']", count: 1
+  end
+
+  it "allows a custom crown logo link and custom title" do
+    render_component({
+      logo_link: "https://www.example.com/",
+      logo_link_title: "Go to example",
+    })
+
+    assert_select "a.govuk-header__link--homepage[href='https://www.example.com/']", count: 1
+    assert_select "a.govuk-header__link--homepage[title='Go to example']", count: 1
+  end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Adds the `logo_link` parameter to the navigation header.

## Why
<!-- What are the reasons behind this change being made? -->

So the navigation header can have a custom link for the crown logo, which make the behaviour of the other header and will stop it from breaking the smoke tests.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
None.
