### PR TITLE
Remove scroll tracking from frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove scroll tracking from frontend ([PR #2546](https://github.com/alphagov/govuk_publishing_components/pull/2546))
 * Remove scroll tracking from collections ([PR #2543](https://github.com/alphagov/govuk_publishing_components/pull/2543))
 * Remove jQuery from Google Analytics Universal Tracker ([PR #2540](https://github.com/alphagov/govuk_publishing_components/pull/2540))
 * Remove jQuery from external link tracker ([PR #2538](https://github.com/alphagov/govuk_publishing_components/pull/2538))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js
@@ -126,8 +126,7 @@
       ['Heading', 'Travelling with children'],
       ['Heading', 'Ireland, the UK, the Channel Islands and the Isle of Man'],
       ['Heading', 'Exemptions for work, medical or compassionate reasons']
-    ],
-    '/find-travel-test-provider': percentages
+    ]
   }
 
   function ScrollTracker (sitewideConfig) {


### PR DESCRIPTION
## What
**NOTE** this PR depends upon this one: https://github.com/alphagov/frontend/pull/3104

Remove scroll tracking from pages in `frontend`, specifically:

- https://www.gov.uk/find-travel-test-provider

These pages will be updated to use the new scroll tracker. Because the existing scroll tracker is initialised in the gem and the new one is initialised at an application level, this PR can only be merged and deployed into a new version of the gem when `frontend` is updated to use the new scroll tracker, otherwise we risk having either no scroll tracking on these pages or double the scroll tracking. Note that this also needs to be co-ordinated with deploying to `static`, as that's where the analytics code is included.

## Why
Twofold:

- we built a [new scroll tracker](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/analytics/auto_scroll_tracker.md) recently to improve on limitations of the existing one, and this is part of the migration from the old to the new
- the old scroll tracker uses jQuery, and we want to get rid of it

## Visual Changes
None.

Trello card: https://trello.com/c/sdugtMbX/37-migrate-to-new-scroll-tracker
