### PR TITLE
Make action link blue icon smaller on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Make action link blue arrow smaller on mobile ([PR #2353](https://github.com/alphagov/govuk_publishing_components/pull/2353))
 * Remove unneeded scroll tracking ([PR #2354](https://github.com/alphagov/govuk_publishing_components/pull/2354))
 
 ## 27.7.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -94,13 +94,19 @@
 
 .gem-c-action-link--blue-arrow {
   &:before {
-    width: 45px;
-    height: 35px;
+    width: 36px;
+    height: 28px;
     background: image-url("govuk_publishing_components/action-link-arrow--blue.png");
     background: image-url("govuk_publishing_components/action-link-arrow--blue.svg"), linear-gradient(transparent, transparent);
     background-repeat: no-repeat;
-    background-size: 35px auto;
+    background-size: 28px auto;
     background-position: 0 0;
+
+    @include govuk-media-query($from: tablet) {
+      width: 45px;
+      height: 35px;
+      background-size: 35px auto;
+    }
   }
 }
 


### PR DESCRIPTION
## What
Make the action link blue arrow option icon smaller - should be around 80% smaller on mobile than desktop. Originally there was no size difference.

## Why
To fit with design.

## Visual Changes

Before and after

![blue_arrow_example](https://user-images.githubusercontent.com/861310/137160301-d3541861-3bbe-4dbb-a06f-6c7c57ce6a29.png)

Desktop, top (unchanged)
Mobile, bottom (now smaller)

Trello card: https://trello.com/c/IdVDZamX/41-adapt-landing-page-desktop-layout-to-show-h2s-in-the-left-hand-column