### PR TITLE
Amend account layout phase banner link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Amend account layout phase banner link ([PR #2397](https://github.com/alphagov/govuk_publishing_components/pull/2397))
+
 ## 27.10.0
 
 * Revert "Update navigation header focus states" ([PR #2395](https://github.com/alphagov/govuk_publishing_components/pull/2395))

--- a/app/views/govuk_publishing_components/components/layout_for_public/_account-layout.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_for_public/_account-layout.html.erb
@@ -1,15 +1,7 @@
 <div class="govuk-width-container">
-  <% message = capture do %>
-    <%= t("components.layout_for_public.account_layout.feedback.banners.phase_intro") %>
-    <a class="govuk-link" href=<%= GovukPersonalisation::Urls.feedback %>>
-      <%= t("components.layout_for_public.account_layout.feedback.banners.phase_link") %>
-    </a>
-    <%= t("components.layout_for_public.account_layout.feedback.banners.phase_outro") %>
-  <% end %>
-
   <%= render "govuk_publishing_components/components/phase_banner", {
     phase: "beta",
-    message: message
+    message: sanitize(t("components.layout_for_public.account_layout.feedback.banners.phase_banner_html"))
   } unless omit_account_phase_banner %>
 
   <div class="govuk-grid-row govuk-main-wrapper">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,9 +94,7 @@ en:
       account_layout:
         feedback:
           banners:
-            phase_intro: This is a new service – your
-            phase_link: feedback
-            phase_outro: will help us to improve it.
+            phase_banner_html: This is a new service – your <a class="govuk-link" href="https://signin.account.gov.uk/contact-us?supportType=PUBLIC">feedback</a> will help us to improve it.
         navigation:
           destroy_user_session: Sign out
           menu_bar:


### PR DESCRIPTION
## What
Changes `layout_for_public` account variation to use the correct link to DI's contact form for feedback

## Why
So that GOVUK account pages are in line with DI account pages

----


https://trello.com/c/vIjbnGSj/1087-account-pages-tidy-up-for-launch