### PR TITLE
Adjust navigation header black bar height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 * Add more spacing in the navigation header mobile layout ([PR #2421](https://github.com/alphagov/govuk_publishing_components/pull/2421 ))
+* Adjust navigation header black bar height ([PR #2422](https://github.com/alphagov/govuk_publishing_components/pull/2422 ))
 
 ## 27.11.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -98,6 +98,8 @@
 
 $icon-size: 20px;
 $chevron-indent-spacing: 7px;
+$black-bar-height: 50px;
+$search-width-or-height: $black-bar-height;
 
 @mixin chevron($colour, $update: false) {
   @if ($update == true) {
@@ -131,9 +133,9 @@ $chevron-indent-spacing: 7px;
   bottom: 0;
   content: " ";
   height: govuk-spacing(1);
-  left: govuk-spacing(4);
+  left: govuk-spacing(3);
   position: absolute;
-  right: govuk-spacing(4);
+  right: govuk-spacing(3);
   top: auto;
 }
 
@@ -165,7 +167,7 @@ $chevron-indent-spacing: 7px;
   position: relative;
 
   .lte-ie8 & {
-    height: govuk-spacing(9);
+    height: $black-bar-height;
   }
 
   [hidden] {
@@ -183,8 +185,8 @@ $chevron-indent-spacing: 7px;
 
 .gem-c-layout-super-navigation-header__header-logo {
   height: govuk-spacing(6);
-  padding-bottom: govuk-spacing(3);
-  padding-top: govuk-spacing(3);
+  padding-bottom: govuk-spacing(2);
+  padding-top: govuk-spacing(2);
 
   @include govuk-media-query($from: "desktop") {
     display: block;
@@ -327,7 +329,7 @@ $chevron-indent-spacing: 7px;
       // stylelint-enable max-nesting-depth
 
       height: govuk-spacing(4);
-      padding: govuk-spacing(4);
+      padding: govuk-spacing(3);
       position: relative;
 
       &:before {
@@ -344,28 +346,40 @@ $chevron-indent-spacing: 7px;
 
       // stylelint-disable max-nesting-depth
       @include focus-and-focus-visible {
-        box-shadow: none;
-        color: $govuk-focus-text-colour;
+        &,
+        &:hover {
+          box-shadow: none;
+          color: $govuk-focus-text-colour;
 
-        &:after {
-          background: $govuk-focus-text-colour;
+          &:after {
+            background: $govuk-focus-text-colour;
+          }
         }
       }
 
       @include focus-not-focus-visible {
         &,
         &:hover {
-          color: govuk-colour("white");
           text-decoration: none;
         }
-      }
-      // stylelint-enable max-nesting-depth
 
-      &:focus:not(:focus-visible) {
+        & {
+          color: govuk-colour("white");
+        }
+
+        &:hover {
+          color: govuk-colour("mid-grey");
+
+          &:after {
+            background: govuk-colour("mid-grey");
+          }
+        }
+
         &:after {
           background: none;
         }
       }
+      // stylelint-enable max-nesting-depth
 
       &:after {
         @include pseudo-underline;
@@ -424,8 +438,8 @@ $chevron-indent-spacing: 7px;
       @if $govuk-typography-use-rem {
         font-size: govuk-px-to-rem(16px);
       }
-      height: govuk-spacing(9);
-      padding: govuk-spacing(4);
+      height: $black-bar-height;
+      padding: govuk-spacing(3);
       position: relative;
       text-decoration: none;
 
@@ -510,7 +524,7 @@ $chevron-indent-spacing: 7px;
       background: $govuk-brand-colour;
 
       &:hover {
-        background: none;
+        background: govuk-colour("black");
 
         &:before {
           left: 0;
@@ -523,6 +537,30 @@ $chevron-indent-spacing: 7px;
 
         &:before {
           content: none;
+        }
+      }
+
+      &:after {
+        left: 0;
+        right: 0;
+      }
+
+      @include focus-not-focus-visible {
+        background: $govuk-link-colour;
+
+        &:hover {
+          background: govuk-colour("black");
+        }
+      }
+
+      @include focus-and-focus-visible {
+        &:hover {
+          background: $govuk-focus-colour;
+        }
+
+        &:after,
+        &:hover:after {
+          background: $govuk-focus-colour;
         }
       }
     }
@@ -575,10 +613,10 @@ $chevron-indent-spacing: 7px;
   box-sizing: border-box;
   color: govuk-colour("white");
   cursor: pointer;
-  height: govuk-spacing(9);
+  height: $black-bar-height;
   padding: 0;
   position: absolute;
-  right: ((govuk-spacing(9) - govuk-spacing(3)) - 1px); // width of the search button (60px) - 15px - 1px to create an overlap between buttons and stop the border appearing to hang off the buttons when they're focused/open
+  right: (($search-width-or-height - govuk-spacing(3)) - 1px); // width of the search button (50px) - 15px - 1px to create an overlap between buttons and stop the border appearing to hang off the buttons when they're focused/open
   top: 0;
   z-index: 10;
 
@@ -659,7 +697,7 @@ $chevron-indent-spacing: 7px;
   display: inline-block;
   border-left: 1px solid govuk-colour("white");
   border-right: 1px solid govuk-colour("white");
-  margin: govuk-spacing(2) 0;
+  margin: 0;
   padding: govuk-spacing(2) govuk-spacing(4);
 
   @include govuk-media-query($from: 360px) {
@@ -676,12 +714,12 @@ $chevron-indent-spacing: 7px;
   border: 0;
   color: govuk-colour("white");
   cursor: pointer;
-  height: govuk-spacing(9);
-  padding: govuk-spacing(4);
+  height: $search-width-or-height;
+  padding: govuk-spacing(3);
   position: absolute;
   right: (0 - govuk-spacing(3));
   top: 0;
-  width: govuk-spacing(9);
+  width: $search-width-or-height;
 
   @include focus-and-focus-visible {
     @include govuk-focused-text;
@@ -750,7 +788,7 @@ $chevron-indent-spacing: 7px;
   font-weight: normal;
   left: 0;
   line-height: 22px;
-  padding: govuk-spacing(4) 0;
+  padding: govuk-spacing(3) 0;
   pointer-events: none;
   position: absolute;
   right: 0;
@@ -770,7 +808,6 @@ $chevron-indent-spacing: 7px;
     left: 0;
     position: absolute;
     right: 0;
-    top: govuk-spacing(9);
   }
 }
 


### PR DESCRIPTION
## What

This changes the height of the navigation header to match the GOV.UK Frontend header.

Also fixes `:focus:hover` state for browsers that support `:focus-visible` - to support both `:focus` and `:focus-visible` we need to add the styles for both `:focus` and `:focus-visible` - then undo the styles `:focus` styles for browsers that support `:focus-visible`. This means that any undone styles need to be re-addded back - and the `:focus:hover` state was previously missed.

## Why

In the far distant past and for reasons unknown the black bar in the header component was adjusted to be a different height to the height of the GOV.UK Frontend / Design System header component. This meant that when a user goes from www.gov.uk to a service, the header would change height - which is not the seamless experience that we're aiming for.

## Visual Changes

### Height change

| Screen size | Before | After |
| ----------- | ------ | ----- |
| < 360px | ![image](https://user-images.githubusercontent.com/1732331/140755543-1066beee-5e3e-4807-8810-63548a57e73c.png) | ![image](https://user-images.githubusercontent.com/1732331/140754846-463161d7-d18e-4d9b-bf5d-82a4e24c44bb.png) |
| >= 360px | ![image](https://user-images.githubusercontent.com/1732331/140755485-f5317706-5a3e-43fb-932b-225ecc129527.png) | ![image](https://user-images.githubusercontent.com/1732331/140755161-c854807d-913d-4bad-be88-e4f71b44198c.png) |
| Desktop | ![image](https://user-images.githubusercontent.com/1732331/140755377-dbf42629-1a56-4226-afe5-cf1f281542e5.png) | ![image](https://user-images.githubusercontent.com/1732331/140755234-c97035b6-be47-4e35-aa5b-bb017215d5ad.png) |

### State fixes for no-JavaScript layout links

#### Search link `:focus-visible:hover`

Before:

![search link focus-visible hover - should focus state](https://user-images.githubusercontent.com/1732331/140919631-413276f6-6604-4806-a7aa-d5453131ea9f.png)

After:

![search link focus-visible hover - is now focus state](https://user-images.githubusercontent.com/1732331/140919630-a22d9125-e49f-4a49-8e74-e8950e3e82b4.png)

#### Search link `:focus:hover`

Before:

![search link focus hover - should be grey](https://user-images.githubusercontent.com/1732331/140919743-9e09579f-fdbd-42e4-a05a-901e855c06cb.png)

After:
![search link focus hover - now grey](https://user-images.githubusercontent.com/1732331/140919739-07c875b3-1955-402e-b23a-960f700c9928.png)
 
#### Search link `:focus`

Before:
![search link focus - underline visible](https://user-images.githubusercontent.com/1732331/140919969-6754299c-a9ed-4139-a8d1-888bcb192328.png)

After:
![search link focus - underline not visible](https://user-images.githubusercontent.com/1732331/140919963-042ae81b-fde6-45eb-85e7-deaeafe50d8f.png)

#### Link `:hover`

Before:
![link hover state - text white not grey](https://user-images.githubusercontent.com/1732331/140920120-4604a93a-ab06-498a-a947-8bd2fb3d3664.png)

After:
![link hover state - text now grey](https://user-images.githubusercontent.com/1732331/140920115-b04801c3-20ba-4e6d-834c-5b56d74835d6.png)

#### Link `:focus:hover`

Before:
![link focus hover - text should be black](https://user-images.githubusercontent.com/1732331/140920213-0509c273-9e92-47ee-98f9-85ad517fbb0b.png)

After:


![link focus hover - text is now black](https://user-images.githubusercontent.com/1732331/140920208-88cc6b27-2901-4b03-928e-36cd310568f3.png)

