### PR TITLE
Fix print styles for organisation logos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Extend GTM analytics click tracking ([PR #2786](https://github.com/alphagov/govuk_publishing_components/pull/2786))
 * GOVUK Frontend 4.1.0 updates ([PR #2794](https://github.com/alphagov/govuk_publishing_components/pull/2794))
+* Fix print styles for organisation logos ([PR #2751](https://github.com/alphagov/govuk_publishing_components/pull/2751))
 
 ## 29.10.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -10,6 +10,7 @@
 @import "components/print/govspeak-html-publication";
 @import "components/print/govspeak";
 @import "components/print/layout-super-navigation-header";
+@import "components/print/organisation-logo";
 @import "components/print/step-by-step-nav-header";
 @import "components/print/step-by-step-nav";
 @import "components/print/textarea";

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_organisation-logo.scss
@@ -1,3 +1,7 @@
+.gem-c-organisation-logo {
+  width: 25%;
+}
+
 .gem-c-organisation-logo__image {
   max-width: 100%;
 }


### PR DESCRIPTION
## What
Sets a width for the organisation logo component when being printed so that it is not excessively large if image used for organisation logo is a large image. This resolves issue https://github.com/alphagov/govuk_publishing_components/issues/2374.

## Why
When printing a page with the organisation logo component, there was no width set on the image so it would be printed at the size of the image itself. This meant if the image was large then the image would appear much larger than it had on the page itself. A potential fix would be to hide the organisation logo when printing but as the organisation logo is the only indication on the page when printed that the page is originating from an organisation I thought it was important to retain it.

## Visual Changes
N.B. this is print view only

### Before
![Screenshot 2022-05-03 at 14 16 52](https://user-images.githubusercontent.com/3727504/166459948-4126ae6f-81ad-49e6-ab4e-441c37731ef0.png)


### After
![Screenshot 2022-05-03 at 14 17 05](https://user-images.githubusercontent.com/3727504/166459966-e079fcab-ba78-4b72-b885-d6cde3e694fe.png)
