### PR TITLE
Update super nav popular links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix font for menu paragraphs [#2509](https://github.com/alphagov/govuk_publishing_components/pull/2509)
 * Add large mode on mobile only to search component ([PR #2510](https://github.com/alphagov/govuk_publishing_components/pull/2510))
 * Port the grid_helper sass mixin to the components gem ([PR #2517](https://github.com/alphagov/govuk_publishing_components/pull/2517))
+* Update super nav popular links ([PR #2519](https://github.com/alphagov/govuk_publishing_components/pull/2519))
 
 ## 27.17.0
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -185,15 +185,17 @@ en:
       navigation_search_heading: Search and popular pages
       navigation_search_subheading: Search
       popular_links:
-      - label: 'Coronavirus (COVID-19): guidance'
-        href: "/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do"
+      - label: 'Coronavirus (COVID-19)'
+        href: "/coronavirus"
       - label: 'Brexit: check what you need to do'
         href: "/brexit"
       - label: Sign in to your personal tax account
         href: "/personal-tax-account"
       - label: Find a job
         href: "/find-a-job"
-      - label: Sign in to your Universal Credit account
+      - label: 'Personal tax account: sign in'
+        href: "/personal-tax-account"
+      - label: 'Universal Credit account: sign in'
         href: "/sign-in-universal-credit"
       popular_links_heading: Popular on GOV.UK
       search_text: Search GOV.UK


### PR DESCRIPTION
## What
Update the popular links section of the super navigation menu.

## Why
To keep this content in line with the "Popular on GOV.UK" section of the homepage.

[Card](https://trello.com/c/n1wwl3Mx/709-update-the-popular-on-govuk-links-in-the-menu-bar-and-devise-process-for-this-in-future)

## Visual Changes
### Before
![Screenshot 2021-12-14 at 17 29 37](https://user-images.githubusercontent.com/64783893/146050062-3ef836bc-7d3c-4a02-bd5a-f494960e6042.png)

### After
![Screenshot 2021-12-14 at 17 29 51](https://user-images.githubusercontent.com/64783893/146050081-4cc8e354-6ec6-4254-ae72-e2ec5c242010.png)
