### PR TITLE
Release version 29.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 29.3.0
 
 * Remove Coronavirus and Brexit footers ([PR #2685](https://github.com/alphagov/govuk_publishing_components/pull/2685))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (29.2.0)
+    govuk_publishing_components (29.3.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -157,7 +157,6 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
-    io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     kgio (2.11.4)
@@ -189,8 +188,7 @@ GEM
       digest
       net-protocol
       timeout
-    net-protocol (0.1.2)
-      io-wait
+    net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
       digest

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "29.2.0".freeze
+  VERSION = "29.3.0".freeze
 end


### PR DESCRIPTION
Includes

- https://github.com/alphagov/govuk_publishing_components/pull/2685

This removes the coronavirus header and footer
