### PR TITLE
Remove brexit as a topic from the super navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add an explicit margin zero to the super navigation mobile menu button ([PR #2445](https://github.com/alphagov/govuk_publishing_components/pull/2445))
+* Remove brexit as a topic from the super navigation header ([PR #2446](https://github.com/alphagov/govuk_publishing_components/pull/2446))
 
 ## 27.12.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -855,8 +855,8 @@ $search-width-or-height: $black-bar-height;
 
 .gem-c-layout-super-navigation-header__navigation-second-items--topics {
   @include govuk-media-query($from: "desktop") {
-    @include columns(18, 2, "li");
-    @include columns-children(18, 2, "li");
+    @include columns(17, 2, "li");
+    @include columns-children(17, 2, "li");
   }
 }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,8 +125,6 @@ en:
           href: "/browse/benefits"
         - label: Births, death, marriages and care
           href: "/browse/births-deaths-marriages"
-        - label: Brexit
-          href: "/brexit"
         - label: Business and self-employed
           href: "/browse/business"
         - label: Childcare and parenting


### PR DESCRIPTION
## What
Remove Brexit as an item under the topics menu on the super navigation header.

## Why
The Brexit landing page is being wound down. This has been approved by the Brexit team.

[Card](https://trello.com/c/EQXkO2fv/637-remove-brexit-link-from-topics)

## Visual Changes
### Topics menu open
Before:
![Screenshot 2021-11-12 at 12 21 35](https://user-images.githubusercontent.com/64783893/141466538-5e112310-24fb-47f3-976e-2006c5cbaf67.png)

After:
![Screenshot 2021-11-12 at 12 21 20](https://user-images.githubusercontent.com/64783893/141466563-cbd023ce-635e-4be3-a8a1-e7abf862e246.png)
