### PR TITLE
Increase font-size of previous and next navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update the list of popular links in the super navigation header ([#2660](https://github.com/alphagov/govuk_publishing_components/pull/2660))
 * Remove Brexit call to action from contextual sidebar ([#2518](https://github.com/alphagov/govuk_publishing_components/pull/2518))
 * Add spellcheck to input [PR #2654](https://github.com/alphagov/govuk_publishing_components/pull/2654)
+* Increase font-size of previous_and_next_navigation, improve important icon ([PR #2659](https://github.com/alphagov/govuk_publishing_components/pull/2659))
 
 ## 28.9.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
@@ -9,7 +9,7 @@
 }
 
 .gem-c-pagination__item {
-  @include govuk-font($size: 16, $line-height: (20 / 16));
+  @include govuk-font($size: 19);
   list-style: none;
 
   &:first-child {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_warning-callout.scss
@@ -9,7 +9,7 @@
 .govspeak, // Legacy class name that's still used in some content items - needs to be kept until `.govspeak` is removed from the content items.
 .gem-c-govspeak {
   .help-notice {
-    $icon-size: 34px;
+    $icon-size: 35px;
     $line-height-mobile: 20px;
     $line-height-tablet: 25px;
 


### PR DESCRIPTION
## What

Increase `font-size` on [`previous_and_next_navigation`](http://govuk-publishing-components.dev.gov.uk//component-guide/previous_and_next_navigation/preview)

## Why

As part of on-going work to improve accessibility and wider upcoming DS `font-size` increase work

## Visual Changes

### Before > After

![Screenshot 2022-03-04 at 16 53 02](https://user-images.githubusercontent.com/71266765/156805556-2b573457-f3ea-4fc6-9a3c-4bf639f734b5.png)

## Anything else 

Related PRs

https://github.com/alphagov/govuk_publishing_components/pull/2652
https://github.com/alphagov/govuk_publishing_components/pull/2650

Small adjustment on warning / important icon - rendering size was not correct, pixel off meant it was blurry

![Screenshot 2022-03-09 at 13 15 49](https://user-images.githubusercontent.com/71266765/157449653-663bf781-8fd5-40bb-b37e-c4d5eb0dd4ca.png)