### PR TITLE
Remove duplicate link in menu header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove duplicate link in menu header ([PR #2547](https://github.com/alphagov/govuk_publishing_components/pull/2547))
+
 ## 27.20.0
 
 * Add signup link component ([PR #2525](https://github.com/alphagov/govuk_publishing_components/pull/2525))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -189,8 +189,6 @@ en:
         href: "/coronavirus"
       - label: 'Brexit: check what you need to do'
         href: "/brexit"
-      - label: Sign in to your personal tax account
-        href: "/personal-tax-account"
       - label: Find a job
         href: "/find-a-job"
       - label: 'Personal tax account: sign in'


### PR DESCRIPTION
## What
Remove the link in the search section of the header menu: `Sign in to your personal tax account`.

## Why
This is a duplicate of the link further down in the same list: `Personal tax account: sign in` which is our preferred wording.

[Card](https://trello.com/c/DoDlY3ou/719-remove-sign-in-to-you-personal-tax-account-from-search-menu)

## Visual Changes
### Before
![Screenshot 2022-01-04 at 15 14 34](https://user-images.githubusercontent.com/64783893/148082198-3d8aee22-84fe-4573-b417-edf0ba12e2bc.png)

### After
![Screenshot 2022-01-04 at 15 14 56](https://user-images.githubusercontent.com/64783893/148082220-8837610a-c35e-4761-8f30-6d66a8ceabf8.png)
