### PR TITLE
Update feedback component to resolve spam problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fix a bug in the scroll tracker ([PR #2554](https://github.com/alphagov/govuk_publishing_components/pull/2554))
 * Add check to big number to convert plus suffixes to subscript elements ([PR #2570](https://github.com/alphagov/govuk_publishing_components/pull/2570))
+* Update feedback component to resolve spam problem ([PR #2574](https://github.com/alphagov/govuk_publishing_components/pull/2574))
 
 ## 28.2.0
 

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -23,6 +23,12 @@
       <h3 class="gem-c-feedback__form-heading"><%= t("components.feedback.help_us_improve_govuk") %></h3>
       <p id="feedback_explanation" class="gem-c-feedback__form-paragraph"><%= t("components.feedback.dont_include_personal_info") %></p>
 
+      <% # Added for spam bots only %>
+      <div class="govuk-visually-hidden" aria-hidden="true">
+        <label for="feedback_maybe">This field is for robots only. Please leave blank</label>
+        <input id="feedback_maybe" type="text" pattern=".{0}" tabindex="-1" autocomplete="off" >
+      </div>
+
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
           text: t("components.feedback.what_doing")
@@ -46,3 +52,23 @@
     </div>
   </div>
 </form>
+
+<%
+  # I've added the following script inline in case of a scenario where a bot is able to parse the page, 
+  # without downloading any of the external scripts. 
+  # This seems to be a more reliable way to make sure the script is executed.
+%>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var input = document.querySelector("#feedback_maybe"),
+      form = document.querySelector("#something-is-wrong")
+
+    form.addEventListener("submit", spamCapture);
+
+    function spamCapture(e) {
+      if (input.value.length !== 0) return;
+      e.preventDefault();
+    }
+  });
+</script>

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -1,17 +1,23 @@
-<%
-  contact_govuk_path = "/contact/govuk"
-%>
-
 <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
   <div class="gem-c-feedback__prompt-questions js-prompt-questions" hidden>
     <h2 class="gem-c-feedback__prompt-question"><%= t("components.feedback.is_this_page_useful") %></h2>
     
     <ul class="gem-c-feedback__option-list">
-      <li class="gem-c-feedback__option-list-item" style="display: none" hidden="hidden">
-        <!-- Maybe button exists only to try and capture clicks by bots -->
-        <button data-track-category="yesNoFeedbackForm" data-track-action="ffMaybeClick" aria-expanded="false" style="display: none" hidden="hidden" aria-hidden="true">
+      <li class="gem-c-feedback__option-list-item govuk-visually-hidden" style="display: none" hidden>
+        <% # Maybe button exists only to try and capture clicks by bots %>
+        <%= link_to "/contact/govuk", {
+          class: 'gem-c-feedback__prompt-link',
+          data: {
+            'track-category' => 'yesNoFeedbackForm',
+            'track-action' => 'ffMaybeClick'
+          },
+          role: 'button',
+          style: 'display: none',
+          hidden: 'hidden',
+          'aria-hidden': 'true',
+        } do %>
           <%= t("components.feedback.maybe") %>
-        </button>
+        <% end %>
       </li>
       <li class="gem-c-feedback__option-list-item">
         <button class="govuk-button gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">


### PR DESCRIPTION
## What
https://trello.com/c/I0WfBF4P/1011-update-feedback-component-to-resolve-spam-problem

There has been an increase in spam coming from the feedback component from the 6th of Jan, which seems to coincide with the deployment of the new feedback component. https://govuk.zendesk.com/agent/tickets/4834840

**Solution - multiple changes**

- Changed the _Maybe_ button to be a link. Bots that click 'Maybe' will be redirected elsewhere (to the contact page)
- Replaced HTML comments with Ruby comments e.g. `<% # Maybe button exists only to try and capture clicks by bots %>` which may make it harder for more advanced bots to identify elements added for spam bots only
- Added fake (honeypot) input field
  - The input field includes a pattern attribute that will fail (and generate HTML validation) for anything other than an empty string 
  - Added inline JavaScript to check on form submission if the honeypot field has been filled in and to prevent submission 
- I’m not sure if we should also have some server side protection too? (to be investigated separately https://github.com/alphagov/feedback)
- For non CSS users, the input is labelled as **"This field is for robots only. Please leave blank"**

## Why

It seems likely that by resolving a number of accessibility issues (https://trello.com/c/MOshcFm1/771-update-feedback-component-to-hide-and-show-content-in-a-more-robust-way) we have inadvertently made it easier for spam bots to access the feedback component forms.

See:

- https://github.com/alphagov/govuk_publishing_components/pull/2435
- https://github.com/alphagov/govuk_publishing_components/pull/2568