### PR TITLE
Improve custom dimensions code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Allow attachments to display link to accessible format request form [PR #2636](https://github.com/alphagov/govuk_publishing_components/pull/2636)
+* Improve custom dimensions code ([PR #2646](https://github.com/alphagov/govuk_publishing_components/pull/2646))
 
 ## 28.7.1
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/page-content.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/page-content.js
@@ -14,7 +14,7 @@
       case isDocumentCollectionPage():
         return document.querySelectorAll('.document-collection .group-title').length
       case isMainstreamBrowsePage():
-        return countVisible(document.querySelectorAll('#subsection ul')) || document.querySelectorAll('#section ul').length
+        return countVisible(document.querySelectorAll('#subsection ul')) || document.querySelectorAll('#section ul').length || document.querySelectorAll('#root ul').length
       case isTopicPage():
         return document.querySelectorAll('.topics-page nav.index-list').length
       case isPolicyAreaPage():
@@ -45,7 +45,7 @@
       case isDocumentCollectionPage():
         return document.querySelectorAll('.document-collection .group-document-list li a').length
       case isMainstreamBrowsePage():
-        return countVisible(document.querySelectorAll('#subsection ul a')) || document.querySelectorAll('#section ul a').length
+        return countVisible(document.querySelectorAll('#subsection ul a')) || document.querySelectorAll('#section ul a').length || document.querySelectorAll('#root ul a').length
       case isTopicPage():
         return document.querySelectorAll('.topics-page .index-list ul a').length ||
           document.querySelectorAll('.topics-page .topics ul a').length
@@ -71,7 +71,7 @@
   function getMetaAttribute (selector) {
     var element = document.querySelector(selector)
     if (element) {
-      return element.getAttribute('content')
+      return element.getAttribute('content').toLowerCase()
     }
   }
 

--- a/spec/javascripts/govuk_publishing_components/analytics/page-content.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/page-content.spec.js
@@ -165,6 +165,17 @@ describe('Page content', function () {
       createMetaTags('format', 'mainstream_browse_page')
     })
 
+    it('gets the number of sections in the browse root', function () {
+      var parent = createDummyElement('div', false, 'root')
+
+      for (var i = 1; i <= 3; i++) {
+        createDummyElement('ul', false, false, false, false, parent)
+      }
+
+      var result = window.GOVUK.PageContent.getNumberOfSections()
+      expect(result).toEqual(3)
+    })
+
     it('gets the number of sections when there is a browse section', function () {
       var parent = createDummyElement('div', false, 'section')
 
@@ -190,6 +201,21 @@ describe('Page content', function () {
 
       var result = window.GOVUK.PageContent.getNumberOfSections()
       expect(result).toEqual(3)
+    })
+
+    it('gets the number of links in the browse root', function () {
+      var parent = createDummyElement('div', false, 'section')
+      var child
+
+      for (var i = 1; i <= 2; i++) {
+        child = createDummyElement('ul', false, false, false, false, parent)
+        for (var x = 1; x <= 4; x++) {
+          createDummyElement('a', false, false, false, false, child)
+        }
+      }
+
+      var result = window.GOVUK.PageContent.getNumberOfLinks()
+      expect(result).toEqual(8)
     })
 
     it('gets the number of links when there is a browse section', function () {


### PR DESCRIPTION
## What
Improve the analytics custom dimensions code.

- more specifically, the PageContent code called from custom dimensions to supply custom dimensions 26 and 27
- on mainstream browse pages, they should report not only the number of sections and total number of links in the two right hand columns (if visible) but also the left hand column, if that is the only column
- also the code to identify the application and page as collections and browse assumed the meta tag content was 'collections', which is true on live but in Dev for some reason it was 'Collections', which made testing this difficult, so have lowercased that identifier to make it more certain
- also added tests for these two new columns

## Why
We're fixing the analytics on the browse page so we can understand it better before making any changes.

## Visual Changes
None.

Trello card: https://trello.com/c/uyaekaKj/394-fix-google-analytics-page-path-on-ajax-events-on-mainstream-browse-pages
