### PR TITLE
Update Start button so info text is associated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## 27.14.2
 
+* Update Start button so info text is associated ([PR #2476](https://github.com/alphagov/govuk_publishing_components/pull/2476))
 * Update search component ([PR #2462](https://github.com/alphagov/govuk_publishing_components/pull/2462))
 * Fix link to Crown Copyright in footer ([PR #2475](https://github.com/alphagov/govuk_publishing_components/pull/2475))
 * Fix single page notification button data attributes for tracking ([PR #2471](https://github.com/alphagov/govuk_publishing_components/pull/2471))

--- a/app/views/govuk_publishing_components/components/_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_button.html.erb
@@ -27,5 +27,5 @@
 <% end %>
 
 <% if button.info_text %>
-  <%= tag.span button.info_text, class: button.info_text_classes %>
+  <%= tag.span button.info_text, button.info_text_options %>
 <% end %>

--- a/lib/govuk_publishing_components/presenters/button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/button_helper.rb
@@ -11,6 +11,7 @@ module GovukPublishingComponents
                   :rel,
                   :data_attributes,
                   :margin_bottom,
+                  :id,
                   :inline_layout,
                   :target,
                   :type,
@@ -49,16 +50,39 @@ module GovukPublishingComponents
         @value = local_assigns[:value]
         @classes = local_assigns[:classes]
         @aria_label = local_assigns[:aria_label]
+        @info_text_id = "info-text-id-#{SecureRandom.hex(4)}"
+        @button_id = "button-id-#{SecureRandom.hex(4)}"
       end
 
       def link?
         href.present?
       end
 
+      def info_text?
+        info_text.present?
+      end
+
+      def aria_labelledby
+        if info_text?
+          text = "#{@button_id} "
+          text << @info_text_id
+          text
+        end
+      end
+
+      def info_text_options
+        options = { class: info_text_classes }
+        options[:aria] = { hidden: true } if info_text?
+        options[:id] = @info_text_id if info_text?
+        options
+      end
+
       def html_options
         options = { class: css_classes }
         options[:role] = "button" if link?
         options[:type] = button_type
+        options[:id] = @button_id if info_text?
+        options[:aria] = { labelledby: aria_labelledby }
         options[:rel] = rel if rel
         options[:data] = data_attributes if data_attributes
         options[:title] = title if title

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -90,6 +90,13 @@ describe "Button", type: :view do
     assert_select ".gem-c-button__info-text", text: "Information text"
   end
 
+  it "renders info text and the relevant aria attributes " do
+    render_component(text: "Start now", info_text: "Information text")
+    assert_select ".govuk-button", text: "Start now"
+    assert_select ".govuk-button[aria-labelledby]", count: 1
+    assert_select ".gem-c-button__info-text[aria-hidden='true']", count: 1
+  end
+
   it "renders info text with margin bottom" do
     render_component(text: "Start now", info_text: "Information text", margin_bottom: true)
 


### PR DESCRIPTION
## What

Update start button to link info text below

## Why

"If you provide information text to a button, the text is rendered underneath the button but not linked to it in any way. This means it won't be read out to screenreader users when they focus on the button, and they could miss important information."

Closes #2083 

## Visual Changes

No visual changes

### Screen reader example.

https://user-images.githubusercontent.com/71266765/143418992-921ca3f9-f737-4964-bf35-a64b877ebfd7.mov
