### PR TITLE
Remove jQuery from static analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove jQuery from static analytics ([PR #2526](https://github.com/alphagov/govuk_publishing_components/pull/2526))
 * Remove unused scrolltracker ([PR #2551](https://github.com/alphagov/govuk_publishing_components/pull/2551))
 * Tweak metadata component "See all updates" interaction ([PR #2552](https://github.com/alphagov/govuk_publishing_components/pull/2552))
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics.js
@@ -1,4 +1,5 @@
 //= require govuk_publishing_components/lib/cookie-functions
+//= require govuk_publishing_components/lib/extend-object
 //= require ./analytics/pii
 //= require ./analytics/google-analytics-universal-tracker
 //= require ./analytics/analytics

--- a/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js
@@ -7,11 +7,11 @@
 
   CustomDimensions.getAndExtendDefaultTrackingOptions = function (extraOptions) {
     var trackingOptions = this.customDimensions()
-    return this.extend(trackingOptions, extraOptions)
+    return GOVUK.extendObject(trackingOptions, extraOptions)
   }
 
   CustomDimensions.customDimensions = function () {
-    var dimensions = this.extend(
+    var dimensions = GOVUK.extendObject(
       {},
       customDimensionsFromBrowser(),
       customDimensionsFromMetaTags(),
@@ -23,24 +23,6 @@
       dimensions[key] = new GOVUK.Analytics.PIISafe(String(dimensions[key]))
     }
     return dimensions
-  }
-
-  CustomDimensions.extend = function (out) {
-    out = out || {}
-
-    for (var i = 1; i < arguments.length; i++) {
-      if (!arguments[i]) {
-        continue
-      }
-
-      for (var key in arguments[i]) {
-        if (Object.prototype.hasOwnProperty.call(arguments[i], key)) {
-          out[key] = arguments[i][key]
-        }
-      }
-    }
-
-    return out
   }
 
   function customDimensionsFromBrowser () {

--- a/app/assets/javascripts/govuk_publishing_components/analytics/static-analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/static-analytics.js
@@ -1,4 +1,4 @@
-/* global GOVUK, $, ga */
+/* global GOVUK, ga */
 
 (function () {
   'use strict'
@@ -20,7 +20,7 @@
     ga(function (tracker) {
       this.gaClientId = tracker.get('clientId')
 
-      $(window).trigger('gaClientSet')
+      GOVUK.triggerEvent(window, 'gaClientSet')
 
       // Start up ecommerce tracking
       GOVUK.Ecommerce.start()
@@ -49,7 +49,7 @@
     // Add the cookie banner status as a custom dimension
     var cookieBannerShown = !this.getCookie('seen_cookie_message')
     var cookieBannerDimension = { dimension100: cookieBannerShown ? cookieBannerShown.toString() : 'false' }
-    $.extend(options, cookieBannerDimension)
+    options = GOVUK.extendObject(options, cookieBannerDimension)
 
     var trackingOptions = GOVUK.CustomDimensions.getAndExtendDefaultTrackingOptions(options)
     this.analytics.trackPageview(path, title, trackingOptions)
@@ -83,7 +83,7 @@
 
     var cookieOptions = getOptionsFromCookie()
 
-    $.extend(cookieOptions, options)
+    cookieOptions = GOVUK.extendObject(cookieOptions, options)
 
     this.setCookie('analytics_next_page_call', cookieOptions)
   }


### PR DESCRIPTION
## What
Remove jQuery from `static-analytics.js`.

Also now includes the commit from this PR: https://github.com/alphagov/govuk_publishing_components/pull/2553

## Why
We're removing jQuery from GOV.UK.

## Visual Changes
None.

Trello card: https://trello.com/c/aq1AxjNr/397-remove-jquery-from-gem-analytics-code