### PR TITLE
Fix organisation logo size when printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix organisation logo size when printing ([PR #2371](https://github.com/alphagov/govuk_publishing_components/pull/2371)) PATCH
+
 ## 27.8.0
 
 * Remove Coronavirus priority taxons ([PR #2357](https://github.com/alphagov/govuk_publishing_components/pull/2357))

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_organisation-logo.scss
@@ -1,0 +1,3 @@
+.gem-c-organisation-logo__image {
+  max-width: 100%;
+}


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
This quick fix constrains the logo when printing to be no more than the width of the page.

## Why
<!-- What are the reasons behind this change being made? -->
The organisation logo is unconstrained when printing - so if a large image is used it'll be printed out large.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
Print preview of component in page before:

<img width="581" alt="Screenshot 2021-10-18 at 13 56 26" src="https://user-images.githubusercontent.com/1732331/137738576-89bb76c7-1a58-465a-99da-5ab4a59260cb.png">

Print preview of component in page after:
<img width="576" alt="Screenshot 2021-10-18 at 13 56 54" src="https://user-images.githubusercontent.com/1732331/137738586-8eafe95e-50fb-41d4-a6fd-9a6109df7799.png">


