### PR TITLE
Version 27.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.4.0
 
 * Add blue arrow option to action link ([PR #2330](https://github.com/alphagov/govuk_publishing_components/pull/2330))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.3.1)
+    govuk_publishing_components (27.4.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.3.1".freeze
+  VERSION = "27.4.0".freeze
 end


### PR DESCRIPTION
## 27.4.0

* Add blue arrow option to action link ([PR #2330](https://github.com/alphagov/govuk_publishing_components/pull/2330))
