### PR TITLE
Fix font size on super navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add underlines to mobile menu links on super navigation no-js view ([PR #2404](https://github.com/alphagov/govuk_publishing_components/pull/2404))
 * Add black border to the bottom of the closed header search button ([PR #2405](https://github.com/alphagov/govuk_publishing_components/pull/2405))
+* Fix font size on super navigation header ([PR #2407](https://github.com/alphagov/govuk_publishing_components/pull/2407))
 
 ## 27.10.3
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -271,7 +271,9 @@ $chevron-indent-spacing: 7px;
 
   display: inline-block;
   font-size: 19px;
-  font-size: govuk-px-to-rem(19px);
+  @if $govuk-typography-use-rem {
+    font-size: govuk-px-to-rem(19px);
+  }
   font-weight: bold;
   margin: govuk-spacing(3) 0;
 
@@ -312,7 +314,13 @@ $chevron-indent-spacing: 7px;
     @include govuk-media-query($from: "desktop") {
       float: left;
       font-size: 16px;
-      font-size: govuk-px-to-rem(16px);
+
+      // stylelint-disable max-nesting-depth
+      @if $govuk-typography-use-rem {
+        font-size: govuk-px-to-rem(16px);
+      }
+      // stylelint-enable max-nesting-depth
+
       height: govuk-spacing(4);
       padding: govuk-spacing(4);
       position: relative;
@@ -408,7 +416,9 @@ $chevron-indent-spacing: 7px;
       color: govuk-colour("white");
       float: left;
       font-size: 16px;
-      font-size: govuk-px-to-rem(16px);
+      @if $govuk-typography-use-rem {
+        font-size: govuk-px-to-rem(16px);
+      }
       height: govuk-spacing(9);
       padding: govuk-spacing(4);
       position: relative;


### PR DESCRIPTION
## What
Rem units are not meant to be used in compatibility mode (in conjunction with legacy dependencies such as `govuk_template`) as the `font-size` for the root element is not controlled. Hence we wrap these declarations and only apply them when rem units are set to be used by `govuk-frontend`.

## Why
To fix the font size when the super navigation header is used in compatibility mode (e.g. https://www.gov.uk/search).

## Visual Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![www gov uk_search (1)](https://user-images.githubusercontent.com/788096/139929517-55588136-0e5a-4366-b1f5-a6fe339b1f60.png)


</td><td valign="top">

![www gov uk_search](https://user-images.githubusercontent.com/788096/139929526-36afdf2d-3db0-407e-8b37-7d3dbfe0d153.png)



</td></tr>
</table>

