### PR TITLE
Make metadata component "See all updates" link href less generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Make metadata component "See all updates" link href less generic ([PR #2562](https://github.com/alphagov/govuk_publishing_components/pull/2562))
+
 ## 28.1.0
 
 * Remove jQuery from mailto-link-tracker ([PR #2542](https://github.com/alphagov/govuk_publishing_components/pull/2542))

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -44,7 +44,7 @@
       <dd class="gem-c-metadata__definition">
         <%= last_updated %>
         <% if local_assigns.include?(:see_updates_link) %>
-          &#8212; <a href="#history" class="gem-c-metadata__definition-link govuk-!-display-none-print js-see-all-updates-link"
+          &#8212; <a href="#full-publication-update-history" class="gem-c-metadata__definition-link govuk-!-display-none-print js-see-all-updates-link"
                              data-track-category="content-history"
                              data-track-action="see-all-updates-link-clicked"
                              data-track-label="history">


### PR DESCRIPTION
Using `#history` is too generic and causing problems as described in this issue https://github.com/alphagov/govuk_publishing_components/issues/600

This changes the href to something less generic. 

To prevent this being a breaking change in `government-frontend`, I opened [this PR](https://github.com/alphagov/government-frontend/pull/2330) which temporarily adds a container with the updated id around the `published-dates` component.  

Once the change in this PR has been rolled out to `government-frontend`, the additional container can be removed, and the id of the component wrapper updated from "history" to "full-publication-update-history".

Opened on behalf of @danacotoran 