### PR TITLE
Remove references to `master` branch

### DIFF
--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request:
 
 jobs:

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -16,7 +16,7 @@
   // This block is duplicated from Whitehall as a transitional step, see the
   // commit message for 2d893c10ee3f2cab27162b9aba38b12379a71d07 before making
   // changes, original version:
-  // https://github.com/alphagov/whitehall/blob/master/app/assets/stylesheets/frontend/helpers/_attachment.scss
+  // https://github.com/alphagov/whitehall/blob/main/app/assets/stylesheets/frontend/helpers/_attachment.scss
   $thumbnail-width: 99px;
 
   .attachment {

--- a/app/views/govuk_publishing_components/component_guide/index.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/index.html.erb
@@ -20,7 +20,7 @@
   <p>Components are packages of template, style, behaviour and documentation that live in your application.</p>
   <p>See the <a href="https://github.com/alphagov/govuk_publishing_components">govuk_publishing_components gem</a> for further details, or <a href="https://docs.publishing.service.gov.uk/manual/components.html#component-guides">a list of all component guides</a>.</p>
   <ul>
-    <li>Read about how to <a href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/publishing-to-rubygems.md">release a new version of the gem</a></li>
+    <li>Read about how to <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/publishing-to-rubygems.md">release a new version of the gem</a></li>
     <% if ENV["MAIN_COMPONENT_GUIDE"] %>
       <li><a href="/component-guide/audit">View component audits</a></li>
     <% end %>
@@ -105,5 +105,5 @@
 </ul>
 
 <div class="component-markdown">
-  <p class="govuk-body">If you cannot find a suitable component consider extending an existing component or <a href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/generate-a-new-component.md">creating a new one</a>.</p>
+  <p class="govuk-body">If you cannot find a suitable component consider extending an existing component or <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/generate-a-new-component.md">creating a new one</a>.</p>
 </div>

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -13,7 +13,7 @@
       <% if !@component_doc.accessibility_criteria.present? %>
         <div class="component-violation">
           <h2 class="component-violation__title">This component is not valid</h2>
-          <a class="component-violation__link" href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/accessibility_acceptance_criteria.md">Please define accessibility acceptance criteria for this component.</a>
+          <a class="component-violation__link" href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/accessibility_acceptance_criteria.md">Please define accessibility acceptance criteria for this component.</a>
         </div>
       <% end %>
       <%= render 'govuk_publishing_components/components/lead_paragraph', text: @component_doc.description %>

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -191,7 +191,7 @@ examples:
     context:
       right_to_left: true
   with_branding:
-    description: Where this component could be used on an organisation page (such as the [Attorney General's Office](https://www.gov.uk/government/organisations/attorney-generals-office)) branding can be applied for link colours and border colours. See the [branding documentation](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) for more details.
+    description: Where this component could be used on an organisation page (such as the [Attorney General's Office](https://www.gov.uk/government/organisations/attorney-generals-office)) branding can be applied for link colours and border colours. See the [branding documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_branding.md) for more details.
     data:
       brand: 'department-for-environment-food-rural-affairs'
       format_numbers: true

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -2,7 +2,7 @@ name: Document list
 description: An ordered list of documents including a document type, when updated and a link.
 body: |
   Outputs a list to documents, based on an array of document data. A "document" in this context can be an asset (such as a ODT or other downloadable document) or a web page.
-  
+
   The component can display:
 
   * a document title
@@ -116,7 +116,7 @@ examples:
           public_updated_at: 2017-07-19 15:01:48
           document_type: 'Statutory guidance'
   with_branding:
-    description: Where this component could be used on an organisation page (such as the [Attorney General's Office](https://www.gov.uk/government/organisations/attorney-generals-office)) branding can be applied for link colours and border colours. See the [branding documentation](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) for more details.
+    description: Where this component could be used on an organisation page (such as the [Attorney General's Office](https://www.gov.uk/government/organisations/attorney-generals-office)) branding can be applied for link colours and border colours. See the [branding documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_branding.md) for more details.
     data:
       brand: 'attorney-generals-office'
       items:
@@ -308,9 +308,9 @@ examples:
   with_rel_link_attribute:
     description: |
       The [rel attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel) is an option attribute to dictate the relationship between the document being linked to and the current page. This is predominantly used by search engines to help index journeys through a website.
-      
+
       On GOV.UK, this is typically used to dictate an external website being linked to with `rel="external"`, however this component supports:
-      
+
       - external
       - nofollow
       - noopener

--- a/app/views/govuk_publishing_components/components/docs/heading.yml
+++ b/app/views/govuk_publishing_components/components/docs/heading.yml
@@ -65,7 +65,7 @@ examples:
       padding: true
       border_top: 2
   with_branding:
-    description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) can be added to the component as shown, if a top border is included.
+    description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_branding.md) can be added to the component as shown, if a top border is included.
     data:
       text: 'Branding'
       brand: 'department-for-environment-food-rural-affairs'

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -166,7 +166,7 @@ examples:
       heading_text: 'John McJohnson'
       description: 'Deputy director for Parks and Small Trees'
   with_branding:
-    description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) can be added to the component as shown.
+    description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_branding.md) can be added to the component as shown.
     data:
       brand: "department-for-work-pensions"
       href: "/again-not-a-page"

--- a/app/views/govuk_publishing_components/components/docs/meta_tags.yml
+++ b/app/views/govuk_publishing_components/components/docs/meta_tags.yml
@@ -4,9 +4,9 @@ body: |
   This takes a content-store links hash like object which it can then turn into
   the correct analytics identifier metadata tags.
 
-  These are additionally used by the <a href="https://github.com/alphagov/govuk-browser-extension">GOV.UK browser extension</a> to provide details about a given page. 
+  These are additionally used by the <a href="https://github.com/alphagov/govuk-browser-extension">GOV.UK browser extension</a> to provide details about a given page.
 
-  The code which reads the meta tags can be found <a href="https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js">in custom-dimensions.js</a>.
+  The code which reads the meta tags can be found <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js">in custom-dimensions.js</a>.
 accessibility_criteria: |
   The analytics meta tags component should not be visible to any users.
 display_html: true
@@ -24,7 +24,7 @@ examples:
   with_content_history_tags:
     description: |
       The tags in this object will generate the `content-has-history` tag, set to true. This tag is triggered when either, within `content_item`:
-      
+
       1. `public_updated_at` and `first_public_at` within `details` are both present and they aren't the same value
       2. `change_history` within `details` is present and it has a value of more than 1
 

--- a/app/views/govuk_publishing_components/components/docs/metadata.yml
+++ b/app/views/govuk_publishing_components/components/docs/metadata.yml
@@ -359,7 +359,7 @@ examples:
       dark_background: true
   with_custom_margin_bottom:
     description: |
-      The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to the `margin-bottom` values defined in the [responsive-bottom-margin mixin](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/components/mixins/_margins.scss#L1)
+      The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to the `margin-bottom` values defined in the [responsive-bottom-margin mixin](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/stylesheets/govuk_publishing_components/components/mixins/_margins.scss#L1)
     data:
       first_published: 14 June 2014
       last_updated: 10 September 2015

--- a/app/views/govuk_publishing_components/components/docs/share_links.yml
+++ b/app/views/govuk_publishing_components/components/docs/share_links.yml
@@ -80,7 +80,7 @@ examples:
         }
       ]
   with_branding:
-    description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) can be added to the component as shown.
+    description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_branding.md) can be added to the component as shown.
     data:
       brand: 'attorney-generals-office'
       links: [

--- a/app/views/govuk_publishing_components/components/docs/subscription_links.yml
+++ b/app/views/govuk_publishing_components/components/docs/subscription_links.yml
@@ -46,7 +46,7 @@ examples:
       email_signup_link: '/foreign-travel-advice/singapore/email-signup'
       feed_link_box_value: 'https://www.gov.uk/government/organisations/attorney-generals-office.atom'
   with_branding:
-    description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) can be added to the component as shown.
+    description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_branding.md) can be added to the component as shown.
     data:
       brand: 'attorney-generals-office'
       email_signup_link: '/foreign-travel-advice/singapore/email-signup'

--- a/app/views/govuk_publishing_components/components/docs/translation_nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/translation_nav.yml
@@ -60,7 +60,7 @@ examples:
     context:
       right_to_left: true
   with_branding:
-    description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md) can be added to the component as shown.
+    description: Organisation [colour branding](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_branding.md) can be added to the component as shown.
     data:
       brand: 'wales-office'
       translations:
@@ -134,4 +134,3 @@ examples:
             dimension29: 'dimension29Welsh'
     context:
       dark_background: true
-

--- a/docs/accessibility_acceptance_criteria.md
+++ b/docs/accessibility_acceptance_criteria.md
@@ -30,7 +30,7 @@ In this case it was helpful to create a shared definition of an accessible link 
 
 ### Don't define the solution
 
-Accessibility acceptance criteria are similar to [acceptance criteria in user stories](https://www.gov.uk/service-manual/agile-delivery/writing-user-stories#acceptance-criteria). Good acceptance criteria describe an outcome rather than the solution.  
+Accessibility acceptance criteria are similar to [acceptance criteria in user stories](https://www.gov.uk/service-manual/agile-delivery/writing-user-stories#acceptance-criteria). Good acceptance criteria describe an outcome rather than the solution.
 
 The criteria should give room for interpretation and allow designers and developers to make improvements over time. Ideally if technology or designs change the criteria will still apply.
 
@@ -54,7 +54,7 @@ In code we can use these criteria to write unit tests that prevent regressions. 
 
 ### Accessible autocomplete
 
-At GDS we first used accessibility acceptance criteria when building the [accessible autocomplete](https://github.com/alphagov/accessible-autocomplete). Theodor Vararu, Léonie Watson and Ed Horsford defined the following [autocomplete accessibility criteria](https://github.com/alphagov/accessible-autocomplete/blob/master/accessibility-criteria.md) — the necessary behaviours that an autocomplete needs to meet to be usable by assistive technologies:
+At GDS we first used accessibility acceptance criteria when building the [accessible autocomplete](https://github.com/alphagov/accessible-autocomplete). Theodor Vararu, Léonie Watson and Ed Horsford defined the following [autocomplete accessibility criteria](https://github.com/alphagov/accessible-autocomplete/blob/main/accessibility-criteria.md) — the necessary behaviours that an autocomplete needs to meet to be usable by assistive technologies:
 
 > The field with autocomplete must:
 > 1. Be focusable with a keyboard

--- a/docs/analytics/analytics.md
+++ b/docs/analytics/analytics.md
@@ -170,7 +170,7 @@ named tracker, and sessions will persist to the other domain.
 
 Once a service starts sending analytics data to the shared GA property and has configured their system to include `www.gov.uk` in their cross domain linking, we must also configure `www.gov.uk` to include their domain in our cross linker configuration.
 
-Add the domain of the service to [`init.js.erb`](https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/init.js.erb#L44).
+Add the domain of the service to [`init.js.erb`](https://github.com/alphagov/static/blob/main/app/assets/javascripts/analytics.js.erb).
 
 Here's an [example of an earlier PR](https://github.com/alphagov/static/pull/1845) to do this.
 

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -53,9 +53,9 @@ Example:
 
 If a component includes a heading, consider including an option to control the heading level (see the [heading component](https://components.publishing.service.gov.uk/component-guide/heading/specific_heading_level) for example).
 
-Components can use other components within their template, if required (see the [input component](https://github.com/alphagov/govuk_publishing_components/blob/master/app/views/govuk_publishing_components/components/_input.html.erb#L37) for example).
+Components can use other components within their template, if required (see the [input component](https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_input.html.erb#L37) for example).
 
-Complex components can be split into smaller partials to make them easier to understand and maintain (see the [feedback component](https://github.com/alphagov/govuk_publishing_components/blob/master/app/views/govuk_publishing_components/components/_feedback.html.erb) for example).
+Complex components can be split into smaller partials to make them easier to understand and maintain (see the [feedback component](https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_feedback.html.erb) for example).
 
 Components should not have an option to include arbitrary classes as this could violate the principle of isolation. If there is a requirement for a styling variation on a component this should be included as an option e.g. `small: true`.
 
@@ -152,7 +152,7 @@ examples:
 
 Markdown listing what this component must do to be accessible.
 
-[Shared accessibility criteria](https://github.com/alphagov/govuk_publishing_components/blob/master/app/models/govuk_publishing_components/shared_accessibility_criteria.rb) can be included in a list as shown. They are pre-written accessibility criteria that can apply to more than one component, created to avoid duplication. For example, links within components should all accept focus, be focusable with a keyboard, etc.
+[Shared accessibility criteria](https://github.com/alphagov/govuk_publishing_components/blob/main/app/models/govuk_publishing_components/shared_accessibility_criteria.rb) can be included in a list as shown. They are pre-written accessibility criteria that can apply to more than one component, created to avoid duplication. For example, links within components should all accept focus, be focusable with a keyboard, etc.
 
 A component can have accessibility criteria, shared accessibility criteria, or both.
 
@@ -186,7 +186,7 @@ The component guide will wrap a `dark_background` context example with a `dark-b
 
 ## Styles
 
-With the exception of namespaces, follow the [GOV.UK Frontend CSS conventions](https://github.com/alphagov/govuk-frontend/blob/master/docs/contributing/coding-standards/css.md), which describes in more detail our approach to namespaces, linting and BEM (block, element, modifier) CSS naming methodology.
+With the exception of namespaces, follow the [GOV.UK Frontend CSS conventions](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/coding-standards/css.md), which describes in more detail our approach to namespaces, linting and BEM (block, element, modifier) CSS naming methodology.
 
 Components can rely on classes from GOV.UK Frontend to allow for modification that build on top of the styles from the Design System. This follows the [recommendations for extending](https://design-system.service.gov.uk/get-started/extending-and-modifying-components/#small-modifications-to-components) from the Design System guide.
 
@@ -210,7 +210,7 @@ This makes it clear what the base component is, what the modifier is, and where 
 
 `.block__element--modifier {}`
 
-All CSS selectors should follow the BEM naming convention shown above, explained in [more detail here](https://github.com/alphagov/govuk-frontend/blob/master/docs/contributing/coding-standards/css.md#block-element-modifier-bem).
+All CSS selectors should follow the BEM naming convention shown above, explained in [more detail here](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/coding-standards/css.md#block-element-modifier-bem).
 
 Note: to avoid long and complicated class names, we follow the [BEM guidance](http://getbem.com/faq/#css-nested-elements) that classes do not have to reflect the nested nature of the DOM. We also try to avoid nesting classes too deeply so that styles can be overridden if needed.
 
@@ -258,11 +258,11 @@ SVGs can also be used for images, ideally inline in templates and compressed.
 
 ## JavaScript
 
-Follow the [GOV.UK Frontend JS conventions](https://github.com/alphagov/govuk-frontend/blob/master/docs/contributing/coding-standards/js.md).
+Follow the [GOV.UK Frontend JS conventions](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/coding-standards/js.md).
 
-Scripts should use the [module pattern](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/javascript-modules.md) and be linted using [StandardJS](https://standardjs.com/).
+Scripts should use the [module pattern](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/javascript-modules.md) and be linted using [StandardJS](https://standardjs.com/).
 
-Most components should have an option to include arbitrary data attributes (see the [checkboxes component](https://components.publishing.service.gov.uk/component-guide/checkboxes/checkboxes_with_data_attributes) for example). These can be used for many purposes including tracking (see the [select component](https://components.publishing.service.gov.uk/component-guide/select/with_tracking) for [example code](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/components/select.js)) but specific tracking should only be added to a component where there is a real need for it.
+Most components should have an option to include arbitrary data attributes (see the [checkboxes component](https://components.publishing.service.gov.uk/component-guide/checkboxes/checkboxes_with_data_attributes) for example). These can be used for many purposes including tracking (see the [select component](https://components.publishing.service.gov.uk/component-guide/select/with_tracking) for [example code](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/components/select.js)) but specific tracking should only be added to a component where there is a real need for it.
 
 Some [common JavaScript modules](https://github.com/alphagov/govuk_publishing_components/tree/master/app/assets/javascripts/govuk_publishing_components/lib) are available. If new functionality is required, consider adding it as a common module.
 
@@ -298,7 +298,7 @@ Code can be called and referred to in the template as follows:
 
 ### Shared helper
 
-There is a [shared helper](https://github.com/alphagov/govuk_publishing_components/blob/master/lib/govuk_publishing_components/presenters/shared_helper.rb) that can provide common functionality to all components. This includes:
+There is a [shared helper](https://github.com/alphagov/govuk_publishing_components/blob/main/lib/govuk_publishing_components/presenters/shared_helper.rb) that can provide common functionality to all components. This includes:
 
 - set margin bottom and top
 - set heading level and heading font size

--- a/docs/javascript-modules.md
+++ b/docs/javascript-modules.md
@@ -12,7 +12,7 @@ JavaScript modules can be specified in markup using `data-` attributes:
 </div>
 ```
 
-Modules are found and started in [dependencies.js](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/dependencies.js) by including `./modules.js` and running the following. This is called by [static](https://github.com/alphagov/static/blob/main/app/assets/javascripts/application.js#L1) once for all applications on GOV.UK.
+Modules are found and started in [dependencies.js](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/dependencies.js) by including `./modules.js` and running the following. This is called by [static](https://github.com/alphagov/static/blob/main/app/assets/javascripts/application.js#L1) once for all applications on GOV.UK.
 
 ```javascript
 document.addEventListener('DOMContentLoaded', function () {
@@ -54,7 +54,7 @@ AnExampleModule.prototype.init = function ($module) {
   } else {
     this.startModule = this.startModule.bind(this)
     window.addEventListener('cookie-consent', this.startModule)
-  }  
+  }
 }
 
 AnExampleModule.prototype.startModule = function () {

--- a/docs/publishing-to-rubygems.md
+++ b/docs/publishing-to-rubygems.md
@@ -15,7 +15,7 @@ Before publishing a new version [check the open and approved pull requests](http
 
   See [Semantic Versioning](https://semver.org/) for more information.
 
-3. Update [`CHANGELOG.md`](/CHANGELOG.md) "Unreleased" heading with the new version number and [review the latest commits](https://github.com/alphagov/govuk_publishing_components/commits/master) to make sure the latest changes are correctly reflected in the [CHANGELOG]((/CHANGELOG.md)).
+3. Update [`CHANGELOG.md`](/CHANGELOG.md) "Unreleased" heading with the new version number and [review the latest commits](https://github.com/alphagov/govuk_publishing_components/commits/main) to make sure the latest changes are correctly reflected in the [CHANGELOG]((/CHANGELOG.md)).
 
 4. Update [`lib/govuk_publishing_components/version.rb`](/lib/govuk_publishing_components/version.rb) version with the new version number.
 

--- a/docs/publishing-to-rubygems.md
+++ b/docs/publishing-to-rubygems.md
@@ -2,7 +2,7 @@
 
 Before publishing a new version [check the open and approved pull requests](https://github.com/alphagov/govuk_publishing_components/pulls?q=is%3Apr+is%3Aopen+review%3Aapproved) and reach out to the authors to see if you can get their work published in the same release.
 
-1. Checkout **master** and pull latest changes.
+1. Checkout **main** and pull latest changes.
 
 2. Create and checkout a new branch (`release-[version-number]`).
   The version number is determined by looking at the [current "Unreleased" changes in CHANGELOG](/CHANGELOG.md) and updating the previous release number depending on the kind of entries:
@@ -28,6 +28,6 @@ Before publishing a new version [check the open and approved pull requests](http
 
 7. Create a pull request and copy the changelog text for the current version in the pull request description.
 
-8. Once the pull request is approved, merge to master. This action will trigger the CI to publish the new version to RubyGems. A [dependabot](https://github.com/dependabot) pull request will automatically be raised in frontend applications.
+8. Once the pull request is approved, merge into the `main` branch. This action will trigger the CI to publish the new version to RubyGems. A [dependabot](https://github.com/dependabot) pull request will automatically be raised in frontend applications.
 
 See an [example pull request](https://github.com/alphagov/govuk_publishing_components/pull/873/files) for publishing a new version to RubyGems.

--- a/lib/generators/govuk_publishing_components/templates/_component.html.erb
+++ b/lib/generators/govuk_publishing_components/templates/_component.html.erb
@@ -1,3 +1,3 @@
 <div class="<%= @component_prefix %><%= @public_name %>">
-  <h2><a href="https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_conventions.md">How to build a component</a></h2>
+  <h2><a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_conventions.md">How to build a component</a></h2>
 </div>

--- a/lib/govuk_publishing_components/app_helpers/brand_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/brand_helper.rb
@@ -7,7 +7,7 @@ module GovukPublishingComponents
 
       # Apply government organisation branding to individual components, specifically
       # link colour and border colour
-      # see https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_branding.md
+      # see https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_branding.md
 
       def brand_class
         "brand--#{@brand}" if @brand


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Removes references to the `master` branch from:

 - the visual regression test workflow
 - numerous links in component documentation, comments, and the documentation for releasing a new version of the gem
 - updates the guide to releasing a new version of the gem

## Why
<!-- What are the reasons behind this change being made? -->

The `main` branch is being used as the primary branch on this repo, so the visual regression test should be updated to reflect that.

The `master` branch isn't in use in the links that have been updated - so can be fixed.

Documentation should be as up-to-date as possible, so references to the `master` branch should be swapped out.

## Visual Changes
None.
