### PR TITLE
Add SVG thumbnail styles for Whitehall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add styles for Whitehall SVG icons ([PR #2788](https://github.com/alphagov/govuk_publishing_components/pull/2788))
 * Make auditing check static for missing assets ([PR #2755](https://github.com/alphagov/govuk_publishing_components/pull/2755))
 * Update analytics logic for new browse page metatags ([PR #2778](https://github.com/alphagov/govuk_publishing_components/pull/2778))
 * Tracking changes for the footer ([PR #2774](https://github.com/alphagov/govuk_publishing_components/pull/2774))

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -37,7 +37,8 @@
       margin-left: -($thumbnail-width + govuk-spacing(6) - $govuk-border-width);
       padding-bottom: govuk-spacing(3);
 
-      img {
+      img,
+      svg {
         display: block;
         width: $thumbnail-width;
         height: 140px;
@@ -55,6 +56,11 @@
         }
 
         box-shadow: 0 2px 2px rgba(govuk-colour("black"), .4);
+      }
+
+      svg {
+        fill: govuk-colour("mid-grey", $legacy: "grey-3");
+        stroke: govuk-colour("mid-grey", $legacy: "grey-3");
       }
     }
 


### PR DESCRIPTION
## What
<!-- Description of the change being made -->

Adding CSS for SVG attachment thumbnail icons now being used by Whitehall.

<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->

We've added some SVG icons to Whitehall in alphagov/whitehall#6550 as a transitional step towards using the attachment components. However, because they're not rendered by whitehall itself, the CSS to style these icons needs to be available in other frontend apps, so this would appear to be the correct place for it (although adding to the legacy Whitehall-supporting css is obviously not ideal).

This is actually trying to remain close to the style of the attachment component, without depending on the component 

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

### Before

The original icon that we're replacing:

![Screenshot 2022-05-20 at 17 09 59](https://user-images.githubusercontent.com/3986/169568707-fcaff311-bc05-41a1-a5dd-98dceecbce98.png)

### After

The icon properly styled, when the CSS in this PR is applied:

<img width="650" alt="Screenshot 2022-05-19 at 10 27 09" src="https://user-images.githubusercontent.com/3986/169568789-6e3676f0-ad94-45f2-a6ec-af8553853e50.png">

The icon improperly styled:

<img width="654" alt="Screenshot 2022-05-19 at 10 22 25" src="https://user-images.githubusercontent.com/3986/169568875-093476a8-f1bd-4b45-806a-30ff92d5d548.png">

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
