### PR TITLE
Don't use webdrivers for yarn chromedriver

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint:scss": "stylelint app/assets/stylesheets/",
     "lint": "yarn run lint:js && yarn run lint:scss",
     "jasmine:prepare": "bundle exec rake app:assets:clobber app:assets:precompile",
-    "jasmine:ci": "yarn run jasmine:prepare && bundle exec rake app:webdrivers:chromedriver:update && PATH=~/.webdrivers:$PATH yarn run jasmine-browser-runner runSpecs",
+    "jasmine:ci": "yarn run jasmine:prepare && yarn run jasmine-browser-runner runSpecs",
     "jasmine:browser": "yarn run jasmine:prepare && yarn run jasmine-browser-runner"
   },
   "standardx": {


### PR DESCRIPTION
Trello: https://trello.com/c/21VMx1NV/264-migrate-apps-to-use-jasmine-browser-runner

In the time since PR 2625 [1] was merged we've learnt that the webdrivers
gem is going to cause a problem for the GOV.UK development environment,
govuk-docker, when running on M1 macs.

We have decided to change tact and focus on installing a chromedriver on
the underlying machine rather than using webdrivers as a source of this
software [2] [3]. This seems extra pragmatic now that we have Javascript
dependencies also using chromedriver.

A step towards this is removing this intertwining of Ruby webdriver
dependency from this repo's yarn tests.

The effect merging this will have is:

- The build will continue to pass in GitHub Actions CI - chromedriver is
  installed
- Users running jasmine tests in govuk-docker will need to be using [2]
- Users running jasmine tests on their local machine will have to
  install chromedriver manually (there is a helpful prompt)

[1]: https://github.com/alphagov/govuk_publishing_components/pull/2625
[2]: https://github.com/alphagov/govuk-docker/pull/577
[3]: https://github.com/alphagov/govuk_test/pull/43
