### PR TITLE
Fix focus state and update API for the big number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Make action link blue arrow smaller on mobile ([PR #2353](https://github.com/alphagov/govuk_publishing_components/pull/2353))
 * Remove unneeded scroll tracking ([PR #2354](https://github.com/alphagov/govuk_publishing_components/pull/2354))
 * Update CSS for input component (`with_search_icon` variation) ([PR #2355](https://github.com/alphagov/govuk_publishing_components/pull/2355))
+* Fix focus state and update API for the big number ([PR #2359](https://github.com/alphagov/govuk_publishing_components/pull/2359))
 
 ## 27.7.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
@@ -38,4 +38,12 @@
       @include govuk-link-hover-decoration;
     }
   }
+
+  &:focus,
+  &:focus:hover {
+    .gem-c-big-number__label,
+    .gem-c-big-number__value--decorated {
+      text-decoration: none;
+    }
+  }
 }

--- a/app/views/govuk_publishing_components/components/_big_number.html.erb
+++ b/app/views/govuk_publishing_components/components/_big_number.html.erb
@@ -4,6 +4,7 @@
   label ||= nil
   href ||= nil
   data_attributes ||= nil
+  aria ||= nil
   classes = ["gem-c-big-number__value"]
   
   if label.nil? && href
@@ -25,7 +26,7 @@
     <% end %>
   <% end %>
   
-  <%= tag.div class: "gem-c-big-number" do %>
+  <%= tag.div class: "gem-c-big-number", aria: aria do %>
     <% unless href.nil? %>
       <%= link_to big_number_value, href, class: "govuk-link gem-c-big-number__link", data: data_attributes %>
     <% else %>

--- a/app/views/govuk_publishing_components/components/docs/big_number.yml
+++ b/app/views/govuk_publishing_components/components/docs/big_number.yml
@@ -54,3 +54,10 @@ examples:
       label: Ministerial departments
       data_attributes:
         department-count: true
+  with_aria_attributes:
+    description: Aria attributes are applied to the whole component instance
+    data:
+      number: 23
+      label: Ministerial departments
+      aria:
+        hidden: true

--- a/spec/components/big_number_spec.rb
+++ b/spec/components/big_number_spec.rb
@@ -56,6 +56,20 @@ describe "Big number", type: :view do
     assert_select ".gem-c-big-number__link[data-my-cool-attribute='cool']"
   end
 
+  it "adds aria attributes to the big number if that attribute is present" do
+    render_component({
+      number: 500,
+      href: "/tests",
+      aria: {
+        hidden: true,
+        live: "polite",
+      },
+    })
+
+    assert_select ".gem-c-big-number[aria-hidden='true']"
+    assert_select ".gem-c-big-number[aria-live='polite']"
+  end
+
   it "adds data attributes to the span containing the number value if a href attribute is not present" do
     render_component({
       number: 500,


### PR DESCRIPTION
## What
Makes 2 quick changes to the [big number component](https://components.publishing.service.gov.uk/component-guide/big_number):

1. Amends the focus state so that there aren't any underlines on hover for big numbers that are links.
2. Adds the option to pass aria attributes to the big number

## Why
One for general component health, the other to meet a need on the departments page of GOV.UK (see https://github.com/alphagov/collections/pull/2545)

## Visual Changes (for the focus hover update only)
| Before | After |
| --- | --- |
| ![Screenshot 2021-10-14 at 15 41 43](https://user-images.githubusercontent.com/64783893/137340441-19533698-c1fb-4388-bf43-f2a7bad1177a.png) | ![Screenshot 2021-10-14 at 15 41 22](https://user-images.githubusercontent.com/64783893/137340483-ea8fea79-22fc-4a2d-b03a-e1ad5f4583e2.png) | 