### PR TITLE
Increase font-size on document list

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -66,7 +66,8 @@
 
 .gem-c-document-list__attribute {
   @include govuk-text-colour;
-  @include govuk-font(14);
+  @include govuk-font(16);
+  color: $govuk-secondary-text-colour;
   display: inline-block;
   list-style: none;
   padding-right: govuk-spacing(4);


### PR DESCRIPTION
## What

Increases the font size & updates to [secondary colour](https://design-system.service.gov.uk/styles/colour/) on the [`document_list` component](https://components-gem-pr-2650.herokuapp.com/component-guide/document_list)

## Why

As part of on-going work to improve accessibility

## Visual Changes

### Before > After

#### Mobile

![Screenshot 2022-03-02 at 12 04 22](https://user-images.githubusercontent.com/71266765/156358948-c1a59b41-29be-47cf-8611-3519247b8d44.png)

#### Desktop

![Screenshot 2022-03-02 at 12 03 29](https://user-images.githubusercontent.com/71266765/156358952-fd097c55-0cbe-4a3e-a714-2bf79c0377d8.png)

## Anything else

https://components-gem-pr-2652.herokuapp.com/component-guide/document_list