### PR TITLE
Bump gem to 28.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 28.1.0
 
 * Remove jQuery from mailto-link-tracker ([PR #2542](https://github.com/alphagov/govuk_publishing_components/pull/2542))
 * Remove jQuery from static analytics ([PR #2526](https://github.com/alphagov/govuk_publishing_components/pull/2526))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (28.0.0)
+    govuk_publishing_components (28.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "28.0.0".freeze
+  VERSION = "28.1.0".freeze
 end


### PR DESCRIPTION
Includes:
* Remove jQuery from mailto-link-tracker ([PR #2542](https://github.com/alphagov/govuk_publishing_components/pull/2542))
* Remove jQuery from static analytics ([PR #2526](https://github.com/alphagov/govuk_publishing_components/pull/2526))
* Remove unused scrolltracker ([PR #2551](https://github.com/alphagov/govuk_publishing_components/pull/2551))
* Tweak metadata component "See all updates" interaction ([PR #2552](https://github.com/alphagov/govuk_publishing_components/pull/2552))
* Change accordion language ([PR #2338](https://github.com/alphagov/govuk_publishing_components/pull/2338))