### PR TITLE
Fix font for menu paragraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix font for menu paragraphs [#2509](https://github.com/alphagov/govuk_publishing_components/pull/2509)
+
 ## 27.17.0
 
 * Alter use of pseudo-underline mixin to allow for different button sizes ([PR #2501](https://github.com/alphagov/govuk_publishing_components/pull/2501))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -963,6 +963,7 @@ $pseudo-underline-height: 3px;
 }
 
 .gem-c-layout-super-navigation-header__navigation-second-item-description {
+  @include govuk-typography-common;
   font-size: 16px;
   @if $govuk-typography-use-rem {
     font-size: govuk-px-to-rem(16px);


### PR DESCRIPTION
## What / Why
Transport was not explicitly set on the menu items, so if viewing in Heroku for example the menu styling would appear broken.


## Visual Changes

### Before
<img width="510" alt="Screenshot 2021-12-08 at 8 23 34 pm" src="https://user-images.githubusercontent.com/424772/145433424-b713b783-990a-4eb0-9929-cabd61b10e36.png">


### After
<img width="531" alt="Screenshot 2021-12-09 at 4 07 54 pm" src="https://user-images.githubusercontent.com/424772/145433459-0a3f3361-c2ee-4f71-9fce-b3648b5bc1b7.png">

