### PR TITLE
Release version 27.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,16 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 27.18.0
 
 * Remove jQuery from page-content ([PR #2505](https://github.com/alphagov/govuk_publishing_components/pull/2505))
-* Replace use of `includes()` in `explicit-cross-domain-links.js` with `indexOf()` alternative [#2515](https://github.com/alphagov/govuk_publishing_components/pull/2515)
-* Fix font for menu paragraphs [#2509](https://github.com/alphagov/govuk_publishing_components/pull/2509)
+* Replace use of `includes()` in `explicit-cross-domain-links.js` with `indexOf()` alternative [PR #2515](https://github.com/alphagov/govuk_publishing_components/pull/2515)
+* Fix font for menu paragraphs [PR #2509](https://github.com/alphagov/govuk_publishing_components/pull/2509)
 * Add large mode on mobile only to search component ([PR #2510](https://github.com/alphagov/govuk_publishing_components/pull/2510))
 * Port the grid_helper sass mixin to the components gem ([PR #2517](https://github.com/alphagov/govuk_publishing_components/pull/2517))
 * Update super nav popular links ([PR #2519](https://github.com/alphagov/govuk_publishing_components/pull/2519))
 * Fix single page notification button flash of unpersonalised content ([PR #2512](https://github.com/alphagov/govuk_publishing_components/pull/2512))
-Add missing class for slimmer header ([PR #2521](https://github.com/alphagov/govuk_publishing_components/pull/2521))
-
+* Add missing class for slimmer header ([PR #2521](https://github.com/alphagov/govuk_publishing_components/pull/2521))
 
 ## 27.17.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (27.17.0)
+    govuk_publishing_components (27.18.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "27.17.0".freeze
+  VERSION = "27.18.0".freeze
 end


### PR DESCRIPTION
* Remove jQuery from page-content ([PR #2505](https://github.com/alphagov/govuk_publishing_components/pull/2505))
* Replace use of `includes()` in `explicit-cross-domain-links.js` with `indexOf()` alternative [PR #2515](https://github.com/alphagov/govuk_publishing_components/pull/2515)
* Fix font for menu paragraphs [PR #2509](https://github.com/alphagov/govuk_publishing_components/pull/2509)
* Add large mode on mobile only to search component ([PR #2510](https://github.com/alphagov/govuk_publishing_components/pull/2510))
* Port the grid_helper sass mixin to the components gem ([PR #2517](https://github.com/alphagov/govuk_publishing_components/pull/2517))
* Update super nav popular links ([PR #2519](https://github.com/alphagov/govuk_publishing_components/pull/2519))
* Fix single page notification button flash of unpersonalised content ([PR #2512](https://github.com/alphagov/govuk_publishing_components/pull/2512))
* Add missing class for slimmer header ([PR #2521](https://github.com/alphagov/govuk_publishing_components/pull/2521))