### PR TITLE
[DO NOT MERGE] Remove vaccination-status from Google Analytics

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics/pii.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/pii.js
@@ -12,6 +12,9 @@
   var UNLOCK_TOKEN_PATTERN = /unlock_token=[a-zA-Z0-9-]+/g
   var STATE_PATTERN = /state=.[^&]+/g
 
+  // specific URL parameters to be redacted from smart answer URLs
+  var VACCINATION_STATUS_PATTERN = /vaccination_status=.[^&]+/g
+
   function shouldStripDates () {
     var metas = document.querySelectorAll('meta[name="govuk:static-analytics:strip-dates"]')
     return metas.length > 0
@@ -19,6 +22,11 @@
 
   function shouldStripPostcodes () {
     var metas = document.querySelectorAll('meta[name="govuk:static-analytics:strip-postcodes"]')
+    return metas.length > 0
+  }
+
+  function shouldStripVaccinationStatus () {
+    var metas = document.querySelectorAll('meta[name="govuk:static-analytics:strip-vaccination-status"]')
     return metas.length > 0
   }
 
@@ -43,6 +51,7 @@
   var pii = function () {
     this.stripDatePII = shouldStripDates()
     this.stripPostcodePII = shouldStripPostcodes()
+    this.stripVaccinationStatusPII = shouldStripVaccinationStatus()
     this.queryStringParametersToStrip = queryStringParametersToStrip()
   }
 
@@ -70,6 +79,9 @@
     }
     if (this.stripPostcodePII === true) {
       stripped = stripped.replace(POSTCODE_PATTERN, '[postcode]')
+    }
+    if (this.stripVaccinationStatusPII === true) {
+      stripped = stripped.replace(VACCINATION_STATUS_PATTERN, 'vaccination_status=[vaccination_status]')
     }
     return stripped
   }

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -41,6 +41,7 @@ module GovukPublishingComponents
         meta_tags["govuk:content-has-history"] = "true" if has_content_history?
         meta_tags["govuk:static-analytics:strip-dates"] = "true" if should_strip_dates_pii?(content_item, local_assigns)
         meta_tags["govuk:static-analytics:strip-postcodes"] = "true" if should_strip_postcode_pii?(content_item, local_assigns)
+        meta_tags["govuk:static-analytics:strip-vaccination-status"] = "true" if should_strip_vaccination_status_pii?(content_item, local_assigns)
 
         meta_tags
       end
@@ -186,6 +187,15 @@ module GovukPublishingComponents
 
         formats_that_might_include_postcodes = %w[smart_answer finder]
         formats_that_might_include_postcodes.include?(content_item[:document_type])
+      end
+
+      def should_strip_vaccination_status_pii?(content_item, local_assigns)
+        # allow override if we explicitly want to strip pii (or not) regardless of
+        # document_type
+        return local_assigns[:strip_vaccination_status_pii] if local_assigns.key?(:strip_vaccination_status_pii)
+
+        formats_that_might_include_vaccination_status = %w[smart_answer finder]
+        formats_that_might_include_vaccination_status.include?(content_item[:document_type])
       end
     end
   end

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -419,6 +419,31 @@ describe "Meta tags", type: :view do
     assert_no_meta_tag("govuk:static-analytics:strip-postcodes")
   end
 
+  it "renders the govuk:static-analytics:strip-vaccination-status tag if the content item is a 'smart-answer'" do
+    render_component(content_item: { document_type: "smart_answer" })
+    assert_meta_tag("govuk:static-analytics:strip-vaccination-status", "true")
+  end
+
+  it "renders the govuk:static-analytics:strip-vaccination-status tag if the content item is a 'finder'" do
+    render_component(content_item: { document_type: "finder" })
+    assert_meta_tag("govuk:static-analytics:strip-vaccination-status", "true")
+  end
+
+  it "doesn't render the govuk:static-analytics:strip-vaccination-status tag if the document_type isn't relevant" do
+    render_component(content_item: { document_type: "guidance" })
+    assert_no_meta_tag("govuk:static-analytics:strip-vaccination-status")
+  end
+
+  it "renders the govuk:static-analytics:strip-vaccination-status tag if explicitly told to even if it wouldn't otherwise" do
+    render_component(content_item: { document_type: "guidance" }, strip_vaccination_status_pii: true)
+    assert_meta_tag("govuk:static-analytics:strip-vaccination-status", "true")
+  end
+
+  it "doesn't render the govuk:static-analytics:strip-vaccination-status tag if explicitly told not to even if it would otherwise" do
+    render_component(content_item: { document_type: "smart_answer" }, strip_vaccination_status_pii: false)
+    assert_no_meta_tag("govuk:static-analytics:strip-vaccination-status")
+  end
+
   def assert_political_status_for(political, current, expected_political_status)
     render_component(content_item: { details: { political: political, government: { current: current, slug: "government" } } })
     assert_meta_tag("govuk:political-status", expected_political_status)

--- a/spec/javascripts/govuk_publishing_components/analytics/google-analytics-universal-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/google-analytics-universal-tracker.spec.js
@@ -18,6 +18,7 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
     addGoogleAnalyticsSpy()
     pageWantsDatesStripped()
     pageWantsPostcodesStripped()
+    pageWantsVaccinationStatusStripped()
 
     universal = new GOVUK.GoogleAnalyticsUniversalTracker('id', {
       cookieDomain: 'cookie-domain.com',
@@ -28,6 +29,7 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
   afterEach(function () {
     $('head').find('meta[name="govuk:static-analytics:strip-dates"]').remove()
     $('head').find('meta[name="govuk:static-analytics:strip-postcodes"]').remove()
+    $('head').find('meta[name="govuk:static-analytics:strip-vaccination-status"]').remove()
     $('[src="https://www.google-analytics.com/analytics.js"]').remove()
 
     if (GOVUK.analytics.trackEvent.calls) {
@@ -212,11 +214,11 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
 
   describe('when tracking all events', function () {
     beforeAll(function () {
-      window.history.replaceState(null, null, '?address=an.email@digital.cabinet-office.gov.uk&postcode=sw11wa&date=2019-01-01')
+      window.history.replaceState(null, null, '?address=an.email@digital.cabinet-office.gov.uk&postcode=sw11wa&date=2019-01-01&vaccination_status=fully-vaccinated')
     })
 
     afterAll(function () {
-      var href = window.location.href.replace('?address=an.email@digital.cabinet-office.gov.uk&postcode=sw11wa&date=2019-01-01', '')
+      var href = window.location.href.replace('?address=an.email@digital.cabinet-office.gov.uk&postcode=sw11wa&date=2019-01-01&vaccination_status=fully-vaccinated', '')
       window.history.replaceState(null, null, href)
     })
 
@@ -224,6 +226,7 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
       expect(window.ga.calls.mostRecent().args[2]).toContain('address=[email]')
       expect(window.ga.calls.mostRecent().args[2]).toContain('postcode=[postcode]')
       expect(window.ga.calls.mostRecent().args[2]).toContain('date=[date]')
+      expect(window.ga.calls.mostRecent().args[2]).toContain('vaccination_status=[vaccination_status]')
     })
 
     it('removes any pii from the title', function () {
@@ -248,11 +251,11 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
     var callIndex
 
     beforeAll(function () {
-      window.history.replaceState(null, null, '?address=an.email@digital.cabinet-office.gov.uk&postcode=sw11wa&date=2019-01-01')
+      window.history.replaceState(null, null, '?address=an.email@digital.cabinet-office.gov.uk&postcode=sw11wa&date=2019-01-01&vaccination_status=fully-vaccinated')
     })
 
     afterAll(function () {
-      var href = window.location.href.replace('?address=an.email@digital.cabinet-office.gov.uk&postcode=sw11wa&date=2019-01-01', '')
+      var href = window.location.href.replace('?address=an.email@digital.cabinet-office.gov.uk&postcode=sw11wa&date=2019-01-01&vaccination_status=fully-vaccinated', '')
       window.history.replaceState(null, null, href)
     })
 
@@ -284,6 +287,7 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
       addGoogleAnalyticsSpy()
       pageWantsDatesStripped()
       pageWantsPostcodesStripped()
+      pageWantsVaccinationStatusStripped()
 
       universal = new GOVUK.GoogleAnalyticsUniversalTracker('id', {
         cookieDomain: 'cookie-domain.com',
@@ -291,7 +295,7 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
       })
 
       expect(window.ga.calls.allArgs()).toContain(['set', 'title', 'With [email] [date] and [postcode] in it'])
-      expect(window.ga.calls.argsFor(4)[2]).toContain('?address=[email]&postcode=[postcode]&date=[date]')
+      expect(window.ga.calls.argsFor(4)[2]).toContain('?address=[email]&postcode=[postcode]&date=[date]&vaccination_status=[vaccination_status]')
 
       $('title').html(title)
     })
@@ -349,5 +353,9 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
 
   function pageWantsPostcodesStripped () {
     $('head').append('<meta name="govuk:static-analytics:strip-postcodes" value="does not matter" />')
+  }
+
+  function pageWantsVaccinationStatusStripped () {
+    $('head').append('<meta name="govuk:static-analytics:strip-vaccination-status" value="does not matter" />')
   }
 })

--- a/spec/javascripts/govuk_publishing_components/analytics/pii.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/pii.spec.js
@@ -71,6 +71,7 @@ describe('GOVUK.PII', function () {
     beforeEach(function () {
       pageWantsDatesStripped()
       pageWantsPostcodesStripped()
+      pageWantsVaccinationStatusStripped()
       pii = new GOVUK.Pii()
     })
 
@@ -182,9 +183,23 @@ describe('GOVUK.PII', function () {
     })
   })
 
+  describe('when there is a a govuk:static-analytics:strip-vaccination-status meta tag present', function () {
+    beforeEach(function () {
+      pageWantsVaccinationStatusStripped()
+      pii = new GOVUK.Pii()
+    })
+
+    it('observes the meta tag and strips out vaccination_status', function () {
+      expect(pii.stripVaccinationStatusPII).toEqual(true)
+      var string = pii.stripPII('gov.uk/thing?vaccination_status=fully-vaccinated')
+      expect(string).toEqual('gov.uk/thing?vaccination_status=[vaccination_status]')
+    })
+  })
+
   function resetHead () {
     $('head').find('meta[name="govuk:static-analytics:strip-postcodes"]').remove()
     $('head').find('meta[name="govuk:static-analytics:strip-dates"]').remove()
+    $('head').find('meta[name="govuk:static-analytics:strip-vaccination-status"]').remove()
     $('head').find('meta[name="govuk:static-analytics:strip-query-string-parameters"]').remove()
   }
 
@@ -194,6 +209,10 @@ describe('GOVUK.PII', function () {
 
   function pageWantsPostcodesStripped () {
     $('head').append('<meta name="govuk:static-analytics:strip-postcodes" value="does not matter" />')
+  }
+
+  function pageWantsVaccinationStatusStripped () {
+    $('head').append('<meta name="govuk:static-analytics:strip-vaccination-status" value="does not matter" />')
   }
 
   function pageWantsQueryStringParametersStripped (parameters) {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
Remove the users response to the `vaccination-status` question from the `location` (URL) field in the [`check-travel-during-coronavirus` Smart Answer flow](https://github.com/alphagov/smart-answers/pull/5724) that we currently send to Google Analytics.
<!-- Remember to add this to the CHANGELOG if applicable -->

Linked - https://github.com/alphagov/smart-answers/pull/5736

## Why
<!-- What are the reasons behind this change being made? -->
A users vaccination status is considered health data, so we should remove it from being exposed outside of the application.

## Visual Changes
None

[Trello](https://trello.com/c/DInfO64C/540-mvp-innout-decide-what-to-do-from-a-data-privacy-angle)