### PR TITLE
Add margin bottom helper to list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove Coronavirus priority taxons ([PR #2357](https://github.com/alphagov/govuk_publishing_components/pull/2357))
+* Add `margin_bottom` spacing to list component ([PR #2363](https://github.com/alphagov/govuk_publishing_components/pull/2363))
 * Fix auditing bug and add documentation ([PR #2351](https://github.com/alphagov/govuk_publishing_components/pull/2351))
 * Make action link blue arrow smaller on mobile ([PR #2353](https://github.com/alphagov/govuk_publishing_components/pull/2353))
 * Remove unneeded scroll tracking ([PR #2354](https://github.com/alphagov/govuk_publishing_components/pull/2354))

--- a/app/views/govuk_publishing_components/components/_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_list.html.erb
@@ -6,10 +6,15 @@
   list_type ||= "unordered"
   visible_counters ||= nil
 
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+
   classes = %w[gem-c-list govuk-list]
-  classes << "govuk-list--bullet" if visible_counters && list_type === "unordered"
-  classes << "govuk-list--number" if visible_counters && list_type === "number"
+  classes << "govuk-list--bullet" if visible_counters and list_type === "unordered"
+  classes << "govuk-list--number" if visible_counters and list_type === "number"
   classes << "govuk-list--spaced" if extra_spacing
+  # Setting the  `margin_bottom` to 4 is the same as the default margin - so we
+  # can omit the override class. To do this we leave out `4` from the array:
+  classes << (shared_helper.get_margin_bottom) if [0,1,2,3,5,6,7,8,9].include?(local_assigns[:margin_bottom])
 
   # Default list type is unordered list.
   list_tag = "ul"

--- a/app/views/govuk_publishing_components/components/docs/list.yml
+++ b/app/views/govuk_publishing_components/components/docs/list.yml
@@ -62,3 +62,11 @@ examples:
     data:
       id: 'super-fantastic-chocolate-list'
       <<: *default-example-data
+  with_margin:
+    description: |
+      Sets the margin on the bottom of the list element.
+
+      The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a 20px margin.
+    data:
+      margin_bottom: 9
+      <<: *default-example-data

--- a/spec/components/list_spec.rb
+++ b/spec/components/list_spec.rb
@@ -118,4 +118,47 @@ describe "List", type: :view do
     assert_select "ul.govuk-list li a[data-track-action='action']"
     assert_select "ul.govuk-list li a[data-track-label='Test item']"
   end
+
+  it "adds margin" do
+    render_component(
+      margin_bottom: 7,
+      items: [
+        "<a href='https://example.com/'>Test item</a>",
+        "<a href='https://example.com/'>Another test item</a>",
+      ],
+    )
+    assert_select '.gem-c-list.govuk-\!-margin-bottom-7'
+  end
+
+  it "defaults to no bottom margin if an incorrect value is passed" do
+    render_component(
+      margin_bottom: 20,
+      items: [
+        "<a href='https://example.com/'>Test item</a>",
+        "<a href='https://example.com/'>Another test item</a>",
+      ],
+    )
+    assert_select "[class='^=govuk-\!-margin-bottom-']", false
+  end
+
+  it "has no margin class added by default" do
+    render_component(
+      items: [
+        "<a href='https://example.com/'>Test item</a>",
+        "<a href='https://example.com/'>Another test item</a>",
+      ],
+    )
+    assert_select "[class='^=govuk-\!-margin-bottom-']", false
+  end
+
+  it "has no margin class added if `margin_bottom` set to 4" do
+    render_component(
+      margin_bottom: 4,
+      items: [
+        "<a href='https://example.com/'>Test item</a>",
+        "<a href='https://example.com/'>Another test item</a>",
+      ],
+    )
+    assert_select "[class='^=govuk-\!-margin-bottom-']", false
+  end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Allows the bottom margin to be set on the list component.

## Why
<!-- What are the reasons behind this change being made? -->

To give the component greater flexibility when it comes to spacing.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
![image](https://user-images.githubusercontent.com/1732331/137359399-63825c4e-1825-4bf5-a03d-ffa2da3ea945.png)
