### PR TITLE
Don't show Brexit side nav on hub pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Tweak to sidebar navigation on Brexit hub pages ([PR #2449](https://github.com/alphagov/govuk_publishing_components/pull/2449))
 * Add an explicit margin zero to the super navigation mobile menu button ([PR #2445](https://github.com/alphagov/govuk_publishing_components/pull/2445))
 * Remove brexit as a topic from the super navigation header ([PR #2446](https://github.com/alphagov/govuk_publishing_components/pull/2446))
 

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -111,10 +111,10 @@ module GovukPublishingComponents
       def show_brexit_related_links?
         # If tagged directly to /brexit or /world/brexit
         # Or if tagged to a taxon which has /brexit as a parent
-        # And is not the brexit checker start page
-        brexit_start_page_content_id = "58d093a1-787d-4f36-a568-86da23a7b884"
-        page_content_id = content_item["content_id"]
-        tagged_to_brexit? && (page_content_id != brexit_start_page_content_id)
+        # And is not the brexit hub pages
+        return false if brexit_hub_pages.include?(content_item["content_id"])
+
+        tagged_to_brexit?
       end
 
       def brexit_cta_document_exceptions


### PR DESCRIPTION
## What

We removed the direct link from hub pages to the checker in https://github.com/alphagov/govuk_publishing_components/pull/2432 but we now want to remove the Brexit sidebar nav completely from these two pages ([businesses](https://www.gov.uk/guidance/brexit-guidance-for-businesses) and [individuals](https://www.gov.uk/guidance/brexit-guidance-for-individuals-and-families)) to stop circular journeys.

We can remove the logic around "brexit_start_page_content_id" because that page hasn't existed for a while.

