### PR TITLE
Add new fields for spam detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add timer field in attempt to reduce spam on feedback component ([PR #2830](https://github.com/alphagov/govuk_publishing_components/pull/2830))
+
 ## 29.12.1
 
 * Standardise some analytics attributes ([PR #2831](https://github.com/alphagov/govuk_publishing_components/pull/2831))

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -142,6 +142,19 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       '<h2>Sorry, we’re unable to send your message as you haven’t given us any information.</h2>',
       ' <p>Please tell us what you were doing or what went wrong</p>'
     ].join('')
+
+    var honeyPot = document.createElement('input')
+    honeyPot.setAttribute('type', 'hidden')
+    honeyPot.setAttribute('name', 'token')
+    var timer = 0;
+    honeyPot.setAttribute('value', timer)
+
+    var timerUpdater = setInterval( function() {
+        timer = timer + 0.5;
+        honeyPot.setAttribute('value', timer)
+    }, 500);
+    this.somethingIsWrongForm.appendChild(honeyPot)
+
   }
 
   Feedback.prototype.setHiddenValuesNotUsefulForm = function (gaClientId) {

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -75,11 +75,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }.bind(this))
 
     this.somethingIsWrongButton.addEventListener('click', function (e) {
-      this.timerFunction = function () {
+      this.timerInterval = setInterval(function () {
         this.timer = this.timer + 1
         this.timerHoneyPot.setAttribute('value', this.timer)
-      }
-      this.timerInterval = setInterval(this.timerFunction.bind(this), 1000)
+      }.bind(this), 1000)
     }.bind(this))
 
     this.somethingIsWrongForm.addEventListener('paste', function (e) {

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -83,21 +83,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }.bind(this), 1000)
     }.bind(this))
 
-    this.pasteListener = function () {
-      this.pastes = this.pastes + 1
-      this.pastesHoneyPot.setAttribute('value', this.pastes)
-    }.bind(this)
-
-    this.keypressListener = function () {
-      this.keypresses = this.keypresses + 1
-      this.keypressHoneyPot.setAttribute('value', this.keypresses)
-    }.bind(this)
-
-    this.whatDoingInput.addEventListener('paste', this.pasteListener)
-    this.whatWrongInput.addEventListener('paste', this.pasteListener)
-    this.whatDoingInput.addEventListener('keypress', this.keypressListener)
-    this.whatWrongInput.addEventListener('keypress', this.keypressListener)
-
     // much of the JS needed to support sending the form contents via this script is
     // unsupported by IE, even IE11. This check causes IE to not intercept form submits
     // and let them happen normally, which is handled already by the backend
@@ -169,26 +154,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     ].join('')
 
     this.timer = 0
-    this.pastes = 0
-    this.keypresses = 0
 
     this.timerHoneyPot = document.createElement('input')
     this.timerHoneyPot.setAttribute('type', 'hidden')
     this.timerHoneyPot.setAttribute('name', 'timer')
     this.timerHoneyPot.setAttribute('value', this.timer)
     this.somethingIsWrongForm.appendChild(this.timerHoneyPot)
-
-    this.pastesHoneyPot = document.createElement('input')
-    this.pastesHoneyPot.setAttribute('type', 'hidden')
-    this.pastesHoneyPot.setAttribute('name', 'pastes')
-    this.pastesHoneyPot.setAttribute('value', this.pastes)
-    this.somethingIsWrongForm.appendChild(this.pastesHoneyPot)
-
-    this.keypressHoneyPot = document.createElement('input')
-    this.keypressHoneyPot.setAttribute('type', 'hidden')
-    this.keypressHoneyPot.setAttribute('name', 'keypresses')
-    this.keypressHoneyPot.setAttribute('value', this.keypresses)
-    this.somethingIsWrongForm.appendChild(this.keypressHoneyPot)
   }
 
   Feedback.prototype.setHiddenValuesNotUsefulForm = function (gaClientId) {

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -76,7 +76,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     this.somethingIsWrongButton.addEventListener('click', function (e) {
       this.timerFunction = function () {
-        this.timer = this.timer + 0.5
+        this.timer = this.timer + 1
         this.timerHoneyPot.setAttribute('value', this.timer)
       }
       this.timerInterval = setInterval(this.timerFunction.bind(this), 500)

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -74,6 +74,28 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.setHiddenValuesNotUsefulForm(gaClientId)
     }.bind(this))
 
+    this.somethingIsWrongButton.addEventListener('click', function (e) {
+      this.timerFunction = function () {
+        this.timer = this.timer + 0.5
+        this.timerHoneyPot.setAttribute('value', this.timer)
+      }
+      this.timerInterval = setInterval(this.timerFunction.bind(this), 500)
+    }.bind(this))
+
+    this.somethingIsWrongForm.addEventListener('paste', function (e) {
+      if (e.target.tagName.toLowerCase() === 'textarea') {
+        this.pastes = this.pastes + 1
+        this.pastesHoneyPot.setAttribute('value', this.pastes)
+      }
+    }.bind(this))
+
+    this.somethingIsWrongForm.addEventListener('keypress', function (e) {
+      if (e.target.tagName.toLowerCase() === 'textarea') {
+        this.keypresses = this.keypresses + 1
+        this.keypressHoneyPot.setAttribute('value', this.keypresses)
+      }
+    }.bind(this))
+
     // much of the JS needed to support sending the form contents via this script is
     // unsupported by IE, even IE11. This check causes IE to not intercept form submits
     // and let them happen normally, which is handled already by the backend
@@ -94,6 +116,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
               this.revealInitialPrompt()
               this.setInitialAriaAttributes()
               this.activeForm.hidden = true
+              clearInterval(this.timerInterval)
             } else {
               this.showError(xhr)
               this.enableSubmitFormButton($form)
@@ -143,18 +166,27 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       ' <p>Please tell us what you were doing or what went wrong</p>'
     ].join('')
 
-    var honeyPot = document.createElement('input')
-    honeyPot.setAttribute('type', 'hidden')
-    honeyPot.setAttribute('name', 'token')
-    var timer = 0;
-    honeyPot.setAttribute('value', timer)
+    this.timer = 0
+    this.pastes = 0
+    this.keypresses = 0
 
-    var timerUpdater = setInterval( function() {
-        timer = timer + 0.5;
-        honeyPot.setAttribute('value', timer)
-    }, 500);
-    this.somethingIsWrongForm.appendChild(honeyPot)
+    this.timerHoneyPot = document.createElement('input')
+    this.timerHoneyPot.setAttribute('type', 'hidden')
+    this.timerHoneyPot.setAttribute('name', 'timer')
+    this.timerHoneyPot.setAttribute('value', this.timer)
+    this.somethingIsWrongForm.appendChild(this.timerHoneyPot)
 
+    this.pastesHoneyPot = document.createElement('input')
+    this.pastesHoneyPot.setAttribute('type', 'hidden')
+    this.pastesHoneyPot.setAttribute('name', 'pastes')
+    this.pastesHoneyPot.setAttribute('value', this.pastes)
+    this.somethingIsWrongForm.appendChild(this.pastesHoneyPot)
+
+    this.keypressHoneyPot = document.createElement('input')
+    this.keypressHoneyPot.setAttribute('type', 'hidden')
+    this.keypressHoneyPot.setAttribute('name', 'keypresses')
+    this.keypressHoneyPot.setAttribute('value', this.keypresses)
+    this.somethingIsWrongForm.appendChild(this.keypressHoneyPot)
   }
 
   Feedback.prototype.setHiddenValuesNotUsefulForm = function (gaClientId) {
@@ -198,6 +230,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         .focus()
     } else {
       this.activeForm = false
+      clearInterval(this.timerInterval)
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -19,6 +19,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.promptSuccessMessage = this.$module.querySelector('.js-prompt-success')
     this.surveyWrapper = this.$module.querySelector('#survey-wrapper')
     this.jshiddenClass = 'js-hidden'
+    this.whatDoingInput = this.$module.querySelector('[name=what_doing]')
+    this.whatWrongInput = this.$module.querySelector('[name=what_wrong]')
   }
 
   Feedback.prototype.init = function () {
@@ -81,19 +83,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }.bind(this), 1000)
     }.bind(this))
 
-    this.somethingIsWrongForm.addEventListener('paste', function (e) {
-      if (e.target.tagName.toLowerCase() === 'textarea') {
-        this.pastes = this.pastes + 1
-        this.pastesHoneyPot.setAttribute('value', this.pastes)
-      }
-    }.bind(this))
+    this.pasteListener = function () {
+      this.pastes = this.pastes + 1
+      this.pastesHoneyPot.setAttribute('value', this.pastes)
+    }.bind(this)
 
-    this.somethingIsWrongForm.addEventListener('keypress', function (e) {
-      if (e.target.tagName.toLowerCase() === 'textarea') {
-        this.keypresses = this.keypresses + 1
-        this.keypressHoneyPot.setAttribute('value', this.keypresses)
-      }
-    }.bind(this))
+    this.keypressListener = function () {
+      this.keypresses = this.keypresses + 1
+      this.keypressHoneyPot.setAttribute('value', this.keypresses)
+    }.bind(this)
+
+    this.whatDoingInput.addEventListener('paste', this.pasteListener)
+    this.whatWrongInput.addEventListener('paste', this.pasteListener)
+    this.whatDoingInput.addEventListener('keypress', this.keypressListener)
+    this.whatWrongInput.addEventListener('keypress', this.keypressListener)
 
     // much of the JS needed to support sending the form contents via this script is
     // unsupported by IE, even IE11. This check causes IE to not intercept form submits

--- a/app/assets/javascripts/govuk_publishing_components/components/feedback.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/feedback.js
@@ -79,7 +79,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         this.timer = this.timer + 1
         this.timerHoneyPot.setAttribute('value', this.timer)
       }
-      this.timerInterval = setInterval(this.timerFunction.bind(this), 500)
+      this.timerInterval = setInterval(this.timerFunction.bind(this), 1000)
     }.bind(this))
 
     this.somethingIsWrongForm.addEventListener('paste', function (e) {

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -765,7 +765,7 @@ describe('Feedback component', function () {
       var $whatDoing = $form.querySelector('[name=what_doing]')
       var $whatWrong = $form.querySelector('[name=what_wrong]')
 
-      var pasteEvent = new ClipboardEvent('paste')
+      var pasteEvent = new window.ClipboardEvent('paste')
 
       $whatDoing.dispatchEvent(pasteEvent)
       $whatWrong.dispatchEvent(pasteEvent)
@@ -779,7 +779,7 @@ describe('Feedback component', function () {
       var $whatDoing = $form.querySelector('[name=what_doing]')
       var $whatWrong = $form.querySelector('[name=what_wrong]')
 
-      var keypressEvent = new KeyboardEvent('keypress')
+      var keypressEvent = new window.KeyboardEvent('keypress')
 
       $whatDoing.dispatchEvent(keypressEvent)
       $whatWrong.dispatchEvent(keypressEvent)

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -738,6 +738,56 @@ describe('Feedback component', function () {
     })
   }
 
+  describe('testing honeypot metadata on the "report a problem" form', function () {
+    beforeEach(function () {
+      jasmine.clock().install()
+      loadFeedbackComponent()
+      $('.js-something-is-wrong')[0].click()
+    })
+
+    afterEach(function () {
+      jasmine.clock().uninstall()
+    })
+
+    it('has an incrementing timer field', function () {
+      var $form = $('.gem-c-feedback #something-is-wrong')
+      var $timer = $form.find('input[name=timer]')
+      expect($timer.val()).toBe('0')
+      jasmine.clock().tick(1000)
+      expect($timer.val()).toBe('1')
+      jasmine.clock().tick(3000)
+      expect($timer.val()).toBe('4')
+    })
+
+    it('has a paste detection field', function () {
+      var $form = document.querySelector('.gem-c-feedback #something-is-wrong')
+      var $pastes = $form.querySelector('input[name=pastes]')
+      var $whatDoing = $form.querySelector('[name=what_doing]')
+      var $whatWrong = $form.querySelector('[name=what_wrong]')
+
+      var pasteEvent = new ClipboardEvent('paste')
+
+      $whatDoing.dispatchEvent(pasteEvent)
+      $whatWrong.dispatchEvent(pasteEvent)
+
+      expect($pastes.value).toBe('2')
+    })
+
+    it('has a keypress detection field', function () {
+      var $form = document.querySelector('.gem-c-feedback #something-is-wrong')
+      var $keypresses = $form.querySelector('input[name=keypresses]')
+      var $whatDoing = $form.querySelector('[name=what_doing]')
+      var $whatWrong = $form.querySelector('[name=what_wrong]')
+
+      var keypressEvent = new KeyboardEvent('keypress')
+
+      $whatDoing.dispatchEvent(keypressEvent)
+      $whatWrong.dispatchEvent(keypressEvent)
+
+      expect($keypresses.value).toBe('2')
+    })
+  })
+
   function loadFeedbackComponent () {
     new GOVUK.Modules.Feedback($('.gem-c-feedback')[0]).init()
   }

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -351,7 +351,10 @@ describe('Feedback component', function () {
           what_doing: ['I was looking for some information about local government.'],
           what_wrong: ['The background should be green.'],
           referrer: ['unknown'],
-          javascript_enabled: ['true']
+          javascript_enabled: ['true'],
+          timer: ['0'],
+          pastes: ['0'],
+          keypresses: ['0']
         })
       })
 

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -352,9 +352,7 @@ describe('Feedback component', function () {
           what_wrong: ['The background should be green.'],
           referrer: ['unknown'],
           javascript_enabled: ['true'],
-          timer: ['0'],
-          pastes: ['0'],
-          keypresses: ['0']
+          timer: ['0']
         })
       })
 
@@ -757,34 +755,6 @@ describe('Feedback component', function () {
       expect($timer.val()).toBe('1')
       jasmine.clock().tick(3000)
       expect($timer.val()).toBe('4')
-    })
-
-    it('has a paste detection field', function () {
-      var $form = document.querySelector('.gem-c-feedback #something-is-wrong')
-      var $pastes = $form.querySelector('input[name=pastes]')
-      var $whatDoing = $form.querySelector('[name=what_doing]')
-      var $whatWrong = $form.querySelector('[name=what_wrong]')
-
-      var pasteEvent = new window.ClipboardEvent('paste')
-
-      $whatDoing.dispatchEvent(pasteEvent)
-      $whatWrong.dispatchEvent(pasteEvent)
-
-      expect($pastes.value).toBe('2')
-    })
-
-    it('has a keypress detection field', function () {
-      var $form = document.querySelector('.gem-c-feedback #something-is-wrong')
-      var $keypresses = $form.querySelector('input[name=keypresses]')
-      var $whatDoing = $form.querySelector('[name=what_doing]')
-      var $whatWrong = $form.querySelector('[name=what_wrong]')
-
-      var keypressEvent = new window.KeyboardEvent('keypress')
-
-      $whatDoing.dispatchEvent(keypressEvent)
-      $whatWrong.dispatchEvent(keypressEvent)
-
-      expect($keypresses.value).toBe('2')
     })
   })
 


### PR DESCRIPTION
Hi @andysellick 

Would you be able to review this PR? 

Not sure if it needs new tests, and if so what the tests would be.

Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Adds:
- A timer hidden field to see how quickly the form is submitted. Uses `setInterval` to update the field.
- A paste count hidden field and listener which detects how many pastes are inserted into the form `textarea`.
- A keypress count hidden field and listener which detects how many keypresses are inserted into the form `textarea`.

It then works in combination with the backend to filter out the spam: https://github.com/alphagov/feedback/pull/1452

## Why
<!-- What are the reasons behind this change being made? -->
We are experimenting using JS to provide metadata which might help reduce spam on the feedback component.

