### PR TITLE
Remove jQuery from external link tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove jQuery from external link tracker ([PR #2538](https://github.com/alphagov/govuk_publishing_components/pull/2538))
 * Remove jQuery from download link tracker ([PR #2534](https://github.com/alphagov/govuk_publishing_components/pull/2534))
 * **BREAKING:** Update feedback component to fix accessibility issues ([PR #2435](https://github.com/alphagov/govuk_publishing_components/pull/2435))
   You must make the following changes when you migrate to this release:

--- a/spec/javascripts/govuk_publishing_components/analytics/external-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/external-link-tracker.spec.js
@@ -9,10 +9,10 @@ describe('GOVUK.analyticsPlugins.externalLinkTracker', function () {
   beforeEach(function () {
     $links = $(
       '<div class="external-links">' +
-        '<a href="http://www.nationalarchives.gov.uk"> National Archives </a>' +
-        '<a href="https://www.nationalarchives.gov.uk"></a>' +
-        '<a href="https://www.nationalarchives.gov.uk/one.pdf">National Archives PDF</a>' +
-        '<a href="https://www.nationalarchives.gov.uk/an/image/link.png"><img src="/img" /></a>' +
+        '<a href="http://www.nationalarchives1.gov.uk"> National Archives </a>' +
+        '<a href="https://www.nationalarchives2.gov.uk"></a>' +
+        '<a href="https://www.nationalarchives3.gov.uk/one.pdf">National Archives PDF</a>' +
+        '<a href="https://www.nationalarchives4.gov.uk/an/image/link.png"><img src="/img" /></a>' +
       '</div>' +
       '<div class="internal-links">' +
         '<a href="/some-path">Local link</a>' +
@@ -45,7 +45,7 @@ describe('GOVUK.analyticsPlugins.externalLinkTracker', function () {
     GOVUK.analyticsPlugins.externalLinkTracker({ externalLinkUploadCustomDimension: 36 })
 
     $('.external-links a').each(function () {
-      $(this).trigger('click')
+      GOVUK.triggerEvent($(this)[0], 'click')
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalled()
       if (GOVUK.analytics.trackEvent.calls) {
         GOVUK.analytics.trackEvent.calls.reset()
@@ -53,7 +53,7 @@ describe('GOVUK.analyticsPlugins.externalLinkTracker', function () {
     })
 
     $('.internal-links a').each(function () {
-      $(this).trigger('click')
+      GOVUK.triggerEvent($(this)[0], 'click')
       expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
       if (GOVUK.analytics.trackEvent.calls) {
         GOVUK.analytics.trackEvent.calls.reset()
@@ -63,40 +63,52 @@ describe('GOVUK.analyticsPlugins.externalLinkTracker', function () {
 
   it('listens to click events on elements within external links', function () {
     GOVUK.analyticsPlugins.externalLinkTracker({ externalLinkUploadCustomDimension: 36 })
-    $('.external-links a img').trigger('click')
+    GOVUK.triggerEvent($('.external-links a img')[0], 'click')
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-      'External Link Clicked', 'https://www.nationalarchives.gov.uk/an/image/link.png', { transport: 'beacon' })
+      'External Link Clicked', 'https://www.nationalarchives4.gov.uk/an/image/link.png', { transport: 'beacon' })
   })
 
   it('tracks an external link\'s href and link text', function () {
     GOVUK.analyticsPlugins.externalLinkTracker({ externalLinkUploadCustomDimension: 36 })
-    $('.external-links a').trigger('click')
+    var links = document.querySelectorAll('.external-links a')
+    for (var i = 0; i < links.length; i++) {
+      GOVUK.triggerEvent(links[i], 'click')
+    }
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-      'External Link Clicked', 'http://www.nationalarchives.gov.uk', { transport: 'beacon', label: 'National Archives' })
+      'External Link Clicked', 'http://www.nationalarchives1.gov.uk', { transport: 'beacon', label: 'National Archives' })
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-      'External Link Clicked', 'https://www.nationalarchives.gov.uk', { transport: 'beacon' })
+      'External Link Clicked', 'https://www.nationalarchives2.gov.uk', { transport: 'beacon' })
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-      'External Link Clicked', 'https://www.nationalarchives.gov.uk/one.pdf', { transport: 'beacon', label: 'National Archives PDF' })
+      'External Link Clicked', 'https://www.nationalarchives3.gov.uk/one.pdf', { transport: 'beacon', label: 'National Archives PDF' })
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'External Link Clicked', 'https://www.nationalarchives4.gov.uk/an/image/link.png', { transport: 'beacon' })
   })
 
   it('duplicates the url info in a custom dimension to be used to join with a Google Analytics upload', function () {
     GOVUK.analyticsPlugins.externalLinkTracker({ externalLinkUploadCustomDimension: 36 })
-    $('.external-links a').trigger('click')
+    var links = document.querySelectorAll('.external-links a')
+    for (var i = 0; i < links.length; i++) {
+      GOVUK.triggerEvent(links[i], 'click')
+    }
 
-    expect(GOVUK.analytics.setDimension).toHaveBeenCalledWith(36, 'http://www.nationalarchives.gov.uk')
+    expect(GOVUK.analytics.setDimension).toHaveBeenCalledWith(36, 'http://www.nationalarchives1.gov.uk')
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-      'External Link Clicked', 'http://www.nationalarchives.gov.uk', { transport: 'beacon', label: 'National Archives' })
+      'External Link Clicked', 'http://www.nationalarchives1.gov.uk', { transport: 'beacon', label: 'National Archives' })
   })
 
   it('does not duplicate the url info if a custom dimension is not provided', function () {
     GOVUK.analyticsPlugins.externalLinkTracker()
-    $('.external-links a').trigger('click')
+    var links = document.querySelectorAll('.external-links a')
+    for (var i = 0; i < links.length; i++) {
+      GOVUK.triggerEvent(links[i], 'click')
+    }
 
     expect(GOVUK.analytics.setDimension).not.toHaveBeenCalled()
-    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('External Link Clicked', 'http://www.nationalarchives.gov.uk', { transport: 'beacon', label: 'National Archives' })
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('External Link Clicked', 'http://www.nationalarchives1.gov.uk', { transport: 'beacon', label: 'National Archives' })
   })
 })


### PR DESCRIPTION
## What
Removes jQuery from the external link tracker. This is a script that sends a tracking event when a consenting user clicks on a link to a page that isn't on www.gov.uk.

I've had to restructure this code quite a bit, partly because of the way event listeners work in JS vs jQuery and partly because the tests kept failing. 

The reason behind this was the `click` event listener was persisting between tests with the previous value for customDimension, so the test was technically passing but failing because the click event was occurring multiple times. This was originally solved with jQuery by using the `off` event listener remove, but in JS you have to pass the function that attached the listener, which was far more complex. Instead, the options are now attached to the external link tracker object, and get overwritten. This means the click events are still firing multiple times in the tests, but they're all firing correctly (in reality the tracker would only ever be initialised once). This tracker is only called here in the gem, by `static-analytics.js`.

Another change is how the code detects that the link is an external link. Before this was done using a clever selector, but the JS equivalent (`matches`) was resulting in some weird errors, so I've had to go a bit old school and parse the `href` attribute manually.

This code shares some similarities with the [download link tracker](https://github.com/alphagov/govuk_publishing_components/pull/2534), so maybe at some point we could try to consolidate them.

## Why
We're removing jQuery from GOV.UK.

## Visual Changes
None.

Trello card: https://trello.com/c/aq1AxjNr/397-remove-jquery-from-gem-analytics-code
