### PR TITLE
Remove jQuery from download link tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove jQuery from download link tracker ([PR #2534](https://github.com/alphagov/govuk_publishing_components/pull/2534))
 * **BREAKING:** Update feedback component to fix accessibility issues ([PR #2435](https://github.com/alphagov/govuk_publishing_components/pull/2435))
   You must make the following changes when you migrate to this release:
   - Upgrade `static` to the latest version before you upgrade your application

--- a/app/assets/javascripts/govuk_publishing_components/analytics/download-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/download-link-tracker.js
@@ -1,39 +1,44 @@
 ;(function (global) {
   'use strict'
 
-  var $ = global.jQuery
   var GOVUK = global.GOVUK || {}
 
   GOVUK.analyticsPlugins = GOVUK.analyticsPlugins || {}
   GOVUK.analyticsPlugins.downloadLinkTracker = function (options) {
     options = options || {}
     var downloadLinkSelector = options.selector
+    var selectors = downloadLinkSelector.split(',')
 
     if (downloadLinkSelector) {
-      $('body').on('click', downloadLinkSelector, trackDownload)
+      document.querySelector('body').addEventListener('click', function (event) {
+        var element = event.target
+        if (element.tagName !== 'A') {
+          element = element.closest('a')
+        }
+
+        if (!element) {
+          return
+        }
+
+        for (var i = 0; i < selectors.length; i++) {
+          if (element.matches(selectors[i].trim())) {
+            trackDownload(element)
+            break
+          }
+        }
+      })
     }
 
-    function trackDownload (evt) {
-      var $link = getLinkFromEvent(evt)
-      var href = $link.attr('href')
+    function trackDownload (element) {
+      var href = element.getAttribute('href')
       var evtOptions = { transport: 'beacon' }
-      var linkText = $.trim($link.text())
+      var linkText = element.textContent.trim()
 
       if (linkText) {
         evtOptions.label = linkText
       }
 
       GOVUK.analytics.trackEvent('Download Link Clicked', href, evtOptions)
-    }
-
-    function getLinkFromEvent (evt) {
-      var $target = $(evt.target)
-
-      if (!$target.is('a')) {
-        $target = $target.parents('a')
-      }
-
-      return $target
     }
   }
 

--- a/spec/javascripts/govuk_publishing_components/analytics/download-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/download-link-tracker.spec.js
@@ -38,25 +38,31 @@ describe('GOVUK.analyticsPlugins.downloadLinkTracker', function () {
 
   it('listens to clicks on links that match the selector', function () {
     $('.download-links a').each(function () {
-      $(this).trigger('click')
+      GOVUK.triggerEvent($(this)[0], 'click')
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalled()
       GOVUK.analytics.trackEvent.calls.reset()
     })
 
     $('.normal-links a').each(function () {
-      $(this).trigger('click')
+      GOVUK.triggerEvent($(this)[0], 'click')
       expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
       GOVUK.analytics.trackEvent.calls.reset()
     })
   })
 
   it('listens to click events on elements within download links', function () {
-    $('.download-links a img').trigger('click')
+    var links = document.querySelectorAll('.download-links a img')
+    for (var i = 0; i < links.length; i++) {
+      GOVUK.triggerEvent(links[i], 'click')
+    }
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('Download Link Clicked', '/an/image/link.png', { transport: 'beacon' })
   })
 
   it('tracks a download link as an event with link text as the label', function () {
-    $('.download-links a').trigger('click')
+    var links = document.querySelectorAll('.download-links a')
+    for (var i = 0; i < links.length; i++) {
+      GOVUK.triggerEvent(links[i], 'click')
+    }
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'Download Link Clicked', '/one.pdf', { label: 'PDF', transport: 'beacon' })


### PR DESCRIPTION
## What
Removes jQuery from the download link tracker, which tracks clicks on links to downloadable assets.

It works as follows. Once users consent to analytics, the tracker attaches a click event listener to all pages on the body element. If the clicked element is a link (or inside a link) that matches a particular selector, a tracking event is fired to GA.

The download link tracker is called in `static-analytics.js` and the selector passed is `'a[href*="/government/uploads"], a[href*="assets.publishing.service.gov.uk"]'`. Broadly, these match links to downloadable assets.

I've had to change the code more than I expected to remove jQuery owing to how easy it is to attach an event listener to multiple elements in jQuery compared to the relative complexity of that in vanilla JS. This change has meant that the `getLinkFromEvent` function is no longer needed, as the check for the element type needs to be done much earlier in the code, before the tracking function is called.

## Why
We're removing jQuery from GOV.UK.

## Visual Changes
None.

Trello card: https://trello.com/c/aq1AxjNr/397-remove-jquery-from-gem-analytics-code
