### PR TITLE
Release 28.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 28.9.1
 
 * Update the list of popular links in the super navigation header ([#2660](https://github.com/alphagov/govuk_publishing_components/pull/2660))
 * Remove Brexit call to action from contextual sidebar ([#2518](https://github.com/alphagov/govuk_publishing_components/pull/2518))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (28.9.0)
+    govuk_publishing_components (28.9.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "28.9.0".freeze
+  VERSION = "28.9.1".freeze
 end


### PR DESCRIPTION
## Release 28.9.1

* Update the list of popular links in the super navigation header ([https://github.com/alphagov/govuk_publishing_components/pull/2660](https://github.com/alphagov/govuk_publishing_components/pull/2660))
* Remove Brexit call to action from contextual sidebar ([https://github.com/alphagov/govuk_publishing_components/pull/2518](https://github.com/alphagov/govuk_publishing_components/pull/2518))
