### PR TITLE
Restore accessible autocomplete component

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
@@ -1,18 +1,19 @@
 /* eslint-env jquery */
 /* global accessibleAutocomplete */
 // = require accessible-autocomplete/dist/accessible-autocomplete.min.js
+
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
   function AccessibleAutocomplete ($module) {
     this.$module = $module
-    this.selectElem = this.$module.querySelector('select')
+    this.selectElement = this.$module.querySelector('select')
   }
 
   AccessibleAutocomplete.prototype.init = function () {
     var configOptions = {
-      selectElement: document.getElementById(this.selectElem.getAttribute('id')),
+      selectElement: this.selectElement,
       autoselect: true,
       confirmOnBlur: true,
       preserveNullOptions: true, // https://github.com/alphagov/accessible-autocomplete#null-options
@@ -22,43 +23,50 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     configOptions.onConfirm = this.onConfirm
     new accessibleAutocomplete.enhanceSelectElement(configOptions) // eslint-disable-line no-new, new-cap
+    this.autoCompleteInput = this.$module.querySelector('.autocomplete__input')
+    if (this.autoCompleteInput) {
+      this.autoCompleteInput.addEventListener('keyup', this.handleKeyup.bind(this))
+    }
   }
 
   // custom onConfirm function because will likely need future expansion e.g. tracking
-  // the accessible-autocomplete doesn't update the hidden select if an onConfirm function is supplied
-  // https://github.com/alphagov/accessible-autocomplete/issues/322
-  // also it doesn't update either way if the user chooses something then deletes it
-  AccessibleAutocomplete.prototype.onConfirm = function () {
-    if (!this.govukModule.autoCompleteInput) {
-      this.govukModule.autoCompleteInput = this.govukModule.$module.querySelector('.autocomplete__input')
-    }
-    var label = this.govukModule.autoCompleteInput.value
-
-    if (typeof label !== 'undefined') {
+  AccessibleAutocomplete.prototype.onConfirm = function (value) {
+    // onConfirm fires on selecting an option
+    // also fires when blurring the input, which then provides `value` as undefined
+    // so we only update the hidden select if there's a value, and handle clearing it separately
+    if (typeof value !== 'undefined') {
+      // the accessible-autocomplete doesn't update the hidden select if an onConfirm function is supplied
+      // https://github.com/alphagov/accessible-autocomplete/issues/322
       var options = this.selectElement.querySelectorAll('option')
-
       for (var i = 0; i < options.length; i++) {
         var text = options[i].textContent
-        if (text === label) {
+        if (text === value) {
           this.govukModule.setSelectOption(options[i])
           break
         }
       }
-    } else {
-      this.govukModule.clearSelect()
+    }
+  }
+
+  // seems to be a bug in the accessible autocomplete where clearing the input
+  // doesn't update the select, so we have to do this
+  AccessibleAutocomplete.prototype.handleKeyup = function (e) {
+    var value = this.autoCompleteInput.value
+
+    if (value.length === 0) {
+      this.clearSelect()
     }
   }
 
   AccessibleAutocomplete.prototype.setSelectOption = function (option) {
     var value = option.value
-    this.selectElem.value = value
+    this.selectElement.value = value
+    window.GOVUK.triggerEvent(this.selectElement, 'change')
   }
 
   AccessibleAutocomplete.prototype.clearSelect = function () {
-    var empty = this.selectElem.querySelector('option[value=""]')
-    if (empty) {
-      empty.setAttribute('selected', true)
-    }
+    this.selectElement.value = ''
+    window.GOVUK.triggerEvent(this.selectElement, 'change')
   }
 
   Modules.AccessibleAutocomplete = AccessibleAutocomplete

--- a/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
@@ -1,0 +1,79 @@
+/* eslint-env jquery */
+/* global accessibleAutocomplete */
+// = require accessible-autocomplete/dist/accessible-autocomplete.min.js
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  'use strict'
+
+  Modules.AccessibleAutocomplete = function () {
+    var $selectElem
+
+    this.start = function ($element) {
+      $selectElem = $element.find('select')
+
+      var configOptions = {
+        selectElement: document.getElementById($selectElem.attr('id')),
+        showAllValues: true,
+        confirmOnBlur: true,
+        preserveNullOptions: true, // https://github.com/alphagov/accessible-autocomplete#null-options
+        defaultValue: ''
+      }
+
+      configOptions.onConfirm = this.onConfirm
+
+      new accessibleAutocomplete.enhanceSelectElement(configOptions) // eslint-disable-line no-new, new-cap
+      // attach the onConfirm function to data attr, to call it in finder-frontend when clearing facet tags
+      $selectElem.data('onconfirm', this.onConfirm)
+    }
+
+    this.onConfirm = function (label, value, removeDropDown) {
+      function escapeHTML (str) {
+        return new window.Option(str).innerHTML
+      }
+
+      if ($selectElem.data('track-category') !== undefined && $selectElem.data('track-action') !== undefined) {
+        track($selectElem.data('track-category'), $selectElem.data('track-action'), label, $selectElem.data('track-options'))
+      }
+      // This is to compensate for the fact that the accessible-autocomplete library will not
+      // update the hidden select if the onConfirm function is supplied
+      // https://github.com/alphagov/accessible-autocomplete/issues/322
+      if (typeof label !== 'undefined') {
+        if (typeof value === 'undefined') {
+          value = $selectElem.children('option').filter(function () { return $(this).html() === escapeHTML(label) }).val()
+        }
+
+        if (typeof value !== 'undefined') {
+          var $option = $selectElem.find('option[value=\'' + value + '\']')
+          // if removeDropDown we are clearing the selection from outside the component
+          var selectState = typeof removeDropDown === 'undefined'
+          $option.prop('selected', selectState)
+          $selectElem.change()
+        }
+
+        // used to clear the autocomplete when clicking on a facet tag in finder-frontend
+        // very brittle but menu visibility is determined by autocomplete after this function is called
+        // setting autocomplete val to '' causes menu to appear, we don't want that, this solves it
+        // ideally will rewrite autocomplete to have better hooks in future
+        if (removeDropDown) {
+          $selectElem.closest('.gem-c-accessible-autocomplete').addClass('gem-c-accessible-autocomplete--hide-menu')
+          setTimeout(function () {
+            $('.autocomplete__menu').remove() // this element is recreated every time the user starts typing
+            $selectElem.closest('.gem-c-accessible-autocomplete').removeClass('gem-c-accessible-autocomplete--hide-menu')
+          }, 100)
+        }
+      }
+    }
+
+    function track (category, action, label, options) {
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        options = options || {}
+        options.label = label
+
+        window.GOVUK.analytics.trackEvent(category, action, options)
+      }
+    }
+  }
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accessible-autocomplete.js
@@ -25,11 +25,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       configOptions.onConfirm = this.onConfirm
 
       new accessibleAutocomplete.enhanceSelectElement(configOptions) // eslint-disable-line no-new, new-cap
-      // attach the onConfirm function to data attr, to call it in finder-frontend when clearing facet tags
-      $selectElem.data('onconfirm', this.onConfirm)
     }
 
-    this.onConfirm = function (label, value, removeDropDown) {
+    this.onConfirm = function (label) {
       function escapeHTML (str) {
         return new window.Option(str).innerHTML
       }
@@ -47,22 +45,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
         if (typeof value !== 'undefined') {
           var $option = $selectElem.find('option[value=\'' + value + '\']')
-          // if removeDropDown we are clearing the selection from outside the component
-          var selectState = typeof removeDropDown === 'undefined'
-          $option.prop('selected', selectState)
-          $selectElem.change()
-        }
-
-        // used to clear the autocomplete when clicking on a facet tag in finder-frontend
-        // very brittle but menu visibility is determined by autocomplete after this function is called
-        // setting autocomplete val to '' causes menu to appear, we don't want that, this solves it
-        // ideally will rewrite autocomplete to have better hooks in future
-        if (removeDropDown) {
-          $selectElem.closest('.gem-c-accessible-autocomplete').addClass('gem-c-accessible-autocomplete--hide-menu')
-          setTimeout(function () {
-            $('.autocomplete__menu').remove() // this element is recreated every time the user starts typing
-            $selectElem.closest('.gem-c-accessible-autocomplete').removeClass('gem-c-accessible-autocomplete--hide-menu')
-          }, 100)
         }
       }
     }

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -11,6 +11,7 @@ $govuk-new-link-styles: true;
 @import "govuk/components/all";
 
 // components
+@import "components/accessible-autocomplete";
 @import "components/accordion";
 @import "components/action-link";
 @import "components/attachment";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
@@ -1,0 +1,31 @@
+@import url(asset-path("accessible-autocomplete/dist/accessible-autocomplete.min.css"));
+
+.gem-c-accessible-autocomplete {
+  .autocomplete__input {
+    z-index: 1;
+  }
+
+  .autocomplete__dropdown-arrow-down {
+    z-index: 0;
+  }
+
+  .autocomplete__option {
+    @include govuk-font(19);
+  }
+
+  .autocomplete__list .autocomplete__option {
+    padding: 5px 6px;
+
+    &:before {
+      position: relative;
+      top: 3px;
+      padding-top: 2px;
+    }
+  }
+}
+
+.gem-c-accessible-autocomplete--hide-menu {
+  .autocomplete__menu {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
@@ -11,6 +11,7 @@
 
   .autocomplete__option {
     @include govuk-font(19);
+    min-height: 1.3em; // this ensures a blank item has a height
   }
 
   .autocomplete__list .autocomplete__option {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
@@ -5,10 +5,6 @@
     z-index: 1;
   }
 
-  .autocomplete__dropdown-arrow-down {
-    z-index: 0;
-  }
-
   .autocomplete__option {
     @include govuk-font(19);
     min-height: 1.3em; // this ensures a blank item has a height
@@ -22,11 +18,5 @@
       top: 3px;
       padding-top: 2px;
     }
-  }
-}
-
-.gem-c-accessible-autocomplete--hide-menu {
-  .autocomplete__menu {
-    display: none;
   }
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accessible-autocomplete.scss
@@ -1,4 +1,4 @@
-@import url(asset-path("accessible-autocomplete/dist/accessible-autocomplete.min.css"));
+@import url(asset-path("accessible-autocomplete/dist/accessible-autocomplete.min.css")); // stylelint-disable function-url-quotes
 
 .gem-c-accessible-autocomplete {
   .autocomplete__input {

--- a/app/views/govuk_publishing_components/components/_accessible_autocomplete.html.erb
+++ b/app/views/govuk_publishing_components/components/_accessible_autocomplete.html.erb
@@ -1,0 +1,27 @@
+<%
+  id ||= "autocomplete-#{SecureRandom.hex(4)}"
+  label ||= nil
+  data_attributes ||= nil
+  options ||= []
+  selected_option ||= nil
+
+  classes = %w(gem-c-accessible-autocomplete govuk-form-group)
+%>
+<% if label && options.any? %>
+  <%= tag.div class: classes, data: { module: "accessible-autocomplete" } do %>
+    <%=
+      render "govuk_publishing_components/components/label", {
+        html_for: id
+      }.merge(label.symbolize_keys)
+    %>
+
+    <%=
+      select_tag(
+        id,
+        options_for_select(options, selected_option),
+        class: "govuk-select",
+        data: data_attributes
+      )
+    %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
+++ b/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
@@ -27,16 +27,3 @@ examples:
         text: 'Countries'
       options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us']]
       selected_option: ['United Kingdom', 'gb']
-  with_tracking_enabled:
-    description: |
-     This example shows tracking enabled on an autocomplete. Tracking will be enabled automatically when `track_category` and `track_action` are specified in `data_attributes`.
-    data:
-      id: 'tracking-enabled-autocomplete'
-      label:
-        text: 'Countries'
-      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us']]
-      data_attributes:
-        track_category: 'chosen_category'
-        track_action: 'chosen_action'
-        track_option:
-          custom_dimension: 'your_custom_dimension'

--- a/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
+++ b/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
@@ -1,9 +1,7 @@
-name: Accessible autocomplete
+name: Accessible autocomplete (experimental)
 description: An autocomplete component, built to be accessible.
 body: |
-  This component uses the [Accessible Autocomplete](https://github.com/alphagov/accessible-autocomplete) code to create an accessible autocomplete element. The autocomplete is created with the `showAllValues`
-  option set to `true` and the `confirmOnBlur` option set to `false` (see [Autocomplete examples](https://alphagov.github.io/accessible-autocomplete/examples) here). It also depends upon the
-  [label component](https://github.com/component-guide/label).
+  This component uses the [Accessible Autocomplete](https://github.com/alphagov/accessible-autocomplete) code to progressively enhance a hidden select element (see [Autocomplete examples](https://alphagov.github.io/accessible-autocomplete/examples) here). It depends upon the [label component](https://github.com/component-guide/label).
 
   If Javascript is disabled, the component appears as a select box, so the user can still select an option.
 accessibility_criteria: |

--- a/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
+++ b/app/views/govuk_publishing_components/components/docs/accessible_autocomplete.yml
@@ -1,0 +1,42 @@
+name: Accessible autocomplete
+description: An autocomplete component, built to be accessible.
+body: |
+  This component uses the [Accessible Autocomplete](https://github.com/alphagov/accessible-autocomplete) code to create an accessible autocomplete element. The autocomplete is created with the `showAllValues`
+  option set to `true` and the `confirmOnBlur` option set to `false` (see [Autocomplete examples](https://alphagov.github.io/accessible-autocomplete/examples) here). It also depends upon the
+  [label component](https://github.com/component-guide/label).
+
+  If Javascript is disabled, the component appears as a select box, so the user can still select an option.
+accessibility_criteria: |
+  [Accessibility acceptance criteria](https://github.com/alphagov/accessible-autocomplete/blob/master/accessibility-criteria.md)
+examples:
+  default:
+    data:
+      label:
+        text: 'Countries'
+      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us'], ['The Separate Customs Territory of Taiwan, Penghu, Kinmen, and Matsu (Chinese Taipei)', 'tw']]
+  with_unique_identifier:
+    data:
+      id: 'unique-autocomplete'
+      label:
+        text: 'Countries'
+      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us']]
+  with_selected_option_chosen:
+    data:
+      id: 'selected-option-chosen-autocomplete'
+      label:
+        text: 'Countries'
+      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us']]
+      selected_option: ['United Kingdom', 'gb']
+  with_tracking_enabled:
+    description: |
+     This example shows tracking enabled on an autocomplete. Tracking will be enabled automatically when `track_category` and `track_action` are specified in `data_attributes`.
+    data:
+      id: 'tracking-enabled-autocomplete'
+      label:
+        text: 'Countries'
+      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us']]
+      data_attributes:
+        track_category: 'chosen_category'
+        track_action: 'chosen_action'
+        track_option:
+          custom_dimension: 'your_custom_dimension'

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -35,6 +35,7 @@ Rails.application.config.assets.precompile += %w[
 
 # GOV.UK Frontend assets
 Rails.application.config.assets.precompile += %w[
+  accessible-autocomplete/dist/accessible-autocomplete.min.css
   govuk-logotype-crown.png
   favicon.ico
   govuk-opengraph-image.png

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "extends": "stylelint-config-gds/scss"
   },
   "dependencies": {
+    "accessible-autocomplete": "git://github.com/alphagov/accessible-autocomplete.git",
     "axe-core": "^3.5.4",
     "govuk-frontend": "^3.14.0",
     "jquery": "1.12.4",

--- a/spec/components/accessible_autocomplete_spec.rb
+++ b/spec/components/accessible_autocomplete_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+describe "AccessibleAutocomplete", type: :view do
+  def component_name
+    "accessible_autocomplete"
+  end
+
+  it "renders select element" do
+    render_component(
+      id: "basic-autocomplete",
+      label: { text: "Countries" },
+      options: [["United Kingdom", "gb"], ["United States", "us"]],
+    )
+
+    assert_select ".govuk-label", text: "Countries", for: "basic-autocomplete"
+    assert_select "select#basic-autocomplete"
+    assert_select "select[multiple]", false
+    assert_select "select#basic-autocomplete option[value=gb]"
+    assert_select "select#basic-autocomplete option[value=gb]", text: "United Kingdom"
+    assert_select "select#basic-autocomplete option[value=us]"
+    assert_select "select#basic-autocomplete option[value=us]", text: "United States"
+  end
+
+  it "renders select element with selected value" do
+    render_component(
+      id: "basic-autocomplete",
+      label: { text: "Countries" },
+      options: [["United Kingdom", "gb"], ["United States", "us"]],
+      selected_option: ["United States", "us"],
+    )
+
+    assert_select ".govuk-label", text: "Countries", for: "basic-autocomplete"
+    assert_select "select#basic-autocomplete"
+    assert_select "select#basic-autocomplete option[value=gb]"
+    assert_select "select#basic-autocomplete option[value=us][selected]"
+  end
+
+  it "does not render when no data is specified" do
+    assert_empty render_component({})
+  end
+
+  it "does not render when no label is specified" do
+    assert_empty render_component(
+      id: "basic-autocomplete",
+      options: [["United Kingdom", "gb"], ["United States", "us"]],
+    )
+  end
+
+  it "does not render when no options are specified" do
+    assert_empty render_component(
+      id: "basic-autocomplete",
+      label: { text: "Countries" },
+    )
+  end
+end

--- a/spec/javascripts/components/accessible-autocomplete-spec.js
+++ b/spec/javascripts/components/accessible-autocomplete-spec.js
@@ -6,13 +6,13 @@ describe('An accessible autocomplete component', function () {
 
   function loadAutocompleteComponent () {
     window.setFixtures(html)
-    var autocomplete = new GOVUK.Modules.AccessibleAutocomplete()
-    autocomplete.start($('.gem-c-accessible-autocomplete'))
+    var autocomplete = new GOVUK.Modules.AccessibleAutocomplete($('.gem-c-accessible-autocomplete')[0])
+    autocomplete.init()
   }
 
   var html =
-    '<div class="gem-c-accessible-autocomplete" data-module="accessible-autocomplete">' +
-      '<select id="test" class="govuk-select" data-track-category="category" data-track-action="action">' +
+    '<div class="gem-c-accessible-autocomplete">' +
+      '<select id="test" class="govuk-select">' +
         '<option value=""></option>' +
         '<option value="mo">Moose</option>' +
         '<option value="de">Deer</option>' +
@@ -69,58 +69,6 @@ describe('An accessible autocomplete component', function () {
 
     it('the input is cleared', function () {
       expect($('select').val()).toEqual('')
-    })
-  })
-
-  describe('triggers a Google Analytics event', function () {
-    beforeEach(function (done) {
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      }
-      spyOn(GOVUK.analytics, 'trackEvent')
-
-      loadAutocompleteComponent()
-
-      $('.autocomplete__input').val('Moose').click().focus().trigger(
-        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
-      ).blur()
-
-      testAsyncWithDeferredReturnValue().done(function () {
-        done()
-      })
-    })
-
-    it('when a valid option is chosen', function () {
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', Object({ label: 'Moose' }))
-    })
-  })
-
-  describe('triggers a Google Analytics event', function () {
-    beforeEach(function (done) {
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      }
-      spyOn(GOVUK.analytics, 'trackEvent')
-
-      loadAutocompleteComponent()
-
-      $('.autocomplete__input').val('Deer').click().focus().trigger(
-        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
-      ).blur()
-
-      $('.autocomplete__input').val('').click().focus().trigger(
-        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
-      ).blur()
-
-      testAsyncWithDeferredReturnValue().done(function () {
-        done()
-      })
-    })
-
-    it('when an input is cleared', function () {
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', Object({ label: '' }))
     })
   })
 })

--- a/spec/javascripts/components/accessible-autocomplete-spec.js
+++ b/spec/javascripts/components/accessible-autocomplete-spec.js
@@ -1,0 +1,126 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+describe('An accessible autocomplete component', function () {
+  'use strict'
+
+  function loadAutocompleteComponent () {
+    window.setFixtures(html)
+    var autocomplete = new GOVUK.Modules.AccessibleAutocomplete()
+    autocomplete.start($('.gem-c-accessible-autocomplete'))
+  }
+
+  var html =
+    '<div class="gem-c-accessible-autocomplete" data-module="accessible-autocomplete">' +
+      '<select id="test" class="govuk-select" data-track-category="category" data-track-action="action">' +
+        '<option value=""></option>' +
+        '<option value="mo">Moose</option>' +
+        '<option value="de">Deer</option>' +
+      '</select>' +
+    '</div>'
+
+  // the autocomplete onConfirm function fires after the tests run unless we put
+  // in a timeout like this - makes the tests a bit verbose unfortunately
+  function testAsyncWithDeferredReturnValue () {
+    var deferred = $.Deferred()
+
+    setTimeout(function () {
+      deferred.resolve()
+    }, 500)
+
+    return deferred.promise()
+  }
+
+  describe('updates the hidden select when', function () {
+    beforeEach(function (done) {
+      loadAutocompleteComponent()
+
+      // the autocomplete is complex enough that all of these
+      // events are necessary to simulate user input
+      $('.autocomplete__input').val('Moose').click().focus().trigger(
+        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
+      ).blur()
+
+      testAsyncWithDeferredReturnValue().done(function () {
+        done()
+      })
+    })
+
+    it('an option is selected', function () {
+      expect($('select').val()).toEqual('mo')
+    })
+  })
+
+  describe('updates the hidden select when', function () {
+    beforeEach(function (done) {
+      loadAutocompleteComponent()
+
+      $('select').val('de').change()
+      $('.autocomplete__input').val('Deer')
+
+      $('.autocomplete__input').val('').click().focus().trigger(
+        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
+      ).blur()
+
+      testAsyncWithDeferredReturnValue().done(function () {
+        done()
+      })
+    })
+
+    it('the input is cleared', function () {
+      expect($('select').val()).toEqual('')
+    })
+  })
+
+  describe('triggers a Google Analytics event', function () {
+    beforeEach(function (done) {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      }
+      spyOn(GOVUK.analytics, 'trackEvent')
+
+      loadAutocompleteComponent()
+
+      $('.autocomplete__input').val('Moose').click().focus().trigger(
+        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
+      ).blur()
+
+      testAsyncWithDeferredReturnValue().done(function () {
+        done()
+      })
+    })
+
+    it('when a valid option is chosen', function () {
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', Object({ label: 'Moose' }))
+    })
+  })
+
+  describe('triggers a Google Analytics event', function () {
+    beforeEach(function (done) {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      }
+      spyOn(GOVUK.analytics, 'trackEvent')
+
+      loadAutocompleteComponent()
+
+      $('.autocomplete__input').val('Deer').click().focus().trigger(
+        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
+      ).blur()
+
+      $('.autocomplete__input').val('').click().focus().trigger(
+        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
+      ).blur()
+
+      testAsyncWithDeferredReturnValue().done(function () {
+        done()
+      })
+    })
+
+    it('when an input is cleared', function () {
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', Object({ label: '' }))
+    })
+  })
+})

--- a/spec/javascripts/components/accessible-autocomplete-spec.js
+++ b/spec/javascripts/components/accessible-autocomplete-spec.js
@@ -2,11 +2,14 @@
 /* global GOVUK */
 
 describe('An accessible autocomplete component', function () {
-  'use strict'
+  var fixture, select
 
   function loadAutocompleteComponent () {
-    window.setFixtures(html)
-    var autocomplete = new GOVUK.Modules.AccessibleAutocomplete($('.gem-c-accessible-autocomplete')[0])
+    fixture = document.createElement('div')
+    document.body.appendChild(fixture)
+    fixture.innerHTML = html
+    select = fixture.querySelector('select')
+    var autocomplete = new GOVUK.Modules.AccessibleAutocomplete(fixture.querySelector('.gem-c-accessible-autocomplete'))
     autocomplete.init()
   }
 
@@ -26,20 +29,28 @@ describe('An accessible autocomplete component', function () {
 
     setTimeout(function () {
       deferred.resolve()
-    }, 500)
+    }, 1)
 
     return deferred.promise()
   }
 
+  afterEach(function () {
+    fixture.remove()
+  })
+
   describe('updates the hidden select when', function () {
     beforeEach(function (done) {
       loadAutocompleteComponent()
+      var input = fixture.querySelector('.autocomplete__input')
+      input.value = 'Moose'
 
       // the autocomplete is complex enough that all of these
       // events are necessary to simulate user input
-      $('.autocomplete__input').val('Moose').click().focus().trigger(
-        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
-      ).blur()
+      // need to use triggerEvent as direct e.g. .click() doesn't work headless
+      window.GOVUK.triggerEvent(input, 'focus')
+      window.GOVUK.triggerEvent(input, 'keyup')
+      window.GOVUK.triggerEvent(input, 'click')
+      window.GOVUK.triggerEvent(input, 'blur')
 
       testAsyncWithDeferredReturnValue().done(function () {
         done()
@@ -47,7 +58,7 @@ describe('An accessible autocomplete component', function () {
     })
 
     it('an option is selected', function () {
-      expect($('select').val()).toEqual('mo')
+      expect(select.value).toEqual('mo')
     })
   })
 
@@ -55,12 +66,16 @@ describe('An accessible autocomplete component', function () {
     beforeEach(function (done) {
       loadAutocompleteComponent()
 
-      $('select').val('de').change()
-      $('.autocomplete__input').val('Deer')
+      var input = fixture.querySelector('.autocomplete__input')
+      input.value = 'Deer'
+      select.value = 'de'
+      window.GOVUK.triggerEvent(select, 'change')
 
-      $('.autocomplete__input').val('').click().focus().trigger(
-        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
-      ).blur()
+      input.value = ''
+      window.GOVUK.triggerEvent(input, 'focus')
+      window.GOVUK.triggerEvent(input, 'keyup')
+      window.GOVUK.triggerEvent(input, 'click')
+      window.GOVUK.triggerEvent(input, 'blur')
 
       testAsyncWithDeferredReturnValue().done(function () {
         done()
@@ -68,7 +83,7 @@ describe('An accessible autocomplete component', function () {
     })
 
     it('the input is cleared', function () {
-      expect($('select').val()).toEqual('')
+      expect(select.value).toEqual('')
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,6 +469,12 @@ accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+"accessible-autocomplete@git://github.com/alphagov/accessible-autocomplete.git":
+  version "2.0.3"
+  resolved "git://github.com/alphagov/accessible-autocomplete.git#935f0d43aea1c606e6b38985e3fe7049ddbe98be"
+  dependencies:
+    preact "^8.3.1"
+
 acorn-jsx@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
@@ -3253,6 +3259,11 @@ postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+preact@^8.3.1:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.3.tgz#78c2a5562fcecb1fed1d0055fa4ac1e27bde17c1"
+  integrity sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## What
Restores the accessible autocomplete component, with changes.

This uses the [accessible autocomplete](https://github.com/alphagov/accessible-autocomplete) code to progressively enhance a select element. This is based on the accessible autocomplete component that [existed briefly](https://github.com/alphagov/govuk_publishing_components/pull/1038) in the gem until we didn't need it anymore, but with some changes, specifically:

- we don't currently need tracking
- tracking might be needed in the future so this includes a custom `onConfirm` function (a custom `onConfirm` was originally included because we needed to [externally control the component](https://github.com/alphagov/finder-frontend/pull/970) in `finder-frontend`)
- the autocomplete `onConfirm` seems to have a bug where it fires when the autocomplete is blurred, but passes `undefined` even if something has been correctly entered in the autocomplete. An event listener has been added to the component to compensate for this
- all of the stuff to do with multiple selections has been removed, because we don't need that and it was really experimental
- tests have been updated

## Why
We're exploring using this component in a travel smart answer and it's currently the most suitable thing available.

## Visual Changes

![Screenshot 2021-12-03 at 12 27 16](https://user-images.githubusercontent.com/861310/144602458-1fe94523-2e1b-4984-ba4a-bc64b1f4242a.png)
