### PR TITLE
Fix a bug in the scroll tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix a bug in the scroll tracker ([PR #2554](https://github.com/alphagov/govuk_publishing_components/pull/2554))
+
 ## 28.2.0
 
 * Remove almost the last of the miscellaneous jQuery ([PR #2556](https://github.com/alphagov/govuk_publishing_components/pull/2556))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/auto-scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/auto-scroll-tracker.js
@@ -199,7 +199,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     for (var i = 0; i < this.config.percentages.length; i++) {
       var percent = this.config.percentages[i]
-      var pos = (pageHeight / 100) * percent
+      // subtract 1 pixel to solve a bug where 100% can't be reached in some cases
+      var pos = ((pageHeight / 100) * percent) - 1
       var alreadySeen = false
       if (trackedNodes.length) {
         alreadySeen = trackedNodes[i].alreadySeen


### PR DESCRIPTION
## What / why
Fixes the following problem with the scroll tracker.

- even though the tests pass, when run on an actual page the percentage tracking for 100% sometimes wasn't firing
- I think this was due to a rounding problem when the page height was a fraction rather than a whole number, the position of 100% was always slightly below what could be actually scrolled to
- the solution is to subtract one pixel from each calculated percentage position, which ensures that the page can be scrolled down far enough that the 100% percentage scroll track event can fire

## Visual Changes
None.
