### PR TITLE
[DO NOT MERGE] Add GTM tracking module initial version

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics.js
@@ -18,3 +18,5 @@
 //= require ./analytics/explicit-cross-domain-links
 //= require ./analytics/track-click
 //= require ./analytics/track-select-change
+
+//= require ./analytics/gtm-tracking

--- a/app/assets/javascripts/govuk_publishing_components/analytics/gtm-tracking.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/gtm-tracking.js
@@ -1,0 +1,26 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function GtmTracking ($module) {
+    this.$module = $module
+  }
+
+  GtmTracking.prototype.init = function () {
+    this.$module.addEventListener('click', this.handleClick.bind(this))
+  }
+
+  GtmTracking.prototype.handleClick = function (event) {
+    var element = event.target
+    try {
+      var gtmData = JSON.parse(element.getAttribute('data-gtm-attributes'))
+      gtmData.event = 'analytics'
+      window.dataLayer = window.dataLayer || []
+      window.dataLayer.push(gtmData)
+    } catch (e) {
+      console.error('GTM configuration error: ' + e.message, window.location)
+    }
+  }
+
+  Modules.GtmTracking = GtmTracking
+})(window.GOVUK.Modules)

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -1,7 +1,4 @@
 <%
-  local_assigns[:margin_bottom] ||= 0
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
-
   text ||= false
   nowrap_text ||= false
   href ||= false
@@ -17,9 +14,23 @@
   nhs_icon ||= false
   brexit_icon ||= false
   transparent_icon ||= false
-  data ||= nil
   classes ||= nil
   font_size ||= nil
+
+  local_assigns[:margin_bottom] ||= 0
+  local_assigns[:data] ||= {}
+  local_assigns[:data][:gtm_attributes] ||= {}
+  local_assigns[:data][:gtm_attributes][:event_name] ||= 'action_link'
+  local_assigns[:data][:gtm_attributes][:component] ||= {}
+  local_assigns[:data][:gtm_attributes][:component][:category] ||= 'navigation'
+  local_assigns[:data][:gtm_attributes][:component][:main_type] ||= 'action link'
+  local_assigns[:data][:gtm_attributes][:component][:comp_text] ||= text
+  local_assigns[:data][:gtm_attributes][:component][:comp_url] ||= href
+  local_assigns[:data][:gtm_attributes][:component][:comp_action] ||= 'click'
+  local_assigns[:data][:gtm_attributes][:component][:comp_accessible_asset] ||= false
+
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  data = shared_helper.get_data_attributes
 
   css_classes = %w(gem-c-action-link)
   css_classes << "gem-c-action-link--light-text" if light_text

--- a/app/views/govuk_publishing_components/components/docs/action_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/action_link.yml
@@ -18,6 +18,19 @@ examples:
       href: "/page"
       data:
         attr_test: "hasDataAttribute"
+  with_gtm_attributes:
+    description: |
+      Given the GTM `true` parameter, the component will automatically apply a `data-gtm-attributes` parameter, containing information about the component for tracking purposes.
+
+      These attributes are populated with data from the component, but can also be overridden by passing new values.
+    data:
+      text: "Example"
+      href: "/page"
+      gtm: true
+      data:
+        attr1: "test 1"
+        gtm_attributes:
+          event_name: override
   with_js_classes:
     description: Use `js-` prefixed classes only as interaction hooks – to query and operate on elements via JavaScript. Classes are added to the link itself.
     data:

--- a/lib/govuk_publishing_components/presenters/shared_helper.rb
+++ b/lib/govuk_publishing_components/presenters/shared_helper.rb
@@ -45,6 +45,40 @@ module GovukPublishingComponents
         end
       end
 
+      def get_data_attributes
+        has_gtm = @options[:gtm] || false
+        data_attributes = @options[:data] || {}
+
+        return data_attributes unless has_gtm
+
+        not_available = "n/a"
+        gtm_attributes = {
+          event_name: not_available,
+          event_of_interest: false,
+          privacy: false,
+          component: {
+            category: not_available,
+            main_type: not_available,
+            sub_type: not_available,
+            variant: not_available,
+            sup: not_available,
+            text: not_available,
+            url: not_available,
+            value: not_available,
+            position: not_available,
+            action: not_available,
+            section: not_available,
+            heading: not_available,
+            accessible_asset: not_available,
+          },
+        }
+        data_attributes[:gtm_attributes] ||= {}
+        data_attributes[:gtm_attributes].deep_merge!(gtm_attributes) do |_key, passed_val, default_val|
+          passed_val || default_val
+        end
+        data_attributes
+      end
+
       def t_locale(content, options = {})
         # Check if the content string has a translation
         content_translation_available = translation_present?(content)

--- a/spec/javascripts/govuk_publishing_components/analytics/gtm-tracking.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/gtm-tracking.spec.js
@@ -1,0 +1,35 @@
+/* eslint-env jasmine, jquery */
+var GOVUK = window.GOVUK || {}
+
+describe('Google Tag Manager tracking', function () {
+  var el
+  var attributesFromComponent = {
+    event_name: 'this component',
+    component: {
+      main_type: 'example',
+      url: 'https://www.gov.uk'
+    }
+  }
+  var allAttributes = JSON.parse(JSON.stringify(attributesFromComponent))
+  // attributes set either by the GTM script or the component itself
+  allAttributes.event = 'analytics'
+
+  beforeEach(function () {
+    el = document.createElement('div')
+    el.setAttribute('data-gtm-attributes', JSON.stringify(attributesFromComponent))
+    document.body.appendChild(el)
+  })
+
+  afterEach(function () {
+    window.dataLayer = []
+    document.body.removeChild(el)
+  })
+
+  it('tracks clicks', function () {
+    var gtmTracking = new GOVUK.Modules.GtmTracking(el)
+    gtmTracking.init()
+
+    el.click()
+    expect(window.dataLayer[0]).toEqual(allAttributes)
+  })
+})

--- a/spec/lib/govuk_publishing_components/components/shared_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/shared_helper_spec.rb
@@ -57,6 +57,164 @@ RSpec.describe GovukPublishingComponents::Presenters::SharedHelper do
       }.to raise_error(ArgumentError, "Passed classes must be prefixed with `js-`")
     end
 
+    it "sets data attributes" do
+      attributes = {
+        example_attribute: 14,
+      }
+      expected_attributes = {
+        example_attribute: 14,
+      }
+      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(data: attributes)
+      expect(shared_helper.get_data_attributes).to eql(expected_attributes)
+    end
+
+    it "sets default GTM attributes" do
+      local_assigns = {
+        gtm: true,
+      }
+      expected_attributes = {
+        gtm_attributes: {
+          event_name: "n/a",
+          event_of_interest: false,
+          privacy: false,
+          component: {
+            category: "n/a",
+            main_type: "n/a",
+            sub_type: "n/a",
+            variant: "n/a",
+            sup: "n/a",
+            text: "n/a",
+            url: "n/a",
+            value: "n/a",
+            position: "n/a",
+            action: "n/a",
+            section: "n/a",
+            heading: "n/a",
+            accessible_asset: "n/a",
+          },
+        },
+      }
+      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+      expect(shared_helper.get_data_attributes).to eql(expected_attributes)
+    end
+
+    it "accepts given GTM attributes" do
+      local_assigns = {
+        gtm: true,
+        data: {
+          gtm_attributes: {
+            event_name: "this component",
+          },
+        },
+      }
+      expected_attributes = {
+        gtm_attributes: {
+          event_name: "this component",
+          event_of_interest: false,
+          privacy: false,
+          component: {
+            category: "n/a",
+            main_type: "n/a",
+            sub_type: "n/a",
+            variant: "n/a",
+            sup: "n/a",
+            text: "n/a",
+            url: "n/a",
+            value: "n/a",
+            position: "n/a",
+            action: "n/a",
+            section: "n/a",
+            heading: "n/a",
+            accessible_asset: "n/a",
+          },
+        },
+      }
+      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+      expect(shared_helper.get_data_attributes).to eql(expected_attributes)
+    end
+
+    it "allows both data attributes and gtm attributes" do
+      local_assigns = {
+        gtm: true,
+        data: {
+          attribute1: "1",
+          attribute2: "2",
+          gtm_attributes: {
+            event_name: "this component",
+            component: {
+              category: "this category",
+            },
+          },
+        },
+      }
+      expected_attributes = {
+        attribute1: "1",
+        attribute2: "2",
+        gtm_attributes: {
+          event_name: "this component",
+          event_of_interest: false,
+          privacy: false,
+          component: {
+            category: "this category",
+            main_type: "n/a",
+            sub_type: "n/a",
+            variant: "n/a",
+            sup: "n/a",
+            text: "n/a",
+            url: "n/a",
+            value: "n/a",
+            position: "n/a",
+            action: "n/a",
+            section: "n/a",
+            heading: "n/a",
+            accessible_asset: "n/a",
+          },
+        },
+      }
+      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+      expect(shared_helper.get_data_attributes).to eql(expected_attributes)
+    end
+
+    it "allows gtm attributes to be overridden if passed with data attributes" do
+      local_assigns = {
+        gtm: true,
+        data: {
+          attribute1: "1",
+          gtm_attributes: {
+            event_name: "test",
+            component: {
+              category: "navigation",
+            },
+          },
+        },
+      }
+      expected_attributes = {
+        attribute1: "1",
+        gtm_attributes: {
+          event_name: "test",
+          event_of_interest: false,
+          privacy: false,
+          component: {
+            category: "navigation",
+            main_type: "n/a",
+            sub_type: "n/a",
+            variant: "n/a",
+            sup: "n/a",
+            text: "n/a",
+            url: "n/a",
+            value: "n/a",
+            position: "n/a",
+            action: "n/a",
+            section: "n/a",
+            heading: "n/a",
+            accessible_asset: "n/a",
+          },
+        },
+      }
+      shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+      expect(shared_helper.get_data_attributes).to eql(expected_attributes)
+    end
+
     it "returns nil if given locale is same as page locale" do
       default_locale = I18n.locale
       shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({})


### PR DESCRIPTION
## What
Adds JavaScript to handle Google Tag Manager (GTM) tracking.

- listens for clicks on elements with data-module="gtm-tracking"
- expects a data-gtm-attributes attribute on the clicked element, containing an object that can be extracted using JSON parse to get the required attributes to push to the GTM dataLayer

All this script currently does is push to the dataLayer. It requires that GTM has been initialised at the application level using the [Google Tag Manager script component](https://components.publishing.service.gov.uk/component-guide/google_tag_manager_script) for anything to actually be registered in GA.

This PR is currently incomplete as there are unanswered questions about the attributes and how they will work. Mainly:

- for attributes that are component specific, how do we add these to components - are they hard coded into the component or always passed
- what the values for a lot of these attributes should be

## Why
We're migrating towards GA4 with Google Tag Manager and this is part of the initial work to prepare for that.

## Visual Changes
None.

Trello card: https://trello.com/c/PBL5ZR5c/841-ga4-push-gtm-data-from-clicks-to-the-action-link-component
