### PR TITLE
Add cross domain linking to main GA property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add cross domain linking to main GA property ([PR #2378](https://github.com/alphagov/govuk_publishing_components/pull/2378))
 * Fix organisation logo size when printing ([PR #2371](https://github.com/alphagov/govuk_publishing_components/pull/2371)) PATCH
 
 ## 27.8.0

--- a/app/assets/javascripts/govuk_publishing_components/analytics/google-analytics-universal-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/google-analytics-universal-tracker.js
@@ -36,11 +36,20 @@
       fieldsObject = { cookieDomain: fieldsObject }
     }
 
+    function setLinkedDomains () {
+      var domains = window.GOVUK.analyticsVars.primaryLinkedDomains
+      if (domains && domains.length > 0) {
+        sendToGa('require', 'linker')
+        sendToGa('linker:autoLink', domains)
+      }
+    }
+
     configureProfile()
     anonymizeIp()
     disableAdFeatures()
     stripTitlePII()
     stripLocationPII()
+    setLinkedDomains()
   }
 
   GoogleAnalyticsUniversalTracker.load = function () {

--- a/app/assets/javascripts/govuk_publishing_components/analytics/init.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/init.js
@@ -3,9 +3,12 @@ var analyticsInit = function () {
 
   var analyticsVars = window.GOVUK.analyticsVars || false
   if (analyticsVars) {
-    var gaProperty = window.GOVUK.analyticsVars.gaProperty || false
-    var gaPropertyCrossDomain = window.GOVUK.analyticsVars.gaPropertyCrossDomain || false
-    var linkedDomains = window.GOVUK.analyticsVars.linkedDomains || false
+    // the property naming convention here isn't consistent, but used in static and
+    // govuk-account-manager-prototype, so hard to change
+    var primaryGaProperty = window.GOVUK.analyticsVars.gaProperty || false
+
+    var crossDomainGaProperty = window.GOVUK.analyticsVars.gaPropertyCrossDomain || false
+    var crossDomainLinkedDomains = window.GOVUK.analyticsVars.linkedDomains || false
   }
 
   window.GOVUK.Analytics.checkDigitalIdentityConsent = function (location) {
@@ -39,7 +42,7 @@ var analyticsInit = function () {
 
   // Disable analytics by default
   // This will be reversed below, if the consent cookie says usage cookies are allowed
-  var disabler = 'ga-disable-' + gaProperty
+  var disabler = 'ga-disable-' + primaryGaProperty
   window[disabler] = true
 
   if (consentCookie && consentCookie.usage) {
@@ -48,14 +51,14 @@ var analyticsInit = function () {
     // Load Google Analytics libraries
     window.GOVUK.StaticAnalytics.load()
 
-    if (gaProperty) {
+    if (primaryGaProperty) {
       // Use document.domain in dev, preview and staging so that tracking works
       // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
       var cookieDomain = (document.domain === 'www.gov.uk') ? '.www.gov.uk' : document.domain
 
       // Configure profiles, setup custom vars, track initial pageview
       var analytics = new window.GOVUK.StaticAnalytics({
-        universalId: gaProperty,
+        universalId: primaryGaProperty,
         cookieDomain: cookieDomain,
         allowLinker: true
       })
@@ -63,8 +66,9 @@ var analyticsInit = function () {
       // Make interface public for virtual pageviews and events
       window.GOVUK.analytics = analytics
 
-      if (linkedDomains && linkedDomains.length > 0) {
-        window.GOVUK.analytics.addLinkedTrackerDomain(gaPropertyCrossDomain, 'govuk', linkedDomains)
+      // set up linking of domains for cross domain ga property
+      if (crossDomainLinkedDomains && crossDomainLinkedDomains.length > 0) {
+        window.GOVUK.analytics.addLinkedTrackerDomain(crossDomainGaProperty, 'govuk', crossDomainLinkedDomains)
       }
     }
   } else {


### PR DESCRIPTION

## What
Adds the ability to setup cross domain linking on the main GA property for our analytics. This is done by setting the variable `window.GOVUK.analyticsVars.primaryLinkedDomains` prior to calling the analytics code (I'll raise a separate PR to do this in `static`).

The 'short' explanation:

- we already have cross domain linking configured for a second GA property. The way this works is that the analytics code is passed the property and the list of domains, and this is created and linking set up all in one go, using the `addLinkedTrackerDomain` function
- however, we now want to add cross domain tracking into the main property as well, for a different set of domains (well, one - for the new DI accounts system). We could call the same function, but by that point we've already created the property, so instead the code has been modified to check for the presence of linked domains for the primary property and initialise the linker in the function for creating the main property
- all of this is a bit of a spaghetti - ideally we'd have one clear function that creates a property and optionally configures cross domain linking, and we'd call that as many times as there are properties
- also tried to clarify some of the variable names in init.js, but as some of this is currently being called from accounts I don't want to introduce breaking changes

## Why
This is needed urgently for the upcoming work to migrate the accounts platform partially onto the DI work.

## Visual Changes
None.

Trello card: https://trello.com/c/w3WVrDKm/149-add-cross-domain-tracking-to-main-govuk-tracker
