### PR TITLE
Small amends to sitewide menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Update analytics logic for new browse page metatags ([PR #2778](https://github.com/alphagov/govuk_publishing_components/pull/2778))
 * Tracking changes for the footer ([PR #2774](https://github.com/alphagov/govuk_publishing_components/pull/2774))
 * Update Ukraine CTA in the contextual sidebar ([PR #2779](https://github.com/alphagov/govuk_publishing_components/pull/2779))
+* Small amends to sitewide menu ([PR #2776](https://github.com/alphagov/govuk_publishing_components/pull/2776))
 
 ## 29.9.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -382,10 +382,8 @@ $button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
         }
 
         .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
-          border-color: $button-pipe-colour;
-
           &:before {
-            @include chevron($button-pipe-colour, true);
+            @include chevron(govuk-colour("mid-grey"), true);
           }
         }
       }
@@ -464,7 +462,7 @@ $button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
 .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
   @include govuk-media-query($from: "desktop") {
     display: inline-block;
-    padding: govuk-spacing(2) govuk-spacing(6) govuk-spacing(2) govuk-spacing(5);
+    padding: govuk-spacing(1) govuk-spacing(6) govuk-spacing(1) govuk-spacing(5);
   }
 }
 
@@ -606,10 +604,6 @@ $button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
         }
       }
     }
-  }
-
-  &:after {
-    @include pseudo-underline;
   }
 
   // Open button modifier
@@ -771,6 +765,7 @@ $button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
   background: govuk-colour("light-grey");
 
   @include govuk-media-query($from: "desktop") {
+    border-bottom: 1px govuk-colour("mid-grey") solid;
     left: 0;
     position: absolute;
     right: 0;


### PR DESCRIPTION
## What

Small set of design tweaks for the global navbar. These include

- reducing the height of the border (pipes)
- changing the colour of the chevron on hover so that it is the same colour as the text and the pipes
- adding a thin light grey border to the bottom of the menu background

<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why

Requested by the Find and View Explore Team. Small changes to bring navbar more in line with the designs.
<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

![Screenshot 2022-05-19 at 09 38 46](https://user-images.githubusercontent.com/3727504/169251029-13b3b0d1-2a16-4662-b4a2-4c69fb30d929.png)

![Screenshot 2022-05-19 at 09 35 59](https://user-images.githubusercontent.com/3727504/169250512-0d41ce30-37f1-49a5-9665-1945cb4ae689.png)

![Screenshot 2022-05-19 at 09 36 53](https://user-images.githubusercontent.com/3727504/169250605-8326a672-4a7d-4694-aa6e-34f313448278.png)

### After

![Screenshot 2022-05-19 at 09 37 44](https://user-images.githubusercontent.com/3727504/169250794-00e523e5-c7ac-42e9-97d1-8faee89ee0cd.png)

![Screenshot 2022-05-19 at 09 37 49](https://user-images.githubusercontent.com/3727504/169250807-e2db4764-e9d4-47fe-b9fe-b68389dc40b1.png)

![Screenshot 2022-05-19 at 09 37 52](https://user-images.githubusercontent.com/3727504/169250820-280e0bef-a6c0-47cb-a0b6-428ebe103f6b.png)

Reviewed with Gracie and design changes here approved.

[Relevant Trello Card](https://trello.com/c/H6UF1kC6/882-small-amends-to-the-sitewide-menu)