### PR TITLE
Include Rails Translation Manager and set correct root

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,6 +244,10 @@ GEM
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 7)
+    rails_translation_manager (1.0.0)
+      activesupport
+      i18n-tasks
+      rails-i18n
     railties (6.1.4.1)
       actionpack (= 6.1.4.1)
       activesupport (= 6.1.4.1)
@@ -386,6 +390,7 @@ DEPENDENCIES
   jasmine_selenium_runner (~> 3.0.0)
   percy-capybara (~> 4.0, >= 4.0.2)
   pry-byebug
+  rails_translation_manager
   rake
   rspec-rails (~> 5.0)
   rubocop-govuk

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,9 @@ APP_RAKEFILE = File.expand_path("spec/dummy/Rakefile", __dir__)
 load "rails/tasks/engine.rake"
 load "rails/tasks/statistics.rake"
 
+rails_translation_manager = Gem::Specification.find_by_name("rails_translation_manager").gem_dir
+load "#{rails_translation_manager}/lib/tasks/translation.rake"
+
 require "bundler/gem_tasks"
 
 RuboCop::RakeTask.new

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "jasmine_selenium_runner", "~> 3.0.0"
   s.add_development_dependency "percy-capybara", "~> 4.0", ">= 4.0.2"
   s.add_development_dependency "pry-byebug"
+  s.add_development_dependency "rails_translation_manager"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-rails", "~> 5.0"
   s.add_development_dependency "rubocop-govuk"

--- a/spec/dummy/Rakefile
+++ b/spec/dummy/Rakefile
@@ -3,4 +3,14 @@
 
 require_relative "config/application"
 
+module Rails
+  def self.root
+    if caller.first.include? "rails_translation_manager"
+      Pathname.new(Dir.pwd.to_s.sub("/spec/dummy", ""))
+    else
+      Pathname.new(Dir.pwd)
+    end
+  end
+end
+
 Rails.application.load_tasks


### PR DESCRIPTION
This PR includes Rails Translation Manager and sets the actual Gem root when called by RTM.

Supersedes https://github.com/alphagov/rails_translation_manager/pull/17.

More info in the commits ->

---

Trello:
https://trello.com/c/k4rrt3UG/2686-update-csv-import-rails-translation-manager-3
