### PR TITLE
Add underlines to mobile menu links on super navigation no-js view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add underlines to mobile menu links on super navigation no-js view ([PR #2404](https://github.com/alphagov/govuk_publishing_components/pull/2404))
+
 ## 27.10.3
 
 * Update navigation header focus states (take two) ([PR #2401](https://github.com/alphagov/govuk_publishing_components/pull/2401))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -268,7 +268,6 @@ $chevron-indent-spacing: 7px;
 .gem-c-layout-super-navigation-header__navigation-second-toggle-button {
   @include govuk-link-common;
   @include govuk-link-style-no-visited-state;
-  @include govuk-link-style-no-underline;
 
   display: inline-block;
   font-size: 19px;
@@ -369,6 +368,7 @@ $chevron-indent-spacing: 7px;
 .gem-c-layout-super-navigation-header__navigation-item-link {
   .js-module-initialised & {
     margin-left: govuk-spacing(4);
+    @include govuk-link-style-no-underline;
   }
 }
 
@@ -480,6 +480,10 @@ $chevron-indent-spacing: 7px;
         }
       }
     }
+  }
+
+  .js-module-initialised & {
+    @include govuk-link-style-no-underline;
   }
 }
 


### PR DESCRIPTION
## What
Adds underlines to links on the [super navigation](https://components.publishing.service.gov.uk/component-guide/layout_super_navigation_header) no-js mobile view.

## Why
So that no-js mobile users are able to identify the headings as links.

[Card](https://trello.com/c/D0tQKcxN/574-underlines-on-no-js-version-of-menu)

## Visual Changes
Below for js disabled view. No visual changes for js enabled view.

| Before | After |
| --- | --- |
| ![Screenshot 2021-11-02 at 12 52 15](https://user-images.githubusercontent.com/64783893/139850773-af356c00-90ec-4584-9b35-c37ac7a393fd.png) | ![Screenshot 2021-11-02 at 12 51 05](https://user-images.githubusercontent.com/64783893/139850793-861391d9-7567-4ebf-9c9b-2623aab229dd.png) |