### PR TITLE
Remove jQuery from mailto-link-tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove jQuery from mailto-link-tracker ([PR #2542](https://github.com/alphagov/govuk_publishing_components/pull/2542))
 * Remove jQuery from static analytics ([PR #2526](https://github.com/alphagov/govuk_publishing_components/pull/2526))
 * Remove unused scrolltracker ([PR #2551](https://github.com/alphagov/govuk_publishing_components/pull/2551))
 * Tweak metadata component "See all updates" interaction ([PR #2552](https://github.com/alphagov/govuk_publishing_components/pull/2552))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/mailto-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/mailto-link-tracker.js
@@ -1,36 +1,36 @@
+//= require ../vendor/polyfills/closest.js
 ;(function (global) {
   'use strict'
 
-  var $ = global.jQuery
   var GOVUK = global.GOVUK || {}
 
   GOVUK.analyticsPlugins = GOVUK.analyticsPlugins || {}
   GOVUK.analyticsPlugins.mailtoLinkTracker = function () {
-    var mailtoLinkSelector = 'a[href^="mailto:"]'
+    document.querySelector('body').addEventListener('click', function (event) {
+      var element = event.target
+      if (element.tagName !== 'A') {
+        element = element.closest('a')
+      }
 
-    $('body').on('click', mailtoLinkSelector, trackClickEvent)
+      if (!element) {
+        return
+      }
 
-    function trackClickEvent (evt) {
-      var $link = getLinkFromEvent(evt)
+      var href = element.getAttribute('href')
+      if (href.substring(0, 7) === 'mailto:') {
+        trackClickEvent(element, href)
+      }
+    })
+
+    function trackClickEvent (element, href) {
       var options = { transport: 'beacon' }
-      var href = $link.attr('href')
-      var linkText = $.trim($link.text())
+      var linkText = element.textContent
 
       if (linkText) {
-        options.label = linkText
+        options.label = linkText.trim()
       }
 
       GOVUK.analytics.trackEvent('Mailto Link Clicked', href, options)
-    }
-
-    function getLinkFromEvent (evt) {
-      var $target = $(evt.target)
-
-      if (!$target.is('a')) {
-        $target = $target.parents('a')
-      }
-
-      return $target
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/mailto-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/mailto-link-tracker.js
@@ -17,6 +17,11 @@
       }
 
       var href = element.getAttribute('href')
+
+      if (!href) {
+        return
+      }
+
       if (href.substring(0, 7) === 'mailto:') {
         trackClickEvent(element, href)
       }

--- a/spec/javascripts/components/metadata-spec.js
+++ b/spec/javascripts/components/metadata-spec.js
@@ -11,7 +11,14 @@ describe('The metadata component', function () {
 
   describe('when the "See all updates" link is clicked', function () {
     it('clicks the target if target exists and is not already expanded', function () {
-      var FIXTURE = '<div data-module="metadata"><a href="#toggle-me" class="js-see-all-updates-link"></a></div><div id="toggle-me" data-module="gem-toggle"><a data-controls="target" data-expanded aria-expanded="false"></a><div id="target" class="js-hidden">Target</div></div>'
+      var FIXTURE =
+        '<div data-module="metadata">' +
+          '<a href="#toggle-me" class="js-see-all-updates-link"></a>' +
+        '</div>' +
+        '<div id="toggle-me" data-module="gem-toggle">' +
+          '<a data-controls="target" data-expanded aria-expanded="false"></a>' +
+          '<div id="target" class="js-hidden">Target</div>' +
+        '</div>'
       window.setFixtures(FIXTURE)
       element = document.querySelector('[data-module="metadata"]')
       target = document.querySelector('#toggle-me')

--- a/spec/javascripts/govuk_publishing_components/analytics/mailto-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/mailto-link-tracker.spec.js
@@ -13,6 +13,7 @@ describe('GOVUK.analyticsPlugins.mailtoLinkTracker', function () {
         '<a href="mailto:name1@email.com"></a>' +
         '<a href="mailto:name2@email.com">The link for a mailto</a>' +
         '<a href="mailto:name3@email.com"><img src="/img" /></a>' +
+        '<a>Link without a href</a>' +
       '</div>'
     )
 
@@ -35,8 +36,12 @@ describe('GOVUK.analyticsPlugins.mailtoLinkTracker', function () {
     var links = document.querySelectorAll('.mailto-links a')
     for (var i = 0; i < links.length; i++) {
       GOVUK.triggerEvent(links[i], 'click')
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalled()
-      GOVUK.analytics.trackEvent.calls.reset()
+      if (links[i].getAttribute('href')) {
+        expect(GOVUK.analytics.trackEvent).toHaveBeenCalled()
+        GOVUK.analytics.trackEvent.calls.reset()
+      } else {
+        expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
+      }
     }
   })
 

--- a/spec/javascripts/govuk_publishing_components/analytics/mailto-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/mailto-link-tracker.spec.js
@@ -32,15 +32,19 @@ describe('GOVUK.analyticsPlugins.mailtoLinkTracker', function () {
   })
 
   it('listens to click events on mailto links', function () {
-    $('.mailto-links a').each(function () {
-      $(this).trigger('click')
+    var links = document.querySelectorAll('.mailto-links a')
+    for (var i = 0; i < links.length; i++) {
+      GOVUK.triggerEvent(links[i], 'click')
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalled()
       GOVUK.analytics.trackEvent.calls.reset()
-    })
+    }
   })
 
   it('tracks mailto addresses and link text', function () {
-    $('.mailto-links a').trigger('click')
+    var links = document.querySelectorAll('.mailto-links a')
+    for (var i = 0; i < links.length; i++) {
+      GOVUK.triggerEvent(links[i], 'click')
+    }
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'Mailto Link Clicked', 'mailto:name1@email.com', { transport: 'beacon' })
@@ -50,7 +54,10 @@ describe('GOVUK.analyticsPlugins.mailtoLinkTracker', function () {
   })
 
   it('listens to click events on elements within mailto links', function () {
-    $('.mailto-links a img').trigger('click')
+    var links = document.querySelectorAll('.mailto-links a img')
+    for (var i = 0; i < links.length; i++) {
+      GOVUK.triggerEvent(links[i], 'click')
+    }
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'Mailto Link Clicked', 'mailto:name3@email.com', { transport: 'beacon' })
   })


### PR DESCRIPTION
## What
Removes jQuery from the mailto link tracker, a script that tracks consenting clicks on links that point to an email address e.g. `<a href="mailto:someone@somewhere.something">Email me</a>`.

This script is similar to the [external link tracker](https://github.com/alphagov/govuk_publishing_components/pull/2538) and the [download link tracker](https://github.com/alphagov/govuk_publishing_components/pull/2534) once jQuery has been removed, so maybe once all these PRs are complete some kind of consolidation could be done.

## Why
We're removing jQuery from GOV.UK.

## Visual Changes
None.

Trello card: https://trello.com/c/aq1AxjNr/397-remove-jquery-from-gem-analytics-code
