### PR TITLE
Release v28.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## ## 28.7.0
 
 * Update real user metrics LUX.js to v300 ([PR #2637](https://github.com/alphagov/govuk_publishing_components/pull/2637))
 * Remove `header-navigation.js` ([PR #2632](https://github.com/alphagov/govuk_publishing_components/pull/2632))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (28.6.0)
+    govuk_publishing_components (28.7.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -405,7 +405,7 @@ DEPENDENCIES
   yard
 
 RUBY VERSION
-   ruby 2.7.5p203
+  ruby 2.7.5p203
 
 BUNDLED WITH
    2.3.8

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "28.6.0".freeze
+  VERSION = "28.7.0".freeze
 end


### PR DESCRIPTION
Includes:

* Update real user metrics LUX.js to v300 ([PR #2637](https://github.com/alphagov/govuk_publishing_components/pull/2637))
* Remove `header-navigation.js` ([PR #2632](https://github.com/alphagov/govuk_publishing_components/pull/2632))
* Add support for Rails 7; add support for Ruby 3.0 and 3.1; and drop support for Ruby 2.6 ([PR #2642](https://github.com/alphagov/govuk_publishing_components/pull/2642))