### PR TITLE
Prevent `cookies_policy` cookie related issues 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add underlines to mobile menu links on super navigation no-js view ([PR #2404](https://github.com/alphagov/govuk_publishing_components/pull/2404))
 * Add black border to the bottom of the closed header search button ([PR #2405](https://github.com/alphagov/govuk_publishing_components/pull/2405))
 * Fix font size on super navigation header ([PR #2407](https://github.com/alphagov/govuk_publishing_components/pull/2407))
+* Prevent `cookies_policy` cookie related issues ([PR #2406](https://github.com/alphagov/govuk_publishing_components/pull/2406))
 
 ## 27.10.3
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.js
@@ -19,7 +19,7 @@
         return
       }
       var cookieConsent = GOVUK.getConsentCookie()
-      if (cookieConsent.usage === false) {
+      if (cookieConsent && cookieConsent.usage === false) {
         this.decorate(element, 'cookie_consent=reject')
         return
       }

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -96,6 +96,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.showConfirmationMessage()
     this.$module.cookieBannerConfirmationMessage.focus()
     window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
+    window.GOVUK.setDefaultConsentCookie()
   }
 
   CookieBanner.prototype.showConfirmationMessage = function () {

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -173,6 +173,19 @@ describe('Cookie banner', function () {
     expect(confirmationMessage).toBeVisible()
   })
 
+  it('set cookies_preferences_set cookie, and re-set cookies_policy expiration date when rejecting cookies', function () {
+    spyOn(GOVUK, 'setCookie').and.callThrough()
+    var element = document.querySelector('[data-module="cookie-banner"]')
+    new GOVUK.Modules.CookieBanner(element).init()
+
+    var rejectCookiesButton = document.querySelector('[data-reject-cookies]')
+
+    rejectCookiesButton.click()
+
+    expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_policy', DEFAULT_COOKIE_CONSENT, { days: 365 })
+    expect(GOVUK.setCookie).toHaveBeenCalledWith('cookies_preferences_set', 'true', { days: 365 })
+  })
+
   it('should hide when pressing the "hide" link', function () {
     spyOn(GOVUK, 'setCookie').and.callThrough()
 


### PR DESCRIPTION
## What
On a [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4757358) we received on the Accounts team, a user reports a bug with the cookie banner JavaScript on GOV.UK Accounts which can cause the rest of the JavaScript on the page to fail. From the ticket:
> GOVUK.getConsentCookie() tries to get a cookie called 'cookies_policy'. I looked at the cookies for the GOV.UK Account domain and found that I only had a 'cookie_preferences_set' cookie, but not a 'cookie_policy' cookie, which is why cookieConsent was null.

> I tried viewing the page in an Incognito window, and found the cause of the problem. 'cookie_policy' is set when I first load the page, but 'cookie_preferences_set' is only set when I click a button in the cookie consent banner. Both cookies are set to expire after a year. 'cookie_policy' defaults to only allowing essential cookies. If I say yes to cookies, 'cookie_policy' is re-set to allow all cookies, and 'cookie_preferences_set' is set. This means both cookies have the same expiry date.

> However, if I say no to cookies, 'cookie_preferences_set' is set for the first time but 'cookie_policy' stays the same. This means that these cookies can end up with different expiry times - potentially days, weeks or months apart; whatever the gap is between a user visiting the page for the first time and making a selection in the cookie banner.



### 1. Re-set `cookies_policy` with default values when cookies are rejected
When the cookie banner 'reject' option is selected, the `cookies_preferences_set` cookie is created and set to expire after 365 days. However, the expiration date is not adjusted on the pre-existing `cookies_policy` cookie (which is always set to a default value, unless already present). So the times when `cookies_policy` and `cookies_preferences_set` are due to expire are not in sync.

This updates the cookie banner `rejectCookieConsent` function, so that when cookies are explicitly rejected, the consent cookie is set to its default value, and its expiration date is reset.

### 2. Prevent `explicit-cross-domain-links` script JS error if `cookies_policy` cookie is not present
The explicit cross domain links script has some logic to decorate cross-domain links with a `cookie_consent=reject` parameter if usage cookies have been rejected. 

To determine if usage cookies were rejected, it checks the `cookies_policy` cookie: `if (cookieConsent.usage === false){ ... }`.

In theory, the `cookies_policy` cookie _should_ always exist, because [a check](https://github.com/alphagov/govuk_publishing_components/blob/26e92dedccab43233b54bff3fba667dce809878e/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js#L52) is performed on page load (via cookie banner initialisation script) so that, if it is not already present, `cookies_policy` is created with the default values.

However, as a preventative measure against a scenario where the `cookies_policy` cookie is not present in the browser at the time this piece of code runs, it is a good idea to update the condition from `if (cookieConsent.usage === false)` to `if (cookieConsent && cookieConsent.usage === false)`, which will not throw an `Uncaught TypeError` if the cookie is not found.
