### PR TITLE
Remove jQuery from Google Analytics Universal Tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove jQuery from Google Analytics Universal Tracker ([PR #2540](https://github.com/alphagov/govuk_publishing_components/pull/2540))
 * Remove jQuery from external link tracker ([PR #2538](https://github.com/alphagov/govuk_publishing_components/pull/2538))
 * Remove jQuery from download link tracker ([PR #2534](https://github.com/alphagov/govuk_publishing_components/pull/2534))
 * **BREAKING:** Update feedback component to fix accessibility issues ([PR #2435](https://github.com/alphagov/govuk_publishing_components/pull/2435))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/google-analytics-universal-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/google-analytics-universal-tracker.js
@@ -1,7 +1,6 @@
 ;(function (global) {
   'use strict'
 
-  var $ = global.jQuery
   var GOVUK = global.GOVUK || {}
   var pii
 
@@ -78,7 +77,7 @@
     // Set an options object for the pageview (e.g. transport, sessionControl)
     // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport
     if (typeof options === 'object') {
-      pageviewObject = $.extend(pageviewObject || {}, options)
+      pageviewObject = GOVUK.extendObject(pageviewObject || {}, options)
 
       // trackerName is optional
       if (typeof options.trackerName === 'string') {
@@ -87,10 +86,24 @@
       }
     }
 
-    if (!$.isEmptyObject(pageviewObject)) {
-      sendToGa(trackerName + 'send', 'pageview', pageviewObject)
-    } else {
+    function isEmptyObject (obj) {
+      if (typeof obj === 'undefined') {
+        return true
+      }
+
+      for (var prop in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, prop)) {
+          return false
+        }
+      }
+
+      return JSON.stringify(obj) === JSON.stringify({})
+    }
+
+    if (isEmptyObject(pageviewObject)) {
       sendToGa(trackerName + 'send', 'pageview')
+    } else {
+      sendToGa(trackerName + 'send', 'pageview', pageviewObject)
     }
   }
 
@@ -135,7 +148,7 @@
     }
 
     if (typeof options === 'object') {
-      $.extend(evt, options)
+      evt = GOVUK.extendObject(evt, options)
     }
 
     sendToGa(trackerName + 'send', evt)
@@ -156,7 +169,7 @@
       socialTarget: target
     }
 
-    $.extend(trackingOptions, options)
+    trackingOptions = GOVUK.extendObject(trackingOptions, options)
 
     sendToGa('send', trackingOptions)
   }

--- a/app/assets/javascripts/govuk_publishing_components/lib/extend-object.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/extend-object.js
@@ -1,0 +1,22 @@
+(function (root) {
+  'use strict'
+  window.GOVUK = window.GOVUK || {}
+
+  window.GOVUK.extendObject = function (obj) {
+    obj = obj || {}
+
+    for (var i = 1; i < arguments.length; i++) {
+      if (!arguments[i]) {
+        continue
+      }
+
+      for (var key in arguments[i]) {
+        if (Object.prototype.hasOwnProperty.call(arguments[i], key)) {
+          obj[key] = arguments[i][key]
+        }
+      }
+    }
+
+    return obj
+  }
+}(window))

--- a/spec/javascripts/govuk_publishing_components/lib/extend-object-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/extend-object-spec.js
@@ -1,0 +1,28 @@
+/* eslint-env jasmine, jquery */
+
+describe('The extend object code', function () {
+  it('returns the original object if no further arguments', function () {
+    var obj = { test1: 1 }
+    var test = window.GOVUK.extendObject(obj)
+
+    expect(test).toEqual({ test1: 1 })
+  })
+
+  it('extends an object', function () {
+    var obj = { test1: 1 }
+    var args = { test2: 2 }
+    var test = window.GOVUK.extendObject(obj, args)
+
+    expect(test).toEqual({ test1: 1, test2: 2 })
+  })
+
+  it('extends multiple objects', function () {
+    var obj = { test1: 1 }
+    var args1 = { test2: 2 }
+    var args2 = { test3: 3 }
+    var args3 = { test4: 4 }
+    var test = window.GOVUK.extendObject(obj, args1, args2, args3)
+
+    expect(test).toEqual({ test1: 1, test2: 2, test3: 3, test4: 4 })
+  })
+})


### PR DESCRIPTION
## What
Remove jQuery from Google Analytics Universal Tracker. This is the main script in the analytics code that contains all the things the rest of it depends on, like trackPageView and trackEvent, plus it also contains the snippet of JS from GA that makes everything work.

## Why
We're removing jQuery from GOV.UK.

## Visual Changes
None.

Trello card: https://trello.com/c/aq1AxjNr/397-remove-jquery-from-gem-analytics-code