### PR TITLE
Add GTM analytics click tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+- Add GTM analytics click tracking ([PR #2760](https://github.com/alphagov/govuk_publishing_components/pull/2760))
 - Add wrapper to the component card to ensure link spacing ([PR #2753](https://github.com/alphagov/govuk_publishing_components/pull/2753))
 - Add new logic for counting links/sections on a second level browse page on page view #2733 ([PR #2733](https://github.com/alphagov/govuk_publishing_components/pull/2733))
 * Update cross domain linking script to use init ([PR #2747](https://github.com/alphagov/govuk_publishing_components/pull/2747))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
@@ -1,0 +1,1 @@
+//= require ./analytics-ga4/gtm-click-tracking

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
@@ -1,0 +1,49 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  'use strict'
+
+  function GtmClickTracking (module) {
+    this.module = module
+    this.trackingTrigger = 'data-gtm-event-name' // elements with this attribute get tracked
+  }
+
+  GtmClickTracking.prototype.init = function () {
+    var trackClicksOn = [this.module]
+    if (!this.module.getAttribute(this.trackingTrigger)) {
+      trackClicksOn = this.module.querySelectorAll('[' + this.trackingTrigger + ']')
+    }
+
+    for (var i = 0; i < trackClicksOn.length; i++) {
+      trackClicksOn[i].addEventListener('click', this.trackClick.bind(this))
+    }
+  }
+
+  GtmClickTracking.prototype.trackClick = function (event) {
+    if (window.dataLayer) {
+      var target = event.currentTarget
+      var data = {
+        event: 'analytics',
+        event_name: target.getAttribute('data-gtm-event-name'),
+        // get entire URL apart from domain
+        link_url: window.location.href.substring(window.location.origin.length),
+        ui: JSON.parse(target.getAttribute('data-gtm-attributes'))
+      }
+      var ariaExpanded = this.checkExpandedState(target)
+      if (ariaExpanded) {
+        data.ui.state = ariaExpanded === 'false' ? 'opened' : 'closed'
+      }
+      window.dataLayer.push(data)
+    }
+  }
+
+  GtmClickTracking.prototype.checkExpandedState = function (clicked) {
+    var expanded = clicked.querySelector('[aria-expanded]')
+    if (expanded) {
+      return expanded.getAttribute('aria-expanded')
+    }
+  }
+
+  Modules.GtmClickTracking = GtmClickTracking
+})(window.GOVUK.Modules)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
@@ -1,0 +1,143 @@
+/* eslint-env jasmine */
+
+describe('Google Tag Manager click tracking', function () {
+  var GOVUK = window.GOVUK
+  var element
+
+  beforeEach(function () {
+    window.dataLayer = []
+    element = document.createElement('div')
+  })
+
+  afterEach(function () {
+    document.body.removeChild(element)
+  })
+
+  describe('doing simple tracking on a single element', function () {
+    beforeEach(function () {
+      element.setAttribute('data-gtm-event-name', 'event-name')
+      var attributes = {
+        'test-1': 'test-1 value',
+        'test-2': 'test-2 value'
+      }
+      element.setAttribute('data-gtm-attributes', JSON.stringify(attributes))
+      document.body.appendChild(element)
+      new GOVUK.Modules.GtmClickTracking(element).init()
+    })
+
+    it('pushes gtm attributes to the dataLayer', function () {
+      element.click()
+      var expected = {
+        event: 'analytics',
+        event_name: 'event-name',
+        link_url: window.location.href.substring(window.location.origin.length),
+        ui: {
+          'test-1': 'test-1 value',
+          'test-2': 'test-2 value'
+        }
+      }
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+  })
+
+  describe('doing simple tracking on multiple elements', function () {
+    beforeEach(function () {
+      var attributes1 = {
+        'test-1-1': 'test 1-1 value',
+        'test-1-2': 'test 1-2 value'
+      }
+      var attributes2 = {
+        'test-2-1': 'test 2-1 value',
+        'test-2-2': 'test 2-2 value'
+      }
+      element.innerHTML =
+        '<div data-gtm-event-name="event1-name"' +
+          'data-gtm-attributes=\'' + JSON.stringify(attributes1) + '\'' +
+          'class="clickme"' +
+        '></div>' +
+        '<div data-gtm-event-name="event2-name"' +
+          'data-gtm-attributes=\'' + JSON.stringify(attributes2) + '\'' +
+          'class="clickme"' +
+        '></div>'
+      document.body.appendChild(element)
+      new GOVUK.Modules.GtmClickTracking(element).init()
+    })
+
+    it('pushes gtm attributes to the dataLayer', function () {
+      var clickOn = element.querySelectorAll('.clickme')
+      for (var i = 0; i < clickOn.length; i++) {
+        clickOn[i].click()
+      }
+      var expected = [
+        {
+          event: 'analytics',
+          event_name: 'event1-name',
+          link_url: window.location.href.substring(window.location.origin.length),
+          ui: {
+            'test-1-1': 'test 1-1 value',
+            'test-1-2': 'test 1-2 value'
+          }
+        },
+        {
+          event: 'analytics',
+          event_name: 'event2-name',
+          link_url: window.location.href.substring(window.location.origin.length),
+          ui: {
+            'test-2-1': 'test 2-1 value',
+            'test-2-2': 'test 2-2 value'
+          }
+        }
+      ]
+      expect(window.dataLayer).toEqual(expected)
+    })
+  })
+
+  describe('doing tracking on an expandable element', function () {
+    beforeEach(function () {
+      var attributes = {
+        'test-3-1': 'test 3-1 value',
+        'test-3-2': 'test 3-2 value'
+      }
+      element.innerHTML =
+        '<div data-gtm-event-name="event3-name"' +
+          'data-gtm-attributes=\'' + JSON.stringify(attributes) + '\'' +
+          'class="clickme"' +
+        '>' +
+          '<button aria-expanded="false">Show</button>' +
+        '</div>'
+      document.body.appendChild(element)
+      new GOVUK.Modules.GtmClickTracking(element).init()
+    })
+
+    it('includes the expanded state in the gtm attributes', function () {
+      var clickOn = element.querySelector('.clickme')
+      clickOn.click()
+
+      var expectedFirst = {
+        event: 'analytics',
+        event_name: 'event3-name',
+        link_url: window.location.href.substring(window.location.origin.length),
+        ui: {
+          'test-3-1': 'test 3-1 value',
+          'test-3-2': 'test 3-2 value',
+          state: 'opened'
+        }
+      }
+      expect(window.dataLayer).toEqual([expectedFirst])
+
+      var expectedSecond = {
+        event: 'analytics',
+        event_name: 'event3-name',
+        link_url: window.location.href.substring(window.location.origin.length),
+        ui: {
+          'test-3-1': 'test 3-1 value',
+          'test-3-2': 'test 3-2 value',
+          state: 'closed'
+        }
+      }
+      element.querySelector('[aria-expanded]').setAttribute('aria-expanded', 'true')
+      clickOn.click()
+      expect(window.dataLayer).toEqual([expectedFirst, expectedSecond])
+    })
+  })
+})


### PR DESCRIPTION
## What
Add a generic script for pushing data to the dataLayer for Google Tag Manager. This is an initial approach that may change over time.

- adds generic Google Tag Manager 'click to track' script, that depends upon there being a dataLayer to work
- dataLayer is currently only initialised using the GTM component and environment variables, so should only work on integration
- the analytics-ga4 script is currently not included anywhere, this will be included conditionally in static based on the same environment variables, to avoid code being deployed to live

Right now we're concerned with not doing anything that adds any code to the public site, so these scripts will only be included in static in development environments and on integration.

The script also includes one approach to dealing with tracking on expandable items (specifically accordions right now) where we want to record the open/closed state of the accordion when clicked. This is done by looking for an element with `aria-expanded` in the clicked element. If found, this is used to override the `ui.state` value sent to the dataLayer.

## Why
We want to start progressing with the GA upgrade.

## Visual Changes
None.

Trello card: https://trello.com/c/V0RFrSMK/43-test-technical-approach-to-tracking-on-tabs-and-accordions