### PR TITLE
Add `enterkeyhint` attribute to input and search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add more spacing in the navigation header mobile layout ([PR #2421](https://github.com/alphagov/govuk_publishing_components/pull/2421 ))
 * Adjust navigation header black bar height ([PR #2422](https://github.com/alphagov/govuk_publishing_components/pull/2422 ))
 * Fix chevron rotation for the super navigation header and accordion components on IE9 ([PR #2429](https://github.com/alphagov/govuk_publishing_components/pull/2429))
+* Add `enterkeyhint` attribute to input and search ([PR #2426](https://github.com/alphagov/govuk_publishing_components/pull/2426 ))
 
 ## 27.11.0
 

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -1,13 +1,16 @@
 <%
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
-  id ||= "input-#{SecureRandom.hex(4)}"
-  value ||= nil
-  type ||= "text"
-  describedby ||= nil
+  autocomplete ||= nil
   controls ||= nil
   data ||= nil
-  autocomplete ||= nil
+  describedby ||= nil
+  enterkeyhint ||= nil
+  id ||= "input-#{SecureRandom.hex(4)}"
+  type ||= "text"
+  value ||= nil
+  inputmode ||= nil
+  pattern ||= nil
 
   label ||= nil
   hint ||= nil
@@ -32,6 +35,7 @@
   css_classes << "govuk-input--error" if has_error
   css_classes << "govuk-input--width-#{width}" if [2, 3, 4, 5, 10, 20, 30].include?(width)
   css_classes << "gem-c-input--with-search-icon" if search_icon
+
   form_group_css_classes = %w(govuk-form-group)
   form_group_css_classes << "govuk-form-group--error" if has_error && !grouped
 
@@ -44,14 +48,21 @@
     aria_described_by = aria_described_by.join(" ")
   end
 
+  checked_enterkeyhint = enterkeyhint if [
+    "done",
+    "enter",
+    "go",
+    "next",
+    "previous",
+    "search",
+    "send",
+  ].include?(enterkeyhint)
+
   if type == "number"
     type = "text"
     inputmode = "numeric"
     pattern = "[0-9]*"
   end
-
-  inputmode ||= nil
-  pattern ||= nil
 %>
 
 <%= content_tag :div, class: form_group_css_classes do %>
@@ -87,24 +98,26 @@
     } %>
   <% end %>
 
-  <% input_tag = tag.input name: name,
-    value: value,
-    class: css_classes,
-    id: id,
-    type: type,
-    data: data,
-    autocomplete: autocomplete,
-    tabindex: tabindex,
-    autofocus: autofocus,
-    readonly: readonly,
-    maxlength: maxlength,
-    inputmode: inputmode,
-    pattern: pattern,
+  <% input_tag = tag.input({
     aria: {
       describedby: aria_described_by,
       controls: controls
-    }
-  %>
+    },
+    autocomplete: autocomplete,
+    autofocus: autofocus,
+    class: css_classes,
+    data: data,
+    enterkeyhint: checked_enterkeyhint,
+    id: id,
+    inputmode: inputmode,
+    maxlength: maxlength,
+    name: name,
+    pattern: pattern,
+    readonly: readonly,
+    tabindex: tabindex,
+    type: type,
+    value: value,
+  }) %>
 
   <% if prefix && suffix %>
     <%= tag.div class: "govuk-input__wrapper" do %>

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -43,6 +43,7 @@
       aria: {
         controls: aria_controls,
       },
+      enterkeyhint: "search",
       class: "gem-c-search__item gem-c-search__input js-class-toggle",
       id: id,
       name: name,
@@ -51,7 +52,7 @@
       value: value,
     ) %>
     <div class="gem-c-search__item gem-c-search__submit-wrapper">
-      <%= tag.button class: "gem-c-search__submit", type: "submit", data: data_attributes do %>
+      <%= tag.button class: "gem-c-search__submit", type: "submit", data: data_attributes, enterkeyhint: "search" do %>
         <%= button_text %>
         <%= render "govuk_publishing_components/components/search/search_icon" %>
       <% end %>

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -170,3 +170,13 @@ examples:
       name: "lead-times"
       width: 10
       suffix: "days"
+  with_enterhintkey_attribute:
+    description: |
+      To help users with virtual keyboards this changes the "enter" key to be a word that's more descriptive of the action.
+
+      Must be one of `enter`, `done`, `go`, `next`, `previous`, `search`, or `send`. See the [list of values and descriptions on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/enterkeyhint#values).
+    data:
+      label:
+        text: "Given name"
+      name: given-name
+      enterkeyhint: "next"

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -264,4 +264,22 @@ describe "Input", type: :view do
     assert_select ".gem-c-input--with-search-icon"
     assert_select ".gem-c-input__search-icon"
   end
+
+  it "renders input with an `enterkeyhint` attribute" do
+    render_component(
+      name: "with-enterkeyhint-attribute",
+      enterkeyhint: "search",
+    )
+
+    assert_select ".govuk-input[enterkeyhint='search']"
+  end
+
+  it "doesn't add tje `enterkeyhint` attribute if not an appropriate value" do
+    render_component(
+      name: "without-enterkeyhint-attribute",
+      enterkeyhint: "chocolate",
+    )
+
+    assert_no_selector ".govuk-input[enterkeyhint='chocolate']"
+  end
 end

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -118,4 +118,10 @@ describe "Search", type: :view do
     assert_no_selector ".govuk-label"
     assert_select ".gem-c-search__label", text: "Search on GOV.UK"
   end
+
+  it "renders with `enterkeyhint` attributes on both input and button by default" do
+    render_component({})
+    assert_select "input[enterkeyhint='search']", count: 1
+    assert_select "button[enterkeyhint='search']", count: 1
+  end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Adds `enterkeyhint` option to set the `enterkeyhint` attribute on the input element in the input component.

Sets the `enterkeyhint` attribute to `search` on the input and button elements in the search component.

## Why
<!-- What are the reasons behind this change being made? -->
The `enterkeyhint` attribute can be used to ask virtual keyboards to display a different word or icon for the enter key - for example, 'search' or 'next'.

See the [spec for more details](https://html.spec.whatwg.org/multipage/interaction.html#attr-enterkeyhint).
## Visual Changes
<!-- If the change results in visual changes, show a before and after -->
### Safari on iOS 15

| Before | After |
| - | - |
| ![997A43DA-98AA-4764-A222-04AEBC0ABD21](https://user-images.githubusercontent.com/1732331/140961098-9ccfdaff-d1c7-49ad-8845-b24f2bba356a.PNG) | ![AABF79FB-BAE3-401F-A001-DFB9CE005BD0](https://user-images.githubusercontent.com/1732331/140961104-e33902ab-67a1-4ec9-bd4e-33d621edc9d3.PNG) |

