### PR TITLE
Accept cookie consent from Digital Identity query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Increase size of action link blue arrow ([PR #2343](https://github.com/alphagov/govuk_publishing_components/pull/2343))
 * Remove scroll tracking on pages ([PR #2339](https://github.com/alphagov/govuk_publishing_components/pull/2339))
+* Accept cookie consent from Digital Identity query parameter ([PR #2340](https://github.com/alphagov/govuk_publishing_components/pull/2340))
 
 ## 27.4.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/init.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/init.js
@@ -8,6 +8,25 @@ var analyticsInit = function () {
     var linkedDomains = window.GOVUK.analyticsVars.linkedDomains || false
   }
 
+  window.GOVUK.Analytics.checkDigitalIdentityConsent = function (location) {
+    if (!location || !location.search) return
+    // this checks for the presence of the Digital Identity cookie consent query parameter and updates our consent cookie accordingly
+    // This is so that users don't see multiple cookie banners when they move between the different account management pages, as some will be on GOV.UK and others will be on the DI domain.
+    var digitalIdentityConsent = /([?&]cookie_consent=)(accept|reject)/.exec(location.search)
+    if (digitalIdentityConsent) {
+      if (digitalIdentityConsent[2] === 'accept') {
+        window.GOVUK.setConsentCookie({ usage: true })
+        // set cookies_preferences_set to true to prevent cookie banner showing
+        window.GOVUK.cookie('cookies_preferences_set', 'true')
+      } else if (digitalIdentityConsent[2] === 'reject') {
+        window.GOVUK.setConsentCookie({ usage: false })
+        window.GOVUK.cookie('cookies_preferences_set', 'true')
+      }
+    }
+  }
+
+  window.GOVUK.Analytics.checkDigitalIdentityConsent(window.location)
+
   var consentCookie = window.GOVUK.getConsentCookie()
   var dummyAnalytics = {
     addLinkedTrackerDomain: function () {},

--- a/spec/javascripts/govuk_publishing_components/analytics/analytics.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/analytics.spec.js
@@ -43,6 +43,32 @@ describe('GOVUK.Analytics', function () {
       expect(universalSetupArguments[1]).toEqual(['set', 'anonymizeIp', true])
       expect(universalSetupArguments[2]).toEqual(['set', 'allowAdFeatures', false])
     })
+
+    it('sets usage consent cookie to false when cookie_consent query string parameter has a value of "reject"', function () {
+      var location = {
+        protocol: 'https:',
+        hostname: 'site.example.com',
+        href: 'https://site.example.com/a/path?cookie_consent=reject',
+        search: '?cookie_consent=reject',
+        origin: 'https://site.example.com'
+      }
+      GOVUK.Analytics.checkDigitalIdentityConsent(location)
+      expect(GOVUK.getCookie('cookies_preferences_set')).toBe('true')
+      expect(GOVUK.getConsentCookie().usage).toBe(false)
+    })
+
+    it('sets usage consent cookie to true when cookie_consent query string parameter has a value of "accept"', function () {
+      var location = {
+        protocol: 'https:',
+        hostname: 'site.example.com',
+        href: 'https://site.example.com/a/path?cookie_consent=accept',
+        search: '?cookie_consent=accept',
+        origin: 'https://site.example.com'
+      }
+      GOVUK.Analytics.checkDigitalIdentityConsent(location)
+      expect(GOVUK.getCookie('cookies_preferences_set')).toBe('true')
+      expect(GOVUK.getConsentCookie().usage).toBe(true)
+    })
   })
 
   describe('extracting the default path for a page view', function () {


### PR DESCRIPTION
## What
Check for the presence of the Digital Identity cookie consent query
parameter and update our consent accordingly.

The parameter is called `cookie_consent`, and takes one of three
values:

- `accept`: the user has consented to usage cookies on the other
domain, so we should persist the consent on this domain.

- `reject`: the user has rejected usage cookies on the other domain,
so we should persist the consent on this domain.

- `not-engaged`: the user has not engaged with the cookie banner (or
some other consent mechanism) on the other domain, so we should not
change things on this domain.

In practice we can ignore any value other than `accept` or `reject`,
as those are the only two which trigger a change.

## Why
We're agreed with Digital Identity (DI) that we'll pass cookie consent
between our two domains with query parameters on links and redirects.
This is so that users don't see multiple banners when they move
between the different account management pages, as some will be on
GOV.UK and others will be on the DI domain.

The Privacy team have approved sharing of consents.

## Visual Changes
None

---

[Trello card](https://trello.com/c/FaSZn9xh/1044-accept-cookie-consent-flag-from-di)
