### PR TITLE
Allow attachments to display a link to request accessible format form for pilot orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow attachments to display link to accessible format request form [PR #2636](https://github.com/alphagov/govuk_publishing_components/pull/2636)
+
 ## 28.7.1
 
 * Re-release of 28.7.0 with the missing node dependencies restored. ([PR #2648](https://github.com/alphagov/govuk_publishing_components/pull/2648))

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -83,7 +83,9 @@
       <% end %>
     <% end %>
 
-    <% if attachment.alternative_format_contact_email %>
+    <% if attachment.display_accessible_format_request_form_link? %>
+      <%= link_to "Request an accessible format of this document", "/contact/govuk/request-accessible-format?content_id=#{attachment.owning_document_content_id}&attachment_id=#{attachment.attachment_id}", class: "govuk-link" %>
+    <% elsif attachment.alternative_format_contact_email %>
       <%= tag.p t("components.attachment.request_format_text"), class: "gem-c-attachment__metadata" %>
       <%= render "govuk_publishing_components/components/details", {
         title: t("components.attachment.request_format_cta")

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -76,6 +76,17 @@ examples:
         content_type: application/pdf
         file_size: 20000
         alternative_format_contact_email: defra.helpline@defra.gsi.gov.uk
+  with_link_to_request_accessible_format_form:
+    data:
+      attachment:
+        title: "Department for Transport information asset register"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/747661/department-for-transport-information-asset-register.csv
+        filename: department-for-transport-information-asset-register.csv
+        content_type: application/pdf
+        file_size: 20000
+        owning_document_content_id: 456_abc
+        attachment_id: 123
+        alternative_format_contact_email: alternative.formats@education.gov.uk
   with_data_attributes:
     data:
       attachment:

--- a/lib/govuk_publishing_components/presenters/attachment.rb
+++ b/lib/govuk_publishing_components/presenters/attachment.rb
@@ -1,6 +1,16 @@
 module GovukPublishingComponents
   module Presenters
     class Attachment
+      # DfE, DWP, DHSC, HMRC, DVSA and PHE are taking part in a pilot to use a form
+      # rather than direct email for users to request accessible formats. When the pilot
+      # scheme is rolled out further this can be removed.
+      EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT = %w[alternative.formats@education.gov.uk
+                                                     accessible.formats@dwp.gov.uk
+                                                     publications@dhsc.gov.uk
+                                                     different.format@hmrc.gov.uk
+                                                     gov.uk.publishing@dvsa.gov.uk
+                                                     publications@phe.gov.uk].freeze
+
       delegate :opendocument?, :document?, :spreadsheet?, to: :content_type
 
       attr_reader :attachment_data
@@ -8,6 +18,7 @@ module GovukPublishingComponents
       # Expects a hash of attachment data
       # * title and url are required
       # * content_type, filename, file_size, number of pages, alternative_format_contact_email can be provided
+      # * attachment_id and owning_document_content_id are required to use the accessible format request form
       def initialize(attachment_data)
         @attachment_data = attachment_data.with_indifferent_access
       end
@@ -47,6 +58,14 @@ module GovukPublishingComponents
         attachment_data[:alternative_format_contact_email]
       end
 
+      def attachment_id
+        attachment_data[:attachment_id]
+      end
+
+      def owning_document_content_id
+        attachment_data[:owning_document_content_id]
+      end
+
       def reference
         reference = []
         reference << "ISBN #{attachment_data[:isbn]}" if attachment_data[:isbn].present?
@@ -69,6 +88,10 @@ module GovukPublishingComponents
 
       def is_official_document
         attachment_data[:command_paper_number].present? || attachment_data[:hoc_paper_number].present? || attachment_data[:unnumbered_command_paper].eql?(true) || attachment_data[:unnumbered_hoc_paper].eql?(true)
+      end
+
+      def display_accessible_format_request_form_link?
+        EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT.include?(alternative_format_contact_email) && owning_document_content_id.present? && attachment_id.present?
       end
 
       class SupportedContentType

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -74,7 +74,7 @@ describe "Attachment", type: :view do
     assert_select "a[href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation']"
   end
 
-  it "shows section to request a different format if a contact email is provided" do
+  it "shows section to request a different format if a contact email is provided that is not in the pilot" do
     render_component(
       attachment: {
         title: "Attachment",
@@ -84,6 +84,20 @@ describe "Attachment", type: :view do
       },
     )
     assert_select "a[href='mailto:defra.helpline@defra.gsi.gov.uk']"
+  end
+
+  it "shows a link to the accesible format request form if the contact email is in the pilot, and an owning document content id and attachment id are provided" do
+    render_component(
+      attachment: {
+        title: "Attachment",
+        url: "attachment",
+        attachment_id: "123",
+        owning_document_content_id: "abc_456",
+        content_type: "application/vnd.oasis.opendocument.spreadsheet",
+        alternative_format_contact_email: "alternative.formats@education.gov.uk",
+      },
+    )
+    assert_select "a[href='/contact/govuk/request-accessible-format?content_id=abc_456&attachment_id=123']", text: "Request an accessible format of this document"
   end
 
   it "does not show opendocument metadata if disabled" do

--- a/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
@@ -223,4 +223,40 @@ RSpec.describe GovukPublishingComponents::Presenters::Attachment do
       expect(attachment.is_official_document).to be false
     end
   end
+
+  describe "#display_accessible_format_request_form_link?" do
+    it "returns true if the attachment id and owning document content id are provided and the alternative email address is in the pilot" do
+      attachment = described_class.new(
+        attachment_id: "123",
+        owning_document_content_id: "456",
+        alternative_format_contact_email: "alternative.formats@education.gov.uk",
+      )
+      expect(attachment.display_accessible_format_request_form_link?).to be true
+    end
+
+    it "returns false if the attachment id is not provided" do
+      attachment = described_class.new(
+        owning_document_content_id: "456",
+        alternative_format_contact_email: "alternative.formats@education.gov.uk",
+      )
+      expect(attachment.display_accessible_format_request_form_link?).to be false
+    end
+
+    it "returns false if the owning document content id is not provided" do
+      attachment = described_class.new(
+        attachment_id: "123",
+        alternative_format_contact_email: "alternative.formats@education.gov.uk",
+      )
+      expect(attachment.display_accessible_format_request_form_link?).to be false
+    end
+
+    it "returns false if the alternative email address is not on the pilot" do
+      attachment = described_class.new(
+        attachment_id: "123",
+        owning_document_content_id: "456",
+        alternative_format_contact_email: "alternative.formats@organisation_not_in_pilot.gov.uk",
+      )
+      expect(attachment.display_accessible_format_request_form_link?).to be false
+    end
+  end
 end


### PR DESCRIPTION
## What
A small number of organisation are taking part in a pilot scheme to use a new form for users to request accessible formats, rather than sending an email.

If an attachment's alternative_format_contact_email is included in the list of pilot organisation emails, and the provided attachment data includes the attachment ID and the parent content items content ID, then a link to the form is rendered instead of an invitation to email.

## Why
To allow various consuming applications to provide minimal extra details (the attachment ID and parental content ID) and present a link to the new, more accessible, form.

## Visual Changes

### Before
<img width="1000" alt="Screenshot 2022-02-24 at 13 53 26" src="https://user-images.githubusercontent.com/13475227/155537172-f5900026-b48d-4d0d-bdc0-f4cb047f5378.png">

### After
<img width="1008" alt="Screenshot 2022-02-24 at 16 11 58" src="https://user-images.githubusercontent.com/13475227/155563099-34298603-7772-4a98-b57f-3126482a3b7f.png">



[trello](https://trello.com/c/JESTQ5fd/1093-accessible-format-request-add-check-for-organisation-pilot-involvement-to-govukpublishingcomponents)