### PR TITLE
Release 27.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.14.1
 
 * Remove redundant API value from big number component ([PR #2459](https://github.com/alphagov/govuk_publishing_components/pull/2459))
 * Remove use of `govuk-list` from navigation header ([PR #2460](https://github.com/alphagov/govuk_publishing_components/pull/2460))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.14.0)
+    govuk_publishing_components (27.14.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.14.0".freeze
+  VERSION = "27.14.1".freeze
 end


### PR DESCRIPTION
Includes:

* Remove redundant API value from big number component ([PR #2459](https://github.com/alphagov/govuk_publishing_components/pull/2459))
* Remove use of `govuk-list` from navigation header ([PR #2460](https://github.com/alphagov/govuk_publishing_components/pull/2460))
