### PR TITLE
Bump gem to 27.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.10.0
 
 * Revert "Update navigation header focus states" ([PR #2395](https://github.com/alphagov/govuk_publishing_components/pull/2395))
 * Revert Revert "Fix layout jank when on slow connection" ([PR #2394](https://github.com/alphagov/govuk_publishing_components/pull/2394))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.9.2)
+    govuk_publishing_components (27.10.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.9.2".freeze
+  VERSION = "27.10.0".freeze
 end


### PR DESCRIPTION

* Revert "Update navigation header focus states" ([PR #2395](https://github.com/alphagov/govuk_publishing_components/pull/2395))
* Revert Revert "Fix layout jank when on slow connection" ([PR #2394](https://github.com/alphagov/govuk_publishing_components/pull/2394))
* Add option to render `layout_for_public` footer without a top border ([PR #2393](https://github.com/alphagov/govuk_publishing_components/pull/2393))
