### PR TITLE
Add GitHub Actions to Dependabot monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,3 +70,9 @@ updates:
   - dependency-name: jquery
     versions:
     - ">= 3.a, < 4"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "03:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Adds GitHub Actions to the list of things that Dependabot should keep up to date.

## Why
<!-- What are the reasons behind this change being made? -->

We use a single GitHub Action for visual regression testing, which relies on several images - these should be kept up to date to avoid any security flaws or other nefarious happenings.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
None.
