### PR TITLE
Version 29.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 29.12.0
 
 * Remove accessible format request pilot support ([PR #2826](https://github.com/alphagov/govuk_publishing_components/pull/2826))
 * GTM analytics add page views ([PR #2814](https://github.com/alphagov/govuk_publishing_components/pull/2814))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (29.11.0)
+    govuk_publishing_components (29.12.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "29.11.0".freeze
+  VERSION = "29.12.0".freeze
 end


### PR DESCRIPTION
## 29.12.0

* Remove accessible format request pilot support ([PR #2826](https://github.com/alphagov/govuk_publishing_components/pull/2826))
* GTM analytics add page views ([PR #2814](https://github.com/alphagov/govuk_publishing_components/pull/2814))
* Add id attribute to error alert component ([PR #2825](https://github.com/alphagov/govuk_publishing_components/pull/2825))
* Add gem-track-click to specific sections of layout_footer ([PR #2800](https://github.com/alphagov/govuk_publishing_components/pull/2800))
* Change menubar P elements to use H elements ([PR #2817](https://github.com/alphagov/govuk_publishing_components/pull/2817))
* Add Options to Accordion Section Tracking ([PR #2813](https://github.com/alphagov/govuk_publishing_components/pull/2813))
* Add gtm click tracking for details component ([PR #2811](https://github.com/alphagov/govuk_publishing_components/pull/2811/))
