### PR TITLE
Don't use embedded Ruby for rum-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use a data attribute to specify RUM (real user monitoring) script location ([PR #2682](https://github.com/alphagov/govuk_publishing_components/pull/2682))
+
 ## 28.9.2
 
 * Migrate cross domain tracking script from static ([PR #2607](https://github.com/alphagov/govuk_publishing_components/pull/2607))

--- a/app/assets/javascripts/govuk_publishing_components/rum-loader.js
+++ b/app/assets/javascripts/govuk_publishing_components/rum-loader.js
@@ -1,5 +1,5 @@
-(function() {
-  var parsedCookie = (function() {
+(function () {
+  var parsedCookie = (function () {
     try {
       var cookies = document.cookie.split(';')
 
@@ -18,7 +18,7 @@
     return {}
   })()
 
-  var insertScript = function() {
+  var insertScript = function () {
     var marker = document.querySelector('script[data-lux-reporter-script]')
 
     if (!marker) {
@@ -37,7 +37,7 @@
   if (parsedCookie.usage === true) {
     insertScript()
   } else {
-    window.addEventListener('cookie-consent', function() {
+    window.addEventListener('cookie-consent', function () {
       insertScript()
     })
   }

--- a/app/assets/javascripts/govuk_publishing_components/rum-loader.js
+++ b/app/assets/javascripts/govuk_publishing_components/rum-loader.js
@@ -1,6 +1,4 @@
 (function() {
-  var scriptSrc = '<%= path_to_javascript("govuk_publishing_components/vendor/lux/lux-reporter") %>'
-
   var parsedCookie = (function() {
     try {
       var cookies = document.cookie.split(';')
@@ -20,11 +18,16 @@
     return {}
   })()
 
-  var insertScript = function(source) {
-    var marker = document.getElementsByTagName('script')[0]
+  var insertScript = function() {
+    var marker = document.querySelector('script[data-lux-reporter-script]')
+
+    if (!marker) {
+      console.error("Failed to configure real-user-monitoring because couldn't the lux-reporter script path wasn't available")
+      return
+    }
 
     var script = document.createElement('script')
-    script.src = source
+    script.src = marker.getAttribute('data-lux-reporter-script')
     script.async = true
     script.defer = true
 
@@ -32,10 +35,10 @@
   }
 
   if (parsedCookie.usage === true) {
-    insertScript(scriptSrc)
+    insertScript()
   } else {
     window.addEventListener('cookie-consent', function() {
-      insertScript(scriptSrc)
+      insertScript()
     })
   }
 })()

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -51,7 +51,13 @@
     <title><%= title %></title>
 
     <%= javascript_include_tag "govuk_publishing_components/vendor/lux/lux-measurer", { async: true } %>
-    <%= javascript_include_tag "govuk_publishing_components/rum-loader", { async: true } %>
+    <%= javascript_include_tag "govuk_publishing_components/rum-loader",
+      {
+        async: true,
+        data: {
+          "lux-reporter-script": path_to_javascript("govuk_publishing_components/vendor/lux/lux-reporter")
+        }
+      } %>
 
     <%= csrf_meta_tags %>
 


### PR DESCRIPTION
## What
This removes the sole use of an embedded ruby file for JavaScript file generation. It replaces this with the variable being embedded as a data attribute that is retrieved at runtime.

## Why
Mixing Ruby and JavaScript can cause a variety of challenges and limits the portability of the script. This script has been changed to instead use a data attribute on the script tag rather than needing embedded Ruby.

The immediate problem I had to resolve with this is that this didn't work properly with Sprockets 4. However as mixing Ruby and JavaScript is an undesirable approach I felt it best to decouple this.

## Visual Changes
None