### PR TITLE
Remove use of govuk-font from the big number component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove use of govuk-font from the big number component ([PR #2493](https://github.com/alphagov/govuk_publishing_components/pull/2493))
+
 ## 27.15.0
 
 * Update Start button so info text is associated ([PR #2476](https://github.com/alphagov/govuk_publishing_components/pull/2476))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
@@ -1,13 +1,25 @@
 .gem-c-big-number {
   margin-bottom: govuk-spacing(3);
+  font-family: $govuk-font-family;
 }
 
 .gem-c-big-number__value {
-  @include govuk-font($size: 80, $weight: bold);
+  font-size: 80px;
+  font-weight: 700;
+  line-height: 1;
+
+  @if $govuk-typography-use-rem {
+    font-size: govuk-px-to-rem(80px);
+  }
 }
 
 .gem-c-big-number__label {
-  @include govuk-font($size: 16, $weight: bold, $line-height: 2);
+  font-size: 16px;
+  font-weight: 700;
+
+  @if $govuk-typography-use-rem {
+    font-size: govuk-px-to-rem(16px);
+  }
 
   // This pseudo element is to bypass an issue with NVDA where block level elements are dictated separately.
   // What's happening here is that the label and the number technically have an inline relationship but appear to have a block relationship thanks to this element


### PR DESCRIPTION
## What
Updates the [big number](https://components.publishing.service.gov.uk/component-guide/big_number) component to not use the design system's [`govuk-font`](https://components.publishing.service.gov.uk/component-guide/big_number) sass mixin.

## Why
Currently, the govuk-font mixin enforces responsive typography when in this case we want it to maintain the same font between screen sizes. Additionally, the current label font size is 16px which reverts to 14px on mobile, an inaccessible font size. We use a similar approach on the super navigation header, check that component for examples if you're curious about this.

### Trello cards
- https://trello.com/c/5VUAmVR7/682-3homepage-big-numbers-on-tablet-fix-sizing
- https://trello.com/c/RU79pucB/688-homepage-mobile-big-numbers-are-not-big

## Visual Changes
There is no visual change to the big number on tablet or desktop. Below is using [this page](https://components.publishing.service.gov.uk/component-guide/big_number/with_link) for reference.

### Mobile (tested at 321px)
Before:
![Screenshot 2021-12-01 at 14 36 23](https://user-images.githubusercontent.com/64783893/144256483-c5aeb711-e3d6-4f11-9b8c-0f4cd3725991.png)

After:
![Screenshot 2021-12-01 at 14 36 35](https://user-images.githubusercontent.com/64783893/144256506-8b6be38a-510e-4084-9467-e08d2a01303d.png)

