### PR TITLE
Release 29.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 29.9.0
 
 * Update LUX to v301 ([PR #2773](https://github.com/alphagov/govuk_publishing_components/pull/2773))
 * Fix http protocol reporting in Safari ([PR #2781](https://github.com/alphagov/govuk_publishing_components/pull/2781))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (29.8.0)
+    govuk_publishing_components (29.9.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "29.8.0".freeze
+  VERSION = "29.9.0".freeze
 end


### PR DESCRIPTION
## 29.9.0

* Update LUX to v301 ([PR #2773](https://github.com/alphagov/govuk_publishing_components/pull/2773))
* Fix http protocol reporting in Safari ([PR #2781](https://github.com/alphagov/govuk_publishing_components/pull/2781))

