### PR TITLE
Change menubar P elements to use H elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add gem-track-click to specific sections of layout_footer ([PR #2800](https://github.com/alphagov/govuk_publishing_components/pull/2800))
+* Change menubar P elements to use H elements ([PR #2817](https://github.com/alphagov/govuk_publishing_components/pull/2817))
 
 ## 29.11.0
 

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -141,9 +141,9 @@
                   <div class="govuk-grid-row">
                     <div class="govuk-grid-column-one-third-from-desktop">
                       <% if link[:description].present? %>
-                        <p class="govuk-body-l gem-c-layout-super-navigation-header__menu-description">
+                        <h3 class="govuk-body-l gem-c-layout-super-navigation-header__menu-description">
                           <%= link[:description] %>
-                        </p>
+                        </h3>
                       <% end %>
                     </div>
                     <div class="govuk-grid-column-two-thirds-from-desktop">


### PR DESCRIPTION
## What

Improve the accessibility of the main menu by changing `<p>` elements to `<hX>` elements. [Trello](https://trello.com/c/W317oTLq/1067-fix-menubar-items-that-use-p-tags-in-titles-and-not-heading-elements)

## Why

Paragraph elements aren't announced by screen-readers in the same way as heading elements. This can hinder screen-reader users from properly navigating the page. This small fix helps those users by triggering a heading announcement.

## Visual Changes

Not applicable