### PR TITLE
add wrapper to the component card to ensure link spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+Add wrapper to the component card to ensure link spacing ([PR #2753](https://github.com/alphagov/govuk_publishing_components/pull/2753))
+
 ## 29.7.0
 
 * Auditing enhancements ([PR #2428](https://github.com/alphagov/govuk_publishing_components/pull/2428))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -50,12 +50,19 @@
   // We use grid to split the container into column widths, so manage the horizontal spacing with
   // internal margins.
   margin: 0 govuk-spacing(3);
-  padding: govuk-spacing(3) 0 govuk-spacing(6) 0;
+  padding: govuk-spacing(1) 0 govuk-spacing(4) 0;
+}
+
+.gem-c-cards__list-item-wrapper {
+  // this wrapper ensures that the clickable area of the card only
+  // covers the area of the card containing text so in a grid of cards
+  // there is space above and below each link
+  padding: govuk-spacing(2) govuk-spacing(6) govuk-spacing(2) 0;
   position: relative;
 }
 
 .gem-c-cards__sub-heading {
-  margin: 0 govuk-spacing(6) govuk-spacing(2) 0;
+  margin-bottom: govuk-spacing(2);
 }
 
 .gem-c-cards__link {
@@ -79,7 +86,7 @@
     height: $dimension;
     position: absolute;
     right: govuk-spacing(1);
-    top: govuk-spacing(4);
+    top: govuk-spacing(3);
     @include prefixed-transform($rotate: 45deg);
     width: $dimension;
   }
@@ -98,5 +105,5 @@
 }
 
 .gem-c-cards__description {
-  margin: 0;
+  margin: 0 govuk-spacing(-6) 0 0;
 }

--- a/app/views/govuk_publishing_components/components/_cards.html.erb
+++ b/app/views/govuk_publishing_components/components/_cards.html.erb
@@ -31,17 +31,19 @@
         end
       %>
         <li class="gem-c-cards__list-item">
-          <%= content_tag("h#{sub_heading_level}", class: "gem-c-cards__sub-heading govuk-heading-s") do %>
-            <%= 
-              link_to link[:text], link[:path], 
-              class: "govuk-link gem-c-cards__link", 
-              data: link[:data_attributes],
-              "data-track-count": "cardLink"
-            %>
-          <% end %>
-          <% if item[:description] %>
-            <p class="govuk-body gem-c-cards__description"><%= item[:description] %></p>
-          <% end %>
+          <div class="gem-c-cards__list-item-wrapper">
+            <%= content_tag("h#{sub_heading_level}", class: "gem-c-cards__sub-heading govuk-heading-s") do %>
+              <%=
+                link_to link[:text], link[:path],
+                class: "govuk-link gem-c-cards__link",
+                data: link[:data_attributes],
+                "data-track-count": "cardLink"
+              %>
+            <% end %>
+            <% if item[:description] %>
+              <p class="govuk-body gem-c-cards__description"><%= item[:description] %></p>
+            <% end %>
+          </div>
         </li>
       <% end %>
     <% end %>


### PR DESCRIPTION
## What
Add a wrapper to the content of the card component.

## Why
When testing for how usable the collections pages were with a magnifier tool, I noticed that there was a difference to how the cards were implemented in the govuk_publishing_components gem to how they were implemented on GOV.UK itself. The cards on GOV.UK have a wrapper containing the sub-heading and description so that the area of the card that acts as a link is only the portion of the card containing text and not the entire area of the card. This means there is a space between each card above and below on the grid. In the govuk_publishing_components implementation of the card, there is no wrapper which means the entire card acts as a link and so there is no spacing above and blow each card on the grid. This could potentially make the site less usable if using a magnifying tool as the user could accidentally click on the wrong link. 

## Before
![Screenshot 2022-05-04 at 09 36 29](https://user-images.githubusercontent.com/3727504/166647927-c2e0e3d2-cb5b-4dec-a728-7e4f1fad0f07.png)


## After
![Screenshot 2022-05-04 at 09 35 01](https://user-images.githubusercontent.com/3727504/166647881-76da7bad-f163-423a-9a56-3d16fc130132.png)


[Related Trello Card](https://trello.com/c/Fpj1ARx0/933-do-frontend-resilience-cross-browser-and-assistive-tech-testing-on-level-0-1-templates)