### PR TITLE
Remove code for accessible format request pilot.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove accessible format request pilot support ([PR #2826](https://github.com/alphagov/govuk_publishing_components/pull/2826))
 * Add gem-track-click to specific sections of layout_footer ([PR #2800](https://github.com/alphagov/govuk_publishing_components/pull/2800))
 * Change menubar P elements to use H elements ([PR #2817](https://github.com/alphagov/govuk_publishing_components/pull/2817))
 * Add Options to Accordion Section Tracking ([PR #2813](https://github.com/alphagov/govuk_publishing_components/pull/2813))

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -83,9 +83,7 @@
       <% end %>
     <% end %>
 
-    <% if attachment.display_accessible_format_request_form_link? %>
-      <%= link_to "Request an accessible format of this document", "/contact/govuk/request-accessible-format?content_id=#{attachment.owning_document_content_id}&attachment_id=#{attachment.attachment_id}", class: "govuk-link" %>
-    <% elsif attachment.alternative_format_contact_email %>
+    <% if attachment.alternative_format_contact_email %>
       <%= tag.p t("components.attachment.request_format_text"), class: "gem-c-attachment__metadata" %>
       <%= render "govuk_publishing_components/components/details", {
         title: t("components.attachment.request_format_cta")

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -76,17 +76,6 @@ examples:
         content_type: application/pdf
         file_size: 20000
         alternative_format_contact_email: defra.helpline@defra.gsi.gov.uk
-  with_link_to_request_accessible_format_form:
-    data:
-      attachment:
-        title: "Department for Transport information asset register"
-        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/747661/department-for-transport-information-asset-register.csv
-        filename: department-for-transport-information-asset-register.csv
-        content_type: application/pdf
-        file_size: 20000
-        owning_document_content_id: 456_abc
-        attachment_id: 123
-        alternative_format_contact_email: govuk_publishing_components@example.com
   with_data_attributes:
     data:
       attachment:

--- a/lib/govuk_publishing_components/presenters/attachment_helper.rb
+++ b/lib/govuk_publishing_components/presenters/attachment_helper.rb
@@ -1,13 +1,6 @@
 module GovukPublishingComponents
   module Presenters
     class AttachmentHelper
-      # Various departments are taking part in a pilot to use a form
-      # rather than direct email for users to request accessible formats. When the pilot
-      # scheme is rolled out further this can be removed.
-      # Currently DfE, DWP and DVSA are participating in the pilot.
-      EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT = %w[govuk_publishing_components@example.com
-                                                     alternative.formats@education.gov.uk].freeze
-
       delegate :opendocument?, :document?, :spreadsheet?, to: :content_type
 
       attr_reader :attachment_data
@@ -15,7 +8,6 @@ module GovukPublishingComponents
       # Expects a hash of attachment data
       # * title and url are required
       # * content_type, filename, file_size, number of pages, alternative_format_contact_email can be provided
-      # * attachment_id and owning_document_content_id are required to use the accessible format request form
       def initialize(attachment_data)
         @attachment_data = attachment_data.with_indifferent_access
       end
@@ -55,14 +47,6 @@ module GovukPublishingComponents
         attachment_data[:alternative_format_contact_email]
       end
 
-      def attachment_id
-        attachment_data[:attachment_id]
-      end
-
-      def owning_document_content_id
-        attachment_data[:owning_document_content_id]
-      end
-
       def reference
         reference = []
         reference << "ISBN #{attachment_data[:isbn]}" if attachment_data[:isbn].present?
@@ -85,10 +69,6 @@ module GovukPublishingComponents
 
       def is_official_document
         attachment_data[:command_paper_number].present? || attachment_data[:hoc_paper_number].present? || attachment_data[:unnumbered_command_paper].eql?(true) || attachment_data[:unnumbered_hoc_paper].eql?(true)
-      end
-
-      def display_accessible_format_request_form_link?
-        EMAILS_IN_ACCESSIBLE_FORMAT_REQUEST_PILOT.include?(alternative_format_contact_email) && owning_document_content_id.present? && attachment_id.present?
       end
 
       class SupportedContentType

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -86,20 +86,6 @@ describe "Attachment", type: :view do
     assert_select "a[href='mailto:defra.helpline@defra.gsi.gov.uk']"
   end
 
-  it "shows a link to the accesible format request form if the contact email is in the pilot, and an owning document content id and attachment id are provided" do
-    render_component(
-      attachment: {
-        title: "Attachment",
-        url: "attachment",
-        attachment_id: "123",
-        owning_document_content_id: "abc_456",
-        content_type: "application/vnd.oasis.opendocument.spreadsheet",
-        alternative_format_contact_email: "govuk_publishing_components@example.com",
-      },
-    )
-    assert_select "a[href='/contact/govuk/request-accessible-format?content_id=abc_456&attachment_id=123']", text: "Request an accessible format of this document"
-  end
-
   it "does not show opendocument metadata if disabled" do
     render_component(
       attachment: {

--- a/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/attachment_spec.rb
@@ -223,40 +223,4 @@ RSpec.describe GovukPublishingComponents::Presenters::AttachmentHelper do
       expect(attachment.is_official_document).to be false
     end
   end
-
-  describe "#display_accessible_format_request_form_link?" do
-    it "returns true if the attachment id and owning document content id are provided and the alternative email address is in the pilot" do
-      attachment = described_class.new(
-        attachment_id: "123",
-        owning_document_content_id: "456",
-        alternative_format_contact_email: "govuk_publishing_components@example.com",
-      )
-      expect(attachment.display_accessible_format_request_form_link?).to be true
-    end
-
-    it "returns false if the attachment id is not provided" do
-      attachment = described_class.new(
-        owning_document_content_id: "456",
-        alternative_format_contact_email: "govuk_publishing_components@example.com",
-      )
-      expect(attachment.display_accessible_format_request_form_link?).to be false
-    end
-
-    it "returns false if the owning document content id is not provided" do
-      attachment = described_class.new(
-        attachment_id: "123",
-        alternative_format_contact_email: "govuk_publishing_components@example.com",
-      )
-      expect(attachment.display_accessible_format_request_form_link?).to be false
-    end
-
-    it "returns false if the alternative email address is not on the pilot" do
-      attachment = described_class.new(
-        attachment_id: "123",
-        owning_document_content_id: "456",
-        alternative_format_contact_email: "invalid@example.com",
-      )
-      expect(attachment.display_accessible_format_request_form_link?).to be false
-    end
-  end
 end


### PR DESCRIPTION
## What
Support for the Request Accessible Format form is being removed.

## Why
All participating departments have pulled out of the pilot, so removing code makes sense while we rethink. It may be reinstated from the git history, or if the pilot does not recur, we keep the code tidy by removing it.

## Visual Changes
No visual changes, but With Accessible Format Request form option has been removed from items rendered for visual regression check.

https://trello.com/c/iZEzpeFy/1340-remove-dfe-from-the-accessible-format-pilot