### PR TITLE
Clear DOM remnants after FilterComponentsSpec

### DIFF
--- a/spec/javascripts/govuk_publishing_components/FilterComponentsSpec.js
+++ b/spec/javascripts/govuk_publishing_components/FilterComponentsSpec.js
@@ -2,19 +2,20 @@
 
 var FilterComponents = window.GOVUK.FilterComponents
 
+var form, list
+
 function addFormInput () {
-  var form = document.createElement('form')
+  form = document.createElement('form')
   form.setAttribute('data-module', 'filter-components')
   document.body.appendChild(form)
 };
 
 function removeFormInput () {
-  var form = document.querySelector('form')
   document.body.removeChild(form)
 }
 
 function addComponents () {
-  var list = document.createElement('ul')
+  list = document.createElement('ul')
   list.classList.add('component-list')
 
   // Set up accordion component
@@ -43,6 +44,10 @@ function addComponents () {
   document.body.appendChild(list)
 };
 
+function removeComponents () {
+  document.body.removeChild(list)
+}
+
 describe('FilterComponents', function () {
   beforeAll(function () {
     addFormInput()
@@ -51,6 +56,7 @@ describe('FilterComponents', function () {
 
   afterAll(function () {
     removeFormInput()
+    removeComponents()
   })
 
   it('hides all components that do not match search criteria', function () {


### PR DESCRIPTION
## What
Clear DOM remnants after `FilterComponentsSpec`

## Why
We clear the search input after this test suite, but not the generate list of components, leaving a few DOM elements behind which can potentially interfere with other tests.

## Visual Changes

### Before
<img width="864" alt="Screenshot 2022-02-14 at 17 56 22" src="https://user-images.githubusercontent.com/788096/153920027-d3414126-3d84-4958-bcd5-ef5dba16a584.png">


### After
<img width="864" alt="Screenshot 2022-02-14 at 17 56 47" src="https://user-images.githubusercontent.com/788096/153920052-9469ab7f-45ae-433f-ac4c-98803a68f927.png">

