### PR TITLE
Reduce the weight of super navigation header chevrons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Adjust navigation header black bar height ([PR #2422](https://github.com/alphagov/govuk_publishing_components/pull/2422 ))
 * Fix chevron rotation for the super navigation header and accordion components on IE9 ([PR #2429](https://github.com/alphagov/govuk_publishing_components/pull/2429))
 * Add `enterkeyhint` attribute to input and search ([PR #2426](https://github.com/alphagov/govuk_publishing_components/pull/2426 ))
+* Reduce the weight of super navigation header chevrons ([PR #2436](https://github.com/alphagov/govuk_publishing_components/pull/2436))
 
 ## 27.11.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -109,8 +109,8 @@ $search-width-or-height: $black-bar-height;
     border-right-color: $colour;
   } @else {
     @include prefixed-transform($rotate: 45deg, $translateY: -35%);
-    border-bottom: 3px solid $colour;
-    border-right: 3px solid $colour;
+    border-bottom: 2px solid $colour;
+    border-right: 2px solid $colour;
     content: " ";
     display: inline-block;
     height: 8px;


### PR DESCRIPTION
## What
Reduce the weight of super navigation header chevrons from 2px to 3px.

## Why
Recommendation from our designer so that the chevrons don't look as heavy.

[Card](https://trello.com/c/3TsCU55d/631-chevrons-are-a-bit-heavy-make-them-2px)

## Visual Changes
### Desktop
Before:
![Screenshot 2021-11-10 at 16 50 51](https://user-images.githubusercontent.com/64783893/141157591-76f309e1-3e3d-4c71-a7f2-98a5a4b5a6ca.png)

After:
![Screenshot 2021-11-10 at 16 52 09](https://user-images.githubusercontent.com/64783893/141157637-d143f0d5-c520-4ecb-a4d4-81a39de66fa9.png)

### Mobile
Before:
![Screenshot 2021-11-10 at 16 51 02](https://user-images.githubusercontent.com/64783893/141157713-eecf2fd2-184d-4468-a9d9-fb07216d5cf1.png)

After:
![Screenshot 2021-11-10 at 16 52 35](https://user-images.githubusercontent.com/64783893/141157754-d39d3a7e-488f-4b7a-97f2-d45cc2a75b70.png)

### Mobile sub-menu
Before:
![Screenshot 2021-11-10 at 16 51 11](https://user-images.githubusercontent.com/64783893/141157811-1623f5a4-ff90-44cf-8706-2c7dd4ca24dc.png)

After:
![Screenshot 2021-11-10 at 16 52 47](https://user-images.githubusercontent.com/64783893/141157868-fdf79aa2-1d95-4403-806c-2f50b66591e5.png)
