### PR TITLE
Remove redundant API value from big number component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove redundant API value from big number component ([PR #2459](https://github.com/alphagov/govuk_publishing_components/pull/2459))
+
 ## 27.14.0
 
 * Get single page notification button from personalisation API on load ([PR #2443](https://github.com/alphagov/govuk_publishing_components/pull/2443))

--- a/app/views/govuk_publishing_components/components/_big_number.html.erb
+++ b/app/views/govuk_publishing_components/components/_big_number.html.erb
@@ -1,5 +1,4 @@
 <%
-  href ||= nil
   number ||= nil
   label ||= nil
   href ||= nil


### PR DESCRIPTION
## What
Removes a stray `href` from the big number API presets

## Why
This is a repeated value and is therefore redundant!

No visual changes.