### PR TITLE
Re-work `explicit-cross-domain-links.js`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## Unreleased
 
 * Alter use of pseudo-underline mixin to allow for different button sizes ([#2501](https://github.com/alphagov/govuk_publishing_components/pull/2501))
+* Re-work explicit-cross-domain-links.js ([PR #2502](https://github.com/alphagov/govuk_publishing_components/pull/2502))
 
 ## 27.16.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -97,7 +97,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.cookieBannerConfirmationMessage.focus()
     window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
     window.GOVUK.setDefaultConsentCookie()
-    window.GOVUK.triggerEvent(window, 'cookie-reject')
   }
 
   CookieBanner.prototype.showConfirmationMessage = function () {

--- a/docs/javascript-modules.md
+++ b/docs/javascript-modules.md
@@ -69,8 +69,6 @@ This functionality runs like this:
 - if cookies have been consented, the module calls the rest of its code and carries on as normal
 - if cookies have not been consented, the listener is created and calls the rest of the module when the `cookie-consent` event is fired by the cookie banner
 
-If a module has functionality which is dependent on rejecting cookies, that module should listen for the `cookie-reject` event. This event is fired by the cookie banner when the user rejects cookies.
-
 ### Module structure
 
 A module must add its constructor to `GOVUK.Modules` and it must have an `init` method. The simplest module looks like:

--- a/spec/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.spec.js
@@ -42,28 +42,37 @@ describe('Explicit cross-domain linker', function () {
     delete window.gaplugins
   })
 
-  describe('links', function () {
+  describe('when a cross-domain link is clicked', function () {
     beforeEach(function () {
-      element = $('<a href="/somewhere">')
+      element = $('<a href="#">')
     })
 
     it('modifies the link href to append cookie_consent parameter "not-engaged" if cookies_preferences_set cookie is "false"', function () {
       GOVUK.cookie('cookies_preferences_set', 'false')
       explicitCrossDomainLinks.start(element)
-      expect(element.attr('href')).toEqual('/somewhere?cookie_consent=not-engaged')
+      expect(element.attr('href')).toEqual('#')
+      window.GOVUK.triggerEvent(element[0], 'click')
+      expect(element.attr('href')).toEqual('#?cookie_consent=not-engaged')
+      expect(window.location.href).toContain('?cookie_consent=not-engaged')
     })
 
     it('modifies the link href to append cookie_consent parameter "not-engaged" if cookies_preferences_set cookie is not set', function () {
       GOVUK.cookie('cookies_preferences_set', null)
       explicitCrossDomainLinks.start(element)
-      expect(element.attr('href')).toEqual('/somewhere?cookie_consent=not-engaged')
+      expect(element.attr('href')).toEqual('#')
+      window.GOVUK.triggerEvent(element[0], 'click')
+      expect(element.attr('href')).toEqual('#?cookie_consent=not-engaged')
+      expect(window.location.href).toContain('?cookie_consent=not-engaged')
     })
 
     it('modifies the link href to append cookie_consent parameter "reject" if usage cookies have been rejected', function () {
       GOVUK.cookie('cookies_preferences_set', 'true')
       GOVUK.setConsentCookie({ usage: false })
       explicitCrossDomainLinks.start(element)
-      expect(element.attr('href')).toEqual('/somewhere?cookie_consent=reject')
+      expect(element.attr('href')).toEqual('#')
+      window.GOVUK.triggerEvent(element[0], 'click')
+      expect(element.attr('href')).toEqual('#?cookie_consent=reject')
+      expect(window.location.href).toContain('?cookie_consent=reject')
     })
 
     describe('user has accepted cookies', function () {
@@ -73,16 +82,23 @@ describe('Explicit cross-domain linker', function () {
         trackers = [{ ga_mock: 'foobar' }]
 
         explicitCrossDomainLinks.start(element)
+        expect(element.attr('href')).toEqual('#')
+        window.GOVUK.triggerEvent(element[0], 'click')
 
-        expect(element.attr('href')).toEqual('/somewhere?cookie_consent=accept&_ga=abc123')
+        expect(element.attr('href')).toEqual('#?cookie_consent=accept&_ga=abc123')
+        expect(window.location.href).toContain('?cookie_consent=accept&_ga=abc123')
       })
 
       it('modifies the link href to only append cookie_consent "accept" if there are no trackers', function () {
         GOVUK.cookie('cookies_preferences_set', 'true')
         GOVUK.setConsentCookie({ usage: true })
         trackers = []
+
         explicitCrossDomainLinks.start(element)
-        expect(element.attr('href')).toEqual('/somewhere?cookie_consent=accept')
+        expect(element.attr('href')).toEqual('#')
+        window.GOVUK.triggerEvent(element[0], 'click')
+        expect(element.attr('href')).toEqual('#?cookie_consent=accept')
+        expect(window.location.href).toContain('?cookie_consent=accept')
       })
 
       it('modifies the link href to only append cookie_consent "accept" if ga is not initalised on window', function () {
@@ -90,34 +106,15 @@ describe('Explicit cross-domain linker', function () {
         GOVUK.setConsentCookie({ usage: true })
         window.ga = undefined
         explicitCrossDomainLinks.start(element)
-        expect(element.attr('href')).toEqual('/somewhere?cookie_consent=accept')
-      })
-    })
-
-    describe('user has interacted with the cookie banner on the current page', function () {
-      beforeEach(function () {
-        GOVUK.cookie('cookies_preferences_set', null)
-        explicitCrossDomainLinks.start(element)
-        GOVUK.cookie('cookies_preferences_set', 'true')
-      })
-      it('modifies the link href to append cookie_consent parameter "accept" if the cookie-consent event was fired', function () {
-        GOVUK.setConsentCookie({ usage: true })
-        window.ga = undefined
-        window.GOVUK.triggerEvent(window, 'cookie-consent')
-
-        expect(element.attr('href')).toEqual('/somewhere?cookie_consent=accept')
-      })
-
-      it('modifies the link href to append cookie_consent parameter "reject" if the cookie-reject event was fired', function () {
-        GOVUK.setConsentCookie({ usage: false })
-        window.GOVUK.triggerEvent(window, 'cookie-reject')
-
-        expect(element.attr('href')).toEqual('/somewhere?cookie_consent=reject')
+        expect(element.attr('href')).toEqual('#')
+        window.GOVUK.triggerEvent(element[0], 'click')
+        expect(element.attr('href')).toEqual('#?cookie_consent=accept')
+        expect(window.location.href).toContain('?cookie_consent=accept')
       })
     })
   })
 
-  describe('forms', function () {
+  describe('when a cross-domain form is submitted', function () {
     beforeEach(function () {
       element = $('<form method="POST" action="/somewhere">' +
                '<input type="hidden" name="key" value="value" />' +
@@ -128,12 +125,17 @@ describe('Explicit cross-domain linker', function () {
     it('modifies the form action to append cookie_consent parameter "not-engaged" if cookies_preferences_set cookie is "false"', function () {
       GOVUK.cookie('cookies_preferences_set', 'false')
       explicitCrossDomainLinks.start(element)
+      expect(element.attr('action')).toEqual('/somewhere')
+      window.GOVUK.triggerEvent(element[0], 'submit')
+
       expect(element.attr('action')).toEqual('/somewhere?cookie_consent=not-engaged')
     })
 
     it('modifies the form action to append cookie_consent parameter "not-engaged" if cookies_preferences_set cookie is not set', function () {
       GOVUK.cookie('cookies_preferences_set', null)
       explicitCrossDomainLinks.start(element)
+      expect(element.attr('action')).toEqual('/somewhere')
+      window.GOVUK.triggerEvent(element[0], 'submit')
       expect(element.attr('action')).toEqual('/somewhere?cookie_consent=not-engaged')
     })
 
@@ -141,6 +143,8 @@ describe('Explicit cross-domain linker', function () {
       GOVUK.cookie('cookies_preferences_set', 'true')
       GOVUK.setConsentCookie({ usage: false })
       explicitCrossDomainLinks.start(element)
+      expect(element.attr('action')).toEqual('/somewhere')
+      window.GOVUK.triggerEvent(element[0], 'submit')
       expect(element.attr('action')).toEqual('/somewhere?cookie_consent=reject')
     })
 
@@ -150,6 +154,8 @@ describe('Explicit cross-domain linker', function () {
         GOVUK.setConsentCookie({ usage: true })
         trackers = [{ ga_mock: 'foobar' }]
         explicitCrossDomainLinks.start(element)
+        expect(element.attr('action')).toEqual('/somewhere')
+        window.GOVUK.triggerEvent(element[0], 'submit')
         expect(element.attr('action')).toEqual('/somewhere?cookie_consent=accept&_ga=abc123')
       })
 
@@ -158,6 +164,8 @@ describe('Explicit cross-domain linker', function () {
         GOVUK.setConsentCookie({ usage: true })
         trackers = []
         explicitCrossDomainLinks.start(element)
+        expect(element.attr('action')).toEqual('/somewhere')
+        window.GOVUK.triggerEvent(element[0], 'submit')
         expect(element.attr('action')).toEqual('/somewhere?cookie_consent=accept')
       })
 
@@ -166,29 +174,9 @@ describe('Explicit cross-domain linker', function () {
         GOVUK.setConsentCookie({ usage: true })
         window.ga = undefined
         explicitCrossDomainLinks.start(element)
+        expect(element.attr('action')).toEqual('/somewhere')
+        window.GOVUK.triggerEvent(element[0], 'submit')
         expect(element.attr('action')).toEqual('/somewhere?cookie_consent=accept')
-      })
-    })
-
-    describe('user has interacted with the cookie banner on the current page', function () {
-      beforeEach(function () {
-        GOVUK.cookie('cookies_preferences_set', null)
-        explicitCrossDomainLinks.start(element)
-        GOVUK.cookie('cookies_preferences_set', 'true')
-      })
-      it('modifies the form action to append cookie_consent parameter "accept" if the cookie-consent event was fired', function () {
-        GOVUK.setConsentCookie({ usage: true })
-        window.ga = undefined
-        window.GOVUK.triggerEvent(window, 'cookie-consent')
-
-        expect(element.attr('action')).toEqual('/somewhere?cookie_consent=accept')
-      })
-
-      it('modifies the form action to append cookie_consent parameter "reject" if the cookie-reject event was fired', function () {
-        GOVUK.setConsentCookie({ usage: false })
-        window.GOVUK.triggerEvent(window, 'cookie-reject')
-
-        expect(element.attr('action')).toEqual('/somewhere?cookie_consent=reject')
       })
     })
   })

--- a/spec/javascripts/govuk_publishing_components/modules.spec.js
+++ b/spec/javascripts/govuk_publishing_components/modules.spec.js
@@ -140,20 +140,6 @@ describe('GOVUK Modules', function () {
       }
       GOVUK.Modules.TestCookieDependencyModule = TestCookieDependencyModule
 
-      // GOV.UK Frontend Module that depends on rejected cookies to start
-      function TestCookieRejectDependencyModule (element) {
-        this.element = element
-      }
-      TestCookieRejectDependencyModule.prototype.init = function () {
-        this.startModule = this.startModule.bind(this)
-        window.addEventListener('cookie-reject', this.startModule)
-      }
-      TestCookieRejectDependencyModule.prototype.startModule = function () {
-        window.removeEventListener('cookie-reject', this.startModule)
-        callbackFrontendModule(this.element)
-      }
-      GOVUK.Modules.TestCookieRejectDependencyModule = TestCookieRejectDependencyModule
-
       container = $('<div></div>')
     })
 
@@ -165,7 +151,6 @@ describe('GOVUK Modules', function () {
       delete GOVUK.Modules.GovukTestAlertPublishingAndFrontendModule
       delete GOVUK.Modules.TestAlertPublishingAndFrontendModule
       delete GOVUK.Modules.TestCookieDependencyModule
-      delete GOVUK.Modules.TestCookieRejectDependencyModule
 
       container.remove()
     })
@@ -240,17 +225,6 @@ describe('GOVUK Modules', function () {
       GOVUK.modules.start(container)
       expect(callbackFrontendModule.calls.count()).toBe(0)
       window.GOVUK.triggerEvent(window, 'cookie-consent')
-      expect(callbackFrontendModule.calls.count()).toBe(1)
-    })
-
-    it('starts delayed modules once cookies have been rejected', function () {
-      var module = $('<div data-module="test-cookie-reject-dependency-module"></div>')
-      container.append(module)
-      $('body').append(container)
-
-      GOVUK.modules.start(container)
-      expect(callbackFrontendModule.calls.count()).toBe(0)
-      window.GOVUK.triggerEvent(window, 'cookie-reject')
       expect(callbackFrontendModule.calls.count()).toBe(1)
     })
 


### PR DESCRIPTION
It has transpired that the `explicit-cross-domain-links.js` script was not
set up correctly which is breaking our cross domain tracking currently.

The source of the issue is the `_ga` parameter which contains a timestamp
which actually expires and becomes invalid after two minutes.

The way the script worked previously was that the relevant cross-domain
links and forms on the page were decorated with the `_ga` and
`cookie_consent` parameters on page load. Doing it on page load is an
issue due to the time-sensitive nature of the `_ga` parameter, as
mentioned above.

This changes the way the script works so that instead of decorating
crossdomain links and forms with additional parameters on page load, we
decorate them when they are interacted with.
Besides ensuring that the `_ga` param is always valid and up-to-date, this
also makes it so that there is no longer a need to listen for cookie
banner events, so I also removed the `cookie-reject` event as part of this
commit (this event was explicitly introduced for the `explicit-cross-domain-links.js`
script and is not used anywhere else currently).


----


https://trello.com/c/VaRq2typ/27-fix-cross-domain-issue