### PR TITLE
Release v27.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.12.0
 
 * Add more spacing in the navigation header mobile layout ([PR #2421](https://github.com/alphagov/govuk_publishing_components/pull/2421 ))
 * Adjust navigation header black bar height ([PR #2422](https://github.com/alphagov/govuk_publishing_components/pull/2422 ))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.11.0)
+    govuk_publishing_components (27.12.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.11.0".freeze
+  VERSION = "27.12.0".freeze
 end


### PR DESCRIPTION
Includes:

* Add more spacing in the navigation header mobile layout ([PR #2421](https://github.com/alphagov/govuk_publishing_components/pull/2421 ))
* Adjust navigation header black bar height ([PR #2422](https://github.com/alphagov/govuk_publishing_components/pull/2422 ))
* Fix chevron rotation for the super navigation header and accordion components on IE9 ([PR #2429](https://github.com/alphagov/govuk_publishing_components/pull/2429))
* Add `enterkeyhint` attribute to input and search ([PR #2426](https://github.com/alphagov/govuk_publishing_components/pull/2426 ))
* Retire the Brexit checker part of the Brexit call to action ([PR #2432](https://github.com/alphagov/govuk_publishing_components/pull/2432)) (patch change)
* Reduce the weight of super navigation header chevrons ([PR #2436](https://github.com/alphagov/govuk_publishing_components/pull/2436))