### PR TITLE
Increase big number label size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
 
 ## Unreleased
 
-* Alter use of pseudo-underline mixin to allow for different button sizes ([#2501](https://github.com/alphagov/govuk_publishing_components/pull/2501))
+* Alter use of pseudo-underline mixin to allow for different button sizes ([PR #2501](https://github.com/alphagov/govuk_publishing_components/pull/2501))
 * Re-work explicit-cross-domain-links.js ([PR #2502](https://github.com/alphagov/govuk_publishing_components/pull/2502))
 * Update govspeak table styles ([PR #2470](https://github.com/alphagov/govuk_publishing_components/pull/2470))
+* Increase big number label size ([PR #2506](https://github.com/alphagov/govuk_publishing_components/pull/2506))
 
 ## 27.16.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
@@ -15,12 +15,7 @@
 }
 
 .gem-c-big-number__label {
-  font-size: 16px;
-  @include govuk-typography-weight-bold;
-
-  @if $govuk-typography-use-rem {
-    font-size: govuk-px-to-rem(16px);
-  }
+  @include govuk-font($size: 19, $weight: bold);
 
   // This pseudo element is to bypass an issue with NVDA where block level elements are dictated separately.
   // What's happening here is that the label and the number technically have an inline relationship but appear to have a block relationship thanks to this element


### PR DESCRIPTION
## What
Reinstates the use of `govuk-font` for [big number labels](https://components.publishing.service.gov.uk/component-guide/big_number/with_labels) so that it is 19px on desktop and 16px on mobile (change managed by the font mixin).

## Why
Recommendations by our designer as part of the new homepage work. The larger label will generally make it more legible on desktop.

[Card](https://trello.com/c/ilFWAf2G/699-sort-out-label-font-on-big-number-component)

## Visual Changes
### Before
![Screenshot 2021-12-09 at 11 29 21](https://user-images.githubusercontent.com/64783893/145388623-e3cc371a-3dcd-474c-846c-d6dede60d38c.png)

### After
![Screenshot 2021-12-09 at 11 29 28](https://user-images.githubusercontent.com/64783893/145388649-acd674da-0224-44cd-9ed5-d6e8e399919b.png)
