### PR TITLE
Remove almost the last of the miscellaneous jQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove almost the last of the miscellaneous jQuery ([PR #2556](https://github.com/alphagov/govuk_publishing_components/pull/2556))
 * Make metadata component "See all updates" link href less generic ([PR #2562](https://github.com/alphagov/govuk_publishing_components/pull/2562))
 * Update feedback component to add "display none" to "maybe" (spam prevention) button ([PR #2568](https://github.com/alphagov/govuk_publishing_components/pull/2568))
 * Apply margin bottom helper to big number component ([PR #2566](https://github.com/alphagov/govuk_publishing_components/pull/2566))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/auto-track-event.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/auto-track-event.js
@@ -1,30 +1,30 @@
-;(function (global) {
-  'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-  var GOVUK = global.GOVUK || {}
-  GOVUK.Modules = GOVUK.Modules || {}
+(function (Modules) {
+  function AutoTrackEvent ($module) {
+    this.$module = $module
+  }
 
-  GOVUK.Modules.AutoTrackEvent = function () {
-    this.start = function (element) {
-      var options = { nonInteraction: 1 } // automatic events shouldn't affect bounce rate
-      var category = element.data('track-category')
-      var action = element.data('track-action')
-      var label = element.data('track-label')
-      var value = element.data('track-value')
+  AutoTrackEvent.prototype.init = function () {
+    var options = { nonInteraction: 1 } // automatic events shouldn't affect bounce rate
+    var category = this.$module.getAttribute('data-track-category')
+    var action = this.$module.getAttribute('data-track-action')
+    var label = this.$module.getAttribute('data-track-label')
+    var value = parseInt(this.$module.getAttribute('data-track-value'))
 
-      if (typeof label === 'string') {
-        options.label = label
-      }
+    if (typeof label === 'string') {
+      options.label = label
+    }
 
-      if (value || value === 0) {
-        options.value = value
-      }
+    if (value || value === 0) {
+      options.value = value
+    }
 
-      if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
-        GOVUK.analytics.trackEvent(category, action, options)
-      }
+    if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+      window.GOVUK.analytics.trackEvent(category, action, options)
     }
   }
 
-  global.GOVUK = GOVUK
-})(window)
+  Modules.AutoTrackEvent = AutoTrackEvent
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/analytics/pii.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/pii.js
@@ -1,5 +1,3 @@
-/* global $ */
-
 ;(function (global) {
   'use strict'
 
@@ -15,15 +13,21 @@
   var STATE_PATTERN = /state=.[^&]+/g
 
   function shouldStripDates () {
-    return ($('meta[name="govuk:static-analytics:strip-dates"]').length > 0)
+    var metas = document.querySelectorAll('meta[name="govuk:static-analytics:strip-dates"]')
+    return metas.length > 0
   }
 
   function shouldStripPostcodes () {
-    return ($('meta[name="govuk:static-analytics:strip-postcodes"]').length > 0)
+    var metas = document.querySelectorAll('meta[name="govuk:static-analytics:strip-postcodes"]')
+    return metas.length > 0
   }
 
   function queryStringParametersToStrip () {
-    var value = $('meta[name="govuk:static-analytics:strip-query-string-parameters"]').attr('content')
+    var meta = document.querySelector('meta[name="govuk:static-analytics:strip-query-string-parameters"]')
+    var value = false
+    if (meta) {
+      value = meta.getAttribute('content')
+    }
     var parameters = []
 
     if (value) {

--- a/app/assets/javascripts/govuk_publishing_components/analytics/track-click.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/track-click.js
@@ -4,10 +4,11 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function GemTrackClick () { }
+  function GemTrackClick ($module) {
+    this.$module = $module
+  }
 
-  GemTrackClick.prototype.start = function ($module) {
-    this.$module = $module[0]
+  GemTrackClick.prototype.init = function () {
     this.$module.handleClick = this.handleClick.bind(this)
     var trackLinksOnly = this.$module.hasAttribute('data-track-links-only')
     var limitToElementClass = this.$module.getAttribute('data-limit-to-element-class')

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -1,4 +1,3 @@
-/* eslint-env jquery */
 // = require govuk/vendor/polyfills/Element/prototype/closest.js
 // = require govuk/components/checkboxes/checkboxes.js
 window.GOVUK = window.GOVUK || {}

--- a/app/assets/javascripts/govuk_publishing_components/components/details.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/details.js
@@ -1,4 +1,3 @@
-/* eslint-env jquery */
 // = require govuk/components/details/details.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}

--- a/app/assets/javascripts/govuk_publishing_components/components/details.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/details.js
@@ -15,8 +15,8 @@ window.GOVUK.Modules.GovukDetails = window.GOVUKFrontend;
 
   GemDetails.prototype.init = function () {
     if (this.customTrackLabel) { // If a custom label has been provided, we can simply call the tracking module
-      var trackDetails = new window.GOVUK.Modules.GemTrackClick()
-      trackDetails.start($(this.$summary))
+      var trackDetails = new window.GOVUK.Modules.GemTrackClick(this.$summary)
+      trackDetails.init()
     } else if (this.detailsClick) { // If no custom label is set, we use the open/close status as the label
       this.detailsClick.addEventListener('click', function (event) {
         this.trackDefault(this.$summary)

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/barchart-enhancement.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/barchart-enhancement.js
@@ -2,7 +2,7 @@
 
 window.GOVUK = window.GOVUK || {};
 
-(function (GOVUK, $) {
+(function (GOVUK) {
   'use strict'
 
   var BarchartEnhancement = function ($element) {
@@ -30,4 +30,4 @@ window.GOVUK = window.GOVUK || {};
   }
 
   GOVUK.GovspeakBarchartEnhancement = BarchartEnhancement
-}(window.GOVUK, window.jQuery))
+}(window.GOVUK))

--- a/spec/javascripts/components/details-spec.js
+++ b/spec/javascripts/components/details-spec.js
@@ -11,7 +11,7 @@ describe('Details component', function () {
 
   beforeEach(function () {
     spyOn(GOVUK.analytics, 'trackEvent')
-    spyOn(GOVUK.Modules, 'GemTrackClick').and.callFake(function () { this.start = function () {} })
+    spyOn(GOVUK.Modules, 'GemTrackClick').and.callFake(function () { this.init = function () {} })
 
     FIXTURE =
       '<details class="gem-c-details govuk-details" data-module="gem-details">' +

--- a/spec/javascripts/govuk_publishing_components/analytics/auto-track-event.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/auto-track-event.spec.js
@@ -9,7 +9,6 @@ describe('An auto event tracker', function () {
     element
 
   beforeEach(function () {
-    tracker = new GOVUK.Modules.AutoTrackEvent()
     spyOn(GOVUK.analytics, 'trackEvent')
   })
 
@@ -28,7 +27,8 @@ describe('An auto event tracker', function () {
       '</div>'
     )
 
-    tracker.start(element)
+    tracker = new GOVUK.Modules.AutoTrackEvent(element[0])
+    tracker.init()
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'category', 'action', { nonInteraction: 1 })
   })
@@ -44,7 +44,8 @@ describe('An auto event tracker', function () {
       '</div>'
     )
 
-    tracker.start(element)
+    tracker = new GOVUK.Modules.AutoTrackEvent(element[0])
+    tracker.init()
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'category', 'action', { label: 'label', value: 10, nonInteraction: 1 })
   })

--- a/spec/javascripts/govuk_publishing_components/analytics/track-click.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/track-click.spec.js
@@ -4,6 +4,13 @@ describe('A click tracker', function () {
   var GOVUK = window.GOVUK
   var element
 
+  function initModule (element, click) {
+    new GOVUK.Modules.GemTrackClick(element).init()
+    if (click) {
+      GOVUK.triggerEvent(element, 'click')
+    }
+  }
+
   beforeEach(function () {
     spyOn(GOVUK.analytics, 'trackEvent')
   })
@@ -20,9 +27,7 @@ describe('A click tracker', function () {
       '<div data-module="gem-track-click" data-track-category="category" data-track-action="action" data-track-label="Foo">Bar</div>'
     )
 
-    new GOVUK.Modules.GemTrackClick().start(element)
-    element[0].click()
-
+    initModule(element[0], true)
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', { label: 'Foo', transport: 'beacon' })
   })
 
@@ -31,9 +36,7 @@ describe('A click tracker', function () {
       '<a data-module="gem-track-click" data-track-category="category" data-track-action="1" data-track-label="/" data-track-dimension="dimension-value" data-track-dimension-index="29" href="#">Home</a>'
     )
 
-    new GOVUK.Modules.GemTrackClick().start(element)
-    element[0].click()
-
+    initModule(element[0], true)
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'category',
       '1',
@@ -46,9 +49,7 @@ describe('A click tracker', function () {
       '<div data-module="gem-track-click" data-track-category="category" data-track-action="action" data-track-label="Foo" data-track-dimension-index="29">Bar</div>'
     )
 
-    new GOVUK.Modules.GemTrackClick().start(element)
-    element[0].click()
-
+    initModule(element[0], true)
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', { label: 'Foo', transport: 'beacon' })
   })
 
@@ -57,9 +58,7 @@ describe('A click tracker', function () {
       '<div data-module="gem-track-click" data-track-category="category" data-track-action="action" data-track-label="Foo" data-track-dimension="Home">Bar!</div>'
     )
 
-    new GOVUK.Modules.GemTrackClick().start(element)
-    element[0].click()
-
+    initModule(element[0], true)
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', { label: 'Foo', transport: 'beacon' })
   })
 
@@ -68,9 +67,7 @@ describe('A click tracker', function () {
       '<a data-module="gem-track-click" data-track-category="category" data-track-action="1" data-track-label="/" data-track-value="9" href="#">Home</a>'
     )
 
-    new GOVUK.Modules.GemTrackClick().start(element)
-    element[0].click()
-
+    initModule(element[0], true)
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'category',
       '1',
@@ -83,9 +80,7 @@ describe('A click tracker', function () {
       "<a data-module='gem-track-click' data-track-category='category' data-track-action='1' data-track-label='/' data-track-options='{\"dimension28\": \"foo\", \"dimension29\": \"bar\"}' href='#'>Home</a>"
     )
 
-    new GOVUK.Modules.GemTrackClick().start(element)
-    element[0].click()
-
+    initModule(element[0], true)
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'category',
       '1',
@@ -112,7 +107,7 @@ describe('A click tracker', function () {
       '</div>'
     )
 
-    new GOVUK.Modules.GemTrackClick().start(element)
+    initModule(element[0], false)
 
     element.find('.nothing')[0].click()
     expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
@@ -137,7 +132,7 @@ describe('A click tracker', function () {
       '</div>'
     )
 
-    new GOVUK.Modules.GemTrackClick().start(element)
+    initModule(element[0], false)
 
     element.find('a.first')[0].click()
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat1', 'action1', { label: '#link1', transport: 'beacon' })
@@ -160,7 +155,7 @@ describe('A click tracker', function () {
       '</div>'
     )
 
-    new GOVUK.Modules.GemTrackClick().start(element)
+    initModule(element[0], false)
 
     element.find('.nothing')[0].click()
     expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
@@ -189,7 +184,7 @@ describe('A click tracker', function () {
       '</div>'
     )
 
-    new GOVUK.Modules.GemTrackClick().start(element)
+    initModule(element[0], false)
 
     element.find('.nothing')[0].click()
     expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
@@ -216,7 +211,7 @@ describe('A click tracker', function () {
       '</div>'
     )
 
-    new GOVUK.Modules.GemTrackClick().start(element)
+    initModule(element[0], false)
 
     element.find('.child-of-link')[0].click()
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('parent-category', 'parent-action', { label: 'parent-label', transport: 'beacon' })


### PR DESCRIPTION
## What
Remove the remaining bits of jQuery from the components gem. Actually, this doesn't quite remove all the jQuery as `modules.js` still requires it as it expects either a JS node or a jQuery object to be passed to it, but apart from that, I think this now removes all the jQuery.

## Why
We're removing jQuery from GOV.UK.

## Visual Changes
None.

Trello card: https://trello.com/c/aq1AxjNr/397-remove-jquery-from-gem-analytics-code