### PR TITLE
Remove Coronavirus and Brexit footers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove Coronavirus and Brexit footers ([PR #2685](https://github.com/alphagov/govuk_publishing_components/pull/2685))
+
 ## 29.2.0
 
 * Remove HMRC email from attachment for accessible format request pilot ([PR #2710](https://github.com/alphagov/govuk_publishing_components/pull/2710))

--- a/lib/govuk_publishing_components/presenters/public_layout_helper.rb
+++ b/lib/govuk_publishing_components/presenters/public_layout_helper.rb
@@ -3,40 +3,6 @@ module GovukPublishingComponents
     class PublicLayoutHelper
       FOOTER_NAV = [
         {
-          title: "Coronavirus (COVID-19)",
-          columns: 2,
-          items: [
-            {
-              href: "/coronavirus",
-              text: "Coronavirus (COVID-19): guidance and support",
-              attributes: {
-                data: {
-                  track_category: "footerClicked",
-                  track_action: "coronavirusLinks",
-                  track_label: "Coronavirus (COVID-19): guidance and support",
-                },
-              },
-            },
-          ],
-        },
-        {
-          title: "Brexit",
-          columns: 1,
-          items: [
-            {
-              href: "/brexit",
-              text: "Check what you need to do",
-              attributes: {
-                data: {
-                  track_category: "footerClicked",
-                  track_action: "transitionLinks",
-                  track_label: "Check what you need to do",
-                },
-              },
-            },
-          ],
-        },
-        {
           title: "Services and information",
           columns: 2,
           items: [


### PR DESCRIPTION
Trello: https://trello.com/c/eb6MoA95

## What
Remove the config for the Coronavirus and Brexit footers

## Why
As we move to endemic and Coronavirus team winds down, we are removing Coronavirus navigation/ product debt.

## Visual Changes
### Before
<img width="1047" alt="Screenshot 2022-03-15 at 14 17 51" src="https://user-images.githubusercontent.com/5793815/158421360-d338a9bd-7e6f-435b-9f2a-516f831232a8.png">

### After
<img width="1047" alt="Screenshot 2022-03-15 at 15 20 24" src="https://user-images.githubusercontent.com/5793815/158421348-ffc92522-ceb3-4a05-b392-4fe1c78e8049.png">

## Note
This gem needs to be updated in [static](https://github.com/alphagov/static) for the changes to the footer in the layout to take effect.

