### PR TITLE
Add an explicit margin zero to the super navigation mobile menu button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add an explicit margin zero to the super navigation mobile menu button ([PR #2445](https://github.com/alphagov/govuk_publishing_components/pull/2445))
+
 ## 27.12.0
 
 * Add more spacing in the navigation header mobile layout ([PR #2421](https://github.com/alphagov/govuk_publishing_components/pull/2421 ))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -617,6 +617,7 @@ $search-width-or-height: $black-bar-height;
   cursor: pointer;
   height: $black-bar-height;
   padding: 0;
+  margin: 0;
   position: absolute;
   right: (($search-width-or-height - govuk-spacing(3)) - 1px); // width of the search button (50px) - 15px - 1px to create an overlap between buttons and stop the border appearing to hang off the buttons when they're focused/open
   top: 0;


### PR DESCRIPTION
## What
Adds `margin: 0` to the super navigation mobile menu button to explicitly specify that the button has no margin

## Why
Safari adds a 2px margin to either side of buttons by default which creates a tiny visual snaffu for the super nav UI on mobile.

[Card](https://trello.com/c/dnfepAma/635-4-small-issue-with-pipe-on-mobile-when-search-is-open-safari)

## Visual Changes
### Safari, mobile view, search button open
Before:
![Screenshot 2021-11-12 at 11 16 55](https://user-images.githubusercontent.com/64783893/141461249-38ad4d65-d3fc-45e0-9cf8-72c3da952eed.png)

After:
![Screenshot 2021-11-12 at 11 17 21](https://user-images.githubusercontent.com/64783893/141461267-40236300-7def-440a-89df-14cadf5ee8e8.png)
