### PR TITLE
Update RubyGems publishing to use `main` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
   release:
     needs: test
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Update the `ci.yml` gem publishing workflow if statement to work on the `main` branch, rather than being on the `master` branch.


## Why
<!-- What are the reasons behind this change being made? -->

We want to rename the `master` branch with `main` to match the other repositories in the alphagov organisation.

Once this has been merged in this repo can then [rename the `master` branch][1] to `main`, and then publish the gem from the `main` branch.


## Visual Changes
None.


[1]: https://github.com/github/renaming#renaming-existing-branches
