### PR TITLE
Fix HTTP protocol reporting in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update LUX to v301 ([PR #2773](https://github.com/alphagov/govuk_publishing_components/pull/2773))
+* Fix http protocol reporting in Safari ([PR #2781](https://github.com/alphagov/govuk_publishing_components/pull/2781))
 
 ## 29.8.0
 

--- a/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-measurer.js
+++ b/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-measurer.js
@@ -171,16 +171,25 @@ if (
 // `DOMContentReady` event before we can see what the HTTP version is.
 //
 // [1]: https://github.com/alphagov/govuk-rfcs/pull/148
-try {
-  if (typeof performance !== 'undefined') {
-    document.addEventListener('DOMContentLoaded', function () {
-      var getEntriesByType = performance.getEntriesByType('navigation')
 
-      if (getEntriesByType.length > 0) {
-        var httpProtocol = performance.getEntriesByType('navigation')[0].nextHopProtocol
-        LUX.addData("http-protocol", httpProtocol)
-      }
-    })
+var measureHTTPProtocol = function () {
+  var getEntriesByType = performance.getEntriesByType('navigation')
+
+  if (getEntriesByType.length > 0) {
+    var httpProtocol = JSON.parse(JSON.stringify(performance.getEntriesByType('navigation')[0].nextHopProtocol))
+    LUX.addData("http-protocol", httpProtocol)
+  }
+}
+
+try {
+  if (typeof performance !== 'undefined' && typeof performance.getEntriesByType !== 'undefined') {
+    if (document.readyState === 'complete') {
+      measureHTTPProtocol()
+    } else {
+      window.addEventListener('load', function() {
+        measureHTTPProtocol()
+      })
+    }
   }
 } catch (e) {
   console.error('Error in LUX reporting the HTTP protocol (' + window.location + '):', e)


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Fix the HTTP protocol reporting into Speedcurve RUM as Safari was not reporting any data.

This used `DOMContentLoaded` to make sure that `performance.getEntriesByType()` was not undefined. However, this was not reporting anything in Safari. It appears that the event listener was being added after the event was fired.

Checking the `readyState` of the document lets us see whether the document is loading or ready - and then, depending on the state, either the `load` event has a listener attached or the measurement is done immediately.

Adds extra check to make sure that `performance.getEntriesByType` is not undefined - so can be used without throwing an error.

## Why
<!-- What are the reasons behind this change being made? -->
Monitoring the type of HTTP connection that a user's using will allow us to see how the different HTTP protocols affect performance - with Safari missing a large chunk of users were being missed out from this investigation.

## Visual Changes
None.
