### PR TITLE
Extend GTM analytics click tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Extend GTM analytics click tracking ([PR #2786](https://github.com/alphagov/govuk_publishing_components/pull/2786))
 * GOVUK Frontend 4.1.0 updates ([PR #2794](https://github.com/alphagov/govuk_publishing_components/pull/2794))
 
 ## 29.10.0

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
@@ -38,10 +38,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
   }
 
+  // check either element is expandable or contains expandable element
   GtmClickTracking.prototype.checkExpandedState = function (clicked) {
-    var expanded = clicked.querySelector('[aria-expanded]')
-    if (expanded) {
-      return expanded.getAttribute('aria-expanded')
+    var isExpandable = clicked.getAttribute('aria-expanded')
+    var containsExpandable = clicked.querySelector('[aria-expanded]')
+
+    if (isExpandable) {
+      return isExpandable
+    } else if (containsExpandable) {
+      return containsExpandable.getAttribute('aria-expanded')
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
@@ -1,3 +1,4 @@
+// = require govuk/vendor/polyfills/Element/prototype/closest.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
@@ -10,31 +11,35 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   GtmClickTracking.prototype.init = function () {
-    var trackClicksOn = [this.module]
-    if (!this.module.getAttribute(this.trackingTrigger)) {
-      trackClicksOn = this.module.querySelectorAll('[' + this.trackingTrigger + ']')
-    }
-
-    for (var i = 0; i < trackClicksOn.length; i++) {
-      trackClicksOn[i].addEventListener('click', this.trackClick.bind(this))
-    }
+    this.module.addEventListener('click', this.trackClick.bind(this), true) // useCapture must be true
   }
 
   GtmClickTracking.prototype.trackClick = function (event) {
     if (window.dataLayer) {
-      var target = event.currentTarget
-      var data = {
-        event: 'analytics',
-        event_name: target.getAttribute('data-gtm-event-name'),
-        // get entire URL apart from domain
-        link_url: window.location.href.substring(window.location.origin.length),
-        ui: JSON.parse(target.getAttribute('data-gtm-attributes'))
+      var target = this.findTrackingAttributes(event.target)
+      if (target) {
+        var data = {
+          event: 'analytics',
+          event_name: target.getAttribute('data-gtm-event-name'),
+          // get entire URL apart from domain
+          link_url: window.location.href.substring(window.location.origin.length),
+          ui: JSON.parse(target.getAttribute('data-gtm-attributes')) || {}
+        }
+        var ariaExpanded = this.checkExpandedState(target)
+        if (ariaExpanded) {
+          data.ui.state = ariaExpanded === 'false' ? 'opened' : 'closed'
+          data.ui.text = data.ui.text || target.innerText
+        }
+        window.dataLayer.push(data)
       }
-      var ariaExpanded = this.checkExpandedState(target)
-      if (ariaExpanded) {
-        data.ui.state = ariaExpanded === 'false' ? 'opened' : 'closed'
-      }
-      window.dataLayer.push(data)
+    }
+  }
+
+  GtmClickTracking.prototype.findTrackingAttributes = function (clicked) {
+    if (clicked.hasAttribute('[' + this.trackingTrigger + ']')) {
+      return clicked
+    } else {
+      return clicked.closest('[' + this.trackingTrigger + ']')
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -45,6 +45,21 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
     if (this.$module.getAttribute('data-track-sections') === 'true') {
       this.addEventListenerSections()
     }
+
+    // look for data attributes to put onto the 'show/hide all' link
+    var showAllAttributes = this.$module.getAttribute('data-show-all-attributes')
+    if (showAllAttributes) {
+      try {
+        var showAll = this.$module.querySelector('.' + this.showAllControls)
+        var values = JSON.parse(showAllAttributes)
+        var keys = Object.keys(values)
+        for (var i = 0; i < keys.length; i++) {
+          showAll.setAttribute('data-' + keys[i], values[keys[i]])
+        }
+      } catch (e) {
+        console.error('Could not read accordion data attributes error: ' + e.message, window.location)
+      }
+    }
   }
 
   // Navigate to and open accordions with anchored content on page load if a hash is present

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -27,6 +27,9 @@
   data_attributes[:track_show_all_clicks] = track_show_all_clicks
   data_attributes[:track_sections] = track_sections
 
+  data_attributes_show_all ||= nil
+  data_attributes[:show_all_attributes] = data_attributes_show_all if data_attributes_show_all
+
   translations.each do |key, translation|
     locales[key] = shared_helper.t_locale(translation)
     data_attributes[key] = t(translation)
@@ -47,8 +50,8 @@
   <%= tag.div(class: accordion_classes, id: id, data: data_attributes) do %>
     <% items.each_with_index do |item, i| %>
       <%
-        # The GOVUK Frontend JavaScript for this component 
-        # uses a loop starting at 1 for accessing heading ID values, 
+        # The GOVUK Frontend JavaScript for this component
+        # uses a loop starting at 1 for accessing heading ID values,
         # hence the increment below
         index = i + 1
 
@@ -65,11 +68,10 @@
             content_tag(
               shared_helper.get_heading_level,
               content_tag(
-                'span', 
-                item[:heading][:text], 
+                'span',
+                item[:heading][:text],
                 class: "govuk-accordion__section-button",
                 id: "#{id}-heading-#{index}"
-                
               ),
               class: "govuk-accordion__section-heading",
               id: item[:heading][:id],

--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -189,10 +189,17 @@ examples:
 
       Each item can also have a `data_attributes` hash. These `data_attributes` are placed on the `button` that triggers the opening and closing - useful for differentiating between each section of the accordion.
 
+      Data attributes can also be added to the 'Show/hide all' link using the `data_attributes_show_all` option, primarily where custom tracking is required. These attributes are read from the accordion markup and then added to the link by JavaScript (which is how the link is created).
     data:
       data_attributes:
           gtm: gtm-accordion
           ga: ga-accordion
+      data_attributes_show_all:
+        module: example
+        track-action: click
+        ui:
+          type: test
+          text: something
       items:
         - heading:
             text: Writing well for the web

--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -277,13 +277,13 @@ examples:
             html: <p class="govuk-body">This is the content for How people read.</p>
   with_the_anchor_link_navigation:
     description: |
-      Some apps require custom `id`s per accordion section heading. Custom `id`s allow you to link section headings, sometimes across multiple pages. 
-      
+      Some apps require custom `id`s per accordion section heading. Custom `id`s allow you to link section headings, sometimes across multiple pages.
+
       For example on [guidance pages for Content Designers, referred to as "manuals",](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#associations) each manual includes multiple sets of accordions and will reference between specific sections to easily access content.
 
-      Using the same rules, custom `id`s automatically open accordions when users click within another accordion that links to either 
+      Using the same rules, custom `id`s automatically open accordions when users click within another accordion that links to either
 
-      * the `id` of an accordion section heading 
+      * the `id` of an accordion section heading
       * an `id` within the content of an accordion (this will also automatically navigate to and open accordions on page load)
 
       This feature will only be used if the `anchor_navigation` flag is passed as `true`. This mitigates performance risk from event listeners on a large number of links.
@@ -294,13 +294,13 @@ examples:
       items:
         - heading:
             text: Writing well for the web
-            id: writing-well-for-the-web
+            id: writing-well-for-the-web-1
           content:
-            html: <p class="govuk-body">This is content for accordion 1 of 2</p><p class="govuk-body">This content contains a <a href="#anchor-nav-test" class="govuk-link">link</a></p>
+            html: <p class="govuk-body">This is content for accordion 1 of 2</p><p class="govuk-body">This content contains a <a href="#anchor-nav-test-1" class="govuk-link">link</a></p>
         - heading:
             text: Writing well for specialists
           content:
-            html: <p class="govuk-body" id="anchor-nav-test">This is content for accordion 2 of 2</p>
+            html: <p class="govuk-body" id="anchor-nav-test-1">This is content for accordion 2 of 2</p>
         - heading:
             text: Know your audience
           content:
@@ -312,31 +312,31 @@ examples:
   with_track_show_all_clicks:
     description: |
       To switch on Google Analytics for the "Show all sections" button on click, pass `track_show_all_clicks: true` the values passed on open will be
-      `Event Action: accordionOpened` `Event Category: pageElementInteraction` `Event Label: Show all sections` 
+      `Event Action: accordionOpened` `Event Category: pageElementInteraction` `Event Label: Show all sections`
     data:
       track_show_all_clicks: true
       items:
         - heading:
             text: Writing well for the web
-            id: writing-well-for-the-web
+            id: writing-well-for-the-web-2
           content:
-            html: <p class="govuk-body">This is content for accordion 1 of 2</p><p class="govuk-body">This content contains a <a href="#anchor-nav-test" class="govuk-link">link</a></p>
+            html: <p class="govuk-body">This is content for accordion 1 of 2</p>
         - heading:
             text: Writing well for specialists
           content:
-            html: <p class="govuk-body" id="anchor-nav-test">This is content for accordion 2 of 2</p>
+            html: <p class="govuk-body">This is content for accordion 2 of 2</p>
   with_track_sections:
     description: |
       To switch on Google Analytics for each section, on click, pass `track_sections: true` the values passed on open will be
       `Event Action: accordionOpened` / `accordionClosed` `Event Category: pageElementInteraction` and the `Event Label` being the heading text.
-      
+
       (`track_show_all_clicks: true` can be added to track the "Show all sections" button as well, if required)
     data:
       track_sections: true
       items:
         - heading:
             text: Writing well for the web
-            id: writing-well-for-the-web
+            id: writing-well-for-the-web-3
           content:
             html: <p class="govuk-body">This is content for accordion 1 of 2</p><p class="govuk-body">This content contains a <a href="#anchor-nav-test" class="govuk-link">link</a></p>
         - heading:

--- a/docs/analytics-gtm/gtm-click-tracking.md
+++ b/docs/analytics-gtm/gtm-click-tracking.md
@@ -1,0 +1,107 @@
+# Google Tag Manager click tracking
+
+This is an experimental script to allow click tracking through Google Tag Manager to be added to any element using data attributes.
+
+## Basic use
+
+```html
+<div data-module="gtm-click-tracking">
+  <div
+    data-gtm-event-name="anything"
+    data-gtm-attributes='{"type":"something","index":0,"index-total":1,"section":"n/a","text":"Click me"}'>
+    Click me
+  </div>
+</div>
+```
+
+The module is initialised on the parent element, but tracking only occurs when clicks happen:
+
+- on child elements that have a `data-gtm-event-name` attribute
+- on the parent if it has a `data-gtm-event-name` attribute
+
+The contents of `data-gtm-attributes` are parsed as a JSON object and included in the information passed to GTM. In the example above, the following would be pushed to the dataLayer. Note that the `link_url` attribute is automatically populated with the current page path.
+
+```
+{
+  'event': 'analytics',
+  'event_name': 'anything',
+  'link_url': '/government/publications/cheese',
+  'ui': {
+    'type': 'something',
+    'index': '0',
+    'index-total': '1',
+    'section': 'n/a',
+    'text': 'Click me'
+  }
+}
+```
+
+## Advanced use
+
+In some situations we want to track dynamic elements like the 'Show/hide all' links on accordions. This is complicated by the element being created and updated dynamically using separate JavaScript, and the need to track the state of the element when clicked (to record whether it was opened or closed).
+
+This is handled using the following approach.
+
+```erb
+<div data-module="gtm-click-tracking">
+  <%
+    show_all_attributes = {
+      type: "accordion",
+      index: 0,
+      "index-total": 5,
+      section: "n/a"
+    }
+  %>
+  <%= render 'govuk_publishing_components/components/accordion', {
+    data_attributes_show_all: {
+      "gtm-event-name": "select_content",
+      "gtm-attributes": show_all_attributes.to_json
+    },
+    items: []
+  } %>
+</div>
+```
+
+This works as follows.
+
+- data attributes are added to the accordion's 'Show/hide all' link using the `data_attributes_show_all` option in the component
+- `GtmClickTracking` can now be triggered because the accordion is wrapped in the module and its 'Show/hide all' link has a `gtm-event-name` attribute
+- `GtmClickTracking` checks for the presence of an `aria-expanded` attribute, either on the clicked element or a child of the clicked element
+- if it finds one, it sets the `state` attribute of `ui` to either 'opened' or 'closed' depending on the value of `aria-expanded`
+- if `data-gtm-attributes` does not include `text`, `GtmClickTracking` automatically uses the text of the clicked element
+
+When a user clicks 'Show all sections' the following information is pushed to the dataLayer.
+
+```
+{
+  'event': 'analytics',
+  'event_name': 'select_content',
+  'link_url': '/government/publications/cheese',
+  'ui': {
+    'type': 'accordion',
+    'index': '0',
+    'index-total': '5',
+    'section': 'n/a',
+    'text': 'Show all sections',
+    'state': 'opened'
+  }
+}
+```
+
+When a user clicks 'Hide all sections' the following information is pushed to the dataLayer.
+
+```
+{
+  'event': 'analytics',
+  'event_name': 'select_content',
+  'link_url': '/government/publications/cheese',
+  'ui': {
+    'type': 'accordion',
+    'index': '0',
+    'index-total': '5',
+    'section': 'n/a',
+    'text': 'Hide all sections',
+    'state': 'closed'
+  }
+}
+```

--- a/spec/components/accordion_spec.rb
+++ b/spec/components/accordion_spec.rb
@@ -174,6 +174,26 @@ describe "Accordion", type: :view do
     assert_select "[data-gtm='google-tag-manager']", count: 2
   end
 
+  it "data attributes for show all link are present when required" do
+    test_data = {
+      id: "test-for-data-attributes",
+      data_attributes_show_all: {
+        module: "example",
+        track_action: "click",
+      },
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          content: { html: "<p>Content 1.</p>" },
+        },
+      ],
+    }
+
+    render_component(test_data)
+
+    assert_select ".govuk-accordion[data-show-all-attributes='{\"module\":\"example\",\"track_action\":\"click\"}']"
+  end
+
   it '`data-module="govuk-accordion"` attribute is present when no custom data attributes given' do
     test_data = {
       id: "test-for-module-data-attributes",

--- a/spec/javascripts/components/accordion-spec.js
+++ b/spec/javascripts/components/accordion-spec.js
@@ -1,0 +1,60 @@
+/* eslint-env jasmine */
+/* global GOVUK */
+
+describe('Accordion component', function () {
+  var accordion
+  var container
+  // this markup intentionally contains elements added by JavaScript i.e. the 'Show all sections' link
+  // this link is created by JS from govuk-frontend, which cannot be executed as part of this test
+  // so we add the markup manually
+  var html =
+    '<div class="gem-c-accordion" data-show-text="Show" data-hide-text="Hide" data-show-all-text="Show all sections" data-hide-all-text="Hide all sections" data-this-section-visually-hidden=" this section">' +
+      '<div class="govuk-accordion__controls">' +
+        '<button type="button" class="govuk-accordion__show-all gem-c-accordion__show-all" aria-expanded="false">' +
+          '<span class="govuk-accordion__show-all-text">Show all sections</span>' +
+        '</button>' +
+      '</div>' +
+      '<div class="govuk-accordion__section">' +
+        '<div class="govuk-accordion__section-header">' +
+          '<h2 class="govuk-accordion__section-heading">' +
+            '<span class="govuk-accordion__section-button" id="default-id-078ef791-heading-1">Writing well for the web</span>' +
+          '</h2>' +
+        '</div>' +
+        '<div id="default-id-078ef791-content-1" class="govuk-accordion__section-content" aria-labelledby="default-id-078ef791-heading-1">' +
+          '<p class="govuk-body">This is the content for Writing well for the web.</p>' +
+        '</div>' +
+      '</div>' +
+      '<div class="govuk-accordion__section">' +
+        '<div class="govuk-accordion__section-header">' +
+          '<h2 class="govuk-accordion__section-heading">' +
+            '<span class="govuk-accordion__section-button" id="default-id-078ef791-heading-2">Writing well for specialists</span>' +
+          '</h2>' +
+        '</div>' +
+        '<div id="default-id-078ef791-content-2" class="govuk-accordion__section-content" aria-labelledby="default-id-078ef791-heading-2">' +
+          '<p class="govuk-body">This is the content for Writing well for specialists.</p>' +
+        '</div>' +
+      '</div>' +
+    '</div>'
+
+  function startAccordion () {
+    new GOVUK.Modules.GemAccordion(accordion).init()
+  }
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+    accordion = document.querySelector('.gem-c-accordion')
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
+  it('does something', function () {
+    accordion.setAttribute('data-show-all-attributes', '{"module":"example","track-action":"click"}')
+    startAccordion()
+    expect(document.querySelector('.govuk-accordion__show-all').getAttribute('data-module')).toEqual('example')
+    expect(document.querySelector('.govuk-accordion__show-all').getAttribute('data-track-action')).toEqual('click')
+  })
+})

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
@@ -98,6 +98,50 @@ describe('Google Tag Manager click tracking', function () {
         'test-3-1': 'test 3-1 value',
         'test-3-2': 'test 3-2 value'
       }
+      element.setAttribute('data-gtm-event-name', 'event3-name')
+      element.setAttribute('data-gtm-attributes', JSON.stringify(attributes))
+      element.setAttribute('aria-expanded', 'false')
+      document.body.appendChild(element)
+      new GOVUK.Modules.GtmClickTracking(element).init()
+    })
+
+    it('includes the expanded state in the gtm attributes', function () {
+      element.click()
+
+      var expectedFirst = {
+        event: 'analytics',
+        event_name: 'event3-name',
+        link_url: window.location.href.substring(window.location.origin.length),
+        ui: {
+          'test-3-1': 'test 3-1 value',
+          'test-3-2': 'test 3-2 value',
+          state: 'opened'
+        }
+      }
+      expect(window.dataLayer).toEqual([expectedFirst])
+
+      var expectedSecond = {
+        event: 'analytics',
+        event_name: 'event3-name',
+        link_url: window.location.href.substring(window.location.origin.length),
+        ui: {
+          'test-3-1': 'test 3-1 value',
+          'test-3-2': 'test 3-2 value',
+          state: 'closed'
+        }
+      }
+      element.setAttribute('aria-expanded', 'true')
+      element.click()
+      expect(window.dataLayer).toEqual([expectedFirst, expectedSecond])
+    })
+  })
+
+  describe('doing tracking on an element that contains an expandable element', function () {
+    beforeEach(function () {
+      var attributes = {
+        'test-3-1': 'test 3-1 value',
+        'test-3-2': 'test 3-2 value'
+      }
       element.innerHTML =
         '<div data-gtm-event-name="event3-name"' +
           'data-gtm-attributes=\'' + JSON.stringify(attributes) + '\'' +

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
@@ -13,6 +13,25 @@ describe('Google Tag Manager click tracking', function () {
     document.body.removeChild(element)
   })
 
+  describe('configuring tracking incompletely', function () {
+    beforeEach(function () {
+      element.setAttribute('data-gtm-event-name', 'event-name')
+      document.body.appendChild(element)
+      new GOVUK.Modules.GtmClickTracking(element).init()
+    })
+
+    it('does not cause an error', function () {
+      element.click()
+      var expected = {
+        event: 'analytics',
+        event_name: 'event-name',
+        link_url: window.location.href.substring(window.location.origin.length),
+        ui: {}
+      }
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+  })
+
   describe('doing simple tracking on a single element', function () {
     beforeEach(function () {
       element.setAttribute('data-gtm-event-name', 'event-name')
@@ -96,7 +115,8 @@ describe('Google Tag Manager click tracking', function () {
     beforeEach(function () {
       var attributes = {
         'test-3-1': 'test 3-1 value',
-        'test-3-2': 'test 3-2 value'
+        'test-3-2': 'test 3-2 value',
+        text: 'some text'
       }
       element.setAttribute('data-gtm-event-name', 'event3-name')
       element.setAttribute('data-gtm-attributes', JSON.stringify(attributes))
@@ -115,7 +135,8 @@ describe('Google Tag Manager click tracking', function () {
         ui: {
           'test-3-1': 'test 3-1 value',
           'test-3-2': 'test 3-2 value',
-          state: 'opened'
+          state: 'opened',
+          text: 'some text'
         }
       }
       expect(window.dataLayer).toEqual([expectedFirst])
@@ -127,7 +148,8 @@ describe('Google Tag Manager click tracking', function () {
         ui: {
           'test-3-1': 'test 3-1 value',
           'test-3-2': 'test 3-2 value',
-          state: 'closed'
+          state: 'closed',
+          text: 'some text'
         }
       }
       element.setAttribute('aria-expanded', 'true')
@@ -164,7 +186,8 @@ describe('Google Tag Manager click tracking', function () {
         ui: {
           'test-3-1': 'test 3-1 value',
           'test-3-2': 'test 3-2 value',
-          state: 'opened'
+          state: 'opened',
+          text: 'Show'
         }
       }
       expect(window.dataLayer).toEqual([expectedFirst])
@@ -176,10 +199,12 @@ describe('Google Tag Manager click tracking', function () {
         ui: {
           'test-3-1': 'test 3-1 value',
           'test-3-2': 'test 3-2 value',
-          state: 'closed'
+          state: 'closed',
+          text: 'Hide'
         }
       }
       element.querySelector('[aria-expanded]').setAttribute('aria-expanded', 'true')
+      element.querySelector('button').textContent = 'Hide'
       clickOn.click()
       expect(window.dataLayer).toEqual([expectedFirst, expectedSecond])
     })


### PR DESCRIPTION
## What
Extend the GTM click tracking, specifically:

- if an element contained an expanding element (indicated by the aria-expanded attribute) information about that was included in the dataLayer push
- this now checks if the clicked element itself has that attribute
- will be used on the accordion show/hide all element

Also updates the accordion component:

- allows data attributes to be added to the show/hide all link
- this means we can trigger the GTM click tracking on this element and include the expanded/collapsed state, all without any custom analytics code in the component

## Why
We want to track the state of expanding/collapsing elements on user interaction. At the moment there's some custom code that does this, but we should be able to do it by passing data attributes and having the overall module be smart enough to handle it without additional custom code.

## Visual Changes
None.

Trello card: https://trello.com/c/V0RFrSMK/43-test-technical-approach-to-tracking-on-tabs-and-accordions
