### PR TITLE
Add margin top and bottom option to inset text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add margin top and margin bottom to inset text ([PR #2616](https://github.com/alphagov/govuk_publishing_components/pull/2616))
 * Bump `govuk-frontend` from 3.14.0 to 4.0.0 ([PR #2355](https://github.com/alphagov/govuk_publishing_components/pull/2533))
 * Change JavaScript modules from start to init ([PR #2605](https://github.com/alphagov/govuk_publishing_components/pull/2605))
 * Share icons line-height ([PR #2602](https://github.com/alphagov/govuk_publishing_components/pull/2602))

--- a/app/views/govuk_publishing_components/components/_inset_text.html.erb
+++ b/app/views/govuk_publishing_components/components/_inset_text.html.erb
@@ -1,7 +1,18 @@
 <%
   id ||= "inset-text-#{SecureRandom.hex(4)}"
+  margin_top ||= 6
+  margin_bottom ||= 6
+
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({
+    margin_top: margin_top,
+    margin_bottom: margin_bottom
+  })
+
+  classes = %w[gem-c-inset-text govuk-inset-text]
+  classes << shared_helper.get_margin_top
+  classes << shared_helper.get_margin_bottom
 %>
-<%= tag.div id: id, class: "gem-c-inset-text govuk-inset-text" do %>
+<%= tag.div id: id, class: classes do %>
   <% if defined? text %>
     <%= text %>
   <% elsif block_given? %>

--- a/app/views/govuk_publishing_components/components/docs/inset_text.yml
+++ b/app/views/govuk_publishing_components/components/docs/inset_text.yml
@@ -18,3 +18,9 @@ examples:
           <h2 class="govuk-heading-m" id='heading'>To publish this step by step you need to</h2>
           <a class="govuk-link" href='/foo'>Check for broken links</a>
         </div>
+  with_custom_margins:
+    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having margin of 6 (30px) top and bottom.
+    data:
+      text: "When a failure occurs, you must submit logbook, landing and transhipment data manually to the UK Fisheries Call Centre each day and by no later than 23.59 UTC"
+      margin_top: 0
+      margin_bottom: 9

--- a/spec/components/inset_text_spec.rb
+++ b/spec/components/inset_text_spec.rb
@@ -8,7 +8,7 @@ describe "Inset text", type: :view do
   it "renders inset text" do
     render_component(text: "It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.")
 
-    assert_select(".govuk-inset-text", text: "It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.")
+    assert_select(".govuk-inset-text.govuk-\\!-margin-top-6.govuk-\\!-margin-bottom-6", text: "It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.")
   end
 
   it "renders a block" do
@@ -28,5 +28,15 @@ describe "Inset text", type: :view do
 
     assert_select(".govuk-inset-text", text: "Bar")
     assert_select(".govuk-inset-text p#foo", false, "Block should not have rendered")
+  end
+
+  it "applies custom margin bottom and top" do
+    render_component(
+      text: "margin!",
+      margin_top: 0,
+      margin_bottom: 9,
+    )
+
+    assert_select(".govuk-inset-text.govuk-\\!-margin-top-0.govuk-\\!-margin-bottom-9", text: "margin!")
   end
 end


### PR DESCRIPTION
## What
Adds options to control the margin top and bottom for the inset text component. Previously both were hard coded as 30px.

## Why
Need some more flexibility when using it in smart-answers.

## Visual Changes

![Screenshot 2022-02-11 at 14 18 53](https://user-images.githubusercontent.com/861310/153608040-db34d158-3aa1-45ef-a077-a649fb502b7b.png)

Trello card: https://trello.com/c/LUeE9FAO/641-product-team-template-card