### PR TITLE
Extend new scroll tracker functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * Remove redundant API value from big number component ([PR #2459](https://github.com/alphagov/govuk_publishing_components/pull/2459))
 * Remove use of `govuk-list` from navigation header ([PR #2460](https://github.com/alphagov/govuk_publishing_components/pull/2460))
+* Extend new scroll tracker functionality ([PR #2411](https://github.com/alphagov/govuk_publishing_components/pull/2411))
 
 ## 27.14.0
 

--- a/docs/analytics/auto_scroll_tracker.md
+++ b/docs/analytics/auto_scroll_tracker.md
@@ -20,11 +20,31 @@ AutoScrollTracker is a GOVUK.Module and can be initialised by adding the relevan
 
 By default, AutoScrollTracker tracks by percentage scrolled. Specifically, it will fire a GA event when the user scrolls to 20%, 40%, 60%, 80% and 100% of the page height.
 
-It can track headings instead of percentages, using this additional option:
+It can track headings instead of percentages, using the `data-track-type` option.
 
 ```html
 <% content_for :extra_head_content do %>
   <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker" data-track-type="headings"/>
+<% end %>
+```
+
+If only some headings need to be tracked, they can be specified using the `data-track-headings` option as shown. This option has been included with the module to support legacy tracking. It is not recommended for future use as headings on pages can change, which would prevent the tracking from working.
+
+```html
+<% content_for :extra_head_content do %>
+  <%= tag.meta name: "govuk-scroll-tracker", content: "", data: { module: "auto-scroll-tracker", "track-type": "headings", "track-headings": ["Example heading", "Another example heading"].to_json } %>
+ end %>
+```
+
+A single template may render multiple pages and different configurations may be required. If this is the case, configuration can be handled by the template.
+
+```html
+<% content_for :extra_head_content do %>
+  <% if ["/foreign-travel-advice/benin", "/foreign-travel-advice/france"].include?(content_item.base_path) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker" data-track-type="headings" data-track-headings="['Summary']"/>
+  <% else %>
+    <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker"/>
+  <% end %>
 <% end %>
 ```
 

--- a/spec/javascripts/govuk_publishing_components/lib/auto-scroll-tracker-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/auto-scroll-tracker-spec.js
@@ -47,6 +47,48 @@ describe('GOVUK.AutoScrollTracker', function () {
     expect(scrollTracker2.getWindowDetails).not.toHaveBeenCalled()
   })
 
+  describe('with invalid configuration', function () {
+    beforeEach(function () {
+      var el = document.createElement('div')
+      var data = 'invalid-json'
+      el.setAttribute('data-track-headings', data)
+      scrollTracker = new GOVUK.Modules.AutoScrollTracker(el)
+    })
+
+    it('does not start scroll tracking', function () {
+      scrollTracker.init()
+
+      expect(window.GOVUK.analyticsVars.scrollTrackerStarted).toEqual(false)
+    })
+  })
+
+  describe('tracking specific headings', function () {
+    var el
+
+    beforeEach(function () {
+      var headings = '<main><h1>First heading</h1><h2>Second heading</h2><h2>Third heading</h2></main>'
+      el = document.createElement('div')
+      el.innerHTML = headings
+      document.body.appendChild(el)
+      var data = '["First heading", "Third heading"]'
+      el.setAttribute('data-track-headings', data)
+      el.setAttribute('data-track-type', 'headings')
+      scrollTracker = new GOVUK.Modules.AutoScrollTracker(el)
+    })
+
+    afterEach(function () {
+      document.body.removeChild(el)
+    })
+
+    it('only tracks those headings', function () {
+      scrollTracker.init()
+
+      expect(scrollTracker.trackedNodes.length).toEqual(2)
+      expect(scrollTracker.trackedNodes[0].eventData.label).toEqual('First heading')
+      expect(scrollTracker.trackedNodes[1].eventData.label).toEqual('Third heading')
+    })
+  })
+
   describe('when tracking headings', function () {
     var el
 


### PR DESCRIPTION
## What
Extend the functionality of the new scroll tracking script, to provide new features. Specifically:

- allows specific URLs to be targeted or excluded from scroll tracking, where a template renders more than one URL
- allows specific URLs to track custom percentage positions or specific headings only

## Why
Attempts to migrate scroll tracking from the old script to the new script have highlighted features that require implementation.

## Visual Changes
None.

Trello card: https://trello.com/c/sdugtMbX/37-migrate-to-new-scroll-tracker
