### PR TITLE
Raise deprecation warnings on unused components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Raise deprecation warnings on unused components: `admin_analytics`, `government_navigation`, `highlight_boxes` and `taxonomy_list` ([PR #2362](https://github.com/alphagov/govuk_publishing_components/pull/2362))
 * Adjust cookie_consent parameter conditions ([PR #2399](https://github.com/alphagov/govuk_publishing_components/pull/2399))
 
 ## 27.10.1

--- a/app/views/govuk_publishing_components/components/_admin_analytics.html.erb
+++ b/app/views/govuk_publishing_components/components/_admin_analytics.html.erb
@@ -1,4 +1,7 @@
-<% user_organisation ||= nil %>
+<%
+  warn('DEPRECATION WARNING: admin_analytics component is deprecated and will be removed in a future major release of govuk_publishing_components')
+  user_organisation ||= nil
+%>
 
 <script class="analytics">
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/app/views/govuk_publishing_components/components/_government_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_government_navigation.html.erb
@@ -1,4 +1,5 @@
 <%
+  warn('DEPRECATION WARNING: government_navigation component is deprecated and will be removed in a future major release of govuk_publishing_components')
   active ||= nil
 %>
 

--- a/app/views/govuk_publishing_components/components/_highlight_boxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_highlight_boxes.html.erb
@@ -1,4 +1,5 @@
 <%
+  warn('DEPRECATION WARNING: highlight_boxes component is deprecated and will be removed in a future major release of govuk_publishing_components')
   items ||= []
   inverse ||= false
   half_width ||= false

--- a/app/views/govuk_publishing_components/components/_taxonomy_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_taxonomy_list.html.erb
@@ -1,4 +1,5 @@
 <%
+  warn('DEPRECATION WARNING: taxonomy_list component is deprecated and will be removed in a future major release of govuk_publishing_components')
   highlight_box ||= false
   document_list ||= false
   image_cards ||= false


### PR DESCRIPTION
## What
Raise deprecation warnings on unused components that we plan to retire in 28.0.0

I've been pondering whether or not to raise these using `ActiveSupport`, but thinking that we use `govuk_publishing_components` outside the Rails realm (e.g. developer docs using Middleman) I'm getting skeptical about it. 
Happy to hear suggestions for a more effective approach.

## Why
We plan to retire a few components that are not being used and we don't plan to use them in the near future.

## Visual Changes
No visual changes
