### PR TITLE
Add pipes between buttons on super nav header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Fix a bug in the scroll tracker ([PR #2554](https://github.com/alphagov/govuk_publishing_components/pull/2554))
 * Add check to big number to convert plus suffixes to subscript elements ([PR #2570](https://github.com/alphagov/govuk_publishing_components/pull/2570))
 * Update feedback component to resolve spam problem ([PR #2574](https://github.com/alphagov/govuk_publishing_components/pull/2574))
+=======
+* Add pipes between buttons on super nav header ([PR #2575](https://github.com/alphagov/govuk_publishing_components/pull/2575))
 
 ## 28.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -18,7 +18,7 @@ $pseudo-underline-height: 3px;
     content: "";
     display: inline-block;
     height: 8px;
-    margin: 0 8px 0 2px;
+    margin: 0 10px 0 2px;
     vertical-align: middle;
     width: 8px;
   }

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -6,6 +6,7 @@ $chevron-indent-spacing: 7px;
 $black-bar-height: 50px;
 $search-width-or-height: $black-bar-height;
 $pseudo-underline-height: 3px;
+$button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
 
 @mixin chevron($colour, $update: false) {
   @if ($update == true) {
@@ -172,6 +173,15 @@ $pseudo-underline-height: 3px;
   @include govuk-media-query($from: "desktop") {
     border-bottom: 0;
     padding: 0;
+
+    &:first-of-type {
+      margin-right: -1px;
+
+      .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
+        border-left: 1px solid $button-pipe-colour;
+        border-right: 1px solid $button-pipe-colour;
+      }
+    }
   }
 }
 
@@ -313,22 +323,28 @@ $pseudo-underline-height: 3px;
   padding: 0;
 
   @include focus-not-focus-visible {
-    &:before {
-      @include chevron($govuk-link-colour);
+    .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
+      &:before {
+        @include chevron($govuk-link-colour);
+      }
     }
   }
 
   @include focus-not-focus-visible {
     &:hover {
-      &:before {
-        @include chevron($govuk-link-hover-colour, true);
+      .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
+        &:before {
+          @include chevron($govuk-link-hover-colour, true);
+        }
       }
     }
   }
 
   &:focus {
-    &:before {
-      @include chevron($govuk-focus-text-colour, true);
+    .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
+      &:before {
+        @include chevron($govuk-focus-text-colour, true);
+      }
     }
   }
 
@@ -345,12 +361,15 @@ $pseudo-underline-height: 3px;
         font-size: govuk-px-to-rem(16px);
       }
       height: $black-bar-height;
-      padding: govuk-spacing(3) govuk-spacing(6) govuk-spacing(3) govuk-spacing(5);
       position: relative;
       text-decoration: none;
 
-      &:before {
-        @include chevron(govuk-colour("white"), true);
+      .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
+        border-color: $button-pipe-colour;
+
+        &:before {
+          @include chevron(govuk-colour("white"), true);
+        }
       }
     }
     @include focus-not-focus-visible {
@@ -362,8 +381,12 @@ $pseudo-underline-height: 3px;
           background: govuk-colour("mid-grey");
         }
 
-        &:before {
-          @include chevron(govuk-colour("mid-grey"), true);
+        .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
+          border-color: $button-pipe-colour;
+
+          &:before {
+            @include chevron($button-pipe-colour, true);
+          }
         }
       }
     }
@@ -375,16 +398,22 @@ $pseudo-underline-height: 3px;
         background: $govuk-focus-text-colour;
       }
 
-      &:before {
-        @include chevron($govuk-focus-text-colour, true);
+      .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
+        border-color: $govuk-focus-colour;
+
+        &:before {
+          @include chevron($govuk-focus-text-colour, true);
+        }
       }
     }
   }
 
   &.gem-c-layout-super-navigation-header__open-button {
     @include focus-not-focus-visible {
-      &:before {
-        @include prefixed-transform($rotate: 225deg, $translateY: 1px);
+      .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
+        &:before {
+          @include prefixed-transform($rotate: 225deg, $translateY: 1px);
+        }
       }
     }
 
@@ -393,8 +422,13 @@ $pseudo-underline-height: 3px;
         background: govuk-colour("light-grey");
         color: $govuk-link-colour;
 
-        &:before {
-          @include chevron($govuk-link-colour, true);
+        // stylelint-disable max-nesting-depth
+        .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
+          border-color: govuk-colour("light-grey");
+
+          &:before {
+            @include chevron($govuk-link-colour, true);
+          }
         }
 
         &:after {
@@ -406,8 +440,12 @@ $pseudo-underline-height: 3px;
         background-color: $govuk-focus-colour;
         color: $govuk-focus-text-colour;
 
-        &:before {
-          @include chevron($govuk-focus-text-colour, true);
+        .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
+          border-color: $govuk-focus-colour;
+
+          &:before {
+            @include chevron($govuk-focus-text-colour, true);
+          }
         }
 
         &:after {
@@ -416,9 +454,17 @@ $pseudo-underline-height: 3px;
       }
     }
   }
+  // stylelint-enable max-nesting-depth
 
   .js-module-initialised & {
     @include govuk-link-style-no-underline;
+  }
+}
+
+.gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
+  @include govuk-media-query($from: "desktop") {
+    display: inline-block;
+    padding: govuk-spacing(2) govuk-spacing(6) govuk-spacing(2) govuk-spacing(5);
   }
 }
 
@@ -550,7 +596,7 @@ $pseudo-underline-height: 3px;
     box-shadow: none;
 
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
-      border-color: govuk-colour("mid-grey");
+      border-color: $button-pipe-colour;
       color: govuk-colour("white");
 
       @include govuk-media-query($from: 360px) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -550,7 +550,7 @@ $pseudo-underline-height: 3px;
     box-shadow: none;
 
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
-      border-color: govuk-colour("white");
+      border-color: govuk-colour("mid-grey");
       color: govuk-colour("white");
 
       @include govuk-media-query($from: 360px) {

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -108,24 +108,28 @@
                   track_dimension_index: "29",
                 }
               } %>
-              <%= content_tag(:button, link[:label], {
-                aria: {
-                  controls: "super-navigation-menu__section-#{unique_id}",
-                  expanded: false,
-                  label: show_menu_text,
-                },
-                class: "gem-c-layout-super-navigation-header__navigation-second-toggle-button",
-                data: {
-                  text_for_hide: hide_menu_text,
-                  text_for_show: show_menu_text,
-                  toggle_desktop_group: "top",
-                  toggle_mobile_group: "second",
-                  tracking_key: tracking_label,
-                },
-                hidden: true,
-                id: "super-navigation-menu__section-#{unique_id}-toggle",
-                type: "button",
-              }) if has_children %>
+              <% if has_children %>
+                <%= content_tag(:button, {
+                  aria: {
+                    controls: "super-navigation-menu__section-#{unique_id}",
+                    expanded: false,
+                    label: show_menu_text,
+                  },
+                  class: "gem-c-layout-super-navigation-header__navigation-second-toggle-button",
+                  data: {
+                    text_for_hide: hide_menu_text,
+                    text_for_show: show_menu_text,
+                    toggle_desktop_group: "top",
+                    toggle_mobile_group: "second",
+                    tracking_key: tracking_label,
+                  },
+                  hidden: true,
+                  id: "super-navigation-menu__section-#{unique_id}-toggle",
+                  type: "button",
+                }) do %>
+                  <%= tag.span link[:label], class: "gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner" %>
+                <% end %>
+              <% end %>
             </div>
             <% if has_children %>
               <div


### PR DESCRIPTION
## What
A couple of changes to the super nav header:

- Implement `spans` within the desktop buttons to create a visual pipe effect between buttons on desktop, like we have on mobile
- Change the colour of pipes to the design system `mid-grey`
- nudge the chevrons ever so slightly away from their respective buttons

## Why
This is to solve a problem where the desktop buttons appear to have a big gap between them when it's simply the width of the buttons which we need to maintain for the purpose of focus and open states. Solution produced alongside a designer.

[Card](https://trello.com/c/GHzPAVUT/725-desktop-padding-has-left-the-spacing-on-topics-and-gov-activity-inconsistent-timebox)

## Visual Changes
### Before
![Screenshot 2022-01-20 at 17 22 13](https://user-images.githubusercontent.com/64783893/150389698-6a5a43ad-7adc-4fe7-a413-47042843371d.png)

### After
![Screenshot 2022-01-21 at 16 54 56](https://user-images.githubusercontent.com/64783893/150569241-09ba42ba-d2b6-40fe-9841-b90cfd29b2dc.png)
