### PR TITLE
Use the correct mixins for applying font in the big number component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Use the correct mixins for applying font in the big number component ([PR #2494](https://github.com/alphagov/govuk_publishing_components/pull/2494))
 * Remove use of govuk-font from the big number component ([PR #2493](https://github.com/alphagov/govuk_publishing_components/pull/2493))
 
 ## 27.15.0

--- a/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
@@ -1,11 +1,12 @@
 .gem-c-big-number {
   margin-bottom: govuk-spacing(3);
-  font-family: $govuk-font-family;
+  @include govuk-typography-common;
+  @include govuk-text-colour;
 }
 
 .gem-c-big-number__value {
   font-size: 80px;
-  font-weight: 700;
+  @include govuk-typography-weight-bold;
   line-height: 1;
 
   @if $govuk-typography-use-rem {
@@ -15,7 +16,7 @@
 
 .gem-c-big-number__label {
   font-size: 16px;
-  font-weight: 700;
+  @include govuk-typography-weight-bold;
 
   @if $govuk-typography-use-rem {
     font-size: govuk-px-to-rem(16px);


### PR DESCRIPTION
## What
A follow on from https://github.com/alphagov/govuk_publishing_components/pull/2493 to use design system mixins and variables in as many places as possible whilst not using `govuk-font`.

## Why
Following the merging of 2493, Ollie Byford from the design system team left some comments noting the existence of mixins like `govuk-typography-common` and how they would be useful here. See his review on 2493 for details.

### Trello cards
- https://trello.com/c/5VUAmVR7/682-3homepage-big-numbers-on-tablet-fix-sizing
- https://trello.com/c/RU79pucB/688-homepage-mobile-big-numbers-are-not-big

Will not be including visual changes as the only change is the difference in colour from system black (#000000) to the design system "black" which isn't perceivable to the naked eye.