### PR TITLE
Add variant tracking to card component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * **BREAKING:** Remove all jQuery from the components gem ([PR #2613](https://github.com/alphagov/govuk_publishing_components/pull/2613))
 * Add compatibility with Sprockets 4, see [Sprockets documentation](https://github.com/rails/sprockets/blob/master/UPGRADING.md) on how to upgrade your Rails app ([PR #2691](https://github.com/alphagov/govuk_publishing_components/pull/2691))
 * Use a data attribute to specify RUM (real user monitoring) script location ([PR #2682](https://github.com/alphagov/govuk_publishing_components/pull/2682))
+* Add variant tracking to card component ([PR #2689](https://github.com/alphagov/govuk_publishing_components/pull/2689))
 
 ## 28.9.2
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/page-content.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/page-content.js
@@ -13,6 +13,8 @@
         return document.querySelectorAll('[data-track-count="accordionSection"]').length
       case isDocumentCollectionPage():
         return document.querySelectorAll('.document-collection .group-title').length
+      case isNewBrowsePage():
+        return document.querySelectorAll('[data-track-count="cardList"]').length
       case isMainstreamBrowsePage():
         return countVisible(document.querySelectorAll('#subsection ul')) || document.querySelectorAll('#section ul').length || document.querySelectorAll('#root ul').length
       case isTopicPage():
@@ -44,6 +46,8 @@
         return document.querySelectorAll('a[data-track-category="navAccordionLinkClicked"]').length
       case isDocumentCollectionPage():
         return document.querySelectorAll('.document-collection .group-document-list li a').length
+      case isNewBrowsePage():
+        return document.querySelectorAll('[data-track-count="cardLink"]').length
       case isMainstreamBrowsePage():
         return countVisible(document.querySelectorAll('#subsection ul a')) || document.querySelectorAll('#section ul a').length || document.querySelectorAll('#root ul a').length
       case isTopicPage():
@@ -67,6 +71,7 @@
   var metaApplicationSelector = 'meta[name="govuk:rendering-application"]'
   var metaFormatSelector = 'meta[name="govuk:format"]'
   var metaNavigationTypeSelector = 'meta[name="govuk:navigation-page-type"]'
+  var metaSectionSelector = 'meta[name="govuk:section"]'
 
   function getMetaAttribute (selector) {
     var element = document.querySelector(selector)
@@ -91,6 +96,12 @@
     return getMetaAttribute(metaApplicationSelector) === 'collections' &&
       getMetaAttribute(metaFormatSelector) === 'taxon' &&
       getMetaAttribute(metaNavigationTypeSelector) === 'leaf'
+  }
+
+  function isNewBrowsePage () {
+    return getMetaAttribute(metaApplicationSelector) === 'collections' &&
+      getMetaAttribute(metaSectionSelector) === 'new_browse_page' &&
+      getMetaAttribute(metaFormatSelector) === 'mainstream_browse_page'
   }
 
   function isMainstreamBrowsePage () {

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -19,7 +19,7 @@
       <% end %>
     <% end %>    
 
-    <%= content_tag('ul', class: ul_classes) do %>
+    <%= content_tag('ul', class: ul_classes, "data-track-count": "cardList" ) do %>
       <%
         items.each do |item|
         link = item[:link]
@@ -33,7 +33,8 @@
             <%= 
               link_to link[:text], link[:path], 
               class: "govuk-link gem-c-cards__link", 
-              data: link[:data_attributes] 
+              data: link[:data_attributes],
+              "data-track-count": "cardLink"
             %>
           <% end %>
           <% if item[:description] %>

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -18,7 +18,9 @@
         <%= heading %>
       <% end %>
     <% end %>    
-
+    <%# data-track-count is used for analytics purposes in 
+    https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics/page-content.js 
+    %>
     <%= content_tag('ul', class: ul_classes, "data-track-count": "cardList" ) do %>
       <%
         items.each do |item|


### PR DESCRIPTION
## What

Add tracking `dimension26` and `dimension32` for tracking sections and number of links

## Why

New [variant browse pages](https://github.com/alphagov/collections/pull/2673) have been designed and built that are based in `collections` need analytics added for Browse Level 0 & 1.

## Visual Changes

NA

Passes the number of sections and links, for ref - 

![dimension26 being highlighted on omnibug google analytics tracking plugin that reveals the number 8 which the number of links on the page](https://user-images.githubusercontent.com/71266765/158845246-67cea382-c699-475e-a261-9901798fb4bd.png)

## Anything else?
 
This is being added as part of an AB test.  Depending on the outcome and changes this may need to be either a) removed b) altered