### PR TITLE
Version 28.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 28.6.0
 
 * Add margin top and margin bottom to inset text ([PR #2616](https://github.com/alphagov/govuk_publishing_components/pull/2616))
 * Bump `govuk-frontend` from 3.14.0 to 4.0.0 ([PR #2355](https://github.com/alphagov/govuk_publishing_components/pull/2533))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (28.5.0)
+    govuk_publishing_components (28.6.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "28.5.0".freeze
+  VERSION = "28.6.0".freeze
 end


### PR DESCRIPTION
## 28.6.0

* Add margin top and margin bottom to inset text ([PR #2616](https://github.com/alphagov/govuk_publishing_components/pull/2616))
* Bump `govuk-frontend` from 3.14.0 to 4.0.0 ([PR #2355](https://github.com/alphagov/govuk_publishing_components/pull/2533))
* Change JavaScript modules from start to init ([PR #2605](https://github.com/alphagov/govuk_publishing_components/pull/2605))
* Share icons line-height ([PR #2602](https://github.com/alphagov/govuk_publishing_components/pull/2602))
* Update conditional reveal ([PR #2602](https://github.com/alphagov/govuk_publishing_components/pull/2612))
* Update Accordion design ([PR #2581](https://github.com/alphagov/govuk_publishing_components/pull/2581))
* Update step-by-step design ([PR #2601](https://github.com/alphagov/govuk_publishing_components/pull/2601))