### PR TITLE
Amend `explicit-cross-domain-links.js` code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update search component ([PR #2462](https://github.com/alphagov/govuk_publishing_components/pull/2462))
 * Fix link to Crown Copyright in footer ([PR #2475](https://github.com/alphagov/govuk_publishing_components/pull/2475))
 * Fix single page notification button data attributes for tracking ([PR #2471](https://github.com/alphagov/govuk_publishing_components/pull/2471))
+* Amend `explicit-cross-domain-links.js` code ([PR #2464](https://github.com/alphagov/govuk_publishing_components/pull/2464))
 
 ## 27.14.1
 

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -97,6 +97,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.cookieBannerConfirmationMessage.focus()
     window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
     window.GOVUK.setDefaultConsentCookie()
+    window.GOVUK.triggerEvent(window, 'cookie-reject')
   }
 
   CookieBanner.prototype.showConfirmationMessage = function () {

--- a/docs/javascript-modules.md
+++ b/docs/javascript-modules.md
@@ -69,6 +69,8 @@ This functionality runs like this:
 - if cookies have been consented, the module calls the rest of its code and carries on as normal
 - if cookies have not been consented, the listener is created and calls the rest of the module when the `cookie-consent` event is fired by the cookie banner
 
+If a module has functionality which is dependent on rejecting cookies, that module should listen for the `cookie-reject` event. This event is fired by the cookie banner when the user rejects cookies.
+
 ### Module structure
 
 A module must add its constructor to `GOVUK.Modules` and it must have an `init` method. The simplest module looks like:

--- a/spec/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.spec.js
@@ -66,7 +66,7 @@ describe('Explicit cross-domain linker', function () {
       expect(element.attr('href')).toEqual('/somewhere?cookie_consent=reject')
     })
 
-    describe('user accepts cookies', function () {
+    describe('user has accepted cookies', function () {
       it('modifies the link href to append cookie_consent parameter "accept" and adds _ga if trackers are present', function () {
         GOVUK.cookie('cookies_preferences_set', 'true')
         GOVUK.setConsentCookie({ usage: true })
@@ -91,6 +91,28 @@ describe('Explicit cross-domain linker', function () {
         window.ga = undefined
         explicitCrossDomainLinks.start(element)
         expect(element.attr('href')).toEqual('/somewhere?cookie_consent=accept')
+      })
+    })
+
+    describe('user has interacted with the cookie banner on the current page', function () {
+      beforeEach(function () {
+        GOVUK.cookie('cookies_preferences_set', null)
+        explicitCrossDomainLinks.start(element)
+        GOVUK.cookie('cookies_preferences_set', 'true')
+      })
+      it('modifies the link href to append cookie_consent parameter "accept" if the cookie-consent event was fired', function () {
+        GOVUK.setConsentCookie({ usage: true })
+        window.ga = undefined
+        window.GOVUK.triggerEvent(window, 'cookie-consent')
+
+        expect(element.attr('href')).toEqual('/somewhere?cookie_consent=accept')
+      })
+
+      it('modifies the link href to append cookie_consent parameter "reject" if the cookie-reject event was fired', function () {
+        GOVUK.setConsentCookie({ usage: false })
+        window.GOVUK.triggerEvent(window, 'cookie-reject')
+
+        expect(element.attr('href')).toEqual('/somewhere?cookie_consent=reject')
       })
     })
   })
@@ -145,6 +167,28 @@ describe('Explicit cross-domain linker', function () {
         window.ga = undefined
         explicitCrossDomainLinks.start(element)
         expect(element.attr('action')).toEqual('/somewhere?cookie_consent=accept')
+      })
+    })
+
+    describe('user has interacted with the cookie banner on the current page', function () {
+      beforeEach(function () {
+        GOVUK.cookie('cookies_preferences_set', null)
+        explicitCrossDomainLinks.start(element)
+        GOVUK.cookie('cookies_preferences_set', 'true')
+      })
+      it('modifies the form action to append cookie_consent parameter "accept" if the cookie-consent event was fired', function () {
+        GOVUK.setConsentCookie({ usage: true })
+        window.ga = undefined
+        window.GOVUK.triggerEvent(window, 'cookie-consent')
+
+        expect(element.attr('action')).toEqual('/somewhere?cookie_consent=accept')
+      })
+
+      it('modifies the form action to append cookie_consent parameter "reject" if the cookie-reject event was fired', function () {
+        GOVUK.setConsentCookie({ usage: false })
+        window.GOVUK.triggerEvent(window, 'cookie-reject')
+
+        expect(element.attr('action')).toEqual('/somewhere?cookie_consent=reject')
       })
     })
   })

--- a/spec/javascripts/govuk_publishing_components/modules.spec.js
+++ b/spec/javascripts/govuk_publishing_components/modules.spec.js
@@ -140,6 +140,20 @@ describe('GOVUK Modules', function () {
       }
       GOVUK.Modules.TestCookieDependencyModule = TestCookieDependencyModule
 
+      // GOV.UK Frontend Module that depends on rejected cookies to start
+      function TestCookieRejectDependencyModule (element) {
+        this.element = element
+      }
+      TestCookieRejectDependencyModule.prototype.init = function () {
+        this.startModule = this.startModule.bind(this)
+        window.addEventListener('cookie-reject', this.startModule)
+      }
+      TestCookieRejectDependencyModule.prototype.startModule = function () {
+        window.removeEventListener('cookie-reject', this.startModule)
+        callbackFrontendModule(this.element)
+      }
+      GOVUK.Modules.TestCookieRejectDependencyModule = TestCookieRejectDependencyModule
+
       container = $('<div></div>')
     })
 
@@ -151,6 +165,7 @@ describe('GOVUK Modules', function () {
       delete GOVUK.Modules.GovukTestAlertPublishingAndFrontendModule
       delete GOVUK.Modules.TestAlertPublishingAndFrontendModule
       delete GOVUK.Modules.TestCookieDependencyModule
+      delete GOVUK.Modules.TestCookieRejectDependencyModule
 
       container.remove()
     })
@@ -225,6 +240,17 @@ describe('GOVUK Modules', function () {
       GOVUK.modules.start(container)
       expect(callbackFrontendModule.calls.count()).toBe(0)
       window.GOVUK.triggerEvent(window, 'cookie-consent')
+      expect(callbackFrontendModule.calls.count()).toBe(1)
+    })
+
+    it('starts delayed modules once cookies have been rejected', function () {
+      var module = $('<div data-module="test-cookie-reject-dependency-module"></div>')
+      container.append(module)
+      $('body').append(container)
+
+      GOVUK.modules.start(container)
+      expect(callbackFrontendModule.calls.count()).toBe(0)
+      window.GOVUK.triggerEvent(window, 'cookie-reject')
       expect(callbackFrontendModule.calls.count()).toBe(1)
     })
 


### PR DESCRIPTION
Amend `explicit-cross-domain-links` code to account for the possibility of someone accepting/rejecting cookies on the page that the cross-domain link is present. 

This was raised as a bug on the Brexit page, where the **Sign in** link is a cross-domain link (leading to DI Sign In territory). 
If someone has interacted with the cookie banner on this page, the link treats them as if they have not, i.e the `?cookie_consent=not_engaged` parameter remains unchanged, and the GA parameter is not added (if they have accepted cookies). The setting applies only after the page is reloaded.

## Before (the correct parameters are appended to the cross domain link only after the page is reloaded)
https://user-images.githubusercontent.com/7116819/143051955-22e6eb6a-f22f-48b1-b2e1-e6e59df52665.mov


## After (the correct parameters are appended to the cross domain link instantly when cookies are accepted or rejected)

https://user-images.githubusercontent.com/7116819/143052834-1f00cbc2-b2fe-41a6-8948-89e97a4e5b67.mov



Upon detecting the cookie consent or rejection event, the cross-domain link module should re-run and append the correct parameters to any cross domain links present on the page.
