### PR TITLE
Check if primary_publisher nil OR empty in meta_tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Check if primary_publisher nil OR empty in meta_tags ([PR #2829](https://github.com/alphagov/govuk_publishing_components/pull/2829))
+
 ## 29.12.0
 
 * Remove accessible format request pilot support ([PR #2826](https://github.com/alphagov/govuk_publishing_components/pull/2826))

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -43,8 +43,8 @@ module GovukPublishingComponents
         meta_tags["govuk:updated-at"] = content_item[:updated_at] if content_item[:updated_at]
         meta_tags["govuk:public-updated-at"] = content_item[:public_updated_at] if content_item[:public_updated_at]
         primary_publisher = content_item.dig(:links, :primary_publishing_organisation)
-        primary_publisher = primary_publisher.first[:title] if primary_publisher
-        meta_tags["govuk:primary-publishing-organisation"] = primary_publisher if primary_publisher
+        primary_publisher = primary_publisher.first[:title] unless primary_publisher.blank?
+        meta_tags["govuk:primary-publishing-organisation"] = primary_publisher unless primary_publisher.blank?
 
         meta_tags
       end

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -379,6 +379,43 @@ describe "Meta tags", type: :view do
     assert_no_meta_tag("govuk:static-analytics:strip-postcodes")
   end
 
+  it "renders govuk:primary-publishing-organisation if primary_publishing_organisation" do
+    content_item = {
+      "links": {
+        "primary_publishing_organisation": [
+          {
+            "title": "an organisation",
+          },
+        ],
+      },
+    }
+
+    render_component(content_item: example_document_for("case_study", "case_study").merge(content_item))
+    assert_meta_tag("govuk:primary-publishing-organisation", "an organisation")
+  end
+
+  it "doesn't render govuk:primary-publishing-organisation if primary_publishing_organisation empty array" do
+    content_item = {
+      "links": {
+        "primary_publishing_organisation": [],
+      },
+    }
+
+    render_component(content_item: example_document_for("case_study", "case_study").merge(content_item))
+    assert_no_meta_tag("govuk:primary-publishing-organisation")
+  end
+
+  it "doesn't render govuk:primary-publishing-organisation if primary_publishing_organisation nil" do
+    content_item = {
+      "links": {
+        "primary_publishing_organisation": nil,
+      },
+    }
+
+    render_component(content_item: example_document_for("case_study", "case_study").merge(content_item))
+    assert_no_meta_tag("govuk:primary-publishing-organisation")
+  end
+
   it "renders the static-analytics:strip-postcodes tag if explicitly told to even if it wouldn't otherwise" do
     render_component(content_item: { document_type: "guidance" }, strip_postcode_pii: true)
     assert_meta_tag("govuk:static-analytics:strip-postcodes", "true")


### PR DESCRIPTION
## What

Add check to meta_tags to make sure primary_publisher is not an empty array before attempting to access a hash in the array.

## Why

Tests were intermittently failing on collections and after some digging, it was discovered that this was because that the random schema generated for tests can occasionally result in `primary_publishing_organisation` being set to an empty array. This would cause accessing the key of the first hash of the array in `meta_tags` to fail which would mean tests would fail. This commit adds `.blank?` to the primary_publisher check which means that if the array is empty then an error will not be caused by this line. This fixes the collections tests but in theory should also fix other intermittently failing tests in other applications.


