### PR TITLE
Add flag to hide Intervention Banner component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleaased
+
+* Add flag to hide Intervention Banner component [#2516](https://github.com/alphagov/govuk_publishing_components/pull/2516)
+
 ## 27.18.0
 
 * Remove jQuery from page-content ([PR #2505](https://github.com/alphagov/govuk_publishing_components/pull/2505))

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -3,7 +3,9 @@
   suggestion_link_text ||= false
   suggestion_link_url ||= false
   suggestion_text ||= nil
+  hide ||= false
   new_tab ||= false
+
 
   data_attributes ||= {}
   data_attributes[:module] = 'intervention'
@@ -34,9 +36,16 @@
 
     suggestion_link_text = intervention_helper.accessible_text
   end
+
+  section_options = {
+    class: "gem-c-intervention",
+    role: "region", aria: aria_attributes,
+    data: data_attributes,
+  }
+  section_options.merge!({ hidden: true }) if hide
 %>
 <% if suggestion_text || (suggestion_link_text && suggestion_link_url) %>
-  <%= tag.section class: "gem-c-intervention", role: "region", aria: aria_attributes, data: data_attributes do %>
+  <%= tag.section section_options do %>
     <p class="govuk-body">
       <%= tag.span suggestion_text, class: "gem-c-intervention__textwrapper" if suggestion_text %>
       <% if suggestion_link_text && suggestion_link_url %>

--- a/app/views/govuk_publishing_components/components/docs/intervention.yml
+++ b/app/views/govuk_publishing_components/components/docs/intervention.yml
@@ -38,6 +38,15 @@ examples:
       suggestion_link_text: "You can now apply for a permit online."
       suggestion_link_url: "/permit"
 
+  with_hide:
+    description: |
+      This example is for when we want to hide by default and display to the user based on some logic,
+      either in the backend or with Javascript.
+    data:
+      suggestion_link_text: "You may be invited to fill in a questionnaire"
+      suggestion_link_url: "/questionnaire"
+      hide: true
+
   open_suggestion_link_in_new_tab:
     description: |
       When sending users to another online task, you don't want to completely hijack

--- a/spec/components/intervention_spec.rb
+++ b/spec/components/intervention_spec.rb
@@ -64,6 +64,18 @@ describe "Intervention", type: :view do
     assert_empty render_component({})
   end
 
+  describe "hide" do
+    it "hides the banner if specified" do
+      render_component(
+        suggestion_link_text: "Travel abroad",
+        suggestion_link_url: "/travel-abroad",
+        hide: true,
+      )
+
+      assert_select ".gem-c-intervention[hidden]"
+    end
+  end
+
   describe "new tab" do
     it "renders with target=_'blank' with new_tab option" do
       render_component(


### PR DESCRIPTION
## What

Add a param to the component to hide the banner by default. This allows for logic in both the backend or Javascript to manipulate that component easily to display it based on whatever logic.

## Why
We want to selectively display a link to an online tree test for specific topics on GOV.UK. Adding this flag allows us to control whether to display the banner for our user research recruitment.

Related PR: https://github.com/alphagov/collections/pull/2630

[Trello card](https://trello.com/c/1o6QiDxC/646-add-banner-for-user-research-exercise-to-selected-pages)

## Visual Changes
<img width="898" alt="Screenshot 2021-12-13 at 6 00 35 pm" src="https://user-images.githubusercontent.com/424772/145867909-02825a00-c956-49fd-91a6-b1d7426df482.png">

