### PR TITLE
Update the design of the mobile menu button on the super navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update the design of the mobile menu button on the super navigation ([PR #2382](https://github.com/alphagov/govuk_publishing_components/pull/2382))
+
 ## 27.10.5
 
 * Prevent `cookies_policy` cookie related issues ([PR #2406](https://github.com/alphagov/govuk_publishing_components/pull/2406))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -556,38 +556,39 @@ $chevron-indent-spacing: 7px;
 
 // Styles for top level navigation toggle button.
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button {
-  @include govuk-font($size: 19, $weight: "bold", $line-height: 20px);
+  @include govuk-link-common;
+  @include govuk-link-style-no-visited-state;
+  @include govuk-link-style-no-underline;
+
+  font-size: 16px;
+  @if $govuk-typography-use-rem {
+    font-size: govuk-px-to-rem(16px);
+  }
+  font-weight: 700;
   background: govuk-colour("black");
   border: 0;
-  border-left: 1px solid govuk-colour("white");
-  border-right: 1px solid govuk-colour("white");
   box-sizing: border-box;
   color: govuk-colour("white");
   cursor: pointer;
   height: govuk-spacing(9);
-  margin-right: -1px;
-  padding: govuk-spacing(4);
+  padding: 0;
   position: absolute;
-  right: (govuk-spacing(9) - govuk-spacing(3));
+  right: ((govuk-spacing(9) - govuk-spacing(3)) - 1px); // width of the search button (60px) - 15px - 1px to create an overlap between buttons and stop the border appearing to hang off the buttons when they're focused/open
   top: 0;
-
-  @include govuk-media-query($from: 360px) {
-    right: govuk-spacing(9);
-
-    &:before {
-      @include chevron(govuk-colour("white"));
-    }
-  }
+  z-index: 10;
 
   @include focus-and-focus-visible {
     @include govuk-focused-text;
-    border-color: $govuk-focus-colour;
     box-shadow: none;
-    z-index: 10;
 
-    @include govuk-media-query($from: 360px) {
-      &:before {
-        @include chevron(govuk-colour("black"), true);
+    .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+      border-color: $govuk-focus-colour;
+      color: govuk-colour("black");
+
+      @include govuk-media-query($from: 360px) {
+        &:before {
+          @include chevron(govuk-colour("black"), true);
+        }
       }
     }
   }
@@ -596,41 +597,69 @@ $chevron-indent-spacing: 7px;
   // See https://www.tpgi.com/focus-visible-and-backwards-compatibility/
   @include focus-not-focus-visible {
     background: none;
-    border-color: govuk-colour("white");
     box-shadow: none;
-    color: govuk-colour("white");
 
-    @include govuk-media-query($from: 360px) {
-      &:before {
-        @include chevron(govuk-colour("white"), true);
+    .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+      border-color: govuk-colour("white");
+      color: govuk-colour("white");
+
+      @include govuk-media-query($from: 360px) {
+        &:before {
+          @include chevron(govuk-colour("white"), true);
+        }
       }
     }
   }
 
   // Open button modifier
   &.gem-c-layout-super-navigation-header__open-button {
+    // stylelint-disable max-nesting-depth
     @include focus-and-focus-visible {
       @include govuk-focused-text;
-      border-color: $govuk-focus-colour;
       box-shadow: none;
-      color: $govuk-focus-colour;
 
-      @include govuk-media-query($from: 360px) {
-        &:before {
-          @include chevron($govuk-focus-colour, true);
+      .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+        color: govuk-colour("black");
+        border-color: $govuk-focus-colour;
+
+        @include govuk-media-query($from: 360px) {
+          &:before {
+            @include chevron(govuk-colour("black"), true);
+            transform: translateY(0) rotate(225deg);
+          }
         }
       }
     }
 
     @include focus-not-focus-visible {
       background: govuk-colour("light-grey");
-      color: govuk-colour("light-grey");
 
-      @include govuk-media-query($from: 360px) {
-        &:before {
-          @include chevron(govuk-colour("light-grey"));
+      .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+        color: govuk-colour("black");
+        border-color: govuk-colour("light-grey");
+
+        @include govuk-media-query($from: 360px) {
+          &:before {
+            @include chevron(govuk-colour("black"));
+            transform: translateY(0) rotate(225deg);
+          }
         }
       }
+    }
+    // stylelint-enable max-nesting-depth
+  }
+}
+
+.gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+  display: inline-block;
+  border-left: 1px solid govuk-colour("white");
+  border-right: 1px solid govuk-colour("white");
+  margin: govuk-spacing(2) 0;
+  padding: govuk-spacing(2) govuk-spacing(4);
+
+  @include govuk-media-query($from: 360px) {
+    &:before {
+      @include chevron(govuk-colour("white"));
     }
   }
 }
@@ -640,7 +669,6 @@ $chevron-indent-spacing: 7px;
   @include govuk-font($size: 19, $weight: "bold", $line-height: 20px);
   background: govuk-colour("black");
   border: 0;
-  border-left: 1px solid govuk-colour("white");
   color: govuk-colour("white");
   cursor: pointer;
   height: govuk-spacing(9);
@@ -654,6 +682,7 @@ $chevron-indent-spacing: 7px;
     @include govuk-focused-text;
     border-color: $govuk-focus-colour;
     box-shadow: none;
+    z-index: 11;
   }
 
   &:focus:not(:focus-visible) {
@@ -663,11 +692,9 @@ $chevron-indent-spacing: 7px;
     color: govuk-colour("white");
   }
 
-  @include govuk-media-query($from: 360px) {
-    right: 0;
-  }
-
   @include govuk-media-query($from: "desktop") {
+    right: 0;
+
     @include focus-not-focus-visible {
       background: $govuk-brand-colour;
       border-bottom: 1px solid govuk-colour("black");

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -80,13 +80,8 @@
         id="super-navigation-menu-toggle"
         type="button"
       >
-        Menu
-        <span
-          aria-hidden="true"
-          class="gem-c-layout-super-navigation-header__navigation-top-toggle-close-icon"
-          focusable="false"
-        >
-          &times;
+        <span class="gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner">
+          Menu
         </span>
       </button>
       <ul id="super-navigation-menu" class="gem-c-layout-super-navigation-header__navigation-items">


### PR DESCRIPTION
## What
Update the design of the menu button, seen in mobile view on the [super navigation header](https://components.publishing.service.gov.uk/component-guide/layout_super_navigation_header) ([public page for in situ example](https://components.publishing.service.gov.uk/public)), specifically:

- Replaces the top to bottom borders around the menu button with "pipes"
- Revises the behaviour so that on open, the menu button no longer displays an "x" but instead cotinues to show "menu" with a reversed chevron.

## Why
Part of the explore team's iteration of the new navigation header. The altered appearance on open is to ensure that the button is consistent in its behaviour with other toggle buttons in the same component.

[Card](https://trello.com/c/nCcmmUuA/562-update-mobile-menu-button)
[Test URL](https://govuk-publis-update-sup-igfem5.herokuapp.com/public)

## Visual Changes
| Scenario | Before | After |
| --- | --- | --- |
| 320px closed | ![Screenshot 2021-10-25 at 16 12 16](https://user-images.githubusercontent.com/64783893/138725748-1a86ad90-fc51-49b4-ae88-0dbb53fde029.png) | ![Screenshot 2021-10-25 at 16 12 28](https://user-images.githubusercontent.com/64783893/138725778-b819fdb4-f786-40c9-b618-af714d643121.png) |
| 320px open | ![Screenshot 2021-10-25 at 16 12 52](https://user-images.githubusercontent.com/64783893/138725867-2a703ad2-2ac6-47aa-a957-76e5f9a7b50d.png) | ![Screenshot 2021-10-25 at 16 13 02](https://user-images.githubusercontent.com/64783893/138725925-b64e1e12-df1a-4898-9025-dbf42a2ec1ab.png) |
| 400px closed | ![Screenshot 2021-10-25 at 16 13 56](https://user-images.githubusercontent.com/64783893/138725970-9009ca57-9a47-4f5f-8bb2-c0b3cbba4184.png) | ![Screenshot 2021-10-26 at 10 54 57](https://user-images.githubusercontent.com/64783893/138855430-c388996e-8c1c-427f-95ab-dbc03c0786b9.png) |
| 400px open | ![Screenshot 2021-10-25 at 16 14 22](https://user-images.githubusercontent.com/64783893/138726123-b52ee3a1-e587-4f2d-b876-e6d21f4b2ce2.png) | ![Screenshot 2021-10-26 at 10 55 15](https://user-images.githubusercontent.com/64783893/138855501-34fbdd8a-88e1-421e-b748-22eba96a3c7f.png) |