### PR TITLE
Update govspeak table styles

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -14,7 +14,7 @@
     margin: govuk-spacing(6) 0;
     overflow-x: auto;
     width: 100%;
-    @include govuk-font($size: 14);
+    @include govuk-font($size: 19);
 
     caption {
       text-align: left;
@@ -24,12 +24,16 @@
     th,
     td {
       vertical-align: top;
-      padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
-      border-bottom: solid 1px govuk-colour("mid-grey", $legacy: "grey-2");
+      padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) 0;
+      border-bottom: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
+
+      &:last-child {
+        padding: govuk-spacing(2) 0 govuk-spacing(2) 0;
+      }
     }
 
     th {
-      @include govuk-font($size: 14, $weight: bold);
+      @include govuk-font($size: 19, $weight: bold);
       text-align: left;
       color: $govuk-text-colour;
     }


### PR DESCRIPTION
## What
https://trello.com/c/SXYdqORT/852-review-govspeak-table-and-possibly-other-components

## Why
- It's not consistent with Component Guide and the Design System
- Not adhering to accessibility standards
- Could other components in Govspeak have the same issue as well?

## Visual changes
<table role="table">
<thead>
<tr>
<th>Before (inputs)</th>
<th>After (desktop)</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/143206338-3cd63031-2c5a-4299-bbc2-6b5a0575958c.png"><img src="https://user-images.githubusercontent.com/87758239/143206338-3cd63031-2c5a-4299-bbc2-6b5a0575958c.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/143206378-a2aae16d-1064-49e9-a702-da515ddaca43.png"><img src="https://user-images.githubusercontent.com/87758239/143206378-a2aae16d-1064-49e9-a702-da515ddaca43.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</table>

<table role="table">
<thead>
<tr>
<th>Before (mobile)</th>
<th>After (mobile - with horizontal scroll)</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/143206363-2afd2878-8d44-423f-b717-d457b85725ea.png"><img src="https://user-images.githubusercontent.com/87758239/143206363-2afd2878-8d44-423f-b717-d457b85725ea.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/143206413-b8850bc3-5091-4864-93ce-c55dddfcff58.png"><img src="https://user-images.githubusercontent.com/87758239/143206413-b8850bc3-5091-4864-93ce-c55dddfcff58.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</table>