### PR TITLE
Update the pseudo underline mixin and its usage on the super navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add an explicit margin zero to the super navigation mobile menu button ([PR #2445](https://github.com/alphagov/govuk_publishing_components/pull/2445))
 * Remove brexit as a topic from the super navigation header ([PR #2446](https://github.com/alphagov/govuk_publishing_components/pull/2446))
+* Update the pseudo underline mixin and it's usage on the super navigation header ([PR #2439](https://github.com/alphagov/govuk_publishing_components/pull/2439))
 
 ## 27.12.0
 
@@ -20,7 +21,6 @@
 * Add `enterkeyhint` attribute to input and search ([PR #2426](https://github.com/alphagov/govuk_publishing_components/pull/2426 ))
 * Retire the Brexit checker part of the Brexit call to action ([PR #2432](https://github.com/alphagov/govuk_publishing_components/pull/2432)) (patch change)
 * Reduce the weight of super navigation header chevrons ([PR #2436](https://github.com/alphagov/govuk_publishing_components/pull/2436))
-* Update the pseudo underline mixin and it's usage on the super navigation header ([PR #2439](https://github.com/alphagov/govuk_publishing_components/pull/2439))
 
 ## 27.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add `enterkeyhint` attribute to input and search ([PR #2426](https://github.com/alphagov/govuk_publishing_components/pull/2426 ))
 * Retire the Brexit checker part of the Brexit call to action ([PR #2432](https://github.com/alphagov/govuk_publishing_components/pull/2432)) (patch change)
 * Reduce the weight of super navigation header chevrons ([PR #2436](https://github.com/alphagov/govuk_publishing_components/pull/2436))
+* Update the pseudo underline mixin and it's usage on the super navigation header ([PR #2439](https://github.com/alphagov/govuk_publishing_components/pull/2439))
 
 ## 27.11.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -480,7 +480,7 @@ $search-width-or-height: $black-bar-height;
   &.gem-c-layout-super-navigation-header__open-button {
     @include focus-not-focus-visible {
       &:before {
-        @include prefixed-transform($rotate: 225deg, $translateY: 0);
+        @include prefixed-transform($rotate: 225deg, $translateY: 1px);
       }
     }
 
@@ -679,7 +679,7 @@ $search-width-or-height: $black-bar-height;
         @include govuk-media-query($from: 360px) {
           &:before {
             @include chevron(govuk-colour("black"), true);
-            @include prefixed-transform($rotate: 225deg, $translateY: 0);
+            @include prefixed-transform($rotate: 225deg, $translateY: 1px);
           }
         }
       }
@@ -699,7 +699,7 @@ $search-width-or-height: $black-bar-height;
         @include govuk-media-query($from: 360px) {
           &:before {
             @include chevron($govuk-link-colour);
-            @include prefixed-transform($rotate: 225deg, $translateY: 0);
+            @include prefixed-transform($rotate: 225deg, $translateY: 1px);
           }
         }
       }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -134,7 +134,7 @@ $search-width-or-height: $black-bar-height;
   background: none;
   bottom: 0;
   content: " ";
-  height: govuk-spacing(1);
+  height: 3px;
   left: govuk-spacing(3);
   position: absolute;
   right: govuk-spacing(3);

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -657,12 +657,20 @@ $search-width-or-height: $black-bar-height;
     }
   }
 
+  &:after {
+    @include pseudo-underline;
+  }
+
   // Open button modifier
   &.gem-c-layout-super-navigation-header__open-button {
     // stylelint-disable max-nesting-depth
     @include focus-and-focus-visible {
       @include govuk-focused-text;
       box-shadow: none;
+
+      &:after {
+        background-color: $govuk-focus-colour;
+      }
 
       .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
         color: govuk-colour("black");
@@ -680,13 +688,17 @@ $search-width-or-height: $black-bar-height;
     @include focus-not-focus-visible {
       background: govuk-colour("light-grey");
 
+      &:after {
+        background-color: $govuk-link-colour;
+      }
+
       .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
-        color: govuk-colour("black");
+        color: $govuk-link-colour;
         border-color: govuk-colour("light-grey");
 
         @include govuk-media-query($from: 360px) {
           &:before {
-            @include chevron(govuk-colour("black"));
+            @include chevron($govuk-link-colour);
             @include prefixed-transform($rotate: 225deg, $translateY: 0);
           }
         }


### PR DESCRIPTION
## What
Makes the following amendments to the super nav:

- Applies the pseudo underline to the mobile menu button
- Reduces the weight of the pseudo underline
- Nudges the chevron on open down by 1px

## Why
- So that the mobile menu button follows the "open" behaviour of buttons on desktop
- So that the pseudo underlines are inline with design system link style hover thickness (3px)
- So that the chevrons aren't floating too high on open

[Card](https://trello.com/c/U5BwCztJ/632-mobile-menu-open-show-the-active-doo-dad-blue-bottom-border-as-we-have-on-desktop)

## Visual Changes
### Desktop button hover
Before:
<img width="343" alt="Screenshot 2021-11-12 at 09 34 51" src="https://user-images.githubusercontent.com/64783893/141445472-c0b2f359-ba2f-481c-a380-7079cf78c386.png">

After:
<img width="346" alt="Screenshot 2021-11-12 at 09 31 59" src="https://user-images.githubusercontent.com/64783893/141445514-38dfd6d8-f635-4eb8-9811-dcf32e2ff7ee.png">

### Desktop button open
Before:
<img width="346" alt="Screenshot 2021-11-12 at 09 35 18" src="https://user-images.githubusercontent.com/64783893/141445546-4f5dd1c6-4274-42f7-b558-b4b7a8206979.png">

After:
<img width="344" alt="Screenshot 2021-11-12 at 09 32 13" src="https://user-images.githubusercontent.com/64783893/141445579-f83b8af4-de35-4ace-b280-3ce2dc7d4e0d.png">

### Mobile open
Before:
<img width="159" alt="Screenshot 2021-11-12 at 09 35 35" src="https://user-images.githubusercontent.com/64783893/141445605-30198379-6c8a-4510-b186-857a7d1a9658.png">

After:
<img width="160" alt="Screenshot 2021-11-12 at 09 32 45" src="https://user-images.githubusercontent.com/64783893/141445623-b1d55332-df20-469b-9f68-f6446238794b.png">