### PR TITLE
Release v27.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.10.6
 
 * Bump `govuk-frontend` from 3.13.0 to 3.14.0 ([PR #2334](https://github.com/alphagov/govuk_publishing_components/pull/2334 ))
 * Add single page notification component ([PR #2293](https://github.com/alphagov/govuk_publishing_components/pull/2293))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.10.5)
+    govuk_publishing_components (27.10.6)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.10.5".freeze
+  VERSION = "27.10.6".freeze
 end


### PR DESCRIPTION
Includes:

* Bump `govuk-frontend` from 3.13.0 to 3.14.0 ([PR #2334](https://github.com/alphagov/govuk_publishing_components/pull/2334 ))
* Add single page notification component ([PR #2293](https://github.com/alphagov/govuk_publishing_components/pull/2293))
* Update the design of the mobile menu button on the super navigation ([PR #2382](https://github.com/alphagov/govuk_publishing_components/pull/2382))
* Update positioning and border colour on super navigation search button ([PR #2413](https://github.com/alphagov/govuk_publishing_components/pull/2413))
