### PR TITLE
Add id attribute to error alert component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Remove accessible format request pilot support ([PR #2826](https://github.com/alphagov/govuk_publishing_components/pull/2826))
 * GTM analytics add page views ([PR #2814](https://github.com/alphagov/govuk_publishing_components/pull/2814))
+* Add id attribute to error alert component ([PR #2825](https://github.com/alphagov/govuk_publishing_components/pull/2825))
 * Add gem-track-click to specific sections of layout_footer ([PR #2800](https://github.com/alphagov/govuk_publishing_components/pull/2800))
 * Change menubar P elements to use H elements ([PR #2817](https://github.com/alphagov/govuk_publishing_components/pull/2817))
 * Add Options to Accordion Section Tracking ([PR #2813](https://github.com/alphagov/govuk_publishing_components/pull/2813))

--- a/app/views/govuk_publishing_components/components/_error_alert.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_alert.html.erb
@@ -1,7 +1,10 @@
-<% description ||= nil %>
-<% data_attributes ||= {} %>
+<%
+  id ||= nil
+  description ||= nil
+  data_attributes ||= {}
+%>
 
-<%= tag.div class: "gem-c-error-alert", data: { module: "initial-focus" }.merge(data_attributes), role: "alert", tabindex: "-1" do %>
+<%= tag.div id: id, class: "gem-c-error-alert", data: { module: "initial-focus" }.merge(data_attributes), role: "alert", tabindex: "-1" do %>
   <% if description.present? %>
     <%= tag.h2 message, class: "gem-c-error-summary__title" %>
     <%= tag.div description, class: "gem-c-error-summary__body" %>

--- a/app/views/govuk_publishing_components/components/docs/error_alert.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_alert.yml
@@ -27,3 +27,7 @@ examples:
       description: A further description
       data_attributes:
         tracking: GTM-123AB
+  with_specified_id_attribute:
+    data:
+      id: test-id
+      message: Message to alert the user to a unsuccessful action goes here

--- a/spec/components/error_alert_spec.rb
+++ b/spec/components/error_alert_spec.rb
@@ -10,6 +10,11 @@ describe "Error Alert", type: :view do
     assert_select ".gem-c-error-alert__message", text: "Foo"
   end
 
+  it "allows an id to be specified" do
+    render_component(message: "Foo", id: "test-id")
+    assert_select "#test-id .gem-c-error-alert__message", text: "Foo"
+  end
+
   it "allows a block to be given for description" do
     render_component(message: "Foo", description: "Bar")
 


### PR DESCRIPTION
## What
Can now add id as a parameter to the error alert component.

## Why
When trying to [add an anchor link to the location form in frontend](https://github.com/alphagov/frontend/pull/3263/), noticed that I could not add an id to the error alert component. Now id is accepted as a param and can be set on error alert.

[Related Trello Card](https://trello.com/c/rCnJ2YEg/1086-fgm-help-and-advice-postcode-search-anchor-link-when-an-error-occurs)

Needed to be merged before https://github.com/alphagov/frontend/pull/3263