### PR TITLE
Update feedback component to fix accessibility issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ## Unreleased
 
+* **BREAKING:** Update feedback component to fix accessibility issues ([PR #2435](https://github.com/alphagov/govuk_publishing_components/pull/2435))
+  You must make the following changes when you migrate to this release:
+  - Upgrade `static` to the latest version before you upgrade your application
 * Remove duplicate link in menu header ([PR #2547](https://github.com/alphagov/govuk_publishing_components/pull/2547))
 
 ## 27.20.0

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -25,10 +25,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.setInitialAriaAttributes()
     this.setHiddenValues()
 
+    this.prompt.hidden = false
+    for (var k = 0; k < this.promptQuestions.length; k++) {
+      this.promptQuestions[k].hidden = false
+    }
+    this.surveyForm.hidden = true
+
     for (var j = 0; j < this.toggleForms.length; j++) {
       this.toggleForms[j].addEventListener('click', function (e) {
         e.preventDefault()
-        var el = e.target
+        var el = e.target.closest('button')
         this.toggleForm(el.getAttribute('aria-controls'))
         this.trackEvent(this.getTrackEventParams(el))
         this.updateAriaAttributes(el)
@@ -36,6 +42,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
 
     for (var i = 0; i < this.closeForms.length; i++) {
+      this.closeForms[i].hidden = false
       this.closeForms[i].addEventListener('click', function (e) {
         e.preventDefault()
         var el = e.target
@@ -89,7 +96,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
               this.showFormSuccess(xhr.message)
               this.revealInitialPrompt()
               this.setInitialAriaAttributes()
-              this.activeForm.classList.toggle(this.jshiddenClass)
+              this.activeForm.hidden ? this.activeForm.hidden = false : this.activeForm.hidden = true
             } else {
               this.showError(xhr)
               this.enableSubmitFormButton($form)
@@ -114,9 +121,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   Feedback.prototype.setInitialAriaAttributes = function () {
-    for (var i = 0; i < this.forms.length; i++) {
-      this.forms[i].setAttribute('aria-hidden', true)
-    }
     this.pageIsNotUsefulButton.setAttribute('aria-expanded', false)
     this.somethingIsWrongButton.setAttribute('aria-expanded', false)
   }
@@ -168,20 +172,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Feedback.prototype.updateAriaAttributes = function (linkClicked) {
     linkClicked.setAttribute('aria-expanded', true)
-    var controls = linkClicked.getAttribute('aria-controls')
-    var ariaControls = document.querySelector('#' + controls)
-    ariaControls.setAttribute('aria-hidden', false)
   }
 
   Feedback.prototype.toggleForm = function (formId) {
     this.activeForm = this.$module.querySelector('#' + formId)
-    this.activeForm.classList.toggle(this.jshiddenClass)
-    this.prompt.classList.toggle(this.jshiddenClass)
+    this.activeForm.hidden ? this.activeForm.hidden = false : this.activeForm.hidden = true
+    this.prompt.hidden ? this.prompt.hidden = false : this.prompt.hidden = true
 
-    var formIsVisible = !this.activeForm.classList.contains(this.jshiddenClass)
-
-    if (formIsVisible) {
-      this.activeForm.querySelector('.gem-c-input').focus()
+    if (!this.activeForm.hidden) {
+      this.activeForm.querySelectorAll('.gem-c-textarea .govuk-textarea, .gem-c-input.govuk-input')[0]
+        .focus()
     } else {
       this.activeForm = false
     }
@@ -223,20 +223,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
     var $errors = this.activeForm.querySelector('.js-errors')
     $errors.innerHTML = error
-    $errors.classList.remove(this.jshiddenClass)
+    $errors.hidden = false
     $errors.focus()
   }
 
   Feedback.prototype.showFormSuccess = function () {
     for (var i = 0; i < this.promptQuestions.length; i++) {
-      this.promptQuestions[i].classList.add(this.jshiddenClass)
+      this.promptQuestions[i].hidden = true
     }
-    this.promptSuccessMessage.classList.remove(this.jshiddenClass)
+    this.promptSuccessMessage.hidden = false
     this.promptSuccessMessage.focus()
   }
 
   Feedback.prototype.revealInitialPrompt = function () {
-    this.prompt.classList.remove(this.jshiddenClass)
+    this.prompt.hidden = false
     this.prompt.focus()
   }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -6,6 +6,12 @@
     margin-top: govuk-spacing(9);
     border-bottom: 1px solid govuk-colour("white");
   }
+
+  // Scoped to the feedback component temporarily
+  [hidden] {
+    // stylelint-disable-next-line declaration-no-important
+    display: none !important;
+  }
 }
 
 .gem-c-feedback__prompt-questions {
@@ -237,39 +243,4 @@
   &:focus {
     outline: $govuk-focus-width solid $govuk-focus-colour;
   }
-}
-
-// hide without js
-// show with js, unless also has the js-hidden class
-.gem-c-feedback__js-show,
-.gem-c-feedback__prompt-success,
-.gem-c-feedback__prompt-questions,
-.gem-c-feedback__error-summary {
-  display: none;
-
-  .js-enabled & {
-    display: block;
-
-    &.js-hidden {
-      display: none;
-    }
-  }
-}
-
-// maintain table display for prompt and prompt-questions
-.js-enabled .gem-c-feedback__prompt {
-  @include govuk-media-query($from: tablet) {
-    display: table;
-  }
-}
-
-.js-enabled .gem-c-feedback__prompt-questions {
-  @include govuk-media-query($from: tablet) {
-    display: table-cell;
-  }
-}
-
-// show the default feedback form without js
-.js-enabled .gem-c-feedback__form.js-hidden {
-  display: none;
 }

--- a/app/views/govuk_publishing_components/components/docs/feedback.yml
+++ b/app/views/govuk_publishing_components/components/docs/feedback.yml
@@ -5,6 +5,11 @@ body: |
 
   This component uses JavaScript for expanding and collapsing and also for submitting form responses. This code is not compatible with Internet Explorer, so IE11 and down do not use JavaScript to submit the forms, instead falling back to a normal form submission.
 accessibility_criteria: |
+  The form must:
+
+  * be functional and accessible with JavaScript disabled
+  * be usable and accessible with stylesheets disabled
+
   Form elements in the component must:
 
   * accept focus

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -1,9 +1,10 @@
 <form action="/contact/govuk/problem_reports"
   id="something-is-wrong"
-  class="gem-c-feedback__form js-feedback-form js-hidden"
+  class="gem-c-feedback__form js-feedback-form"
   data-track-category="Onsite Feedback"
   data-track-action="GOV.UK Send Form"
-  method="post">
+  method="post"
+  hidden>
   <button
     class="govuk-button govuk-button--secondary gem-c-feedback__close gem-c-feedback__js-show js-close-form"
     data-track-category="Onsite Feedback"
@@ -15,26 +16,28 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <div class="gem-c-feedback__error-summary gem-c-feedback__js-show js-hidden js-errors" tabindex="-1"></div>
+      <div class="gem-c-feedback__error-summary gem-c-feedback__js-show js-errors" tabindex="-1" hidden></div>
 
       <input type="hidden" name="url" value="<%= url_without_pii %>">
 
       <h3 class="gem-c-feedback__form-heading"><%= t("components.feedback.help_us_improve_govuk") %></h3>
       <p id="feedback_explanation" class="gem-c-feedback__form-paragraph"><%= t("components.feedback.dont_include_personal_info") %></p>
 
-      <%= render "govuk_publishing_components/components/input", {
+      <%= render "govuk_publishing_components/components/textarea", {
         label: {
           text: t("components.feedback.what_doing")
         },
         name: "what_doing",
+        rows: 3,
         describedby: "feedback_explanation"
       } %>
 
-      <%= render "govuk_publishing_components/components/input", {
+      <%= render "govuk_publishing_components/components/textarea", {
         label: {
           text: t("components.feedback.what_wrong")
         },
-        name: "what_wrong"
+        name: "what_wrong",
+        rows: 3
       } %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -1,6 +1,6 @@
 <form action="/contact/govuk/email-survey-signup"
   id="page-is-not-useful"
-  class="gem-c-feedback__form gem-c-feedback__form--email gem-c-feedback__js-show js-feedback-form js-hidden"
+  class="gem-c-feedback__form gem-c-feedback__form--email gem-c-feedback__js-show js-feedback-form"
   data-track-category="yesNoFeedbackForm"
   data-track-action="Send Form"
   method="post">
@@ -9,13 +9,14 @@
     data-track-category="yesNoFeedbackForm"
     data-track-action="ffFormClose"
     aria-controls="page-is-not-useful"
-    aria-expanded="true">
+    aria-expanded="true"
+    hidden>
     <%= t("components.feedback.close") %>
   </button>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds" id="survey-wrapper">
-      <div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>
+      <div class="gem-c-feedback__error-summary js-errors" tabindex="-1" hidden></div>
 
       <input name="email_survey_signup[survey_id]" type="hidden" value="footer_satisfaction_survey">
       <input name="email_survey_signup[survey_source]" type="hidden" value="<%= path_without_pii %>">

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -3,10 +3,10 @@
 %>
 
 <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
-  <div class="gem-c-feedback__prompt-questions js-prompt-questions">
+  <div class="gem-c-feedback__prompt-questions js-prompt-questions" hidden>
     <h2 class="gem-c-feedback__prompt-question"><%= t("components.feedback.is_this_page_useful") %></h2>
     <!-- Maybe button exists only to try and capture clicks by bots -->
-    <button data-track-category="yesNoFeedbackForm" data-track-action="ffMaybeClick" aria-expanded="false" style="display: none" hidden="hidden" aria-hidden="true">
+    <button data-track-category="yesNoFeedbackForm" data-track-action="ffMaybeClick" aria-expanded="false" hidden>
       <%= t("components.feedback.maybe") %>
     </button>
     
@@ -23,10 +23,10 @@
       </li>
     </ul>
   </div>
-  <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-success js-prompt-success js-hidden" role="alert">
+  <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-success js-prompt-success" role="alert" hidden>
     <%= t("components.feedback.thank_you_for_feedback") %>
   </div>
-  <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions">
+  <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions" hidden>
     <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV-UK Open Form" aria-controls="something-is-wrong" aria-expanded="false">
       <%= t("components.feedback.something_wrong") %>
     </button>

--- a/spec/component_guide/component_index_spec.rb
+++ b/spec/component_guide/component_index_spec.rb
@@ -73,6 +73,7 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
 @import 'govuk_publishing_components/components/step-by-step-nav-related';
 @import 'govuk_publishing_components/components/tabs';
+@import 'govuk_publishing_components/components/textarea';
 @import 'govuk_publishing_components/components/title';"
 
     expected_print_sass = "@import 'govuk_publishing_components/govuk_frontend_support';
@@ -81,6 +82,7 @@ describe "Component guide index" do
 @import 'govuk_publishing_components/components/print/layout-super-navigation-header';
 @import 'govuk_publishing_components/components/print/step-by-step-nav';
 @import 'govuk_publishing_components/components/print/step-by-step-nav-header';
+@import 'govuk_publishing_components/components/print/textarea';
 @import 'govuk_publishing_components/components/print/title';"
 
     expect(page).to have_selector(".component-doc-h2", text: "Gem components used by this app (17)")

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -5,7 +5,7 @@ describe('Feedback component', function () {
   var FIXTURE =
   '<div class="gem-c-feedback">' +
     '<div class="gem-c-feedback__prompt js-prompt" tabindex="-1">' +
-      '<div class="js-prompt-questions">' +
+      '<div class="js-prompt-questions" hidden>' +
         '<h3 class="gem-c-feedback__is-useful-question">Is this page useful?</h3>' +
         '<ul class="gem-c-feedback__option-list">' +
           '<li class="gem-c-feedback__option-list-item gem-c-feedback__option-list-item--useful">' +
@@ -25,46 +25,46 @@ describe('Feedback component', function () {
           '</li>' +
         '</ul>' +
       '</div>' +
-      '<div class="gem-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">' +
+      '<div class="gem-c-feedback__prompt-success js-prompt-success" tabindex="-1" hidden>' +
         'Thanks for your feedback.' +
       '</div>' +
     '</div>' +
 
-    '<form action="/contact/govuk/page_improvements" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="Onsite Feedback" data-track-action="GOV.UK Send Form">' +
+    '<form action="/contact/govuk/page_improvements" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form" data-track-category="Onsite Feedback" data-track-action="GOV.UK Send Form" hidden>' +
       '<button class="govuk-button govuk-button--secondary gem-c-feedback__close gem-c-feedback__js-show js-close-form" data-track-category="Onsite Feedback" data-track-action="GOV.UK Close Form" aria-controls="something-is-wrong">Close</button>' +
       '<div class="grid-row">' +
         '<div class="column-two-thirds" id="survey-wrapper">' +
-          '<div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>' +
+          '<div class="gem-c-feedback__error-summary js-errors" tabindex="-1" hidden></div>' +
 
           '<input type="hidden" name="url" value="http://example.com/path/to/page">' +
 
           '<h2 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h2>' +
           '<p class="gem-c-feedback__form-paragraph">Don\'t include personal or financial information like your National Insurance number or credit card details.</p>' +
 
-          '<div class="gem-c-label">' +
-            '<label class="gem-c-label__text" for="input-29a3904f">' +
+          '<div class="gem-c-textarea">' +
+            '<label class="gem-c-label__text" for="textarea-a19ef216">' +
               'What were you doing?' +
             '</label>' +
+            '<textarea name="what_doing" class="govuk-textarea" id="textarea-a19ef216" rows="2"></textarea>' +
           '</div>' +
-          '<input class="gem-c-input " id="input-29a3904f" name="what_doing" type="text">' +
 
-          '<div class="gem-c-label">' +
-            '<label class="gem-c-label__text" for="input-3ad718b1">' +
+          '<div class="gem-c-textarea">' +
+            '<label class="gem-c-label__text" for="textarea-da67721e">' +
               'What went wrong?' +
             '</label>' +
+            '<textarea name="what_wrong" class="govuk-textarea" id="textarea-da67721e" rows="2"></textarea>' +
           '</div>' +
-          '<input class="gem-c-input " id="input-3ad718b1" name="what_wrong" type="text">' +
 
           '<input class="gem-c-feedback__submit" type="submit" value="Submit">' +
         '</div>' +
       '</div>' +
     '</form>' +
 
-    '<form action="/contact/govuk/email-survey-signup" id="page-is-not-useful" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="yesNoFeedbackForm" data-track-action="Send Form">' +
-      '<button class="govuk-button govuk-button--secondary gem-c-feedback__close js-close-form" data-track-category="yesNoFeedbackForm" data-track-action="ffFormClose" aria-controls="page-is-not-useful">Close</button>' +
+    '<form action="/contact/govuk/email-survey-signup" id="page-is-not-useful" class="gem-c-feedback__form js-feedback-form" data-track-category="yesNoFeedbackForm" data-track-action="Send Form">' +
+      '<button class="govuk-button govuk-button--secondary gem-c-feedback__close js-close-form" data-track-category="yesNoFeedbackForm" data-track-action="ffFormClose" aria-controls="page-is-not-useful" hidden>Close</button>' +
       '<div class="grid-row">' +
         '<div class="column-two-thirds">' +
-          '<div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>' +
+          '<div class="gem-c-feedback__error-summary js-errors" tabindex="-1" hidden></div>' +
           '<input name="email_survey_signup[survey_source]" type="hidden" value="a_source">' +
           '<input name="email_survey_signup[survey_id]" type="hidden" value="an_id">' +
 
@@ -76,7 +76,7 @@ describe('Feedback component', function () {
               'Email address' +
             '</label>' +
           '</div>' +
-          '<input class="gem-c-input " id="input-111111" name="email_survey_signup[email_address]" type="text">' +
+          '<input class="gem-c-input govuk-input" id="input-111111" name="email_survey_signup[email_address]" type="text">' +
 
           '<input class="gem-c-feedback__submit" type="submit" value="Send me the survey">' +
         '</div>' +
@@ -98,21 +98,14 @@ describe('Feedback component', function () {
   it('hides the forms', function () {
     loadFeedbackComponent()
 
-    expect($('.gem-c-feedback .js-feedback-form')).toHaveClass('js-hidden')
+    expect($('.gem-c-feedback .js-feedback-form').prop('hidden')).toBe(true)
   })
 
   it('shows the prompt', function () {
     loadFeedbackComponent()
 
-    expect($('.gem-c-feedback .js-prompt')).not.toHaveClass('js-hidden')
-    expect($('.gem-c-feedback .js-prompt-questions')).not.toHaveClass('js-hidden')
-  })
-
-  it('conveys that the feedback forms are hidden', function () {
-    loadFeedbackComponent()
-
-    expect($('.js-feedback-form#something-is-wrong').attr('aria-hidden')).toBe('true')
-    expect($('.js-feedback-form#page-is-not-useful').attr('aria-hidden')).toBe('true')
+    expect($('.gem-c-feedback .js-prompt').prop('hidden')).toBe(false)
+    expect($('.gem-c-feedback .js-prompt-questions').prop('hidden')).toBe(false)
   })
 
   it('conveys that the form is not expanded', function () {
@@ -159,7 +152,7 @@ describe('Feedback component', function () {
 
       var $success = $('.js-prompt-success')
 
-      expect($success).not.toHaveClass('js-hidden')
+      expect(($success).prop('hidden')).toBe(false)
       expect($success).toHaveText('Thanks for your feedback.')
     })
 
@@ -167,7 +160,7 @@ describe('Feedback component', function () {
       loadFeedbackComponent()
       $('.js-page-is-useful')[0].click()
 
-      expect($('.js-prompt-questions')).toHaveClass('js-hidden')
+      expect($('.js-prompt-questions').prop('hidden')).toBe(true)
     })
 
     it('triggers a Google Analytics event', function () {
@@ -183,21 +176,14 @@ describe('Feedback component', function () {
       loadFeedbackComponent()
       $('.js-page-is-not-useful')[0].click()
 
-      expect($('.gem-c-feedback .js-feedback-form#page-is-not-useful')).not.toHaveClass('js-hidden')
+      expect($('.gem-c-feedback .js-feedback-form#page-is-not-useful').prop('hidden')).toBe(false)
     })
 
     it('hides the prompt', function () {
       loadFeedbackComponent()
       $('.js-page-is-not-useful')[0].click()
 
-      expect($('.gem-c-feedback .js-prompt')).toHaveClass('js-hidden')
-    })
-
-    it('conveys that the form is now visible', function () {
-      loadFeedbackComponent()
-      $('.js-page-is-not-useful')[0].click()
-
-      expect($('.js-feedback-form#page-is-not-useful').attr('aria-hidden')).toBe('false')
+      expect($('.gem-c-feedback .js-prompt').prop('hidden')).toBe(true)
     })
 
     it('conveys that the form is now expanded', function () {
@@ -230,21 +216,14 @@ describe('Feedback component', function () {
       loadFeedbackComponent()
       $('.js-something-is-wrong')[0].click()
 
-      expect($('.gem-c-feedback .js-feedback-form#something-is-wrong')).not.toHaveClass('js-hidden')
+      expect($('.gem-c-feedback .js-feedback-form#something-is-wrong').prop('hidden')).toBe(false)
     })
 
     it('hides the prompt', function () {
       loadFeedbackComponent()
       $('.js-something-is-wrong')[0].click()
 
-      expect($('.gem-c-feedback .js-prompt')).toHaveClass('js-hidden')
-    })
-
-    it('conveys that the form is now visible', function () {
-      loadFeedbackComponent()
-      $('.js-something-is-wrong')[0].click()
-
-      expect($('.js-feedback-form').attr('aria-hidden')).toBe('false')
+      expect($('.gem-c-feedback .js-prompt').prop('hidden')).toBe(true)
     })
 
     it('conveys that the form is now expanded', function () {
@@ -257,7 +236,7 @@ describe('Feedback component', function () {
 
     it('focusses the first field in the form', function () {
       loadFeedbackComponent()
-      var $input = $('#something-is-wrong .gem-c-input')[0]
+      var $input = $('#something-is-wrong .govuk-textarea')[0]
       spyOn($input, 'focus')
       $('.js-something-is-wrong')[0].click()
 
@@ -280,18 +259,12 @@ describe('Feedback component', function () {
     })
 
     it('hides the form', function () {
-      expect($('.gem-c-feedback #something-is-wrong')).toHaveClass('js-hidden')
+      expect($('.gem-c-feedback #something-is-wrong').prop('hidden')).toBe(true)
     })
 
     it('shows the prompt', function () {
-      expect($('.gem-c-feedback .js-prompt')).not.toHaveClass('js-hidden')
+      expect($('.gem-c-feedback .js-prompt').prop('hidden')).toBe(false)
       expect(document.activeElement).toBe($('.js-something-is-wrong').get(0))
-    })
-
-    it('conveys that the feedback form is hidden', function () {
-      loadFeedbackComponent()
-
-      expect($('#something-is-wrong.js-feedback-form').attr('aria-hidden')).toBe('true')
     })
 
     it('conveys that the form is not expanded', function () {
@@ -316,18 +289,12 @@ describe('Feedback component', function () {
     })
 
     it('hides the form', function () {
-      expect($('.gem-c-feedback #page-is-not-useful')).toHaveClass('js-hidden')
+      expect($('.gem-c-feedback #page-is-not-useful').prop('hidden')).toBe(true)
     })
 
     it('shows the prompt', function () {
-      expect($('.gem-c-feedback .js-prompt')).not.toHaveClass('js-hidden')
+      expect($('.gem-c-feedback .js-prompt').prop('hidden')).toBe(false)
       expect(document.activeElement).toBe($('.js-page-is-not-useful').get(0))
-    })
-
-    it('conveys that the feedback form is hidden', function () {
-      loadFeedbackComponent()
-
-      expect($('#page-is-not-useful.js-feedback-form').attr('aria-hidden')).toBe('true')
     })
 
     it('conveys that the form is not expanded', function () {
@@ -400,7 +367,7 @@ describe('Feedback component', function () {
 
         var $success = $('.js-prompt-success')
 
-        expect($success).not.toHaveClass('js-hidden')
+        expect(($success).prop('hidden')).toBe(false)
         expect($success).toHaveText('Thanks for your feedback.')
       })
 
@@ -427,7 +394,7 @@ describe('Feedback component', function () {
           responseText: '{}'
         })
 
-        expect($('#something-is-wrong')).toHaveClass('js-hidden')
+        expect($('#something-is-wrong').prop('hidden')).toBe(true)
       })
 
       it('hides the links to show the feedback form', function () {
@@ -440,7 +407,7 @@ describe('Feedback component', function () {
           responseText: '{}'
         })
 
-        expect($('.js-prompt-questions')).toHaveClass('js-hidden')
+        expect($('.js-prompt-questions').prop('hidden')).toBe(true)
       })
     })
 
@@ -494,7 +461,7 @@ describe('Feedback component', function () {
 
         var $prompt = $('.js-prompt-success')
 
-        expect($prompt).not.toHaveClass('js-hidden')
+        expect(($prompt).prop('hidden')).toBe(false)
         expect($prompt).toHaveText('Thanks for your feedback.')
       })
 
@@ -521,7 +488,7 @@ describe('Feedback component', function () {
           responseText: '{}'
         })
 
-        expect($('.js-feedback-form')).toHaveClass('js-hidden')
+        expect($('.js-feedback-form').prop('hidden')).toBe(true)
       })
 
       it('hides the links to show the feedback form', function () {
@@ -534,7 +501,7 @@ describe('Feedback component', function () {
           responseText: '{}'
         })
 
-        expect($('.js-prompt-questions')).toHaveClass('js-hidden')
+        expect($('.js-prompt-questions').prop('hidden')).toBe(true)
       })
     })
 


### PR DESCRIPTION
## Note (local testing)
There is an issue whereby the feedback assets (CSS and JS) are currently shipped twice:

- from the application e.g. `government-frontend`
- from `static`.

The assets should only be imported from static. However, at the moment, if we remove the assets at the application level then there are style problems where the feedback component styles are overridden by subsequent imports. An example is documented here: https://github.com/alphagov/whitehall/pull/6240#issuecomment-977888889.

For now, to test locally, it's necessary to:
- update the Gemfile for `gem 'govuk_publishing_components', path: '../govuk_publishing_components'` at **both** the application level (e.g. `government-frontend`) and `static`
- import the textarea component styles `@import 'govuk_publishing_components/components/textarea';` in to `application.scss` for `static`.

## What
https://trello.com/c/MOshcFm1/771-update-feedback-component-to-hide-and-show-content-in-a-more-robust-way
- Stop hiding things with CSS classes and/or "display:none" and hide them with the HTML "hidden" attribute instead. 
- The close buttons should only be revealed at the right time, and the forms themselves should be presented by using JS to switch off the hidden attribute
- When JS is disabled the 'Help us improve GOV.UK' form should display. When JS is enabled the form should be hidden with JS using the HTML attribute "hidden".
- Make the text input fields more usable for longer messages
- Make sure the text input limit is implemented properly and the error message matches it
- Update 'Accessibility acceptance criteria'.

## Why
- Tidy up the feedback component so that it no longer relies on CSS hiding/showing to manage interaction 

## Visual changes
<table role="table">
<thead>
<tr>
<th>Before (inputs)</th>
<th>After (inputs)</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/141774593-4675c4d6-bac1-40ff-b675-e85f750e889f.png"><img src="https://user-images.githubusercontent.com/87758239/141774593-4675c4d6-bac1-40ff-b675-e85f750e889f.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/141774583-10718a32-30fc-4be3-9ac6-307a391b7ec3.png"><img src="https://user-images.githubusercontent.com/87758239/141774583-10718a32-30fc-4be3-9ac6-307a391b7ec3.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</table>

<table role="table">
<thead>
<tr>
<th>Before (JS disabled & CSS enabled)</th>
<th>After (JS disabled & CSS enabled)</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/141774798-b0fce000-0fba-4a55-b388-db7b2a6e59a6.png"><img src="https://user-images.githubusercontent.com/87758239/141774798-b0fce000-0fba-4a55-b388-db7b2a6e59a6.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/141774788-e39890aa-8430-4dba-bd6c-fb1dece21d5d.png"><img src="https://user-images.githubusercontent.com/87758239/141774788-e39890aa-8430-4dba-bd6c-fb1dece21d5d.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</table>

<table role="table">
<thead>
<tr>
<th>Before (JS enabled & CSS disabled)</th>
<th>After (JS enabled & CSS disabled)</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/141774987-85bb881a-72c9-4fd9-8ee2-ed28ea7b9929.png"><img src="https://user-images.githubusercontent.com/87758239/141774987-85bb881a-72c9-4fd9-8ee2-ed28ea7b9929.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/141774985-7b4189f6-485e-4c66-9521-63480dd48047.png"><img src="https://user-images.githubusercontent.com/87758239/141774985-7b4189f6-485e-4c66-9521-63480dd48047.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</table>

<table role="table">
<thead>
<tr>
<th>Before (JS disabled & CSS disabled)</th>
<th>After (JS disabled & CSS disabled)</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/141775450-5b61667f-0640-4b5b-8f92-de8c73f04c20.png"><img src="https://user-images.githubusercontent.com/87758239/141775450-5b61667f-0640-4b5b-8f92-de8c73f04c20.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/141775444-0899beee-ab6a-482a-a8f0-7d4c2f4cdc59.png"><img src="https://user-images.githubusercontent.com/87758239/141775444-0899beee-ab6a-482a-a8f0-7d4c2f4cdc59.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</table>

## Anything Else
- `var el = e.target.closest('button')` - just wanted to highlight the use of the `closest()` method here. We seem to have a polyfill included in the bundle for this so I expect it's okay.
- `hidden` can be overridden with display properties e.g. from https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden -
> Note: Changing the value of the CSS display property on an element with the hidden attribute overrides the behaviour. For instance, elements styled display: flex will be displayed despite the hidden attribute's presence.

The best thing seems to be to include something like this `[hidden] { display: none !important; }`. For now, I've scoped it to the feedback component, but I think this should be added to our global styles.

- I have removed occurrences of `aria-hidden` since it should not be added when the HTML hidden attribute is present https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute