### PR TITLE
Strip postcodes from more document types in meta_tags component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Strip postcodes from more document types in meta_tags component #2720 ([PR #2720](https://github.com/alphagov/govuk_publishing_components/pull/2720))
+
 ## 29.3.0
 
 * Remove Coronavirus and Brexit footers ([PR #2685](https://github.com/alphagov/govuk_publishing_components/pull/2685))

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -1,6 +1,8 @@
 module GovukPublishingComponents
   module Presenters
     class MetaTags
+      FORMATS_THAT_MIGHT_INCLUDE_POSTCODES = %w[smart_answer finder local_transaction place special_route transaction].freeze
+
       attr_reader :content_item, :details, :links, :local_assigns, :request
 
       def initialize(content_item, local_assigns, request)
@@ -148,8 +150,7 @@ module GovukPublishingComponents
         # document_type
         return local_assigns[:strip_postcode_pii] if local_assigns.key?(:strip_postcode_pii)
 
-        formats_that_might_include_postcodes = %w[smart_answer finder]
-        formats_that_might_include_postcodes.include?(content_item[:document_type])
+        FORMATS_THAT_MIGHT_INCLUDE_POSTCODES.include?(content_item[:document_type])
       end
     end
   end

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -366,14 +366,12 @@ describe "Meta tags", type: :view do
     assert_no_meta_tag("govuk:static-analytics:strip-dates")
   end
 
-  it "renders the static-analytics:strip-postcodes tag if the content item is a 'smart-answer'" do
-    render_component(content_item: { document_type: "smart_answer" })
-    assert_meta_tag("govuk:static-analytics:strip-postcodes", "true")
-  end
-
-  it "renders the static-analytics:strip-postcodes tag if the content item is a 'finder'" do
-    render_component(content_item: { document_type: "finder" })
-    assert_meta_tag("govuk:static-analytics:strip-postcodes", "true")
+  it "renders the static-analytics:strip-postcodes tag if the document_type is relevant" do
+    formats_that_might_include_postcodes = GovukPublishingComponents::Presenters::MetaTags::FORMATS_THAT_MIGHT_INCLUDE_POSTCODES
+    formats_that_might_include_postcodes.each do |format|
+      render_component(content_item: { document_type: format })
+      assert_meta_tag("govuk:static-analytics:strip-postcodes", "true")
+    end
   end
 
   it "doesn't render the static-analytics:strip-postcodes tag if the document_type isn't relevant" do
@@ -387,8 +385,11 @@ describe "Meta tags", type: :view do
   end
 
   it "doesn't render the static-analytics:strip-postcodes tag if explicitly told not to even if it would otherwise" do
-    render_component(content_item: { document_type: "smart_answer" }, strip_postcode_pii: false)
-    assert_no_meta_tag("govuk:static-analytics:strip-postcodes")
+    formats_that_might_include_postcodes = GovukPublishingComponents::Presenters::MetaTags::FORMATS_THAT_MIGHT_INCLUDE_POSTCODES
+    formats_that_might_include_postcodes.each do |format|
+      render_component(content_item: { document_type: format }, strip_postcode_pii: false)
+      assert_no_meta_tag("govuk:static-analytics:strip-postcodes")
+    end
   end
 
   def assert_political_status_for(political, current, expected_political_status)


### PR DESCRIPTION
## What
The documents types listed below will now include the `<meta name="govuk:static-analytics:strip-postcodes" content="true">` meta tag.

- transaction
- local_transaction
- place
- special_route

This will ensure that postcodes strings are replaced with "[postcode]" in any pages with these document types.

## Why
To stop personal postcode data from being sent to Google Analytics.

## Testing

I deployed the changes to integration and tested the pages below using the [Google Analytics Debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en) browser extension for Google Chrome, the differences in the "location" being sent to GA are shown below.

| Integration | Live |
| ----------- | ----------- |
| `/contact-electoral-registration-office?postcode=[postcode]` | `/contact-electoral-registration-office?postcode=SW11AA` |
| `/find-driving-test-centre?postcode=[postcode]` | `/find-driving-test-centre?postcode=SW11AA` |
| `/find-local-council?postcode=[postcode]` | `/find-local-council?postcode=SW11AA` |
| `/apply-for-secondary-school-place?postcode=[postcode]` | `/apply-for-secondary-school-place?postcode=SW11AA` |
| `/apply-for-primary-school-place?postcode=[postcode]` | `/apply-for-primary-school-place?postcode=SW11AA` |
| `/disabled-students-allowances-assessment-centre?postcode=[postcode]` | `/disabled-students-allowances-assessment-centre?postcode=SW11AA` |
| `/find-out-about-right-to-buy-from-your-council?postcode=[postcode]` | `/find-out-about-right-to-buy-from-your-council?postcode=SW11AA` |
| `/check-long-term-flood-risk?postcode=[postcode]` | `check-long-term-flood-risk?postcode=SW11AA` |