### PR TITLE
Bump gem to 27.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.17.0
 
 * Alter use of pseudo-underline mixin to allow for different button sizes ([PR #2501](https://github.com/alphagov/govuk_publishing_components/pull/2501))
 * Re-work explicit-cross-domain-links.js ([PR #2502](https://github.com/alphagov/govuk_publishing_components/pull/2502))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.16.0)
+    govuk_publishing_components (27.17.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.16.0".freeze
+  VERSION = "27.17.0".freeze
 end


### PR DESCRIPTION
Includes:
* Alter use of pseudo-underline mixin to allow for different button sizes ([PR #2501](https://github.com/alphagov/govuk_publishing_components/pull/2501))
* Re-work explicit-cross-domain-links.js ([PR #2502](https://github.com/alphagov/govuk_publishing_components/pull/2502))
* Update govspeak table styles ([PR #2470](https://github.com/alphagov/govuk_publishing_components/pull/2470))
* Increase big number label size ([PR #2506](https://github.com/alphagov/govuk_publishing_components/pull/2506))
* Fix typo in menu([#2503](https://github.com/alphagov/govuk_publishing_components/pull/2503))