### PR TITLE
Release v27.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.10.3
 
 * Update navigation header focus states (take two) ([PR #2401](https://github.com/alphagov/govuk_publishing_components/pull/2401))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.10.2)
+    govuk_publishing_components (27.10.3)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.10.2".freeze
+  VERSION = "27.10.3".freeze
 end


### PR DESCRIPTION
Release  v27.10.3, which includes:

 * Update navigation header focus states (take two) (#2401)
