### PR TITLE
Pin rails to 6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       govuk_personalisation (>= 0.7.0)
       kramdown
       plek
-      rails (>= 6)
+      rails (~> 6)
       rouge
       sprockets (< 4)
 
@@ -101,7 +101,7 @@ GEM
     execjs (2.8.1)
     faker (2.19.0)
       i18n (>= 1.6, < 2)
-    faraday (2.1.0)
+    faraday (2.2.0)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.1)
@@ -121,9 +121,9 @@ GEM
       sentry-ruby (~> 4.5.0)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
-    govuk_personalisation (0.11.1)
+    govuk_personalisation (0.11.2)
       plek (>= 1.9.0)
-      rails (~> 6)
+      rails (>= 6, < 8)
     govuk_schemas (4.3.0)
       json-schema (~> 2.8.0)
     govuk_test (2.3.0)
@@ -255,7 +255,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.5)
-    rouge (3.27.0)
+    rouge (3.28.0)
     rspec-core (3.10.2)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.2)

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "govuk_personalisation", ">= 0.7.0"
   s.add_dependency "kramdown"
   s.add_dependency "plek"
-  s.add_dependency "rails", ">= 6"
+  s.add_dependency "rails", "~> 6"
   s.add_dependency "rouge"
   s.add_dependency "sprockets", "< 4"
 


### PR DESCRIPTION
## What
Pin rails to ~6

## Why
Jenkins fails consistently on any current or old branch when testing with ruby 2.7 – the only workaround I could find after a day of investigations is to pin rails to 6 (as 7 seems to be causing the issue), so I'm proposing  this to unblock current work
