### PR TITLE
Add shared accessibility criteria for button

### DIFF
--- a/app/models/govuk_publishing_components/shared_accessibility_criteria.rb
+++ b/app/models/govuk_publishing_components/shared_accessibility_criteria.rb
@@ -16,5 +16,22 @@ Links in the component must:
 - have meaningful text
       "
     end
+
+    def self.button
+      "
+Buttons in the component must:
+
+- accept focus
+- be focusable with a keyboard
+- be usable with a keyboard
+- indicate when they have focus
+- change in appearance when touched (in the touch-down state)
+- change in appearance when hovered
+- be usable with touch
+- be usable with [voice commands](https://www.w3.org/WAI/perspectives/voice.html)
+- have visible text
+- have meaningful text
+      "
+    end
   end
 end


### PR DESCRIPTION
## What
Add shared accessibility criteria for buttons in components.

## Why
We've got shared accessibility criteria for links but nothing else. I realised that lots of components have buttons in, and this could save us some effort.

The criteria are the same as for links, which feels a little repetitive except that each criteria specifically talks about links and buttons. Also some components have buttons, some have links, some have both.

## Visual Changes

![Screenshot 2021-11-09 at 09 54 36](https://user-images.githubusercontent.com/861310/140902644-71214822-0a8d-4435-b249-d1e01ce6cf67.png)

![Screenshot 2021-11-09 at 09 48 22](https://user-images.githubusercontent.com/861310/140902673-1d1a3731-f519-4df4-befa-5581a3e88094.png)

