### PR TITLE
Add `margin_bottom` option to the metadata component and update margin mixins to use the standard GOVUK spacing scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Unreleased
 
-* Add `margin_bottom` option to the metadata component ([PR #2450](https://github.com/alphagov/govuk_publishing_components/pull/2450))
+* Add `margin_bottom` option to the metadata component and update margin mixins to use the standard GOVUK spacing scale ([PR #2450](https://github.com/alphagov/govuk_publishing_components/pull/2450))
 * Tweak to sidebar navigation on Brexit hub pages ([PR #2449](https://github.com/alphagov/govuk_publishing_components/pull/2449))
 * Add an explicit margin zero to the super navigation mobile menu button ([PR #2445](https://github.com/alphagov/govuk_publishing_components/pull/2445))
 * Remove brexit as a topic from the super navigation header ([PR #2446](https://github.com/alphagov/govuk_publishing_components/pull/2446))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add `margin_bottom` option to the metadata component ([PR #2450](https://github.com/alphagov/govuk_publishing_components/pull/2450))
 * Tweak to sidebar navigation on Brexit hub pages ([PR #2449](https://github.com/alphagov/govuk_publishing_components/pull/2449))
 * Add an explicit margin zero to the super navigation mobile menu button ([PR #2445](https://github.com/alphagov/govuk_publishing_components/pull/2445))
 * Remove brexit as a topic from the super navigation header ([PR #2446](https://github.com/alphagov/govuk_publishing_components/pull/2446))

--- a/app/assets/stylesheets/govuk_publishing_components/components/mixins/_margins.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/mixins/_margins.scss
@@ -2,7 +2,7 @@
   margin-bottom: govuk-spacing(3);
 
   @include govuk-media-query($from: tablet) {
-    margin-bottom: govuk-spacing(6) * 1.5;
+    margin-bottom: govuk-spacing(7);
   }
 }
 
@@ -10,7 +10,7 @@
   margin-top: govuk-spacing(3);
 
   @include govuk-media-query($from: tablet) {
-    margin-top: govuk-spacing(6) * 1.5;
+    margin-top: govuk-spacing(7);
   }
 }
 

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -11,9 +11,11 @@
   direction_class = ""
   direction_class = " direction-#{direction}" if local_assigns.include?(:direction)
 
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   classes = %w(gem-c-metadata)
   classes << "direction-#{direction}" if local_assigns.include?(:direction)
   classes << "gem-c-metadata--inverse" if inverse
+  classes << shared_helper.get_margin_bottom if local_assigns[:margin_bottom]
 %>
 <%= content_tag :div, class: classes, data: { module: "gem-toggle" } do %>
   <dl data-module="gem-track-click">

--- a/app/views/govuk_publishing_components/components/docs/metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/metadata.yml
@@ -357,3 +357,10 @@ examples:
         Applies to: England, Scotland, and Wales (see detailed guidance for <a href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for" rel="external">Northern Ireland</a>)
     context:
       dark_background: true
+  with_custom_margin_bottom:
+    description: |
+      The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to the `margin-bottom` values defined in the [responsive-bottom-margin mixin](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/components/mixins/_margins.scss#L1)
+    data:
+      first_published: 14 June 2014
+      last_updated: 10 September 2015
+      margin_bottom: 2

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -200,6 +200,12 @@ describe "Metadata", type: :view do
     assert_select ".gem-c-metadata.gem-c-metadata--inverse"
   end
 
+  it "applies a custom margin-bottom class if margin_bottom is specified" do
+    render_component(from: "<a href='/link'>Department</a>", margin_bottom: 2)
+
+    assert_select '.gem-c-metadata.govuk-\!-margin-bottom-2'
+  end
+
   def assert_truncation(length, limit)
     assert_select ".gem-c-metadata__toggle-items", count: 1
     assert_select ".gem-c-metadata__definition > a", count: limit


### PR DESCRIPTION
1. Add `margin_bottom` option to the metadata component, because sometimes there is a need to adjust the margins of the metadata component (more specifically, it will be necessary to adjust the spacing when we add the [email notification button](https://components.publishing.service.gov.uk/component-guide/single_page_notification_button) under the metadata component)

2. Update margin mixins to use the standard `govuk-spacing` scale – for some reason, the `responsive-bottom-margin` and `responsive-top-margin` mixins were using `govuk-spacing(6) * 1.5` values (probably because the standard spacing scale does not support 45px spacing). 
This replaces `govuk-spacing(6) * 1.5` with `govuk-spacing(7)` which translates to 40px which is just 5px less and should not make for a noticeable difference.

