### PR TITLE
Provide compatibility with Sprockets 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add compatibility with Sprockets 4, see [Sprockets documentation](https://github.com/rails/sprockets/blob/master/UPGRADING.md) on how to upgrade your Rails app ([PR #2691](https://github.com/alphagov/govuk_publishing_components/pull/2691))
 * Use a data attribute to specify RUM (real user monitoring) script location ([PR #2682](https://github.com/alphagov/govuk_publishing_components/pull/2682))
 
 ## 28.9.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       plek
       rails (>= 6)
       rouge
-      sprockets (< 4)
+      sprockets (>= 3)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,10 +242,10 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
-    rails-i18n (7.0.2)
+    rails-i18n (7.0.3)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
-    rails_translation_manager (1.4.0)
+    rails_translation_manager (1.5.0)
       activesupport
       csv (~> 3.2)
       i18n-tasks
@@ -389,7 +389,7 @@ DEPENDENCIES
   i18n-coverage
   percy-capybara (~> 5.0.0)
   pry-byebug
-  rails_translation_manager
+  rails_translation_manager (>= 1.5)
   rake
   rspec-rails (~> 5.0)
   rubocop-govuk

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,7 +337,7 @@ GEM
     sentry-ruby-core (4.5.2)
       concurrent-ruby
       faraday
-    sprockets (3.7.2)
+    sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require "rubocop/rake_task"
 require "rspec/core/rake_task"
 
 APP_RAKEFILE = File.expand_path("spec/dummy/Rakefile", __dir__)
+ENV["RAILS_TRANSLATION_MANAGER_LOCALE_ROOT"] ||= File.expand_path("config/locales", __dir__)
 
 load "rails/tasks/engine.rake"
 load "rails/tasks/statistics.rake"

--- a/app/assets/config/govuk_publishing_components_manifest.js
+++ b/app/assets/config/govuk_publishing_components_manifest.js
@@ -1,0 +1,15 @@
+// Pre-compile image and font assets from here and govuk-frontend
+//= link_tree ../images
+//= link_tree ../../../node_modules/govuk-frontend/govuk/assets/images
+//= link_tree ../../../node_modules/govuk-frontend/govuk/assets/fonts
+
+// Create asset files of each of the files in these directory
+//= link_directory ../javascripts/component_guide
+//= link_directory ../javascripts/govuk_publishing_components
+
+// Pre-compile these specific files
+//= link govuk_publishing_components/vendor/modernizr.js
+//= link govuk_publishing_components/vendor/lux/lux-reporter.js
+//= link govuk_publishing_components/vendor/lux/lux-measurer.js
+//= link component_guide/application.css
+//= link component_guide/print.css

--- a/app/assets/config/govuk_publishing_components_manifest.js
+++ b/app/assets/config/govuk_publishing_components_manifest.js
@@ -1,3 +1,0 @@
-// JS and CSS bundles for the gem
-//= link_directory ../javascripts/govuk_publishing_components .js
-//= link_directory ../stylesheets/govuk_publishing_components .css

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,0 @@
-// This file is needed for govuk_publishing_components to support
-// app:assets:precompile with Sprockets 4, it will error without it.
-//
-// See govuk_publishing_components_manifest.js for the list of assets to be
-// pre-compiled.

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,5 @@
+// This file is needed for govuk_publishing_components to support
+// app:assets:precompile with Sprockets 4, it will error without it.
+//
+// See govuk_publishing_components_manifest.js for the list of assets to be
+// pre-compiled.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -15,3 +15,10 @@ Rails.application.config.assets.paths += %W[
   #{__dir__}/../../node_modules/govuk-frontend/
   #{__dir__}/../../node_modules/
 ]
+
+# We've experienced segmentation faults when pre-compiling assets with libsass.
+# Disabling Sprockets 4's export_concurrent setting seems to resolve the issues
+# see: https://github.com/rails/sprockets/issues/633
+Rails.application.config.assets.configure do |env|
+  env.export_concurrent = false if env.respond_to?(:export_concurrent=)
+end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,10 +1,22 @@
 return unless Rails.application.config.respond_to?(:assets)
 
+# In Sprockets 4, it is expected that applications will prefer to use
+# a manifest.js to define which assets should be prcompiled rather
+# than the using Rails.application.config.assets.precompile array.
+#
+# We are currently using assets.precompile array rather than a
+# govuk_publishing_components_manifest.js for Sprockets backwards
+# compatibility with version 3 and an easier installation process
+#
+# Once we drop Sprockets 3 we may want to consider moving these
+# directives to a manifest file.
+
 # GOV.UK Publishing Components assets
 Rails.application.config.assets.precompile += %w[
   component_guide/accessibility-test.js
   component_guide/application.js
   component_guide/filter-components.js
+  component_guide/application.css
   component_guide/print.css
   govuk_publishing_components/rum-loader.js
   govuk_publishing_components/vendor/lux/lux-reporter.js

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,62 +1,13 @@
 return unless Rails.application.config.respond_to?(:assets)
 
-# In Sprockets 4, it is expected that applications will prefer to use
-# a manifest.js to define which assets should be prcompiled rather
-# than the using Rails.application.config.assets.precompile array.
+# Include the govuk_publishing_components manifest into list of assets to
+# be pre-compiled. This allows that the same Sprockets manifest to be used 0
+# with Sprockets 3 and 4 without applications needing to manually require it.
 #
-# We are currently using assets.precompile array rather than a
-# govuk_publishing_components_manifest.js for Sprockets backwards
-# compatibility with version 3 and an easier installation process
-#
-# Once we drop Sprockets 3 we may want to consider moving these
-# directives to a manifest file.
-
-# GOV.UK Publishing Components assets
-Rails.application.config.assets.precompile += %w[
-  component_guide/accessibility-test.js
-  component_guide/application.js
-  component_guide/filter-components.js
-  component_guide/application.css
-  component_guide/print.css
-  govuk_publishing_components/rum-loader.js
-  govuk_publishing_components/vendor/lux/lux-reporter.js
-  govuk_publishing_components/vendor/lux/lux-measurer.js
-  govuk_publishing_components/all_components.js
-  govuk_publishing_components/dependencies.js
-  govuk_publishing_components/ie.js
-  govuk_publishing_components/modules.js
-  govuk_publishing_components/vendor/modernizr.js
-  govuk_publishing_components/analytics.js
-  govuk_publishing_components/component_guide.css
-  govuk_publishing_components/favicon-development.png
-  govuk_publishing_components/favicon-example.png
-  govuk_publishing_components/favicon-integration.png
-  govuk_publishing_components/favicon-production.png
-  govuk_publishing_components/favicon-staging.png
-  govuk_publishing_components/govuk-logo.png
-  govuk_publishing_components/govuk-schema-placeholder-1x1.png
-  govuk_publishing_components/govuk-schema-placeholder-4x3.png
-  govuk_publishing_components/govuk-schema-placeholder-16x9.png
-  govuk_publishing_components/search-button.png
-  govuk_publishing_components/icon-file-download.svg
-  govuk_publishing_components/icon-important.svg
-  govuk_publishing_components/crests/*.png
-  govuk_publishing_components/take-action-amber.svg
-  govuk_publishing_components/take-action-green.svg
-  govuk_publishing_components/take-action-red.svg
-]
-
-# GOV.UK Frontend assets
-Rails.application.config.assets.precompile += %w[
-  govuk-logotype-crown.png
-  favicon.ico
-  govuk-opengraph-image.png
-  govuk-mask-icon.svg
-  govuk-apple-touch-icon-180x180.png
-  govuk-apple-touch-icon-167x167.png
-  govuk-apple-touch-icon-152x152.png
-  govuk-apple-touch-icon.png
-]
+# In future we may want applications to link directly to this from their
+# manifest file as the use of `config.assets.precompile` is discouraged
+# from version 4: https://github.com/rails/sprockets/blob/58cca17aa447fcee17703e4ab4dbfaab630e7ed4/UPGRADING.md
+Rails.application.config.assets.precompile += %w[govuk_publishing_components_manifest.js]
 
 Rails.application.config.assets.paths += %W[
   #{__dir__}/../../node_modules/govuk-frontend/govuk/assets/images

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "plek"
   s.add_dependency "rails", ">= 6"
   s.add_dependency "rouge"
-  s.add_dependency "sprockets", "< 4"
+  s.add_dependency "sprockets", ">= 3"
 
   s.add_development_dependency "capybara", "~> 3.25"
   s.add_development_dependency "faker", ">= 2.11"

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "i18n-coverage"
   s.add_development_dependency "percy-capybara", "~> 5.0.0"
   s.add_development_dependency "pry-byebug"
-  s.add_development_dependency "rails_translation_manager"
+  s.add_development_dependency "rails_translation_manager", ">= 1.5"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-rails", "~> 5.0"
   s.add_development_dependency "rubocop-govuk"

--- a/spec/dummy/Rakefile
+++ b/spec/dummy/Rakefile
@@ -3,14 +3,4 @@
 
 require_relative "config/application"
 
-module Rails
-  def self.root
-    if caller.first.include? "rails_translation_manager"
-      Pathname.new(Dir.pwd.to_s.sub("/spec/dummy", ""))
-    else
-      Pathname.new(Dir.pwd)
-    end
-  end
-end
-
 Rails.application.load_tasks

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -2,4 +2,3 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
-//= link govuk_publishing_components_manifest.js

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,1 +1,0 @@
-Rails.application.config.assets.precompile += %w[print.css]


### PR DESCRIPTION
## What

This updates the asset configuration of this gem so that applications that depend on it can upgrade to Sprockets 4, but does not force them. It also updates the Gemfile.lock and the dummy so that the application equivalent of this is running on Sprockets 4. It also uses a Sprockets manifest approach to configuring the files for pre-compiling.

This release will support version 3 and 4 of Sprockets but we may find that we need to eventually pin this as needing Sprockets 4 as we are losing implicit testing of Sprockets 3 here, and in time this compatibility may just break. I didn't make that change now as I didn't want to push out a release that required immediate manual effort from developers to upgrade to, but a future step could be to deprecate Sprockets 3 usage.

## Why

Most GOV.UK apps that provide a HTML interface use Sprockets for assets and, due to this gem, those apps are still using Sprockets 3.x. The last release of which was in 2018.

## Testing

I've tried to release out with Content Publisher and Government Frontend running this code with both Sprockets 3 and 4 and experienced no problems.