### PR TITLE
Correctly translate list of nations in Devolved Nations component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
++ Correctly translate the connector word in the Devolved Nations component ([PR #2326](https://github.com/alphagov/govuk_publishing_components/pull/2326))
+
 ## 27.3.0
 
 * Allow custom logo link in navigation header ([PR #2320](https://github.com/alphagov/govuk_publishing_components/pull/2320)) MINOR

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -43,6 +43,12 @@ ar:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ ar:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ ar:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ ar:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -46,6 +46,7 @@ ar:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -45,8 +45,10 @@ ar:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -43,6 +43,12 @@ az:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ az:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ az:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ az:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -46,6 +46,7 @@ az:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -45,8 +45,10 @@ az:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -45,8 +45,10 @@ be:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -46,6 +46,7 @@ be:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -43,6 +43,12 @@ be:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ be:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ be:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ be:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -43,6 +43,12 @@ bg:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ bg:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ bg:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ bg:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -45,8 +45,10 @@ bg:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -46,6 +46,7 @@ bg:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -43,6 +43,12 @@ bn:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ bn:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ bn:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ bn:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -45,8 +45,10 @@ bn:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -46,6 +46,7 @@ bn:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -45,8 +45,10 @@ cs:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -46,6 +46,7 @@ cs:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -43,6 +43,12 @@ cs:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ cs:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ cs:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ cs:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -43,6 +43,12 @@ cy:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ cy:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ cy:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ cy:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -45,8 +45,10 @@ cy:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -46,6 +46,7 @@ cy:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -46,6 +46,7 @@ da:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -43,6 +43,12 @@ da:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ da:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ da:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ da:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -45,8 +45,10 @@ da:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -46,6 +46,7 @@ de:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -45,8 +45,10 @@ de:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -43,6 +43,12 @@ de:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ de:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ de:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ de:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -45,8 +45,10 @@ dr:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -43,6 +43,12 @@ dr:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ dr:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ dr:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ dr:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -46,6 +46,7 @@ dr:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -46,6 +46,7 @@ el:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -43,6 +43,12 @@ el:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ el:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ el:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ el:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -45,8 +45,10 @@ el:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,8 +48,10 @@ en:
       title: Cookies on GOV.UK
     devolved_nations:
       applies_to: Applies to
+      connectors:
+        last_word: " and "
+        two_words: " and "
       england: England
-      last_word_connector: " and "
       northern_ireland: Northern Ireland
       scotland: Scotland
       wales: Wales

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
     devolved_nations:
       applies_to: Applies to
       england: England
+      last_word_connector: " and "
       northern_ireland: Northern Ireland
       scotland: Scotland
       wales: Wales

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -45,8 +45,10 @@ es-419:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -43,6 +43,12 @@ es-419:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ es-419:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ es-419:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ es-419:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -46,6 +46,7 @@ es-419:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -43,6 +43,12 @@ es:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ es:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ es:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ es:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -45,8 +45,10 @@ es:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -46,6 +46,7 @@ es:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -43,6 +43,12 @@ et:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ et:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ et:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ et:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -46,6 +46,7 @@ et:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -45,8 +45,10 @@ et:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -46,6 +46,7 @@ fa:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -45,8 +45,10 @@ fa:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -43,6 +43,12 @@ fa:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ fa:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ fa:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ fa:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -46,6 +46,7 @@ fi:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -45,8 +45,10 @@ fi:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -43,6 +43,12 @@ fi:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ fi:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ fi:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ fi:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -46,6 +46,7 @@ fr:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -45,8 +45,10 @@ fr:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -43,6 +43,12 @@ fr:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ fr:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ fr:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ fr:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -46,6 +46,7 @@ gd:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -43,6 +43,12 @@ gd:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ gd:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ gd:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ gd:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -45,8 +45,10 @@ gd:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -43,6 +43,12 @@ gu:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ gu:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ gu:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ gu:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -46,6 +46,7 @@ gu:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -45,8 +45,10 @@ gu:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -46,6 +46,7 @@ he:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -43,6 +43,12 @@ he:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ he:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ he:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ he:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -45,8 +45,10 @@ he:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -45,8 +45,10 @@ hi:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -46,6 +46,7 @@ hi:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -43,6 +43,12 @@ hi:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ hi:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ hi:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ hi:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -45,8 +45,10 @@ hr:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -46,6 +46,7 @@ hr:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -43,6 +43,12 @@ hr:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ hr:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ hr:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ hr:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -45,8 +45,10 @@ hu:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -43,6 +43,12 @@ hu:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ hu:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ hu:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ hu:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -46,6 +46,7 @@ hu:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -46,6 +46,7 @@ hy:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -43,6 +43,12 @@ hy:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ hy:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ hy:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ hy:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -45,8 +45,10 @@ hy:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -46,6 +46,7 @@ id:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -45,8 +45,10 @@ id:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -43,6 +43,12 @@ id:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ id:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ id:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ id:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -46,6 +46,7 @@ is:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -45,8 +45,10 @@ is:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -43,6 +43,12 @@ is:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ is:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ is:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ is:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -45,8 +45,10 @@ it:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -46,6 +46,7 @@ it:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -43,6 +43,12 @@ it:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ it:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ it:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ it:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -46,6 +46,7 @@ ja:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -43,6 +43,12 @@ ja:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ ja:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ ja:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ ja:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -45,8 +45,10 @@ ja:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -46,6 +46,7 @@ ka:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -43,6 +43,12 @@ ka:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ ka:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ ka:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ ka:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -45,8 +45,10 @@ ka:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -43,6 +43,12 @@ kk:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ kk:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ kk:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ kk:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -45,8 +45,10 @@ kk:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -46,6 +46,7 @@ kk:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -46,6 +46,7 @@ ko:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -45,8 +45,10 @@ ko:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -43,6 +43,12 @@ ko:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ ko:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ ko:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ ko:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -46,6 +46,7 @@ lt:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -45,8 +45,10 @@ lt:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -43,6 +43,12 @@ lt:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ lt:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ lt:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ lt:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -45,8 +45,10 @@ lv:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -46,6 +46,7 @@ lv:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -43,6 +43,12 @@ lv:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ lv:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ lv:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ lv:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -46,6 +46,7 @@ ms:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -45,8 +45,10 @@ ms:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -43,6 +43,12 @@ ms:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ ms:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ ms:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ ms:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -43,6 +43,12 @@ mt:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ mt:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ mt:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ mt:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -45,8 +45,10 @@ mt:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -46,6 +46,7 @@ mt:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -46,6 +46,7 @@ nl:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -43,6 +43,12 @@ nl:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ nl:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ nl:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ nl:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -45,8 +45,10 @@ nl:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -43,6 +43,12 @@
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -45,8 +45,10 @@
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -46,6 +46,7 @@
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -43,6 +43,12 @@ pa-pk:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ pa-pk:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ pa-pk:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ pa-pk:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -45,8 +45,10 @@ pa-pk:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -46,6 +46,7 @@ pa-pk:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -45,8 +45,10 @@ pa:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -43,6 +43,12 @@ pa:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ pa:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ pa:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ pa:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -46,6 +46,7 @@ pa:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -43,6 +43,12 @@ pl:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ pl:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ pl:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ pl:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -45,8 +45,10 @@ pl:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -46,6 +46,7 @@ pl:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -43,6 +43,12 @@ ps:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ ps:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ ps:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ ps:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -46,6 +46,7 @@ ps:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -45,8 +45,10 @@ ps:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -43,6 +43,12 @@ pt:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ pt:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ pt:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ pt:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -46,6 +46,7 @@ pt:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -45,8 +45,10 @@ pt:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -46,6 +46,7 @@ ro:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -43,6 +43,12 @@ ro:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ ro:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ ro:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ ro:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -45,8 +45,10 @@ ro:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -45,8 +45,10 @@ ru:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -43,6 +43,12 @@ ru:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ ru:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ ru:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ ru:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -46,6 +46,7 @@ ru:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -46,6 +46,7 @@ si:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -45,8 +45,10 @@ si:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -43,6 +43,12 @@ si:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ si:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ si:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ si:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -46,6 +46,7 @@ sk:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -43,6 +43,12 @@ sk:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ sk:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ sk:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ sk:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -45,8 +45,10 @@ sk:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -46,6 +46,7 @@ sl:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -45,8 +45,10 @@ sl:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -43,6 +43,12 @@ sl:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ sl:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ sl:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ sl:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -45,8 +45,10 @@ so:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -43,6 +43,12 @@ so:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ so:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ so:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ so:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -46,6 +46,7 @@ so:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -45,8 +45,10 @@ sq:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -46,6 +46,7 @@ sq:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -43,6 +43,12 @@ sq:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ sq:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ sq:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ sq:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -46,6 +46,7 @@ sr:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -45,8 +45,10 @@ sr:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -43,6 +43,12 @@ sr:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ sr:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ sr:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ sr:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -46,6 +46,7 @@ sv:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -43,6 +43,12 @@ sv:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ sv:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ sv:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ sv:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -45,8 +45,10 @@ sv:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -46,6 +46,7 @@ sw:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -43,6 +43,12 @@ sw:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ sw:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ sw:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ sw:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -45,8 +45,10 @@ sw:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -43,6 +43,12 @@ ta:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ ta:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ ta:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ ta:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -46,6 +46,7 @@ ta:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -45,8 +45,10 @@ ta:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -43,6 +43,12 @@ th:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ th:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ th:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ th:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -46,6 +46,7 @@ th:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -45,8 +45,10 @@ th:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -45,8 +45,10 @@ tk:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -46,6 +46,7 @@ tk:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -43,6 +43,12 @@ tk:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ tk:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ tk:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ tk:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -45,8 +45,10 @@ tr:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -46,6 +46,7 @@ tr:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -43,6 +43,12 @@ tr:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ tr:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ tr:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ tr:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -43,6 +43,12 @@ uk:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ uk:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ uk:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ uk:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -46,6 +46,7 @@ uk:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -45,8 +45,10 @@ uk:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -43,6 +43,12 @@ ur:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ ur:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ ur:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ ur:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -45,8 +45,10 @@ ur:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -46,6 +46,7 @@ ur:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -46,6 +46,7 @@ uz:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -43,6 +43,12 @@ uz:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ uz:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ uz:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ uz:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -45,8 +45,10 @@ uz:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -43,6 +43,12 @@ vi:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ vi:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ vi:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ vi:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -45,8 +45,10 @@ vi:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -46,6 +46,7 @@ vi:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -43,6 +43,12 @@ zh-hk:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ zh-hk:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ zh-hk:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ zh-hk:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -45,8 +45,10 @@ zh-hk:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -46,6 +46,7 @@ zh-hk:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -43,6 +43,12 @@ zh-tw:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ zh-tw:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ zh-tw:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ zh-tw:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -45,8 +45,10 @@ zh-tw:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -46,6 +46,7 @@ zh-tw:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -43,6 +43,12 @@ zh:
       hide:
       text:
       title:
+    devolved_nations:
+      applies_to:
+      england:
+      northern_ireland:
+      scotland:
+      wales:
     feedback:
       close:
       dont_include_personal_info:
@@ -69,10 +75,36 @@ zh:
       news_and_communications:
       statistics:
       worldwide:
+    intervention:
+      description:
+      dismiss_link_text:
+      dismiss_post_link:
+      title:
     layout_footer:
       copyright_html:
       licence_html:
       support_links:
+    layout_for_public:
+      account_layout:
+        feedback:
+          banners:
+            footer_intro:
+            footer_link:
+            footer_outro:
+            phase_intro:
+            phase_link:
+            phase_outro:
+            title:
+        navigation:
+          destroy_user_session:
+          menu_bar:
+            account:
+              link_text:
+            manage:
+              link_text:
+            security:
+              link_text:
+          user_root_path:
     layout_header:
       hide_button:
       menu:
@@ -82,6 +114,9 @@ zh:
     layout_super_navigation_header:
       logo_link_title:
       logo_text:
+      menu_toggle_label:
+        hide:
+        show:
       navigation_links:
       navigation_menu_heading:
       navigation_search_heading:
@@ -100,6 +135,8 @@ zh:
       toggle_more:
     modal_dialogue:
       close_modal:
+    notice:
+      banner_title:
     organisation_schema:
       all_content_search_description:
     previous_and_next_navigation:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -46,6 +46,7 @@ zh:
     devolved_nations:
       applies_to:
       england:
+      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -45,8 +45,10 @@ zh:
       title:
     devolved_nations:
       applies_to:
+      connectors:
+        last_word:
+        two_words:
       england:
-      last_word_connector:
       northern_ireland:
       scotland:
       wales:

--- a/lib/govuk_publishing_components/presenters/devolved_nations_helper.rb
+++ b/lib/govuk_publishing_components/presenters/devolved_nations_helper.rb
@@ -12,7 +12,7 @@ module GovukPublishingComponents
           .select { |_, v| v[:applicable] == true }
           .map { |k, _| I18n.t("components.devolved_nations.#{k}") }
           .sort
-          .to_sentence(last_word_connector: " and ")
+          .to_sentence(last_word_connector: I18n.t("components.devolved_nations.last_word_connector"))
       end
 
       def nations_with_urls

--- a/lib/govuk_publishing_components/presenters/devolved_nations_helper.rb
+++ b/lib/govuk_publishing_components/presenters/devolved_nations_helper.rb
@@ -12,7 +12,10 @@ module GovukPublishingComponents
           .select { |_, v| v[:applicable] == true }
           .map { |k, _| I18n.t("components.devolved_nations.#{k}") }
           .sort
-          .to_sentence(last_word_connector: I18n.t("components.devolved_nations.last_word_connector"))
+          .to_sentence(
+            two_words_connector: I18n.t("components.devolved_nations.connectors.two_words"),
+            last_word_connector: I18n.t("components.devolved_nations.connectors.last_word"),
+          )
       end
 
       def nations_with_urls


### PR DESCRIPTION
## What
Allows the connector word in the Devolved Nations component to be correctly translated.

## Why
At the moment, we are always using the English word `and` to join lists of three or more nations, but using the language default for two items.

Where there isn't a translation for `Applies to` or the nation names (e.g. in Welsh), we fallback to English for all the string, except the word `and` for two item lists, e.g. `Applies to England a Wales` (where `a` is the Welsh word for `and`).

Following this work, the fallback string will all be in English, i.e. `Applies to England and Wales` and we will be able to have the entire string translated in the future.

## Visual Changes
For Welsh content applicable to two nations, from:

```
Applies to England a Wales
```

to

```
Applies to England and Wales
```

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4723387)