### PR TITLE
remove coronavirus topic from menu bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 * Auditing enhancements ([PR #2428](https://github.com/alphagov/govuk_publishing_components/pull/2428))
 * Fix JS bug in MagnaCharta for stacked charts ([PR #2731](https://github.com/alphagov/govuk_publishing_components/pull/2731))
+* Remove coronavirus topic from menu bar ([PR #2745
+](https://github.com/alphagov/govuk_publishing_components/pull/2745))
 
 ## 29.6.0
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,8 +175,6 @@ en:
           href: "/browse/childcare-parenting"
         - label: Citizenship and living in the UK
           href: "/browse/citizenship"
-        - label: Coronavirus (COVID‑19)
-          href: "/coronavirus"
         - label: Crime, justice and the law
           href: "/browse/justice"
         - label: Disabled people


### PR DESCRIPTION
## What
Remove Coronavirus link from the menu bar.

## Why
This change was requested by the Covid team.

### Before
![Screenshot 2022-04-29 at 10 03 27](https://user-images.githubusercontent.com/3727504/165915484-f9911276-c176-4fa3-a0b5-4becf204da54.png)


### After
![Screenshot 2022-04-29 at 10 03 03](https://user-images.githubusercontent.com/3727504/165915628-647d04c8-626e-48c6-91cb-41b8e8cff30d.png)

