### PR TITLE
Drop Psych 4 dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 28.8.1
+
+* Drop dependency `psych >= 4` that was breaking downstream apps [PR #2655](https://github.com/alphagov/govuk_publishing_components/pull/2655)
+
 ## 28.8.0
 
 * Allow attachments to display link to accessible format request form [PR #2636](https://github.com/alphagov/govuk_publishing_components/pull/2636)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (28.8.0)
+    govuk_publishing_components (28.8.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
       govuk_personalisation (>= 0.7.0)
       kramdown
       plek
-      psych (>= 4)
       rails (>= 6)
       rouge
       sprockets (< 4)
@@ -215,8 +214,6 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    psych (4.0.3)
-      stringio
     public_suffix (4.0.6)
     puma (5.6.2)
       nio4r (~> 2.0)
@@ -346,7 +343,6 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
-    stringio (3.0.1)
     strscan (3.0.1)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)

--- a/app/models/govuk_publishing_components/component_docs.rb
+++ b/app/models/govuk_publishing_components/component_docs.rb
@@ -45,7 +45,7 @@ module GovukPublishingComponents
     end
 
     def parse_documentation(file)
-      { id: File.basename(file, ".yml") }.merge(YAML.unsafe_load_file(file)).with_indifferent_access
+      { id: File.basename(file, ".yml") }.merge(YAML.load_file(file)).with_indifferent_access
     end
 
     def app_documentation_directory

--- a/app/models/govuk_publishing_components/component_docs.rb
+++ b/app/models/govuk_publishing_components/component_docs.rb
@@ -45,7 +45,10 @@ module GovukPublishingComponents
     end
 
     def parse_documentation(file)
-      { id: File.basename(file, ".yml") }.merge(YAML.load_file(file)).with_indifferent_access
+      # Psych 4's YAML.unsafe_load_file === Psych 3's YAML.load_file
+      # but until we drop support for Ruby 2.7 and Ruby 3.0, we need to support both major versions of Psych
+      yaml = YAML.respond_to?(:unsafe_load_file) ? YAML.unsafe_load_file(file) : YAML.load_file(file)
+      { id: File.basename(file, ".yml") }.merge(yaml).with_indifferent_access
     end
 
     def app_documentation_directory

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency "govuk_personalisation", ">= 0.7.0"
   s.add_dependency "kramdown"
   s.add_dependency "plek"
-  s.add_dependency "psych", ">= 4"
   s.add_dependency "rails", ">= 6"
   s.add_dependency "rouge"
   s.add_dependency "sprockets", "< 4"

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "28.8.0".freeze
+  VERSION = "28.8.1".freeze
 end

--- a/spec/components/all_components_spec.rb
+++ b/spec/components/all_components_spec.rb
@@ -13,7 +13,7 @@ describe "All components" do
       end
 
       it "has the correct documentation" do
-        yaml = YAML.unsafe_load_file(yaml_file)
+        yaml = YAML.load_file(yaml_file)
 
         expect(yaml["name"]).not_to be_nil
         expect(yaml["description"]).not_to be_nil

--- a/spec/components/all_components_spec.rb
+++ b/spec/components/all_components_spec.rb
@@ -13,7 +13,9 @@ describe "All components" do
       end
 
       it "has the correct documentation" do
-        yaml = YAML.load_file(yaml_file)
+        # Psych 4's YAML.unsafe_load_file === Psych 3's YAML.load_file
+        # but until we drop support for Ruby 2.7 and Ruby 3.0, we need to support both major versions of Psych
+        yaml = YAML.respond_to?(:unsafe_load_file) ? YAML.unsafe_load_file(yaml_file) : YAML.load_file(yaml_file)
 
         expect(yaml["name"]).not_to be_nil
         expect(yaml["description"]).not_to be_nil


### PR DESCRIPTION
## What

This PR drops the gem's dependency on `psych >= 4`.

## Why

It was breaking downstream applications that had come to implicitly depend on the Psych version that [comes with the Ruby standard library](https://stdgems.org/psych/). This isn't an unreasonable assumption for applications to make, and this gem's explicit dependence on Psych 4 meant that applications expecting to have Psych 3 were tripping over the breaking API changes between the two versions.

For example, see alphagov/content-publisher#2464.

## Visual Changes

None.