### PR TITLE
Add tracking on the accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@
 ## Unreleased
 
 * Remove the last traces of jQuery ([PR #2702](https://github.com/alphagov/govuk_publishing_components/pull/2702))
+* Add tracking on the accordion ([#2693](https://github.com/alphagov/govuk_publishing_components/pull/2693))
 
 ## 29.1.0
 
-* Remove "priority breadcrumbs" ([PR #2666](https://github.com/alphagov/govuk_publishing_components/pull/2666))
+* Remove "priority breadcrumbs" ([#2666](https://github.com/alphagov/govuk_publishing_components/pull/2666))
 
 ## 29.0.1
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/analytics.js
@@ -3,7 +3,7 @@
 
   var GOVUK = global.GOVUK || {}
   // For usage and initialisation see:
-  // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md#create-an-analytics-tracker
+  // https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics/analytics.md
 
   var Analytics = function (config) {
     this.pii = new GOVUK.Pii()

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -28,6 +28,7 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
   GemAccordion.prototype.init = function () {
     // Indicate that JavaScript has worked
     this.$module.classList.add('gem-c-accordion--active')
+    this.$module.querySelector('.' + this.showAllControls).classList.add('gem-c-accordion__show-all')
 
     // Feature flag for anchor tag navigation used on manuals
     if (this.$module.getAttribute('data-anchor-navigation') === 'true') {

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -14,6 +14,8 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
     this.sectionHeaderClass = 'govuk-accordion__section-header'
     this.sectionInnerContent = 'govuk-accordion__section-content'
     this.showAllControls = 'govuk-accordion__show-all'
+    this.sectionButton = 'govuk-accordion__section-button'
+    this.headingText = 'govuk-accordion__section-heading-text'
 
     // Translated component content and language attribute pulled from data attributes
     this.$module.actions = {}
@@ -38,6 +40,10 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
     // Feature flag for "Show all sections" GA click event tracking
     if (this.$module.getAttribute('data-track-show-all-clicks') === 'true') {
       this.addAccordionOpenAllTracking()
+    }
+    // Feature flag for each section GA click event tracking
+    if (this.$module.getAttribute('data-track-sections') === 'true') {
+      this.addEventListenerSections()
     }
   }
 
@@ -107,6 +113,26 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
         window.GOVUK.analytics.trackEvent('pageElementInteraction', action, options)
       }
     })
+  }
+
+  GemAccordion.prototype.addEventListenerSections = function () {
+    var sections = this.$module.querySelectorAll('.' + this.sectionButton)
+    nodeListForEach(sections, function (section) {
+      section.addEventListener('click', this.addAccordionSectionTracking.bind(this, section))
+    }.bind(this))
+  }
+
+  // If the Accordion's sections are opened on click, then pass them to the GA event tracking
+  GemAccordion.prototype.addAccordionSectionTracking = function (section) {
+    var expanded = section.getAttribute('aria-expanded') === 'false'
+    var label = section.querySelector('.' + this.headingText).textContent
+    var action = expanded ? 'accordionOpened' : 'accordionClosed'
+    var options = { transport: 'beacon', label: label }
+
+    if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+      window.GOVUK.analytics.trackEvent('pageElementInteraction', action, options)
+      console.log('pageElementInteraction', action, options)
+    }
   }
 
   Modules.GemAccordion = GemAccordion

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -13,6 +13,7 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
     this.sectionClassExpanded = 'govuk-accordion__section--expanded'
     this.sectionHeaderClass = 'govuk-accordion__section-header'
     this.sectionInnerContent = 'govuk-accordion__section-content'
+    this.showAllControls = 'govuk-accordion__show-all'
 
     // Translated component content and language attribute pulled from data attributes
     this.$module.actions = {}
@@ -32,6 +33,10 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
     if (this.$module.getAttribute('data-anchor-navigation') === 'true') {
       this.openByAnchorOnLoad()
       this.addEventListenersForAnchors()
+    }
+    // Feature flag for "Show all sections" GA click event tracking
+    if (this.$module.getAttribute('data-track-show-all-clicks') === 'true') {
+      this.addAccordionOpenAllTracking()
     }
   }
 
@@ -88,6 +93,19 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
     } else if (this.$module.actions.locale) {
       return this.$module.actions.locale
     }
+  }
+
+  // To track the Accordion's "Show all sections" / "Hide all sections" button click events and pass them to the GA event tracking
+  GemAccordion.prototype.addAccordionOpenAllTracking = function () {
+    this.$module.querySelector('.' + this.showAllControls).addEventListener('click', function (event) {
+      var expanded = event.target.getAttribute('aria-expanded') === 'true'
+      var label = expanded ? 'Show all sections' : 'Hide all sections'
+      var action = expanded ? 'accordionOpened' : 'accordionClosed'
+      var options = { transport: 'beacon', label: label }
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        window.GOVUK.analytics.trackEvent('pageElementInteraction', action, options)
+      }
+    })
   }
 
   Modules.GemAccordion = GemAccordion

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
@@ -1,2 +1,7 @@
 @import "mixins/prefixed-transform";
 @import "govuk/components/accordion/accordion";
+
+// Prevent elements inside the button from receiving click events
+.gem-c-accordion__show-all > * {
+  pointer-events: none;
+}

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -6,6 +6,7 @@
   items ||= []
   anchor_navigation ||= false
   track_show_all_clicks ||= false
+  track_sections ||= false
 
   accordion_classes = %w(gem-c-accordion govuk-accordion)
   accordion_classes << (shared_helper.get_margin_bottom)
@@ -24,6 +25,7 @@
   data_attributes[:module] = 'govuk-accordion gem-accordion'
   data_attributes[:anchor_navigation] = anchor_navigation
   data_attributes[:track_show_all_clicks] = track_show_all_clicks
+  data_attributes[:track_sections] = track_sections
 
   translations.each do |key, translation|
     locales[key] = shared_helper.t_locale(translation)

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -5,6 +5,7 @@
   id ||= "default-id-#{SecureRandom.hex(4)}"
   items ||= []
   anchor_navigation ||= false
+  track_show_all_clicks ||= false
 
   accordion_classes = %w(gem-c-accordion govuk-accordion)
   accordion_classes << (shared_helper.get_margin_bottom)
@@ -22,6 +23,7 @@
   data_attributes ||= {}
   data_attributes[:module] = 'govuk-accordion gem-accordion'
   data_attributes[:anchor_navigation] = anchor_navigation
+  data_attributes[:track_show_all_clicks] = track_show_all_clicks
 
   translations.each do |key, translation|
     locales[key] = shared_helper.t_locale(translation)

--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -325,3 +325,21 @@ examples:
             text: Writing well for specialists
           content:
             html: <p class="govuk-body" id="anchor-nav-test">This is content for accordion 2 of 2</p>
+  with_track_sections:
+    description: |
+      To switch on Google Analytics for each section, on click, pass `track_sections: true` the values passed on open will be
+      `Event Action: accordionOpened` / `accordionClosed` `Event Category: pageElementInteraction` and the `Event Label` being the heading text.
+      
+      (`track_show_all_clicks: true` can be added to track the "Show all sections" button as well, if required)
+    data:
+      track_sections: true
+      items:
+        - heading:
+            text: Writing well for the web
+            id: writing-well-for-the-web
+          content:
+            html: <p class="govuk-body">This is content for accordion 1 of 2</p><p class="govuk-body">This content contains a <a href="#anchor-nav-test" class="govuk-link">link</a></p>
+        - heading:
+            text: Writing well for specialists
+          content:
+            html: <p class="govuk-body" id="anchor-nav-test">This is content for accordion 2 of 2</p>

--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -309,3 +309,19 @@ examples:
             text: How people read
           content:
             html: <p class="govuk-body">This is the content for How people read.</p>
+  with_track_show_all_clicks:
+    description: |
+      To switch on Google Analytics for the "Show all sections" button on click, pass `track_show_all_clicks: true` the values passed on open will be
+      `Event Action: accordionOpened` `Event Category: pageElementInteraction` `Event Label: Show all sections` 
+    data:
+      track_show_all_clicks: true
+      items:
+        - heading:
+            text: Writing well for the web
+            id: writing-well-for-the-web
+          content:
+            html: <p class="govuk-body">This is content for accordion 1 of 2</p><p class="govuk-body">This content contains a <a href="#anchor-nav-test" class="govuk-link">link</a></p>
+        - heading:
+            text: Writing well for specialists
+          content:
+            html: <p class="govuk-body" id="anchor-nav-test">This is content for accordion 2 of 2</p>

--- a/docs/analytics/analytics.md
+++ b/docs/analytics/analytics.md
@@ -279,7 +279,7 @@ to strip postcodes at initialize time as follows:
 Any value other than the JS literal `true` will leave the analytics module
 configured not to strip.
 
-#### Avoding false positives
+#### Avoiding false positives
 
 Sometimes you will have data you want to send to analytics that looks like PII
 and would be stripped out.  For example on GOV.UK the content_ids that belong
@@ -297,3 +297,6 @@ analytics tracker without attempting to strip PII from it.  For example:
   GOVUK.analytics.setDimension(1, new GOVUK.Analytics.PIISafe('this-is-not-an@email-address-but-it-looks-like-one'));
   GOVUK.analytics.trackEvent('report title clicked', new GOVUK.Analytics.PIISafe('this report title looks like it contains a P0 5TC ode but it does not really'));
 ````
+#### Tooling
+
+[Omnibug](https://chrome.google.com/webstore/detail/omnibug/bknpehncffejahipecakbfkomebjmokl?hl=en) is a useful extension to easily capture and review the events being sent to Google Analytics.


### PR DESCRIPTION
## What

Add click event tracking for [Accordion's](https://components.publishing.service.gov.uk/component-guide/accordion) "Show all sections" button behind a feature flag.

Also, add click event tracking for each section, also behind a feature flag.

## Why

For PA's to track when button is interacted with for new GOVUK Explore, Browse Pages AB variant. Replicates bespoke functionality found on `/coronavirus`.

## Visual Changes

Example capture on `collections`

https://user-images.githubusercontent.com/71266765/160830285-f25dcd8a-47a8-4c74-8b88-8129cdd8c8a9.mov

https://user-images.githubusercontent.com/71266765/160697806-59bd56b0-5b4b-4ffd-a014-82e3877a6cea.mov

## Anything else

Issue raised to capture tracking testing that is missing from this PR.
https://github.com/alphagov/govuk_publishing_components/issues/2694

Related PRs
https://github.com/alphagov/collections/pull/2673
https://github.com/alphagov/collections/pull/2709
