### PR TITLE
Realign list of topics in navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Auditing enhancements ([PR #2428](https://github.com/alphagov/govuk_publishing_components/pull/2428))
 * Fix JS bug in MagnaCharta for stacked charts ([PR #2731](https://github.com/alphagov/govuk_publishing_components/pull/2731))
 * Remove coronavirus topic from menu bar ([PR #2745](https://github.com/alphagov/govuk_publishing_components/pull/2745))
+* Realign list of topics in navigation header ([PR #2750](https://github.com/alphagov/govuk_publishing_components/pull/2750))
 
 ## 29.6.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -816,7 +816,7 @@ $button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
 
 .gem-c-layout-super-navigation-header__navigation-second-items--topics {
   @include govuk-media-query($from: "desktop") {
-    @include columns($items: 17, $columns: 2, $selector: "li", $flow: column);
+    @include columns($items: 16, $columns: 2, $selector: "li", $flow: column);
   }
 }
 


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Updates the `columns` mixin with the updated number of items in the list of topics in the navigation header.

## Why
<!-- What are the reasons behind this change being made? -->

An [item was removed from the topics listed in the navigation header][removed], which requires the CSS grid layout to be rejigged to avoid lopsided columns.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before
![image](https://user-images.githubusercontent.com/1732331/166437446-0da78ad0-8949-4ac2-b776-48830c87a329.png)

### After
![image](https://user-images.githubusercontent.com/1732331/166437396-00e5542c-e63c-444b-b7f7-fdd2dbf10973.png)

[removed]: https://github.com/alphagov/govuk_publishing_components/pull/2745
