### PR TITLE
Add page margin back when screen size allows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update the design of the mobile menu button on the super navigation ([PR #2382](https://github.com/alphagov/govuk_publishing_components/pull/2382))
+* Add page margin back when screen size allows ([PR #2418](https://github.com/alphagov/govuk_publishing_components/pull/2418))
 
 ## 27.10.5
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -577,6 +577,10 @@ $chevron-indent-spacing: 7px;
   top: 0;
   z-index: 10;
 
+  @include govuk-media-query($from: 360px) {
+    right: (govuk-spacing(9) - 1px);
+  }
+
   @include focus-and-focus-visible {
     @include govuk-focused-text;
     box-shadow: none;
@@ -677,6 +681,10 @@ $chevron-indent-spacing: 7px;
   right: (0 - govuk-spacing(3));
   top: 0;
   width: govuk-spacing(9);
+
+  @include govuk-media-query($from: 360px) {
+    right: 0;
+  }
 
   @include focus-and-focus-visible {
     @include govuk-focused-text;


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Adds the page margin back when the screen size is above 360px wide.

## Why
<!-- What are the reasons behind this change being made? -->
The navigation header needs to be smaller when below 360px wide - so the chevron is removed and the right side page margin is removed. Once above 360px wide these can both be added back in - but only the chevron was, which resulted in an ever so slightly lopsided header. This adds the margin back.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

| Screen size | Before | After |
| ----------- | ------ | ----- |
| < 360px     | ![image](https://user-images.githubusercontent.com/1732331/140374577-6050b6c5-997a-4a18-b63a-46526058f463.png) | ![image](https://user-images.githubusercontent.com/1732331/140374473-18e58799-6adc-4623-9fe3-cc01eef18529.png)  |
| < 360px focused | ![image](https://user-images.githubusercontent.com/1732331/140375458-9a01a250-55bd-4f6d-b815-b904ae7e56ef.png) | ![image](https://user-images.githubusercontent.com/1732331/140375579-c52f0026-a7d8-46be-9041-4a01c022bafb.png) |
| >= 360px    | ![image](https://user-images.githubusercontent.com/1732331/140375256-30f5f9d1-72bf-42d4-ad40-ff4dcf4d8105.png) | ![image](https://user-images.githubusercontent.com/1732331/140374907-6b039637-edf2-4d32-b50e-5817e60ce811.png) |
| >= 360px focused | ![image](https://user-images.githubusercontent.com/1732331/140375674-5f534f4a-ce98-4e31-90b8-525950e62af5.png) | ![image](https://user-images.githubusercontent.com/1732331/140375850-06fe41b5-69b6-43bd-8313-324d8a0eaad1.png) |








