### PR TITLE
 Update card tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Migrate cross domain tracking script from static ([PR #2607](https://github.com/alphagov/govuk_publishing_components/pull/2607))
+* Update card tracking ([PR #2679](https://github.com/alphagov/govuk_publishing_components/pull/2679))
 
 ## 28.9.1
 

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -4,6 +4,7 @@
   sub_heading_level ||= 3
   two_column_layout ||= false
   local_assigns ||= nil
+  data_attributes ||= nil
 
   ul_classes = %w[gem-c-cards__list]
   ul_classes << 'gem-c-cards__list--two-column-desktop' if two_column_layout
@@ -16,8 +17,9 @@
       <%= content_tag(shared_helper.get_heading_level, class: "gem-c-cards__heading govuk-heading-m") do %>
         <%= heading %>
       <% end %>
-    <% end %>
-    <%= content_tag 'ul', class: ul_classes do %>
+    <% end %>    
+
+    <%= content_tag('ul', class: ul_classes) do %>
       <%
         items.each do |item|
         link = item[:link]
@@ -25,33 +27,15 @@
         if !link[:path].present?
           raise ArgumentError, "The cards component requires a href for all the links"
         end
-
-        data_attributes = nil
-        attributes = link[:tracking_attributes].presence
-
-        if attributes && attributes[:track_category] && attributes[:track_action]
-          data_attributes = {
-            track_action: attributes[:track_action],
-            track_category: attributes[:track_category],
-            track_dimension_index: attributes[:track_dimension_index],
-            track_dimension: link[:text],
-            track_label: link[:path],
-          }
-        end
-
-        link = capture do
-           link_to(link[:text], link[:path], {
-             class: "govuk-link gem-c-cards__link",
-             data: data_attributes,
-           })
-        end
       %>
-
         <li class="gem-c-cards__list-item">
           <%= content_tag("h#{sub_heading_level}", class: "gem-c-cards__sub-heading govuk-heading-s") do %>
-            <%= link %>
+            <%= 
+              link_to link[:text], link[:path], 
+              class: "govuk-link gem-c-cards__link", 
+              data: link[:data_attributes] 
+            %>
           <% end %>
-
           <% if item[:description] %>
             <p class="govuk-body gem-c-cards__description"><%= item[:description] %></p>
           <% end %>

--- a/app/views/govuk_publishing_components/components/docs/cards.yml
+++ b/app/views/govuk_publishing_components/components/docs/cards.yml
@@ -116,24 +116,30 @@ examples:
             text: Benefits
             path: http://www.gov.uk
           description: Includes eligibility, appeals, tax credits and Universal Credit
-  with_tracking_attributes:
+  with_data_attributes:
     description: |
-      Tracking can be enabled on the cards component by passing a minimum of data_track_category and data_track_action. Other tracking attributes are optional. Note: tracking events do not currently fire within the component guide.
+      Data attributes can be passed to individual links within the component as shown.
     data:
       items:
         - link:
             text: Benefits
             path: http://www.gov.uk
-            tracking_attributes:
-              track_action: track_action
+            data_attributes:
               track_category: homepageClicked
+              track_action: track-action
+              track_label: track-label
+              track_dimension: track-dimension
               track_dimension_index: 29
+              track_value: 9
           description: Includes eligibility, appeals, tax credits and Universal Credit
         - link:
             text: Births, deaths, marriages and&nbsp;care
             path: http://www.gov.uk
-            tracking_attributes:
-              track_action: track_action
+            data_attributes:
               track_category: homepageClicked
+              track_action: track-action
+              track_label: track-label
+              track_dimension: track-dimension
               track_dimension_index: 29
+              track_value: 9
           description: Parenting, civil partnerships, divorce and Lasting Power of Attorney

--- a/app/views/govuk_publishing_components/components/docs/list.yml
+++ b/app/views/govuk_publishing_components/components/docs/list.yml
@@ -66,7 +66,7 @@ examples:
     description: |
       Sets the margin on the bottom of the list element.
 
-      The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a 20px margin.
+      The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a `20px` margin.
     data:
       margin_bottom: 9
       <<: *default-example-data

--- a/spec/components/cards_spec.rb
+++ b/spec/components/cards_spec.rb
@@ -128,10 +128,11 @@ describe "Cards", type: :view do
           link: {
             text: "Benefits",
             path: "http://www.gov.uk",
-            tracking_attributes: {
+            data_attributes: {
               track_action: "some_action",
               track_category: "homepageClicked",
               track_dimension_index: 29,
+              track_label: "http://www.gov.uk",
             },
           },
         },
@@ -142,24 +143,5 @@ describe "Cards", type: :view do
     assert_select ".govuk-link.gem-c-cards__link[data-track-action='some_action']", count: 1
     assert_select ".govuk-link.gem-c-cards__link[data-track-category='homepageClicked']", count: 1
     assert_select ".govuk-link.gem-c-cards__link[data-track-dimension-index='29']", count: 1
-  end
-
-  it "doesn't render any tracking attributes if the required attributes are not set" do
-    test_data = {
-      items: [
-        {
-          link: {
-            text: "Benefits",
-            path: "http://www.gov.uk",
-            tracking_attributes: {
-              # This omits action and category which are required
-              track_dimension_index: 29,
-            },
-          },
-        },
-      ],
-    }
-    render_component(test_data)
-    assert_select ".govuk-link.gem-c-cards__link[data-track-dimension-index='1']", count: 0
   end
 end


### PR DESCRIPTION
## What

Update [`cards` component](http://govuk-publishing-components.dev.gov.uk/component-guide/cards/) tracking to be more flexible so values can be passed more easily. 

## Why

Closes [2565](https://github.com/alphagov/govuk_publishing_components/issues/2656)

## Visual Changes

NA (language adjustment flagged on visual regression)

## Anything else

Related PR - https://github.com/alphagov/collections/pull/2673
Part of wider epic - "Build new page templates for GOV.UK Browse"

Small adjustment to [`list`](https://components.publishing.service.gov.uk/component-guide/list) docs.
Related PR: small adjustment to [`lead_paragraph`](https://github.com/alphagov/govuk_publishing_components/pull/2681) prompted during review 