### PR TITLE
Version 29.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 29.11.0
 
 * Extend GTM analytics click tracking ([PR #2786](https://github.com/alphagov/govuk_publishing_components/pull/2786))
 * GOVUK Frontend 4.1.0 updates ([PR #2794](https://github.com/alphagov/govuk_publishing_components/pull/2794))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (29.10.0)
+    govuk_publishing_components (29.11.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "29.10.0".freeze
+  VERSION = "29.11.0".freeze
 end


### PR DESCRIPTION
## 29.11.0

* Extend GTM analytics click tracking ([PR #2786](https://github.com/alphagov/govuk_publishing_components/pull/2786))
* GOVUK Frontend 4.1.0 updates ([PR #2794](https://github.com/alphagov/govuk_publishing_components/pull/2794))
* Fix print styles for organisation logos ([PR #2751](https://github.com/alphagov/govuk_publishing_components/pull/2751))
* Change "governmentActivityLink" to "governmentactivityLink" ([PR #2798](https://github.com/alphagov/govuk_publishing_components/pull/2798))
