### PR TITLE
Remove DWP email from accessible format request pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add wrapper to the component card to ensure link spacing ([PR #2753](https://github.com/alphagov/govuk_publishing_components/pull/2753))
 - Add new logic for counting links/sections on a second level browse page on page view #2733 ([PR #2733](https://github.com/alphagov/govuk_publishing_components/pull/2733))
 * Update cross domain linking script to use init ([PR #2747](https://github.com/alphagov/govuk_publishing_components/pull/2747))
+* Remove DWP email from attachment accessible format request pilot([PR #2764](https://github.com/alphagov/govuk_publishing_components/pull/2764))
 
 ## 29.7.0
 

--- a/lib/govuk_publishing_components/presenters/attachment_helper.rb
+++ b/lib/govuk_publishing_components/presenters/attachment_helper.rb
@@ -7,7 +7,6 @@ module GovukPublishingComponents
       # Currently DfE, DWP and DVSA are participating in the pilot.
       EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT = %w[govuk_publishing_components@example.com
                                                      alternative.formats@education.gov.uk
-                                                     accessible.formats@dwp.gov.uk
                                                      gov.uk.publishing@dvsa.gov.uk].freeze
 
       delegate :opendocument?, :document?, :spreadsheet?, to: :content_type


### PR DESCRIPTION
DWP are being removed from the accessible format request pilot scheme.

[trello](https://trello.com/c/RTiwn1cB/1251-make-live-after-12-april-330pm-remove-dwp-from-the-request-accessible-format-pilot)