### PR TITLE
Add spellcheck to input 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove Brexit call to action from contextual sidebar ([#2518](https://github.com/alphagov/govuk_publishing_components/pull/2518))
+* Add spellcheck to input [PR #2654](https://github.com/alphagov/govuk_publishing_components/pull/2654)
 
 ## 28.9.0
 

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -7,6 +7,7 @@
   describedby ||= nil
   enterkeyhint ||= nil
   id ||= "input-#{SecureRandom.hex(4)}"
+  spellcheck ||= "false"
   type ||= "text"
   value ||= nil
   inputmode ||= nil
@@ -63,6 +64,7 @@
     inputmode = "numeric"
     pattern = "[0-9]*"
   end
+
 %>
 
 <%= content_tag :div, class: form_group_css_classes do %>
@@ -114,6 +116,7 @@
     name: name,
     pattern: pattern,
     readonly: readonly,
+    spellcheck: spellcheck,
     tabindex: tabindex,
     type: type,
     value: value

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -24,12 +24,19 @@ examples:
         text: "What is your name?"
       name: "name"
   specific_input_type:
-    description: By default the input will be type="text". This parameter accepts an alternative, e.g. "search" or "email". No validation is done on this input.
+    description: By default the input will be `type="text"`. This parameter accepts an alternative, e.g. `search` or `email`. `spellcheck="false"` is the default this can be changed by passing a `true` value. Consider adding `autocomplete`. No validation is done on this input.
     data:
       label:
         text: "What is your email address?"
       name: "address"
       type: "email"
+  with_autocomplete:
+    data:
+      label:
+        text: "Automatically complete the field with a user's email address (in supporting browsers)"
+      name: "name"
+      type: "email"
+      autocomplete: "email"
   numeric_input:
     description: If input is set to `type="number"` we set the component up as described in the [GOV.UK Design System guidance](https://design-system.service.gov.uk/components/text-input/#numbers) adding `inputmode` and `pattern`. These values can be overridden if necessary.
     data:
@@ -46,11 +53,11 @@ examples:
       id: "hasid"
   with_aria_attributes:
     description: |
-      The component accepts two possible aria attributes: aria-describedby and aria-controls.
+      The component accepts two possible aria attributes: `aria-describedby` and `aria-controls`.
 
-      [aria-describedby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute) is used to indicate the ID of the element that describes the input. This will be overridden in the event of an error, where the error will be used for the describedby attribute value. This example uses the ID of the main container for demonstration purposes as there aren't any useful elements with IDs in the component guide. In real use this would be passed the ID of an element that correctly described the input.
+      [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute) is used to indicate the `ID` of the element that describes the input. This will be overridden in the event of an error, where the error will be used for the `describedby` attribute value. This example uses the `ID` of the main container for demonstration purposes as there aren't any useful elements with `IDs` in the component guide. In real use this would be passed the `ID` of an element that correctly described the input.
 
-      aria-controls allows the addition of an aria-controls attribute, for use in places like the finders where the page is updated dynamically after value changes to the input.
+      `aria-controls` allows the addition of an `aria-controls` attribute, for use in places like the finders where the page is updated dynamically after value changes to the input.
     data:
       label:
         text: "This is an example only and may not work with a screen reader"
@@ -104,13 +111,6 @@ examples:
       name: "name"
       value: "You can't type more"
       maxlength: 10
-  with_autocomplete:
-    data:
-      label:
-        text: "Automatically complete the field with a user's email address (in supporting browsers)"
-      name: "name"
-      type: "email"
-      autocomplete: "email"
   with_custom_width:
     data:
       label:
@@ -119,17 +119,20 @@ examples:
       name: "name"
       width: 10
   with_search_icon:
+    description: |
+        Adds a search icon, [spellcheck](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck) can also be added to indicate that the element should be, if possible, checked for spelling errors.
     data:
       label:
         text: "Search the internet"
       name: "search-box"
       type: "search"
       search_icon: true
+      spellcheck: true
   with_label_as_heading:
     description: |
-      Wraps the label in a heading tag. Valid options are 1 to 6. To adjust the size of the label/heading, use the `heading_size` option. Valid options are 's', 'm', 'l' and 'xl'.
+      Wraps the label in a heading tag. Valid options are `1` to `6`. To adjust the size of the label/heading, use the `heading_size` option. Valid options are `s`, `m`, `l` and `xl`.
 
-      Based on the [heading/label pattern](https://design-system.service.gov.uk/patterns/question-pages/) in the Design System.
+      Based on the [heading/label pattern](https://design-system.service.gov.uk/patterns/question-pages/) in the GOV.UK Design System.
     data:
       label:
         text: "This is a heading 1 and a label"

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -31,6 +31,7 @@ describe "Input", type: :view do
 
     assert_select ".govuk-input[type='email']"
     assert_select ".govuk-input[name='email-address']"
+    assert_select ".govuk-input[spellcheck='false']"
   end
 
   # https://design-system.service.gov.uk/components/text-input/#numbers
@@ -41,6 +42,7 @@ describe "Input", type: :view do
     )
 
     assert_select ".govuk-input[type='text'][pattern='[0-9]*'][inputmode='numeric']"
+    assert_select ".govuk-input[spellcheck='false']"
   end
 
   it "renders an input with a given id" do
@@ -93,6 +95,7 @@ describe "Input", type: :view do
     )
 
     assert_select ".govuk-input[autocomplete='name']"
+    assert_select ".govuk-input[spellcheck='false']"
   end
 
   it "renders input with a data attributes" do


### PR DESCRIPTION
## What

Update `inputs` to include `spellcheck=""false"` by default - allows the option to be changed to `true` when required

## Why

Inline with [GOVUK Design System Guidance](https://design-system.service.gov.uk/patterns/email-addresses/), noted as part of accessible format request epic

Many inputs like `email` and `name` have no value being spellchecked due to their nature.  However other fields do, allows this option to be manually passed if required.

## Visual Changes

NA

## Anything else

Docs have been updated, code formatting added + `autocomplete` has been moved to be grouped next to email as this is highly recommended to be used in conjunction  