### PR TITLE
Add support to open Intervention links in new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Remove whitespace from pseudo-element content ([PR #2482](https://github.com/alphagov/govuk_publishing_components/pull/2482))
 * Update navigation header toggle button spacing ([PR #2483](https://github.com/alphagov/govuk_publishing_components/pull/2483))
 * Update search toggle / link hover state underline thickness ([PR #2484](https://github.com/alphagov/govuk_publishing_components/pull/2484))
+* Add support to open Intervention links in new tab ([#2465](https://github.com/alphagov/govuk_publishing_components/pull/2465))
 
 ## 27.14.2
 

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -35,7 +35,7 @@
     suggestion_link_text << accessible_text unless suggestion_link_text.include?(accessible_text)
   end
 %>
-<% if suggestion_text || (suggestion_link_text && suggestion_link_text) %>
+<% if suggestion_text || (suggestion_link_text && suggestion_link_url) %>
   <%= tag.section class: "gem-c-intervention", role: "region", aria: aria_attributes, data: data_attributes do %>
     <p class="govuk-body">
       <%= tag.span suggestion_text, class: "gem-c-intervention__textwrapper" if suggestion_text %>

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -32,8 +32,7 @@
 
     suggestion_tag_options.merge!({ target: target, rel: rel })
 
-    accessible_text = I18n.t("components.intervention.accessible_link_text_suffix")
-    suggestion_link_text << accessible_text unless suggestion_link_text.include?(accessible_text)
+    suggestion_link_text = intervention_helper.accessible_text
   end
 %>
 <% if suggestion_text || (suggestion_link_text && suggestion_link_url) %>

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -16,14 +16,28 @@
 
   intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new(local_assigns)
   dismiss_href = intervention_helper.dismiss_link
+
+  suggestion_tag_options = {
+    class: "govuk-link gem-c-intervention__suggestion-link",
+    href: suggestion_link_url,
+    data: suggestion_data_attributes,
+  }
+
+  new_tab ||= false
+  if new_tab
+    target = "_blank"
+    rel = "noopener noreferrer"
+    rel << " external" unless suggestion_link_url && suggestion_link_url.start_with?("/", "https://gov.uk", "https://www.gov.uk")
+
+    suggestion_tag_options.merge!({ target: target, rel: rel })
+  end
 %>
 <% if suggestion_text or (suggestion_link_text and suggestion_link_text) %>
   <%= tag.section class: "gem-c-intervention", role: "region", aria: aria_attributes, data: data_attributes do %>
     <p class="govuk-body">
       <%= tag.span suggestion_text, class: "gem-c-intervention__textwrapper" if suggestion_text %>
       <% if suggestion_link_text and suggestion_link_url %>
-        <%= tag.a suggestion_link_text, class: "govuk-link gem-c-intervention__suggestion-link", href: suggestion_link_url, data: suggestion_data_attributes %>
-
+        <%= tag.a suggestion_link_text, suggestion_tag_options %>
       <% end %>
     </p>
 

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -24,12 +24,15 @@
   }
 
   new_tab ||= false
-  if new_tab
+  if new_tab && (suggestion_link_text && suggestion_link_text)
     target = "_blank"
     rel = "noopener noreferrer"
     rel << " external" unless suggestion_link_url && suggestion_link_url.start_with?("/", "https://gov.uk", "https://www.gov.uk")
 
     suggestion_tag_options.merge!({ target: target, rel: rel })
+
+    accessible_text = I18n.t("components.intervention.accessible_link_text_suffix")
+    suggestion_link_text << accessible_text unless suggestion_link_text.include?(accessible_text)
   end
 %>
 <% if suggestion_text || (suggestion_link_text && suggestion_link_text) %>

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -32,11 +32,11 @@
     suggestion_tag_options.merge!({ target: target, rel: rel })
   end
 %>
-<% if suggestion_text or (suggestion_link_text and suggestion_link_text) %>
+<% if suggestion_text || (suggestion_link_text && suggestion_link_text) %>
   <%= tag.section class: "gem-c-intervention", role: "region", aria: aria_attributes, data: data_attributes do %>
     <p class="govuk-body">
       <%= tag.span suggestion_text, class: "gem-c-intervention__textwrapper" if suggestion_text %>
-      <% if suggestion_link_text and suggestion_link_url %>
+      <% if suggestion_link_text && suggestion_link_url %>
         <%= tag.a suggestion_link_text, suggestion_tag_options %>
       <% end %>
     </p>

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -3,6 +3,7 @@
   suggestion_link_text ||= false
   suggestion_link_url ||= false
   suggestion_text ||= nil
+  new_tab ||= false
 
   data_attributes ||= {}
   data_attributes[:module] = 'intervention'
@@ -13,6 +14,8 @@
   aria_attributes[:label] = 'Intervention'
 
   local_assigns[:query_string] ||= request.query_string
+  local_assigns[:suggestion_link_text] = suggestion_link_text
+  local_assigns[:suggestion_link_url] = suggestion_link_url
 
   intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new(local_assigns)
   dismiss_href = intervention_helper.dismiss_link
@@ -23,11 +26,9 @@
     data: suggestion_data_attributes,
   }
 
-  new_tab ||= false
-  if new_tab && (suggestion_link_text && suggestion_link_text)
+  if new_tab && (suggestion_link_text && suggestion_link_url)
     target = "_blank"
-    rel = "noopener noreferrer"
-    rel << " external" unless suggestion_link_url && suggestion_link_url.start_with?("/", "https://gov.uk", "https://www.gov.uk")
+    rel = intervention_helper.security_attr
 
     suggestion_tag_options.merge!({ target: target, rel: rel })
 

--- a/app/views/govuk_publishing_components/components/docs/intervention.yml
+++ b/app/views/govuk_publishing_components/components/docs/intervention.yml
@@ -42,9 +42,10 @@ examples:
     description: |
       When sending users to another online task, you don't want to completely hijack
       their original flow on GOV.UK. Adding the option to open links in a new tab helps to address this.
-      Link text *must* tell the user that the link opens in a new tab.
+      Link text should tell the user that the link opens in a new tab.
+      Note: "(opens in a new tab)" is added to link text if the phrase isn't included.
     data:
-      suggestion_link_text: "You can now apply for a permit online (opens in a new tab)"
+      suggestion_link_text: "You can now apply for a permit online"
       suggestion_link_url: "www.google.com/permit"
       new_tab: true
 

--- a/app/views/govuk_publishing_components/components/docs/intervention.yml
+++ b/app/views/govuk_publishing_components/components/docs/intervention.yml
@@ -38,6 +38,16 @@ examples:
       suggestion_link_text: "You can now apply for a permit online."
       suggestion_link_url: "/permit"
 
+  open_suggestion_link_in_new_tab:
+    description: |
+      When sending users to another online task, you don't want to completely hijack
+      their original flow on GOV.UK. Adding the option to open links in a new tab helps to address this.
+      Link text *must* tell the user that the link opens in a new tab.
+    data:
+      suggestion_link_text: "You can now apply for a permit online (opens in a new tab)"
+      suggestion_link_url: "www.google.com/permit"
+      new_tab: true
+
   with_data_attributes:
     description: |
       This example shows the use of `suggestion_data_attributes` and

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,8 @@ en:
       news_and_communications: News and communications
       statistics: Statistics
       worldwide: Worldwide
+    intervention:
+      accessible_link_text_suffix: " (opens in a new tab)"
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
       licence_html: All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated

--- a/lib/govuk_publishing_components/presenters/intervention_helper.rb
+++ b/lib/govuk_publishing_components/presenters/intervention_helper.rb
@@ -1,10 +1,12 @@
 module GovukPublishingComponents
   module Presenters
     class InterventionHelper
-      attr_reader :query_string
+      attr_reader :query_string, :suggestion_link_text, :suggestion_link_url
 
       def initialize(local_assigns)
         @query_string = local_assigns[:query_string]
+        @suggestion_link_text = local_assigns[:suggestion_link_text]
+        @suggestion_link_url = local_assigns[:suggestion_link_url]
       end
 
       def dismiss_link
@@ -13,6 +15,13 @@ module GovukPublishingComponents
         else
           "?hide-intervention=true"
         end
+      end
+
+      def security_attr
+        rel = "noopener noreferrer"
+        rel << " external" unless @suggestion_link_url.start_with?("/", "https://gov.uk", "https://www.gov.uk")
+
+        rel
       end
     end
   end

--- a/lib/govuk_publishing_components/presenters/intervention_helper.rb
+++ b/lib/govuk_publishing_components/presenters/intervention_helper.rb
@@ -1,12 +1,17 @@
 module GovukPublishingComponents
   module Presenters
     class InterventionHelper
-      attr_reader :query_string, :suggestion_link_text, :suggestion_link_url
-
       def initialize(local_assigns)
+        @accessible_text_suffix = I18n.t("components.intervention.accessible_link_text_suffix")
         @query_string = local_assigns[:query_string]
         @suggestion_link_text = local_assigns[:suggestion_link_text]
         @suggestion_link_url = local_assigns[:suggestion_link_url]
+      end
+
+      def accessible_text
+        @suggestion_link_text << @accessible_text_suffix unless @suggestion_link_text.include?(@accessible_text_suffix)
+
+        @suggestion_link_text
       end
 
       def dismiss_link
@@ -23,6 +28,10 @@ module GovukPublishingComponents
 
         rel
       end
+
+    private
+
+      attr_reader :accessible_text_suffix, :query_string, :suggestion_link_text, :suggestion_link_url
     end
   end
 end

--- a/spec/components/intervention_spec.rb
+++ b/spec/components/intervention_spec.rb
@@ -103,5 +103,25 @@ describe "Intervention", type: :view do
 
       assert_select "a[target='_blank']", false
     end
+
+    it "appends accesible link text" do
+      render_component(
+        suggestion_link_text: "Travel abroad",
+        suggestion_link_url: "/travel-abroad",
+        new_tab: true,
+      )
+
+      assert_select ".gem-c-intervention", text: "Travel abroad (opens in a new tab)"
+    end
+
+    it "doesn't append accessible link text if link text is already included" do
+      render_component(
+        suggestion_link_text: "Travel abroad (opens in a new tab) guidance",
+        suggestion_link_url: "/travel-abroad",
+        new_tab: true,
+      )
+
+      assert_select ".gem-c-intervention", text: "Travel abroad (opens in a new tab) guidance"
+    end
   end
 end

--- a/spec/components/intervention_spec.rb
+++ b/spec/components/intervention_spec.rb
@@ -63,4 +63,45 @@ describe "Intervention", type: :view do
   it "doesn't render anything if no parameter is passed" do
     assert_empty render_component({})
   end
+
+  describe "new tab" do
+    it "renders with target=_'blank' with new_tab option" do
+      render_component(
+        suggestion_link_text: "Travel abroad",
+        suggestion_link_url: "/travel-abroad",
+        new_tab: true,
+      )
+
+      assert_select "a[target='_blank']"
+    end
+
+    it "renders with security attributes" do
+      render_component(
+        suggestion_link_text: "Travel abroad",
+        suggestion_link_url: "/travel-abroad",
+        new_tab: true,
+      )
+
+      assert_select "a[rel='noopener noreferrer']"
+    end
+
+    it "renders with security attributes for external links" do
+      render_component(
+        suggestion_link_text: "Travel abroad",
+        suggestion_link_url: "https://https://www.nationalarchives.gov.uk/",
+        new_tab: true,
+      )
+
+      assert_select "a[rel='noopener noreferrer external']"
+    end
+
+    it "renders no target attribute without the new_tab option" do
+      render_component(
+        suggestion_link_text: "Travel abroad",
+        suggestion_link_url: "/travel-abroad",
+      )
+
+      assert_select "a[target='_blank']", false
+    end
+  end
 end

--- a/spec/lib/govuk_publishing_components/components/intervention_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/intervention_helper_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe GovukPublishingComponents::Presenters::InterventionHelper do
 
         expect(security_attrs).to eql("noopener noreferrer")
       end
+
+      it "returns appends external attribute for new tab external links" do
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", suggestion_link_url: "https://www.nationalarchives.gov.uk" })
+        security_attrs = intervention_helper.security_attr
+
+        expect(security_attrs).to eql("noopener noreferrer external")
+      end
+    end
     end
   end
 end

--- a/spec/lib/govuk_publishing_components/components/intervention_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/intervention_helper_spec.rb
@@ -40,6 +40,21 @@ RSpec.describe GovukPublishingComponents::Presenters::InterventionHelper do
         expect(security_attrs).to eql("noopener noreferrer external")
       end
     end
+
+    describe ".accessible_link_text" do
+      it "appends text to make new tab link accessible" do
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", suggestion_link_url: "/path-to-page" })
+        link_text = intervention_helper.accessible_text
+
+        expect(link_text).to eq("Text (opens in a new tab)")
+      end
+
+      it "doesn't append text if link text is already accessible" do
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Travel abroad (opens in a new tab) guidance", suggestion_link_url: "/path-to-page" })
+        link_text = intervention_helper.accessible_text
+
+        expect(link_text).to eq("Travel abroad (opens in a new tab) guidance")
+      end
     end
   end
 end

--- a/spec/lib/govuk_publishing_components/components/intervention_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/intervention_helper_spec.rb
@@ -25,11 +25,13 @@ RSpec.describe GovukPublishingComponents::Presenters::InterventionHelper do
       end
     end
 
-    it "returns the default query string if the one passed is empty" do
-      existing_query_string = ""
-      intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ query_string: existing_query_string })
-      new_query_string = intervention_helper.dismiss_link
-      expect(new_query_string).to eql("?hide-intervention=true")
+    describe ".security_attr" do
+      it "returns default security attributes for new tab links" do
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", suggestion_link_url: "/path-to-page" })
+        security_attrs = intervention_helper.security_attr
+
+        expect(security_attrs).to eql("noopener noreferrer")
+      end
     end
   end
 end

--- a/spec/lib/govuk_publishing_components/components/intervention_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/intervention_helper_spec.rb
@@ -1,16 +1,28 @@
 RSpec.describe GovukPublishingComponents::Presenters::InterventionHelper do
   describe "Intervention helper" do
-    it "returns the default dismiss query string" do
-      intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({})
-      default_dismiss_link = intervention_helper.dismiss_link
-      expect(default_dismiss_link).to eql("?hide-intervention=true")
-    end
+    describe ".dismiss_link" do
+      it "returns the default dismiss query string" do
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({})
+        default_dismiss_link = intervention_helper.dismiss_link
 
-    it "adds the dismiss query string parameter" do
-      existing_query_string = "?a=b"
-      intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ query_string: existing_query_string })
-      new_query_string = intervention_helper.dismiss_link
-      expect(new_query_string).to eql("?a=b&hide-intervention=true")
+        expect(default_dismiss_link).to eql("?hide-intervention=true")
+      end
+
+      it "adds the dismiss query string parameter" do
+        existing_query_string = "?a=b"
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ query_string: existing_query_string })
+        new_query_string = intervention_helper.dismiss_link
+
+        expect(new_query_string).to eql("?a=b&hide-intervention=true")
+      end
+
+      it "returns the default query string if the one passed is empty" do
+        existing_query_string = ""
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ query_string: existing_query_string })
+        new_query_string = intervention_helper.dismiss_link
+
+        expect(new_query_string).to eql("?hide-intervention=true")
+      end
     end
 
     it "returns the default query string if the one passed is empty" do


### PR DESCRIPTION
## What
Adds a parameter to the Intervention banner to allow links to open in a new tab.

## Why
In order to drive users to another online task, we don't want to completely hijack their original flow on GOV.UK. Adding the option to open links in a new tab helps to address this.

## Visual Changes

![localhost_3212_component-guide_intervention_hide-intervention=true(iPhone 6_7_8)](https://user-images.githubusercontent.com/424772/143084216-27979f2f-fe2e-4aa2-b1e2-8506f5cd8cb0.png)

![Screenshot 2021-11-23 at 6 38 32 pm](https://user-images.githubusercontent.com/424772/143084228-45186d8f-7cee-4276-81fc-8fc706f422fc.png)

