### PR TITLE
Fix issue with detecting aria-expanded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Change menubar P elements to use H elements ([PR #2817](https://github.com/alphagov/govuk_publishing_components/pull/2817))
 * Add Options to Accordion Section Tracking ([PR #2813](https://github.com/alphagov/govuk_publishing_components/pull/2813))
 * Add gtm click tracking for details component ([PR #2811](https://github.com/alphagov/govuk_publishing_components/pull/2811/))
+* Fix aria-expanded issue on gtm accordion click tracing ([PR #2822](https://github.com/alphagov/govuk_publishing_components/pull/2822))
 
 ## 29.11.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
@@ -27,7 +27,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
 
         // Ensure it only tracks aria-expanded in an accordion element, instead of in any child of the clicked element
-        if (target.closest('[data-module="govuk-accordion gem-accordion"]') || target.closest('[data-module="gem-accordion govuk-accordion"]')) {
+        if (target.closest('.gem-c-accordion')) {
           var ariaExpanded = this.getClosestAttribute(target, 'aria-expanded')
         }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
@@ -25,7 +25,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           link_url: window.location.href.substring(window.location.origin.length),
           ui: JSON.parse(target.getAttribute('data-gtm-attributes')) || {}
         }
-        var ariaExpanded = this.getClosestAttribute(target, 'aria-expanded')
+
+        // Ensure it only tracks aria-expanded in an accordion element, instead of in any child of the clicked element
+        if (target.closest('[data-module="govuk-accordion gem-accordion"]') || target.closest('[data-module="gem-accordion govuk-accordion"]')) {
+          var ariaExpanded = this.getClosestAttribute(target, 'aria-expanded')
+        }
+
         /*
           the details component uses an 'open' attribute instead of aria-expanded, so we need to check if we're on a details component.
           since details deletes the 'open' attribute when closed, we need this boolean, otherwise every element which

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
@@ -119,6 +119,7 @@ describe('Google Tag Manager click tracking', function () {
         text: 'some text'
       }
       element.setAttribute('data-gtm-event-name', 'event3-name')
+      element.setAttribute('data-module', 'govuk-accordion gem-accordion')
       element.setAttribute('data-gtm-attributes', JSON.stringify(attributes))
       element.setAttribute('aria-expanded', 'false')
       document.body.appendChild(element)
@@ -152,6 +153,7 @@ describe('Google Tag Manager click tracking', function () {
           text: 'some text'
         }
       }
+      element.setAttribute('data-module', 'gem-accordion govuk-accordion')
       element.setAttribute('aria-expanded', 'true')
       element.click()
       expect(window.dataLayer).toEqual([expectedFirst, expectedSecond])
@@ -209,7 +211,7 @@ describe('Google Tag Manager click tracking', function () {
     })
   })
 
-  describe('doing tracking on an element that contains an expandable element', function () {
+  describe('doing tracking on an accordion element that contains an expandable element', function () {
     beforeEach(function () {
       var attributes = {
         'test-3-1': 'test 3-1 value',
@@ -219,6 +221,7 @@ describe('Google Tag Manager click tracking', function () {
         '<div data-gtm-event-name="event3-name"' +
           'data-gtm-attributes=\'' + JSON.stringify(attributes) + '\'' +
           'class="clickme"' +
+          'data-module="govuk-accordion gem-accordion"' +
         '>' +
           '<button aria-expanded="false">Show</button>' +
         '</div>'
@@ -254,6 +257,7 @@ describe('Google Tag Manager click tracking', function () {
           text: 'Hide'
         }
       }
+      clickOn.setAttribute('data-module', 'gem-accordion govuk-accordion')
       element.querySelector('[aria-expanded]').setAttribute('aria-expanded', 'true')
       element.querySelector('button').textContent = 'Hide'
       clickOn.click()
@@ -310,6 +314,46 @@ describe('Google Tag Manager click tracking', function () {
       clickOn.click()
 
       expect(window.dataLayer).toEqual([expectedFirst, expectedSecond])
+    })
+  })
+
+  describe('doing tracking on an clicked parent element containing a nested accordion', function () {
+    beforeEach(function () {
+      element.innerHTML = `
+      <div data-gtm-event-name="event3-name" class="clickme">
+        <div class='content'>Content</div>
+        <div class='accoridon' data-module="govuk-accordion gem-accordion">
+          <button aria-expanded="false">Show</button>
+        </div>
+      </div>`
+      document.body.appendChild(element)
+      new GOVUK.Modules.GtmClickTracking(element).init()
+    })
+
+    it('should not track the aria-expanded state', function () {
+      var clickOn = element.querySelector('.clickme')
+      clickOn.click()
+      expect(window.dataLayer[0].ui.state).toEqual(undefined)
+    })
+  })
+
+  describe('doing tracking on an clicked parent element containing a details element', function () {
+    beforeEach(function () {
+      element.innerHTML = `
+      <div data-gtm-event-name="event3-name" class="clickme">
+        <div class='content'>Content</div>
+        <details>
+          Details element
+        </details>
+      </div>`
+      document.body.appendChild(element)
+      new GOVUK.Modules.GtmClickTracking(element).init()
+    })
+
+    it('should not track the open/closed state', function () {
+      var clickOn = element.querySelector('.clickme')
+      clickOn.click()
+      expect(window.dataLayer[0].ui.state).toEqual(undefined)
     })
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
@@ -118,8 +118,8 @@ describe('Google Tag Manager click tracking', function () {
         'test-3-2': 'test 3-2 value',
         text: 'some text'
       }
+      element.classList.add('gem-c-accordion')
       element.setAttribute('data-gtm-event-name', 'event3-name')
-      element.setAttribute('data-module', 'govuk-accordion gem-accordion')
       element.setAttribute('data-gtm-attributes', JSON.stringify(attributes))
       element.setAttribute('aria-expanded', 'false')
       document.body.appendChild(element)
@@ -153,7 +153,6 @@ describe('Google Tag Manager click tracking', function () {
           text: 'some text'
         }
       }
-      element.setAttribute('data-module', 'gem-accordion govuk-accordion')
       element.setAttribute('aria-expanded', 'true')
       element.click()
       expect(window.dataLayer).toEqual([expectedFirst, expectedSecond])
@@ -220,8 +219,7 @@ describe('Google Tag Manager click tracking', function () {
       element.innerHTML =
         '<div data-gtm-event-name="event3-name"' +
           'data-gtm-attributes=\'' + JSON.stringify(attributes) + '\'' +
-          'class="clickme"' +
-          'data-module="govuk-accordion gem-accordion"' +
+          'class="gem-c-accordion"' +
         '>' +
           '<button aria-expanded="false">Show</button>' +
         '</div>'
@@ -230,7 +228,7 @@ describe('Google Tag Manager click tracking', function () {
     })
 
     it('includes the expanded state in the gtm attributes', function () {
-      var clickOn = element.querySelector('.clickme')
+      var clickOn = element.querySelector('.gem-c-accordion')
       clickOn.click()
 
       var expectedFirst = {
@@ -257,7 +255,6 @@ describe('Google Tag Manager click tracking', function () {
           text: 'Hide'
         }
       }
-      clickOn.setAttribute('data-module', 'gem-accordion govuk-accordion')
       element.querySelector('[aria-expanded]').setAttribute('aria-expanded', 'true')
       element.querySelector('button').textContent = 'Hide'
       clickOn.click()
@@ -322,7 +319,7 @@ describe('Google Tag Manager click tracking', function () {
       element.innerHTML = `
       <div data-gtm-event-name="event3-name" class="clickme">
         <div class='content'>Content</div>
-        <div class='accoridon' data-module="govuk-accordion gem-accordion">
+        <div class='accoridon' class='gem-c-accordion'">
           <button aria-expanded="false">Show</button>
         </div>
       </div>`


### PR DESCRIPTION
Hi @andysellick 

Would you be able to approve this PR if all is OK?

Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Adds an if statement to check wether `aria-expanded` is inside an accordion component

## Why
<!-- What are the reasons behind this change being made? -->
Without this, imagine you had the following HTML:

```HTML
    <div data-gtm-event-name="event3-name" data-gtm-attributes='${JSON.stringify(attributes)}' class="clickme">
        <div class='content'>
            abc
        </div>
        <div class='accordion'>
            <button aria-expanded="false">Show</button>
        </div>
    </div>
```

Clicking on the parent div would trigger the accordion click tracking to run, since it has a nested `aria-expanded` element inside it. We only want that tracking to run when the accordion is clicked.