### PR TITLE
Add draggable=false to links disguised as buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@
 * Tweak to sidebar navigation on Brexit hub pages ([PR #2449](https://github.com/alphagov/govuk_publishing_components/pull/2449))
 * Add an explicit margin zero to the super navigation mobile menu button ([PR #2445](https://github.com/alphagov/govuk_publishing_components/pull/2445))
 * Remove brexit as a topic from the super navigation header ([PR #2446](https://github.com/alphagov/govuk_publishing_components/pull/2446))
-* Update the pseudo underline mixin and it's usage on the super navigation header ([PR #2439](https://github.com/alphagov/govuk_publishing_components/pull/2439))
+* Update the pseudo underline mixin and its usage on the super navigation header ([PR #2439](https://github.com/alphagov/govuk_publishing_components/pull/2439))
 * Fix layout glitch seen when scrollbar is permanently visible ([PR #2444](https://github.com/alphagov/govuk_publishing_components/pull/2444 ))
+* Add draggable=false to links disguised as buttons ([PR #2448](https://github.com/alphagov/govuk_publishing_components/pull/2448))
 
 ## 27.12.0
 

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -66,6 +66,7 @@ module GovukPublishingComponents
         options[:name] = name if name.present? && value.present?
         options[:value] = value if name.present? && value.present?
         options[:aria] = { label: aria_label } if aria_label
+        options[:draggable] = false if link?
         options
       end
 

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -34,6 +34,14 @@ describe "Button", type: :view do
     assert_select ".govuk-button[type=button]"
   end
 
+  it "renders with draggable=false if a href is included" do
+    render_component(text: "Not draggable")
+    assert_select "a.govuk-button[draggable=false]", false
+
+    render_component(text: "Not draggable", href: "#")
+    assert_select "a.govuk-button[draggable=false]"
+  end
+
   it "renders start now button" do
     render_component(text: "Start now", href: "#", start: true)
     assert_select ".govuk-button[href='#']", text: /Start now/


### PR DESCRIPTION
## What
Add `draggable="false"` as an attribute for links styled to look like buttons.

## Why
Fixes https://github.com/alphagov/govuk_publishing_components/issues/1558

No visual changes