### PR TITLE
Release 29.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 29.6.0
 
 * Updated link for the Ukraine Invasion Call To Action #2739 ([PR #2739](https://github.com/alphagov/govuk_publishing_components/pull/2739))
 * Use locale files to generate header links in public_layout instead of constant in public_layout_helper #2719 ([PR #2719](https://github.com/alphagov/govuk_publishing_components/pull/2719))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (29.5.0)
+    govuk_publishing_components (29.6.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -156,7 +156,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     kgio (2.11.4)
-    kramdown (2.3.2)
+    kramdown (2.4.0)
       rexml
     link_header (0.0.8)
     logstasher (2.1.5)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "29.5.0".freeze
+  VERSION = "29.6.0".freeze
 end


### PR DESCRIPTION
Release 29.6.0

* Updated link for the Ukraine Invasion Call To Action #2739 ([PR #2739](https://github.com/alphagov/govuk_publishing_components/pull/2739))
* Use locale files to generate header links in public_layout instead of constant in public_layout_helper #2719 ([PR #2719](https://github.com/alphagov/govuk_publishing_components/pull/2719))
