### PR TITLE
Move "Departments" into "Government Activity" menu

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -46,6 +46,10 @@
   grid-template-columns: fractions($columns);
   -ms-grid-rows: fractions($rows);
   grid-template-rows: fractions($rows);
+}
+
+@mixin columns-children($items, $columns, $selector: "*") {
+  $rows: ceil($items / $columns);
 
   // Internet Explorer 10-11 require each element to be placed in the grid -
   // the `grid-auto-flow` property isn't supported. This means that both the
@@ -776,9 +780,7 @@ $chevron-indent-spacing: 7px;
 
     & > li {
       box-sizing: border-box;
-      margin-bottom: 0;
-      padding-left: govuk-spacing(3);
-      padding-right: govuk-spacing(3);
+      margin: 0 govuk-spacing(3) govuk-spacing(2) govuk-spacing(3);
     }
   }
 }
@@ -786,13 +788,62 @@ $chevron-indent-spacing: 7px;
 .gem-c-layout-super-navigation-header__navigation-second-items--topics {
   @include govuk-media-query($from: "desktop") {
     @include columns(18, 2, "li");
+    @include columns-children(18, 2, "li");
   }
 }
 
 .gem-c-layout-super-navigation-header__navigation-second-items--government-activity {
+  & > li:first-child {
+    margin-bottom: govuk-spacing(7);
+  }
+
   @include govuk-media-query($from: "desktop") {
-    @include columns(5, 2, "li");
-    padding-bottom: govuk-spacing(3);
+    @include columns(7, 2, "li");
+    padding-bottom: 0;
+
+    & > li,
+    & > li:first-child {
+      margin-bottom: govuk-spacing(4);
+    }
+
+    @supports (display: grid) {
+      & > li:first-child {
+        grid-column: span 2;
+      }
+    }
+
+    & > li:first-child {
+      border-bottom: 1px solid $govuk-border-colour;
+      padding-bottom: 0;
+      -ms-grid-column-span: 2;
+      -ms-grid-column: 1;
+      -ms-grid-row: 1;
+    }
+
+    & > li:nth-child(2) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 2;
+    }
+
+    & > li:nth-child(3) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 3;
+    }
+
+    & > li:nth-child(4) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 4;
+    }
+
+    & > li:nth-child(5) {
+      -ms-grid-column: 2;
+      -ms-grid-row: 2;
+    }
+
+    & > li:nth-child(6) {
+      -ms-grid-column: 2;
+      -ms-grid-row: 3;
+    }
   }
 }
 
@@ -804,6 +855,10 @@ $chevron-indent-spacing: 7px;
   @include govuk-media-query($from: "desktop") {
     font-weight: bold;
     padding: 0;
+
+    &:after {
+      content: none;
+    }
   }
 }
 
@@ -814,19 +869,21 @@ $chevron-indent-spacing: 7px;
 }
 
 // Dropdown menu footer links.
-.gem-c-layout-super-navigation-header__navigation-second-footer {
-  border-top: 1px solid govuk-colour("mid-grey");
+.gem-c-layout-super-navigation-header__navigation-second-footer-break {
+  @include govuk-media-query($until: "desktop") {
+    display: none;
+  }
 }
 
 .gem-c-layout-super-navigation-header__navigation-second-footer-list {
   list-style: none;
-  padding-bottom: govuk-spacing(8);
-  padding-top: govuk-spacing(4);
-
-  @include govuk-grid-column($width: "two-thirds", $float: right, $at: "desktop");
+  padding: 0 0 govuk-spacing(8) 0;
 
   @include govuk-media-query($from: "desktop") {
-    padding: govuk-spacing(7) 0 govuk-spacing(8) 0;
+    margin: 0 (0 - govuk-spacing(3)) 0 (0 - govuk-spacing(3));
+    padding: govuk-spacing(8) 0 govuk-spacing(9) 0;
+    @include columns(2, 2, "li");
+    @include columns-children(2, 2, "li");
   }
 }
 
@@ -835,15 +892,12 @@ $chevron-indent-spacing: 7px;
   position: relative;
 
   @include govuk-media-query($from: "desktop") {
-    box-sizing: border-box;
-    float: left;
-    padding: 0 govuk-spacing(3);
-    width: 50%;
+    padding: 0 govuk-spacing(3) 0 govuk-spacing(3);
   }
 }
 
 .gem-c-layout-super-navigation-header__navigation-second-footer-link {
-  @include govuk-font($size: 19, $weight: bold);
+  @include govuk-font($size: 19, $weight: normal);
   display: inline-block;
   margin: govuk-spacing(1) 0;
 

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -147,8 +147,8 @@
                         </p>
                       <% end %>
                     </div>
-                    <% if link[:menu_contents].present? %>
-                      <div class="govuk-grid-column-two-thirds-from-desktop">
+                    <div class="govuk-grid-column-two-thirds-from-desktop">
+                      <% if link[:menu_contents].present? %>
                           <ul class="govuk-list gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--<%= link[:label].parameterize %>">
                             <% link[:menu_contents].each do | item | %>
                               <%
@@ -172,39 +172,32 @@
                               </li>
                             <% end %>
                           </ul>
-                      </div>
-                    <% end %>
-                  </div>
-                  <% if link[:footer_links].present? %>
-                    <div class="govuk-grid-row">
-                      <div class="govuk-grid-column-full">
-                        <div class="gem-c-layout-super-navigation-header__navigation-second-footer">
-                          <div class="govuk-grid-row">
-                            <ul class="gem-c-layout-super-navigation-header__navigation-second-footer-list">
-                              <% link[:footer_links].each do | item | %>
-                                <li class="gem-c-layout-super-navigation-header__navigation-second-footer-item">
-                                  <%= link_to item[:label], item[:href], {
-                                    class: [
-                                      "govuk-link",
-                                      "gem-c-layout-super-navigation-header__navigation-second-footer-link",
-                                    ],
-                                    data: {
-                                      module: "gem-track-click",
-                                      track_action: "#{tracking_label}Link",
-                                      track_category: "headerClicked",
-                                      track_label: item[:href],
-                                      track_dimension: item[:label],
-                                      track_dimension_index: "29",
-                                    }
-                                  } %>
-                                </li>
-                              <% end %>
-                            </ul>
-                          </div>
-                        </div>
-                      </div>
+                      <% end %>
+                      <% if link[:footer_links].present? %>
+                        <hr class="gem-c-layout-super-navigation-header__navigation-second-footer-break govuk-section-break govuk-section-break--visible">
+                        <ul class="gem-c-layout-super-navigation-header__navigation-second-footer-list">
+                          <% link[:footer_links].each do | item | %>
+                            <li class="gem-c-layout-super-navigation-header__navigation-second-footer-item">
+                              <%= link_to item[:label], item[:href], {
+                                class: [
+                                  "govuk-link",
+                                  "gem-c-layout-super-navigation-header__navigation-second-footer-link",
+                                ],
+                                data: {
+                                  module: "gem-track-click",
+                                  track_action: "#{tracking_label}Link",
+                                  track_category: "headerClicked",
+                                  track_label: item[:href],
+                                  track_dimension: item[:label],
+                                  track_dimension_index: "29",
+                                }
+                              } %>
+                            </li>
+                          <% end %>
+                        </ul>
+                      <% end %>
                     </div>
-                  <% end %>
+                  </div>
                 </div>
               </div>
             <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,13 +157,14 @@ en:
           href: "/browse/visas-immigration"
         - label: Working, jobs and pensions
           href: "/browse/working"
-      - label: Departments
-        href: "/government/organisations"
       - label: Government activity
         href: "/search/news-and-communications"
-        description: Find out what the government is doing
+        description: Search for a department and find out what the government is doing
         menu_contents: # If adding or removing items, remember to update the
                        # `columns` in the layout-super-navigation-header SCSS.
+        - label: Departments
+          href: "/government/organisations"
+          description: Departments, agencies and public bodies
         - label: News
           href: "/search/news-and-communications"
           description: News stories, speeches, letters and notices

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -68,8 +68,8 @@ describe "Super navigation header", type: :view do
     render_component({})
 
     assert_select ".gem-c-layout-super-navigation-header__navigation-items", count: 1
-    assert_select ".gem-c-layout-super-navigation-header__navigation-items .gem-c-layout-super-navigation-header__navigation-item", count: 3
-    assert_select ".gem-c-layout-super-navigation-header__navigation-items .gem-c-layout-super-navigation-header__navigation-item .gem-c-layout-super-navigation-header__navigation-item-link", count: 3
+    assert_select ".gem-c-layout-super-navigation-header__navigation-items .gem-c-layout-super-navigation-header__navigation-item", count: 2
+    assert_select ".gem-c-layout-super-navigation-header__navigation-items .gem-c-layout-super-navigation-header__navigation-item .gem-c-layout-super-navigation-header__navigation-item-link", count: 2
   end
 
   it "renders the search menu with links in it" do


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Move the "Departments" link into the "Government activity" submenu.

## Why
<!-- What are the reasons behind this change being made? -->

The "Departments" link to wasn't being as well used as predicted, with users not finding what they wanted when clicking on the link. This means it could be moved to under the "Government activity" menu, with the hope that it stops being distracting and increases user engagement with the topics menu.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
Before:
![image](https://user-images.githubusercontent.com/1732331/140089296-d226e927-ee97-4f8a-8123-edcc5c1ec224.png)

After:
![image](https://user-images.githubusercontent.com/1732331/140089465-fd7a67dd-b672-42b4-9539-2e4fc6d5a273.png)

Before:
![image](https://user-images.githubusercontent.com/1732331/140089412-1a4d2522-1d8d-4f59-802e-16e74960d51e.png)

After:
![image](https://user-images.githubusercontent.com/1732331/140089532-4de9dd9e-8343-4d31-8523-bc9dc8fc6f2c.png)

