### PR TITLE
Add large mode on mobile only to search component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix font for menu paragraphs [#2509](https://github.com/alphagov/govuk_publishing_components/pull/2509)
+* Add large mode on mobile only to search component ([PR #2510](https://github.com/alphagov/govuk_publishing_components/pull/2510))
 
 ## 27.17.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -1,6 +1,25 @@
 $input-size: 40px;
 $large-input-size: 50px;
 
+@mixin large-mode {
+  .gem-c-search__label {
+    @include govuk-font($size: 19, $line-height: $large-input-size);
+  }
+
+  .gem-c-search__input[type="search"] {
+    height: $large-input-size;
+  }
+
+  .gem-c-search__submit {
+    width: $large-input-size;
+    height: $large-input-size;
+
+    .gem-c-search__icon {
+      @include icon-positioning($large-input-size);
+    }
+  }
+}
+
 .gem-c-search {
   position: relative;
   margin-bottom: 30px;
@@ -220,21 +239,12 @@ $large-input-size: 50px;
 }
 
 .gem-c-search--large {
-  .gem-c-search__label {
-    @include govuk-font($size: 19, $line-height: $large-input-size);
-  }
+  @include large-mode;
+}
 
-  .gem-c-search__input[type="search"] {
-    height: $large-input-size;
-  }
-
-  .gem-c-search__submit {
-    width: $large-input-size;
-    height: $large-input-size;
-
-    .gem-c-search__icon {
-      @include icon-positioning($large-input-size);
-    }
+.gem-c-search--large-on-mobile {
+  @include govuk-media-query($until: "tablet") {
+    @include large-mode;
   }
 }
 

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -21,6 +21,7 @@
   classes << (shared_helper.get_margin_top)
   classes << (shared_helper.get_margin_bottom) if local_assigns[:margin_bottom]
   classes << "gem-c-search--large" if size == "large"
+  classes << "gem-c-search--large-on-mobile" if size == "large-mobile"
   classes << "gem-c-search--no-border" if no_border
   if local_assigns[:on_govuk_blue].eql?(true)
     classes << "gem-c-search--on-govuk-blue"

--- a/app/views/govuk_publishing_components/components/docs/search.yml
+++ b/app/views/govuk_publishing_components/components/docs/search.yml
@@ -44,6 +44,9 @@ examples:
   large_version:
     data:
       size: "large"
+  large_version_on_mobile_only:
+    data:
+      size: "large-mobile"
   change_field_name:
     description: To be used if you need to change the default name 'q'
     data:

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -49,6 +49,11 @@ describe "Search", type: :view do
     assert_select ".gem-c-search.gem-c-search--large"
   end
 
+  it "renders a large search box on mobile only" do
+    render_component(size: "large-mobile")
+    assert_select ".gem-c-search.gem-c-search--large-on-mobile"
+  end
+
   it "renders a search box with a default name" do
     render_component({})
     assert_select 'input[name="q"]'


### PR DESCRIPTION
## What
Adds `large-mobile` as an option for the `size` attribute on the [search component](https://components.publishing.service.gov.uk/component-guide/search). This means that the "large" styles, previously applied to all screen sizes via `size: "large"`, will only be applied to the search component on mobile.

## Why
Recommendation from our designer as part of the homepage work to make sure that the search box looks nice between screen sizes.

[Card](https://trello.com/c/Ss9cKnkL/702-homepage-stretch-goal-smaller-search-bar-on-desktop)

## How it looks
### Desktop
![Screenshot 2021-12-09 at 16 17 16](https://user-images.githubusercontent.com/64783893/145434189-77b8a438-ea97-43d8-8d1d-ab3d3dfe8eb7.png)

### Mobile
![Screenshot 2021-12-09 at 16 17 33](https://user-images.githubusercontent.com/64783893/145434205-b467498b-4333-4d76-a478-fc19d605f926.png)
