### PR TITLE
GOVUK Frontend 4.1.0 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* GOVUK Frontend 4.1.0 updates ([PR #2794](https://github.com/alphagov/govuk_publishing_components/pull/2794))
+
 ## 29.10.0
 
 * Add styles for Whitehall SVG icons ([PR #2788](https://github.com/alphagov/govuk_publishing_components/pull/2788))

--- a/app/views/govuk_publishing_components/components/_character_count.html.erb
+++ b/app/views/govuk_publishing_components/components/_character_count.html.erb
@@ -17,7 +17,7 @@
 
     <%= render "govuk_publishing_components/components/textarea", { id: id, character_count: true }.merge(textarea.symbolize_keys) %>
 
-    <div id="<%= id %>-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
+    <div id="<%= id %>-info" class="govuk-hint govuk-character-count__message">
       <%= t("components.character_count.body", number: maxlength || maxwords, type: maxwords ? t("components.character_count.type.words") : t("components.character_count.type.characters")) %>
     </div>
   <% end %>

--- a/app/views/govuk_publishing_components/components/_date_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_date_input.html.erb
@@ -29,7 +29,6 @@
     aria_described_by << describedby if describedby
     aria_described_by = aria_described_by.join(" ")
   end
-
 %>
 
 <%= content_tag :div, class: form_group_css_classes do %>

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -62,9 +62,7 @@
   if type == "number"
     type = "text"
     inputmode = "numeric"
-    pattern = "[0-9]*"
   end
-
 %>
 
 <%= content_tag :div, class: form_group_css_classes do %>

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -41,7 +41,7 @@ describe "Input", type: :view do
       type: "number",
     )
 
-    assert_select ".govuk-input[type='text'][pattern='[0-9]*'][inputmode='numeric']"
+    assert_select ".govuk-input[type='text'][inputmode='numeric']"
     assert_select ".govuk-input[spellcheck='false']"
   end
 


### PR DESCRIPTION
## What
Make some minor changes to our component markup following the release of `govuk-frontend` 4.1.0, specifically:

- remove 'aria-live' attribute from character count component (not needed anymore)
- remove 'pattern' attribute from date input component (not needed anymore)

## Why
We don't import markup for components from `govuk-frontend`, we've hard coded it into `.erb` templates and heavily modified it. This means that when we get a new release of `govuk-frontend` we need to check the release notes to see if anything has changed. For this release only two minor things have changed.

- https://github.com/alphagov/govuk-frontend/releases/tag/v4.1.0
- https://github.com/alphagov/govuk_publishing_components/blob/main/docs/upgrade-govuk-frontend.md

## Visual Changes
None.
