### PR TITLE
Update to sprockets 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* **BREAKING:** Update sprockets to 4 ([PR #2684](https://github.com/alphagov/govuk_publishing_components/pull/2684))
+
+  You must make the following changes when you migrate to this release:
+  - Update your application to latest sprockets version (by running `bundle update sprockets`)
+  - Create and configure `app/assets/config/manifest.js`; you can use the following [`manifest.js`](https://github.com/alphagov/govuk_publishing_components/blob/d40bd06c871b6a197aa244250d6fb2744eda3a49/spec/dummy/app/assets/config/manifest.js) or refer to the [migration docs to sprockets 4](https://github.com/rails/sprockets/blob/master/UPGRADING.md);
+
 ## 28.9.1
 
 * Update the list of popular links in the super navigation header ([#2660](https://github.com/alphagov/govuk_publishing_components/pull/2660))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       plek
       rails (>= 6)
       rouge
-      sprockets (< 4)
+      sprockets
 
 GEM
   remote: https://rubygems.org/
@@ -337,7 +337,7 @@ GEM
     sentry-ruby-core (4.5.2)
       concurrent-ruby
       faraday
-    sprockets (3.7.2)
+    sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)

--- a/app/assets/config/govuk_publishing_components_manifest.js
+++ b/app/assets/config/govuk_publishing_components_manifest.js
@@ -1,3 +1,0 @@
-// JS and CSS bundles for the gem
-//= link_directory ../javascripts/govuk_publishing_components .js
-//= link_directory ../stylesheets/govuk_publishing_components .css

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,15 @@
+// JS and CSS bundles for the gem
+//= link_directory ../javascripts/govuk_publishing_components .js
+//= link_directory ../javascripts/govuk_publishing_components/analytics .js
+//= link_directory ../javascripts/govuk_publishing_components/components .js
+//= link_directory ../javascripts/govuk_publishing_components/lib .js
+//= link_directory ../javascripts/govuk_publishing_components/vendor .js
+//= link_directory ../stylesheets/govuk_publishing_components .css
+
+// JS and CSS bundles for the component guide
+//= link_directory ../javascripts/component_guide .js
+//= link_directory ../javascripts/component_guide/vendor .js
+//= link_directory ../stylesheets/component_guide .css
+
+// Images for the gem, so that views can link to them
+//= link_tree ../images/govuk_publishing_components

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,6 +1,10 @@
 return unless Rails.application.config.respond_to?(:assets)
 
 # GOV.UK Publishing Components assets
+Rails.application.config.assets.precompile = %w[
+  manifest.js
+]
+
 Rails.application.config.assets.precompile += %w[
   component_guide/accessibility-test.js
   component_guide/application.js

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -56,3 +56,9 @@ Rails.application.config.assets.paths += %W[
   #{__dir__}/../../node_modules/govuk-frontend/
   #{__dir__}/../../node_modules/
 ]
+
+# Disable concurency otherwise the assets will be compiled in a random order
+# resulting in failures where, for example, a mixin is called but not yet compiled
+Rails.application.config.assets.configure do |environment|
+  environment.export_concurrent = false
+end

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "plek"
   s.add_dependency "rails", ">= 6"
   s.add_dependency "rouge"
-  s.add_dependency "sprockets", "< 4"
+  s.add_dependency "sprockets"
 
   s.add_development_dependency "capybara", "~> 3.25"
   s.add_development_dependency "faker", ">= 2.11"

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,5 +1,6 @@
-
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
-//= link govuk_publishing_components_manifest.js
+//= link component_guide/application.js
+//= link component_guide/application.css
+//= link manifest.js


### PR DESCRIPTION
## What
This PR updates sprockets to latest major versions, which require precompiled assets to be declared via `manifest.js`

## Why
To keep our dependencies up to date. Fixes #1972

## Notes
Configuration tested with:

- [x] collections
- [x] content-publisher
- [ ] email-alert-frontend
- [ ] feedback
- [x] finder-frontend
- [x] frontend
- [x] government-frontend
- [ ] govspeak
- [ ] info-frontend
- [ ] licence-finder
- [ ] manuals-frontend
- [ ] service-manual-frontend
- [x] smart-answers
- [ ] whitehall
- [x] static

## Visual Changes
n/a