### PR TITLE
Release 29.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 29.1.0
 
 * Remove "priority breadcrumbs" ([#2666](https://github.com/alphagov/govuk_publishing_components/pull/2666))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (29.0.1)
+    govuk_publishing_components (29.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -161,7 +161,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     kgio (2.11.4)
-    kramdown (2.3.1)
+    kramdown (2.3.2)
       rexml
     link_header (0.0.8)
     logstasher (2.1.5)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "29.0.1".freeze
+  VERSION = "29.1.0".freeze
 end


### PR DESCRIPTION
Includes:

* Remove "priority breadcrumbs" ([#2666](https://github.com/alphagov/govuk_publishing_components/pull/2666))

This removes the super/priority breadcrumb from contextual navigation. It's not a breaking change because standard breadcrumbs replace them.
