### PR TITLE
Hide feedback component error summary on submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update real user metrics LUX.js to v300 ([PR #2637](https://github.com/alphagov/govuk_publishing_components/pull/2637))
 * Remove `header-navigation.js` ([PR #2632](https://github.com/alphagov/govuk_publishing_components/pull/2632))
 * Add support for Rails 7; add support for Ruby 3.0 and 3.1; and drop support for Ruby 2.6 ([PR #2642](https://github.com/alphagov/govuk_publishing_components/pull/2642))
+* Hide feedback component error summary on submission ([PR #2557](https://github.com/alphagov/govuk_publishing_components/pull/2557))
 
 ## 28.6.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -87,21 +87,22 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           var params = new FormData($form)
           params = new URLSearchParams(params).toString()
 
-          xhr.open('POST', url, true)
-          xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded')
-
-          xhr.onreadystatechange = function () {
-            if (xhr.readyState === 4 && xhr.status === 200) {
+          this.done = function () {
+            if (xhr.status === 200) {
               this.trackEvent(this.getTrackEventParams($form))
               this.showFormSuccess(xhr.message)
               this.revealInitialPrompt()
               this.setInitialAriaAttributes()
-              this.activeForm.hidden ? this.activeForm.hidden = false : this.activeForm.hidden = true
+              this.activeForm.hidden = true
             } else {
               this.showError(xhr)
               this.enableSubmitFormButton($form)
             }
           }.bind(this)
+
+          xhr.addEventListener('loadend', this.done)
+          xhr.open('POST', url, true)
+          xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded')
 
           this.disableSubmitFormButton($form)
           xhr.send(params)


### PR DESCRIPTION
## What
https://trello.com/c/7G5XEeyS/995-feedback-component-issue-error-message-briefly-shown-on-form-submission-and-then-goes-away

On form submission, the **Form error alert / summary component** is briefly shown, before the form is submitted.

1) I think this can be resolved with on* event handler properties and specifically `loadend`. The `loadend` event is fired when a request has completed, whether successfully (on load) or unsuccessfully (on abort or error). https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/loadend_event.

This removes the need to check for individual `readyState` changes (through `onreadystatechange`) which is why the error alert / summary component is currently seen (described below). 

For a successful submission, we can check for a HTTP status code of 200. Anything else is handled as an error.

2) There is no need to toggle form visibility on submission. Instead the form should be hidden:

https://github.com/alphagov/govuk_publishing_components/blob/4e62e2d947d1a116fe6d831318e059fc42f03c3c/app/assets/javascripts/govuk_publishing_components/components/feedback.js#L99

## Why

This is what seems to be going on (video attached - _Feedback component issue - 720.mov_):

https://user-images.githubusercontent.com/87758239/148771046-05372911-c16d-4887-80c8-ec14c4563eb6.mov

- The user clicks **Report a problem with this page**, completes and / or submits the form
- An XHR request is initialised
- The status of the request is updated:
  - Status is initially `2` Code inside the `else` condition is executed including the `showError` function and the error message is displayed
  - Status is updated to `3` - same thing happens
  - Finally, the status is updated to `4` (Done) and code inside the `if` condition is executed - e.g. `showFormSuccess` where the **Thank you for your feedback** message is shown.

There is still an error though it’s invisible to the user in that the error summary is still displayed (but the user doesn't see it because the form is now hidden). Since the code in this block is only executed when `readyState` is 'done' (`xhr.readyState === 4 && xhr.status === 200`) I think the correct approach is hide the error summary altogether rather than try to toggle the element's visibility.

https://github.com/alphagov/govuk_publishing_components/blob/4e62e2d947d1a116fe6d831318e059fc42f03c3c/app/assets/javascripts/govuk_publishing_components/components/feedback.js#L93-L104

## Anything else

I considered if we could replace XMLHttpRequest with the Fetch API but rejected the idea because of browser compatibility (specifically IE and Edge). However, I have since read with regards to unsupported features in IE (e.g. the `URLSearchParams` API):

https://github.com/alphagov/govuk_publishing_components/blob/4e62e2d947d1a116fe6d831318e059fc42f03c3c/app/assets/javascripts/govuk_publishing_components/components/feedback.js#L77-L82

Therefore, in future, I think we could use the Fetch API here since the fallback would be the same.