### PR TITLE
Fix JS bug in MagnaCharta for stacked charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix JS bug in MagnaCharta for stacked charts ([PR #2731](https://github.com/alphagov/govuk_publishing_components/pull/2731))
+
 ## 29.6.0
 
 * Updated link for the Ukraine Invasion Call To Action #2739 ([PR #2739](https://github.com/alphagov/govuk_publishing_components/pull/2739))

--- a/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/govspeak/magna-charta.js
@@ -51,6 +51,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     // giving the table a class of mc-stacked
     this.options.stacked = this.$table.classList.contains('mc-stacked')
 
+    // stacked charts require tables to use the th element in the table header
+    // if the th element is not included, then the ENABLED flag is set to false
+    // this will stop the chart and toggleLink from being rendered
+    if (this.options.stacked) {
+      var allTheTHsInTableHead = this.$table.querySelectorAll('thead th')
+      if (allTheTHsInTableHead.length === 0) {
+        this.ENABLED = false
+      }
+    }
+
     // set the negative option based on
     // giving the table a class of mc-negative
     this.options.negative = this.$table.classList.contains('mc-negative')
@@ -106,12 +116,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   MagnaCharta.prototype.apply = function () {
     if (this.ENABLED) {
-      this.constructChart()
-      this.addClassesToHeader()
-      this.applyWidths()
-      this.insert()
-      this.$table.classList.add('mc-hidden')
-      this.applyOutdent()
+      try {
+        this.constructChart()
+        this.addClassesToHeader()
+        this.applyWidths()
+        this.insert()
+        this.$table.classList.add('mc-hidden')
+        this.applyOutdent()
+      } catch (error) {
+        console.error('MagnaCharta error:', error)
+      }
     }
   }
 

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
@@ -115,6 +115,16 @@ describe('Magna charta', function () {
       '</tbody>' +
     '</table>'
 
+  var noHeader =
+    '<table id="noHeader" class="mc-stacked">' +
+      '<caption>No Table Header</caption>' +
+      '<tbody>' +
+        '<tr><td>Testing One</td><td>5</td><td>6</td><td>11</td></tr>' +
+        '<tr><td>Testing Two</td><td>6</td><td>2</td><td>8</td></tr>' +
+        '<tr><td>Testing Three</td><td>3</td><td>9</td><td>12</td></tr>' +
+      '</tbody>' +
+    '</table>'
+
   describe('creating a graph of a single table', function () {
     beforeEach(function () {
       element = $('<div/>').attr('id', 'test-magna-charta').html(single)
@@ -391,6 +401,26 @@ describe('Magna charta', function () {
       graph.find('.mc-bar-cell span').each(function (i, item) {
         expect(item.style.marginLeft).toBe('100%')
       })
+    })
+  })
+
+  describe('creating a graph of a table missing header elements', function () {
+    beforeEach(function () {
+      element = $('<div/>').attr('id', 'test-magna-charta').html(noHeader)
+      $('body').append(element)
+      magna = new GOVUK.Modules.MagnaCharta(element.find('#noHeader')[0], { returnReference: true })
+      magna.init()
+      graph = element.find('.mc-chart')
+      table = element.find('table')
+    })
+
+    afterEach(function () {
+      $('body').find('#test-magna-charta').remove()
+    })
+
+    it('marks a chart as not enabled and does not create a chart', function () {
+      expect(magna.ENABLED).toBe(false)
+      expect(graph.length).toBe(0)
     })
   })
 


### PR DESCRIPTION
## What
Improve the error handling for stacked charts when the table source HTML does not include the required table header elements.

## Why
Without the error handling, not only will the Chart will not be rendered, but any remaining JavaScript will not be run after the error, leading to further issues with other components in the bundled JS file.

## Visual Changes

| **Before**  | **After** |
| ----------- | ----------- |
| If the table header elements are not present, the chart is not rendered, however the "toggleLink" button is still displayed with misleading text | If the table header elements are not present, the chart and toggleLink button are not rendered |
| <img width="852" alt="Screenshot 2022-04-14 at 09 55 27" src="https://user-images.githubusercontent.com/28779939/163350971-7669c3b2-5b32-4aaa-9ac9-c3d971d66cb6.png">  | <img width="867" alt="Screenshot 2022-04-14 at 09 56 11" src="https://user-images.githubusercontent.com/28779939/163350989-475acf2b-7662-46f9-abcc-4ea9de988b3e.png"> |

Fixes https://github.com/alphagov/govuk_publishing_components/issues/1968