### PR TITLE
Add extra options for show/hide all sections accordion click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Bump govuk-frontend from 4.1.0 to 4.2.0 ([PR #2836](https://github.com/alphagov/govuk_publishing_components/pull/2836))
 * Add personally identifiable information (PII) remover to GTM ([PR #2842](https://github.com/alphagov/govuk_publishing_components/pull/2842))
 * Fix broken preview link for "previous and next navigation" component ([PR #2853](https://github.com/alphagov/govuk_publishing_components/pull/2853))
+* Add extra options for show/hide all sections accordion click ([PR #2840](https://github.com/alphagov/govuk_publishing_components/pull/2840))
 
 ## 29.13.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -124,6 +124,16 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
       var label = expanded ? 'Show all sections' : 'Hide all sections'
       var action = expanded ? 'accordionOpened' : 'accordionClosed'
       var options = { transport: 'beacon', label: label }
+
+      var extraOptions = event.target && event.target.getAttribute('data-track-options')
+
+      // this uses the same logic as track-click.js handleClick
+      // means we can add a custom dimensions on click
+      if (extraOptions) {
+        extraOptions = JSON.parse(extraOptions)
+        for (var k in extraOptions) options[k] = extraOptions[k]
+      }
+
       if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
         window.GOVUK.analytics.trackEvent('pageElementInteraction', action, options)
       }

--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -189,7 +189,7 @@ examples:
 
       Each item can also have a `data_attributes` hash. These `data_attributes` are placed on the `button` that triggers the opening and closing - useful for differentiating between each section of the accordion.
 
-      Data attributes can also be added to the 'Show/hide all' link using the `data_attributes_show_all` option, primarily where custom tracking is required. These attributes are read from the accordion markup and then added to the link by JavaScript (which is how the link is created).
+      Data attributes can also be added to the 'Show/hide all' link using the `data_attributes_show_all` option, primarily where custom tracking is required. These attributes are read from the accordion markup and then added to the link by JavaScript (which is how the link is created). If `track_options` within `data_attributes_show_all` is set, then it is possible to pass a custom dimension when 'Show/Hide all' is clicked.
     data:
       data_attributes:
           gtm: gtm-accordion
@@ -197,6 +197,7 @@ examples:
       data_attributes_show_all:
         gtm-event-name: example
         gtm-attributes: "{ 'ui': { 'type': 'type value', 'section': 'section value' } }"
+        tracking-options: "{ 'dimension114': 1 }"
       items:
         - heading:
             text: Writing well for the web

--- a/spec/javascripts/components/accordion-spec.js
+++ b/spec/javascripts/components/accordion-spec.js
@@ -16,6 +16,16 @@ describe('Accordion component', function () {
       '</div>' +
       '<div class="govuk-accordion__section">' +
         '<div class="govuk-accordion__section-header">' +
+          '<h2 class="govuk-accordion__section-heading" data-track-count="accordionSection" data-track-options="{&quot;dimension114&quot;:1}">' +
+            '<button type="button" class="govuk-accordion__section-button" aria-expanded="false">' +
+              '<span class="govuk-accordion__section-heading-text">' +
+                'Accordion Section Heading Text' +
+              '</span>' +
+            '</button>' +
+          '</h2>' +
+        '</div>' +
+      '<div class="govuk-accordion__section">' +
+        '<div class="govuk-accordion__section-header">' +
           '<h2 class="govuk-accordion__section-heading">' +
             '<span class="govuk-accordion__section-button" id="default-id-078ef791-heading-1">Writing well for the web</span>' +
           '</h2>' +
@@ -41,6 +51,8 @@ describe('Accordion component', function () {
   }
 
   beforeEach(function () {
+    spyOn(GOVUK.analytics, 'trackEvent')
+
     container = document.createElement('div')
     container.innerHTML = html
     document.body.appendChild(container)
@@ -49,6 +61,32 @@ describe('Accordion component', function () {
 
   afterEach(function () {
     document.body.removeChild(container)
+    if (GOVUK.analytics.trackEvent.calls) {
+      GOVUK.analytics.trackEvent.calls.reset()
+    }
+  })
+
+  it('applies custom attributes to click event if specified in section', function () {
+    accordion.setAttribute('data-track-sections', 'true')
+
+    startAccordion()
+    document.querySelector('.govuk-accordion__section-header button').click()
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionOpened', { transport: 'beacon', label: 'Accordion Section Heading Text', dimension114: 1 })
+  })
+
+  it('applies custom attributes to click event if specified in show/hide section', function () {
+    var object = {
+      'track-options': JSON.stringify({
+        dimensionExample: 'Example value'
+      })
+    }
+
+    accordion.setAttribute('data-track-show-all-clicks', 'true')
+    accordion.setAttribute('data-show-all-attributes', JSON.stringify(object))
+
+    startAccordion()
+    document.querySelector('.gem-c-accordion__show-all').click()
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionClosed', Object({ transport: 'beacon', label: 'Hide all sections', dimensionExample: 'Example value' }))
   })
 
   it('applies given data attributes to the show/hide all link', function () {
@@ -60,11 +98,15 @@ describe('Accordion component', function () {
     }
     var wrappingObject = {
       'gtm-event-name': 'example',
-      'show-all-attributes': JSON.stringify(object)
+      'show-all-attributes': JSON.stringify(object),
+      'track-options': JSON.stringify({
+        dimensionExample: 'Example value'
+      })
     }
     accordion.setAttribute('data-show-all-attributes', JSON.stringify(wrappingObject))
     startAccordion()
     expect(document.querySelector('.govuk-accordion__show-all').getAttribute('data-gtm-event-name')).toEqual('example')
     expect(document.querySelector('.govuk-accordion__show-all').getAttribute('data-show-all-attributes')).toEqual(JSON.stringify(object))
+    expect(document.querySelector('.govuk-accordion__show-all').getAttribute('data-track-options')).toEqual(JSON.stringify({ dimensionExample: 'Example value' }))
   })
 })


### PR DESCRIPTION
## What

Adds ability to add extra options to the click anayltics event for showing/hiding all the sections of an accordion.

## Why

In a [previous PR ](https://github.com/alphagov/govuk_publishing_components/pull/2813)I added the ability to add extra options to click events for opening sections in an accordion but I did not include the Show/Hide All Sections button. For tracking purposes it means that if an attribute is not passed in an event, then an event cannot be filtered on that attribute. Therefore adding the ability to pass attributes to the Show/Hide All Sections button means it can be more easily inlcuded in searches/filters on click events.

[Relevant Trello Card](https://trello.com/c/hDJRk2hS/1096-add-tracking-for-position-of-show-hide-all-sections-in-accordion-on-new-browse-level-2-curated-topics)