### PR TITLE
Include extend object script explicitly

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics.js
@@ -1,4 +1,5 @@
 //= require govuk_publishing_components/lib/cookie-functions
+//= require govuk_publishing_components/lib/extend-object
 //= require ./analytics/pii
 //= require ./analytics/google-analytics-universal-tracker
 //= require ./analytics/analytics


### PR DESCRIPTION
## What
- this script was added recently to fill in for jQuery's extend function, which combines two objects
- it's used exclusively by the analytics code but while it's included in the gem it doesn't seem to be pulled into static, where the analytics code is used
- this script is included in static, so adding the extend script here to ensure it's picked up

## Why
Some of the changes that now depend on the `extendObject` script have now been deployed (although there are more to come, specifically https://github.com/alphagov/govuk_publishing_components/pull/2526). When I run `government-frontend` locally with a local `static`, I get the error below. Strangely, it doesn't seem to be happening on live, which I can't explain, but it still seems like a good idea to explicitly include this script.

![Screenshot 2022-01-07 at 08 31 19](https://user-images.githubusercontent.com/861310/148520024-a63c38e2-00a2-4f4d-8785-3f79125352b4.png)


## Visual Changes
None.
