### PR TITLE
Fix layout glitch seen when scrollbar is permanently visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add an explicit margin zero to the super navigation mobile menu button ([PR #2445](https://github.com/alphagov/govuk_publishing_components/pull/2445))
 * Remove brexit as a topic from the super navigation header ([PR #2446](https://github.com/alphagov/govuk_publishing_components/pull/2446))
 * Update the pseudo underline mixin and it's usage on the super navigation header ([PR #2439](https://github.com/alphagov/govuk_publishing_components/pull/2439))
+* Fix layout glitch seen when scrollbar is permanently visible ([PR #2444](https://github.com/alphagov/govuk_publishing_components/pull/2444 ))
 
 ## 27.12.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
@@ -102,7 +102,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   // either `desktop` or `mobile` so it can be interpolated to access the
   // `data-toggle-{desktop|mobile}-group` attribute.
   var windowSize = function () {
-    return window.innerWidth >= SETTINGS.breakpoint.desktop ? 'desktop' : 'mobile'
+    return document.documentElement.clientWidth >= SETTINGS.breakpoint.desktop ? 'desktop' : 'mobile'
   }
 
   function SuperNavigationMegaMenu ($module) {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Fixes #2430 - the layout would become disjointed as width that triggered CSS changes was different to the width that triggered JavaScript changes _only if_ the scrollbar was permanently visible. This was due to the use of `window.innerWidth` which reports the width of the viewport including the width of the scrollbar. Using `document.documentElement.clientWidth` reports the width of the viewport sans any bars.

## Why
<!-- What are the reasons behind this change being made? -->

Because layout bugs are not good to have.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before 

https://user-images.githubusercontent.com/1732331/141364868-c5008dbd-112f-4d65-baed-b7f9a1da83ce.mov

### After

https://user-images.githubusercontent.com/1732331/141364778-3fd75cee-e1b3-4d59-bd35-699a14554127.mov


