### PR TITLE
Release 27.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.8.0
 
 * Remove Coronavirus priority taxons ([PR #2357](https://github.com/alphagov/govuk_publishing_components/pull/2357))
 * Add `margin_bottom` spacing to list component ([PR #2363](https://github.com/alphagov/govuk_publishing_components/pull/2363))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.7.0)
+    govuk_publishing_components (27.8.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.7.0".freeze
+  VERSION = "27.8.0".freeze
 end


### PR DESCRIPTION
## 27.8.0

* Remove Coronavirus priority taxons ([PR #2357](https://github.com/alphagov/govuk_publishing_components/pull/2357))
* Add `margin_bottom` spacing to list component ([PR #2363](https://github.com/alphagov/govuk_publishing_components/pull/2363))
* Fix auditing bug and add documentation ([PR #2351](https://github.com/alphagov/govuk_publishing_components/pull/2351))
* Make action link blue arrow smaller on mobile ([PR #2353](https://github.com/alphagov/govuk_publishing_components/pull/2353))
* Remove unneeded scroll tracking ([PR #2354](https://github.com/alphagov/govuk_publishing_components/pull/2354))
* Update CSS for input component (`with_search_icon` variation) ([PR #2355](https://github.com/alphagov/govuk_publishing_components/pull/2355))
* Fix focus state and update API for the big number ([PR #2359](https://github.com/alphagov/govuk_publishing_components/pull/2359))
* Add legend examples for radio input ([PR #2333](https://github.com/alphagov/govuk_publishing_components/pull/2333))
