### PR TITLE
Remove unneeded brackets from shared helper calls

### DIFF
--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -9,7 +9,7 @@
 
   accordion_classes = %w(gem-c-accordion)
   accordion_classes << 'gem-c-accordion--condensed' if condensed
-  accordion_classes << (shared_helper.get_margin_bottom)
+  accordion_classes << shared_helper.get_margin_bottom
 
   translations = {
     show_text: "components.accordion.show",

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -33,7 +33,7 @@
   css_classes << "gem-c-action-link--simple-light" if simple_light
   css_classes << "gem-c-action-link--with-subtext" if subtext
   css_classes << "gem-c-action-link--mobile-subtext" if mobile_subtext
-  css_classes << (shared_helper.get_margin_bottom)
+  css_classes << shared_helper.get_margin_bottom
 
   link_classes = %w(govuk-link gem-c-action-link__link)
   link_classes << shared_helper.classes if classes

--- a/app/views/govuk_publishing_components/components/_details.html.erb
+++ b/app/views/govuk_publishing_components/components/_details.html.erb
@@ -4,7 +4,7 @@
   open ||= nil
   margin_bottom ||= 3
   css_classes = %w(gem-c-details govuk-details)
-  css_classes << (shared_helper.get_margin_bottom)
+  css_classes << shared_helper.get_margin_bottom
 
   details_data_attributes = {}
   details_data_attributes[:module] = 'govuk-details gem-details'

--- a/app/views/govuk_publishing_components/components/_heading.html.erb
+++ b/app/views/govuk_publishing_components/components/_heading.html.erb
@@ -10,7 +10,7 @@
   classes << heading_helper.classes
   classes << brand_helper.brand_class
   classes << brand_helper.border_color_class
-  classes << (shared_helper.get_margin_bottom) if [*0..9].include?(local_assigns[:margin_bottom])
+  classes << shared_helper.get_margin_bottom if [*0..9].include?(local_assigns[:margin_bottom])
 %>
 <%= content_tag(shared_helper.get_heading_level, text,
   class: classes,

--- a/app/views/govuk_publishing_components/components/_hint.html.erb
+++ b/app/views/govuk_publishing_components/components/_hint.html.erb
@@ -3,7 +3,7 @@
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   css_classes = %w( gem-c-hint govuk-hint )
-  css_classes << (shared_helper.get_margin_bottom)
+  css_classes << shared_helper.get_margin_bottom
 %>
 
 <%= tag.div id: id, class: css_classes do %>

--- a/app/views/govuk_publishing_components/components/_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_list.html.erb
@@ -14,7 +14,7 @@
   classes << "govuk-list--spaced" if extra_spacing
   # Setting the  `margin_bottom` to 4 is the same as the default margin - so we
   # can omit the override class. To do this we leave out `4` from the array:
-  classes << (shared_helper.get_margin_bottom) if [0,1,2,3,5,6,7,8,9].include?(local_assigns[:margin_bottom])
+  classes << shared_helper.get_margin_bottom if [0,1,2,3,5,6,7,8,9].include?(local_assigns[:margin_bottom])
 
   # Default list type is unordered list.
   list_tag = "ul"

--- a/app/views/govuk_publishing_components/components/_notice.html.erb
+++ b/app/views/govuk_publishing_components/components/_notice.html.erb
@@ -16,7 +16,7 @@
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   css_classes = %w[govuk-notification-banner gem-c-notice]
-  css_classes << (shared_helper.get_margin_bottom)
+  css_classes << shared_helper.get_margin_bottom
 
   aria_attributes = {label: 'Notice'}
   aria_attributes[:live] = 'polite' if aria_live

--- a/app/views/govuk_publishing_components/components/_print_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_print_link.html.erb
@@ -15,8 +15,8 @@
 
   wrapper_classes = %w(gem-c-print-link govuk-!-display-none-print)
   wrapper_classes << "gem-c-print-link--show-without-js" unless require_js
-  wrapper_classes << (shared_helper.get_margin_top)
-  wrapper_classes << (shared_helper.get_margin_bottom)
+  wrapper_classes << shared_helper.get_margin_top
+  wrapper_classes << shared_helper.get_margin_bottom
 
   classes = %w[govuk-link]
   classes << "govuk-body-s gem-c-print-link__button" if href.nil?

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -18,8 +18,8 @@
   data_attributes[:module] = 'gem-track-click'
 
   classes = %w[gem-c-search govuk-!-display-none-print]
-  classes << (shared_helper.get_margin_top)
-  classes << (shared_helper.get_margin_bottom) if local_assigns[:margin_bottom]
+  classes << shared_helper.get_margin_top
+  classes << shared_helper.get_margin_bottom if local_assigns[:margin_bottom]
   classes << "gem-c-search--large" if size == "large"
   classes << "gem-c-search--large-on-mobile" if size == "large-mobile"
   classes << "gem-c-search--no-border" if no_border

--- a/app/views/govuk_publishing_components/components/_subscription_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription_links.html.erb
@@ -9,7 +9,7 @@
   local_assigns[:margin_bottom] = 0 if local_assigns[:margin_bottom] > 9
 
   css_classes = %w( gem-c-subscription-links govuk-!-display-none-print )
-  css_classes << (shared_helper.get_margin_bottom) unless local_assigns[:margin_bottom] == 0
+  css_classes << shared_helper.get_margin_bottom unless local_assigns[:margin_bottom] == 0
   css_classes << brand_helper.brand_class
   css_classes << "gem-c-subscription-links--with-feed-box" if sl_helper.feed_link_box_value
 

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -25,7 +25,7 @@
   css_classes << "govuk-textarea--error" if has_error
   form_group_css_classes = %w(gem-c-textarea govuk-form-group)
   form_group_css_classes << "govuk-form-group--error" if has_error
-  form_group_css_classes << (shared_helper.get_margin_bottom)
+  form_group_css_classes << shared_helper.get_margin_bottom
 
   aria_described_by ||= nil
   if hint || has_error || describedby

--- a/app/views/govuk_publishing_components/components/_title.html.erb
+++ b/app/views/govuk_publishing_components/components/_title.html.erb
@@ -13,8 +13,8 @@
 
   classes = %w[gem-c-title]
   classes << "gem-c-title--inverse" if inverse
-  classes << (shared_helper.get_margin_top)
-  classes << (shared_helper.get_margin_bottom)
+  classes << shared_helper.get_margin_top
+  classes << shared_helper.get_margin_bottom
 
   heading_classes = %w[gem-c-title__text]
   heading_classes << (average_title_length.present? ? 'govuk-heading-l' : 'govuk-heading-xl')
@@ -30,7 +30,7 @@
   <% if context && !context_inside %>
     <%= @context_block %>
   <% end %>
-  
+
   <h1 class="<%= heading_classes.join(" ") %>">
     <% if context && context_inside %>
       <%= @context_block %>


### PR DESCRIPTION
## What
Remove unneeded brackets around calls to the shared helper. Changes:

- `classes << (shared_helper.get_margin_bottom)`

to

- `classes << shared_helper.get_margin_bottom`

## Why
I noticed this a while ago and it's been bugging me.

## Visual Changes
None.
