### PR TITLE
Add 'Invasion of Ukraine' CTA to pages tagged to the topical event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add 'Invasion of Ukraine' CTA to pages tagged to the topical event ([PR #2657](https://github.com/alphagov/govuk_publishing_components/pull/2657))
+
 ## 28.8.1
 
 * Drop dependency `psych >= 4` that was breaking downstream apps [PR #2655](https://github.com/alphagov/govuk_publishing_components/pull/2655)

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -19,6 +19,7 @@ $transition-campaign-red: #ff003b;
 }
 
 .gem-c-contextual-sidebar__cta {
+  border-top: 2px solid $govuk-brand-colour;
   margin-bottom: govuk-spacing(6);
   background-color: govuk-colour('light-grey', $legacy: 'grey-4');
   display: block;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_related-navigation.scss
@@ -1,6 +1,7 @@
 .gem-c-related-navigation {
   @include govuk-text-colour;
   border-top: 2px solid govuk-colour("blue");
+  margin-bottom: govuk-spacing(9);
 }
 
 .gem-c-related-navigation__main-heading {

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -24,6 +24,10 @@
     } %>
   <% end %>
 
+  <% if navigation.show_ukraine_cta? %>
+    <%= render 'govuk_publishing_components/components/contextual_sidebar/ukraine_cta', content_item: content_item %>
+  <% end %>
+
   <% if navigation.show_brexit_cta? %>
     <%= render 'govuk_publishing_components/components/contextual_sidebar/brexit_cta', content_item: content_item %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_ukraine_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_ukraine_cta.html.erb
@@ -1,0 +1,27 @@
+<% shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns) %>
+<%
+  title = t("components.related_navigation.ukraine.title")
+  link_text = t("components.related_navigation.ukraine.link_text")
+  link_path = t("components.related_navigation.ukraine.link_path")
+  lang = shared_helper.t_locale("components.related_navigation.ukraine.title")
+%>
+
+<% data_attributes = {
+  "module": "gem-track-click",
+  "track-category": "relatedLinkClicked",
+  "track-action": "1.0 Invasion of Ukraine",
+  "track-label": link_path,
+  "track-dimension": link_text,
+  "track-dimension-index": "29",
+} %>
+
+<%= tag.div class: "gem-c-contextual-sidebar__cta" do %>
+  <%= tag.h2 title, class: "gem-c-contextual-sidebar__heading govuk-heading-s" %>
+  <%= tag.p class: "gem-c-contextual-sidebar__text govuk-body" do %>
+    <%= link_to link_text,
+      link_path,
+      class: "govuk-link",
+      data: data_attributes,
+      lang: lang %>
+  <% end %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -112,3 +112,21 @@ examples:
             - content_id: "2f8b848d-23c8-4f42-a41a-df1f81c64d0f"
               title: "Exporting"
               phase: "live"
+
+  with_ukraine_cta:
+    description: For documents tagged to the Ukraine topical event we show a custom 'Ukraine Invasion' call to action element.
+    data:
+      content_item:
+        title: "UK forces arrive to reinforce NATO’s eastern flank"
+        content_id: "a342fd46-d801-4c1e-9d8f-f41fba6da563"
+        locale: "en"
+        links:
+          ordered_related_items:
+          - title: Protecting the UK and promoting a Global Britain
+            base_path: "/government/collections/protecting-the-uk-and-promoting-a-global-britain"
+            locale: "en"
+          topical_events:
+            - content_id: "bfa79635-ffda-4b5d-8266-a9cd3a03649c"
+              title: "Russian invasion of Ukraine: UK government response"
+              base_path: "/government/topical-events/russian-invasion-of-ukraine-uk-government-response"
+              locale: "en"

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -163,6 +163,10 @@ ar:
         link_path: "/brexit"
         link_text: تحقق مما تحتاج إلى القيام به
         title: برِيكْسِت
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: المواقع العالمية
     search_box:
       input_title: بحث

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -159,6 +159,10 @@ az:
         link_path: "/brexit"
         link_text: Nələri etməli olduğunuzu yoxlayın
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Dünya üzrə yerləri
     search_box:
       input_title: Axtar

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -166,6 +166,10 @@ be:
         link_path: "/brexit"
         link_text: Праверце, што вам трэба зрабіць
         title: Брэкзiт
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Мы ў свеце
     search_box:
       input_title: Пошук

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -164,6 +164,10 @@ bg:
         link_path: "/brexit"
         link_text: Проверете какво трябва да направите
         title: Брекзит
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Местоположения по света
     search_box:
       input_title: Търсене

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -161,6 +161,10 @@ bn:
         link_path: "/brexit"
         link_text: আপনার যা করা প্রয়োজন তা দেখুন
         title: ব্রেক্সিট
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: বিশ্বের অবস্থানসমূহ
     search_box:
       input_title: খুঁজুন

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -165,6 +165,10 @@ cs:
         link_path: "/brexit"
         link_text: Zkontrolujte, co je třeba udělat
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Místa ve světě
     search_box:
       input_title: Vyhledávání

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -164,6 +164,10 @@ cy:
         link_path: "/brexit.cy"
         link_text: Gwiriwch beth mae angen i chi wneud
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Lleoliadau byd-eang
     search_box:
       input_title: Chwilio

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -161,6 +161,10 @@ da:
         link_path: "/brexit"
         link_text: Tjek hvad du skal gøre
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Verden Placeringer
     search_box:
       input_title: Søge

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -164,6 +164,10 @@ de:
         link_path: "/brexit"
         link_text: Prüfen Sie, was Sie machen müssen
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Weltweite Standorte
     search_box:
       input_title: Suche

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -162,6 +162,10 @@ dr:
         link_path: "/brexit"
         link_text: بیبینید که چه کاری باید انجام دهید
         title: برکست
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: موقعیت هایی جهان
     search_box:
       input_title: جستجو نمایید

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -160,6 +160,10 @@ el:
         link_path: "/brexit"
         link_text: Ελέγξτε τι πρέπει να κάνετε
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Παγκόσμιες τοποθεσίες
     search_box:
       input_title: Αναζήτηση

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,6 +234,10 @@ en:
         link_path: "/brexit"
         link_text: Check what you need to do
         title: Brexit
+      ukraine:
+        link_path: "/government/topical-events/russian-invasion-of-ukraine-uk-government-response"
+        link_text: Find out about the UK’s response
+        title: Invasion of Ukraine
       world_locations: World locations
     search_box:
       input_title: Search

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -160,6 +160,10 @@ es-419:
         link_path: "/brexit"
         link_text: Verifique lo que debe hacer
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Ubicaciones en el mundo
     search_box:
       input_title: Buscar

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -160,6 +160,10 @@ es:
         link_path: "/brexit"
         link_text: Compruebe lo que necesita hacer
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Ubicaciones mundiales
     search_box:
       input_title: Buscar

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -163,6 +163,10 @@ et:
         link_path: "/brexit"
         link_text: Kontrollige, mida peate tegema
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Maailma asukohad
     search_box:
       input_title: Otsing

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -158,6 +158,10 @@ fa:
         link_path: "/brexit"
         link_text: آنچه را باید انجام دهید، بررسی کنید
         title: برگزیت
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: مکان‌های جهانی
     search_box:
       input_title: جستجو

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -162,6 +162,10 @@ fi:
         link_path: "/brexit"
         link_text: Tarkista, mitä sinun on tehtävä
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Maailman sijainnit
     search_box:
       input_title: Hae

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -160,6 +160,10 @@ fr:
         link_path: "/brexit"
         link_text: Vérifiez ce que vous devez faire
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Emplacements dans le monde
     search_box:
       input_title: Rechercher

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -162,6 +162,10 @@ gd:
         link_path: "/brexit"
         link_text: Seiceáil cad is gá duit aird a thabhairt air
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Áit ar domhan
     search_box:
       input_title: Taighde

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -160,6 +160,10 @@ gu:
         link_path: "/brexit"
         link_text: તમારે શું કરવું પડશે તે તપાસો
         title: બ્રેક્ઝિટ
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: વૈશ્વિક લોકેશન્સ
     search_box:
       input_title: શોધો

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -160,6 +160,10 @@ he:
         link_path: "/brexit"
         link_text: בדוק מה אתה צריך לעשות
         title: " ברקזיט"
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: מיקומים גלובאליים
     search_box:
       input_title: 'חפש '

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -160,6 +160,10 @@ hi:
         link_path: "/brexit"
         link_text: जांचें कि आपको क्या करना है
         title: ब्रेक्सिट
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: वैश्विक स्थान
     search_box:
       input_title: खोजें

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -162,6 +162,10 @@ hr:
         link_path: "/brexit"
         link_text: Provjerite što trebate učiniti
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Svjetske lokacije
     search_box:
       input_title: Pretraga

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -163,6 +163,10 @@ hu:
         link_path: "/brexit"
         link_text: Nézze meg, hogy mit kell tennie
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Helyszínek a világban
     search_box:
       input_title: Keresés

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -164,6 +164,10 @@ hy:
         link_path: "/brexit"
         link_text: Իմացեք, թե ինչ պետք է անեք
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Գտնվելու վայրերը
     search_box:
       input_title: Որոնում

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -160,6 +160,10 @@ id:
         link_path: "/brexit"
         link_text: Periksa apa yang Anda harus lakukan
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Lokasi dunia
     search_box:
       input_title: Cari

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -160,6 +160,10 @@ is:
         link_path: "/brexit"
         link_text: Athugaðu hvað þú þarft að gera
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Staðsetningar úti um allan heim
     search_box:
       input_title: Leita

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -160,6 +160,10 @@ it:
         link_path: "/brexit"
         link_text: Controlla cosa devi fare
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Località del mondo
     search_box:
       input_title: Cerca

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -156,6 +156,10 @@ ja:
         link_path: "/brexit"
         link_text: あなたがする必要があることを確認してください
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: 世界の場所
     search_box:
       input_title: 検索

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -163,6 +163,10 @@ ka:
         link_path: "/brexit"
         link_text: შეამოწმეთ თუ რა უნდა გააკეთოთ
         title: ბრექსითის შემოწმება
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: მსოფლიო ლოკაციები
     search_box:
       input_title: ძიება

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -160,6 +160,10 @@ kk:
         link_path: "/brexit"
         link_text: Не істеу керек екенін қараңыз
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Әлемдегі орындар
     search_box:
       input_title: Іздеу

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -155,6 +155,10 @@ ko:
         link_path:
         link_text:
         title:
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations:
     search_box:
       input_title:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -165,6 +165,10 @@ lt:
         link_path: "/brexit"
         link_text: Pažiūrėkite, ką turite daryti
         title: "„Brexitas“ "
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Pasaulio vietos
     search_box:
       input_title: Ieškoti

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -164,6 +164,10 @@ lv:
         link_path: "/brexit"
         link_text: Noskaidrojiet, kas jums jāpaveic
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Atrašanās vietas pasaulē
     search_box:
       input_title: Meklēt

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -159,6 +159,10 @@ ms:
         link_path: "/brexit"
         link_text: Periksa apa yang perlu anda lakukan
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Lokasi dunia
     search_box:
       input_title: Carian

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -162,6 +162,10 @@ mt:
         link_path: "/brexit"
         link_text: Iċċekkja x'għandek bżonn tagħmel
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Postijiet fid-dinja
     search_box:
       input_title: Fittex

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -160,6 +160,10 @@ nl:
         link_path: "/brexit"
         link_text: Controleer wat u moet doen
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Locaties in de wereld
     search_box:
       input_title: Zoeken

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -160,6 +160,10 @@
         link_path: "/brexit"
         link_text: Sjekk hva du må gjøre
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Steder i verden
     search_box:
       input_title: Søk

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -156,6 +156,10 @@ pa-pk:
         link_path: "/brexit"
         link_text: دیکھو جو تہانوں کرن دی لوڑ اے
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: دُنیا دیاں تھاواں
     search_box:
       input_title: کھوج

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -160,6 +160,10 @@ pa:
         link_path: "/brexit"
         link_text: ਜਾਂਚ ਕਰੋ ਕਿ ਤੁਹਾਨੂੰ ਕੀ ਕਰਨ ਦੀ ਜ਼ਰੂਰਤ ਹੈ
         title: ਬ੍ਰੈਕਸਿਟ
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: ਵਿਸ਼ਵ ਸਥਾਨ
     search_box:
       input_title: ਖੋਜ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -164,6 +164,10 @@ pl:
         link_path: "/brexit"
         link_text: Sprawdź, co musisz zrobić
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Miejsca na świecie
     search_box:
       input_title: Szukaj

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -157,6 +157,10 @@ ps:
         link_path: "/brexit"
         link_text: وګورئ چې تاسو څه کولو ته اړتیا لرئ
         title: بریکسیټ
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: د نړۍ موقعیتونه
     search_box:
       input_title: لټون

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -160,6 +160,10 @@ pt:
         link_path: "/brexit"
         link_text: Verifique o que precisa de fazer
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Locais mundiais
     search_box:
       input_title: Pesquisar

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -161,6 +161,10 @@ ro:
         link_path: "/brexit"
         link_text: Verificați ce trebuie să faceți
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Locații pe glob
     search_box:
       input_title: Căutați

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -164,6 +164,10 @@ ru:
         link_path: "/brexit"
         link_text: Проверьте, что вам нужно сделать
         title: Брексит
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Места нахождения по миру
     search_box:
       input_title: Поиск

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -160,6 +160,10 @@ si:
         link_path: "/brexit"
         link_text: ඔබ කළ යුතු දේ පරීක්ෂා කරන්න
         title: බ්රෙක්සිට්
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: ලෝක ස්ථාන
     search_box:
       input_title: සොයන්න

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -165,6 +165,10 @@ sk:
         link_path: "/brexit"
         link_text: Skontrolujte, čo je potrebné urobiť
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Svetové lokality
     search_box:
       input_title: Vyhľadávanie

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -167,6 +167,10 @@ sl:
         link_path: "/brexit"
         link_text: Preverite, kaj morate storiti
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Lokacije po svetu
     search_box:
       input_title: Iskanje

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -160,6 +160,10 @@ so:
         link_path: "/brexit"
         link_text: Hubi waxaad u baahantahay inaad qabato
         title: Ka bixitaanka Ingiriiska
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Goobaha Dunida
     search_box:
       input_title: Baadh

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -160,6 +160,10 @@ sq:
         link_path: "/brexit"
         link_text: Kontrolloni se çfarë duhet të bëni
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Vendndodhjet globale
     search_box:
       input_title: Kërko

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -161,6 +161,10 @@ sr:
         link_path: "/brexit"
         link_text: Proverite šta treba da uradite
         title: Bregzit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Globalne lokacije
     search_box:
       input_title: Pretraži

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -160,6 +160,10 @@ sv:
         link_path: "/brexit"
         link_text: Kontrollera vad du behöver göra
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Platser i världen
     search_box:
       input_title: Sök på

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -160,6 +160,10 @@ sw:
         link_path: "/brexit"
         link_text: Angalia unachopaswa kufanya
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Maeneo ya kimataifa
     search_box:
       input_title: Tafuta

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -161,6 +161,10 @@ ta:
         link_path: "/brexit"
         link_text: நீங்கள் செய்யவேண்டியது என்ன என்று பாருங்கள்
         title: பிரெக்சிட்
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: உலக இருப்பிடங்கள்
     search_box:
       input_title: தேடு

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -158,6 +158,10 @@ th:
         link_path: "/brexit"
         link_text: ตรวจสอบสิ่งที่คุณต้องทำ
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: สถานที่ทั่วโลก
     search_box:
       input_title: ค้นหา

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -161,6 +161,10 @@ tk:
         link_path: "/brexit"
         link_text: Näme etmelidigiňizi belläň
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Dünýä ýerleri
     search_box:
       input_title: Gözlemek

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -161,6 +161,10 @@ tr:
         link_path: "/brexit"
         link_text: Ne yapmaya ihtiyacınız olduğunu kontrol edin
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Dünya geneli konumlar
     search_box:
       input_title: Ara

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -167,6 +167,10 @@ uk:
         link_path: "/brexit"
         link_text: Перевірте, що вам потрібно зробити
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Світові локації
     search_box:
       input_title: Пошук

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -157,6 +157,10 @@ ur:
         link_path: "/brexit"
         link_text: پڑتال کریں کہ آپ کو کیا کرنے کی ضرورت ہے
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: عالمی مقامات
     search_box:
       input_title: تلاش

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -162,6 +162,10 @@ uz:
         link_path: "/brexit"
         link_text: Нима қилиш зарурлигини текшириш
         title: Брексит
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Жаҳондаги жойлашиш жойи
     search_box:
       input_title: Излаш

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -159,6 +159,10 @@ vi:
         link_path: "/brexit"
         link_text: Kiểm tra những gì bạn cần làm
         title: Brexit
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: Các vị trí trên thế giới
     search_box:
       input_title: Tìm kiếm

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -158,6 +158,10 @@ zh-hk:
         link_path: "/brexit"
         link_text: 查看您需要做的事
         title: 英國脫歐
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: 全世界之地點
     search_box:
       input_title: 搜尋

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -158,6 +158,10 @@ zh-tw:
         link_path: "/brexit"
         link_text: 確認你需要：
         title: 脫歐
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: 世界地點
     search_box:
       input_title: 搜尋

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -158,6 +158,10 @@ zh:
         link_path: "/brexit"
         link_text: 检查您需要做的事情
         title: 英国脱欧
+      ukraine:
+        link_path:
+        link_text:
+        title:
       world_locations: 世界地点
     search_box:
       input_title: 搜索

--- a/lib/govuk_publishing_components/presenters/contextual_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/contextual_navigation.rb
@@ -166,6 +166,22 @@ module GovukPublishingComponents
         step_nav_helper.show_also_part_of_step_nav?
       end
 
+      def content_tagged_to_ukraine_topical_event?
+        ukraine_topical_event_id = "bfa79635-ffda-4b5d-8266-a9cd3a03649c"
+        topical_events = content_item.dig("links", "topical_events").to_a
+        topical_events.each do |topical_event|
+          if topical_event["content_id"].eql?(ukraine_topical_event_id)
+            return true
+          end
+        end
+
+        false
+      end
+
+      def show_ukraine_cta?
+        content_tagged_to_ukraine_topical_event?
+      end
+
       def breadcrumbs_based_on_ancestors
         ContentBreadcrumbsBasedOnAncestors.call(content_item)
       end

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -180,6 +180,34 @@ describe "Contextual navigation" do
     and_i_dont_see_the_secondary_step_by_step_in_the_also_part_of_list
   end
 
+  scenario "There is a page tagged to the 'Russian invasion of Ukraine: UK government response' topical event" do
+    given_theres_a_page_tagged_to_the_ukraine_topical_event
+    and_i_visit_that_page
+    then_i_see_the_ukraine_call_to_action
+  end
+
+  def given_theres_a_page_tagged_to_the_ukraine_topical_event
+    content_store_has_random_item(
+      schema: "news_article",
+      links: {
+        "topical_events" => [{
+          "content_id" => "bfa79635-ffda-4b5d-8266-a9cd3a03649c",
+          "title" => "Russian invasion of Ukraine: UK government response",
+          "locale" => "en",
+          "base_path" => "/government/topical-events/russian-invasion-of-ukraine-uk-government-response",
+          "document_type" => "topical_event",
+        }],
+      },
+    )
+  end
+
+  def then_i_see_the_ukraine_call_to_action
+    within ".gem-c-contextual-sidebar__cta" do
+      expect(page).to have_content("Invasion of Ukraine")
+      expect(page).to have_link("Find out about the UK’s response")
+    end
+  end
+
   include GdsApi::TestHelpers::ContentStore
 
   def given_theres_a_page_with_a_step_by_step


### PR DESCRIPTION
## What
Add 'Invasion of Ukraine' CTA to pages tagged to the [Russian invasion of Ukraine: UK government response](https://www.gov.uk/government/topical-events/russian-invasion-of-ukraine-uk-government-response) topical event.

## Why
To increase awareness

## Visual Changes

[Component example in isolation](https://components-gem-pr-2657.herokuapp.com/component-guide/contextual_sidebar/with_ukraine_cta)

Tested on `government-frontend` with the following pages:
 - `/government/speeches/pm-message-to-the-people-of-ukraine-and-russia-25-february-2022` (without related content links or other CTAs)
 - `/government/publications/russia-sanctions-guidance` (with Brexit CTA)
 - `/government/news/uk-forces-arrive-to-reinforce-natos-eastern-flank` (with related content links)

Note: screenshots below have old copy on them

<table>
<tr><td>Mobile</td><td>Desktop</td>
<tr><td valign="top">

![127 0 0 1_3090_government_news_uk-forces-arrive-to-reinforce-natos-eastern-flank (1)](https://user-images.githubusercontent.com/788096/156597204-1b32875c-95cf-46ff-ac77-02798a422324.png)


</td><td valign="top">

![127 0 0 1_3090_government_news_uk-forces-arrive-to-reinforce-natos-eastern-flank](https://user-images.githubusercontent.com/788096/156597216-488395f3-22ae-4396-84c9-d38a80ef97be.png)


</td>
</tr>
</table>