### PR TITLE
Fix single page notification button flash of unpersonalised content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add large mode on mobile only to search component ([PR #2510](https://github.com/alphagov/govuk_publishing_components/pull/2510))
 * Port the grid_helper sass mixin to the components gem ([PR #2517](https://github.com/alphagov/govuk_publishing_components/pull/2517))
 * Update super nav popular links ([PR #2519](https://github.com/alphagov/govuk_publishing_components/pull/2519))
+* Fix single page notification button flash of unpersonalised content ([PR #2512](https://github.com/alphagov/govuk_publishing_components/pull/2512))
 
 ## 27.17.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/single-page-notification-button.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/single-page-notification-button.js
@@ -7,6 +7,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module = $module
     this.basePath = this.$module.querySelector('input[name="base_path"]').value
     this.buttonLocation = this.$module.getAttribute('data-button-location')
+    this.buttonVisibleClass = 'gem-c-single-page-notification-button--visible'
 
     this.personalisationEndpoint = '/api/personalisation/check-email-subscription?base_path=' + this.basePath
     // This attribute is passed through to the personalisation API to ensure the updated button has the same button_location for analytics
@@ -16,21 +17,30 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   SinglePageNotificationButton.prototype.init = function () {
     var xhr = new XMLHttpRequest()
     xhr.open('GET', this.personalisationEndpoint, true)
+    // if XHR to the personalisation endpoint is taking an incredibly long time to complete, we are better off leaving the button in its default unpersonalised state. Content changing before the user's eyes while they are browsing can be jarring and should be avoided.
+    xhr.timeout = 10000
+
+    xhr.ontimeout = function () {
+      this.makeVisible(this.$module)
+    }.bind(this)
 
     xhr.onreadystatechange = function () {
-      if (xhr.readyState === 4 && xhr.status === 200) {
-        var responseText = xhr.responseText
-        // if response text exists and is JSON parse-able, parse the response and get the button html
-        if (responseText && this.responseIsJSON(responseText)) {
-          var newButton = JSON.parse(responseText).button_html
-          var html = document.createElement('div')
-          html.innerHTML = newButton
-          // test that the html returned contains the button component; if yes, swap the button for the updated version
-          var responseButtonContainer = html.querySelector('form.gem-c-single-page-notification-button')
-          if (responseButtonContainer) {
-            this.$module.parentNode.replaceChild(responseButtonContainer, this.$module)
+      if (xhr.readyState === 4) {
+        if (xhr.status === 200) {
+          var responseText = xhr.responseText
+          // if response text exists and is JSON parse-able, parse the response and get the button html
+          if (responseText && this.responseIsJSON(responseText)) {
+            var newButton = JSON.parse(responseText).button_html
+            var html = document.createElement('div')
+            html.innerHTML = newButton
+            // test that the html returned contains the button component; if yes, swap the button for the updated version
+            var responseButtonContainer = html.querySelector('form.gem-c-single-page-notification-button')
+            if (responseButtonContainer) {
+              this.$module.parentNode.replaceChild(responseButtonContainer, this.$module)
+            }
           }
         }
+        this.makeVisible(this.$module)
       }
     }.bind(this)
     xhr.send()
@@ -43,6 +53,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       return false
     }
     return true
+  }
+
+  SinglePageNotificationButton.prototype.makeVisible = function (target) {
+    target.classList.add(this.buttonVisibleClass)
   }
   Modules.SinglePageNotificationButton = SinglePageNotificationButton
 })(window.GOVUK.Modules)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_single-page-notification-button.scss
@@ -28,3 +28,11 @@
   vertical-align: top;
   margin-right: govuk-spacing(1);
 }
+
+.js-enabled .gem-c-single-page-notification-button.js-personalisation-enhancement {
+  opacity: 0;
+
+  &.gem-c-single-page-notification-button--visible {
+    opacity: 1;
+  }
+}

--- a/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
@@ -9,7 +9,7 @@
   <svg class="gem-c-single-page-notification-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 459.334 459.334"><path fill="currentColor" d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"/></svg><%= component_helper.button_text %>
 <% end %>
 <%= tag.div class: wrapper_classes, data: { module: "gem-track-click"} do %>
-  <%= tag.form class: "gem-c-single-page-notification-button", action: "/email/subscriptions/single-page/new", method: "POST", data: component_helper.data do %>
+  <%= tag.form class: component_helper.classes, action: "/email/subscriptions/single-page/new", method: "POST", data: component_helper.data do %>
     <input type="hidden" name="base_path" value="<%= component_helper.base_path %>">
     <%= content_tag(:button, button_text, {
       class: "govuk-body-s gem-c-single-page-notification-button__submit",

--- a/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb
@@ -1,7 +1,7 @@
 module GovukPublishingComponents
   module Presenters
     class SinglePageNotificationButtonHelper
-      attr_reader :already_subscribed, :data_attributes, :base_path, :js_enhancement, :button_type, :button_location
+      attr_reader :already_subscribed, :data_attributes, :base_path, :js_enhancement, :button_type, :button_location, :classes
 
       def initialize(local_assigns)
         @local_assigns = local_assigns
@@ -11,6 +11,8 @@ module GovukPublishingComponents
         @base_path = @local_assigns[:base_path] || nil
         @button_location = button_location_is_valid? ? @local_assigns[:button_location] : nil
         @button_type = @local_assigns[:already_subscribed] ? "Unsubscribe" : "Subscribe"
+        @classes = %w[gem-c-single-page-notification-button]
+        @classes << "js-personalisation-enhancement" if js_enhancement
       end
 
       def data

--- a/spec/components/single_page_notification_button_spec.rb
+++ b/spec/components/single_page_notification_button_spec.rb
@@ -41,13 +41,14 @@ describe "Single page notification button", type: :view do
     assert_select 'div.govuk-\!-margin-bottom-9 .gem-c-single-page-notification-button'
   end
 
-  it "has a data-module attribute for JavaScript, if the js-enhancement flag is present" do
+  it "has a js-enhancement class and a data-module attribute if the js-enhancement flag is present" do
     render_component({ base_path: "/the-current-page", js_enhancement: true })
-    assert_select ".gem-c-single-page-notification-button[data-module='single-page-notification-button']"
+    assert_select ".gem-c-single-page-notification-button.js-personalisation-enhancement[data-module='single-page-notification-button']"
   end
 
-  it "does not have a data-module attribute if the js-enhancement flag is not present" do
+  it "does not have a js-enhancement class and a data-module attribute if the js-enhancement flag is not present" do
     render_component({ base_path: "/the-current-page" })
+    assert_select ".gem-c-single-page-notification-button.js-personalisation-enhancement", false
     assert_select ".gem-c-single-page-notification-button[data-module='single-page-notification-button']", false
   end
 

--- a/spec/javascripts/components/single-page-notification-button-spec.js
+++ b/spec/javascripts/components/single-page-notification-button-spec.js
@@ -6,7 +6,7 @@ describe('Single page notification component', function () {
 
   beforeEach(function () {
     FIXTURE =
-      '<form class="gem-c-single-page-notification-button old-button-for-test" action="/email/subscriptions/single-page/new" method="POST" data-module="single-page-notification-button">' +
+      '<form class="gem-c-single-page-notification-button old-button-for-test js-personalisation-enhancement" action="/email/subscriptions/single-page/new" method="POST" data-module="single-page-notification-button">' +
         '<input type="hidden" name="base_path" value="/current-page-path">' +
         '<button class="gem-c-single-page-notification-button__submit" type="submit">Get emails about this page</button>' +
     '</form>'
@@ -27,7 +27,7 @@ describe('Single page notification component', function () {
 
   it('includes button_location in the call to the personalisation API when button_location is specified', function () {
     FIXTURE =
-      '<form class="gem-c-single-page-notification-button old-button-for-test" action="/email/subscriptions/single-page/new" method="POST" data-module="single-page-notification-button" data-button-location="top">' +
+      '<form class="gem-c-single-page-notification-button old-button-for-test js-personalisation-enhancement" action="/email/subscriptions/single-page/new" method="POST" data-module="single-page-notification-button" data-button-location="top">' +
         '<input type="hidden" name="base_path" value="/current-page-path">' +
         '<button class="gem-c-single-page-notification-button__submit" type="submit">Get emails about this page</button>' +
       '</form>'
@@ -62,7 +62,7 @@ describe('Single page notification component', function () {
       responseText: responseText
     })
 
-    var button = document.querySelector('form.gem-c-single-page-notification-button.old-button-for-test button')
+    var button = document.querySelector('form.gem-c-single-page-notification-button.old-button-for-test.gem-c-single-page-notification-button--visible button')
     expect(button).toHaveText('Get emails about this page')
     expect(GOVUK.Modules.SinglePageNotificationButton.prototype.responseIsJSON(responseText)).toBe(false)
   })
@@ -77,7 +77,7 @@ describe('Single page notification component', function () {
       responseText: responseText
     })
 
-    var button = document.querySelector('form.gem-c-single-page-notification-button.old-button-for-test button')
+    var button = document.querySelector('form.gem-c-single-page-notification-button.old-button-for-test.gem-c-single-page-notification-button--visible button')
     expect(button).toHaveText('Get emails about this page')
     expect(GOVUK.Modules.SinglePageNotificationButton.prototype.responseIsJSON(responseText)).toBe(false)
   })
@@ -91,8 +91,18 @@ describe('Single page notification component', function () {
       responseText: ''
     })
 
-    var button = document.querySelector('form.gem-c-single-page-notification-button.old-button-for-test button')
+    var button = document.querySelector('form.gem-c-single-page-notification-button.old-button-for-test.gem-c-single-page-notification-button--visible button')
     expect(button).toHaveText('Get emails about this page')
+  })
+
+  it('should remain unchanged if xhr times out', function () {
+    jasmine.clock().install()
+    initButton()
+    jasmine.Ajax.requests.mostRecent().responseTimeout()
+
+    var button = document.querySelector('form.gem-c-single-page-notification-button.old-button-for-test.gem-c-single-page-notification-button--visible button')
+    expect(button).toHaveText('Get emails about this page')
+    jasmine.clock().uninstall()
   })
 
   function initButton () {


### PR DESCRIPTION
Fix flash of unpersonalised content that can happen to the Single page
notification button when someone is logged in and has subscribed to
notifications on the current page.

This feature has been designed with the personalisation bit as a JS
enhancement. A JS request is made to a personalisation endpoint on page
load, which returns a response based on which the button reflects the
subscription status of the current user to the current page.

The swap from old button to updated button should happen in a near
instant in ideal conditions, but can be more obvious in certain
instances (such as if someone's internet connection is not good)

This aims to work around this problem by initially hiding the button
when JS is enabled, then making it visible immediately when XHR has
completed.


### Before

https://user-images.githubusercontent.com/7116819/145800737-23ffb72d-8584-42dc-ba22-9ae66ba38dc9.mov


### After

https://user-images.githubusercontent.com/7116819/145800748-de74ec24-e534-4ebf-8dc8-7c85a0d48c8c.mov





https://trello.com/c/Jbaps55g