### PR TITLE
Remove gem-track-click for individual links, use in header instead

### DIFF
--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -15,12 +15,11 @@
   hide_navigation_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.hide", :label => "navigation")
   show_navigation_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.show", :label => "navigation")
 %>
-<header role="banner" class="gem-c-layout-super-navigation-header">
+<header role="banner" class="gem-c-layout-super-navigation-header" data-module="gem-track-click" data-track-links-only>
   <div class="gem-c-layout-super-navigation-header__container govuk-width-container govuk-clearfix">
     <div class="gem-c-layout-super-navigation-header__header-logo">
       <a
         class="govuk-header__link govuk-header__link--homepage"
-        data-module="gem-track-click"
         data-track-action="logoLink"
         data-track-category="headerClicked"
         data-track-label="<%= logo_link %>"
@@ -100,7 +99,6 @@
               <%= link_to link[:label], link[:href], {
                 class: "gem-c-layout-super-navigation-header__navigation-item-link",
                 data: {
-                  module: "gem-track-click",
                   track_action: "#{tracking_label}Link",
                   track_category: "headerClicked",
                   track_label: link[:href],
@@ -159,7 +157,6 @@
                                 <%= link_to item[:label], item[:href], {
                                   class: link_classes,
                                   data: {
-                                    module: "gem-track-click",
                                     track_action: "#{tracking_label}Link",
                                     track_category: "headerClicked",
                                     track_label: item[:href],
@@ -183,7 +180,6 @@
                                   "gem-c-layout-super-navigation-header__navigation-second-footer-link",
                                 ],
                                 data: {
-                                  module: "gem-track-click",
                                   track_action: "#{tracking_label}Link",
                                   track_category: "headerClicked",
                                   track_label: item[:href],
@@ -312,7 +308,6 @@
                         "gem-c-layout-super-navigation-header__popular-link",
                       ],
                       data: {
-                        module: "gem-track-click",
                         track_action: "popularLink",
                         track_category: "headerClicked",
                         track_label: popular_link[:href],


### PR DESCRIPTION
## What

Remove `data-module="gem-track-click"` from each of the links in the footer, add `data-module="gem-track-click"` to the parent header component instead. 

## Why

Click tracking can be initialised on a parent component instead of each individual component. The previous implementation meant that for each clickable link in the header the module for tracking links was being initialised unnecessarily. Using this alternative approach has benefits such as reducing the number of event listeners by 31 and decreasing memory usage. 

![Screenshot 2022-06-20 at 11 27 52](https://user-images.githubusercontent.com/3727504/174585602-e663d525-e535-4389-b615-fc6e0db55448.png)

Fixes https://github.com/alphagov/govuk_publishing_components/issues/2819