### PR TITLE
Bump gem to 27.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.9.2
 
 * Revert "Fix layout jank when on slow connection" ([PR #2390](https://github.com/alphagov/govuk_publishing_components/pull/2390))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.9.1)
+    govuk_publishing_components (27.9.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.9.1".freeze
+  VERSION = "27.9.2".freeze
 end


### PR DESCRIPTION
Includes:

* Revert "Fix layout jank when on slow connection" ([PR #2390](https://github.com/alphagov/govuk_publishing_components/pull/2390))

Reason for reverting the PR linked above: 
The e2e tests have been consistently failing with the same issues on the dependabot PR bumping the gem to `27.9.1` in `static`.  It was suggested this PR could be the culprit.

We created a branch where we reverted the changes in the PR, then pushed a branch of `static` that used that “revert” branch of the gem. The e2e checks passed on that branch of `static`.