### PR TITLE
Fix selectors in spec

### DIFF
--- a/spec/components/heading_spec.rb
+++ b/spec/components/heading_spec.rb
@@ -81,12 +81,12 @@ describe "Heading", type: :view do
 
   it "defaults to no bottom margin if an incorrect value is passed" do
     render_component(text: "Margin wat", margin_bottom: 20)
-    assert_select "[class='^=govuk-\!-margin-bottom-']", false
+    assert_select "[class^='govuk-\!-margin-bottom-']", false
   end
 
   it "has no margin class added by default" do
     render_component(text: "No margin")
-    assert_select "[class='^=govuk-\!-margin-bottom-']", false
+    assert_select "[class^='govuk-\!-margin-bottom-']", false
   end
 
   it "adds border 1" do

--- a/spec/components/list_spec.rb
+++ b/spec/components/list_spec.rb
@@ -138,7 +138,7 @@ describe "List", type: :view do
         "<a href='https://example.com/'>Another test item</a>",
       ],
     )
-    assert_select "[class='^=govuk-\!-margin-bottom-']", false
+    assert_select "[class^='govuk-\!-margin-bottom-']", false
   end
 
   it "has no margin class added by default" do
@@ -148,7 +148,7 @@ describe "List", type: :view do
         "<a href='https://example.com/'>Another test item</a>",
       ],
     )
-    assert_select "[class='^=govuk-\!-margin-bottom-']", false
+    assert_select "[class^='govuk-\!-margin-bottom-']", false
   end
 
   it "has no margin class added if `margin_bottom` set to 4" do
@@ -159,6 +159,6 @@ describe "List", type: :view do
         "<a href='https://example.com/'>Another test item</a>",
       ],
     )
-    assert_select "[class='^=govuk-\!-margin-bottom-']", false
+    assert_select "[class^='govuk-\!-margin-bottom-']", false
   end
 end

--- a/spec/components/subscription_links_spec.rb
+++ b/spec/components/subscription_links_spec.rb
@@ -35,12 +35,12 @@ describe "subscription links", type: :view do
 
   it "defaults to the initial bottom margin if an incorrect value is passed" do
     render_component(email_signup_link: "email-signup", feed_link: "singapore.atom", margin_bottom: 20)
-    assert_select "[class='^=govuk-\!-margin-bottom-']", false
+    assert_select "[class^='govuk-\!-margin-bottom-']", false
   end
 
   it "has no margin class added by default" do
     render_component(email_signup_link: "email-signup", feed_link: "singapore.atom")
-    assert_select "[class='^=govuk-\!-margin-bottom-']", false
+    assert_select "[class^='govuk-\!-margin-bottom-']", false
   end
 
   it "renders custom texts" do

--- a/spec/components/title_spec.rb
+++ b/spec/components/title_spec.rb
@@ -68,7 +68,7 @@ describe "Title", type: :view do
 
   it "ignores an invalid margin bottom" do
     render_component(title: "Margin wat", margin_bottom: 17)
-    assert_select "[class='^=govuk-\!-margin-bottom-']", false
+    assert_select "[class^='govuk-\!-margin-bottom-']", false
   end
 
   it "has a default margin top of 8" do
@@ -88,7 +88,7 @@ describe "Title", type: :view do
 
   it "ignores an invalid margin top" do
     render_component(title: "Margin wat", margin_top: 17)
-    assert_select "[class='^=govuk-\!-margin-top-']", false
+    assert_select "[class^='govuk-\!-margin-top-']", false
   end
 
   it "applies context language if supplied to a context link" do


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
All the uses of `[class='^=class-name']` have been replaced with the correct formatting: `[class^='class-name']`.

## Why
<!-- What are the reasons behind this change being made? -->

As [highlighted by @owenatgov in another review][1], there were selectors in the spec that weren't formatted correctly - so they were potentially able to giving false negatives and needed fixing.

## Visual Changes
No visual changes.

[1]: https://github.com/alphagov/govuk_publishing_components/pull/2462#discussion_r755090045
