### PR TITLE
Update popular links in the super navigation headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update the list of popular links in the super navigation header #2728 ([PR #2728](https://github.com/alphagov/govuk_publishing_components/pull/2728))
 * Remove tracking on load from intervention ([PR #2725](https://github.com/alphagov/govuk_publishing_components/pull/2725))
 * Strip postcodes from more document types in meta_tags component #2720 ([PR #2720](https://github.com/alphagov/govuk_publishing_components/pull/2720))
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,8 +177,8 @@ en:
       navigation_search_heading: Search and popular pages
       navigation_search_subheading: Search
       popular_links:
-      - label: 'Invasion of Ukraine'
-        href: "/government/topical-events/russian-invasion-of-ukraine-uk-government-response"
+      - label: 'Moving to the UK from Ukraine'
+        href: "/guidance/move-to-the-uk-if-youre-from-ukraine"
       - label: 'Coronavirus (COVID-19)'
         href: "/coronavirus"
       - label: Find a job


### PR DESCRIPTION
## What
Update the list of popular links (to include Moving to the the UK from Ukraine) on the super navigation header component, so that it matches the list of popular links on the homepage. See https://github.com/alphagov/frontend/pull/3196

## Why
Adding Moving to the UK from Ukraine to popular links is a request from content and SMT colleagues.

## Visual Changes

### Before
<img width="1422" alt="Screenshot 2022-04-13 at 12 52 10" src="https://user-images.githubusercontent.com/17481621/163174791-8bee5b2f-185e-4528-b09a-6b8eb5956122.png">


### After
<img width="1425" alt="Screenshot 2022-04-13 at 12 50 53" src="https://user-images.githubusercontent.com/17481621/163174830-aa281337-4751-4798-8444-f3ff9aa440c7.png">

