### PR TITLE
Share icons line-height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Change JavaScript modules from start to init ([PR #2605](https://github.com/alphagov/govuk_publishing_components/pull/2605))
+* Share icons line-height ([PR #2602](https://github.com/alphagov/govuk_publishing_components/pull/2602))
 
 ## 28.5.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -12,11 +12,11 @@ $share-button-height: 30px;
   position: relative;
   display: inline-block;
   min-height: $share-button-height;
+  padding-top: govuk-spacing(1);
   padding-left: ($share-button-width + govuk-spacing(2));
   padding-right: govuk-spacing(2);
   margin-bottom: govuk-spacing(2);
   font-size: $share-button-height / 2;
-  line-height: $share-button-height;
 }
 
 .gem-c-share-links__link {

--- a/app/views/govuk_publishing_components/components/docs/share_links.yml
+++ b/app/views/govuk_publishing_components/components/docs/share_links.yml
@@ -125,7 +125,7 @@ examples:
         },
         {
           href: '/email-share-link',
-          text: 'Share on email to someone you know',
+          text: 'Email',
           icon: 'email'
         },
         {


### PR DESCRIPTION
## What

Update line-height of share icons text _"Share on email to someone you know"_

## Why

Visual correction [noted from this PR](https://github.com/alphagov/govuk_publishing_components/pull/2567)

## Visual Changes

Before > After

![Screenshot 2022-02-01 at 18 43 29](https://user-images.githubusercontent.com/71266765/152031159-c92a6c0d-5872-4622-b44c-5638e65447f2.png)

![Screenshot 2022-02-01 at 18 38 06](https://user-images.githubusercontent.com/71266765/152030944-62d9cddb-d9a3-46b3-bccc-635f053d6ead.png)

## Anything else?
Content update - "Share on email to someone you know" updated to "Email"

