### PR TITLE
Validate locale files

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -82,6 +82,8 @@ ar:
       what_doing: ماذا كنت تفعل؟
       what_wrong: ما الخطأ الذي وقع؟
       'yes': نعم ‏  ‏
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© حقوق نشر التاج الملكي</a>
       licence_html: كل المحتوى متاح بموجب <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">الترخيص الحكومي المفتوح (الإصدار v3.0)</a>، ما لم ينص على خلاف ذلك

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -79,6 +79,8 @@ az:
       what_doing: Nə edirdiniz?
       what_wrong: Hansı yanlışlıq oldu?
       'yes': Bəli
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">Â© Crown copyright</a>
       licence_html: Bütün məzmunlar <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">v3.0 Açıq dövlət lisenziyasına əsasən mövcuddur</a>(başqa cür nəzərdə tutulmuş hallar istisna olmaqla)

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -15,7 +15,6 @@ az:
       opendocument_html: Bu fayl <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation' target=%{target} class='govuk-link'>OpenDocument</a> formatındadır
       order_a_copy: Surətini sifariş edin
       page:
-        one: 1 səhifə
         other: "%{count} səhifə"
       reference: 'İst: %{reference}'
       request_format_cta: İstifadə edilə bilən format tələb edin.

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -85,6 +85,8 @@ be:
       what_doing: Што вы рабiлi?
       what_wrong: Што пайшло не так?
       'yes': Так
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Увесь змест даступны <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, калі не паказана іншае

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -83,6 +83,8 @@ bg:
       what_doing: Какво правихте?
       what_wrong: Какво се обърка?
       'yes': Да
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Цялото съдържание е налично на <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, освен ако не е посочено друго

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -80,6 +80,8 @@ bn:
       what_doing: আপনি কী করছিলেন?
       what_wrong: কী ভুল হয়েছিল?
       'yes': হ্যাঁ
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© ক্রাউন কপিরাইট</a>
       licence_html: শুধুমাত্র অন্যভাবে বর্ণিত থাকা ছাড়া, সকল তথ্য <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">ওপেন গভর্নমেন্ট লাইসেন্স v3.0</a>-এর অধীনে উপলভ্য

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -84,6 +84,8 @@ cs:
       what_doing: Co jste dělal?
       what_wrong: Co se pokazilo?
       'yes': Ano
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Veškerý obsah je k dispozici pod <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, pokud není uvedeno jinak

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -83,6 +83,8 @@ cy:
       what_doing: Beth oeddech chi'n wneud?
       what_wrong: Beth aeth o'i le?
       'yes': Ie
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Hawlfraint y Goron</a>
       licence_html: Mae'r holl gynnwys ar gael o dan <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Drwydded Agored y Llywodraeth v3.0</a>, ac eithrio ble nodir yn wahanol

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -80,6 +80,8 @@ da:
       what_doing: Hvad lavede du?
       what_wrong: Hvad gik galt?
       'yes': ja
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Krown copyright</a>
       licence_html: Alt indhold er tilgængeligt i henhold til <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">åben Forvaltning Licens v3.0</a>, medmindre andet er angivet.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -83,6 +83,8 @@ de:
       what_doing: Was haben Sie gemacht?
       what_wrong: Was ist schief gelaufen?
       'yes': Ja
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Alle Inhalte stehen unter der <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, sofern nicht anders angegeben.

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -81,6 +81,8 @@ dr:
       what_doing: مصروف چه کاری بودید؟
       what_wrong: چه اشتباهی رخ داد؟
       'yes': بلی
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: همه محتویات در<a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, موجود است، مگر در مواردی که خلاف آن ذکر شده باشد.

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -79,6 +79,8 @@ el:
       what_doing: Τι κάνατε;
       what_wrong: Τι πήγε στραβά;
       'yes': Ναι
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Πνευματικά δικαιώματα Crown</a>
       licence_html: Όλο το περιεχόμενο είναι διαθέσιμο βάσει της <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Άδειας Ανοικτής Κυβέρνησης v3.0</a> , εκτός εάν αναφέρεται διαφορετικά

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -79,6 +79,8 @@ es-419:
       what_doing: "¿Qué estaba haciendo?"
       what_wrong: "¿Qué salió mal?"
       'yes': Sí
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Todos los contenidos están disponibles bajo la <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Licencia Gubernamental Abierta v3.0</a>, salvo que se indique lo contrario

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -79,6 +79,8 @@ es:
       what_doing: "¿Qué estaba haciendo?"
       what_wrong: "¿Qué ha fallado?"
       'yes': Sí
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class='govuk-footer__link govuk-footer__copyright-logo' href='http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Derechos de autor de la corona</a>
       licence_html: Todo el contenido está disponible bajo la <a class='govuk-footer__link' href='https://www.nationalarchives.gov.uk/doc/open-government-license/version/3/" rel='license'>Licencia de Gobierno Abierto v3,0</a>, excepto donde se indique lo contrario

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -82,6 +82,8 @@ et:
       what_doing: Mida te tegite?
       what_wrong: Mis läks valesti?
       'yes': Jah
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crowni autoriõigus</a>
       licence_html: Kogu sise on saadaval <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a> all, kui pole märgitud teisiti

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -78,6 +78,8 @@ fa:
       what_doing: داشتید چه کار می‌کردید؟
       what_wrong: چه مشکلی پیش آمد؟
       'yes': بله
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">کپی‌رایت © Crown</a>
       licence_html: تمام محتوا تحت <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">مجوز دولت باز نسخه 3.0</a> در دسترس است، مگر در مواردی که خلاف آن بیان شده باشد

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -15,7 +15,6 @@ fa:
       opendocument_html: این فایل یک قالب <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation' target=%{target} class='govuk-link'>OpenDocument (سند باز)</a> است
       order_a_copy: سفارش یک نسخه کپی
       page:
-        one: 1 صفحه
         other: "%{count} صفحه"
       reference: 'مرجع: %{reference}'
       request_format_cta: درخواست یک قالب با قابلیت دسترسی بهتر.

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -81,6 +81,8 @@ fi:
       what_doing: Mitä olit tekemässä?
       what_wrong: Mikä meni vikaan?
       'yes': Kyllä
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Kruunun tekijänoikeus</a>
       licence_html: Kaikki sisältö on saatavilla osoitteessa <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Avoimen hallinnon lisenssi v3.0</a>, ellei toisin mainita

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -79,6 +79,8 @@ fr:
       what_doing: Que faisiez-vous ?
       what_wrong: Qu'est-ce qui n'a pas marché ?
       'yes': Oui
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Copyright de la Couronne</a>
       licence_html: L'ensemble du contenu est disponible en vertu de la <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, sauf indication contraire.

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -81,6 +81,8 @@ gd:
       what_doing: Cad atá á dhéanamh agat ?
       what_wrong: Cad a chuaigh mícheart?
       'yes': Sea
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Tá an t-ábhar go léir ar fáil faoi <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Oibriú saor in aisce v3.0</a>, mura luaitear a mhalairt

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -79,6 +79,8 @@ gu:
       what_doing: તમે શું કરી રહ્યા હતા?
       what_wrong: શું ગરબડ થઈ?
       'yes': હા
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© ક્રાઉન કૉપીરાઇટ</a>
       licence_html: તમામ સામગ્રી<a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license"> ઓપન ગવર્નમેંટ લાઇસન્સ v3.0</a>હેઠળ ઉપલબ્ધ છે, સિવાય કે અન્યથા જણાવેલ હોય

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -79,6 +79,8 @@ he:
       what_doing: מה אתה עושה?
       what_wrong: מה השתבש?
       'yes': כן
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: כל התוכן זמין תחת <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">פתוח רישיון ממשלתי v3.0</a>, אלא אם מצוין אחרת

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -79,6 +79,8 @@ hi:
       what_doing: आप क्या कर रहे थे?
       what_wrong: क्या गलत हुआ?
       'yes': हां
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© क्राउन कॉपीराइट</a>
       licence_html: सभी सामग्री <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">ओपन गवर्नमेंट लाइसेंस v3.0</a> के तहत उपलब्ध है, अन्यथा दर्शाए गए को छोड़कर

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -81,6 +81,8 @@ hr:
       what_doing: Šta ste radili?
       what_wrong: Što je pošlo po zlu?
       'yes': Da
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Sav sadržaj dostupan je pod <a class="govuk-footer__link"href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"rel="license">Otvorena Državna licenca v3.0</a>, osim ako nije drugačije navedeno

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -82,6 +82,8 @@ hu:
       what_doing: Mit csinált?
       what_wrong: Milyen hiba lépett fel?
       'yes': Igen
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Minden tartalom a <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Nyílt Közigazgatási Engedélyek v3.0</a> keretein belül elérhető, kivéve, ha ettől eltérő információ van feltüntetve

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -83,6 +83,8 @@ hy:
       what_doing: Ի՞նչ էիք փնտրում։
       what_wrong: Ի՞նչը խնդիր առաջացավ։
       'yes': Այո
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Ողջ բովանդակությունը հասանելի է <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0 հրապարակումների սերվերում</a>, բացառությամբ այլ դեպքերի

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -15,7 +15,6 @@ id:
       opendocument_html: File ini berformat <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation' target=%{target} class='govuk-link'>OpenDocument</a>
       order_a_copy: Pesan salinan
       page:
-        one: 1 halaman
         other: "%{count} halaman"
       reference: 'Ref: %{reference}'
       request_format_cta: Minta format yang dapat diakses.

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -80,6 +80,8 @@ id:
       what_doing: Apa yang Anda lakukan?
       what_wrong: Apa yang salah?
       'yes': Ya
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">Hak Cipta © Crown</a>
       licence_html: Semu konten tersedia sesuai <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Lisensi Terbuka Pemerintah v3.0</a>, kecuali dinyatakan berbeda

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -79,6 +79,8 @@ is:
       what_doing: Hvað varstu að gera?
       what_wrong: Hvað fór úrskeiðis?
       'yes': Já
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© höfunarréttur Krúnunnar</a>
       licence_html: Allt efni er aðgengilegt samkvæmt <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, nema annað sé tekið fram

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -79,6 +79,8 @@ it:
       what_doing: Cosa stavi facendo?
       what_wrong: Cosa è andato storto?
       'yes': Sì
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Tutto il contenuto è disponibile sotto la <a class=”govuk-footer__link” href=”https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/” rel=”license”>Open Government Licence v3.0</a>, tranne dove diversamente indicato

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -76,6 +76,8 @@ ja:
       what_doing: 何をしましたか？
       what_wrong: どのような不具合ですか？
       'yes': はい
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: 特に明記されていない限り、すべてのコンテンツは <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>でご利用いただけます。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,7 +15,6 @@ ja:
       opendocument_html: このファイルは、<a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation' target=%{target} class='govuk-link'>OpenDocument</a> 形式です
       order_a_copy: コピーを注文する
       page:
-        one: 1ページ
         other: "％{count}ページ"
       reference: 参照：%{reference}
       request_format_cta: アクセス可能なフォーマットをリクエストしてください。

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -82,6 +82,8 @@ ka:
       what_doing: რას აკეთებდით?
       what_wrong: რა მოხდა არასწორად?
       'yes': დიახ
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© გვირგვინის ქოფირაითი</a>
       licence_html: ყველა მასალა ხელმისაწვდომია <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, გარდა სხვა განცხადებებისა

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -79,6 +79,8 @@ kk:
       what_doing: Сіз не істеп жатыр едіңіз?
       what_wrong: Не дұрыс болмады?
       'yes': Иә
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown авторлық құқығы</a>
       licence_html: Барлық мазмұн <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Ашық мемлекеттік лицензиясы v3.0</a> (басқаша жазылғанды қоспағанда) сайтында қолжетімді

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -15,7 +15,6 @@ ko:
       opendocument_html:
       order_a_copy:
       page:
-        one:
         other:
       reference:
       request_format_cta:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -75,6 +75,8 @@ ko:
       what_doing:
       what_wrong:
       'yes':
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html:
       licence_html:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -84,6 +84,8 @@ lt:
       what_doing: Ką darėte?
       what_wrong: Kas nutiko?
       'yes': Taip
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Visą turinį rasite <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, nebent nurodyta kitaip

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -83,6 +83,8 @@ lv:
       what_doing: Ko jūs darījāt?
       what_wrong: Kādas problēmas radās?
       'yes': Jā
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Britu sadraudzības autortiesības</a>
       licence_html: Viss saturs, kas ir pieejams saskaņā ar <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">valsts izsniegto atklāto licenci v3.0</a>, izņemot, ja norādīts citādi

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -79,6 +79,8 @@ ms:
       what_doing: Apa yang anda buat?
       what_wrong: Apa yang salah?
       'yes': Ya
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Semua kandungan tersedia di bawah <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license"> Lesen Terbuka Kerajaan v3.0 </a>, kecuali jika dinyatakan sebaliknya

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -15,7 +15,6 @@ ms:
       opendocument_html: Fail ini terdapat dalam format <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation' target=%{target} class='govuk-link'>OpenDocument</a>
       order_a_copy: Pesan satu salinan
       page:
-        one: 1 halaman
         other: "%{count} halaman"
       reference: 'Ruj: %{reference}'
       request_format_cta: Minta format yang boleh diakses.

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -81,6 +81,8 @@ mt:
       what_doing: X'kont qed tagħmel?
       what_wrong: X'mar ħażin?
       'yes': Iva
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Il-kontenut huwa kollu disponibbli taħt <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Liċenzja ta' Gvern miftuħ v3.0</a>, except where otherwise stated

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -79,6 +79,8 @@ nl:
       what_doing: Wat was u aan het doen?
       what_wrong: Wat ging er mis?
       'yes': Ja
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Alle inhoud is beschikbaar onder de <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Overheidslicentie v3.0</a>, behalve waar anders vermeld

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -79,6 +79,8 @@
       what_doing: Hva gjorde du?
       what_wrong: Hva gikk galt?
       'yes': Ja
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Alt innhold er tilgjengelig under<a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, med mindre annet er angitt

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -75,6 +75,8 @@ pa-pk:
       what_doing: تُسی کیہ کر رئے سو
       what_wrong: کیہ غلط ہویا اے
       'yes': جی ہاں
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/ information-management/re-using-public-sector-information/copyright-and-re-use/ /crown-copyright/">© کاپی کراؤن رائٹ</a>
       licence_html: سارا مواد ایندے تھلے موجود اے <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">اوپن گورنمنٹ لائسنس v3.0</a>, ایہ قبول کر لو جیڑا ایس توں علاوہ اے

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -79,6 +79,8 @@ pa:
       what_doing: ਤੁਸੀਂ ਕੀ ਕਰ ਰਹੇ ਸੀ?
       what_wrong: ਕੀ ਗਲਤ ਹੋਇਆ?
       'yes': ਹਾਂ
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© ਕ੍ਰਾਊਨ ਕਾਪੀਰਾਈਟ</a>
       licence_html: ਸਾਰੀ ਸਮਗਰੀ <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">ਓਪਨ ਗਵਰਨਮੈਂਟ ਲਾਇਸੈਂਸ v3.0</a>, ਦੇ ਅਧੀਨ ਸਾਰੀ ਸਮਗਰੀ ਉਪਲਬਧ ਹੈ ਸਿਵਾਏ ਇਸਦੇ ਜਿੱਥੇ ਹੋਰ ਨਹੀਂ ਕਿਹਾ ਗਿਆ ਹੈ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -83,6 +83,8 @@ pl:
       what_doing: Co robiłeś?
       what_wrong: Co poszło nie tak?
       'yes': Tak
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Właścicielem praw autorskich jest Korona</a>
       licence_html: Cała zawartość objęta jest licencją <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, chyba że zaznaczono inaczej

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -76,6 +76,8 @@ ps:
       what_doing: ته څه کوې؟
       what_wrong: څه غلط شول؟
       'yes': هو
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class = "govuk-footer__link govuk-footer__copyright-logo" href = "http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use /crown-copyright/"> rown د تاج کاپي حق </a>
       licence_html: ټول مینځپانګه د <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license"> لاندې خلاصې دي د حکومت جواز v3.0 </a> ، پرته لدې چیرې چې بل ډول ویل شوي

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -79,6 +79,8 @@ pt:
       what_doing: O que estava a fazer?
       what_wrong: O que correu mal?
       'yes': Sim
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Direitos de autor da Coroa</a>
       licence_html: Todo o conteúdo está disponível ao abrigo da <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, exceto quando indicado em contrário

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -80,6 +80,8 @@ ro:
       what_doing: Ce făceați?
       what_wrong: Ce eroare a survenit?
       'yes': Da
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Tot conținutul este disponibil conform <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, cu excepția cazurilor în care s-a specificat altceva

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -83,6 +83,8 @@ ru:
       what_doing: Что вы делали?
       what_wrong: Что пошло не так?
       'yes': Да
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Авторское право Британского содружества наций</a>
       licence_html: Все содержимое доступно на <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license"> Открытой государственной лицензии v3.0</a>, если не указано иное

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -79,6 +79,8 @@ si:
       what_doing: ඔබ කුමක් ද කරමින් සිටියේ?
       what_wrong: වැරදුණේ කුමක්ද?
       'yes': ඔව්
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© රාජ්‍ය කතුහිමිකම</a>
       licence_html: සියලු අන්තගතයන් වෙනත් ආකාරයකින් සඳහන් කර තිබුණොත් මිසක <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">රජයේ විවෘත බලපත්‍ර v3.0</a>, යටතේ ලබා ගත හැකිය

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -84,6 +84,8 @@ sk:
       what_doing: Čo ste robili?
       what_wrong: Čo sa pokazilo?
       'yes': Áno
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Korunné autorské práva</a>
       licence_html: Všetok obsah je k dispozícii pod <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">licenciou Open Government Licence v3.0</a>, okrem prípadov, keď je uvedené inak

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -86,6 +86,8 @@ sl:
       what_doing: Kaj ste počeli?
       what_wrong: Kaj je šlo narobe?
       'yes': Da
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govnu-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Avtorske pravice krone</a>
       licence_html: Vsa vsebina je na voljo na <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Odprto vladno dovoljenje v3.0</a>, razen kjer je zapisano drugače

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -79,6 +79,8 @@ so:
       what_doing: Maxaad doonaysaa inuu laguu qabto?
       what_wrong: Maxaa qaldamay?
       'yes': Haa
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Dhamaan qaybaha waxa laga heli karaa <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -79,6 +79,8 @@ sq:
       what_doing: Cfare po bënit?
       what_wrong: Çfarë shkoi keq?
       'yes': Po
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown e drejta e autorit</a>
       licence_html: E gjithë përmbajtja është në dispozicion nën <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Licencën e Qeverisë së Hapur v3.0</a>, përveç rasteve kur thuhet ndryshe

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -16,7 +16,6 @@ sr:
       order_a_copy: Zatražite primerak
       page:
         few:
-        many:
         one: 1 stranica
         other: "%{count} str."
       reference: 'Ref: %{reference}'

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -81,6 +81,8 @@ sr:
       what_doing: Šta ste radili?
       what_wrong: Koji problem se javio?
       'yes': Da
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Sav sadržaj je dostupan pod licencom <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, izuzev ako je drugačije naznačeno

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -79,6 +79,8 @@ sv:
       what_doing: Vad gjorde du?
       what_wrong: Vad gick fel?
       'yes': Ja
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Allt innehåll är tillgängligt enligt <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, om inget annat anges

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -79,6 +79,8 @@ sw:
       what_doing: Ulikuwa unafanya nini?
       what_wrong: Tatizo lipi lililotokea?
       'yes': Ndiyo
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Hakimiliki ya Crown</a>
       licence_html: Maudhui yote yanapatikana chini ya <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, isipokuwa ibainishwe vinginevyo

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -80,6 +80,8 @@ ta:
       what_doing: நீங்கள் என்ன செய்து கொண்டிருந்தீர்கள்?
       what_wrong: என்ன தவறு நடந்தது?
       'yes': ஆம்
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown காப்புரிமை</a>
       licence_html: வேறுவகையில் குறிப்பிடப்படாதவரை அனைத்து உள்ளடக்கமும் <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>-ன்கீழ் கிடைக்கிறது.

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -15,7 +15,6 @@ th:
       opendocument_html: ไฟล์นี้อยู่ในรูปแบบ <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation' target=%{target} class='govuk-link'>OpenDocument</a>
       order_a_copy: สั่งซื้อสำเนา
       page:
-        one: 1 หน้า
         other: "%{count} หน้า"
       reference: 'อ้างอิง: %{reference}'
       request_format_cta: ขอรูปแบบไฟล์ที่สามารถเข้าถึงได้

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -78,6 +78,8 @@ th:
       what_doing: คุณทำอะไรอยู่ในขณะนั้น
       what_wrong: มีสิ่งใดผิดปกติ
       'yes': ใช่
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">ลิขสิทธิ์ © Crown</a>
       licence_html: เนื้อหาทั้งหมดอยู่ภายใต้สัญญาอนุญาต <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government License v3.0</a> ยกเว้นจะระบุไว้เป็นอย่างอื่น

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -80,6 +80,8 @@ tk:
       what_doing: Näme edýärdiňiz?
       what_wrong: Näme nädogry boldy?
       'yes': Hawa
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown awtorlyk hukugy</a>
       licence_html: Ähli mazmun <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Açyk hökümet ygtyýarnamasy v3.0-da görkezilen</a>, eger başgaça bellenilmedik bolsa

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -80,6 +80,8 @@ tr:
       what_doing: Ne yapmaktaydınız?
       what_wrong: Nasıl bir sorun oldu?
       'yes': Evet
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Aksi ifade edilmedikçe tüm içeriğe <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a> adresinden erişilebilir

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -86,6 +86,8 @@ uk:
       what_doing: Що ви робили?
       what_wrong: Що пішло не так?
       'yes': Так
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: Весь вміст доступний за <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Відкритою державною ліцензією v3.0</a>, якщо не зазначено інше

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -76,6 +76,8 @@ ur:
       what_doing: آپ کیا کر رہے تھے؟
       what_wrong: کیا غلط ہوا؟
       'yes': جی ہاں
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown کاپی رائٹ</a>
       licence_html: سوائے ان کے جنہیں بصورت دیگر بیان کیا گیا ہے، <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a> کے تحت تمام مواد دستیاب ہے

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -81,6 +81,8 @@ uz:
       what_doing: Сиз нима қилаётган эдингиз?
       what_wrong: Қандай хатолик бўлди?
       'yes': Ҳа
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Британия миллатлар ҳамдўстлигининг муаллифлик ҳуқуқи</a>
       licence_html: Бутун таркиб <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">“Очиқ давлат лицензияси, версия 3.0” дастурида эришимли</a>, агар бошқаси кўрсатилмаган бўлса

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -79,6 +79,8 @@ vi:
       what_doing: Bạn đang làm gì?
       what_wrong: Sự cố gì đã xảy ra?
       'yes': Có
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Bản quyền Crown</a>
       licence_html: Tất cả nội dung đều có sẵn theo <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Giấy phép Chính phủ Mở pb3.0</a>, trừ khi có quy định khác

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -15,7 +15,6 @@ vi:
       opendocument_html: Tệp này có định dạng <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation' target=%{target} class='govuk-link'>OpenDocument</a>
       order_a_copy: Đặt hàng một bản sao
       page:
-        one: 1 trang
         other: "%{count} trang"
       reference: 'Tham khảo: %{reference}'
       request_format_cta: Yêu cầu một định dạng có thể truy cập.

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -78,6 +78,8 @@ zh-hk:
       what_doing: 您剛才在做什麼？
       what_wrong: 出現什麼錯誤？
       'yes': 是
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown 版權所有</a>
       licence_html: 除另有說明者外，所有內容均可在 <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>獲取。

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -15,7 +15,6 @@ zh-hk:
       opendocument_html: 此文檔為 <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation' target=%{target} class='govuk-link'>OpenDocument</a> 格式
       order_a_copy: 索取副本
       page:
-        one: 1 頁
         other: "%{count} 頁"
       reference: 'Ref: %{reference}'
       request_format_cta: 索取可讀取之格式。

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -78,6 +78,8 @@ zh-tw:
       what_doing: 你做了什麼？
       what_wrong: 哪出錯了？
       'yes': 是的
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
       licence_html: 所有內容都具 <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">英國政府開放授權v3.0</a>，除非另有說明

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -15,7 +15,6 @@ zh-tw:
       opendocument_html: 本檔案於 <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation' target=%{target} class='govuk-link'>開放文件</a> 格式
       order_a_copy: 預定副本
       page:
-        one: 一頁
         other: "%{count} 頁面"
       reference: 參考：%{reference}
       request_format_cta: 請求可參閱格式。

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -15,7 +15,6 @@ zh:
       opendocument_html: 本文件是 <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation' target=%{target} class='govuk-link'>开放式文本</a> 格式
       order_a_copy: 订购副本
       page:
-        one: 1页
         other: "%{count} 页"
       reference: 参考号：%{reference}
       request_format_cta: 申请可访问格式。

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -78,6 +78,8 @@ zh:
       what_doing: 您在干什么？
       what_wrong: 发生了哪些错误？
       'yes': 是
+    intervention:
+      accessible_link_text_suffix:
     layout_footer:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown版权所有</a>
       licence_html: 除另有说明外，所有内容均可在 <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">开放政府许可证第3.0版</a>获取

--- a/spec/lib/locales_validation_spec.rb
+++ b/spec/lib/locales_validation_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+require "rails_translation_manager"
+
+RSpec.describe "locales files" do
+  it "should meet all locale validation requirements" do
+    checker = RailsTranslationManager::LocaleChecker.new("config/locales/*.yml")
+    expect(checker.validate_locales).to be_truthy
+  end
+end


### PR DESCRIPTION
Uses Rails Translation Manager to validate consistency of locale files.

https://trello.com/c/J5bhmwTN/2830-apply-locale-file-validation-to-govuk-publishing-components
