### PR TITLE
Update summary list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## 28.9.0
 
 * Add 'Invasion of Ukraine' CTA to pages tagged to the topical event ([PR #2657](https://github.com/alphagov/govuk_publishing_components/pull/2657))
+* Update summary list ([PR #2622](https://github.com/alphagov/govuk_publishing_components/pull/2622))
 
 ## 28.8.1
 

--- a/app/views/govuk_publishing_components/components/_summary_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_summary_list.html.erb
@@ -32,12 +32,10 @@
 
       <% if delete.any? %>
         <% delete_main_link = capture do %>
-          <%
-            delete_section_link_text = delete[:link_text] || t("components.summary_list.delete")
-          %>
+          <% delete_section_link_text = delete[:link_text] || t("components.summary_list.delete") %>
           <%= link_to delete.fetch(:href),
-                    class: "govuk-link gem-link--destructive",
-                    data: delete.fetch(:data_attributes, {}) do %>
+                class: "govuk-link gem-link--destructive",
+                data: delete.fetch(:data_attributes, {}) do %>
             <%= delete_section_link_text %><%= tag.span " #{title}", class: "govuk-visually-hidden" unless delete[:link_text_no_enhance] -%>
           <% end %>
         <% end %>
@@ -62,39 +60,46 @@
           <%= delete_main_link %>
         <% end %>
       <% end %>
-
     <% end %>
 
+    <% any_body_actions = items.detect { |item| item.has_key?("edit") || item.has_key?("delete") } %>
     <% if items.any? %>
       <%= tag.dl class: "govuk-summary-list" do %>
         <% items.each do |item| %>
-          <%= tag.div class: "govuk-summary-list__row" do %>
+          <%
+            item_body_actions = (item.fetch(:edit, {}).any? || item.fetch(:delete, {}).any?)
+
+            if any_body_actions.present? && !item_body_actions.present?
+              classes = "govuk-summary-list__row govuk-summary-list__row--no-actions"
+            else
+              classes = "govuk-summary-list__row"
+            end
+          %>
+          <%= tag.div class: classes do %>
 
             <%= tag.dt item[:field], class: "govuk-summary-list__key" %>
             <%= tag.dd item[:value], class: "govuk-summary-list__value" %>
 
             <% if item.fetch(:edit, {}).any? %>
               <% edit_link = capture do %>
-                <%
-                  edit_link_text = item[:edit][:link_text] || t("components.summary_list.edit")
-                %>
+                <% edit_link_text = item[:edit][:link_text] || t("components.summary_list.edit") %>
                 <%= link_to item[:edit].fetch(:href),
-                            class: "govuk-link",
-                            data: item[:edit].fetch(:data_attributes, {}) do %>
-                  <%= edit_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" unless item[:edit][:link_text_no_enhance] -%>
+                  class: "govuk-link",
+                  data: item[:edit].fetch(:data_attributes, {}) do %>
+                  <%= edit_link_text %>
+                  <%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" unless item[:edit][:link_text_no_enhance] -%>
                 <% end %>
               <% end %>
             <% end %>
 
             <% if item.fetch(:delete, {}).any? %>
               <% delete_link = capture do %>
-                <%
-                  delete_link_text = item[:delete][:link_text] || t("components.summary_list.delete")
-                %>
+                <% delete_link_text = item[:delete][:link_text] || t("components.summary_list.delete") %>
                 <%= link_to item[:delete].fetch(:href),
-                            class: "govuk-link gem-link--destructive",
-                            data: item[:delete].fetch(:data_attributes, {}) do %>
-                  <%= delete_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" unless item[:delete][:link_text_no_enhance] -%>
+                      class: "govuk-link gem-link--destructive",
+                      data: item[:delete].fetch(:data_attributes, {}) do %>
+                  <%= delete_link_text %>
+                  <%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" unless item[:delete][:link_text_no_enhance] -%>
                 <% end %>
               <% end %>
             <% end %>
@@ -115,17 +120,17 @@
                 <% end %>
               <% end %>
             <% else %>
+            <% if edit_link || delete_link %>
               <%= tag.dd class: "govuk-summary-list__actions" do %>
                 <%= edit_link %>
                 <%= delete_link %>
               <% end %>
             <% end %>
-
           <% end %>
         <% end %>
       <% end %>
     <% end %>
-
-    <%= tag.div block, class: "gem-c-summary__block" if block %>
   <% end %>
+    <%= tag.div block, class: "gem-c-summary__block" if block %>
+    <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/summary_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/summary_list.yml
@@ -1,6 +1,6 @@
 name: Summary list
 description: Use the summary list to summarise information, for example, a user’s responses at the end of a form.
-body:  This component extends the [Summary list component in the Design System](https://design-system.service.gov.uk/components/summary-list/) allowing the rendering of multiple groups of lists, and actions at the group level.
+body:  This component extends the [Summary list component in the GOV.UK Design System](https://design-system.service.gov.uk/components/summary-list/) allowing the rendering of multiple groups of lists, and actions at the group level.
 accessibility_criteria: |
   Action links in the component must:
 
@@ -102,18 +102,13 @@ examples:
       heading_level: 2
       heading_size: l
 
-  with_edit_on_individual_items:
+  with_edit_on_some_individual_items:
     description: For all links shown in the component, see the <a href="/component-guide/summary_list/with_customised_links">with customised links example</a> for guidance.
     data:
       title: "Title, summary and body"
       items:
       - field: "Title"
         value: "Ethical standards for public service providers"
-        edit:
-          href: "edit-title"
-          text: "Edit"
-          data_attributes:
-            gtm: "edit-title"
       - field: "Summary"
         value: "Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication."
         edit:

--- a/spec/components/summary_list_spec.rb
+++ b/spec/components/summary_list_spec.rb
@@ -102,7 +102,7 @@ describe "Summary list", type: :view do
     )
     assert_select ".govuk-summary-list__key", text: "Title"
     assert_select ".govuk-summary-list__value", text: "Ethical standards for public service providers"
-    assert_select 'dd.govuk-summary-list__actions .govuk-link[href="#edit-title"][data-gtm="edit-title"]', text: "Change Title"
+    assert_select 'dd.govuk-summary-list__actions .govuk-link[href="#edit-title"][data-gtm="edit-title"]', text: /Change\s*Title\s*/
   end
 
   it "renders items with only the delete action" do
@@ -122,7 +122,7 @@ describe "Summary list", type: :view do
     )
     assert_select ".govuk-summary-list__key", text: "Title"
     assert_select ".govuk-summary-list__value", text: "Ethical standards for public service providers"
-    assert_select 'dd.govuk-summary-list__actions .govuk-link.gem-link--destructive[href="#delete-title"][data-gtm="delete-title"]', text: "Delete Title"
+    assert_select 'dd.govuk-summary-list__actions .govuk-link.gem-link--destructive[href="#delete-title"][data-gtm="delete-title"]', text: /\s*Delete\s*Title\s*/
   end
 
   it "renders items with both the edit and the delete action" do
@@ -142,8 +142,8 @@ describe "Summary list", type: :view do
     )
     assert_select ".govuk-summary-list__key", text: "Title"
     assert_select ".govuk-summary-list__value", text: "Ethical standards for public service providers"
-    assert_select 'li.govuk-summary-list__actions-list-item .govuk-link[href="#edit-title"]', text: "Change Title"
-    assert_select 'li.govuk-summary-list__actions-list-item .govuk-link.gem-link--destructive[href="#delete-title"]', text: "Delete Title"
+    assert_select 'li.govuk-summary-list__actions-list-item .govuk-link[href="#edit-title"]', text: /\s*Change\s*Title\s*/
+    assert_select 'li.govuk-summary-list__actions-list-item .govuk-link.gem-link--destructive[href="#delete-title"]', text: /\s*Delete\s*Title\s*/
   end
 
   it "renders items with custom text for edit and delete action" do
@@ -163,8 +163,8 @@ describe "Summary list", type: :view do
         },
       ],
     )
-    assert_select '.govuk-summary-list__actions-list-item .govuk-link[href="#edit-title"]', text: "Edit Title"
-    assert_select '.govuk-summary-list__actions-list-item .govuk-link.gem-link--destructive[href="#delete-title"]', text: "Remove Title"
+    assert_select '.govuk-summary-list__actions-list-item .govuk-link[href="#edit-title"]', text: /\s*Edit\s*Title\s*/
+    assert_select '.govuk-summary-list__actions-list-item .govuk-link.gem-link--destructive[href="#delete-title"]', text: /\s*Remove\s*Title\s*/
   end
 
   it "renders the edit action on section" do
@@ -180,7 +180,7 @@ describe "Summary list", type: :view do
         href: "edit-title",
       },
     )
-    assert_select 'div.govuk-summary-list__actions-list .govuk-link[href="edit-title"]', text: "Change Title"
+    assert_select 'div.govuk-summary-list__actions-list .govuk-link[href="edit-title"]', text: /\s*Change\s*Title\s*/
   end
 
   it "renders the delete action on section" do
@@ -196,7 +196,7 @@ describe "Summary list", type: :view do
         href: "delete-title",
       },
     )
-    assert_select 'div.govuk-summary-list__actions-list .govuk-link[href="delete-title"]', text: "Delete Title"
+    assert_select 'div.govuk-summary-list__actions-list .govuk-link[href="delete-title"]', text: /\s*Delete\s*Title\s*/
   end
 
   it "renders the edit and delete actions on section" do
@@ -221,8 +221,8 @@ describe "Summary list", type: :view do
         },
       },
     )
-    assert_select 'ul.govuk-summary-list__actions-list .govuk-summary-list__actions-list-item .govuk-link[href="edit-title"][data-gtm="edit-title"]', text: "Change Title"
-    assert_select 'ul.govuk-summary-list__actions-list .govuk-summary-list__actions-list-item .govuk-link[href="delete-title"][data-gtm="delete-title"]', text: "Delete Title"
+    assert_select 'ul.govuk-summary-list__actions-list .govuk-summary-list__actions-list-item .govuk-link[href="edit-title"][data-gtm="edit-title"]', text: /\s*Change\s*Title\s*/
+    assert_select 'ul.govuk-summary-list__actions-list .govuk-summary-list__actions-list-item .govuk-link[href="delete-title"][data-gtm="delete-title"]', text: /\s*Delete\s*Title\s*/
   end
 
   it "renders the edit and delete actions on section with custom text" do
@@ -243,8 +243,8 @@ describe "Summary list", type: :view do
         link_text: "Destroy",
       },
     )
-    assert_select 'ul.govuk-summary-list__actions-list .govuk-summary-list__actions-list-item .govuk-link[href="edit-title"]', text: "Edit Title"
-    assert_select 'ul.govuk-summary-list__actions-list .govuk-summary-list__actions-list-item .govuk-link[href="delete-title"]', text: "Destroy Title"
+    assert_select 'ul.govuk-summary-list__actions-list .govuk-summary-list__actions-list-item .govuk-link[href="edit-title"]', text: /\s*Edit\s*Title\s*/
+    assert_select 'ul.govuk-summary-list__actions-list .govuk-summary-list__actions-list-item .govuk-link[href="delete-title"]', text: /\s*Destroy\s*Title\s*/
   end
 
   it "renders all links without visually hidden extra text if specified" do
@@ -283,14 +283,14 @@ describe "Summary list", type: :view do
         },
       ],
     )
-    assert_select '.govuk-summary-list__actions-list .govuk-link[href="edit-something"]', text: "Change"
-    assert_select '.govuk-summary-list__actions-list .govuk-link[href="delete-something"]', text: "Delete"
+    assert_select '.govuk-summary-list__actions-list .govuk-link[href="edit-something"]', text: /\s*Change\s*/
+    assert_select '.govuk-summary-list__actions-list .govuk-link[href="delete-something"]', text: /\s*Delete\s*/
 
-    assert_select '.govuk-summary-list__row .govuk-summary-list__actions .govuk-link[href="#edit-item-1-title"]', text: "Change"
-    assert_select '.govuk-summary-list__row .govuk-summary-list__actions .govuk-link.gem-link--destructive[href="#delete-item-1-title"]', text: "Delete"
+    assert_select '.govuk-summary-list__row .govuk-summary-list__actions .govuk-link[href="#edit-item-1-title"]', text: /\s*Change\s*/
+    assert_select '.govuk-summary-list__row .govuk-summary-list__actions .govuk-link.gem-link--destructive[href="#delete-item-1-title"]', text: /\s*Delete\s*/
 
-    assert_select '.govuk-summary-list__row .govuk-summary-list__actions .govuk-link[href="#edit-item-2-title"]', text: "Change Item 2"
-    assert_select '.govuk-summary-list__row .govuk-summary-list__actions .govuk-link.gem-link--destructive[href="#delete-item-2-title"]', text: "Delete Item 2"
+    assert_select '.govuk-summary-list__row .govuk-summary-list__actions .govuk-link[href="#edit-item-2-title"]', text: /\s*Change\s*Item\s*2\s*/
+    assert_select '.govuk-summary-list__row .govuk-summary-list__actions .govuk-link.gem-link--destructive[href="#delete-item-2-title"]', text: /\s*Delete\s*Item\s*2\s*/
   end
 
   it "renders the wider dt layout" do


### PR DESCRIPTION
## What

Update [`summary_list`](https://components.publishing.service.gov.uk/component-guide/summary_list) - adds a modifier class of `--no-actions` to empty rows only when there is a mix of rows with and without actions

## Why

[Prompted from 4.0 update](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md#update-the-html-for-summary-lists), some rows within `summary_list` have an "action" that include links like "`change`, `edit`"  

Only applies 

> if you have a mix of rows with and without actions, add the govuk-summary-list__row--no-actions modifier class to the rows without actions

Inline with Design System / [GOVUK Frontend 4.0 update](https://github.com/alphagov/govuk_publishing_components/pull/2533)

> If you're not using Nunjucks macros, do not include an empty <span class="govuk-summary-list__actions"></span> in rows without actions. Instead, add the govuk-summary-list__row--no-actions modifier class to the row.

## Visual Changes

Previously when a column had "no actions" the column would still be present but would be empty.  This updates removes this `<dd class="govuk-summary-list__actions"></dd>` as the `:after` pseudo element that `no-actions` adds replicates this from a visual standpoint. This also allows Content to span the full container.

![screen shot of the summary list before and after "govuk-summary-list__actions" being removed, the content spans the width of the container](https://user-images.githubusercontent.com/71266765/156049368-8a9f75cc-8851-41b1-ad28-3a07b321f390.png)

When there is mixed actions, the "column" is restored visually: 

![image](https://user-images.githubusercontent.com/71266765/156624341-36b52755-12ca-4db3-bb6a-1727f4c2b388.png)

## Anything else

`govuk_publishing_components`  builds on the [GOVUK Design System](https://design-system.service.gov.uk/components/summary-list/) by adding `gem-c-summary-list__group-title` which adds a heading above the summary list in certain contexts that also can contain an action.  Should this be present the `summary_list` will still extend the full width.

![image](https://user-images.githubusercontent.com/71266765/156624630-8394034c-8b86-4c5c-8559-683920036c86.png)


Design System version of `summary_list`
https://design-system.service.gov.uk/components/summary-list/mixed-actions/index.html

[4.0.1](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md) (already merged) also has a fix that impacts this