### PR TITLE
Standardise some analytics attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Standardise some analytics attributes ([PR #2831](https://github.com/alphagov/govuk_publishing_components/pull/2831))
 * Check if primary_publisher nil OR empty in meta_tags ([PR #2829](https://github.com/alphagov/govuk_publishing_components/pull/2829))
 * Add date of birth autocomplete option for date input ([PR #2802](https://github.com/alphagov/govuk_publishing_components/pull/2802))
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
@@ -16,7 +16,7 @@
           },
           publishing: {
             document_type: this.getMetaContent('format'),
-            publishing_application: this.getMetaContent('publishing-application'),
+            publishing_app: this.getMetaContent('publishing-app'),
             rendering_application: this.getMetaContent('rendering-application'),
             schema_name: this.getMetaContent('schema-name'),
             content_id: this.getMetaContent('content-id')

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
@@ -17,7 +17,7 @@
           publishing: {
             document_type: this.getMetaContent('format'),
             publishing_app: this.getMetaContent('publishing-app'),
-            rendering_application: this.getMetaContent('rendering-application'),
+            rendering_app: this.getMetaContent('rendering-app'),
             schema_name: this.getMetaContent('schema-name'),
             content_id: this.getMetaContent('content-id')
           },

--- a/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js
@@ -64,7 +64,7 @@
       'taxon-slugs': { dimension: 58, defaultValue: 'other' },
       'taxon-ids': { dimension: 59, defaultValue: 'other' },
       'content-has-history': { dimension: 39, defaultValue: 'false' },
-      'publishing-application': { dimension: 89 },
+      'publishing-app': { dimension: 89 },
       'brexit-audience': { dimension: 112 },
       'brexit-superbreadcrumb': { dimension: 111 },
       stepnavs: { dimension: 96 },

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -29,7 +29,7 @@ module GovukPublishingComponents
 
       def add_core_tags(meta_tags)
         meta_tags["govuk:format"] = content_item[:document_type] if content_item[:document_type]
-        meta_tags["govuk:publishing-application"] = content_item[:publishing_app] if content_item[:publishing_app]
+        meta_tags["govuk:publishing-app"] = content_item[:publishing_app] if content_item[:publishing_app]
         meta_tags["govuk:schema-name"] = content_item[:schema_name] if content_item[:schema_name]
         meta_tags["govuk:content-id"] = content_item[:content_id] if content_item[:content_id]
         meta_tags["govuk:navigation-page-type"] = content_item[:navigation_page_type] if content_item[:navigation_page_type]

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -27,9 +27,12 @@ module GovukPublishingComponents
 
     private
 
+      # other meta tags are inserted by slimmer here:
+      # https://github.com/alphagov/slimmer/blob/82144be372aa4afc1f8ff30917c96c2ee3a47ed8/lib/slimmer/processors/metadata_inserter.rb#L15
       def add_core_tags(meta_tags)
         meta_tags["govuk:format"] = content_item[:document_type] if content_item[:document_type]
         meta_tags["govuk:publishing-app"] = content_item[:publishing_app] if content_item[:publishing_app]
+        meta_tags["govuk:rendering-app"] = content_item[:rendering_app] if content_item[:rendering_app]
         meta_tags["govuk:schema-name"] = content_item[:schema_name] if content_item[:schema_name]
         meta_tags["govuk:content-id"] = content_item[:content_id] if content_item[:content_id]
         meta_tags["govuk:navigation-page-type"] = content_item[:navigation_page_type] if content_item[:navigation_page_type]

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -12,7 +12,7 @@ describe "Meta tags", type: :view do
   it "renders with an example case study" do
     render_component(content_item: example_document_for("case_study", "case_study"))
     assert_meta_tag("govuk:format", "case_study")
-    assert_meta_tag("govuk:publishing-application", "whitehall")
+    assert_meta_tag("govuk:publishing-app", "whitehall")
     assert_meta_tag("govuk:analytics:organisations", "<L2><W4>")
     assert_meta_tag("govuk:analytics:world-locations", "<WL3>")
   end

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -13,8 +13,12 @@ describe "Meta tags", type: :view do
     render_component(content_item: example_document_for("case_study", "case_study"))
     assert_meta_tag("govuk:format", "case_study")
     assert_meta_tag("govuk:publishing-app", "whitehall")
+    assert_meta_tag("govuk:rendering-app", "government-frontend")
     assert_meta_tag("govuk:analytics:organisations", "<L2><W4>")
     assert_meta_tag("govuk:analytics:world-locations", "<WL3>")
+    assert_meta_tag("govuk:first-published-at", "2012-12-17T15:45:44.000+00:00")
+    assert_meta_tag("govuk:updated-at", "2018-08-04T10:18:42.566Z")
+    assert_meta_tag("govuk:public-updated-at", "2012-12-17T15:45:44.000+00:00")
   end
 
   it "no meta tags are rendered when there's no trackable data" do
@@ -34,6 +38,7 @@ describe "Meta tags", type: :view do
   it "renders organisation meta tag if current page is organisation" do
     render_component(content_item: example_document_for("organisation", "organisation"))
     assert_meta_tag("govuk:analytics:organisations", "<D1197>")
+    assert_meta_tag("govuk:primary-publishing-organisation", "Department for Exiting the European Union")
   end
 
   it "renders organisations in a meta tag with angle brackets" do

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
@@ -11,6 +11,7 @@ describe('Google Tag Manager click tracking', function () {
 
   afterEach(function () {
     document.body.removeChild(element)
+    window.location.hash = ''
   })
 
   describe('configuring tracking incompletely', function () {
@@ -50,6 +51,29 @@ describe('Google Tag Manager click tracking', function () {
         event: 'analytics',
         event_name: 'event-name',
         link_url: window.location.href.substring(window.location.origin.length),
+        ui: {
+          'test-1': 'test-1 value',
+          'test-2': 'test-2 value'
+        }
+      }
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('gets the full URL including a hash', function () {
+      var currentUrl = window.location.href.substring(window.location.origin.length)
+      // fix a bug where running the test in a browser more than once left a
+      // dangling # that broke the expected URL - would be (url)##myhash
+      var lastChar = currentUrl.substr(currentUrl.length - 1)
+      if (lastChar === '#') {
+        currentUrl = currentUrl.slice(0, -1)
+      }
+      window.location.hash = 'myhash'
+
+      element.click()
+      var expected = {
+        event: 'analytics',
+        event_name: 'event-name',
+        link_url: currentUrl + '#myhash',
         ui: {
           'test-1': 'test-1 value',
           'test-2': 'test-2 value'

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
@@ -19,7 +19,7 @@ describe('Google Tag Manager page view tracking', function () {
       publishing: {
         document_type: 'n/a',
         publishing_app: 'n/a',
-        rendering_application: 'n/a',
+        rendering_app: 'n/a',
         schema_name: 'n/a',
         content_id: 'n/a'
       },
@@ -92,8 +92,8 @@ describe('Google Tag Manager page view tracking', function () {
         value: 'whitehall'
       },
       {
-        gtmName: 'rendering_application',
-        tagName: 'rendering-application',
+        gtmName: 'rendering_app',
+        tagName: 'rendering-app',
         value: 'government-frontend'
       },
       {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
@@ -18,7 +18,7 @@ describe('Google Tag Manager page view tracking', function () {
       },
       publishing: {
         document_type: 'n/a',
-        publishing_application: 'n/a',
+        publishing_app: 'n/a',
         rendering_application: 'n/a',
         schema_name: 'n/a',
         content_id: 'n/a'
@@ -87,8 +87,8 @@ describe('Google Tag Manager page view tracking', function () {
         value: 'detailed_guide'
       },
       {
-        gtmName: 'publishing_application',
-        tagName: 'publishing-application',
+        gtmName: 'publishing_app',
+        tagName: 'publishing-app',
         value: 'whitehall'
       },
       {

--- a/spec/javascripts/govuk_publishing_components/analytics/custom-dimensions.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/custom-dimensions.spec.js
@@ -45,7 +45,7 @@ describe('custom dimensions', function () {
       'taxon-slugs': { dimension: 58, defaultValue: 'other', testValue: 'test-58' },
       'taxon-ids': { dimension: 59, defaultValue: 'other', testValue: 'test-59' },
       'content-has-history': { dimension: 39, defaultValue: 'false', testValue: 'test-39' },
-      'publishing-application': { dimension: 89, testValue: 'test-89' },
+      'publishing-app': { dimension: 89, testValue: 'test-89' },
       'brexit-audience': { dimension: 112, testValue: 'test-112' },
       'brexit-superbreadcrumb': { dimension: 111, testValue: 'test-111' },
       stepnavs: { dimension: 96, testValue: 'test-96' },


### PR DESCRIPTION
## What
Rename some of the attributes used by GA4 page views.

## Why
Trying to clean up some of the code and standardise the names. Ideally the name of something in the content item would persist through to the metadata, the JS and on into GA4, rather than being slightly different at various stages, which could cause confusion in future.

## Visual Changes
None.

Trello cards: 

- https://trello.com/c/mizG5QKy/4-add-tracking-page-views
- https://trello.com/c/GDLkrUws/335-page-views-data-naming-inconsistencies