### PR TITLE
Release v27.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.8.1
 
 * Add cross domain linking to main GA property ([PR #2378](https://github.com/alphagov/govuk_publishing_components/pull/2378))
 * Fix organisation logo size when printing ([PR #2371](https://github.com/alphagov/govuk_publishing_components/pull/2371)) PATCH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.8.0)
+    govuk_publishing_components (27.8.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.8.0".freeze
+  VERSION = "27.8.1".freeze
 end


### PR DESCRIPTION
## Includes

* Add cross domain linking to main GA property ([PR #2378](https://github.com/alphagov/govuk_publishing_components/pull/2378))
* Fix organisation logo size when printing ([PR #2371](https://github.com/alphagov/govuk_publishing_components/pull/2371)) PATCH
