### PR TITLE
Update popular links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update the list of popular links in the super navigation header ([#2660](https://github.com/alphagov/govuk_publishing_components/pull/2660))
 * Remove Brexit call to action from contextual sidebar ([#2518](https://github.com/alphagov/govuk_publishing_components/pull/2518))
 
 ## 28.9.0

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,10 +177,10 @@ en:
       navigation_search_heading: Search and popular pages
       navigation_search_subheading: Search
       popular_links:
+      - label: 'Invasion of Ukraine'
+        href: "/government/topical-events/russian-invasion-of-ukraine-uk-government-response"
       - label: 'Coronavirus (COVID-19)'
         href: "/coronavirus"
-      - label: 'Brexit: check what you need to do'
-        href: "/brexit"
       - label: Find a job
         href: "/find-a-job"
       - label: 'Personal tax account: sign in'


### PR DESCRIPTION
## What
- Update the list of popular links (to include Invasion of Ukraine) on the super navigation header component, so that it matches the list of popular links on the homepage. See https://github.com/alphagov/frontend/pull/3155

## Why
- Adding Invasion of Ukraine to popular links is a request from content and SMT colleagues.

## Visual Changes

### Before

<img width="1031" alt="Screenshot 2022-03-07 at 12 05 23" src="https://user-images.githubusercontent.com/17908089/157031761-841eaf13-594b-4b68-a53f-c45c6c66ed59.png">


### After
<img width="1016" alt="Screenshot 2022-03-07 at 12 05 05" src="https://user-images.githubusercontent.com/17908089/157031789-6b21001a-439b-4a14-ad12-385f7658d97f.png">

