### PR TITLE
Add organisation colour for Department for Levelling Up, Housing and Communities (DLUHC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add brand colour for Department for Levelling Up, Housing and Communities (DLUHC) ([PR #2454](https://github.com/alphagov/govuk_publishing_components/pull/2454))
 * Add `margin_bottom` option to the metadata component and update margin mixins to use the standard GOVUK spacing scale ([PR #2450](https://github.com/alphagov/govuk_publishing_components/pull/2450))
 * Tweak to sidebar navigation on Brexit hub pages ([PR #2449](https://github.com/alphagov/govuk_publishing_components/pull/2449))
 * Add an explicit margin zero to the super navigation mobile menu button ([PR #2445](https://github.com/alphagov/govuk_publishing_components/pull/2445))

--- a/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/govuk_frontend_support.scss
@@ -17,3 +17,12 @@ $gem-quiet-button-colour: govuk-colour("dark-grey", $legacy: "grey-1");
 $gem-quiet-button-hover-colour: darken($gem-quiet-button-colour, 5%);
 
 $gem-hover-dark-background: #dddcdb;
+
+$govuk-colours-organisations: map-merge(
+  $govuk-colours-organisations,
+  (
+    "department-for-levelling-up-housing-and-communities": (
+      colour: #012169,
+    ),
+  )
+);


### PR DESCRIPTION
DLUHC = Department for Levelling Up, Housing and Communities

## What
Adds the brand colour for DLUHC.

The colour has a contrast ratio of 14.75, so not adding a websafe colour for this organisation.

## Why
The same change has been made in [govuk-frontend](https://github.com/alphagov/govuk-frontend/pull/2434), however we need to also make the change here until the next release of govuk-frontend.

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4712566)