### PR TITLE
Bump gem to 27.10.5 and correct CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 27.10.5
+
+* Prevent `cookies_policy` cookie related issues ([PR #2406](https://github.com/alphagov/govuk_publishing_components/pull/2406))
+
 ## 27.10.4
 
 * Add underlines to mobile menu links on super navigation no-js view ([PR #2404](https://github.com/alphagov/govuk_publishing_components/pull/2404))
 * Add black border to the bottom of the closed header search button ([PR #2405](https://github.com/alphagov/govuk_publishing_components/pull/2405))
 * Fix font size on super navigation header ([PR #2407](https://github.com/alphagov/govuk_publishing_components/pull/2407))
-* Prevent `cookies_policy` cookie related issues ([PR #2406](https://github.com/alphagov/govuk_publishing_components/pull/2406))
 
 ## 27.10.3
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.10.4)
+    govuk_publishing_components (27.10.5)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.10.4".freeze
+  VERSION = "27.10.5".freeze
 end


### PR DESCRIPTION
Corrects the changelog as #2406 was accidentally included under `27.10.4`

Includes

* Prevent `cookies_policy` cookie related issues ([PR #2406](https://github.com/alphagov/govuk_publishing_components/pull/2406))

