### PR TITLE
Add notification button to the metadata component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add notification button to the metadata component ([PR #2437](https://github.com/alphagov/govuk_publishing_components/pull/2437))
 * Add more spacing in the navigation header mobile layout ([PR #2421](https://github.com/alphagov/govuk_publishing_components/pull/2421 ))
 * Adjust navigation header black bar height ([PR #2422](https://github.com/alphagov/govuk_publishing_components/pull/2422 ))
 * Fix chevron rotation for the super navigation header and accordion components on IE9 ([PR #2429](https://github.com/alphagov/govuk_publishing_components/pull/2429))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
@@ -1,10 +1,15 @@
+// prevent float related alignment issues in rtl mode
+.direction-rtl .gem-c-single-page-notification-button {
+  clear: both;
+}
+
 .gem-c-single-page-notification-button__submit {
   padding: govuk-spacing(2);
   margin: govuk-spacing(0);
   border: 1px solid $govuk-border-colour;
   color: $govuk-link-colour;
   cursor: pointer;
-  background: none;
+  background-color: govuk-colour("white");
 
   &:focus {
     @include govuk-focused-text;

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -14,6 +14,7 @@
   classes = %w(gem-c-metadata)
   classes << "direction-#{direction}" if local_assigns.include?(:direction)
   classes << "gem-c-metadata--inverse" if inverse
+  base_path ||= nil
 %>
 <%= content_tag :div, class: classes, data: { module: "gem-toggle" } do %>
   <dl data-module="gem-track-click">
@@ -66,4 +67,5 @@
       <% end %>
     <% end %>
   </dl>
+  <%= render 'govuk_publishing_components/components/single_page_notification_button', base_path: base_path if local_assigns.include?(:see_updates_link) && local_assigns.include?(:include_notification_button) %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/metadata.yml
@@ -357,3 +357,13 @@ examples:
         Applies to: England, Scotland, and Wales (see detailed guidance for <a href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for" rel="external">Northern Ireland</a>)
     context:
       dark_background: true
+  with_single_page_notification_button:
+    description: |
+      The component can render with a single page email notification button which allows the user to subscribe to email notifications about the current page. The button should only appear on pages with an update history (therefore it has been set to appear only if `see_updates_link` is true).
+
+      In the initial stages, there is a requirement to control which pages the button appears on – hence the presence of an additional `include_notification_button` flag.
+    data:
+      last_updated: "10 September 2015"
+      base_path: "/current-page"
+      include_notification_button: true
+      see_updates_link: true

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -200,6 +200,25 @@ describe "Metadata", type: :view do
     assert_select ".gem-c-metadata.gem-c-metadata--inverse"
   end
 
+  it "can render the component with a single page notification button, when see_updates_link is true and base_path is present" do
+    render_component(from: "<a href='/link'>Department</a>", include_notification_button: true, see_updates_link: true, base_path: "/current-page")
+
+    assert_select ".gem-c-metadata .gem-c-single-page-notification-button"
+    assert_select ".gem-c-metadata .gem-c-single-page-notification-button input[type='hidden'][value='/current-page']"
+  end
+
+  it "does not render a single page notification button when see_updates_link is not true" do
+    render_component(from: "<a href='/link'>Department</a>", include_notification_button: true, base_path: "/current-page")
+
+    assert_select ".gem-c-metadata .gem-c-single-page-notification-button", false
+  end
+
+  it "does not render a single page notification button when base_path is not present" do
+    render_component(from: "<a href='/link'>Department</a>", include_notification_button: true, see_updates_link: true)
+
+    assert_select ".gem-c-metadata .gem-c-single-page-notification-button", false
+  end
+
   def assert_truncation(length, limit)
     assert_select ".gem-c-metadata__toggle-items", count: 1
     assert_select ".gem-c-metadata__definition > a", count: limit


### PR DESCRIPTION
Add the single page notification button to the version of the metadata
component that includes an update history (and therefore a "see all
updates" link).

The notification button requires a `base_path` therefore a `base_path` must
be passed to the metadata component wherever we want the button to
appear.

In the initial stages we do not want the button to appear everywhere
(i.e on every single page that uses a certain type of template or
publishing format) so there is an additional `include_notification_button`
flag to fine-tune where the button should appear.

