### PR TITLE
Add name attribute to hidden spam input in feedback component

### DIFF
--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -25,8 +25,8 @@
 
       <% # Added for spam bots only %>
       <div class="govuk-visually-hidden" aria-hidden="true">
-        <label for="feedback_maybe">This field is for robots only. Please leave blank</label>
-        <input id="feedback_maybe" type="text" pattern=".{0}" tabindex="-1" autocomplete="off" >
+        <label for="giraffe">This field is for robots only. Please leave blank</label>
+        <input id="giraffe" name="giraffe" type="text" pattern=".{0}" tabindex="-1" autocomplete="off">
       </div>
 
       <%= render "govuk_publishing_components/components/textarea", {
@@ -61,7 +61,7 @@
 
 <script>
   document.addEventListener("DOMContentLoaded", function () {
-    var input = document.querySelector("#feedback_maybe"),
+    var input = document.querySelector("#giraffe"),
       form = document.querySelector("#something-is-wrong")
 
     form.addEventListener("submit", spamCapture);


### PR DESCRIPTION
## What
https://trello.com/c/H8jJvUxV/1021-feedback-component-server-side-fix-for-spam-problem

Add name attribute to hidden (`giraffe`) - "honeypot" input which is needed to access the form data from params in the controller.

## Why

It seems likely that by resolving a number of accessibility issues (https://trello.com/c/MOshcFm1/771-update-feedback-component-to-hide-and-show-content-in-a-more-robust-way) we have inadvertently made it easier for spam bots to access the feedback component forms and client side changes have not resolved the problem. 

## Anything else
Should be deployed before:  https://github.com/alphagov/feedback/pull/1354