### PR TITLE
Change colour palette in graphs to match GSS guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * GA4 analytics schema rework ([PR #2864](https://github.com/alphagov/govuk_publishing_components/pull/2864))
+* Change colour palette in graphs to match GSS guidance ([PR #2782](https://github.com/alphagov/govuk_publishing_components/pull/2782))
 
 ## 29.15.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_charts.scss
@@ -25,12 +25,23 @@
   $caption-side: top; // Caption alignment. Top or bottom.
   $key-width: 160px; // Only used by IE. Other browsers get smallest width that fits content
 
+  // The following accessible colour palette has been developed to meet the colour contrast requirements for adjacent colours (as set out in WCAG 2.1)
+  // For charts, the palette should be used instead of the GOV.UK colour palette - https://design-system.service.gov.uk/styles/colour/
+  // https://gss.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/#section-5
+
+  $gss-colour-dark-blue: #12436d;
+  $gss-colour-turquoise: #28a197;
+  $gss-colour-dark-pink: #801650;
+  $gss-colour-orange: #f46a25;
+  $gss-colour-dark-grey: #3d3d3d;
+  $gss-colour-plum: #a285d1;
+
   // CHART COLOUR SCHEME
 
   $chart-border: govuk-colour("white"); // Chart border colour
   $key-border: govuk-colour("white"); // Key border colour
-  $bar-colours: govuk-colour("blue"), govuk-colour("turquoise"), govuk-colour("green"), govuk-colour("light-green"), govuk-colour("yellow"), govuk-colour("orange"), govuk-colour("red"), govuk-colour("bright-purple", $legacy: "bright-red");
-  $bar-text-colours: govuk-colour("white"), govuk-colour("black"), govuk-colour("white"), govuk-colour("black"), govuk-colour("black"), govuk-colour("black"), govuk-colour("white"), govuk-colour("white");
+  $bar-colours: $gss-colour-dark-blue, $gss-colour-turquoise, $gss-colour-dark-pink, $gss-colour-orange, $gss-colour-dark-grey, $gss-colour-plum;
+  $bar-text-colours: govuk-colour("white"), govuk-colour("white"), govuk-colour("white"), govuk-colour("black"), govuk-colour("white"), govuk-colour("black");
   $bar-cell-colour: govuk-colour("black");
   $bar-outdented-colour: govuk-colour("black");
 

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -181,6 +181,11 @@ examples:
           </tbody>
         </table>
   charts:
+    description: |
+      The Government Statistical Service (GSS) guidance recommends [a limit of four categories as best practice for basic data visualisations](https://gss.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/#section-5).
+
+      Note that charts which have up to 7 categories, [chart with colours](http://govuk-publishing-components.dev.gov.uk/component-guide/govspeak/chart_with_colours/preview), for example, will display subsequent bars in `#3d3d3d`, `#a285d1` and the 7th bar in the default colour of `#0b0c0c` and will still meet the colour contrast requirements for adjacent colours. 
+      Charts that have 8 or more categories will display additional bars in the default colour and will not meet colour contrast requirements for adjacent colours.
     data:
       block: |
         <table class='js-barchart-table mc-auto-outdent'>
@@ -214,8 +219,6 @@ examples:
               <th scope="col">Grapes</th>
               <th scope="col">Strawberries</th>
               <th scope="col">Plums</th>
-              <th scope="col">Apricots</th>
-              <th scope="col">Pineapples</th>
             </tr>
           </thead>
           <tbody>
@@ -228,8 +231,6 @@ examples:
               <td>24</td>
               <td>10</td>
               <td>62</td>
-              <td>29</td>
-              <td>81</td>
             </tr>
             <tr>
               <td>Numbers outside bar</td>
@@ -238,10 +239,8 @@ examples:
               <td>2</td>
               <td>1</td>
               <td>1</td>
-              <td>3</td>
-              <td>3</td>
-              <td>1</td>
               <td>2</td>
+              <td>1</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## What
https://trello.com/c/z28rKuYm/1189-implementation-of-updated-bar-chart-colour-change

- Update the colour palette for the [Govspeak content](https://components.publishing.service.gov.uk/component-guide/govspeak) component to a new palette of 6 colours (reduced from 8)
- Update data visualisation colours guidance to match https://gss.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/#section-5

## Why
To meet the colour contrast requirements for adjacent colours (as set out in WCAG 2.1).

https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html

## Visual changes

<table role="table">
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/168851536-f7c1557a-b919-4bb8-84b8-46e38297fdca.png"><img src="https://user-images.githubusercontent.com/87758239/168851536-f7c1557a-b919-4bb8-84b8-46e38297fdca.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/178240011-f999320e-ccc8-422c-aeae-4244933f4f3d.png"><img src="https://user-images.githubusercontent.com/87758239/178240011-f999320e-ccc8-422c-aeae-4244933f4f3d.png" width="360" style="max-width: 100%;"></a></td>
</tr>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/168851517-8b345907-4f25-4d43-ba06-f5f832a9f87a.png"><img src="https://user-images.githubusercontent.com/87758239/168851517-8b345907-4f25-4d43-ba06-f5f832a9f87a.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/178240323-3c5a23fe-8703-4a9a-a4bf-b1ff74cb5763.png"><img src="https://user-images.githubusercontent.com/87758239/178240323-3c5a23fe-8703-4a9a-a4bf-b1ff74cb5763.png" width="360" style="max-width: 100%;"></a></td>
</tr>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/168849165-89a2834a-62eb-4053-a9a2-04020222942f.png"><img src="https://user-images.githubusercontent.com/87758239/168849165-89a2834a-62eb-4053-a9a2-04020222942f.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/178240712-833ba914-0889-4442-b32b-857562db2506.png"><img src="https://user-images.githubusercontent.com/87758239/178240712-833ba914-0889-4442-b32b-857562db2506.png" width="360" style="max-width: 100%;"></a></td>
</tr>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/168851549-df2ea685-6483-4aa3-a631-3c229812d337.png"><img src="https://user-images.githubusercontent.com/87758239/168851549-df2ea685-6483-4aa3-a631-3c229812d337.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/178240616-68ae956c-ef40-4d4d-89b7-08768b5772bd.png"><img src="https://user-images.githubusercontent.com/87758239/178240616-68ae956c-ef40-4d4d-89b7-08768b5772bd.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</tbody>
</table>

## Anything else
- The number of colours have now been updated from 8 to 6. Should a chart have 7 categories then the 7th bar will be displayed in black (and black with white text for indented bars). This is fine because the chart will still meet the colour contrast requirements for adjacent colours

![govuk-publishing-components dev gov uk_component-guide_govspeak_chart_with_colours_preview](https://user-images.githubusercontent.com/87758239/178240712-833ba914-0889-4442-b32b-857562db2506.png)

- If a chart has 8 bars the next bar will also be displayed in the default style of black which would be a problem

![0 0 0 0_3212_component-guide_govspeak_chart_with_colours_preview (1)](https://user-images.githubusercontent.com/87758239/178241644-d2047db9-9401-43ef-a099-e17dc6600e2a.png)

- This is however against the guidance which recommends a limit of four categories as best practice for basic data visualisations

- https://github.com/alphagov/govuk_publishing_components/issues/2676
- https://github.com/alphagov/govuk-design-system/issues/2099