### PR TITLE
Replace use of `includes()` in `explicit-cross-domain-links.js` with `indexOf()` alternative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Replace use of `includes()` in `explicit-cross-domain-links.js` with `indexOf()` alternative [#2515](https://github.com/alphagov/govuk_publishing_components/pull/2515)
 * Fix font for menu paragraphs [#2509](https://github.com/alphagov/govuk_publishing_components/pull/2509)
 * Add large mode on mobile only to search component ([PR #2510](https://github.com/alphagov/govuk_publishing_components/pull/2510))
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.js
@@ -75,7 +75,7 @@
 
       if (!attributeValue) { return }
 
-      if (attributeValue.includes('?')) {
+      if (attributeValue.indexOf('?') !== -1) {
         attributeValue += '&' + param
       } else {
         attributeValue += '?' + param


### PR DESCRIPTION
`String.prototype.includes()` is not supported in all major browsers. Swap
it for `indexOf()` which benefits from better browser support.

Fixes #2451