### PR TITLE
Adjust how modules.start is run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Adjust how modules.start is run ([PR #](https://github.com/alphagov/govuk_publishing_components/pull/2698))
+
 ## 29.0.0
 
 * **BREAKING:** Remove all jQuery from the components gem ([PR #2613](https://github.com/alphagov/govuk_publishing_components/pull/2613))

--- a/app/assets/javascripts/govuk_publishing_components/dependencies.js
+++ b/app/assets/javascripts/govuk_publishing_components/dependencies.js
@@ -4,6 +4,4 @@
 // that are provided by Slimmer in public frontend applications.
 // = require ./modules.js
 
-document.addEventListener('DOMContentLoaded', function () {
-  window.GOVUK.modules.start()
-})
+window.GOVUK.modules.start()


### PR DESCRIPTION
## What
Take away the document event listener for page ready that wraps the call to `modules.start`.

## Why
The document event listener was added to replace jQuery's document.ready, but now that jQuery isn't included anymore I don't think either are needed, and I have concerns about how well `DOMContentLoaded` is supported in older browsers.

## Visual Changes
None.
