### PR TITLE
Fix typo in menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Re-work explicit-cross-domain-links.js ([PR #2502](https://github.com/alphagov/govuk_publishing_components/pull/2502))
 * Update govspeak table styles ([PR #2470](https://github.com/alphagov/govuk_publishing_components/pull/2470))
 * Increase big number label size ([PR #2506](https://github.com/alphagov/govuk_publishing_components/pull/2506))
+* Fix typo in menu([#2503](https://github.com/alphagov/govuk_publishing_components/pull/2503))
 
 ## 27.16.0
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,7 +170,7 @@ en:
         - label: Research and statistics
           href: "/search/research-and-statistics"
           description: Reports, analysis and official statistics
-        - label: Policy papers and consultation
+        - label: Policy papers and consultations
           href: "/search/policy-papers-and-consultations"
           description: Consultations and strategy
         - label: Transparency


### PR DESCRIPTION
## What
Changes `consultation` to `consultations` in the menu.

[Trello card](https://trello.com/c/2nJZcJO6/696-nav-menu-content-updates)

## Visual Changes

### Before

<img width="510" alt="Screenshot 2021-12-08 at 6 27 42 pm" src="https://user-images.githubusercontent.com/424772/145263595-e70052e5-d1f0-4e0c-b8fd-59f8d3fcbc37.png">

### After

<img width="510" alt="Screenshot 2021-12-08 at 8 23 34 pm" src="https://user-images.githubusercontent.com/424772/145396112-a4205705-bc13-4a39-b968-a6082b719d0c.png">

(NOTE font issue will be fixed in another PR)