### PR TITLE
Add gem-track-click to specific sections of layout_footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add gem-track-click to specific sections of layout_footer ([PR #2800](https://github.com/alphagov/govuk_publishing_components/pull/2800))
+
 ## 29.11.0
 
 * Extend GTM analytics click tracking ([PR #2786](https://github.com/alphagov/govuk_publishing_components/pull/2786))

--- a/app/views/govuk_publishing_components/components/_layout_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_footer.html.erb
@@ -6,9 +6,9 @@
   classes << "gem-c-layout-footer--border" if with_border
 %>
 <%= tag.footer class: classes, role: "contentinfo" do %>
-  <div class="govuk-width-container" data-module="gem-track-click">
+  <div class="govuk-width-container">
     <% if navigation.any? %>
-      <div class="govuk-footer__navigation">
+      <div class="govuk-footer__navigation" data-module="gem-track-click" data-track-links-only>
         <% navigation.each do |item| %>
           <% if item[:items] %>
             <%
@@ -60,7 +60,7 @@
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         <% if meta.any? %>
           <h2 class="govuk-visually-hidden"><%= t("components.layout_footer.support_links") %></h2>
-          <ul class="govuk-footer__inline-list govuk-!-display-none-print">
+          <ul class="govuk-footer__inline-list govuk-!-display-none-print" data-module="gem-track-click" data-track-links-only>
             <% meta[:items].each do |item| %>
               <li class="govuk-footer__inline-list-item">
                 <%


### PR DESCRIPTION
## What
Remove gem-track-click from parent container of layout_footer. Add gem-track-click to the specific elements that contain links and also add 'data-track-links-only'.


## Why
Previously gem-track-click was added to the parent element of layout_footer. As we need to add seperate gem-track-clicks to the copyright links that are generated from the locale files in order to track them, this resulted in double events when the copyright links were clicked. Also added data-track-links-only because when non links were being clicked it was triggering a tracked click event.

