### PR TITLE
Update navigation header toggle button spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 
 ## Unreleased
 
-* Update search toggle / link hover state underline thickness ([PR #2484](https://github.com/alphagov/govuk_publishing_components/pull/2484))
 * Remove whitespace from pseudo-element content ([PR #2482](https://github.com/alphagov/govuk_publishing_components/pull/2482))
+* Update navigation header toggle button spacing ([PR #2483](https://github.com/alphagov/govuk_publishing_components/pull/2483))
+* Update search toggle / link hover state underline thickness ([PR #2484](https://github.com/alphagov/govuk_publishing_components/pull/2484))
 
 ## 27.14.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -136,9 +136,9 @@ $pseudo-underline-height: 3px;
   bottom: 0;
   content: "";
   height: $pseudo-underline-height;
-  left: govuk-spacing(3);
+  left: govuk-spacing(5);
   position: absolute;
-  right: govuk-spacing(3);
+  right: govuk-spacing(6);
   top: auto;
 }
 
@@ -442,7 +442,7 @@ $pseudo-underline-height: 3px;
         font-size: govuk-px-to-rem(16px);
       }
       height: $black-bar-height;
-      padding: govuk-spacing(3);
+      padding: govuk-spacing(3) govuk-spacing(6) govuk-spacing(3) govuk-spacing(5);
       position: relative;
       text-decoration: none;
 


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Update navigation header link / toggle button spacing for the desktop layout.

Ticket: https://trello.com/c/aZhaaNyT

Preview page: https://components-gem-pr-2483.herokuapp.com/public

## Why
<!-- What are the reasons behind this change being made? -->
To make the spacing in the desktoplayout look more balanced.


## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->

Preview page: https://components-gem-pr-2483.herokuapp.com/public

### Before

![components publishing service gov uk_public (7)](https://user-images.githubusercontent.com/1732331/143873060-b99b5eef-75f6-4c81-82b3-5b43068f2cb9.png)

### After

![govuk-publishing-components dev gov uk_public (18)](https://user-images.githubusercontent.com/1732331/143873000-ec5ba960-4713-4019-a033-46787398fa47.png)