### PR TITLE
Fix release GitHub Action and release 28.7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         rubygems: latest
+    - uses: actions/setup-node@v3.0.0
+      with:
+        node-version: lts/* # use the latest LTS release
+    - run: yarn install
     - env:
         GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## ## 28.7.0
+## 28.7.0 - Yanked due to missing node dependencies
 
 * Update real user metrics LUX.js to v300 ([PR #2637](https://github.com/alphagov/govuk_publishing_components/pull/2637))
 * Remove `header-navigation.js` ([PR #2632](https://github.com/alphagov/govuk_publishing_components/pull/2632))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 28.7.1
+
+* Re-release of 28.7.0 with the missing node dependencies restored. ([PR #2648](https://github.com/alphagov/govuk_publishing_components/pull/2648))
+
 ## 28.7.0 - Yanked due to missing node dependencies
 
 * Update real user metrics LUX.js to v300 ([PR #2637](https://github.com/alphagov/govuk_publishing_components/pull/2637))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (28.7.0)
+    govuk_publishing_components (28.7.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -405,7 +405,7 @@ DEPENDENCIES
   yard
 
 RUBY VERSION
-  ruby 2.7.5p203
+   ruby 2.7.5p203
 
 BUNDLED WITH
    2.3.8

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "28.7.0".freeze
+  VERSION = "28.7.1".freeze
 end


### PR DESCRIPTION
## What

This adds a yarn install step to the GitHub Action to release this gem. It then bumps the gem version to 28.7.1.

## Why

The release of 28.7.0 was missing the node_modules dependency, which was a consequence of us trying out a GitHub Actions release process for the first time. 

## Visual Changes
None