### PR TITLE
Make auditing check static for missing assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Make auditing check static for missing assets ([PR #2755](https://github.com/alphagov/govuk_publishing_components/pull/2755))
 * Update analytics logic for new browse page metatags ([PR #2778](https://github.com/alphagov/govuk_publishing_components/pull/2778))
 * Tracking changes for the footer ([PR #2774](https://github.com/alphagov/govuk_publishing_components/pull/2774))
 

--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -24,7 +24,8 @@ module GovukPublishingComponents
         static
         travel-advice-publisher
         whitehall
-      ].sort
+      ]
+
       application_dirs = [GovukPublishingComponents::ApplicationHelper.get_application_name_from_path(Rails.root)] unless ENV["MAIN_COMPONENT_GUIDE"]
 
       gem_path = Gem.loaded_specs["govuk_publishing_components"].full_gem_path

--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -37,7 +37,7 @@ module GovukPublishingComponents
 
       components = AuditComponents.new(gem_path, false)
       applications = analyse_applications(host_dir, application_dirs)
-      compared_data = AuditComparer.new(components.data, applications, false)
+      compared_data = AuditComparer.new(components.data, applications)
 
       @applications = compared_data.applications_data || []
       @components = compared_data.gem_data || []

--- a/app/controllers/govuk_publishing_components/component_guide_controller.rb
+++ b/app/controllers/govuk_publishing_components/component_guide_controller.rb
@@ -13,7 +13,6 @@ module GovukPublishingComponents
       @components_in_use_sass = components_in_use_sass(false)
       @components_in_use_print_sass = components_in_use_sass(true)
       @components_in_use_js = components_in_use_js
-      @index_audit_summary = index_audit_summary
     end
 
     def show
@@ -161,14 +160,6 @@ module GovukPublishingComponents
         h[:title] = component_doc.name
         h[:url] = component_doc_path(component_doc.id) if component_example
       end
-    end
-
-    def index_audit_summary
-      components_gem_path = Gem.loaded_specs["govuk_publishing_components"].full_gem_path
-      components = AuditComponents.new(components_gem_path, true)
-      application = AuditApplications.new(@application_path, GovukPublishingComponents::ApplicationHelper.get_application_name_from_path(@application_path))
-      compared_data = AuditComparer.new(components.data, [application.data], true)
-      compared_data.applications_data[0]
     end
   end
 end

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -2,7 +2,7 @@ module GovukPublishingComponents
   class AuditComparer
     attr_reader :applications_data, :gem_data
 
-    def initialize(gem_data, results, simple)
+    def initialize(gem_data, results)
       if gem_data[:gem_found]
         @applications_using_static = %w[
           collections
@@ -21,7 +21,7 @@ module GovukPublishingComponents
 
         @static_data = find_static(results)
         @gem_data = gem_data
-        @applications_data = sort_results(results, simple)
+        @applications_data = sort_results(results)
         @gem_data[:components_by_application] = get_components_by_application || []
       end
     end
@@ -43,8 +43,7 @@ module GovukPublishingComponents
       key.to_s.gsub("_", " ").capitalize
     end
 
-    def sort_results(results, simple)
-      @simple = simple
+    def sort_results(results)
       data = []
 
       results.each do |result|
@@ -69,31 +68,28 @@ module GovukPublishingComponents
           warnings << warn_about_jquery_references(result[:jquery_references])
           warnings = warnings.flatten
 
-          summary = []
-          unless @simple
-            summary = [
-              {
-                name: "Components in templates",
-                value: templates[:components].flatten.uniq.sort.join(", "),
-              },
-              {
-                name: "Components in stylesheets",
-                value: stylesheets[:components].join(", "),
-              },
-              {
-                name: "Components in print stylesheets",
-                value: print_stylesheets[:components].join(", "),
-              },
-              {
-                name: "Components in javascripts",
-                value: javascripts[:components].join(", "),
-              },
-              {
-                name: "Components in ruby",
-                value: ruby[:components].join(", "),
-              },
-            ]
-          end
+          summary = [
+            {
+              name: "Components in templates",
+              value: templates[:components].flatten.uniq.sort.join(", "),
+            },
+            {
+              name: "Components in stylesheets",
+              value: stylesheets[:components].join(", "),
+            },
+            {
+              name: "Components in print stylesheets",
+              value: print_stylesheets[:components].join(", "),
+            },
+            {
+              name: "Components in javascripts",
+              value: javascripts[:components].join(", "),
+            },
+            {
+              name: "Components in ruby",
+              value: ruby[:components].join(", "),
+            },
+          ]
 
           data << {
             name: result[:name],
@@ -231,8 +227,6 @@ module GovukPublishingComponents
     end
 
     def get_components_by_application
-      return [] if @simple
-
       results = []
       found_something = false
 

--- a/app/views/govuk_publishing_components/audit/_applications.html.erb
+++ b/app/views/govuk_publishing_components/audit/_applications.html.erb
@@ -33,6 +33,11 @@
     <% accordion_content = capture do %>
       <% if application[:application_found] %>
         <% github_link = 'https://github.com/alphagov/' + application[:name] + '/blob/main/' %>
+
+        <% if application[:uses_static] %>
+          <p class="govuk-body">This application uses <a href="https://github.com/alphagov/static" class="govuk-link">static</a>, which can contain assets for components used in more than one application. Warnings for missing component assets in this application that are already included in static have been suppressed.</p>
+        <% end %>
+
         <% application[:warnings].each do |warning| %>
           <p class="govuk-body">
             <strong class="govuk-tag">Warn</strong>

--- a/app/views/govuk_publishing_components/audit/_applications.html.erb
+++ b/app/views/govuk_publishing_components/audit/_applications.html.erb
@@ -22,11 +22,13 @@
   %>
   <% application_items = @applications.map do |application| %>
     <%
-      summary = '<strong class="govuk-tag govuk-tag--red">Application not found</strong>'
+      if @other_applications
+        summary = '<strong class="govuk-tag govuk-tag--red">Application not found</strong>'
 
-      if application[:application_found]
-        summary = "Warnings: 0"
-        summary = "Warnings: <strong class=\"govuk-tag govuk-tag--red\">#{application[:warning_count]}</strong>" if application[:warning_count] > 0
+        if application[:application_found]
+          summary = "Warnings: 0"
+          summary = "Warnings: <strong class=\"govuk-tag govuk-tag--red\">#{application[:warning_count]}</strong>" if application[:warning_count] > 0
+        end
       end
     %>
 
@@ -34,15 +36,19 @@
       <% if application[:application_found] %>
         <% github_link = 'https://github.com/alphagov/' + application[:name] + '/blob/main/' %>
 
-        <% if application[:uses_static] %>
-          <p class="govuk-body">This application uses <a href="https://github.com/alphagov/static" class="govuk-link">static</a>, which can contain assets for components used in more than one application. Warnings for missing component assets in this application that are already included in static have been suppressed.</p>
-        <% end %>
+        <% if @other_applications %>
+          <% if application[:uses_static] %>
+            <p class="govuk-body">This application uses <a href="https://github.com/alphagov/static" class="govuk-link">static</a>, which can contain assets for components used in more than one application. Warnings for missing component assets in this application that are already included in static have been suppressed.</p>
+          <% end %>
 
-        <% application[:warnings].each do |warning| %>
-          <p class="govuk-body">
-            <strong class="govuk-tag">Warn</strong>
-            <strong><%= warning[:component] %></strong> - <%= warning[:message] %>
-          </p>
+          <% application[:warnings].each do |warning| %>
+            <p class="govuk-body">
+              <strong class="govuk-tag">Warn</strong>
+              <strong><%= warning[:component] %></strong> - <%= warning[:message] %>
+            </p>
+          <% end %>
+        <% else %>
+          <p class="govuk-body">More information about this application is available by viewing the component guide from a locally running instance of govuk_publishing_components.</p>
         <% end %>
 
         <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -1,29 +1,11 @@
 <%= render 'govuk_publishing_components/components/title', title: GovukPublishingComponents::Config.component_guide_title, margin_top: 0 %>
 
-<% unless ENV["MAIN_COMPONENT_GUIDE"] %>
-  <p class="govuk-body">
-    <% if @index_audit_summary[:application_found] %>
-      Warnings:
-      <% if @index_audit_summary[:warning_count] > 0 %>
-        <strong class="govuk-tag govuk-tag--red"><%= @index_audit_summary[:warning_count] %></strong>
-      <% else %>
-        <%= @index_audit_summary[:warning_count] %>
-      <% end %>
-      <a href="/component-guide/audit" class="govuk-link">Warning details</a>
-    <% else %>
-      <strong class="govuk-tag govuk-tag--red">Application not found</strong>
-    <% end %>
-  </p>
-<% end %>
-
 <div class="component-markdown">
   <p>Components are packages of template, style, behaviour and documentation that live in your application.</p>
   <p>See the <a href="https://github.com/alphagov/govuk_publishing_components">govuk_publishing_components gem</a> for further details, or <a href="https://docs.publishing.service.gov.uk/manual/components.html#component-guides">a list of all component guides</a>.</p>
   <ul>
     <li>Read about how to <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/publishing-to-rubygems.md">release a new version of the gem</a></li>
-    <% if ENV["MAIN_COMPONENT_GUIDE"] %>
-      <li><a href="/component-guide/audit">View component audits</a></li>
-    <% end %>
+    <li><a href="/component-guide/audit">View component audits</a></li>
   </ul>
 </div>
 

--- a/docs/auditing.md
+++ b/docs/auditing.md
@@ -9,7 +9,7 @@ The aim of the auditing is to provide information about our components and how t
 - where an application is using a component but has not included required assets
 - where an application is not using a component but has included unneeded assets
 
-Note that there may be reasons behind warnings reported by the auditing that mean no action is required. For example, at time of writing the action link component is being used in `collections` and also in the site header, so the Sass for the component is included only in `static`, to prevent duplication. This causes a warning to be raised for `collections`, as it uses the component but doesn't include the Sass.
+In some cases an application may use a component but not include its assets. This is usually because the assets are already included globally in `static`. For example, at time of writing the action link component is being used in `collections` and also in the site header, so the Sass for the component is included only in `static`, to prevent duplication. The auditing checks this and suppresses any warnings for missing assets in applications where they are already included in `static`.
 
 The auditing also includes other warnings, such as:
 

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -79,7 +79,7 @@ describe "Comparing data from an application with the components" do
         ],
       },
     ]
-    comparer = GovukPublishingComponents::AuditComparer.new(gem_not_found, application, false)
+    comparer = GovukPublishingComponents::AuditComparer.new(gem_not_found, application)
     expected = nil
     expect(comparer.applications_data).to match(expected)
   end
@@ -125,7 +125,7 @@ describe "Comparing data from an application with the components" do
         jquery_references: [],
       },
     ]
-    comparer = GovukPublishingComponents::AuditComparer.new(gem, application, false)
+    comparer = GovukPublishingComponents::AuditComparer.new(gem, application)
 
     expected = [
       {
@@ -261,7 +261,7 @@ describe "Comparing data from an application with the components" do
         jquery_references: [],
       },
     ]
-    comparer = GovukPublishingComponents::AuditComparer.new(gem, application, false)
+    comparer = GovukPublishingComponents::AuditComparer.new(gem, application)
 
     expected = [
       {
@@ -340,85 +340,6 @@ describe "Comparing data from an application with the components" do
     expect(comparer.applications_data).to match(expected)
   end
 
-  it "returns a comparison for an application in simple mode without certain data" do
-    application = [
-      {
-        name: "Dummy application",
-        application_found: true,
-        components_found: [
-          {
-            location: "templates",
-            components: [
-              "component one",
-              "component that does not exist",
-            ],
-          },
-          {
-            location: "stylesheets",
-            components: [
-              "component one",
-              "component two",
-              "component four",
-            ],
-          },
-          {
-            location: "print_stylesheets",
-            components: [],
-          },
-          {
-            location: "javascripts",
-            components: [],
-          },
-          {
-            location: "ruby",
-            components: [
-              "component three",
-            ],
-          },
-        ],
-        gem_style_references: [],
-        jquery_references: [],
-      },
-    ]
-    comparer = GovukPublishingComponents::AuditComparer.new(gem, application, true)
-
-    expected = [
-      {
-        name: "Dummy application",
-        application_found: true,
-        uses_static: false,
-        summary: [],
-        warnings: [
-          {
-            component: "component that does not exist",
-            message: "Included in templates but component does not exist",
-          },
-          {
-            component: "component four",
-            message: "Included in stylesheets but component does not exist",
-          },
-          {
-            component: "component three",
-            message: "Included in code but not stylesheets",
-          },
-          {
-            component: "component one",
-            message: "Included in code but not javascripts",
-          },
-          {
-            component: "component two",
-            message: "Included in stylesheets but not code",
-          },
-        ],
-        warning_count: 5,
-        gem_style_references: [],
-        jquery_references: [],
-      },
-    ]
-
-    expect(comparer.applications_data).to match(expected)
-  end
-
   it "returns a comparison for an application using all components" do
     application = [
       {
@@ -455,7 +376,7 @@ describe "Comparing data from an application with the components" do
         jquery_references: [],
       },
     ]
-    comparer = GovukPublishingComponents::AuditComparer.new(gem, application, false)
+    comparer = GovukPublishingComponents::AuditComparer.new(gem, application)
 
     expected = [
       {
@@ -542,7 +463,7 @@ describe "Comparing data from an application with the components" do
         jquery_references: [],
       },
     ]
-    comparer = GovukPublishingComponents::AuditComparer.new(gem, application, false)
+    comparer = GovukPublishingComponents::AuditComparer.new(gem, application)
 
     expected = [
       {

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -299,8 +299,12 @@ describe "Comparing data from an application with the components" do
             component: "component four",
             message: "Included in code but not javascripts",
           },
+          {
+            component: "component one",
+            message: "Included in stylesheets but already included in static",
+          },
         ],
-        warning_count: 2,
+        warning_count: 3,
         gem_style_references: [],
         jquery_references: [],
       },

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -9,25 +9,28 @@ describe "Comparing data from an application with the components" do
       "component one",
       "component two",
       "component three",
+      "component four",
     ],
     component_stylesheets: [
       "component one",
       "component two",
       "component three",
+      "component four",
     ],
     component_print_stylesheets: [
       "component two",
     ],
     component_javascripts: [
       "component one",
+      "component four",
     ],
     component_tests: [],
     component_js_tests: [],
     components_containing_components: [
       {
-        component: "component one",
+        component: "component three",
         sub_components: [
-          "component three",
+          "component four",
         ],
       },
     ],
@@ -91,6 +94,7 @@ describe "Comparing data from an application with the components" do
             location: "templates",
             components: [
               "component one",
+              "component three",
               "component that does not exist",
             ],
           },
@@ -99,7 +103,7 @@ describe "Comparing data from an application with the components" do
             components: [
               "component one",
               "component two",
-              "component four",
+              "component three",
             ],
           },
           {
@@ -127,14 +131,15 @@ describe "Comparing data from an application with the components" do
       {
         name: "Dummy application",
         application_found: true,
+        uses_static: false,
         summary: [
           {
             name: "Components in templates",
-            value: "component one, component that does not exist, component three",
+            value: "component four, component one, component that does not exist, component three",
           },
           {
             name: "Components in stylesheets",
-            value: "component one, component two, component four",
+            value: "component one, component two, component three",
           },
           {
             name: "Components in print stylesheets",
@@ -156,11 +161,11 @@ describe "Comparing data from an application with the components" do
           },
           {
             component: "component four",
-            message: "Included in stylesheets but component does not exist",
+            message: "Included in code but not stylesheets",
           },
           {
-            component: "component three",
-            message: "Included in code but not stylesheets",
+            component: "component four",
+            message: "Included in code but not javascripts",
           },
           {
             component: "component one",
@@ -172,6 +177,161 @@ describe "Comparing data from an application with the components" do
           },
         ],
         warning_count: 5,
+        gem_style_references: [],
+        jquery_references: [],
+      },
+    ]
+
+    expect(comparer.applications_data).to match(expected)
+  end
+
+  # if static contains an asset that an application needs, no warning should be raised
+  it "returns a comparison for an application using individual components and takes static into account" do
+    application = [
+      {
+        name: "collections",
+        application_found: true,
+        components_found: [
+          {
+            location: "templates",
+            components: [
+              "component one",
+              "component two",
+              "component four",
+            ],
+          },
+          {
+            location: "stylesheets",
+            components: [
+              "component one",
+            ],
+          },
+          {
+            location: "print_stylesheets",
+            components: [],
+          },
+          {
+            location: "javascripts",
+            components: [],
+          },
+          {
+            location: "ruby",
+            components: [],
+          },
+        ],
+        gem_style_references: [],
+        jquery_references: [],
+      },
+      {
+        name: "static",
+        application_found: true,
+        components_found: [
+          {
+            location: "templates",
+            components: [
+              "component one",
+              "component two",
+            ],
+          },
+          {
+            location: "stylesheets",
+            components: [
+              "component one",
+              "component two",
+            ],
+          },
+          {
+            location: "print_stylesheets",
+            components: [
+              "component two",
+            ],
+          },
+          {
+            location: "javascripts",
+            components: [
+              "component one",
+            ],
+          },
+          {
+            location: "ruby",
+            components: [],
+          },
+        ],
+        gem_style_references: [],
+        jquery_references: [],
+      },
+    ]
+    comparer = GovukPublishingComponents::AuditComparer.new(gem, application, false)
+
+    expected = [
+      {
+        name: "collections",
+        application_found: true,
+        uses_static: true,
+        summary: [
+          {
+            name: "Components in templates",
+            value: "component four, component one, component two",
+          },
+          {
+            name: "Components in stylesheets",
+            value: "component one",
+          },
+          {
+            name: "Components in print stylesheets",
+            value: "",
+          },
+          {
+            name: "Components in javascripts",
+            value: "",
+          },
+          {
+            name: "Components in ruby",
+            value: "",
+          },
+        ],
+        warnings: [
+          {
+            component: "component four",
+            message: "Included in code but not stylesheets",
+          },
+          {
+            component: "component four",
+            message: "Included in code but not javascripts",
+          },
+        ],
+        warning_count: 2,
+        gem_style_references: [],
+        jquery_references: [],
+      },
+      {
+        name: "static",
+        application_found: true,
+        uses_static: false,
+        summary: [
+          {
+            name: "Components in templates",
+            value: "component one, component two",
+          },
+          {
+            name: "Components in stylesheets",
+            value: "component one, component two",
+          },
+          {
+            name: "Components in print stylesheets",
+            value: "component two",
+          },
+          {
+            name: "Components in javascripts",
+            value: "component one",
+          },
+          {
+            name: "Components in ruby",
+            value: "",
+          },
+        ],
+        warnings: [],
+        warning_count: 0,
         gem_style_references: [],
         jquery_references: [],
       },
@@ -226,6 +386,7 @@ describe "Comparing data from an application with the components" do
       {
         name: "Dummy application",
         application_found: true,
+        uses_static: false,
         summary: [],
         warnings: [
           {
@@ -300,10 +461,11 @@ describe "Comparing data from an application with the components" do
       {
         name: "Dummy application",
         application_found: true,
+        uses_static: false,
         summary: [
           {
             name: "Components in templates",
-            value: "component one, component three, component two",
+            value: "component one, component two",
           },
           {
             name: "Components in stylesheets",
@@ -386,10 +548,11 @@ describe "Comparing data from an application with the components" do
       {
         name: "Dummy application",
         application_found: true,
+        uses_static: false,
         summary: [
           {
             name: "Components in templates",
-            value: "component three, component two",
+            value: "component four, component three, component two",
           },
           {
             name: "Components in stylesheets",
@@ -420,6 +583,10 @@ describe "Comparing data from an application with the components" do
             message: "Included in ruby but component does not exist",
           },
           {
+            component: "component four",
+            message: "Included in code but not stylesheets",
+          },
+          {
             component: "component two",
             message: "Included in code but not stylesheets",
           },
@@ -436,7 +603,7 @@ describe "Comparing data from an application with the components" do
             message: "a_made_up_application/app/views/layouts/dummy_admin_layout.html",
           },
         ],
-        warning_count: 5,
+        warning_count: 6,
       },
     ]
 


### PR DESCRIPTION
## What
If present, use data from `static` to make warnings about missing assets in applications more accurate. Specifically:

- if `static` includes an asset and the application doesn't, no longer raise a warning (asset not actually missing)
- if `static` includes an asset and the application does as well, raise a new warning (asset is duplicated)

We only need to do this for certain applications, specifically the ones that use `static` (`static` is included in the auditing as well, so obviously we need to not compare `static` with itself).

## Why
The warnings in the auditing sometimes contained false positives, which made the warnings generally less reliable. Once we've made the auditing more reliable we can start to, well, rely on it more.

The result of this work is that most of the applications in the auditing now have more warnings. The next step is to manually check and test that these warnings are accurate.

## Visual Changes

Added a bit of visual information about this in the interface (this only appears for applications that use `static`).

![Screenshot 2022-05-09 at 10 42 14](https://user-images.githubusercontent.com/861310/167384163-2a4b0ea5-7dc2-4369-8df9-81ff34c284dd.png)

Warnings for duplication of assets:

![Screenshot 2022-05-13 at 12 22 30](https://user-images.githubusercontent.com/861310/168273341-efe5976a-0896-4450-8275-e123457b02df.png)

