### PR TITLE
Update account template phase banner to match DI one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update account template phase banner to match DI one ([PR #2386](https://github.com/alphagov/govuk_publishing_components/pull/2386))
+
 ## 27.9.0
 
 * Tidy up account layout template for DI launch ([PR #2380](https://github.com/alphagov/govuk_publishing_components/pull/2380))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,9 +94,9 @@ en:
       account_layout:
         feedback:
           banners:
-            phase_intro: We’re trialling GOV.UK accounts - your
+            phase_intro: This is a new service – your
             phase_link: feedback
-            phase_outro: will help us improve them.
+            phase_outro: will help us to improve it.
         navigation:
           destroy_user_session: Sign out
           menu_bar:


### PR DESCRIPTION
Minor phase banner content adjustment to match the DI one which has moved away from the 'trial' language.

### Before
![Screenshot 2021-10-27 at 13 20 22](https://user-images.githubusercontent.com/7116819/139064237-1975b78c-175b-4e17-ab64-4727480d3979.png)


### After 

<img width="1645" alt="Screenshot 2021-10-27 at 13 19 39" src="https://user-images.githubusercontent.com/7116819/139064230-14ade2cd-1f46-4a17-9c60-1b4ed5f266d4.png">

