### PR TITLE
Remove use of `govuk-list` from navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove redundant API value from big number component ([PR #2459](https://github.com/alphagov/govuk_publishing_components/pull/2459))
+* Remove use of `govuk-list` from navigation header ([PR #2460](https://github.com/alphagov/govuk_publishing_components/pull/2460))
 
 ## 27.14.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -845,6 +845,7 @@ $search-width-or-height: $black-bar-height;
 
 // Navigation menu items.
 .gem-c-layout-super-navigation-header__navigation-second-items {
+  list-style: none;
   margin: 0;
   padding: govuk-spacing(6) govuk-spacing(4);
 

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -144,7 +144,7 @@
                     </div>
                     <div class="govuk-grid-column-two-thirds-from-desktop">
                       <% if link[:menu_contents].present? %>
-                          <ul class="govuk-list gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--<%= link[:label].parameterize %>">
+                          <ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--<%= link[:label].parameterize %>">
                             <% link[:menu_contents].each do | item | %>
                               <%
                                 has_description = item[:description].present?


### PR DESCRIPTION

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Remove `govuk-list` from navigation header component, and add `list-style: none` to the component class.

## Why
<!-- What are the reasons behind this change being made? -->

The use of `govuk-list` was slightly problematic - the class was being appearing
after the component styles in some applications due to the application CSS being
later in the cascade that the CSS from Static - so the component spacing would
be overridden.

The only thing that was not being override was `list-style`, so this declaration
was added to the class in the component and `govuk-list` was removed.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
|  | Before | After | 
| - | - | - |
| Topics | ![www gov uk_ (2)](https://user-images.githubusercontent.com/1732331/142851422-351887ab-3111-48b1-b4bd-dbba9cfcf6d6.png) | ![frontend dev gov uk_ (8)](https://user-images.githubusercontent.com/1732331/142851417-7a650f04-c4f3-4fc2-bd23-b8f883103cf3.png)   |
| Government activity | ![www gov uk_ (3)](https://user-images.githubusercontent.com/1732331/142851425-c0279c3a-1e37-48d8-84b4-82ed0518f832.png)| ![frontend dev gov uk_ (9)](https://user-images.githubusercontent.com/1732331/142851420-56857cb5-fca3-46f1-8739-3475da7a6099.png) |