### PR TITLE
Update accordion tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Remove `header-navigation.js` ([PR #2632](https://github.com/alphagov/govuk_publishing_components/pull/2632))
 * Add support for Rails 7; add support for Ruby 3.0 and 3.1; and drop support for Ruby 2.6 ([PR #2642](https://github.com/alphagov/govuk_publishing_components/pull/2642))
 * Hide feedback component error summary on submission ([PR #2557](https://github.com/alphagov/govuk_publishing_components/pull/2557))
+* Update accordion tests ([PR #2647](https://github.com/alphagov/govuk_publishing_components/pull/2647))
 
 ## 28.6.0
 

--- a/spec/components/accordion_spec.rb
+++ b/spec/components/accordion_spec.rb
@@ -5,10 +5,6 @@ describe "Accordion", type: :view do
     "accordion"
   end
 
-  def given_i_visit_a_page_with_the_tabs_component
-    visit "/accordionexample"
-  end
-
   it "does not render anything if no data is passed" do
     test_data = {}
     assert_empty render_component(test_data)
@@ -289,27 +285,5 @@ describe "Accordion", type: :view do
     assert_select "#thanks-nunjucks-heading-1", count: 1
     assert_select "#thanks-nunjucks-summary-1", count: 1
     assert_select "#thanks-nunjucks-content-1", count: 1
-  end
-
-  def given_i_visit_a_page_with_the_accordion_component
-    visit "/accordionexample"
-  end
-
-  def then_the_accordion_load
-    expect(page).to have_css(".gem-c-accordion--active")
-  end
-
-  def then_the_accordion_opens_when_clicked
-    find("#writing-well-for-the-web").click
-    expect(page).to have_css(".govuk-accordion__section.govuk-accordion__section--expanded")
-    find("#writing-well-for-the-web").click
-  end
-
-  def then_the_accordion_has_data_attributes
-    assert_select ".gem-c-accordion[data-show-text='Show']"
-    assert_select ".gem-c-accordion[data-hide-text='Hide']"
-    assert_select ".gem-c-accordion[data-show-all-text='Show all sections']"
-    assert_select ".gem-c-accordion[data-hide-all-text='Hide all sections']"
-    assert_select ".gem-c-accordion[data-this-section-visually-hidden=' this section']"
   end
 end

--- a/spec/features/accordion_spec.rb
+++ b/spec/features/accordion_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe "Accordion", js: true, type: :view do
+  scenario "There is a page with the accordion rendered" do
+    given_i_visit_a_page_with_the_accordion_component
+    then_the_accordion_loads
+    then_the_accordion_javascript_loads
+    when_i_click_the_first_accordion_section
+    then_the_accordion_opens
+    when_i_click_the_first_accordion_section
+    then_the_accordion_has_data_attributes
+  end
+
+  def given_i_visit_a_page_with_the_accordion_component
+    visit "/accordionexample"
+  end
+
+  def then_the_accordion_loads
+    expect(page).to have_css(".gem-c-accordion", visible: :visible)
+    expect(page).not_to have_content("This is the content for Writing well for the web.")
+  end
+
+  def then_the_accordion_javascript_loads
+    expect(page).to have_css(".gem-c-accordion--active", visible: :visible)
+    expect(page).to have_css(".govuk-accordion__show-all", visible: :visible)
+    expect(page).not_to have_content("This is the content for Writing well for the web.")
+  end
+
+  def when_i_click_the_first_accordion_section
+    page.first(".govuk-accordion__section-button").click
+  end
+
+  def then_the_accordion_opens
+    expect(page).to have_selector(".govuk-accordion__section.govuk-accordion__section--expanded", visible: :visible)
+    expect(page).to have_content("This is the content for Writing well for the web.")
+  end
+
+  def then_the_accordion_has_data_attributes
+    expect(page).to have_selector(".gem-c-accordion[data-show-text='Show']", visible: :visible)
+    expect(page).to have_selector(".gem-c-accordion[data-hide-text='Hide']", visible: :visible)
+    expect(page).to have_selector(".gem-c-accordion[data-show-all-text='Show all sections']", visible: :visible)
+    expect(page).to have_selector(".gem-c-accordion[data-hide-all-text='Hide all sections']", visible: :visible)
+    expect(page).to have_selector(".gem-c-accordion[data-this-section-visually-hidden=' this section']", visible: :visible)
+    expect(page).to have_selector(".govuk-accordion__section-heading[data-gtm='gtm-accordion-item-1']", visible: :visible)
+  end
+end


### PR DESCRIPTION
## What

Update testing on the accordion

## Why

Tests [introduced in this PR](https://github.com/alphagov/govuk_publishing_components/pull/2581) were not actually checking against a rendered page.

## Visuals

Testing run against this URL
http://govuk-publishing-components.dev.gov.uk/accordionexample

![image](https://user-images.githubusercontent.com/71266765/156218555-3c54062b-a137-4410-adf4-fb90ef3285c6.png)