### PR TITLE
Release 29.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 29.8.0
 
 * Add GTM analytics click tracking ([PR #2760](https://github.com/alphagov/govuk_publishing_components/pull/2760))
 * Add wrapper to the component card to ensure link spacing ([PR #2753](https://github.com/alphagov/govuk_publishing_components/pull/2753))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (29.7.0)
+    govuk_publishing_components (29.8.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "29.7.0".freeze
+  VERSION = "29.8.0".freeze
 end


### PR DESCRIPTION
Release 29.8.0

* Add GTM analytics click tracking (https://github.com/alphagov/govuk_publishing_components/pull/2760)
* Add wrapper to the component card to ensure link spacing (https://github.com/alphagov/govuk_publishing_components/pull/2753)
* Add new logic for counting links/sections on a second level browse page on page view #2733 (https://github.com/alphagov/govuk_publishing_components/pull/2733)
* Update cross domain linking script to use init (https://github.com/alphagov/govuk_publishing_components/pull/2747)
* Remove DWP email from attachment accessible format request pilot(https://github.com/alphagov/govuk_publishing_components/pull/2764)
* Add HTTP protocol measurement to RUM (https://github.com/alphagov/govuk_publishing_components/pull/2769)