### PR TITLE
Update CSS for input component (`with_search_icon` variation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Make action link blue arrow smaller on mobile ([PR #2353](https://github.com/alphagov/govuk_publishing_components/pull/2353))
 * Remove unneeded scroll tracking ([PR #2354](https://github.com/alphagov/govuk_publishing_components/pull/2354))
+* Update CSS for input component (`with_search_icon` variation) ([PR #2355](https://github.com/alphagov/govuk_publishing_components/pull/2355))
 
 ## 27.7.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_input.scss
@@ -1,8 +1,18 @@
 @import "govuk/components/input/input";
+$search-icon-size: 40px;
 
-.gem-c-input--search-icon {
-  background: govuk-colour("white") url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='currentColor'%3E%3C/path%3E%3C/svg%3E") no-repeat -5px -3px;
-  padding-left: govuk-spacing(6);
+.gem-c-input__search-icon {
+  display: block;
+  position: relative;
+  margin-bottom: -$search-icon-size;
+  z-index: 1;
+  width: $search-icon-size;
+  height: $search-icon-size;
+  @if $govuk-typography-use-rem {
+    margin-bottom: -(govuk-px-to-rem($search-icon-size));
+    height: govuk-px-to-rem($search-icon-size);
+  }
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='currentColor'%3E%3C/path%3E%3C/svg%3E") no-repeat -3px center;
 }
 
 // this overrides styles from static that break the look of the component
@@ -14,7 +24,7 @@
   padding: govuk-spacing(1);
   box-sizing: border-box;
 
-  &.gem-c-input--search-icon {
+  &.gem-c-input--with-search-icon {
     padding-left: govuk-spacing(6);
   }
 }

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -31,7 +31,7 @@
   css_classes = %w(gem-c-input govuk-input)
   css_classes << "govuk-input--error" if has_error
   css_classes << "govuk-input--width-#{width}" if [2, 3, 4, 5, 10, 20, 30].include?(width)
-  css_classes << "gem-c-input--search-icon" if search_icon
+  css_classes << "gem-c-input--with-search-icon" if search_icon
   form_group_css_classes = %w(govuk-form-group)
   form_group_css_classes << "govuk-form-group--error" if has_error && !grouped
 
@@ -120,6 +120,7 @@
       <%= input_tag %><%= tag.span suffix, class: "govuk-input__suffix", aria: { hidden: true } %>
     <% end %>
   <% else %>
+    <%= tag.span class: "gem-c-input__search-icon" if search_icon %>
     <%= input_tag %>
   <% end %>
 <% end %>

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -254,4 +254,14 @@ describe "Input", type: :view do
     assert_select ".govuk-input__wrapper .gem-c-input[name=lead-times]"
     assert_select ".govuk-input__wrapper .govuk-input__suffix[aria-hidden=true]", text: "days"
   end
+
+  it "renders input with search icon" do
+    render_component(
+      label: { text: "Search the internet" },
+      name: "search-box",
+      search_icon: true,
+    )
+    assert_select ".gem-c-input--with-search-icon"
+    assert_select ".gem-c-input__search-icon"
+  end
 end


### PR DESCRIPTION
There is an issue with the [search icon](https://components.publishing.service.gov.uk/component-guide/input/with_search_icon/preview) variant of the input component,
where Chrome user agent for "autofill selected" (when a user selects one
of the autofill options suggested by Chrome) makes the search icon
disappear.


https://user-images.githubusercontent.com/7116819/137169134-66419c3a-42f1-4529-9210-9de5592dc92d.mov



This is happening because the search icon is applied using the
`background` property in CSS, which is being overruled by CSS from the
user agent stylesheet.

After fruitless attempts to override the browser's autofill styling, I
landed on the current solution which is applying the search icon as a
separate element before the input field, rather than as a `background`
image directly on the input.

Closes #2345 

Also fixes an issue where the search icon doesn't align well with the input on an increased magnification level ([screenshot](https://user-images.githubusercontent.com/861310/137282299-b1d006bd-5735-43aa-9941-46e373cf12b6.png)). 

## Visual changes

This update should not result in any visual change to the component (except, of course, that the magnifying glass icon won't disappear on autofill selection anymore)