### PR TITLE
Add Options to Accordion Section Tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add gem-track-click to specific sections of layout_footer ([PR #2800](https://github.com/alphagov/govuk_publishing_components/pull/2800))
 * Change menubar P elements to use H elements ([PR #2817](https://github.com/alphagov/govuk_publishing_components/pull/2817))
+* Add Options to Accordion Section Tracking ([PR #2813](https://github.com/alphagov/govuk_publishing_components/pull/2813))
 
 ## 29.11.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -144,6 +144,18 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
     var action = expanded ? 'accordionOpened' : 'accordionClosed'
     var options = { transport: 'beacon', label: label }
 
+    // optional parameters are added to the parent
+    // heading not the button that is clicked
+    var extraOptions = section.parentElement && section.parentElement.getAttribute('data-track-options')
+
+    // this uses the same logic as track-click.js handleClick
+    // means we can add a custom dimensions on click
+    // (such as the index of the accordion on the page)
+    if (extraOptions) {
+      extraOptions = JSON.parse(extraOptions)
+      for (var k in extraOptions) options[k] = extraOptions[k]
+    }
+
     if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
       window.GOVUK.analytics.trackEvent('pageElementInteraction', action, options)
     }

--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -334,6 +334,8 @@ examples:
       To switch on Google Analytics for each section, on click, pass `track_sections: true` the values passed on open will be
       `Event Action: accordionOpened` / `accordionClosed` `Event Category: pageElementInteraction` and the `Event Label` being the heading text.
 
+      If `track_options` in an item is set, then it is possible to pass a custom dimension when the section is clicked.
+
       (`track_show_all_clicks: true` can be added to track the "Show all sections" button as well, if required)
     data:
       track_sections: true
@@ -343,6 +345,9 @@ examples:
             id: writing-well-for-the-web-3
           content:
             html: <p class="govuk-body">This is content for accordion 1 of 2</p><p class="govuk-body">This content contains a <a href="#anchor-nav-test" class="govuk-link">link</a></p>
+          data_attributes:
+            track_options:
+              dimension114: 1
         - heading:
             text: Writing well for specialists
           content:


### PR DESCRIPTION
## What

The function that fires an analytics event when an accordion is opened or closed can now be passed optional tracking options. This means custom dimensions can now be specified when a user clicks on an accordion section.

## Why

Similar to how link clicks can also append custom dimensions to the analytics event, a request was made that accordion open and close should also include the position (index) of the accordion on the page when clicked. This change means this dimension and any others can be easily added to the accordion open/close event.

[Relevant Trello Card](https://trello.com/c/1Y6WwRZh/1075-add-tracking-for-position-of-accordion-section-on-new-browse-level-2-curated-topics)

