### PR TITLE
Adjust cookie_consent parameter conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Adjust cookie_consent parameter conditions ([PR #2399](https://github.com/alphagov/govuk_publishing_components/pull/2399))
+
 ## 27.10.1
 
 * Amend account layout phase banner link ([PR #2397](https://github.com/alphagov/govuk_publishing_components/pull/2397))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.js
@@ -14,7 +14,7 @@
       // If engaged and rejected, append only ?cookie-consent=reject
       // If engaged and accepted usage, append ?_ga=clientid if available and cookie-consent=accept
 
-      if (cookieBannerEngaged === 'false') {
+      if (cookieBannerEngaged !== 'true') {
         this.decorate(element, 'cookie_consent=not-engaged')
         return
       }

--- a/spec/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.spec.js
@@ -47,8 +47,14 @@ describe('Explicit cross-domain linker', function () {
       element = $('<a href="/somewhere">')
     })
 
-    it('modifies the link href to append cookie_consent parameter "not-engaged" if cookie preferences are not set', function () {
+    it('modifies the link href to append cookie_consent parameter "not-engaged" if cookies_preferences_set cookie is "false"', function () {
       GOVUK.cookie('cookies_preferences_set', 'false')
+      explicitCrossDomainLinks.start(element)
+      expect(element.attr('href')).toEqual('/somewhere?cookie_consent=not-engaged')
+    })
+
+    it('modifies the link href to append cookie_consent parameter "not-engaged" if cookies_preferences_set cookie is not set', function () {
+      GOVUK.cookie('cookies_preferences_set', null)
       explicitCrossDomainLinks.start(element)
       expect(element.attr('href')).toEqual('/somewhere?cookie_consent=not-engaged')
     })
@@ -97,8 +103,14 @@ describe('Explicit cross-domain linker', function () {
              '</form>')
     })
 
-    it('modifies the form action to append cookie_consent parameter "not-engaged" if cookie preferences are not set', function () {
+    it('modifies the form action to append cookie_consent parameter "not-engaged" if cookies_preferences_set cookie is "false"', function () {
       GOVUK.cookie('cookies_preferences_set', 'false')
+      explicitCrossDomainLinks.start(element)
+      expect(element.attr('action')).toEqual('/somewhere?cookie_consent=not-engaged')
+    })
+
+    it('modifies the form action to append cookie_consent parameter "not-engaged" if cookies_preferences_set cookie is not set', function () {
+      GOVUK.cookie('cookies_preferences_set', null)
       explicitCrossDomainLinks.start(element)
       expect(element.attr('action')).toEqual('/somewhere?cookie_consent=not-engaged')
     })


### PR DESCRIPTION
The `cookie_consent` param should also have a value of 'not-engaged' when `cookies_preferences_set` is `null`.  
The reason for this change can be observed by doing the following:
1. clear your browser cookies for gov.uk –  when you refresh the page the cookie banner should appear
2. resist the immediate urge to reject (or accept) cookies 😄
3. visit https://www.gov.uk/brexit and check the `href` of the sign in link – the query string on the link is `cookie_consent=reject`, when it should probably be `cookie_consent=not-engaged`

This adjusts the explicit cross domain links script to always append `cookie_consent=not-engaged` unless `cookies_preferences_set` is explicitly set to 'true'. 

