### PR TITLE
Fix layout jank when on slow connection

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
@@ -233,6 +233,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     // The menu needs to be updated when the window is resized to make sure that
     // the space needed for the dropdown menu is correct.
     window.addEventListener('resize', this.updateStates.bind(this), { passive: true })
+
+    this.$module.classList.add('js-module-initialised')
   }
 
   Modules.SuperNavigationMegaMenu = SuperNavigationMegaMenu

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -225,7 +225,7 @@ $chevron-indent-spacing: 7px;
     display: inline-block;
   }
 
-  .js-enabled & {
+  .js-module-initialised & {
     padding: 0 0 govuk-spacing(9) 0;
 
     @include govuk-media-query($from: "desktop") {
@@ -367,7 +367,7 @@ $chevron-indent-spacing: 7px;
 }
 
 .gem-c-layout-super-navigation-header__navigation-item-link {
-  .js-enabled & {
+  .js-module-initialised & {
     margin-left: govuk-spacing(4);
   }
 }
@@ -535,7 +535,7 @@ $chevron-indent-spacing: 7px;
   padding-bottom: govuk-spacing(4);
   padding-top: govuk-spacing(4);
 
-  .js-enabled & {
+  .js-module-initialised & {
     display: block;
   }
 }
@@ -856,7 +856,7 @@ $chevron-indent-spacing: 7px;
   @include govuk-media-query($from: "desktop") {
     margin: 0;
 
-    .js-enabled & {
+    .js-module-initialised & {
       left: 0;
       position: absolute;
       right: 0;

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -109,4 +109,10 @@ describe "Super navigation header", type: :view do
     assert_select "a.govuk-header__link--homepage[href='https://www.example.com/']", count: 1
     assert_select "a.govuk-header__link--homepage[title='Go to example']", count: 1
   end
+
+  it "doesn't have the initialised class before the JavaScript is run" do
+    render_component({})
+
+    assert_select ".js-module-initialised[data-module=\"super-navigation-mega-menu\"]", false
+  end
 end

--- a/spec/javascripts/components/layout-super-navigation-header-spec.js
+++ b/spec/javascripts/components/layout-super-navigation-header-spec.js
@@ -676,6 +676,18 @@ describe('The super header navigation', function () {
     document.body.removeChild(container)
   })
 
+  describe('on both small and large screens', function () {
+    beforeEach(function () {
+      thisModule.init()
+    })
+
+    it('has the initialised class once the JavaScript has run', function () {
+      var $module = document.querySelector('[data-module="super-navigation-mega-menu"]')
+
+      expect($module).toHaveClass('js-module-initialised')
+    })
+  })
+
   describe('on small screens', function () {
     beforeEach(function () {
       // `windowSize` returns `'mobile'` or `'desktop'` depending on the screen


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Instead of using the global `js-enabled` class the navigation header component now adds it's own `js-module-initialised` class to the component to signify that the layout changes needed for the JavaScript layout to work can be used. This class is added _after_ the component has been successfully initialised, so prevents any layout jank caused by the race between the component JavaScript and the global `js-enabled` class.

Fixes #2368.

## Why
<!-- What are the reasons behind this change being made? -->
The styles for the navigation header used the global `js-enabled` class to tweak the layout for when JavaScript was available. The `js-enabled` class was added to the `<body>` element by an inline script, which meant that the class was added as soon as the inline script was parsed.

If the components JavaScript wasn't yet loaded and/or initialised, this would cause the component layout to be broken until the JavaScript was loaded, parsed, and run. This disconnect between the `js-enabled` class and the component's JavaScript meant that `js-enabled` isn't a true indication of whether the component's JavaScript is available - just that JavaScript is enabled in the browser.

The `js-module-initialised` class is being used to signify that JavaScript is available _and_ the component's JavaScript has successfully run. This allows the layout to be updated in a more controlled manner.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
None.
