### PR TITLE
Add cards component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## 28.8.0
 
+* Add cards component ([PR #2624](https://github.com/alphagov/govuk_publishing_components/pull/2624))
 * Allow attachments to display link to accessible format request form [PR #2636](https://github.com/alphagov/govuk_publishing_components/pull/2636)
 * Improve custom dimensions code ([PR #2646](https://github.com/alphagov/govuk_publishing_components/pull/2646))
 * Increase font size on Attachment ([PR #2650](https://github.com/alphagov/govuk_publishing_components/pull/2650))

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components.scss
@@ -19,6 +19,7 @@ $govuk-new-link-styles: true;
 @import "components/big-number";
 @import "components/breadcrumbs";
 @import "components/button";
+@import "components/cards";
 @import "components/character-count";
 @import "components/checkboxes";
 @import "components/contents-list";

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -5,6 +5,7 @@
 
 @import "components/print/accordion";
 @import "components/print/button";
+@import "components/print/cards";
 @import "components/print/contents-list";
 @import "components/print/govspeak-html-publication";
 @import "components/print/govspeak";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -1,0 +1,82 @@
+@import "mixins/grid-helper";
+@import "mixins/prefixed-transform";
+
+.homepage-services-and-info__list {
+  @include columns($items: 16, $columns: 1, $selector: "li");
+  list-style: none;
+  margin: 0 govuk-spacing(-3);
+  padding: 0;
+
+  @include govuk-media-query($from: "tablet") {
+    @include columns($items: 16, $columns: 2, $selector: "li");
+  }
+
+  @include govuk-media-query($from: "desktop") {
+    @include columns($items: 16, $columns: 3, $selector: "li");
+  }
+
+  .homepage-section__government-activity & {
+    @include columns($items: 6, $columns: 1, $selector: "li");
+    margin-bottom: govuk-spacing(4);
+
+    @include govuk-media-query($from: "tablet") {
+      @include columns($items: 6, $columns: 2, $selector: "li");
+      margin-bottom: 0;
+    }
+  }
+}
+
+.chevron-card {
+  border-top: 1px solid $govuk-border-colour;
+  margin: 0 govuk-spacing(3);
+  padding: govuk-spacing(1) 0 govuk-spacing(4) 0;
+}
+
+.chevron-card__wrapper {
+  padding: govuk-spacing(2) govuk-spacing(6) govuk-spacing(2) 0;
+  position: relative;
+}
+
+.chevron-card__description {
+  margin: 0 govuk-spacing(-6) 0 0;
+}
+
+.chevron-card__link {
+  &:after {
+    bottom: 0;
+    content: "";
+    display: block;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  &:before {
+    $dimension: 7px;
+    $width: 3px;
+
+    border-right: $width solid $govuk-brand-colour;
+    border-top: $width solid $govuk-brand-colour;
+    content: "";
+    display: block;
+    height: $dimension;
+    position: absolute;
+    right: govuk-spacing(1);
+    top: govuk-spacing(3);
+    @include prefixed-transform($rotate: 45deg);
+    width: $dimension;
+  }
+
+  &:hover {
+    &:before {
+      border-color: $govuk-link-hover-colour;
+    }
+  }
+
+  &:focus {
+    &:before {
+      border-color: $govuk-focus-text-colour;
+    }
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -6,28 +6,42 @@
 }
 
 .gem-c-cards__list {
-  @include columns($items: 16, $columns: 1, $selector: "li");
   list-style: none;
   padding: 0;
   // Remove the outermost left and right margin from the internal margin of the list items.
   margin: 0 govuk-spacing(-3);
 
+  display: grid;
+  grid-auto-flow: row;
+  // Use CSS grid to calculate the number of rows
+  grid-template-rows: auto;
+  // Use the tallest cell in the grid to set the height for all rows
+  grid-auto-rows: fractions(1);
+  grid-template-columns: fractions(1);
+
   @include govuk-media-query($from: "tablet") {
-    @include columns($items: 16, $columns: 2, $selector: "li");
+    grid-template-columns: fractions(2);
   }
 
   @include govuk-media-query($from: "desktop") {
-    @include columns($items: 16, $columns: 3, $selector: "li");
+    // Note that browsers that don't support CSS grid display the component as one column on all
+    // breakpoints
+    grid-template-columns: fractions(3);
+
+    // For browsers that don't support CSS grid, constrain the width to 50% to improve usability
+    // especially for screen magnifier users
+    width: 50%;
+
+    // Reset the width for browsers that support CSS grid
+    @supports (display: grid) {
+      width: initial;
+    }
   }
 }
 
 .gem-c-cards__list--two-column-desktop {
-  @include columns($items: 6, $columns: 1, $selector: "li");
-  margin-bottom: govuk-spacing(4);
-
   @include govuk-media-query($from: "desktop") {
-    @include columns($items: 6, $columns: 2, $selector: "li");
-    margin-bottom: 0;
+    grid-template-columns: fractions(2);
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -21,6 +21,16 @@
   }
 }
 
+.gem-c-cards__list--two-column-desktop {
+  @include columns($items: 6, $columns: 1, $selector: "li");
+  margin-bottom: govuk-spacing(4);
+
+  @include govuk-media-query($from: "desktop") {
+    @include columns($items: 6, $columns: 2, $selector: "li");
+    margin-bottom: 0;
+  }
+}
+
 .gem-c-cards__list-item {
   border-top: 1px solid $govuk-border-colour;
   // We use grid to split the container into column widths, so manage the horizontal spacing with

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -1,11 +1,16 @@
 @import "mixins/grid-helper";
 @import "mixins/prefixed-transform";
 
-.homepage-services-and-info__list {
+.gem-c-cards__heading {
+  margin: 0 0 govuk-spacing(6) 0;
+}
+
+.gem-c-cards__list {
   @include columns($items: 16, $columns: 1, $selector: "li");
   list-style: none;
-  margin: 0 govuk-spacing(-3);
   padding: 0;
+  // Remove the outermost left and right margin from the internal margin of the list items.
+  margin: 0 govuk-spacing(-3);
 
   @include govuk-media-query($from: "tablet") {
     @include columns($items: 16, $columns: 2, $selector: "li");
@@ -14,38 +19,26 @@
   @include govuk-media-query($from: "desktop") {
     @include columns($items: 16, $columns: 3, $selector: "li");
   }
-
-  .homepage-section__government-activity & {
-    @include columns($items: 6, $columns: 1, $selector: "li");
-    margin-bottom: govuk-spacing(4);
-
-    @include govuk-media-query($from: "tablet") {
-      @include columns($items: 6, $columns: 2, $selector: "li");
-      margin-bottom: 0;
-    }
-  }
 }
 
-.chevron-card {
+.gem-c-cards__list-item {
   border-top: 1px solid $govuk-border-colour;
+  // We use grid to split the container into column widths, so manage the horizontal spacing with
+  // internal margins.
   margin: 0 govuk-spacing(3);
-  padding: govuk-spacing(1) 0 govuk-spacing(4) 0;
-}
-
-.chevron-card__wrapper {
-  padding: govuk-spacing(2) govuk-spacing(6) govuk-spacing(2) 0;
+  padding: govuk-spacing(3) 0 govuk-spacing(6) 0;
   position: relative;
 }
 
-.chevron-card__description {
-  margin: 0 govuk-spacing(-6) 0 0;
+.gem-c-cards__sub-heading {
+  margin: 0 govuk-spacing(6) govuk-spacing(2) 0;
 }
 
-.chevron-card__link {
+.gem-c-cards__link {
+  // Make the entire list item area clickable
   &:after {
     bottom: 0;
     content: "";
-    display: block;
     left: 0;
     position: absolute;
     right: 0;
@@ -59,11 +52,10 @@
     border-right: $width solid $govuk-brand-colour;
     border-top: $width solid $govuk-brand-colour;
     content: "";
-    display: block;
     height: $dimension;
     position: absolute;
     right: govuk-spacing(1);
-    top: govuk-spacing(3);
+    top: govuk-spacing(4);
     @include prefixed-transform($rotate: 45deg);
     width: $dimension;
   }
@@ -79,4 +71,8 @@
       border-color: $govuk-focus-text-colour;
     }
   }
+}
+
+.gem-c-cards__description {
+  margin: 0;
 }

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_cards.scss
@@ -1,0 +1,4 @@
+.gem-c-cards__sub-heading {
+  margin-top: govuk-spacing(6);
+  margin-bottom: govuk-spacing(1);
+}

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -1,134 +1,86 @@
-<div class="homepage-section__heading homepage-section__heading--border-none">
-<h2 class="gem-c-heading govuk-heading-m govuk-!-margin-bottom-6">Topics</h2>
+<div class="gem-c-cards">
+  <h2 class="gem-c-cards__heading govuk-heading-m">Topics</h2>
+  <ul class="gem-c-cards__list">
+    <li class="gem-c-cards__list-item">
+      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
+        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
+          Benefits
+        </a>
+      </h3>
+      <p class="govuk-body govuk-!-margin-0">Includes eligibility, appeals, tax credits and Universal Credit</p>
+    </li>
+    <li class="gem-c-cards__list-item">
+      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
+        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
+          Births, deaths, marriages and&nbsp;care
+        </a>
+      </h3>
+      <p class="govuk-body govuk-!-margin-0">Parenting, civil partnerships, divorce and Lasting Power of Attorney</p>
+    </li>
+    <li class="gem-c-cards__list-item">
+      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
+        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
+          Business and self-employed
+        </a>
+      </h3>
+      <p class="govuk-body govuk-!-margin-0">Tools and guidance for businesses</p>
+    </li>
+    <li class="gem-c-cards__list-item">
+      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
+        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
+          Childcare and parenting
+        </a>
+      </h3>
+      <p class="govuk-body govuk-!-margin-0">Includes giving birth, fostering, adopting, benefits for children, childcare and schools</p>
+    </li>
+    <li class="gem-c-cards__list-item">
+      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
+        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
+          Citizenship and living in the&nbsp;UK
+        </a>
+      </h3>
+      <p class="govuk-body govuk-!-margin-0">Voting, community participation, life in the UK, international projects</p>
+    </li>
+    <li class="gem-c-cards__list-item">
+      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
+        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
+          Crime, justice and the&nbsp;law
+        </a>
+      </h3>
+      <p class="govuk-body govuk-!-margin-0">Legal processes, courts and the police</p>
+    </li>
+    <li class="gem-c-cards__list-item">
+      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
+        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
+          Benefits
+        </a>
+      </h3>
+      <p class="govuk-body govuk-!-margin-0">Includes eligibility, appeals, tax credits and Universal Credit</p>
+    </li>
+    <li class="gem-c-cards__list-item">
+      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
+        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
+          Benefits
+        </a>
+      </h3>
+      <p class="govuk-body govuk-!-margin-0">Includes eligibility, appeals, tax credits and Universal Credit</p>
+    </li>
+    <li class="gem-c-cards__list-item">
+      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
+        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
+          Benefits
+        </a>
+      </h3>
+      <p class="govuk-body govuk-!-margin-0">Includes eligibility, appeals, tax credits and Universal Credit</p>
+    </li>
+    <li class="gem-c-cards__list-item">
+      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
+        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
+          Benefits
+        </a>
+      </h3>
+      <p class="govuk-body govuk-!-margin-0">Includes eligibility, appeals, tax credits and Universal Credit</p>
+    </li>
+  </ul>
 </div>
 
-<ul class="homepage-services-and-info__list" data-module="gem-track-click">
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Benefits" data-track-label="/browse/benefits" data-track-value="1" href="/browse/benefits">Benefits</a></h3>
-
-    <p class="govuk-body chevron-card__description">Includes eligibility, appeals, tax credits and Universal Credit</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Births, deaths, marriages and&nbsp;care" data-track-label="/browse/births-deaths-marriages" data-track-value="1" href="/browse/births-deaths-marriages">Births, deaths, marriages and&nbsp;care</a></h3>
-
-    <p class="govuk-body chevron-card__description">Parenting, civil partnerships, divorce and Lasting Power of Attorney</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Business and self-employed" data-track-label="/browse/business" data-track-value="1" href="/browse/business">Business and self-employed</a></h3>
-
-    <p class="govuk-body chevron-card__description">Tools and guidance for businesses</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Childcare and parenting" data-track-label="/browse/childcare-parenting" data-track-value="1" href="/browse/childcare-parenting">Childcare and parenting</a></h3>
-
-    <p class="govuk-body chevron-card__description">Includes giving birth, fostering, adopting, benefits for children, childcare and schools</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Citizenship and living in the&nbsp;UK" data-track-label="/browse/citizenship" data-track-value="1" href="/browse/citizenship">Citizenship and living in the&nbsp;UK</a></h3>
-
-    <p class="govuk-body chevron-card__description">Voting, community participation, life in the UK, international projects</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Crime, justice and the&nbsp;law" data-track-label="/browse/justice" data-track-value="1" href="/browse/justice">Crime, justice and the&nbsp;law</a></h3>
-
-    <p class="govuk-body chevron-card__description">Legal processes, courts and the police</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Disabled people" data-track-label="/browse/disabilities" data-track-value="1" href="/browse/disabilities">Disabled people</a></h3>
-
-    <p class="govuk-body chevron-card__description">Includes carers, your rights, benefits and the Equality Act</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Driving and transport" data-track-label="/browse/driving" data-track-value="1" href="/browse/driving">Driving and transport</a></h3>
-
-    <p class="govuk-body chevron-card__description">Includes vehicle tax, MOT and driving licences</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Education and learning" data-track-label="/browse/education" data-track-value="1" href="/browse/education">Education and learning</a></h3>
-
-    <p class="govuk-body chevron-card__description">Includes student loans, admissions and apprenticeships</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Employing people" data-track-label="/browse/employing-people" data-track-value="1" href="/browse/employing-people">Employing people</a></h3>
-
-    <p class="govuk-body chevron-card__description">Includes pay, contracts, hiring and redundancies</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Environment and countryside" data-track-label="/browse/environment-countryside" data-track-value="1" href="/browse/environment-countryside">Environment and countryside</a></h3>
-
-    <p class="govuk-body chevron-card__description">Includes flooding, recycling and wildlife</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Housing and local services" data-track-label="/browse/housing-local-services" data-track-value="1" href="/browse/housing-local-services">Housing and local services</a></h3>
-
-    <p class="govuk-body chevron-card__description">Owning or renting and council services</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Money and tax" data-track-label="/browse/tax" data-track-value="1" href="/browse/tax">Money and tax</a></h3>
-
-    <p class="govuk-body chevron-card__description">Includes debt and Self&nbsp;Assessment</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Passports, travel and living&nbsp;abroad" data-track-label="/browse/abroad" data-track-value="1" href="/browse/abroad">Passports, travel and living&nbsp;abroad</a></h3>
-
-    <p class="govuk-body chevron-card__description">Includes renewing passports and travel advice by country</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Visas and immigration" data-track-label="/browse/visas-immigration" data-track-value="1" href="/browse/visas-immigration">Visas and immigration</a></h3>
-
-    <p class="govuk-body chevron-card__description">Apply to visit, work, study, settle or seek asylum in the&nbsp;UK</p>
-  </div>
-</li>
-
-<li class="chevron-card">
-  <div class="chevron-card__wrapper">
-    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Working, jobs and&nbsp;pensions" data-track-label="/browse/working" data-track-value="1" href="/browse/working">Working, jobs and&nbsp;pensions</a></h3>
-
-    <p class="govuk-body chevron-card__description">Includes holidays, finding a job and redundancy</p>
-  </div>
-</li>
-      </ul>

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -18,7 +18,12 @@
       <% end %>
     <% end %>
     <%= content_tag 'ul', class: ul_classes do %>
-      <% items.each do |item| %>
+      <% items.each do |item|
+        link = item[:link]
+
+        if !link[:path].present?
+          raise ArgumentError, "The cards component requires a href for all the links"
+        end
         <li class="gem-c-cards__list-item">
           <%= content_tag("h#{sub_heading_level}", class: "gem-c-cards__sub-heading govuk-heading-s") do %>
 

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -2,6 +2,7 @@
   heading ||= nil
   items ||= nil
   sub_heading_level ||= 3
+  two_column_layout ||= false
   local_assigns ||= nil
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 %>
@@ -12,7 +13,7 @@
         <%= heading %>
       <% end %>
     <% end %>
-    <ul class="gem-c-cards__list">
+    <ul class="gem-c-cards__list<% if two_column_layout %> gem-c-cards__list--two-column-desktop<% end %>">
       <% items.each do |item| %>
         <li class="gem-c-cards__list-item">
           <%= content_tag("h#{sub_heading_level}", class: "gem-c-cards__sub-heading govuk-heading-s") do %>

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -18,18 +18,38 @@
       <% end %>
     <% end %>
     <%= content_tag 'ul', class: ul_classes do %>
-      <% items.each do |item|
+      <%
+        items.each do |item|
         link = item[:link]
 
         if !link[:path].present?
           raise ArgumentError, "The cards component requires a href for all the links"
         end
+
+        data_attributes = nil
+        attributes = link[:tracking_attributes].presence
+
+        if attributes && attributes[:track_category] && attributes[:track_action]
+          data_attributes = {
+            track_action: attributes[:track_action],
+            track_category: attributes[:track_category],
+            track_dimension_index: attributes[:track_dimension_index],
+            track_dimension: link[:text],
+            track_label: link[:path],
+          }
+        end
+
+        link = capture do
+           link_to(link[:text], link[:path], {
+             class: "govuk-link gem-c-cards__link",
+             data: data_attributes,
+           })
+        end
+      %>
+
         <li class="gem-c-cards__list-item">
           <%= content_tag("h#{sub_heading_level}", class: "gem-c-cards__sub-heading govuk-heading-s") do %>
-
-          <a class="govuk-link gem-c-cards__link" href="<%= item[:link][:path]%>">
-              <%= item[:link][:text] %>
-          </a>
+            <%= link %>
           <% end %>
 
           <% if item[:description] %>

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -1,0 +1,134 @@
+<div class="homepage-section__heading homepage-section__heading--border-none">
+<h2 class="gem-c-heading govuk-heading-m govuk-!-margin-bottom-6">Topics</h2>
+</div>
+
+<ul class="homepage-services-and-info__list" data-module="gem-track-click">
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Benefits" data-track-label="/browse/benefits" data-track-value="1" href="/browse/benefits">Benefits</a></h3>
+
+    <p class="govuk-body chevron-card__description">Includes eligibility, appeals, tax credits and Universal Credit</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Births, deaths, marriages and&nbsp;care" data-track-label="/browse/births-deaths-marriages" data-track-value="1" href="/browse/births-deaths-marriages">Births, deaths, marriages and&nbsp;care</a></h3>
+
+    <p class="govuk-body chevron-card__description">Parenting, civil partnerships, divorce and Lasting Power of Attorney</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Business and self-employed" data-track-label="/browse/business" data-track-value="1" href="/browse/business">Business and self-employed</a></h3>
+
+    <p class="govuk-body chevron-card__description">Tools and guidance for businesses</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Childcare and parenting" data-track-label="/browse/childcare-parenting" data-track-value="1" href="/browse/childcare-parenting">Childcare and parenting</a></h3>
+
+    <p class="govuk-body chevron-card__description">Includes giving birth, fostering, adopting, benefits for children, childcare and schools</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Citizenship and living in the&nbsp;UK" data-track-label="/browse/citizenship" data-track-value="1" href="/browse/citizenship">Citizenship and living in the&nbsp;UK</a></h3>
+
+    <p class="govuk-body chevron-card__description">Voting, community participation, life in the UK, international projects</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Crime, justice and the&nbsp;law" data-track-label="/browse/justice" data-track-value="1" href="/browse/justice">Crime, justice and the&nbsp;law</a></h3>
+
+    <p class="govuk-body chevron-card__description">Legal processes, courts and the police</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Disabled people" data-track-label="/browse/disabilities" data-track-value="1" href="/browse/disabilities">Disabled people</a></h3>
+
+    <p class="govuk-body chevron-card__description">Includes carers, your rights, benefits and the Equality Act</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Driving and transport" data-track-label="/browse/driving" data-track-value="1" href="/browse/driving">Driving and transport</a></h3>
+
+    <p class="govuk-body chevron-card__description">Includes vehicle tax, MOT and driving licences</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Education and learning" data-track-label="/browse/education" data-track-value="1" href="/browse/education">Education and learning</a></h3>
+
+    <p class="govuk-body chevron-card__description">Includes student loans, admissions and apprenticeships</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Employing people" data-track-label="/browse/employing-people" data-track-value="1" href="/browse/employing-people">Employing people</a></h3>
+
+    <p class="govuk-body chevron-card__description">Includes pay, contracts, hiring and redundancies</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Environment and countryside" data-track-label="/browse/environment-countryside" data-track-value="1" href="/browse/environment-countryside">Environment and countryside</a></h3>
+
+    <p class="govuk-body chevron-card__description">Includes flooding, recycling and wildlife</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Housing and local services" data-track-label="/browse/housing-local-services" data-track-value="1" href="/browse/housing-local-services">Housing and local services</a></h3>
+
+    <p class="govuk-body chevron-card__description">Owning or renting and council services</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Money and tax" data-track-label="/browse/tax" data-track-value="1" href="/browse/tax">Money and tax</a></h3>
+
+    <p class="govuk-body chevron-card__description">Includes debt and Self&nbsp;Assessment</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Passports, travel and living&nbsp;abroad" data-track-label="/browse/abroad" data-track-value="1" href="/browse/abroad">Passports, travel and living&nbsp;abroad</a></h3>
+
+    <p class="govuk-body chevron-card__description">Includes renewing passports and travel advice by country</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Visas and immigration" data-track-label="/browse/visas-immigration" data-track-value="1" href="/browse/visas-immigration">Visas and immigration</a></h3>
+
+    <p class="govuk-body chevron-card__description">Apply to visit, work, study, settle or seek asylum in the&nbsp;UK</p>
+  </div>
+</li>
+
+<li class="chevron-card">
+  <div class="chevron-card__wrapper">
+    <h3 class="gem-c-heading govuk-heading-s govuk-!-margin-bottom-2"><a class="govuk-link chevron-card__link" data-track-action="topicsLink" data-track-category="homepageClicked" data-track-dimension-index="29" data-track-dimension="Working, jobs and&nbsp;pensions" data-track-label="/browse/working" data-track-value="1" href="/browse/working">Working, jobs and&nbsp;pensions</a></h3>
+
+    <p class="govuk-body chevron-card__description">Includes holidays, finding a job and redundancy</p>
+  </div>
+</li>
+      </ul>

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -4,6 +4,10 @@
   sub_heading_level ||= 3
   two_column_layout ||= false
   local_assigns ||= nil
+
+  ul_classes = %w[gem-c-cards__list]
+  ul_classes << 'gem-c-cards__list--two-column-desktop' if two_column_layout
+
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 %>
 <% if items.present? %>
@@ -13,7 +17,7 @@
         <%= heading %>
       <% end %>
     <% end %>
-    <ul class="gem-c-cards__list<% if two_column_layout %> gem-c-cards__list--two-column-desktop<% end %>">
+    <%= content_tag 'ul', class: ul_classes do %>
       <% items.each do |item| %>
         <li class="gem-c-cards__list-item">
           <%= content_tag("h#{sub_heading_level}", class: "gem-c-cards__sub-heading govuk-heading-s") do %>
@@ -28,6 +32,6 @@
           <% end %>
         </li>
       <% end %>
-    </ul>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -1,86 +1,32 @@
-<div class="gem-c-cards">
-  <h2 class="gem-c-cards__heading govuk-heading-m">Topics</h2>
-  <ul class="gem-c-cards__list">
-    <li class="gem-c-cards__list-item">
-      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
-        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
-          Benefits
-        </a>
-      </h3>
-      <p class="govuk-body govuk-!-margin-0">Includes eligibility, appeals, tax credits and Universal Credit</p>
-    </li>
-    <li class="gem-c-cards__list-item">
-      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
-        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
-          Births, deaths, marriages and&nbsp;care
-        </a>
-      </h3>
-      <p class="govuk-body govuk-!-margin-0">Parenting, civil partnerships, divorce and Lasting Power of Attorney</p>
-    </li>
-    <li class="gem-c-cards__list-item">
-      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
-        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
-          Business and self-employed
-        </a>
-      </h3>
-      <p class="govuk-body govuk-!-margin-0">Tools and guidance for businesses</p>
-    </li>
-    <li class="gem-c-cards__list-item">
-      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
-        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
-          Childcare and parenting
-        </a>
-      </h3>
-      <p class="govuk-body govuk-!-margin-0">Includes giving birth, fostering, adopting, benefits for children, childcare and schools</p>
-    </li>
-    <li class="gem-c-cards__list-item">
-      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
-        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
-          Citizenship and living in the&nbsp;UK
-        </a>
-      </h3>
-      <p class="govuk-body govuk-!-margin-0">Voting, community participation, life in the UK, international projects</p>
-    </li>
-    <li class="gem-c-cards__list-item">
-      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
-        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
-          Crime, justice and the&nbsp;law
-        </a>
-      </h3>
-      <p class="govuk-body govuk-!-margin-0">Legal processes, courts and the police</p>
-    </li>
-    <li class="gem-c-cards__list-item">
-      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
-        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
-          Benefits
-        </a>
-      </h3>
-      <p class="govuk-body govuk-!-margin-0">Includes eligibility, appeals, tax credits and Universal Credit</p>
-    </li>
-    <li class="gem-c-cards__list-item">
-      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
-        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
-          Benefits
-        </a>
-      </h3>
-      <p class="govuk-body govuk-!-margin-0">Includes eligibility, appeals, tax credits and Universal Credit</p>
-    </li>
-    <li class="gem-c-cards__list-item">
-      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
-        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
-          Benefits
-        </a>
-      </h3>
-      <p class="govuk-body govuk-!-margin-0">Includes eligibility, appeals, tax credits and Universal Credit</p>
-    </li>
-    <li class="gem-c-cards__list-item">
-      <h3 class="gem-c-cards__sub-heading govuk-heading-s ">
-        <a class="govuk-link gem-c-cards__link" href="/browse/benefits">
-          Benefits
-        </a>
-      </h3>
-      <p class="govuk-body govuk-!-margin-0">Includes eligibility, appeals, tax credits and Universal Credit</p>
-    </li>
-  </ul>
-</div>
+<%
+  heading ||= nil
+  items ||= nil
+  sub_heading_level ||= 3
+  local_assigns ||= nil
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+%>
+<% if items.present? %>
+  <div class="gem-c-cards">
+    <% if heading %>
+      <%= content_tag(shared_helper.get_heading_level, class: "gem-c-cards__heading govuk-heading-m") do %>
+        <%= heading %>
+      <% end %>
+    <% end %>
+    <ul class="gem-c-cards__list">
+      <% items.each do |item| %>
+        <li class="gem-c-cards__list-item">
+          <%= content_tag("h#{sub_heading_level}", class: "gem-c-cards__sub-heading govuk-heading-s") do %>
 
+          <a class="govuk-link gem-c-cards__link" href="<%= item[:link][:path]%>">
+              <%= item[:link][:text] %>
+          </a>
+          <% end %>
+
+          <% if item[:description] %>
+            <p class="govuk-body gem-c-cards__description"><%= item[:description] %></p>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/cards.yml
+++ b/app/views/govuk_publishing_components/components/docs/cards.yml
@@ -116,3 +116,24 @@ examples:
             text: Benefits
             path: http://www.gov.uk
           description: Includes eligibility, appeals, tax credits and Universal Credit
+  with_tracking_attributes:
+    description: |
+      Tracking can be enabled on the cards component by passing a minimum of data_track_category and data_track_action. Other tracking attributes are optional. Note: tracking events do not currently fire within the component guide.
+    data:
+      items:
+        - link:
+            text: Benefits
+            path: http://www.gov.uk
+            tracking_attributes:
+              track_action: track_action
+              track_category: homepageClicked
+              track_dimension_index: 29
+          description: Includes eligibility, appeals, tax credits and Universal Credit
+        - link:
+            text: Births, deaths, marriages and&nbsp;care
+            path: http://www.gov.uk
+            tracking_attributes:
+              track_action: track_action
+              track_category: homepageClicked
+              track_dimension_index: 29
+          description: Parenting, civil partnerships, divorce and Lasting Power of Attorney

--- a/app/views/govuk_publishing_components/components/docs/cards.yml
+++ b/app/views/govuk_publishing_components/components/docs/cards.yml
@@ -3,7 +3,7 @@ description: A grid of cards that have a link and a description
 body: |
   The component renders the cards as an unordered list element and visually presents it as a grid. It doesn't use the [GOV.UK Design System grid](https://design-system.service.gov.uk/styles/layout/#grid-system) but sets its own so that it can separately target desktop, tablet and mobile columns.
 
-  You can display the grid in three or two columns on desktop.
+  You can display the grid in three or two columns on desktop. Browsers that don't support CSS grid always display one column.
 
   You must set a `href` for all the links.
 

--- a/app/views/govuk_publishing_components/components/docs/cards.yml
+++ b/app/views/govuk_publishing_components/components/docs/cards.yml
@@ -1,0 +1,118 @@
+name: Cards (experimental)
+description: A grid of cards that have a link and a description
+body: |
+  The component renders the cards as an unordered list element and visually presents it as a grid. It doesn't use the [GOV.UK Design System grid](https://design-system.service.gov.uk/styles/layout/#grid-system) but sets its own so that it can separately target desktop, tablet and mobile columns.
+
+  You can display the grid in three or two columns on desktop.
+
+  You must set a `href` for all the links.
+
+  This component is currently experimental. If you are using it, please feed back any research findings to the GOV.UK Explore team.
+accessibility_criteria: |
+  The component must:
+
+  -  use the correct heading level hierarchy eg. if the component heading uses a `<h2>`, the subheadings must use a `<h3>`
+
+  It is also good practise to include a heading above the list to tell users what the list contains
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      heading: Topics
+      items:
+        - link:
+            text: Benefits
+            path: http://www.gov.uk
+          description: Includes eligibility, appeals, tax credits and Universal Credit
+        - link:
+            text: Births, deaths, marriages and&nbsp;care
+            path: http://www.gov.uk
+          description: Parenting, civil partnerships, divorce and Lasting Power of Attorney
+        - link:
+            text: Business and self-employed
+            path: http://www.gov.uk
+          description: Tools and guidance for businesses
+        - link:
+            text: Childcare and parenting
+            path: http://www.gov.uk
+          description: Includes giving birth, fostering, adopting, benefits for children, childcare and schools
+        - link:
+            text: Citizenship and living in the&nbsp;UK
+            path: http://www.gov.uk
+          description: Voting, community participation, life in the UK, international projects
+        - link:
+            text: Crime, justice and the&nbsp;law
+            path: http://www.gov.uk
+          description: Legal processes, courts and the police
+        - link:
+            text: Disabled people
+            path: http://www.gov.uk
+          description: Includes carers, your rights, benefits and the Equality Act
+        - link:
+            text: Driving and transport
+            path: http://www.gov.uk
+          description: Includes vehicle tax, MOT and driving licences
+        - link:
+            text: Education and learning
+            path: http://www.gov.uk
+          description: Includes student loans, admissions and apprenticeships
+        - link:
+            text: Employing people
+            path: http://www.gov.uk
+          description: Includes pay, contracts, hiring and redundancies
+        - link:
+            text: Environment and countryside
+            path: http://www.gov.uk
+          description: Includes flooding, recycling and wildlife
+        - link:
+            text: Housing and local services
+            path: http://www.gov.uk
+          description: Owning or renting and council services
+  two_column_layout:
+    description:  Override default three column layout on desktop by passing through `two_column_layout` parameter (defaults to `false`).
+    data:
+      two_column_layout: true
+      items:
+        - link:
+            text: Benefits
+            path: http://www.gov.uk
+          description: Includes eligibility, appeals, tax credits and Universal Credit
+        - link:
+            text: Births, deaths, marriages and&nbsp;care
+            path: http://www.gov.uk
+          description: Parenting, civil partnerships, divorce and Lasting Power of Attorney
+        - link:
+            text: Business and self-employed
+            path: http://www.gov.uk
+          description: Tools and guidance for businesses
+        - link:
+            text: Childcare and parenting
+            path: http://www.gov.uk
+          description: Includes giving birth, fostering, adopting, benefits for children, childcare and schools
+        - link:
+            text: Citizenship and living in the&nbsp;UK
+            path: http://www.gov.uk
+          description: Voting, community participation, life in the UK, international projects
+        - link:
+            text: Crime, justice and the&nbsp;law
+            path: http://www.gov.uk
+          description: Legal processes, courts and the police
+        - link:
+            text: Disabled people
+            path: http://www.gov.uk
+          description: Includes carers, your rights, benefits and the Equality Act
+  custom_heading_levels:
+    description: |
+      Override default heading level by passing through `heading_level` parameter (defaults to `<h2>`).
+
+      Override default subheading level by passing through `sub_heading_level` parameter (defaults to `<h3>`)
+    data:
+      heading: Topics
+      heading_level: 3
+      sub_heading_level: 4
+      items:
+        - link:
+            text: Benefits
+            path: http://www.gov.uk
+          description: Includes eligibility, appeals, tax credits and Universal Credit

--- a/spec/components/cards_spec.rb
+++ b/spec/components/cards_spec.rb
@@ -74,6 +74,22 @@ describe "Cards", type: :view do
     assert_select "ul.gem-c-cards__list", count: 1
   end
 
+  it "renders two column list" do
+    test_data = {
+      two_column_layout: true,
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select "ul.gem-c-cards__list.gem-c-cards__list--two-column-desktop", count: 1
+  end
+
   it "renders a list item" do
     test_data = {
       items: [

--- a/spec/components/cards_spec.rb
+++ b/spec/components/cards_spec.rb
@@ -183,4 +183,45 @@ describe "Cards", type: :view do
     assert_select "p.govuk-body.gem-c-cards__description", text: "Includes eligibility, appeals, tax credits and Universal Credit"
   end
 
+  it "renders tracking attributes" do
+    test_data = {
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+            tracking_attributes: {
+              track_action: "some_action",
+              track_category: "homepageClicked",
+              track_dimension_index: 29,
+            },
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select ".govuk-link.gem-c-cards__link[data-track-label='http://www.gov.uk']", count: 1
+    assert_select ".govuk-link.gem-c-cards__link[data-track-action='some_action']", count: 1
+    assert_select ".govuk-link.gem-c-cards__link[data-track-category='homepageClicked']", count: 1
+    assert_select ".govuk-link.gem-c-cards__link[data-track-dimension-index='29']", count: 1
+  end
+
+  it "doesn't render any tracking attributes if the required attributes are not set" do
+    test_data = {
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+            tracking_attributes: {
+              # This omits action and category which are required
+              track_dimension_index: 29,
+            },
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select ".govuk-link.gem-c-cards__link[data-track-dimension-index='1']", count: 0
+  end
 end

--- a/spec/components/cards_spec.rb
+++ b/spec/components/cards_spec.rb
@@ -1,0 +1,154 @@
+require "rails_helper"
+
+describe "Cards", type: :view do
+  def component_name
+    "cards"
+  end
+
+  it "renders nothing when no data is provided" do
+    assert_empty render_component({})
+  end
+
+
+  it "renders list heading" do
+    test_data = {
+      heading: "Topics",
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select ".gem-c-cards__heading.govuk-heading-m", text: "Topics"
+  end
+
+  it "renders list heading using default heading level" do
+    test_data = {
+      heading: "Topics",
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select "h2.gem-c-cards__heading.govuk-heading-m", count: 1
+  end
+
+  it "renders list heading using custom heading level" do
+    test_data = {
+      heading: "Topics",
+      heading_level: 3,
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select "h3.gem-c-cards__heading.govuk-heading-m", count: 1
+  end
+
+  it "renders list" do
+    test_data = {
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select "ul.gem-c-cards__list", count: 1
+  end
+
+  it "renders a list item" do
+    test_data = {
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select ".gem-c-cards__list-item", text: "Benefits"
+  end
+
+  it "renders sub-heading using default heading level" do
+    test_data = {
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select "h3.gem-c-cards__sub-heading.govuk-heading-s", text: "Benefits"
+  end
+
+  it "renders sub-heading using custom heading level" do
+    test_data = {
+      sub_heading_level: 4,
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select "h4.gem-c-cards__sub-heading.govuk-heading-s", text: "Benefits"
+  end
+
+  it "renders a link with href" do
+    test_data = {
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select '.govuk-link.gem-c-cards__link[href="http://www.gov.uk"]', text: "Benefits"
+  end
+
+  it "renders a description" do
+    test_data = {
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "http://www.gov.uk",
+          },
+          description: "Includes eligibility, appeals, tax credits and Universal Credit",
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select "p.govuk-body.gem-c-cards__description", text: "Includes eligibility, appeals, tax credits and Universal Credit"
+  end
+
+end

--- a/spec/components/cards_spec.rb
+++ b/spec/components/cards_spec.rb
@@ -148,7 +148,23 @@ describe "Cards", type: :view do
       ],
     }
     render_component(test_data)
-    assert_select '.govuk-link.gem-c-cards__link[href="http://www.gov.uk"]', text: "Benefits"
+    assert_select ".govuk-link.gem-c-cards__link[href='http://www.gov.uk']", text: "Benefits"
+  end
+
+  it "throws an error if a link doesn't have a href" do
+    test_data = {
+      items: [
+        {
+          link: {
+            text: "Benefits",
+            path: "",
+          },
+        },
+      ],
+    }
+    assert_raises do
+      render_component(test_data)
+    end
   end
 
   it "renders a description" do

--- a/spec/components/cards_spec.rb
+++ b/spec/components/cards_spec.rb
@@ -9,23 +9,6 @@ describe "Cards", type: :view do
     assert_empty render_component({})
   end
 
-
-  it "renders list heading" do
-    test_data = {
-      heading: "Topics",
-      items: [
-        {
-          link: {
-            text: "Benefits",
-            path: "http://www.gov.uk",
-          },
-        },
-      ],
-    }
-    render_component(test_data)
-    assert_select ".gem-c-cards__heading.govuk-heading-m", text: "Topics"
-  end
-
   it "renders list heading using default heading level" do
     test_data = {
       heading: "Topics",
@@ -59,22 +42,7 @@ describe "Cards", type: :view do
     assert_select "h3.gem-c-cards__heading.govuk-heading-m", count: 1
   end
 
-  it "renders list" do
-    test_data = {
-      items: [
-        {
-          link: {
-            text: "Benefits",
-            path: "http://www.gov.uk",
-          },
-        },
-      ],
-    }
-    render_component(test_data)
-    assert_select "ul.gem-c-cards__list", count: 1
-  end
-
-  it "renders two column list" do
+  it "renders two column list variant" do
     test_data = {
       two_column_layout: true,
       items: [
@@ -88,21 +56,6 @@ describe "Cards", type: :view do
     }
     render_component(test_data)
     assert_select "ul.gem-c-cards__list.gem-c-cards__list--two-column-desktop", count: 1
-  end
-
-  it "renders a list item" do
-    test_data = {
-      items: [
-        {
-          link: {
-            text: "Benefits",
-            path: "http://www.gov.uk",
-          },
-        },
-      ],
-    }
-    render_component(test_data)
-    assert_select ".gem-c-cards__list-item", text: "Benefits"
   end
 
   it "renders sub-heading using default heading level" do
@@ -134,21 +87,6 @@ describe "Cards", type: :view do
     }
     render_component(test_data)
     assert_select "h4.gem-c-cards__sub-heading.govuk-heading-s", text: "Benefits"
-  end
-
-  it "renders a link with href" do
-    test_data = {
-      items: [
-        {
-          link: {
-            text: "Benefits",
-            path: "http://www.gov.uk",
-          },
-        },
-      ],
-    }
-    render_component(test_data)
-    assert_select ".govuk-link.gem-c-cards__link[href='http://www.gov.uk']", text: "Benefits"
   end
 
   it "throws an error if a link doesn't have a href" do


### PR DESCRIPTION
## What
The Find & View team created a local cards component for the homepage in [`frontend`](https://github.com/alphagov/frontend).

The component renders cards, each with a link and a description, as an unordered list element and visually presents it as a grid. It doesn't use the [GOV.UK Design System grid](https://design-system.service.gov.uk/styles/layout/#grid-system) but sets its own so that it can separately target desktop, tablet and mobile columns.

This PR:
- Ports the code over from  `frontend` 
- Updates markup to follow BEM conventions
- Adds print styles
- Adds automated template tests
- Allow the grid to be overridden to use two columns on desktop (this variant is currently used in the government activity sections of the homepage)
- Allows heading and subheading levels to be overridden
- Throws an error if any of the links are missing a `href` 
- Adds tracking attributes to the component card links
- Includes a heading element for the component to encourage best practise by having a heading for the landmark 
- Calculates rows with CSS grid and removes the IE11 polyfill: unlike the frontend repo, the new topic page templates can contain an unknown number of items so we're now using CSS grid to calculate rows and their heights, and falling back to a single column for IE11 -  [more information](https://github.com/alphagov/govuk_publishing_components/pull/2624/commits/0212604698d2076ab0445b12010d251bc3ce1268)

### MacOS Google Chrome
![Screenshot 2022-03-02 at 19 20 30](https://user-images.githubusercontent.com/5007934/156433878-916cbe00-44e7-4740-9e9a-f1071012e221.png)

### MacOS Firefox with custom colours
![Screenshot 2022-03-02 at 19 21 31](https://user-images.githubusercontent.com/5007934/156433973-229b568b-7567-4c48-bdaf-6f32dfca341a.png)

### Windows 8 Internet Explorer 11
![Screenshot 2022-03-02 at 19 37 44](https://user-images.githubusercontent.com/5007934/156436650-ac1d18e3-99ef-421c-b7f3-6c3ea82a03be.png)


### iOS 15 Safari

![Screenshot 2022-03-02 at 19 35 59](https://user-images.githubusercontent.com/5007934/156436292-7255844b-de99-460b-a921-80102b42b3c6.png)

## Why
The component is currently used in the list of topics and government activity sections on the homepage. 

We want to reuse it for Mainstream Browse pages so it needs to be made available to other apps via the gem.

## Things to note
- `.component-guide-preview` adds some padding which could make the cards component spacing seem slightly misaligned when comparing with the component on the homepage. I ended up temporarily removing the preview padding when I was checking the component spacing to get around this. 
- At the moment the `get_heading_level` helper is used to set the main heading level for the component. The ability to adjust the subheading level is manually configured in the template. It might be good to look at whether the helper should in fact have the ability to set more than one heading level for the same template, in which case the different heading levels could be linked to help ensure the correct heading level hierarchy. 

### Tested with:

#### Windows	
- [x] Internet Explorer 11	compliant
- [x]  	Edge   97	compliant
- [x]  	Google Chrome (latest versions)	compliant
- [x]  	Mozilla Firefox (latest versions)	compliant

The chevron icon doesn't render correctly on IE8 but we've decided to leave it as is as it's still usable there.

#### macOS	
- [x] Safari 12 & 14	compliant
- [x]  	Google Chrome (latest versions)	compliant
- [x]  	Mozilla Firefox (latest versions)	compliant, including **when changing colours**

#### iOS	
- [x] Safari for iOS 15 	compliant
- [x]  	Google Chrome iOS 15 (latest versions)	compliant

#### Android	
- [x] Google Chrome (latest versions)	compliant
- [x]  	Samsung Internet (latest versions)	compliant

### Assistive tech to test with
- [x] JAWS (desktop screen reader)	18 or later	Chrome (latest version)
- [x] NVDA (desktop screen reader)	Latest	Firefox (latest version)
- [x] VoiceOver on iOS (mobile screen reader)	Latest	Safari (version 12 or later) 
- [x] TalkBack (mobile screen reader)	Latest	Chrome (latest version)
- [x] Windows Magnifier or Apple Zoom (screen magnifiers)	
- [ ] Dragon (speech recognition)	15 or later	Internet Explorer 11

## Other 
 - [x] Design review - see Trello card