### PR TITLE
Remove references to manuals-frontend

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -91,7 +91,7 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
     var $expanded = this.getContainingSection($section)
     var $parent = $header.parentElement
 
-    // manuals-frontend features:
+    // government-frontend features (inherited from manuals-frontend):
     // Should the target anchor link be within the same page, open section - navigate normally
     // Should the target anchor link be within a different, closed section, open this section
     // Should the target anchor link be within a different page and different, closed section open this section

--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -15,7 +15,6 @@ module GovukPublishingComponents
         govspeak-preview
         info-frontend
         licence-finder
-        manuals-frontend
         release
         search-admin
         service-manual-frontend

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -13,7 +13,6 @@ module GovukPublishingComponents
           government-frontend
           info-frontend
           licence-finder
-          manuals-frontend
           service-manual-frontend
           smart-answers
           whitehall


### PR DESCRIPTION
## What
Remove manuals frontend from audits, note that manuals-frontend features are now for government-frontend

## Why
Manuals-frontend now retired

https://trello.com/c/OtjBZRjL/1131-manuals-deprecate-manuals-frontend
