### PR TITLE
Add details click tracking

### DIFF
--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
@@ -158,6 +158,53 @@ describe('Google Tag Manager click tracking', function () {
     })
   })
 
+  describe('doing tracking on an openable element', function () {
+    beforeEach(function () {
+      var attributes = {
+        'test-3-1': 'test 3-1 value',
+        'test-3-2': 'test 3-2 value',
+        text: 'some text'
+      }
+      element.setAttribute('data-gtm-event-name', 'event3-name')
+      element.setAttribute('data-module', 'govuk-details')
+      element.setAttribute('data-gtm-attributes', JSON.stringify(attributes))
+      document.body.appendChild(element)
+      new GOVUK.Modules.GtmClickTracking(element).init()
+    })
+
+    it('includes the open state in the gtm attributes', function () {
+      element.click()
+
+      var expectedFirst = {
+        event: 'analytics',
+        event_name: 'event3-name',
+        link_url: window.location.href.substring(window.location.origin.length),
+        ui: {
+          'test-3-1': 'test 3-1 value',
+          'test-3-2': 'test 3-2 value',
+          state: 'opened',
+          text: 'some text'
+        }
+      }
+      expect(window.dataLayer).toEqual([expectedFirst])
+
+      var expectedSecond = {
+        event: 'analytics',
+        event_name: 'event3-name',
+        link_url: window.location.href.substring(window.location.origin.length),
+        ui: {
+          'test-3-1': 'test 3-1 value',
+          'test-3-2': 'test 3-2 value',
+          state: 'closed',
+          text: 'some text'
+        }
+      }
+      element.setAttribute('open', '')
+      element.click()
+      expect(window.dataLayer).toEqual([expectedFirst, expectedSecond])
+    })
+  })
+
   describe('doing tracking on an element that contains an expandable element', function () {
     beforeEach(function () {
       var attributes = {
@@ -205,6 +252,58 @@ describe('Google Tag Manager click tracking', function () {
       }
       element.querySelector('[aria-expanded]').setAttribute('aria-expanded', 'true')
       element.querySelector('button').textContent = 'Hide'
+      clickOn.click()
+      expect(window.dataLayer).toEqual([expectedFirst, expectedSecond])
+    })
+  })
+
+  describe('doing tracking on an element that contains an openable element', function () {
+    beforeEach(function () {
+      var attributes = {
+        'test-3-1': 'test 3-1 value',
+        'test-3-2': 'test 3-2 value'
+      }
+      element.innerHTML =
+        '<div data-gtm-event-name="event3-name"' +
+          'data-module="govuk-details"' +
+          'data-gtm-attributes=\'' + JSON.stringify(attributes) + '\'' +
+          'class="clickme"' +
+        '>' +
+          '<div class="nested">Example</div>' +
+        '</div>'
+      document.body.appendChild(element)
+      new GOVUK.Modules.GtmClickTracking(element).init()
+    })
+
+    it('includes the expanded state in the gtm attributes', function () {
+      var clickOn = element.querySelector('.clickme')
+      clickOn.click()
+
+      var expectedFirst = {
+        event: 'analytics',
+        event_name: 'event3-name',
+        link_url: window.location.href.substring(window.location.origin.length),
+        ui: {
+          'test-3-1': 'test 3-1 value',
+          'test-3-2': 'test 3-2 value',
+          state: 'opened',
+          text: 'Example'
+        }
+      }
+      expect(window.dataLayer).toEqual([expectedFirst])
+
+      var expectedSecond = {
+        event: 'analytics',
+        event_name: 'event3-name',
+        link_url: window.location.href.substring(window.location.origin.length),
+        ui: {
+          'test-3-1': 'test 3-1 value',
+          'test-3-2': 'test 3-2 value',
+          state: 'closed',
+          text: 'Example'
+        }
+      }
+      element.querySelector('.nested').setAttribute('open', '')
       clickOn.click()
       expect(window.dataLayer).toEqual([expectedFirst, expectedSecond])
     })


### PR DESCRIPTION
Hi @andysellick 

Would you be able to look at this PR? Thanks :+1: (I'm guessing i'll need to update the changelog before merge too)

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
This adds click tracking to the GOV.UK details component. The code:

- Refactors the `aria-expanded` getter function into a generic attribute getter so it can be used for `aria-expanded` and `open`
- Checks if an element can have an 'open' attribute before trying to grab that attribute. This is needed as the closed state for a details attribute is when the `open` attribute doesn't exist. Therefore, you need to check wether the element is allowed to have an `open` attribute in the first place, otherwise every single non-details element would be reported back as `closed` since they are all missing the `open` attribute. This is currently just checking for `govuk-details` in the `data-module` attribute - there might be a safer way to check for this. But this should allow us to extend it to include any component that uses `open` in the future.
- I used slighlty modified tests from the `aria-expanded` tests to make the tests with `open` . Since this code is quite similar to the `aria-expanded` code, do you think we could reduce code duplication between the tests somehow?

## Why
<!-- What are the reasons behind this change being made? -->
The `open` attribute is similar to aria-expanded but has a slightly different 'closed' state, so this needs to be accounted for with extra code.