### PR TITLE
Update Ukraine CTA in the contextual sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Make auditing check static for missing assets ([PR #2755](https://github.com/alphagov/govuk_publishing_components/pull/2755))
 * Update analytics logic for new browse page metatags ([PR #2778](https://github.com/alphagov/govuk_publishing_components/pull/2778))
 * Tracking changes for the footer ([PR #2774](https://github.com/alphagov/govuk_publishing_components/pull/2774))
+* Update Ukraine CTA in the contextual sidebar ([PR #2779](https://github.com/alphagov/govuk_publishing_components/pull/2779))
 
 ## 29.9.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_contextual-sidebar.scss
@@ -8,6 +8,12 @@
   color: $govuk-text-colour;
 }
 
+.gem-c-contextual-sidebar__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
 .gem-c-contextual-sidebar__text {
   @include govuk-font(16);
   margin-bottom: govuk-spacing(1);
@@ -23,4 +29,18 @@
   display: block;
   padding: 0 govuk-spacing(3) govuk-spacing(3);
   text-decoration: none;
+}
+
+.gem-c-contextual-sidebar__cta--ukraine {
+  border-top: 7px solid #fed700;
+  position: relative;
+
+  &:before {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: -14px;
+    border-top: 7px solid #4b7ec1;
+  }
 }

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_ukraine_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_ukraine_cta.html.erb
@@ -1,27 +1,26 @@
 <% shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns) %>
 <%
   title = t("components.related_navigation.ukraine.title")
-  link_text = t("components.related_navigation.ukraine.link_text")
-  link_path = t("components.related_navigation.ukraine.link_path")
   lang = shared_helper.t_locale("components.related_navigation.ukraine.title")
 %>
 
-<% data_attributes = {
-  "module": "gem-track-click",
-  "track-category": "relatedLinkClicked",
-  "track-action": "1.0 Invasion of Ukraine",
-  "track-label": link_path,
-  "track-dimension": link_text,
-  "track-dimension-index": "29",
-} %>
-
-<%= tag.div class: "gem-c-contextual-sidebar__cta" do %>
+<%= tag.div class: "gem-c-contextual-sidebar__cta gem-c-contextual-sidebar__cta--ukraine", data: { module: "gem-track-click" } do %>
   <%= tag.h2 title, class: "gem-c-contextual-sidebar__heading govuk-heading-s" %>
-  <%= tag.p class: "gem-c-contextual-sidebar__text govuk-body" do %>
-    <%= link_to link_text,
-      link_path,
-      class: "govuk-link",
-      data: data_attributes,
-      lang: lang %>
-  <% end %>
+  <%= tag.ul class: "gem-c-contextual-sidebar__list" do %>
+    <% t("components.related_navigation.ukraine.links").each do |link| %>
+      <%= tag.li class: "gem-c-contextual-sidebar__text govuk-body" do %>
+        <%= link_to link[:label],
+          link[:href],
+          class: "govuk-link",
+          data: {
+            "track-category": "relatedLinkClicked",
+            "track-action": "1.0 Invasion of Ukraine",
+            "track-label": link[:href],
+            "track-dimension": link[:label],
+            "track-dimension-index": "29",
+          },
+          lang: lang %>
+      <% end %>
+    <% end %>
+  <% end %>    
 <% end %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -165,9 +165,8 @@ ar:
         link_text: تحقق مما تحتاج إلى القيام به
         title: برِيكْسِت
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: المواقع العالمية
     search_box:
       input_title: بحث

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -161,9 +161,8 @@ az:
         link_text: Nələri etməli olduğunuzu yoxlayın
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Dünya üzrə yerləri
     search_box:
       input_title: Axtar

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -168,9 +168,8 @@ be:
         link_text: Праверце, што вам трэба зрабіць
         title: Брэкзiт
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Мы ў свеце
     search_box:
       input_title: Пошук

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -166,9 +166,8 @@ bg:
         link_text: Проверете какво трябва да направите
         title: Брекзит
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Местоположения по света
     search_box:
       input_title: Търсене

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -163,9 +163,8 @@ bn:
         link_text: আপনার যা করা প্রয়োজন তা দেখুন
         title: ব্রেক্সিট
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: বিশ্বের অবস্থানসমূহ
     search_box:
       input_title: খুঁজুন

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -167,9 +167,8 @@ cs:
         link_text: Zkontrolujte, co je třeba udělat
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Místa ve světě
     search_box:
       input_title: Vyhledávání

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -166,9 +166,8 @@ cy:
         link_text: Gwiriwch beth mae angen i chi wneud
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Lleoliadau byd-eang
     search_box:
       input_title: Chwilio

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -163,9 +163,8 @@ da:
         link_text: Tjek hvad du skal gøre
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Verden Placeringer
     search_box:
       input_title: Søge

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -166,9 +166,8 @@ de:
         link_text: Prüfen Sie, was Sie machen müssen
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Weltweite Standorte
     search_box:
       input_title: Suche

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -164,9 +164,8 @@ dr:
         link_text: بیبینید که چه کاری باید انجام دهید
         title: برکست
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: موقعیت هایی جهان
     search_box:
       input_title: جستجو نمایید

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -162,9 +162,8 @@ el:
         link_text: Ελέγξτε τι πρέπει να κάνετε
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Παγκόσμιες τοποθεσίες
     search_box:
       input_title: Αναζήτηση

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,9 +286,16 @@ en:
         link_text: Check what you need to do
         title: Brexit
       ukraine:
-        link_path: "https://ukstandswithukraine.campaign.gov.uk/"
-        link_text: Find out about the UK’s response
         title: Invasion of Ukraine
+        links:
+        - label: "UK visa support for Ukrainian nationals"
+          href:  "https://www.gov.uk/guidance/support-for-family-members-of-british-nationals-in-ukraine-and-ukrainian-nationals-in-ukraine-and-the-uk"       
+        - label: "Move to the UK if you're coming from Ukraine"
+          href:  "https://www.gov.uk/guidance/move-to-the-uk-if-youre-from-ukraine"
+        - label: "Homes for Ukraine: record your interest"
+          href:  "https://www.gov.uk/register-interest-homes-ukraine"       
+        - label: "Find out about the UK’s response"
+          href:  "https://ukstandswithukraine.campaign.gov.uk/"
       world_locations: World locations
     search_box:
       input_title: Search

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -162,9 +162,8 @@ es-419:
         link_text: Verifique lo que debe hacer
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Ubicaciones en el mundo
     search_box:
       input_title: Buscar

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -162,9 +162,8 @@ es:
         link_text: Compruebe lo que necesita hacer
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Ubicaciones mundiales
     search_box:
       input_title: Buscar

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -165,9 +165,8 @@ et:
         link_text: Kontrollige, mida peate tegema
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Maailma asukohad
     search_box:
       input_title: Otsing

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -160,9 +160,8 @@ fa:
         link_text: آنچه را باید انجام دهید، بررسی کنید
         title: برگزیت
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: مکان‌های جهانی
     search_box:
       input_title: جستجو

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -164,9 +164,8 @@ fi:
         link_text: Tarkista, mitä sinun on tehtävä
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Maailman sijainnit
     search_box:
       input_title: Hae

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -162,9 +162,8 @@ fr:
         link_text: Vérifiez ce que vous devez faire
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Emplacements dans le monde
     search_box:
       input_title: Rechercher

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -164,9 +164,8 @@ gd:
         link_text: Seiceáil cad is gá duit aird a thabhairt air
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Áit ar domhan
     search_box:
       input_title: Taighde

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -162,9 +162,8 @@ gu:
         link_text: તમારે શું કરવું પડશે તે તપાસો
         title: બ્રેક્ઝિટ
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: વૈશ્વિક લોકેશન્સ
     search_box:
       input_title: શોધો

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -162,9 +162,8 @@ he:
         link_text: בדוק מה אתה צריך לעשות
         title: " ברקזיט"
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: מיקומים גלובאליים
     search_box:
       input_title: 'חפש '

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -162,9 +162,8 @@ hi:
         link_text: जांचें कि आपको क्या करना है
         title: ब्रेक्सिट
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: वैश्विक स्थान
     search_box:
       input_title: खोजें

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -164,9 +164,8 @@ hr:
         link_text: Provjerite što trebate učiniti
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Svjetske lokacije
     search_box:
       input_title: Pretraga

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -165,9 +165,8 @@ hu:
         link_text: Nézze meg, hogy mit kell tennie
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Helyszínek a világban
     search_box:
       input_title: Keresés

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -166,9 +166,8 @@ hy:
         link_text: Իմացեք, թե ինչ պետք է անեք
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Գտնվելու վայրերը
     search_box:
       input_title: Որոնում

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -162,9 +162,8 @@ id:
         link_text: Periksa apa yang Anda harus lakukan
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Lokasi dunia
     search_box:
       input_title: Cari

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -162,9 +162,8 @@ is:
         link_text: Athugaðu hvað þú þarft að gera
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Staðsetningar úti um allan heim
     search_box:
       input_title: Leita

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -162,9 +162,8 @@ it:
         link_text: Controlla cosa devi fare
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Località del mondo
     search_box:
       input_title: Cerca

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -158,9 +158,8 @@ ja:
         link_text: あなたがする必要があることを確認してください
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: 世界の場所
     search_box:
       input_title: 検索

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -165,9 +165,8 @@ ka:
         link_text: შეამოწმეთ თუ რა უნდა გააკეთოთ
         title: ბრექსითის შემოწმება
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: მსოფლიო ლოკაციები
     search_box:
       input_title: ძიება

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -162,9 +162,8 @@ kk:
         link_text: Не істеу керек екенін қараңыз
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Әлемдегі орындар
     search_box:
       input_title: Іздеу

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -157,9 +157,8 @@ ko:
         link_text:
         title:
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations:
     search_box:
       input_title:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -167,9 +167,8 @@ lt:
         link_text: Pažiūrėkite, ką turite daryti
         title: "„Brexitas“ "
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Pasaulio vietos
     search_box:
       input_title: Ieškoti

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -166,9 +166,8 @@ lv:
         link_text: Noskaidrojiet, kas jums jāpaveic
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Atrašanās vietas pasaulē
     search_box:
       input_title: Meklēt

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -161,9 +161,8 @@ ms:
         link_text: Periksa apa yang perlu anda lakukan
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Lokasi dunia
     search_box:
       input_title: Carian

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -164,9 +164,8 @@ mt:
         link_text: Iċċekkja x'għandek bżonn tagħmel
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Postijiet fid-dinja
     search_box:
       input_title: Fittex

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -162,9 +162,8 @@ nl:
         link_text: Controleer wat u moet doen
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Locaties in de wereld
     search_box:
       input_title: Zoeken

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -162,9 +162,8 @@
         link_text: Sjekk hva du må gjøre
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Steder i verden
     search_box:
       input_title: Søk

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -158,9 +158,8 @@ pa-pk:
         link_text: دیکھو جو تہانوں کرن دی لوڑ اے
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: دُنیا دیاں تھاواں
     search_box:
       input_title: کھوج

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -162,9 +162,8 @@ pa:
         link_text: ਜਾਂਚ ਕਰੋ ਕਿ ਤੁਹਾਨੂੰ ਕੀ ਕਰਨ ਦੀ ਜ਼ਰੂਰਤ ਹੈ
         title: ਬ੍ਰੈਕਸਿਟ
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: ਵਿਸ਼ਵ ਸਥਾਨ
     search_box:
       input_title: ਖੋਜ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -166,9 +166,8 @@ pl:
         link_text: Sprawdź, co musisz zrobić
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Miejsca na świecie
     search_box:
       input_title: Szukaj

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -159,9 +159,8 @@ ps:
         link_text: وګورئ چې تاسو څه کولو ته اړتیا لرئ
         title: بریکسیټ
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: د نړۍ موقعیتونه
     search_box:
       input_title: لټون

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -162,9 +162,8 @@ pt:
         link_text: Verifique o que precisa de fazer
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Locais mundiais
     search_box:
       input_title: Pesquisar

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -163,9 +163,8 @@ ro:
         link_text: Verificați ce trebuie să faceți
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Locații pe glob
     search_box:
       input_title: Căutați

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -166,9 +166,8 @@ ru:
         link_text: Проверьте, что вам нужно сделать
         title: Брексит
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Места нахождения по миру
     search_box:
       input_title: Поиск

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -162,9 +162,8 @@ si:
         link_text: ඔබ කළ යුතු දේ පරීක්ෂා කරන්න
         title: බ්රෙක්සිට්
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: ලෝක ස්ථාන
     search_box:
       input_title: සොයන්න

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -167,9 +167,8 @@ sk:
         link_text: Skontrolujte, čo je potrebné urobiť
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Svetové lokality
     search_box:
       input_title: Vyhľadávanie

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -169,9 +169,8 @@ sl:
         link_text: Preverite, kaj morate storiti
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Lokacije po svetu
     search_box:
       input_title: Iskanje

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -162,9 +162,8 @@ so:
         link_text: Hubi waxaad u baahantahay inaad qabato
         title: Ka bixitaanka Ingiriiska
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Goobaha Dunida
     search_box:
       input_title: Baadh

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -162,9 +162,8 @@ sq:
         link_text: Kontrolloni se çfarë duhet të bëni
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Vendndodhjet globale
     search_box:
       input_title: Kërko

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -163,9 +163,8 @@ sr:
         link_text: Proverite šta treba da uradite
         title: Bregzit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Globalne lokacije
     search_box:
       input_title: Pretraži

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -162,9 +162,8 @@ sv:
         link_text: Kontrollera vad du behöver göra
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Platser i världen
     search_box:
       input_title: Sök på

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -162,9 +162,8 @@ sw:
         link_text: Angalia unachopaswa kufanya
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Maeneo ya kimataifa
     search_box:
       input_title: Tafuta

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -163,9 +163,8 @@ ta:
         link_text: நீங்கள் செய்யவேண்டியது என்ன என்று பாருங்கள்
         title: பிரெக்சிட்
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: உலக இருப்பிடங்கள்
     search_box:
       input_title: தேடு

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -160,9 +160,8 @@ th:
         link_text: ตรวจสอบสิ่งที่คุณต้องทำ
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: สถานที่ทั่วโลก
     search_box:
       input_title: ค้นหา

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -163,9 +163,8 @@ tk:
         link_text: Näme etmelidigiňizi belläň
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Dünýä ýerleri
     search_box:
       input_title: Gözlemek

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -163,9 +163,8 @@ tr:
         link_text: Ne yapmaya ihtiyacınız olduğunu kontrol edin
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Dünya geneli konumlar
     search_box:
       input_title: Ara

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -169,9 +169,8 @@ uk:
         link_text: Перевірте, що вам потрібно зробити
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Світові локації
     search_box:
       input_title: Пошук

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -159,9 +159,8 @@ ur:
         link_text: پڑتال کریں کہ آپ کو کیا کرنے کی ضرورت ہے
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: عالمی مقامات
     search_box:
       input_title: تلاش

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -164,9 +164,8 @@ uz:
         link_text: Нима қилиш зарурлигини текшириш
         title: Брексит
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Жаҳондаги жойлашиш жойи
     search_box:
       input_title: Излаш

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -161,9 +161,8 @@ vi:
         link_text: Kiểm tra những gì bạn cần làm
         title: Brexit
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: Các vị trí trên thế giới
     search_box:
       input_title: Tìm kiếm

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -160,9 +160,8 @@ zh-hk:
         link_text: 查看您需要做的事
         title: 英國脫歐
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: 全世界之地點
     search_box:
       input_title: 搜尋

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -160,9 +160,8 @@ zh-tw:
         link_text: 確認你需要：
         title: 脫歐
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: 世界地點
     search_box:
       input_title: 搜尋

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -160,9 +160,8 @@ zh:
         link_text: 检查您需要做的事情
         title: 英国脱欧
       ukraine:
-        link_path:
-        link_text:
         title:
+        links:
       world_locations: 世界地点
     search_box:
       input_title: 搜索

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -171,7 +171,9 @@ describe "Contextual navigation" do
   def then_i_see_the_ukraine_call_to_action
     within ".gem-c-contextual-sidebar__cta" do
       expect(page).to have_content("Invasion of Ukraine")
-      expect(page).to have_link("Find out about the UK’s response")
+      within ".gem-c-contextual-sidebar__list" do
+        expect(page).to have_link(href: /.+/)
+      end
     end
   end
 


### PR DESCRIPTION
## What
* Bring more focus to the ‘Invasion of Ukraine’ contextual sidebar by adding a flag-coloured border. [Trello](https://trello.com/c/Ny7zYob1/986-invasion-of-ukraine-navigation-module-change-border-styling)
* Add new links for 4 key user journeys [Trello](https://trello.com/c/Zs0PYtrm/985-invasion-of-ukraine-navigation-module-extra-links)

## Why
There are now four clear entry points for user journeys, which need to be reflected in the links available in the sidebar. These entry points are:

* people fleeing Ukraine applying for a visa to come to the UK
* people fleeing Ukraine arriving in the UK
* UK residents wanting to sponsor someone coming to the UK from Ukraine
* people interested in the government’s response

To make it clear that this component is specifically for Ukraine, the border is changed to resemble the Ukraine flag. 

## Visual Changes

### Before
![image](https://user-images.githubusercontent.com/2166204/168775486-0e1fd846-96fc-4c5e-87b5-348e43c70406.png)

### After
![image](https://user-images.githubusercontent.com/2166204/168775946-907d6e59-4ee6-49cc-b051-9aef09c99693.png)
