### PR TITLE
Update charts to secondary button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@
 ## Unreleased
 
 * Remove the last traces of jQuery ([PR #2702](https://github.com/alphagov/govuk_publishing_components/pull/2702))
-* Add tracking on the accordion ([#2693](https://github.com/alphagov/govuk_publishing_components/pull/2693))
+* Add tracking on the accordion ([PR #2693](https://github.com/alphagov/govuk_publishing_components/pull/2693))
+* Update charts to secondary button ([PR #2408](https://github.com/alphagov/govuk_publishing_components/pull/2480))
 
 ## 29.1.0
 
-* Remove "priority breadcrumbs" ([#2666](https://github.com/alphagov/govuk_publishing_components/pull/2666))
+* Remove "priority breadcrumbs" ([PR #2666](https://github.com/alphagov/govuk_publishing_components/pull/2666))
 
 ## 29.0.1
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
@@ -186,7 +186,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     toggleStatus.classList.add('govuk-visually-hidden', 'mc-toggle-status')
     toggleStatus.setAttribute('role', 'alert')
 
-    link.classList.add('govuk-body-s', 'mc-toggle-button')
+    link.classList.add('govuk-button', 'govuk-button--secondary')
     link.appendChild(toggleText)
     link.appendChild(toggleStatus)
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -271,26 +271,6 @@
     text-align: left;
   }
 
-  .mc-toggle-button {
-    border: 1px solid $govuk-border-colour;
-    color: $govuk-link-colour;
-    cursor: pointer;
-    margin: govuk-spacing(0);
-    padding: govuk-spacing(2);
-    background-color: govuk-colour("white");
-
-    &:hover {
-      background-color: govuk-colour("light-grey");
-      color: $govuk-link-hover-colour;
-    }
-
-    &:focus {
-      @include govuk-focused-text;
-      background-color: $govuk-focus-colour;
-      border-color: transparent;
-    }
-  }
-
   // Hides the original table
   .mc-hidden,
   .mc-hidden caption {

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_govspeak.scss
@@ -73,7 +73,7 @@
     }
   }
 
-  .mc-toggle-button,
+  .govuk-button--secondary,
   .mc-chart-container {
     display: none;
   }

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
@@ -124,7 +124,7 @@ describe('Magna charta', function () {
       graph = element.find('.mc-chart')
       graphContainer = element.find('.mc-chart-container')
       table = element.find('table')
-      toggle = element.find('.mc-toggle-button')
+      toggle = element.find('.govuk-button.govuk-button--secondary')
     })
 
     afterEach(function () {
@@ -321,7 +321,7 @@ describe('Magna charta', function () {
     })
 
     it('graph is shown when toggle is called', function () {
-      element.find('.mc-toggle-button')[0].click()
+      element.find('.govuk-button--secondary')[0].click()
       expect(table).toHaveClass('mc-hidden')
       expect(graphContainer).not.toHaveClass('mc-hidden')
     })


### PR DESCRIPTION
## What

Update Design of [button to match GOV.UK Design System](https://design-system.service.gov.uk/components/button/
) on GOVSpeak Charts.

## Why

[An issue was raised that highlighted several instances](https://github.com/alphagov/govuk_publishing_components/issues/2238) where we have unique buttons and button styles. We don't believe these are required and could be consolidated.  

These particular instances meet the criteria to match the Design System's secondary button properties.

## Visual Changes

### Before > After
![image](https://user-images.githubusercontent.com/71266765/143570940-ecf48e9d-7d7c-4f2d-8b01-c781976bc6c8.png)

## Anything else

Other buttons that meet criteria to be secondary buttons:
https://components.publishing.service.gov.uk/component-guide/subscription_links/with_copyable_feed_link
https://components.publishing.service.gov.uk/component-guide/print_link

## Design review link:

https://components-gem-pr-2480.herokuapp.com/component-guide/govspeak/charts/preview