### PR TITLE
Release 28.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 28.3.0
 
 * Fix a bug in the scroll tracker ([PR #2554](https://github.com/alphagov/govuk_publishing_components/pull/2554))
 * Add check to big number to convert plus suffixes to subscript elements ([PR #2570](https://github.com/alphagov/govuk_publishing_components/pull/2570))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (28.2.0)
+    govuk_publishing_components (28.3.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "28.2.0".freeze
+  VERSION = "28.3.0".freeze
 end


### PR DESCRIPTION
* Fix a bug in the scroll tracker ([PR #2554](https://github.com/alphagov/govuk_publishing_components/pull/2554))
* Add check to big number to convert plus suffixes to subscript elements ([PR #2570](https://github.com/alphagov/govuk_publishing_components/pull/2570))
* Update feedback component to resolve spam problem ([PR #2574](https://github.com/alphagov/govuk_publishing_components/pull/2574))
=======
* Add pipes between buttons on super nav header ([PR #2575](https://github.com/alphagov/govuk_publishing_components/pull/2575))