### PR TITLE
Add some documentation for component translation

### DIFF
--- a/docs/component_principles.md
+++ b/docs/component_principles.md
@@ -42,6 +42,19 @@ A component is a package comprised of template, style, behaviour and documentati
 * visual regression tests
 * automated accessibility tests
 
+### Component translations
+
+All component text should be stored in a [locale file](https://github.com/alphagov/govuk_publishing_components/tree/master/config/locales). We do this for two reasons:
+
+* so that other languages can be added
+* so that text can be easily found and updated
+
+The translation of text passed to a component should be handled by the passing application. For all other text in a component, text should be stored in a locale file, even if we don't have the text in another language.
+
+This includes text that is created in JavaScript - for example, [show/hide text in an accordion](https://github.com/alphagov/govuk_publishing_components/blob/a715bc7ba66838ed0986427051280a000e7f0565/app/views/govuk_publishing_components/components/_accordion.html.erb#L14-L20). This should be supplied from a locale file and added to the component template in data attributes that can be read by the JavaScript, so that this text can be translated.
+
+We do not yet have translated text for all components in all languages.
+
 ## A good component architecture:
 
 * provides a consistent component API to applications


### PR DESCRIPTION
## What
Add some information about component translation to our documentation.

## Why
We don't have any, as referenced in https://github.com/alphagov/govuk_publishing_components/issues/18.

Fixes https://github.com/alphagov/govuk_publishing_components/issues/18

## Visual Changes
None.
