### PR TITLE
Add HMRC to accessible format request pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add compatibility with Sprockets 4, see [Sprockets documentation](https://github.com/rails/sprockets/blob/master/UPGRADING.md) on how to upgrade your Rails app ([PR #2691](https://github.com/alphagov/govuk_publishing_components/pull/2691))
 * Use a data attribute to specify RUM (real user monitoring) script location ([PR #2682](https://github.com/alphagov/govuk_publishing_components/pull/2682))
+* Add HMRC email to attachment accessible format request pilot([PR #2695](https://github.com/alphagov/govuk_publishing_components/pull/2695))
 
 ## 28.9.2
 

--- a/lib/govuk_publishing_components/presenters/attachment.rb
+++ b/lib/govuk_publishing_components/presenters/attachment.rb
@@ -4,8 +4,9 @@ module GovukPublishingComponents
       # Various departments are taking part in a pilot to use a form
       # rather than direct email for users to request accessible formats. When the pilot
       # scheme is rolled out further this can be removed.
-      # Currently the pilot is paused so there are no participants.
-      EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT = %w[govuk_publishing_components@example.com].freeze
+      # Currently the HMRC are participating in the pilot.
+      EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT = %w[govuk_publishing_components@example.com
+                                                     different.format@hmrc.gov.uk].freeze
 
       delegate :opendocument?, :document?, :spreadsheet?, to: :content_type
 


### PR DESCRIPTION
Add HMRC's accessible format email to attachment's list of department emails taking part in the accessible format request pilot.

[trello](https://trello.com/c/7vyvANlE/1172-accessible-format-request-add-links-to-form-for-hmrc-documents-ready-for-user-testing)