### PR TITLE
Remove emails from accessible format request pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Migrate cross domain tracking script from static ([PR #2607](https://github.com/alphagov/govuk_publishing_components/pull/2607))
 * Update card tracking ([PR #2679](https://github.com/alphagov/govuk_publishing_components/pull/2679))
+* Remove accessible format request pilot emails from attachment ([PR](https://github.com/alphagov/govuk_publishing_components/pull/2687))
 
 ## 28.9.1
 

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -86,7 +86,7 @@ examples:
         file_size: 20000
         owning_document_content_id: 456_abc
         attachment_id: 123
-        alternative_format_contact_email: alternative.formats@education.gov.uk
+        alternative_format_contact_email: govuk_publishing_components@example.com
   with_data_attributes:
     data:
       attachment:

--- a/lib/govuk_publishing_components/presenters/attachment.rb
+++ b/lib/govuk_publishing_components/presenters/attachment.rb
@@ -1,15 +1,11 @@
 module GovukPublishingComponents
   module Presenters
     class Attachment
-      # DfE, DWP, DHSC, HMRC, DVSA and PHE are taking part in a pilot to use a form
+      # Various departments are taking part in a pilot to use a form
       # rather than direct email for users to request accessible formats. When the pilot
       # scheme is rolled out further this can be removed.
-      EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT = %w[alternative.formats@education.gov.uk
-                                                     accessible.formats@dwp.gov.uk
-                                                     publications@dhsc.gov.uk
-                                                     different.format@hmrc.gov.uk
-                                                     gov.uk.publishing@dvsa.gov.uk
-                                                     publications@phe.gov.uk].freeze
+      # Currently the pilot is paused so there are no participants.
+      EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT = %w[govuk_publishing_components@example.com].freeze
 
       delegate :opendocument?, :document?, :spreadsheet?, to: :content_type
 

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -94,7 +94,7 @@ describe "Attachment", type: :view do
         attachment_id: "123",
         owning_document_content_id: "abc_456",
         content_type: "application/vnd.oasis.opendocument.spreadsheet",
-        alternative_format_contact_email: "alternative.formats@education.gov.uk",
+        alternative_format_contact_email: "govuk_publishing_components@example.com",
       },
     )
     assert_select "a[href='/contact/govuk/request-accessible-format?content_id=abc_456&attachment_id=123']", text: "Request an accessible format of this document"

--- a/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe GovukPublishingComponents::Presenters::Attachment do
       attachment = described_class.new(
         attachment_id: "123",
         owning_document_content_id: "456",
-        alternative_format_contact_email: "alternative.formats@education.gov.uk",
+        alternative_format_contact_email: "govuk_publishing_components@example.com",
       )
       expect(attachment.display_accessible_format_request_form_link?).to be true
     end
@@ -237,7 +237,7 @@ RSpec.describe GovukPublishingComponents::Presenters::Attachment do
     it "returns false if the attachment id is not provided" do
       attachment = described_class.new(
         owning_document_content_id: "456",
-        alternative_format_contact_email: "alternative.formats@education.gov.uk",
+        alternative_format_contact_email: "govuk_publishing_components@example.com",
       )
       expect(attachment.display_accessible_format_request_form_link?).to be false
     end
@@ -245,7 +245,7 @@ RSpec.describe GovukPublishingComponents::Presenters::Attachment do
     it "returns false if the owning document content id is not provided" do
       attachment = described_class.new(
         attachment_id: "123",
-        alternative_format_contact_email: "alternative.formats@education.gov.uk",
+        alternative_format_contact_email: "govuk_publishing_components@example.com",
       )
       expect(attachment.display_accessible_format_request_form_link?).to be false
     end
@@ -254,7 +254,7 @@ RSpec.describe GovukPublishingComponents::Presenters::Attachment do
       attachment = described_class.new(
         attachment_id: "123",
         owning_document_content_id: "456",
-        alternative_format_contact_email: "alternative.formats@organisation_not_in_pilot.gov.uk",
+        alternative_format_contact_email: "invalid@example.com",
       )
       expect(attachment.display_accessible_format_request_form_link?).to be false
     end


### PR DESCRIPTION
The pilot scheme is being paused so we are temporarily removing the participating emails from the attachment component.

This will prevent links to the accessible format request form being displayed on inaccessible attachments, and instead display the mail_to link.