### PR TITLE
Remove console.log

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -131,7 +131,6 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
 
     if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
       window.GOVUK.analytics.trackEvent('pageElementInteraction', action, options)
-      console.log('pageElementInteraction', action, options)
     }
   }
 


### PR DESCRIPTION
## What
Spotted a `console.log` in the accordion.js, removing.

## Why
Not needed in production - looks like it was added for debug and accidentally left in.

## Visual Changes
None.
