### PR TITLE
Add more spacing in the navigation header mobile layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+* Add more spacing in the navigation header mobile layout ([PR #2421](https://github.com/alphagov/govuk_publishing_components/pull/2421 ))
+
 ## 27.11.0
 
 * Bump `govuk-frontend` from 3.13.0 to 3.14.0 ([PR #2334](https://github.com/alphagov/govuk_publishing_components/pull/2334 ))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -228,24 +228,18 @@ $chevron-indent-spacing: 7px;
   @include govuk-media-query($from: "desktop") {
     display: inline-block;
   }
-
-  .js-module-initialised & {
-    padding: 0 0 govuk-spacing(9) 0;
-
-    @include govuk-media-query($from: "desktop") {
-      padding: 0;
-    }
-  }
 }
 
 .gem-c-layout-super-navigation-header__navigation-item,
 .gem-c-layout-super-navigation-header__search-item {
   display: block;
-  margin: 0 govuk-spacing(3);
+  margin: 0;
+  padding: govuk-spacing(2) govuk-spacing(3);
   position: relative;
 
   @include govuk-media-query($from: "tablet") {
     margin: 0 govuk-spacing(6);
+    padding: govuk-spacing(2) 0;
   }
 
   @include govuk-media-query($from: "desktop") {
@@ -261,8 +255,15 @@ $chevron-indent-spacing: 7px;
 .gem-c-layout-super-navigation-header__navigation-item {
   border-bottom: 1px solid $govuk-border-colour;
 
+  .js-module-initialised & {
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
   @include govuk-media-query($from: "desktop") {
     border-bottom: 0;
+    padding: 0;
   }
 }
 
@@ -279,7 +280,7 @@ $chevron-indent-spacing: 7px;
     font-size: govuk-px-to-rem(19px);
   }
   font-weight: bold;
-  margin: govuk-spacing(3) 0;
+  margin: govuk-spacing(3) 0 govuk-spacing(3) 0;
 
   @include govuk-media-query($from: "desktop") {
     display: block;


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Adjusts the spacing on the navigation header mobile layout.

https://trello.com/c/tfMzKE9j/625-adjust-spacing-on-menu

## Why
<!-- What are the reasons behind this change being made? -->

To better balance the layout of the links and / or buttons.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
| Before | After | 
| - | - |
| ![](https://user-images.githubusercontent.com/1732331/140739918-900ee574-2744-4a1c-9211-ba951846571c.png) | ![](https://user-images.githubusercontent.com/1732331/140739572-921325ef-1dbb-4353-9f2d-ebe6ea32b940.png) |
| ![](https://user-images.githubusercontent.com/1732331/140739934-f08ebb32-53cd-43dc-bc43-5acab989c5ef.png) |  ![](https://user-images.githubusercontent.com/1732331/140739473-c61946bc-092d-44a5-b66b-3ebf52cf89b2.png) |

