### PR TITLE
Add DWP, DfE and DVSA to accessible format request pilot email list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Add DFE, DWP and DVSA emails to attachment accessible format request pilot([PR #2736] (https://github.com/alphagov/govuk_publishing_components/pull/2736))
+
 ## 29.4.0
 
 * Update the list of popular links in the super navigation header #2728 ([PR #2728](https://github.com/alphagov/govuk_publishing_components/pull/2728))

--- a/lib/govuk_publishing_components/presenters/attachment.rb
+++ b/lib/govuk_publishing_components/presenters/attachment.rb
@@ -4,8 +4,11 @@ module GovukPublishingComponents
       # Various departments are taking part in a pilot to use a form
       # rather than direct email for users to request accessible formats. When the pilot
       # scheme is rolled out further this can be removed.
-      # Currently the HMRC are participating in the pilot.
-      EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT = %w[govuk_publishing_components@example.com].freeze
+      # Currently DfE, DWP and DVSA are participating in the pilot.
+      EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT = %w[govuk_publishing_components@example.com
+                                                     alternative.formats@education.gov.uk
+                                                     accessible.formats@dwp.gov.uk
+                                                     gov.uk.publishing@dvsa.gov.uk].freeze
 
       delegate :opendocument?, :document?, :spreadsheet?, to: :content_type
 


### PR DESCRIPTION
This PR adds DWP, DfE and DVSA accessible format request email addresses to the list of emails taking part in the pilot