### PR TITLE
Add border to search icon when JS disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Update card tracking ([PR #2679](https://github.com/alphagov/govuk_publishing_components/pull/2679))
 * Remove accessible format request pilot emails from attachment ([PR #2687](https://github.com/alphagov/govuk_publishing_components/pull/2687))
 * Update docs ([PR #2683](https://github.com/alphagov/govuk_publishing_components/pull/2683))
+* Add border to search icon when JS disabled ([PR #2686](https://github.com/alphagov/govuk_publishing_components/pull/2686))
 
 ## 28.9.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -474,6 +474,7 @@ $button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
   &:visited {
     @include govuk-media-query($from: "desktop") {
       background: $govuk-brand-colour;
+      border-bottom: 1px solid govuk-colour("dark-blue");
 
       &:hover {
         background: govuk-colour("black");


### PR DESCRIPTION
## What

Add border to bottom of search icon on the [`layout_super_navigation_header`](https://components.publishing.service.gov.uk/component-guide/layout_super_navigation_header) when JS is disabled

## Why

> The blue search toggle button has a hairline border at the bottom/ When JavaScript is turned off, the search link should be visually identical - but it lacks the dark bottom border

Closes https://github.com/alphagov/govuk_publishing_components/issues/2674

## Visual Changes

![image](https://user-images.githubusercontent.com/71266765/158579865-b4a0b2c7-c834-46c2-be9f-390acd17ca41.png)