### PR TITLE
Alter use of pseudo-underline mixin to allow for different button sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Alter use of pseudo-underline mixin to allow for different button sizes ([#2501](https://github.com/alphagov/govuk_publishing_components/pull/2501))
+
 ## 27.16.0
 
 * Remove jQuery from custom dimensions ([PR #2473](https://github.com/alphagov/govuk_publishing_components/pull/2473))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -131,14 +131,14 @@ $pseudo-underline-height: 3px;
   top: 0;
 }
 
-@mixin pseudo-underline {
+@mixin pseudo-underline($left: govuk-spacing(4), $right: govuk-spacing(4)) {
   background: none;
   bottom: 0;
   content: "";
   height: $pseudo-underline-height;
-  left: govuk-spacing(5);
+  left: $left;
   position: absolute;
-  right: govuk-spacing(6);
+  right: $right;
   top: auto;
 }
 
@@ -385,7 +385,7 @@ $pseudo-underline-height: 3px;
       // stylelint-enable max-nesting-depth
 
       &:after {
-        @include pseudo-underline;
+        @include pseudo-underline($left: govuk-spacing(5), $right: govuk-spacing(6));
       }
     }
   }
@@ -431,7 +431,7 @@ $pseudo-underline-height: 3px;
 
   @include govuk-media-query($from: "desktop") {
     &:after {
-      @include pseudo-underline;
+      @include pseudo-underline($left: govuk-spacing(5), $right: govuk-spacing(6));
     }
 
     @include focus-not-focus-visible {


### PR DESCRIPTION
## What
Adds options to the `pseudo-underline` mixin within the super nav header to allow them to take different `left` and `right` attributes based on the button using the mixin.

## Why
Led by a bug report from Stephen McCarthy that the underline on the mobile menu button looks a bit weird.

The reason I've made the choice to alter how the mixin is initiated rather than just change the spacing is that this initial spacing is a conscious choice made in https://github.com/alphagov/govuk_publishing_components/pull/2483 This maintains the intent of 2483 whilst fixing this issue.

[Card](https://trello.com/c/SkO1xxdS/703-fix-pseudo-underline-on-mobile-menu-button)

## Visual Changes (mobile only)
### Before
![Screenshot 2021-12-08 at 14 14 13](https://user-images.githubusercontent.com/64783893/145224405-2b073c27-f210-4be2-a29d-7a0de261490f.png)

### After
![Screenshot 2021-12-08 at 14 14 25](https://user-images.githubusercontent.com/64783893/145224424-3f850421-b86e-449e-8f97-42429b0e471f.png)
