### PR TITLE
Raise argument error on image card component

### DIFF
--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -14,14 +14,13 @@
   heading_link_classes = %w[
     gem-c-image-card__title-link
     govuk-link
-  ] 
+  ]
   heading_link_classes << brand_helper.color_class
   extra_link_classes = %w[
     gem-c-image-card__list-item-link
     govuk-link
   ]
   extra_link_classes << brand_helper.color_class
-
 %>
 <% if card_helper.href || card_helper.extra_details.any? %>
   <div class="<%= classes %> <%= brand_helper.brand_class %>"
@@ -55,8 +54,8 @@
                 %>
               <% else %>
                 <%= link[:text] %>
-              <% end %>  
-            </li>    
+              <% end %>
+            </li>
           <% end %>
         </ul>
       <% end %>
@@ -66,4 +65,6 @@
     </div>
     <%= card_helper.image %>
   </div>
+<% else %>
+  <% raise ArgumentError, "The image_card component needs an `href` or `extra_details` in order to render." %>
 <% end %>

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -5,8 +5,10 @@ describe "ImageCard", type: :view do
     "image_card"
   end
 
-  it "renders nothing when no link provided" do
-    assert_empty render_component({})
+  it "fails to render when no link or extra details are given" do
+    assert_raises do
+      render_component({})
+    end
   end
 
   it "shows an image" do


### PR DESCRIPTION
## What
Raise argument error on `image_card` component if no `href` or `extra_details` are provided.

## Why
To prevent this component from silently failing to render.

This is a recommended action following an [incident review](https://docs.google.com/document/d/1DBC7gAhHoNThVqpPxl9DnpCTEfrABthdcSVC0s6RiEw/edit#). There is a wider conversation to have about extending this rule to all components in the library and documenting it.

## Visual Changes
No visual changes
