### PR TITLE
Fix chevron rotation for the super navigation header and accordion components on IE9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@
   of the commit log.
 
 ## Unreleased
+
 * Add more spacing in the navigation header mobile layout ([PR #2421](https://github.com/alphagov/govuk_publishing_components/pull/2421 ))
 * Adjust navigation header black bar height ([PR #2422](https://github.com/alphagov/govuk_publishing_components/pull/2422 ))
+* Fix chevron rotation for the super navigation header and accordion components on IE9 ([PR #2429](https://github.com/alphagov/govuk_publishing_components/pull/2429))
 
 ## 27.11.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
@@ -1,3 +1,5 @@
+@import "mixins/prefixed-transform";
+
 $gem-c-accordion-border-width: 3px;
 $gem-c-accordion-bottom-border-width: 1px;
 
@@ -69,6 +71,7 @@ $gem-c-accordion-bottom-border-width: 1px;
     }
 
     &:after {
+      @include prefixed-transform($rotate: -45deg);
       content: "";
       display: block;
       box-sizing: border-box;
@@ -78,7 +81,6 @@ $gem-c-accordion-bottom-border-width: 1px;
       height: govuk-em(6, 14);
       border-top: govuk-em(2, 14) solid;
       border-right: govuk-em(2, 14) solid;
-      transform: rotate(-45deg);
       left: govuk-em(6, 14);
       bottom: govuk-em(5, 14);
 
@@ -111,7 +113,7 @@ $gem-c-accordion-bottom-border-width: 1px;
 
   // Rotate icon to create "Down" version
   .gem-c-accordion-nav__chevron--down {
-    transform: rotate(180deg);
+    @include prefixed-transform($rotate: 180deg);
   }
 
   .gem-c-accordion__section-heading {
@@ -296,12 +298,12 @@ $gem-c-accordion-bottom-border-width: 1px;
 
     // Reduce Chevron size
     .gem-c-accordion-nav__chevron {
+      @include prefixed-transform($scale: .875);
       width: govuk-em(20, 14);
       height: govuk-em(20, 14);
       margin-left: govuk-em(5, 14);
       border: govuk-em(1, 14) solid;
       border-radius: govuk-em(100, 14);
-      transform: scale(.875);
 
       &:after {
         width: govuk-em(6, 14);
@@ -314,7 +316,7 @@ $gem-c-accordion-bottom-border-width: 1px;
     }
 
     .gem-c-accordion-nav__chevron--down {
-      transform: scale(.875) rotate(180deg);
+      @include prefixed-transform($rotate: 180deg, $scale: .875);
     }
 
     .gem-c-accordion__section-summary {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -1,3 +1,5 @@
+@import "mixins/prefixed-transform";
+
 /// Set grid row or column value using the fraction unit.
 ///
 /// @param {Integer} $number - number of fractions that the grid row or column
@@ -106,13 +108,13 @@ $search-width-or-height: $black-bar-height;
     border-bottom-color: $colour;
     border-right-color: $colour;
   } @else {
+    @include prefixed-transform($rotate: 45deg, $translateY: -35%);
     border-bottom: 3px solid $colour;
     border-right: 3px solid $colour;
     content: " ";
     display: inline-block;
     height: 8px;
     margin: 0 8px 0 2px;
-    transform: translateY(-35%) rotate(45deg);
     vertical-align: middle;
     width: 8px;
   }
@@ -478,7 +480,7 @@ $search-width-or-height: $black-bar-height;
   &.gem-c-layout-super-navigation-header__open-button {
     @include focus-not-focus-visible {
       &:before {
-        transform: translateY(0) rotate(225deg);
+        @include prefixed-transform($rotate: 225deg, $translateY: 0);
       }
     }
 
@@ -668,7 +670,7 @@ $search-width-or-height: $black-bar-height;
         @include govuk-media-query($from: 360px) {
           &:before {
             @include chevron(govuk-colour("black"), true);
-            transform: translateY(0) rotate(225deg);
+            @include prefixed-transform($rotate: 225deg, $translateY: 0);
           }
         }
       }
@@ -684,7 +686,7 @@ $search-width-or-height: $black-bar-height;
         @include govuk-media-query($from: 360px) {
           &:before {
             @include chevron(govuk-colour("black"));
-            transform: translateY(0) rotate(225deg);
+            @include prefixed-transform($rotate: 225deg, $translateY: 0);
           }
         }
       }

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_prefixed-transform.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_prefixed-transform.scss
@@ -1,0 +1,5 @@
+@mixin prefixed-transform($translateY: 0, $rotate: 0, $scale: 1) {
+  -webkit-transform: translateY($translateY) rotate($rotate) scale($scale);
+  -ms-transform: translateY($translateY) rotate($rotate) scale($scale);
+  transform: translateY($translateY) rotate($rotate) scale($scale);
+}


### PR DESCRIPTION
## What
Adds a shared mixin for css `transform` options that includes prefixed versions of the attribute for use by the [super nav](https://components.publishing.service.gov.uk/component-guide/layout_super_navigation_header) and [accordion](http://govuk-publishing-components.dev.gov.uk/component-guide/accordion) components.

## Why
Fixes https://github.com/alphagov/govuk_publishing_components/issues/2419

## Additional notes
- This is not an extensive mixin for the `transform` attribute. It only meets how we're using it currently (in these 2 components, only using `translateY`, `rotate` and `scale`)
- A more extensive solution would be to use an autoprefixer. Will make an issue to this effect.

[Card](https://trello.com/c/HMp5VYUV/624-fix-chevrons-in-menu-and-accordions-for-ie9)

## Visual Changes (IE9 only, no visual changes on other browsers)
### Super nav desktop
Before:
<img width="976" alt="Screenshot 2021-11-09 at 15 45 00" src="https://user-images.githubusercontent.com/64783893/140969244-c203f47b-9a7a-47d8-9de5-a216b557182d.png">

After:
<img width="980" alt="Screenshot 2021-11-09 at 15 42 13" src="https://user-images.githubusercontent.com/64783893/140969203-246f5ebb-7a4a-4ec6-ad49-9df8ee77e84a.png">

### Super nav mobile
Before:
<img width="486" alt="Screenshot 2021-11-09 at 15 45 19" src="https://user-images.githubusercontent.com/64783893/140969360-c2ac57c2-fe74-40fa-af78-5add4032d8dc.png">

After:
<img width="485" alt="Screenshot 2021-11-09 at 15 43 18" src="https://user-images.githubusercontent.com/64783893/140969410-7ec96428-c715-4aa1-b258-4dea74e34e21.png">

### Accordion
Before:
<img width="980" alt="Screenshot 2021-11-09 at 16 20 30" src="https://user-images.githubusercontent.com/64783893/140969459-d4e9204a-5d7f-4023-95b9-7661285277df.png">

After:
<img width="997" alt="Screenshot 2021-11-09 at 16 19 45" src="https://user-images.githubusercontent.com/64783893/140969512-8dc2dd00-7213-4ca4-8533-71b305a36001.png">

