### PR TITLE
Update select.yml

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/select.yml
+++ b/app/views/govuk_publishing_components/components/docs/select.yml
@@ -47,7 +47,7 @@ examples:
     data:
       id: 'dropdown2-1'
       label: 'Choose your preferred thing'
-      hint_text: 'You might need some more information here'
+      hint: 'You might need some more information here'
       hint_id: 'optional-hint-id'
       options:
       - text: 'Something'


### PR DESCRIPTION
## What
Prior to this change, the documentation for the select component suggests passing a parameter called `hint_text`,
however it looks that this should actually be `hint`. Comment on hint_text vs hint on original PR:
https://github.com/alphagov/govuk_publishing_components/pull/2594#discussion_r795723822

## Why
<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before


### After
