### PR TITLE
Tracking changes for the footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Update LUX to v301 ([PR #2773](https://github.com/alphagov/govuk_publishing_components/pull/2773))
 * Fix http protocol reporting in Safari ([PR #2781](https://github.com/alphagov/govuk_publishing_components/pull/2781))
+* Tracking changes for the footer ([PR #2774](https://github.com/alphagov/govuk_publishing_components/pull/2774))
 
 ## 29.8.0
 

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -78,11 +78,29 @@
             d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
           />
         </svg>
-        <span class="govuk-footer__licence-description">
+        <% # this is to avoid having hardcoded data attributes in locale files %>
+        <span
+          class="govuk-footer__licence-description"
+          data-module="gem-track-click"
+          data-track-action="copyrightLink"
+          data-track-category="footerClicked"
+          data-track-label="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+          data-track-options='{"dimension29": "Open Government Licence v3.0"}'
+          data-track-links-only
+        >
           <%= t("components.layout_footer.licence_html") %>
         </span>
       </div>
-      <div class="govuk-footer__meta-item">
+      <% # this is to avoid having hardcoded data attributes in locale files %>
+      <div
+        class="govuk-footer__meta-item"
+        data-module="gem-track-click"
+        data-track-action="copyrightLink"
+        data-track-category="footerClicked"
+        data-track-label="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+        data-track-options='{"dimension29": "© Crown copyright"}'
+        data-track-links-only
+      >
         <%= t("components.layout_footer.copyright_html") %>
       </div>
     </div>

--- a/spec/lib/govuk_publishing_components/components/public_layout_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/public_layout_helper_spec.rb
@@ -1,0 +1,118 @@
+RSpec.describe GovukPublishingComponents::Presenters::PublicLayoutHelper do
+  describe "Public layout helper" do
+    before(:each) do
+      @input = [
+        {
+          title: "Column 1",
+          menu_contents: [
+            {
+              href: "/help",
+              text: "Help",
+              attributes: {
+                an_attribute: "still present",
+              },
+            },
+          ],
+        },
+        {
+          title: "Column 2",
+          menu_contents: [
+            {
+              href: "/contact",
+              text: "contact",
+            },
+          ],
+        },
+      ]
+
+      @plh = GovukPublishingComponents::Presenters::PublicLayoutHelper.new({})
+    end
+
+    it "generates correct data tracking attributes from a link and track action" do
+      track_action = "track_action"
+
+      res = {
+        track_category: "footerClicked",
+        track_action: track_action,
+        track_label: "/help",
+        track_options: {
+          dimension29: "Help",
+        },
+      }
+
+      expect(@plh.generate_data_attribute(@input[0][:menu_contents][0], track_action)).to eql(res)
+    end
+
+    it "adds correct data tracking attributes to each link in a list and keeps existing attributes of links" do
+      track_action = "track_action"
+
+      res = [
+        {
+          href: "/help",
+          text: "Help",
+          attributes: {
+            an_attribute: "still present",
+            data: {
+              track_category: "footerClicked",
+              track_action: track_action,
+              track_label: "/help",
+              track_options: {
+                dimension29: "Help",
+              },
+            },
+          },
+        },
+      ]
+
+      expect(@plh.add_data_attributes_to_links(@input[0][:menu_contents], track_action)).to eql(res)
+    end
+
+    it "adds column sizing to each list of links and data tracking attributes to each link in that list" do
+      res = [
+        {
+          title: "Column 1",
+          columns: @plh.footer_navigation_columns[0],
+          items: [
+            {
+              href: "/help",
+              text: "Help",
+              attributes: {
+                an_attribute: "still present",
+                data: {
+                  track_category: "footerClicked",
+                  track_action: @plh.footer_track_actions[0],
+                  track_label: "/help",
+                  track_options: {
+                    dimension29: "Help",
+                  },
+                },
+              },
+            },
+          ],
+        },
+        {
+          title: "Column 2",
+          columns: @plh.footer_navigation_columns[1],
+          items: [
+            {
+              href: "/contact",
+              text: "contact",
+              attributes: {
+                data: {
+                  track_category: "footerClicked",
+                  track_action: @plh.footer_track_actions[1],
+                  track_label: "/contact",
+                  track_options: {
+                    dimension29: "contact",
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ]
+
+      expect(@plh.navigation_link_generation_from_locale(@input)).to eql(res)
+    end
+  end
+end


### PR DESCRIPTION
## What

Add new data-attributes to links in the footer. For most links in the footer, this involves a new helper method which works out what data attributes a link should have and then adds it to the hash that is used to generate each link. The only exception to this is the copyright and license links. As they have html that is hardcoded in the locale file, they have hardcoded data-tracking variables in their parent element.

## Why
The new data-attributes added to the links in the footer allow the region of the footer to be more easily determined from analytics themselves rather than having to check on the template. The attributes are in the following format and are on all links in the footer (including the copyright links). 

```
  data-track-category: footerClicked
  // this depends on where in the footer the url is
  data-track-action: topicsLink || governmentActivityLink || supportLink || copyrightLink
  data-track-label: <link destination URL>
  data-track-options: {
   dimension29: <link text>
  }
```

[Relevant Trello Card](https://trello.com/c/sn4of3m9/336-implement-consistent-analytics-tracking-on-the-sitewide-footer)
