### PR TITLE
Improve track click documentation

### DIFF
--- a/docs/analytics/track-click.md
+++ b/docs/analytics/track-click.md
@@ -2,7 +2,7 @@
 
 The gem includes a script that allows tracking to be added to clicked elements with relative ease. It depends upon the main analytics code to function.
 
-Basic use:
+## Basic use
 
 ```html
 <a href="/link"
@@ -16,7 +16,9 @@ Basic use:
 
 **NOTE:**  According to [Google Analytics Help](https://support.google.com/analytics/answer/1033068), event label is optional, but recommended.
 
-Advanced use. Adds a custom dimension of `dimension29` with a value of `dimension-value`, and a `value` of `9`.
+## Advanced use
+
+Adds a custom dimension of `dimension29` with a value of `dimension-value`, and a `value` of `9`.
 
 ```html
 <a href="/link"
@@ -31,7 +33,7 @@ Advanced use. Adds a custom dimension of `dimension29` with a value of `dimensio
 </a>
 ```
 
-Track with arbitrary JSON:
+## Track with arbitrary JSON
 
 ```html
 <a href='/link'
@@ -44,26 +46,33 @@ Track with arbitrary JSON:
 </a>
 ```
 
-Specific tracking can also be applied to elements within a container.
+## Track more than one element
+
+Specific tracking can be applied to multiple elements within a container, by applying the data module once to the parent element.
 
 ```html
 <div data-module="gem-track-click">
+  <p>This element has no tracking.</p>
   <a href="/link1"
     data-track-category="cat1"
     data-track-action="action1"
     data-track-label="label1">
-    Link 1
+    This link has tracking
   </a>
-  <a href="/link2"
-    data-track-category="cat2"
-    data-track-action="action2"
-    data-track-label="label2">
-    Link 2
-  </a>
+  <div>
+    <a href="/link2"
+      data-track-category="cat2"
+      data-track-action="action2"
+      data-track-label="label2">
+      This link also has tracking
+    </a>
+  </div>
 </div>
 ```
 
-Where specific attributes cannot be applied to elements, links can be tracked with the link href as the tracking label (and other attributes set on the parent). The `data-track-links-only` attribute ensures that only link clicks are tracked (without it, any click inside the element is tracked).
+## Track links within content
+
+Where tracking attributes cannot be applied to elements, links can be tracked with the link href as the tracking label (and other attributes set on the parent). The `data-track-links-only` attribute ensures that only link clicks are tracked (without it, any click inside the element is tracked). This is helpful where page content is not editable, e.g. content comes from the content item or a publishing tool.
 
 ```html
 <div data-module="gem-track-click"
@@ -75,6 +84,8 @@ Where specific attributes cannot be applied to elements, links can be tracked wi
 </div>
 ```
 
+## Track links within content within a specific element
+
 To apply tracking to links within a specific element within part of a page, use the `data-limit-to-element-class` attribute. This is helpful where page content is not editable, e.g. content comes from the content item or a publishing tool.
 
 ```html
@@ -83,9 +94,9 @@ To apply tracking to links within a specific element within part of a page, use 
   data-track-action="action"
   data-track-links-only
   data-limit-to-element-class="demoBox">
-  <a class="first" href="/link1">Link clicks will not be tracked</a>
+  <a class="first" href="/link1">This link will not be tracked</a>
   <div class="demoBox">
-    <a class="second" href="/link2">Link clicks will be tracked</a>
+    <a class="second" href="/link2">This link will be tracked</a>
   </div>
 </div>
 ```


### PR DESCRIPTION
## What
Improve the documentation for the `gem-track-click` module. Specifically add headings for each example, clarify some of the example markup, and tweak some of the descriptions.

## Why
Mainly because I keep needing to refer to this doc and there were no headings for the specific examples that I could give a direct link to.

## Visual Changes
None.
