### PR TITLE
Version 27.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.8.2
 
 * Replace search icon PNG with SVG ([PR # 2377](https://github.com/alphagov/govuk_publishing_components/pull/2377))
 * Interventions: make more generic ([PR #2329](https://github.com/alphagov/govuk_publishing_components/pull/2329/))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.8.1)
+    govuk_publishing_components (27.8.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.8.1".freeze
+  VERSION = "27.8.2".freeze
 end


### PR DESCRIPTION
Includes:

* Replace search icon PNG with SVG ([PR # 2377](https://github.com/alphagov/govuk_publishing_components/pull/2377))
* Interventions: make more generic ([PR #2329](https://github.com/alphagov/govuk_publishing_components/pull/2329/))
