### PR TITLE
Add black border to the bottom of the closed header search button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add underlines to mobile menu links on super navigation no-js view ([PR #2404](https://github.com/alphagov/govuk_publishing_components/pull/2404))
+* Add black border to the bottom of the closed header search button ([PR #2405](https://github.com/alphagov/govuk_publishing_components/pull/2405))
 
 ## 27.10.3
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -660,14 +660,14 @@ $chevron-indent-spacing: 7px;
   @include govuk-media-query($from: "desktop") {
     @include focus-not-focus-visible {
       background: $govuk-brand-colour;
-      border-bottom: govuk-spacing(1) solid $govuk-brand-colour;
+      border-bottom: 1px solid govuk-colour("black");
       border-left: none;
       position: relative;
     }
 
     &:hover {
       background: govuk-colour("black");
-      border-bottom-color: govuk-colour("mid-grey");
+      border-bottom: govuk-spacing(1) solid govuk-colour("mid-grey");
       color: govuk-colour("mid-grey");
     }
 


### PR DESCRIPTION
## What
Add black border to the bottom of the [super navigation](https://components.publishing.service.gov.uk/component-guide/layout_super_navigation_header) search button. This change is only applied on desktop when the search menu is closed.

## Why
So that it doesn't blend into the blue bar above the covid banner.

[Card](https://trello.com/c/tGotQ6ab/569-add-separator-to-search-icon)

## Visual Changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-11-02 at 17 06 27](https://user-images.githubusercontent.com/64783893/139912962-ce9be04c-92f9-4a8a-bcb5-eee787694be4.png) | ![Screenshot 2021-11-02 at 17 06 11](https://user-images.githubusercontent.com/64783893/139913001-93412a97-435e-4011-929a-94523f5703d6.png) |