### PR TITLE
Update layout_for_public component documentation

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -69,7 +69,7 @@ examples:
         <h2 class="govuk-heading-l">This is a title</h2>
         <p class="govuk-body">This is some body text with <a href="https://example.com">a link</a>.
   with_current_account_navigation:
-    description: "The account layout renders with an account-specific nav to help users navigate different areas of their account. This flag is here to allow control over which option in the nav is highlighted as `current`. Valid options are currently `your-account`, `manage`, and `security`."
+    description: "The account layout renders with an account-specific nav to help users navigate different areas of their account. This flag is here to allow control over which option in the nav is highlighted as `current`. Valid options are currently `your-account` and `manage`."
     data:
       show_account_layout: true
       account_nav_location: "manage"


### PR DESCRIPTION
As of [over a month ago](https://github.com/alphagov/govuk_publishing_components/commit/89aa073d3685a7cc67246960818330613c467d6a), the account navigation no longer includes a separate "security" link so
the documentation should reflect that.
