### PR TITLE
Update nav header search hover state underline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update search toggle / link hover state underline thickness ([PR #2484](https://github.com/alphagov/govuk_publishing_components/pull/2484))
+
 ## 27.14.2
 
 * Update Start button so info text is associated ([PR #2476](https://github.com/alphagov/govuk_publishing_components/pull/2476))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -102,6 +102,7 @@ $icon-size: 20px;
 $chevron-indent-spacing: 7px;
 $black-bar-height: 50px;
 $search-width-or-height: $black-bar-height;
+$pseudo-underline-height: 3px;
 
 @mixin chevron($colour, $update: false) {
   @if ($update == true) {
@@ -134,7 +135,7 @@ $search-width-or-height: $black-bar-height;
   background: none;
   bottom: 0;
   content: " ";
-  height: 3px;
+  height: $pseudo-underline-height;
   left: govuk-spacing(3);
   position: absolute;
   right: govuk-spacing(3);
@@ -762,7 +763,7 @@ $search-width-or-height: $black-bar-height;
 
     &:hover {
       background: govuk-colour("black");
-      border-bottom: govuk-spacing(1) solid govuk-colour("mid-grey");
+      border-bottom: $pseudo-underline-height solid govuk-colour("mid-grey");
       color: govuk-colour("mid-grey");
     }
 


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Updates the hover state of the search link and search toggle button to have the same underline thickness as the other toggle buttons / links.

## Why
<!-- What are the reasons behind this change being made? -->

For visual consistency.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

JavaScript unavailable before: ![](https://user-images.githubusercontent.com/1732331/143874714-66011d5c-9fd3-40ab-873c-f20459959043.png)

JavaScript unavailable after: ![](https://user-images.githubusercontent.com/1732331/143874717-86c2ab91-ce57-4c82-ba56-89a8727bc379.png)

JavaScript available before:
![](https://user-images.githubusercontent.com/1732331/143874928-f4d812c7-7c1c-43c2-baab-104e861fb43e.png)

JavaScript available after:
![](https://user-images.githubusercontent.com/1732331/143874930-0a2520f3-b5c3-40ae-b1e4-30581585a6a8.png)


