### PR TITLE
Remove HMRC from accessible format request pilot in attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove HMRC email from attachment for accessible format request pilot([PR #2710](https://github.com/alphagov/govuk_publishing_components/pull/2710))
 * Remove the last traces of jQuery ([PR #2702](https://github.com/alphagov/govuk_publishing_components/pull/2702))
 * Add tracking on the accordion ([#2693](https://github.com/alphagov/govuk_publishing_components/pull/2693))
 

--- a/lib/govuk_publishing_components/presenters/attachment.rb
+++ b/lib/govuk_publishing_components/presenters/attachment.rb
@@ -5,8 +5,7 @@ module GovukPublishingComponents
       # rather than direct email for users to request accessible formats. When the pilot
       # scheme is rolled out further this can be removed.
       # Currently the HMRC are participating in the pilot.
-      EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT = %w[govuk_publishing_components@example.com
-                                                     different.format@hmrc.gov.uk].freeze
+      EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT = %w[govuk_publishing_components@example.com].freeze
 
       delegate :opendocument?, :document?, :spreadsheet?, to: :content_type
 


### PR DESCRIPTION
## What
Remove HMRC's alternative format request email address from the list of organisations taking part in the pilot scheme.

## Why
Following user research the pilot scheme is now closed for a short period.

[trello](https://trello.com/c/nHsb8wlv/1177-accessible-format-request-turn-off-the-pilot-again)