### PR TITLE
Bump gem to v27.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.9.0
 
 * Tidy up account layout template for DI launch ([PR #2380](https://github.com/alphagov/govuk_publishing_components/pull/2380))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.8.2)
+    govuk_publishing_components (27.9.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.8.2".freeze
+  VERSION = "27.9.0".freeze
 end


### PR DESCRIPTION
Includes:
* Tidy up account layout template for DI launch ([PR #2380](https://github.com/alphagov/govuk_publishing_components/pull/2380))
