### PR TITLE
Update analytics logic for new browse page metatags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update analytics logic for new browse page metatags ([PR #2778](https://github.com/alphagov/govuk_publishing_components/pull/2778))
 * Tracking changes for the footer ([PR #2774](https://github.com/alphagov/govuk_publishing_components/pull/2774))
 
 ## 29.9.0

--- a/app/assets/javascripts/govuk_publishing_components/analytics/page-content.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/page-content.js
@@ -15,8 +15,8 @@
         return document.querySelectorAll('.document-collection .group-title').length
       case isNewBrowsePageLevelTwo():
         // if there are no accordion sections on the browse level 2 page
-        // then it is a default page with only one section
-        return document.querySelectorAll('[data-track-count="accordionSection"]').length || 1
+        // then it is a default page with one or two lists
+        return document.querySelectorAll('[data-track-count="accordionSection"]').length || document.querySelectorAll('main .govuk-list').length
       case isNewBrowsePage():
         return document.querySelectorAll('[data-track-count="cardList"]').length
       case isMainstreamBrowsePage():
@@ -77,7 +77,6 @@
   var metaApplicationSelector = 'meta[name="govuk:rendering-application"]'
   var metaFormatSelector = 'meta[name="govuk:format"]'
   var metaNavigationTypeSelector = 'meta[name="govuk:navigation-page-type"]'
-  var metaSectionSelector = 'meta[name="govuk:section"]'
 
   function getMetaAttribute (selector) {
     var element = document.querySelector(selector)
@@ -111,7 +110,8 @@
 
   function isNewBrowsePage () {
     return getMetaAttribute(metaApplicationSelector) === 'collections' &&
-      getMetaAttribute(metaSectionSelector) === 'new_browse_page' &&
+      (getMetaAttribute(metaNavigationTypeSelector) === 'browse level 0' ||
+       getMetaAttribute(metaNavigationTypeSelector) === 'browse level 1') &&
       getMetaAttribute(metaFormatSelector) === 'mainstream_browse_page'
   }
 

--- a/spec/javascripts/govuk_publishing_components/analytics/page-content.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/page-content.spec.js
@@ -420,6 +420,32 @@ describe('Page content', function () {
     })
   })
 
+  // the template used for the two page types is the same
+  // so testing only one will test both
+  describe('in a browse level 0 or 1 page', function () {
+    beforeEach(function () {
+      createMetaTags('rendering-application', 'collections')
+      createMetaTags('navigation-page-type', 'browse level 0')
+      createMetaTags('format', 'mainstream_browse_page')
+    })
+
+    it('gets the number of card sections', function () {
+      for (var i = 1; i <= 4; i++) {
+        createDummyElement('div', false, false, 'data-track-count', 'cardList')
+      }
+      var result = window.GOVUK.PageContent.getNumberOfSections()
+      expect(result).toEqual(4)
+    })
+
+    it('gets the number of card links', function () {
+      for (var i = 1; i <= 4; i++) {
+        createDummyElement('a', false, false, 'data-track-count', 'cardLink')
+      }
+      var result = window.GOVUK.PageContent.getNumberOfLinks()
+      expect(result).toEqual(4)
+    })
+  })
+
   describe('by default', function () {
     it('gets the number of sidebar sections', function () {
       for (var p = 1; p <= 4; p++) {


### PR DESCRIPTION
## What
Update the conditional statement in `page-content.js `which checks to see if a page is a new browse page. Change logic of counting sections in Browse Level 2 templates to count the number of sections instead of returning the value '1'.

## Why
The values of metatags for new browse pages were changed which made previously written conditional statements in `page-content.js `always return false. The conditional statements have been updated to use the new metatag values so that now counting of sections/links should work on all browse page levels.

Initially the logic for counting sections on Browse Level 2 templates assumed that default pages consisted of 1 section. This is sometimes not the case (there can be related topics) so the logic has been changed to count the number of sections on the page.

[Relevant Trello Card](https://trello.com/c/REnMbbdH/993-dimensions-26-and-27-for-new-topics-level-0-1-pages-not-showing)