### PR TITLE
Fix LUX error in IE 11

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-measurer.js
+++ b/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-measurer.js
@@ -175,8 +175,8 @@ if (
 var measureHTTPProtocol = function () {
   var getEntriesByType = performance.getEntriesByType('navigation')
 
-  if (getEntriesByType.length > 0) {
-    var httpProtocol = JSON.parse(JSON.stringify(performance.getEntriesByType('navigation')[0].nextHopProtocol))
+  if (typeof getEntriesByType !== 'undefined' && getEntriesByType.length > 0) {
+    var httpProtocol = getEntriesByType[0].nextHopProtocol
     LUX.addData("http-protocol", httpProtocol)
   }
 }


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Fixes #2804 by adding an extra check to make sure that a variable exists before seeing what its length is.

Also removes an unnecessary use of `JSON.parse` and  `JSON.stringify`.

## Why
<!-- What are the reasons behind this change being made? -->

We'd like to be able to use `window.performance` in IE without it throwing an error. Whilst the specific `PerformanceResourceTiming.nextHopProtocol` isn't supported in IE[^1], some parts of `PerformanceResourceTiming` are[^2] - so an extra check is needed before querying `nextHopProtocol`'s length.

The use of `JSON.parse(JSON.stringify())` was to see what the contents of the performance object were at a specific point in time whilst debugging  - this isn't required for the production code.

## Visual Changes
None.

## How to check

This needs a couple of steps to make sure that it's working.

 1. Visit the public template page locally (http://govuk-publishing-components.dev.gov.uk/public) or in the preview (https://components-gem-pr-2805.herokuapp.com/public)
 1. Accept all cookies
 1. Open the dev tools and go to the browser's console
 1. running `LUX.getDebug()` will give an array of events that LUX has fired - this can be copied into a [helpful debug tool](https://speedcurve-metrics.github.io/lux.js/debug-parser.html). Some browsers have a helpful `copy()` function built in, so `copy(LUX.getDebug())` will automagically put the array into your clipboard
 3. The results should be similar to the follow two examples:

Not sampled:
```
0 ms: Navigation started at 14/06/2022 10:48:38
367 ms: lux.js v301 is initialising.
368 ms: Sample rate is 1%. This session is not being sampled.
368 ms: Onload handler was triggered after 6367 ms.
368 ms: LUX.addData("http-protocol", "http/1.1")
368 ms: lux.js has finished initialising.
368 ms: Received paint entry at 379 ms
```

Sampled:
```
0 ms: Navigation started at 14/06/2022 11:03:55
278 ms: lux.js v301 is initialising.
278 ms: Sample rate is 1%. This session is being sampled.
278 ms: Onload handler was triggered after 278 ms.
278 ms: lux.js has finished initialising.
278 ms: Received paint entry at 232 ms
290 ms: LUX.addData("http-protocol", "http/1.1")
494 ms: Beginning data collection. New events after this point may not be recorded for this page.
494 ms: LUX.mark("LUX_end")
494 ms: Start render time could not be determined.
496 ms: Main beacon sent
```

[^1]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/nextHopProtocol#browser_compatibility

[^2]: https://developer.mozilla.org/en-US/docs/web/api/performanceresourcetiming#browser_compatibility
