### PR TITLE
Update cross domain linking script to use init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fix JS bug in MagnaCharta for stacked charts ([PR #2731](https://github.com/alphagov/govuk_publishing_components/pull/2731))
 * Remove coronavirus topic from menu bar ([PR #2745](https://github.com/alphagov/govuk_publishing_components/pull/2745))
 * Realign list of topics in navigation header ([PR #2750](https://github.com/alphagov/govuk_publishing_components/pull/2750))
+* Update cross domain linking script to use init ([PR #2747](https://github.com/alphagov/govuk_publishing_components/pull/2747))
 
 ## 29.6.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.js
@@ -1,89 +1,88 @@
-;(function (global) {
-  'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-  var GOVUK = global.GOVUK || {}
-  GOVUK.Modules = GOVUK.Modules || {}
+(function (Modules) {
+  function ExplicitCrossDomainLinks ($module) {
+    this.$module = $module
+  }
 
-  GOVUK.Modules.ExplicitCrossDomainLinks = function () {
-    this.start = function ($module) {
-      this.element = $module[0]
-      this.attribute = 'href'
-      this.attributeValue = this.element.getAttribute(this.attribute)
-      this.eventType = 'click'
-      if (!this.attributeValue) {
-        this.attribute = 'action'
-        this.attributeValue = this.element.getAttribute(this.attribute)
-        this.eventType = 'submit'
-      }
-
-      this.handleEvent = this.handleEvent.bind(this)
-      this.handleCookiesAccepted = this.handleCookiesAccepted.bind(this)
-      // Listens for the 'submit' event if the element is a form, and the 'click' event if it is a link
-      this.element.addEventListener(this.eventType, this.handleEvent)
+  ExplicitCrossDomainLinks.prototype.init = function () {
+    this.attribute = 'href'
+    this.attributeValue = this.$module.getAttribute(this.attribute)
+    this.eventType = 'click'
+    if (!this.attributeValue) {
+      this.attribute = 'action'
+      this.attributeValue = this.$module.getAttribute(this.attribute)
+      this.eventType = 'submit'
     }
 
-    this.handleEvent = function (e) {
-      //  prevent default: we want the link href and/or form action to be decorated before we navigate away
-      e.preventDefault()
-      var cookieBannerEngaged = GOVUK.cookie('cookies_preferences_set')
-      var cookieConsent = GOVUK.getConsentCookie()
+    this.handleEvent = this.handleEvent.bind(this)
+    this.handleCookiesAccepted = this.handleCookiesAccepted.bind(this)
+    // Listens for the 'submit' event if the element is a form, and the 'click' event if it is a link
+    this.$module.addEventListener(this.eventType, this.handleEvent)
+  }
 
-      if (cookieBannerEngaged !== 'true') {
-        // If not engaged, append only ?cookie_consent=not-engaged
-        this.decorate(this.element, 'cookie_consent=not-engaged', this.attribute)
-      } else if (cookieConsent && cookieConsent.usage === true) {
-        this.handleCookiesAccepted()
-      } else {
-        this.decorate(this.element, 'cookie_consent=reject', this.attribute)
-      }
+  ExplicitCrossDomainLinks.prototype.decorate = function (element, param, attribute) {
+    var attributeValue = element.getAttribute(attribute)
 
-      // remove the event listener to avoid an infinite loop
-      this.element.removeEventListener(this.eventType, this.handleEvent)
+    if (!attributeValue) { return }
 
-      // if the element is a form, submit it. If it is a link, click it
-      if (this.eventType === 'submit') {
-        this.element.submit()
-      } else {
-        this.element.click()
-      }
+    if (attributeValue.indexOf('?') !== -1) {
+      attributeValue += '&' + param
+    } else {
+      attributeValue += '?' + param
     }
 
-    this.handleCookiesAccepted = function () {
-      // If the cookie banner was engaged and usage cookie accepted, append ?_ga=clientid if available and cookie_consent=accept
-      var element = this.element
-      var attribute = this.attribute
-      this.decorate(element, 'cookie_consent=accept', attribute)
+    element.setAttribute(attribute, attributeValue)
+  }
 
-      if (!global.ga) {
-        return
-      }
+  ExplicitCrossDomainLinks.prototype.handleEvent = function (e) {
+    //  prevent default: we want the link href and/or form action to be decorated before we navigate away
+    e.preventDefault()
+    var cookieBannerEngaged = window.GOVUK.cookie('cookies_preferences_set')
+    var cookieConsent = window.GOVUK.getConsentCookie()
 
-      global.ga(function () {
-        var trackers = global.ga.getAll()
-
-        if (!trackers.length) { return }
-
-        var linker = new global.gaplugins.Linker(trackers[0])
-        var attrValue = element.getAttribute(attribute)
-
-        element.setAttribute(attribute, linker.decorate(attrValue))
-      })
+    if (cookieBannerEngaged !== 'true') {
+      // If not engaged, append only ?cookie_consent=not-engaged
+      this.decorate(this.$module, 'cookie_consent=not-engaged', this.attribute)
+    } else if (cookieConsent && cookieConsent.usage === true) {
+      this.handleCookiesAccepted()
+    } else {
+      this.decorate(this.$module, 'cookie_consent=reject', this.attribute)
     }
 
-    this.decorate = function (element, param, attribute) {
-      var attributeValue = element.getAttribute(attribute)
+    // remove the event listener to avoid an infinite loop
+    this.$module.removeEventListener(this.eventType, this.handleEvent)
 
-      if (!attributeValue) { return }
-
-      if (attributeValue.indexOf('?') !== -1) {
-        attributeValue += '&' + param
-      } else {
-        attributeValue += '?' + param
-      }
-
-      element.setAttribute(attribute, attributeValue)
+    // if the element is a form, submit it. If it is a link, click it
+    if (this.eventType === 'submit') {
+      this.$module.submit()
+    } else {
+      this.$module.click()
     }
   }
 
-  global.GOVUK = GOVUK
-})(window)
+  ExplicitCrossDomainLinks.prototype.handleCookiesAccepted = function () {
+    // If the cookie banner was engaged and usage cookie accepted, append ?_ga=clientid if available and cookie_consent=accept
+    var element = this.$module
+    var attribute = this.attribute
+    this.decorate(element, 'cookie_consent=accept', attribute)
+
+    if (!window.ga) {
+      return
+    }
+
+    window.ga(function () {
+      var trackers = window.ga.getAll()
+
+      if (!trackers.length) { return }
+
+      var linker = new window.gaplugins.Linker(trackers[0])
+      var attrValue = element.getAttribute(attribute)
+
+      element.setAttribute(attribute, linker.decorate(attrValue))
+    })
+  }
+
+  Modules.ExplicitCrossDomainLinks = ExplicitCrossDomainLinks
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/modules.js
+++ b/app/assets/javascripts/govuk_publishing_components/modules.js
@@ -35,7 +35,6 @@
         for (var j = 0, k = moduleNames.length; j < k; j++) {
           var moduleName = camelCaseAndCapitalise(moduleNames[j])
           var started = element.getAttribute('data-' + moduleNames[j] + '-module-started')
-
           if (typeof GOVUK.Modules[moduleName] === 'function' && !started) {
             // Vanilla JavaScript GOV.UK Modules and GOV.UK Frontend Modules
             if (GOVUK.Modules[moduleName].prototype.init) {

--- a/spec/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/explicit-cross-domain-links.spec.js
@@ -28,7 +28,8 @@ describe('Explicit cross-domain linker', function () {
       decorate: function () {}
     }
 
-    explicitCrossDomainLinks = new GOVUK.Modules.ExplicitCrossDomainLinks()
+    element = $('<a href="#">')
+    explicitCrossDomainLinks = new GOVUK.Modules.ExplicitCrossDomainLinks(element[0])
 
     spyOn(window.gaplugins, 'Linker').and.returnValue(linker)
     spyOn(linker, 'decorate').and.callFake(function (url) {
@@ -43,13 +44,9 @@ describe('Explicit cross-domain linker', function () {
   })
 
   describe('when a cross-domain link is clicked', function () {
-    beforeEach(function () {
-      element = $('<a href="#">')
-    })
-
     it('modifies the link href to append cookie_consent parameter "not-engaged" if cookies_preferences_set cookie is "false"', function () {
       GOVUK.cookie('cookies_preferences_set', 'false')
-      explicitCrossDomainLinks.start(element)
+      explicitCrossDomainLinks.init()
       expect(element.attr('href')).toEqual('#')
       window.GOVUK.triggerEvent(element[0], 'click')
       expect(element.attr('href')).toEqual('#?cookie_consent=not-engaged')
@@ -58,7 +55,7 @@ describe('Explicit cross-domain linker', function () {
 
     it('modifies the link href to append cookie_consent parameter "not-engaged" if cookies_preferences_set cookie is not set', function () {
       GOVUK.cookie('cookies_preferences_set', null)
-      explicitCrossDomainLinks.start(element)
+      explicitCrossDomainLinks.init()
       expect(element.attr('href')).toEqual('#')
       window.GOVUK.triggerEvent(element[0], 'click')
       expect(element.attr('href')).toEqual('#?cookie_consent=not-engaged')
@@ -68,7 +65,7 @@ describe('Explicit cross-domain linker', function () {
     it('modifies the link href to append cookie_consent parameter "reject" if usage cookies have been rejected', function () {
       GOVUK.cookie('cookies_preferences_set', 'true')
       GOVUK.setConsentCookie({ usage: false })
-      explicitCrossDomainLinks.start(element)
+      explicitCrossDomainLinks.init()
       expect(element.attr('href')).toEqual('#')
       window.GOVUK.triggerEvent(element[0], 'click')
       expect(element.attr('href')).toEqual('#?cookie_consent=reject')
@@ -81,7 +78,7 @@ describe('Explicit cross-domain linker', function () {
         GOVUK.setConsentCookie({ usage: true })
         trackers = [{ ga_mock: 'foobar' }]
 
-        explicitCrossDomainLinks.start(element)
+        explicitCrossDomainLinks.init()
         expect(element.attr('href')).toEqual('#')
         window.GOVUK.triggerEvent(element[0], 'click')
 
@@ -94,7 +91,7 @@ describe('Explicit cross-domain linker', function () {
         GOVUK.setConsentCookie({ usage: true })
         trackers = []
 
-        explicitCrossDomainLinks.start(element)
+        explicitCrossDomainLinks.init()
         expect(element.attr('href')).toEqual('#')
         window.GOVUK.triggerEvent(element[0], 'click')
         expect(element.attr('href')).toEqual('#?cookie_consent=accept')
@@ -105,7 +102,7 @@ describe('Explicit cross-domain linker', function () {
         GOVUK.cookie('cookies_preferences_set', 'true')
         GOVUK.setConsentCookie({ usage: true })
         window.ga = undefined
-        explicitCrossDomainLinks.start(element)
+        explicitCrossDomainLinks.init()
         expect(element.attr('href')).toEqual('#')
         window.GOVUK.triggerEvent(element[0], 'click')
         expect(element.attr('href')).toEqual('#?cookie_consent=accept')
@@ -120,11 +117,12 @@ describe('Explicit cross-domain linker', function () {
                '<input type="hidden" name="key" value="value" />' +
                '<button type="submit">Create a GOV.UK account</button>' +
              '</form>')
+      explicitCrossDomainLinks = new GOVUK.Modules.ExplicitCrossDomainLinks(element[0])
     })
 
     it('modifies the form action to append cookie_consent parameter "not-engaged" if cookies_preferences_set cookie is "false"', function () {
       GOVUK.cookie('cookies_preferences_set', 'false')
-      explicitCrossDomainLinks.start(element)
+      explicitCrossDomainLinks.init()
       expect(element.attr('action')).toEqual('/somewhere')
       window.GOVUK.triggerEvent(element[0], 'submit')
 
@@ -133,7 +131,7 @@ describe('Explicit cross-domain linker', function () {
 
     it('modifies the form action to append cookie_consent parameter "not-engaged" if cookies_preferences_set cookie is not set', function () {
       GOVUK.cookie('cookies_preferences_set', null)
-      explicitCrossDomainLinks.start(element)
+      explicitCrossDomainLinks.init()
       expect(element.attr('action')).toEqual('/somewhere')
       window.GOVUK.triggerEvent(element[0], 'submit')
       expect(element.attr('action')).toEqual('/somewhere?cookie_consent=not-engaged')
@@ -142,7 +140,7 @@ describe('Explicit cross-domain linker', function () {
     it('modifies the form action to append cookie_consent parameter "reject" if usage cookies have been rejected', function () {
       GOVUK.cookie('cookies_preferences_set', 'true')
       GOVUK.setConsentCookie({ usage: false })
-      explicitCrossDomainLinks.start(element)
+      explicitCrossDomainLinks.init()
       expect(element.attr('action')).toEqual('/somewhere')
       window.GOVUK.triggerEvent(element[0], 'submit')
       expect(element.attr('action')).toEqual('/somewhere?cookie_consent=reject')
@@ -153,7 +151,7 @@ describe('Explicit cross-domain linker', function () {
         GOVUK.cookie('cookies_preferences_set', 'true')
         GOVUK.setConsentCookie({ usage: true })
         trackers = [{ ga_mock: 'foobar' }]
-        explicitCrossDomainLinks.start(element)
+        explicitCrossDomainLinks.init()
         expect(element.attr('action')).toEqual('/somewhere')
         window.GOVUK.triggerEvent(element[0], 'submit')
         expect(element.attr('action')).toEqual('/somewhere?cookie_consent=accept&_ga=abc123')
@@ -163,7 +161,7 @@ describe('Explicit cross-domain linker', function () {
         GOVUK.cookie('cookies_preferences_set', 'true')
         GOVUK.setConsentCookie({ usage: true })
         trackers = []
-        explicitCrossDomainLinks.start(element)
+        explicitCrossDomainLinks.init()
         expect(element.attr('action')).toEqual('/somewhere')
         window.GOVUK.triggerEvent(element[0], 'submit')
         expect(element.attr('action')).toEqual('/somewhere?cookie_consent=accept')
@@ -173,7 +171,7 @@ describe('Explicit cross-domain linker', function () {
         GOVUK.cookie('cookies_preferences_set', 'true')
         GOVUK.setConsentCookie({ usage: true })
         window.ga = undefined
-        explicitCrossDomainLinks.start(element)
+        explicitCrossDomainLinks.init()
         expect(element.attr('action')).toEqual('/somewhere')
         window.GOVUK.triggerEvent(element[0], 'submit')
         expect(element.attr('action')).toEqual('/somewhere?cookie_consent=accept')


### PR DESCRIPTION
It was noted that cross-domain linking between the account and the DI domain stopped working around 25th March.

Around that time, a lot of good work was done around removing jQuery from GOVUK. As part of that work there were some [changes](https://github.com/alphagov/govuk_publishing_components/commit/613cfcc8f71c96d8099bf28dd51231f48bbec3b9) to the script which starts the modules in `govuk_publishing_components` where support for legacy modules was removed.

The explicit-cross-domain-links script was still using `start()` to initialise so it stopped working around that time. This changes it to `init()`.

To test: on this page https://www.gov.uk/email/subscriptions/single-page/new?topic_id=keeping-a-pet-pig-or-micropig, when you click **Create a GOV.UK account or sign in**, the URL of the next page should have a cookie consent query parameter which reflects whether you've accepted cookies, rejected cookies, or not engaged with the cookie banner.


-----

https://trello.com/c/EM69ov98

