### PR TITLE
Release 29.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 29.2.0
 
-* Remove HMRC email from attachment for accessible format request pilot([PR #2710](https://github.com/alphagov/govuk_publishing_components/pull/2710))
+* Remove HMRC email from attachment for accessible format request pilot ([PR #2710](https://github.com/alphagov/govuk_publishing_components/pull/2710))
 * Remove the last traces of jQuery ([PR #2702](https://github.com/alphagov/govuk_publishing_components/pull/2702))
 * Add tracking on the accordion ([#2693](https://github.com/alphagov/govuk_publishing_components/pull/2693))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (29.1.0)
+    govuk_publishing_components (29.2.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "29.1.0".freeze
+  VERSION = "29.2.0".freeze
 end


### PR DESCRIPTION
Release 29.2.0

* Remove HMRC email from attachment for accessible format request pilot ([PR #2710](https://github.com/alphagov/govuk_publishing_components/pull/2710))
* Remove the last traces of jQuery ([PR #2702](https://github.com/alphagov/govuk_publishing_components/pull/2702))
* Add tracking on the accordion ([#2693](https://github.com/alphagov/govuk_publishing_components/pull/2693))