### PR TITLE
Tweak text size in dropdown menus

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -847,7 +847,7 @@ $search-width-or-height: $black-bar-height;
 
     & > li {
       box-sizing: border-box;
-      margin: 0 govuk-spacing(3) govuk-spacing(2) govuk-spacing(3);
+      margin: 0 govuk-spacing(3);
     }
   }
 }
@@ -870,7 +870,7 @@ $search-width-or-height: $black-bar-height;
 
     & > li,
     & > li:first-child {
-      margin-bottom: govuk-spacing(4);
+      margin-bottom: govuk-spacing(2);
     }
 
     @supports (display: grid) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -915,6 +915,8 @@ $search-width-or-height: $black-bar-height;
 }
 
 .gem-c-layout-super-navigation-header__navigation-second-item-link {
+  font-size: 16px;
+
   &:after {
     @include make-selectable-area-bigger;
   }
@@ -930,7 +932,11 @@ $search-width-or-height: $black-bar-height;
 }
 
 .gem-c-layout-super-navigation-header__navigation-second-item-link--with-description {
-  @include govuk-font($size: 19, $weight: bold);
+  font-size: 16px;
+  @if $govuk-typography-use-rem {
+    font-size: govuk-px-to-rem(16px);
+  }
+  font-weight: bold;
   margin-bottom: 0;
   margin-top: govuk-spacing(2);
 }
@@ -964,7 +970,11 @@ $search-width-or-height: $black-bar-height;
 }
 
 .gem-c-layout-super-navigation-header__navigation-second-footer-link {
-  @include govuk-font($size: 19, $weight: normal);
+  font-size: 16px;
+  @if $govuk-typography-use-rem {
+    font-size: govuk-px-to-rem(16px);
+  }
+  font-weight: bold;
   display: inline-block;
   margin: govuk-spacing(1) 0;
 
@@ -977,6 +987,15 @@ $search-width-or-height: $black-bar-height;
     font-weight: bold;
     padding: 0;
   }
+}
+
+.gem-c-layout-super-navigation-header__navigation-second-item-description {
+  font-size: 16px;
+  @if $govuk-typography-use-rem {
+    font-size: govuk-px-to-rem(16px);
+  }
+  font-weight: normal;
+  margin: govuk-spacing(1) 0 0 0;
 }
 
 // Search dropdown.
@@ -1004,12 +1023,26 @@ $search-width-or-height: $black-bar-height;
 }
 
 // Popular links.
+.gem-c-layout-super-navigation-header__popular-item {
+  position: relative;
+  padding: govuk-spacing(1) 0 govuk-spacing(1) 0;
+}
+
 .gem-c-layout-super-navigation-header__popular-link {
-  padding: govuk-spacing(2) 0;
+  font-size: 16px;
+  @if $govuk-typography-use-rem {
+    font-size: govuk-px-to-rem(16px);
+  }
+  padding: 0;
   display: inline-block;
 
+  &:after {
+    @include make-selectable-area-bigger;
+  }
+
   @include govuk-media-query($from: "desktop") {
-    margin: govuk-spacing(1) 0;
-    padding: 0;
+    &:after {
+      content: none;
+    }
   }
 }

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -163,7 +163,7 @@
                                     track_dimension_index: "29",
                                   }
                                 } %>
-                                <%= tag.p item[:description], class: "govuk-body govuk-!-margin-0 govuk-!-margin-top-1" if has_description %>
+                                <%= tag.p item[:description], class: "gem-c-layout-super-navigation-header__navigation-second-item-description" if has_description %>
                               </li>
                             <% end %>
                           </ul>


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Change the dropdown menu's link and description font size to 16px on tablet and desktop screen sizes.

## Why
<!-- What are the reasons behind this change being made? -->

Previously this wa 19px, which was larger size than the toggle buttons and led to the hierarchy of the navigation header feeling disjointed.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

[Example page preview for these changes](https://components-gem-pr-2438.herokuapp.com/public).

| Screen size | Before | After |
| - | - | - |
| < 360px | ... | ... |
| >= 360px | ... | ... |
| Tablet | ... | ... |
| Desktop | ... | ... |
