### PR TITLE
Tweak metadata component "See all updates" interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Tweak metadata component "See all updates" interaction ([PR #2552](https://github.com/alphagov/govuk_publishing_components/pull/2552))
+
 ## 28.0.0
 
 * **BREAKING:** Update feedback component to fix accessibility issues ([PR #2435](https://github.com/alphagov/govuk_publishing_components/pull/2435))

--- a/app/assets/javascripts/govuk_publishing_components/components/metadata.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/metadata.js
@@ -1,0 +1,27 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function Metadata ($module) {
+    this.$module = $module
+  }
+
+  Metadata.prototype.init = function () {
+    var seeAllUpdates = this.$module.querySelector('.js-see-all-updates-link')
+
+    if (seeAllUpdates) {
+      var target = document.querySelector(seeAllUpdates.getAttribute('href'))
+
+      if (target) {
+        seeAllUpdates.addEventListener('click', function () {
+          var targetToggleTrigger = target.querySelector('[aria-expanded]')
+          if (targetToggleTrigger && targetToggleTrigger.getAttribute('aria-expanded') !== 'true') {
+            targetToggleTrigger.click()
+          }
+        })
+      }
+    }
+  }
+
+  Modules.Metadata = Metadata
+})(window.GOVUK.Modules)

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -17,7 +17,7 @@
   classes << "gem-c-metadata--inverse" if inverse
   classes << shared_helper.get_margin_bottom if local_assigns[:margin_bottom]
 %>
-<%= content_tag :div, class: classes, data: { module: "gem-toggle" } do %>
+<%= content_tag :div, class: classes, data: { module: "gem-toggle metadata" } do %>
   <dl data-module="gem-track-click">
     <% if from.any? %>
       <dt class="gem-c-metadata__term"><%= t("components.metadata.from") %>:</dt>
@@ -44,7 +44,7 @@
       <dd class="gem-c-metadata__definition">
         <%= last_updated %>
         <% if local_assigns.include?(:see_updates_link) %>
-          &#8212; <a href="#history" class="gem-c-metadata__definition-link govuk-!-display-none-print"
+          &#8212; <a href="#history" class="gem-c-metadata__definition-link govuk-!-display-none-print js-see-all-updates-link"
                              data-track-category="content-history"
                              data-track-action="see-all-updates-link-clicked"
                              data-track-label="history">

--- a/spec/javascripts/components/metadata-spec.js
+++ b/spec/javascripts/components/metadata-spec.js
@@ -1,0 +1,58 @@
+/* eslint-env jasmine,jquery */
+/* global GOVUK */
+
+describe('The metadata component', function () {
+  var element
+  var target
+
+  beforeEach(function () {
+    spyOn(GOVUK.Modules.GemToggle.prototype, 'toggleOnClick')
+  })
+
+  describe('when the "See all updates" link is clicked', function () {
+    it('clicks the target if target exists and is not already expanded', function () {
+      var FIXTURE = '<div data-module="metadata"><a href="#toggle-me" class="js-see-all-updates-link"></a></div><div id="toggle-me" data-module="gem-toggle"><a data-controls="target" data-expanded aria-expanded="false"></a><div id="target" class="js-hidden">Target</div></div>'
+      window.setFixtures(FIXTURE)
+      element = document.querySelector('[data-module="metadata"]')
+      target = document.querySelector('#toggle-me')
+
+      init(element, target)
+
+      var trigger = $(element).find('.js-see-all-updates-link')
+      trigger[0].click()
+      expect(GOVUK.Modules.GemToggle.prototype.toggleOnClick).toHaveBeenCalled()
+    })
+
+    it('does not click target if target does not exist', function () {
+      var FIXTURE = '<div data-module="metadata"><a href="#toggle-me" class="js-see-all-updates-link"></a></div>'
+      window.setFixtures(FIXTURE)
+      element = document.querySelector('[data-module="metadata"]')
+
+      init(element)
+
+      var trigger = $(element).find('.js-see-all-updates-link')
+      trigger[0].click()
+
+      expect(GOVUK.Modules.GemToggle.prototype.toggleOnClick).not.toHaveBeenCalled()
+    })
+
+    it('does not click target if target is already expanded', function () {
+      var FIXTURE = '<div data-module="metadata"><a href="#toggle-me" class="js-see-all-updates-link"></a></div><div id="toggle-me" data-module="gem-toggle"><a aria-expanded="true"></a></div>'
+      window.setFixtures(FIXTURE)
+      element = document.querySelector('[data-module="metadata"]')
+      target = document.querySelector('#toggle-me')
+
+      init(element, target)
+
+      var trigger = $(element).find('.js-see-all-updates-link')
+      trigger[0].click()
+
+      expect(GOVUK.Modules.GemToggle.prototype.toggleOnClick).not.toHaveBeenCalled()
+    })
+  })
+
+  function init (element, target) {
+    new GOVUK.Modules.Metadata(element).init()
+    target && new GOVUK.Modules.GemToggle().start($(target))
+  }
+})


### PR DESCRIPTION
On some publications, the metadata component has a "See all updates" link. This is an in-page link which jumps to the list of updates at the bottom of the page like so: 

https://user-images.githubusercontent.com/7116819/148392637-026ed708-bd57-427c-9ebc-91497b2390e9.mov


This is on purpose in order to get around having the list of update notes at the top of the page. The reason for this is that the list of notes can be quite long and so it would not be ideal to have this list before the main content of the publication page as even when hidden behind a visibility toggle, once it's been expanded such a list could take a lot of scrolling to get past and inconvenience some users.

There was some feedback in UR (this was UR for a tangential bit functionality on a publication page) that suggested that people found it confusing that an additional click is required to show the list of updates (i.e after clicking "See all updates" at the top, one must click "see all updates" again at the bottom; the expected behaviour is that the list of update notes should be made visible straight away after the click at the top).

This is a workaround in order to achieve the intended outcome, which adds a simple script for the metadata component which fires a click event on the toggle trigger when the metadata "See all updates" link is clicked.



https://user-images.githubusercontent.com/7116819/148392972-80e91816-eff4-49fa-9e57-1e53068f79e2.mov


---- 

https://trello.com/c/XwSjaTET

