### PR TITLE
Tidy up title documentation

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/title.yml
+++ b/app/views/govuk_publishing_components/components/docs/title.yml
@@ -62,17 +62,6 @@ examples:
       margin_bottom: 0
     context:
       dark_background: true
-  in_html_publication_with_context_link:
-    description: Page titles are used in HTML Publications ([see example](https://www.gov.uk/government/publications/fees-for-civil-and-family-courts/court-fees-for-the-high-court-county-court-and-family-court))
-    data:
-      context:
-        text: Publication
-        href: '/link'
-      title: HTML publication page title
-      inverse: true
-      margin_bottom: 0
-    context:
-      dark_background: true
   using_design_system_template:
     description: |
       This option allows the removal of top margin from the component so that it works within a [Design System page template](https://design-system.service.gov.uk/styles/page-template/default/index.html), where spacing above the title is already provided by padding on the wrapping div.


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Removes the example "In HTML publication with context link" for the title component. No changelog needed, as this is a purely internal change.

## Why
<!-- What are the reasons behind this change being made? -->

This example is no longer supported -  the ability to have linked context was removed in v25.0.0, specifically in #2192.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
Before:
![image](https://user-images.githubusercontent.com/1732331/137353716-ceeb851f-7d77-42f6-85be-570712b020c7.png)

After - it's gone...