### PR TITLE
Update positioning and border colour on super navigation search button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update the design of the mobile menu button on the super navigation ([PR #2382](https://github.com/alphagov/govuk_publishing_components/pull/2382))
+* Update positioning and border colour on super navigation search button ([PR #2413](https://github.com/alphagov/govuk_publishing_components/pull/2413))
 
 ## 27.10.5
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -697,7 +697,7 @@ $chevron-indent-spacing: 7px;
 
     @include focus-not-focus-visible {
       background: $govuk-brand-colour;
-      border-bottom: 1px solid govuk-colour("black");
+      border-bottom: 1px solid govuk-colour("dark-blue");
       border-left: none;
       position: relative;
     }

--- a/app/views/govuk_publishing_components/components/search/_search_icon.html.erb
+++ b/app/views/govuk_publishing_components/components/search/_search_icon.html.erb
@@ -13,15 +13,15 @@
   focusable="false"
 >
   <circle
-    cx="10.0161"
-    cy="10.0161"
+    cx="12.0161"
+    cy="11.0161"
     r="8.51613"
     stroke="currentColor"
     stroke-width="3" />
   <line
-    x1="15.8668"
-    y1="16.3587"
-    x2="25.4475"
+    x1="17.8668"
+    y1="17.3587"
+    x2="26.4475"
     y2="25.9393"
     stroke="currentColor"
     stroke-width="3" />


### PR DESCRIPTION
## What
Updates the search icon SVG positioning and the bottom border colour (desktop only) of the search button on the [super navigation header](https://components.publishing.service.gov.uk/component-guide/layout_super_navigation_header).

## Why
- So that magnifying glass element of the search icon is more centred
- To iterate on https://github.com/alphagov/govuk_publishing_components/pull/2405, reducing the perceived thickness of the border due to the contrast between the black and the blue

## Visual Changes
| View | Before | After |
| --- | --- | --- |
| Desktop | ![Screenshot 2021-11-03 at 16 49 18](https://user-images.githubusercontent.com/64783893/140118149-17c38c1a-46fe-4978-8b16-84889e7c34ba.png) | ![Screenshot 2021-11-03 at 16 49 06](https://user-images.githubusercontent.com/64783893/140118127-4d4ca55d-5938-4820-a039-8ef81c79d69f.png) |
| Mobile | ![Screenshot 2021-11-03 at 16 58 38](https://user-images.githubusercontent.com/64783893/140118174-f297d783-5e89-4f1b-ab50-24fd55c6c279.png) | ![Screenshot 2021-11-03 at 16 58 13](https://user-images.githubusercontent.com/64783893/140118162-e0ead183-90ff-416d-af25-e1ec7a3ecc2a.png) |