### PR TITLE
Add GTM Personally Identifiable Information remover

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
@@ -5,7 +5,7 @@
   var GOVUK = global.GOVUK || {}
 
   GOVUK.Gtm = {
-    PiiRemover: new GOVUK.PiiRemover(),
+    PIIRemover: new GOVUK.PIIRemover(),
     sendPageView: function () {
       if (window.dataLayer) {
         var data = {
@@ -50,15 +50,15 @@
     },
 
     getLocation: function () {
-      return this.PiiRemover.stripPII(document.location.href)
+      return this.PIIRemover.stripPII(document.location.href)
     },
 
     getReferrer: function () {
-      return this.PiiRemover.stripPIIWithOverride(document.referrer, true, true)
+      return this.PIIRemover.stripPIIWithOverride(document.referrer, true, true)
     },
 
     getTitle: function () {
-      return this.PiiRemover.stripPII(document.title)
+      return this.PIIRemover.stripPII(document.title)
     },
 
     // window.httpStatusCode is set in the source of the error page in static

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
@@ -1,9 +1,11 @@
+//= require ./pii-remover
 ;(function (global) {
   'use strict'
 
   var GOVUK = global.GOVUK || {}
 
   GOVUK.Gtm = {
+    PiiRemover: new GOVUK.PiiRemover(),
     sendPageView: function () {
       if (window.dataLayer) {
         var data = {
@@ -48,15 +50,15 @@
     },
 
     getLocation: function () {
-      return document.location.href
+      return this.PiiRemover.stripPII(document.location.href)
     },
 
     getReferrer: function () {
-      return document.referrer
+      return this.PiiRemover.stripPII(document.referrer, true)
     },
 
     getTitle: function () {
-      return document.title
+      return this.PiiRemover.stripPII(document.title)
     },
 
     // window.httpStatusCode is set in the source of the error page in static

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
@@ -54,7 +54,7 @@
     },
 
     getReferrer: function () {
-      return this.PiiRemover.stripPII(document.referrer, true)
+      return this.PiiRemover.stripPIIWithOverride(document.referrer, true, true)
     },
 
     getTitle: function () {

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
@@ -1,0 +1,119 @@
+;(function (global) {
+  'use strict'
+
+  var GOVUK = global.GOVUK || {}
+  var EMAIL_PATTERN = /[^\s=/?&#]+(?:@|%40)[^\s=/?&]+/g
+  var POSTCODE_PATTERN = /\b[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9](?!refund)[ABD-HJLNPQ-Z]{2,3}\b/gi
+  var DATE_PATTERN = /\d{4}(-?)\d{2}(-?)\d{2}/g
+  var ESCAPE_REGEX_PATTERN = /[|\\{}()[\]^$+*?.]/g
+
+  // specific URL parameters to be redacted from accounts URLs
+  var RESET_PASSWORD_TOKEN_PATTERN = /reset_password_token=[a-zA-Z0-9-]+/g
+  var UNLOCK_TOKEN_PATTERN = /unlock_token=[a-zA-Z0-9-]+/g
+  var STATE_PATTERN = /state=.[^&]+/g
+
+  function shouldStripDates () {
+    var metas = document.querySelectorAll('meta[name="govuk:static-analytics:strip-dates"]')
+    return metas.length > 0
+  }
+
+  function shouldStripPostcodes () {
+    var metas = document.querySelectorAll('meta[name="govuk:static-analytics:strip-postcodes"]')
+    return metas.length > 0
+  }
+
+  function queryStringParametersToStrip () {
+    var meta = document.querySelector('meta[name="govuk:static-analytics:strip-query-string-parameters"]')
+    var value = false
+    if (meta) {
+      value = meta.getAttribute('content')
+    }
+    var parameters = []
+
+    if (value) {
+      var split = value.split(',')
+      for (var i = 0; i < split.length; i++) {
+        parameters.push(split[i].trim())
+      }
+    }
+
+    return parameters
+  }
+
+  var PiiRemover = function () {
+    this.stripDatePII = shouldStripDates()
+    this.stripPostcodePII = shouldStripPostcodes()
+    this.queryStringParametersToStrip = queryStringParametersToStrip()
+  }
+
+  PiiRemover.prototype.PIISafe = function (value) {
+    this.value = value
+  }
+
+  PiiRemover.prototype.stripPIIFromString = function (string, stripAllOverride) {
+    var stripped = string.replace(EMAIL_PATTERN, '[email]')
+    stripped = stripped.replace(RESET_PASSWORD_TOKEN_PATTERN, 'reset_password_token=[reset_password_token]')
+    stripped = stripped.replace(UNLOCK_TOKEN_PATTERN, 'unlock_token=[unlock_token]')
+    stripped = stripped.replace(STATE_PATTERN, 'state=[state]')
+    stripped = this.stripQueryStringParameters(stripped)
+
+    if (this.stripDatePII === true || stripAllOverride === true) {
+      stripped = stripped.replace(DATE_PATTERN, '[date]')
+    }
+    if (this.stripPostcodePII === true || stripAllOverride === true) {
+      stripped = stripped.replace(POSTCODE_PATTERN, '[postcode]')
+    }
+    return stripped
+  }
+
+  PiiRemover.prototype.stripPIIFromObject = function (object) {
+    if (object) {
+      if (object instanceof this.PIISafe) {
+        return object.value
+      } else {
+        for (var property in object) {
+          var value = object[property]
+
+          object[property] = this.stripPII(value)
+        }
+        return object
+      }
+    }
+  }
+
+  PiiRemover.prototype.stripPIIFromArray = function (array) {
+    for (var i = 0, l = array.length; i < l; i++) {
+      var elem = array[i]
+
+      array[i] = this.stripPII(elem)
+    }
+    return array
+  }
+
+  PiiRemover.prototype.stripPII = function (value) {
+    if (typeof value === 'string') {
+      return this.stripPIIFromString(value)
+    } else if (Object.prototype.toString.call(value) === '[object Array]' || Object.prototype.toString.call(value) === '[object Arguments]') {
+      return this.stripPIIFromArray(value)
+    } else if (typeof value === 'object') {
+      return this.stripPIIFromObject(value)
+    } else {
+      return value
+    }
+  }
+
+  PiiRemover.prototype.stripQueryStringParameters = function (string) {
+    for (var i = 0; i < this.queryStringParametersToStrip.length; i++) {
+      var parameter = this.queryStringParametersToStrip[i]
+      var escaped = parameter.replace(ESCAPE_REGEX_PATTERN, '\\$&')
+      var regexp = new RegExp('((?:\\?|&)' + escaped + '=)(?:[^&#\\s]*)', 'g')
+      string = string.replace(regexp, '$1[' + parameter + ']')
+    }
+
+    return string
+  }
+
+  GOVUK.PiiRemover = PiiRemover
+
+  global.GOVUK = GOVUK
+})(window)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
@@ -40,17 +40,17 @@
     return parameters
   }
 
-  var PiiRemover = function () {
+  var PIIRemover = function () {
     this.stripDatePII = shouldStripDates()
     this.stripPostcodePII = shouldStripPostcodes()
     this.queryStringParametersToStrip = queryStringParametersToStrip()
   }
 
-  PiiRemover.prototype.PIISafe = function (value) {
+  PIIRemover.prototype.PIISafe = function (value) {
     this.value = value
   }
 
-  PiiRemover.prototype.stripPIIWithOverride = function (value, enableDateStripping, enablePostcodeStripping) {
+  PIIRemover.prototype.stripPIIWithOverride = function (value, enableDateStripping, enablePostcodeStripping) {
     var oldStripDatePII = this.stripDatePII
     var oldPostcodePII = this.stripPostcodePII
 
@@ -65,7 +65,7 @@
     return strippedValue
   }
 
-  PiiRemover.prototype.stripPIIFromString = function (string) {
+  PIIRemover.prototype.stripPIIFromString = function (string) {
     var stripped = string.replace(EMAIL_PATTERN, '[email]')
     stripped = stripped.replace(RESET_PASSWORD_TOKEN_PATTERN, 'reset_password_token=[reset_password_token]')
     stripped = stripped.replace(UNLOCK_TOKEN_PATTERN, 'unlock_token=[unlock_token]')
@@ -81,7 +81,7 @@
     return stripped
   }
 
-  PiiRemover.prototype.stripPIIFromObject = function (object) {
+  PIIRemover.prototype.stripPIIFromObject = function (object) {
     if (object) {
       if (object instanceof this.PIISafe) {
         return object.value
@@ -96,7 +96,7 @@
     }
   }
 
-  PiiRemover.prototype.stripPIIFromArray = function (array) {
+  PIIRemover.prototype.stripPIIFromArray = function (array) {
     for (var i = 0, l = array.length; i < l; i++) {
       var elem = array[i]
 
@@ -105,7 +105,7 @@
     return array
   }
 
-  PiiRemover.prototype.stripPII = function (value) {
+  PIIRemover.prototype.stripPII = function (value) {
     if (typeof value === 'string') {
       return this.stripPIIFromString(value)
     } else if (Object.prototype.toString.call(value) === '[object Array]' || Object.prototype.toString.call(value) === '[object Arguments]') {
@@ -117,7 +117,7 @@
     }
   }
 
-  PiiRemover.prototype.stripQueryStringParameters = function (string) {
+  PIIRemover.prototype.stripQueryStringParameters = function (string) {
     for (var i = 0; i < this.queryStringParametersToStrip.length; i++) {
       var parameter = this.queryStringParametersToStrip[i]
       var escaped = parameter.replace(ESCAPE_REGEX_PATTERN, '\\$&')
@@ -128,7 +128,7 @@
     return string
   }
 
-  GOVUK.PiiRemover = PiiRemover
+  GOVUK.PIIRemover = PIIRemover
 
   global.GOVUK = GOVUK
 })(window)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
@@ -50,12 +50,12 @@
     this.value = value
   }
 
-  PiiRemover.prototype.stripPIIWithOverride = function (value, dateIsEnabled, postcodeIsEnabled) {
+  PiiRemover.prototype.stripPIIWithOverride = function (value, enableDateStripping, enablePostcodeStripping) {
     var oldStripDatePII = this.stripDatePII
     var oldPostcodePII = this.stripPostcodePII
 
-    this.stripDatePII = dateIsEnabled
-    this.stripPostcodePII = postcodeIsEnabled
+    this.stripDatePII = enableDateStripping
+    this.stripPostcodePII = enablePostcodeStripping
 
     var strippedValue = this.stripPII(value)
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
@@ -50,17 +50,32 @@
     this.value = value
   }
 
-  PiiRemover.prototype.stripPIIFromString = function (string, stripAllOverride) {
+  PiiRemover.prototype.stripPIIWithOverride = function (value, dateIsEnabled, postcodeIsEnabled) {
+    var oldStripDatePII = this.stripDatePII
+    var oldPostcodePII = this.stripPostcodePII
+
+    this.stripDatePII = dateIsEnabled
+    this.stripPostcodePII = postcodeIsEnabled
+
+    var strippedValue = this.stripPII(value)
+
+    this.stripDatePII = oldStripDatePII
+    this.stripPostcodePII = oldPostcodePII
+
+    return strippedValue
+  }
+
+  PiiRemover.prototype.stripPIIFromString = function (string) {
     var stripped = string.replace(EMAIL_PATTERN, '[email]')
     stripped = stripped.replace(RESET_PASSWORD_TOKEN_PATTERN, 'reset_password_token=[reset_password_token]')
     stripped = stripped.replace(UNLOCK_TOKEN_PATTERN, 'unlock_token=[unlock_token]')
     stripped = stripped.replace(STATE_PATTERN, 'state=[state]')
     stripped = this.stripQueryStringParameters(stripped)
 
-    if (this.stripDatePII === true || stripAllOverride === true) {
+    if (this.stripDatePII === true) {
       stripped = stripped.replace(DATE_PATTERN, '[date]')
     }
-    if (this.stripPostcodePII === true || stripAllOverride === true) {
+    if (this.stripPostcodePII) {
       stripped = stripped.replace(POSTCODE_PATTERN, '[postcode]')
     }
     return stripped

--- a/docs/analytics-gtm/pii-remover.md
+++ b/docs/analytics-gtm/pii-remover.md
@@ -1,0 +1,103 @@
+# Stripping Personally Identifiable Information (PII)
+
+A module exists for stripping out PII from values. It can accept strings, query parameters, arrays or objects. If the value is an array or object, the child values are looped through and then treated as strings.
+
+99% of the code has been taken from the legacy universal analytics PII redaction code.
+
+## What is redacted
+
+The values that are redacted by default are:
+- Email addresses - `email@gov.uk` becomes `[email]`
+- Reset password tokens become `reset_password_token=[reset_password_token]`
+- Unlock tokens become `unlock_token=[unlock_token]`
+- State values become `state=[state]`
+
+Additional values that can be redacted are:
+- Dates - `2022-02-22` becomes `[date]`
+- Postcodes - `sw1a 1aa` becomes `[postcode]`
+
+
+These aren't enabled by default due to the higher likelihood of producing false positives.
+
+Query string parameters are redacted if there is presence of a `meta[name="govuk:static-analytics:strip-query-string-parameters"]` meta tag, with comma separated query string parameters keys in its `content` attribute. The usage of this query string PII removal in production is unknown at this time.
+
+
+### Enabling additional redaction
+
+In order to enable additional redaction you can:
+
+#### Add meta tags to your application via the `Meta Tags` publishing component:
+
+##### For query string parameters:
+
+Add this meta tag with your query string parameter keys in the `content` section:
+`<meta name="govuk:static-analytics:strip-query-string-parameters" content="query-string-key-1,query-string-key-2"`
+
+##### For dates and postcodes:
+
+```Ruby
+<%= render "govuk_publishing_components/components/meta_tags", {
+  content_item: null,
+  local_assigns: {
+    strip_dates_pii: true,
+    strip_postcodes_pii: true
+  }
+} %>
+```
+
+The `shouldStripDates()` and `shouldStripPostcodes()` functions in the JavaScript will then check if these values exist in order to strip dates and postcodes.
+
+However, this will redact dates and postcodes from every call of the PIIRemover. In order to apply extra redaction to specific values, you can use the `stripPIIWithOverride()` function
+
+
+#### Using the stripPIIWithOverride() function
+
+You can call this function to manually enable the date or postcode stripping on a specific value:
+
+```JavaScript
+var enableDateStripping = true
+var enablePostCodeStripping = true
+var myRedactedValue = this.PIIRemover.stripPIIWithOverride(myValue, enableDateStripping, enablePostcodeStripping)
+```
+
+### Preventing redaction from running on a value
+
+There is a `PIISafe` class that you can wrap your objects or strings in.
+
+`var myValue = new this.PIIRemover.PIISafe(myValue)`
+
+If `myValue` is then passed through to a `stripPII` function, instead of having its PII redacted, its original value will be returned, bypassing any redaction.
+
+## Basic use
+```JavaScript
+var PIIRemover = new GOVUK.PIIRemover()
+
+var myInfo = 'this is an@email.com address, this is a 2019-01-21 date, this is a sw1a 1aa postcode,'
+
+var example1 = PIIRemover.stripPII(myInfo)
+// this is [email] address, this is a 2019-01-21 date, this is a sw1a 1aa postcode 
+
+var example2 = PIIRemover.stripPIIWithOverride(myInfo, true, false)
+// this is [email] address, this is a [date] date, this is a sw1a 1aa postcode
+
+var example3 = PIIRemover.stripPIIWithOverride(myInfo, true, true)
+// this is [email] address, this is a [date] date, this is a [postcode] postcode
+
+var myObject = {'email': 'email@gov.uk', 'other': 'value', 'piiSafe': new PIIRemover.PIISafe('example@gov.uk')}
+
+var example4 = PIIRemover.stripPII(myObject)
+// {'email' : '[email]', 'other': 'value', 'piiSafe': 'example@gov.uk'}
+
+var myArray = ['email@gov.uk', 'hello world']
+var example5 = PIIRemover.stripPII(myArray)
+// ['[email]', 'hello world']
+
+// Meta tag of <meta name="govuk:static-analytics:strip-query-string-parameters" content="strip-parameter-1,strip-parameter-2" />
+var myQueryString = '/test?strip-parameter-1=secret&strip-parameter-2=more-secret'
+var example6 = PIIRemover.stripPII(myQueryString)
+// /test?strip-parameter-1=[strip-parameter-1]&strip-parameter-2=[strip-parameter-2]
+```
+
+The modifications from the universal analytics PII code are that:
+- It now prevents email addresses prepended with a # having the # removed in redaction. This was changed as a valid test was failing due to the # unexpectedly being caught in the redaction.
+- A function was added to manually override wether dates and postcodes are stripped. This was added because we are only applying the PII to certain values now. In Universal Analytics PII was being applied to every value unless it was set as `PIISafe`. Enabling Dates and Postcodes on UA was also done in a way that applied it to every stripPII calls - you weren't easily able to have some values only strip emails, and some strip email, postcodes and dates.

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
@@ -247,4 +247,34 @@ describe('Google Tag Manager page view tracking', function () {
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
+
+  it('removes email pii from the title, location and referrer', function () {
+    document.title = 'example@gov.uk'
+    expected.page.title = '[email]'
+
+    spyOnProperty(document, 'referrer', 'get').and.returnValue('https://gov.uk/example@gov.uk')
+    expected.page.referrer = 'https://gov.uk/[email]'
+
+    // We can't spy on location, so instead we use an anchor link to change the URL temporarily
+
+    // Reset the URL so we can build the expected link string
+    const linkForURLMock = document.createElement('a')
+    linkForURLMock.href = '#'
+    linkForURLMock.click()
+    const location = document.location.href
+
+    expected.page.location = location + '[email]'
+
+    // Add email address to the current page location
+    linkForURLMock.href = '#example@gov.uk'
+    linkForURLMock.click()
+
+    GOVUK.Gtm.sendPageView()
+
+    // Reset the page location for other tests
+    linkForURLMock.href = '#'
+    linkForURLMock.click()
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
@@ -182,6 +182,34 @@ describe('GOVUK.PiiRemover', function () {
     })
   })
 
+  describe('when the override to strip dates and postcodes is present', function () {
+    beforeEach(function () {
+      pageWantsDatesStripped()
+      pageWantsPostcodesStripped()
+      pii = new GOVUK.PiiRemover()
+    })
+
+    it('observes the override and strips out emails', function () {
+      var string = pii.stripPIIWithOverride('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date', false, false)
+      expect(string).toEqual('this is [email] address, this is a sw1a 1aa postcode, this is a 2019-01-21 date')
+    })
+
+    it('observes the override and strips out emails and dates', function () {
+      var string = pii.stripPIIWithOverride('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date', true, false)
+      expect(string).toEqual('this is [email] address, this is a sw1a 1aa postcode, this is a [date] date')
+    })
+
+    it('observes the override and strips out emails and postcodes', function () {
+      var string = pii.stripPIIWithOverride('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date', false, true)
+      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a 2019-01-21 date')
+    })
+
+    it('observes the override and strips out emails, postcodes and dates', function () {
+      var string = pii.stripPIIWithOverride('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date', true, true)
+      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a [date] date')
+    })
+  })
+
   function resetHead () {
     $('head').find('meta[name="govuk:static-analytics:strip-postcodes"]').remove()
     $('head').find('meta[name="govuk:static-analytics:strip-dates"]').remove()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
@@ -1,0 +1,202 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+describe('GOVUK.PiiRemover', function () {
+  var pii
+
+  beforeEach(function () {
+    resetHead()
+    pii = new GOVUK.PiiRemover()
+  })
+
+  afterEach(function () {
+    resetHead()
+  })
+
+  describe('by default', function () {
+    it('strips email addresses, but not postcodes and dates from strings', function () {
+      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date')
+      expect(string).toEqual('this is [email] address, this is a sw1a 1aa postcode, this is a 2019-01-21 date')
+    })
+
+    it('strips email addresses but not dates and postcodes from objects', function () {
+      var obj = {
+        email: 'this is an@email.com address',
+        postcode: 'this is a sw1a 1aa postcode',
+        date: 'this is a 2019-01-21 date'
+      }
+
+      var strippedObj = {
+        email: 'this is [email] address',
+        postcode: 'this is a sw1a 1aa postcode',
+        date: 'this is a 2019-01-21 date'
+      }
+
+      obj = pii.stripPII(obj)
+      expect(obj).toEqual(strippedObj)
+    })
+
+    it('strips email addresses but not dates and postcodes from arrays', function () {
+      var arr = [
+        'this is an@email.com address',
+        'this is a sw1a 1aa postcode',
+        'this is a 2019-01-21 date'
+      ]
+
+      var strippedArr = [
+        'this is [email] address',
+        'this is a sw1a 1aa postcode',
+        'this is a 2019-01-21 date'
+      ]
+
+      arr = pii.stripPII(arr)
+      expect(arr).toEqual(strippedArr)
+    })
+  })
+
+  describe('by default for account specific PII', function () {
+    it('redacts the expected list of URL parameters', function () {
+      var resetPasswordToken = pii.stripPII('https://www.account.publishing.service.gov.uk/new-account?reset_password_token=4be6f4db-f32a-4d75-b0c7-3b3533ff31c4&somethingelse=24342fdjfskf')
+      expect(resetPasswordToken).toEqual('https://www.account.publishing.service.gov.uk/new-account?reset_password_token=[reset_password_token]&somethingelse=24342fdjfskf')
+
+      var unlockToken = pii.stripPII('https://www.account.publishing.service.gov.uk/new-account?unlock_token=4be6f4db-f32a-4d75-b0c7-3b3533ff31c4&somethingelse=24342fdjfskf')
+      expect(unlockToken).toEqual('https://www.account.publishing.service.gov.uk/new-account?unlock_token=[unlock_token]&somethingelse=24342fdjfskf')
+
+      var state = pii.stripPII('https://www.account.publishing.service.gov.uk/new-account?state=4be6f4db-f32a-4d75-b0c7-3b3533ff31c4&somethingelse=24342fdjfskf')
+      expect(state).toEqual('https://www.account.publishing.service.gov.uk/new-account?state=[state]&somethingelse=24342fdjfskf')
+    })
+  })
+
+  describe('when configured to remove all PII', function () {
+    beforeEach(function () {
+      pageWantsDatesStripped()
+      pageWantsPostcodesStripped()
+      pii = new GOVUK.PiiRemover()
+    })
+
+    it('strips email addresses, postcodes and dates from strings', function () {
+      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date')
+      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a [date] date')
+    })
+
+    it('strips all PII from objects', function () {
+      var obj = {
+        email: 'this is an@email.com address',
+        postcode: 'this is a sw1a 1aa postcode',
+        date: 'this is a 2019-01-21 date',
+        uuid: 'd6c2de5d-ef90-45d1-82d4-5f2438369eea'
+      }
+
+      var strippedObj = {
+        email: 'this is [email] address',
+        postcode: 'this is a [postcode] postcode',
+        date: 'this is a [date] date',
+        uuid: 'd6c2de5d-ef90-45d1-82d4-5f2438369eea'
+      }
+
+      obj = pii.stripPII(obj)
+      expect(obj).toEqual(strippedObj)
+    })
+
+    it('strips all PII from arrays', function () {
+      var arr = [
+        'this is an@email.com address',
+        'this is a sw1a 1aa postcode',
+        'this is a 2019-01-21 date'
+      ]
+
+      var strippedArr = [
+        'this is [email] address',
+        'this is a [postcode] postcode',
+        'this is a [date] date'
+      ]
+
+      arr = pii.stripPII(arr)
+      expect(arr).toEqual(strippedArr)
+    })
+  })
+
+  describe('when there is a a govuk:static-analytics:strip-postcodes meta tag present', function () {
+    beforeEach(function () {
+      pageWantsPostcodesStripped()
+      pii = new GOVUK.PiiRemover()
+    })
+
+    it('observes the meta tag and strips out postcodes', function () {
+      expect(pii.stripPostcodePII).toEqual(true)
+      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a long GL194LYX postcode, this is a 2019-01-21 date, this is a d6c2de5d-ef90-45d1-82d4-5f2438369eea content ID, this is a p800refund')
+      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a long [postcode] postcode, this is a 2019-01-21 date, this is a d6c2de5d-ef90-45d1-82d4-5f2438369eea content ID, this is a p800refund')
+    })
+
+    it('doesn\'t strip out UUIDs in URLs', function () {
+      expect(pii.stripPostcodePII).toEqual(true)
+      var string = pii.stripPII('gov.uk/thing?postcode=sw1a1aa&uuid=d6c2de5d-ef90-45d1-82d4-5f2438369eea')
+      expect(string).toEqual('gov.uk/thing?postcode=[postcode]&uuid=d6c2de5d-ef90-45d1-82d4-5f2438369eea')
+    })
+  })
+
+  describe('when there is a govuk:static-analytics:strip-query-string-parameters meta tag present', function () {
+    afterEach(function () {
+      resetHead()
+    })
+
+    it('strips specified query strings that are identified in a string', function () {
+      pageWantsQueryStringParametersStripped(['strip-parameter-1', 'strip-parameter-2'])
+      pii = new GOVUK.PiiRemover()
+      var string = pii.stripPII('this is a string with a url /test?strip-parameter-1=secret&strip-parameter-2=more-secret')
+      expect(string).toEqual('this is a string with a url /test?strip-parameter-1=[strip-parameter-1]&strip-parameter-2=[strip-parameter-2]')
+    })
+
+    it('can strip query strings with special characters', function () {
+      pageWantsQueryStringParametersStripped(['parameter[]'])
+      pii = new GOVUK.PiiRemover()
+      var string = pii.stripPII('/url?parameter[]=secret&parameter[]=more-secret')
+      expect(string).toEqual('/url?parameter[]=[parameter[]]&parameter[]=[parameter[]]')
+    })
+
+    it('matches a URL with a fragment', function () {
+      pageWantsQueryStringParametersStripped(['parameter'])
+      pii = new GOVUK.PiiRemover()
+      var string = pii.stripPII('/url?parameter=secret#anchor')
+      expect(string).toEqual('/url?parameter=[parameter]#anchor')
+    })
+
+    it('doesn\'t match params without a query string prefix', function () {
+      pageWantsQueryStringParametersStripped(['parameter'])
+      pii = new GOVUK.PiiRemover()
+      var string = pii.stripPII('parameter=secret')
+      expect(string).toEqual('parameter=secret')
+    })
+  })
+
+  describe('when there is a a govuk:static-analytics:strip-dates meta tag present', function () {
+    beforeEach(function () {
+      pageWantsDatesStripped()
+      pii = new GOVUK.PiiRemover()
+    })
+
+    it('observes the meta tag and strips out dates', function () {
+      expect(pii.stripDatePII).toEqual(true)
+      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date')
+      expect(string).toEqual('this is [email] address, this is a sw1a 1aa postcode, this is a [date] date')
+    })
+  })
+
+  function resetHead () {
+    $('head').find('meta[name="govuk:static-analytics:strip-postcodes"]').remove()
+    $('head').find('meta[name="govuk:static-analytics:strip-dates"]').remove()
+    $('head').find('meta[name="govuk:static-analytics:strip-query-string-parameters"]').remove()
+  }
+
+  function pageWantsDatesStripped () {
+    $('head').append('<meta name="govuk:static-analytics:strip-dates" value="does not matter" />')
+  }
+
+  function pageWantsPostcodesStripped () {
+    $('head').append('<meta name="govuk:static-analytics:strip-postcodes" value="does not matter" />')
+  }
+
+  function pageWantsQueryStringParametersStripped (parameters) {
+    $('head').append('<meta name="govuk:static-analytics:strip-query-string-parameters" content="' + parameters.join(', ') + '" />')
+  }
+})

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
@@ -1,12 +1,12 @@
 /* eslint-env jasmine, jquery */
 /* global GOVUK */
 
-describe('GOVUK.PiiRemover', function () {
+describe('GOVUK.PIIRemover', function () {
   var pii
 
   beforeEach(function () {
     resetHead()
-    pii = new GOVUK.PiiRemover()
+    pii = new GOVUK.PIIRemover()
   })
 
   afterEach(function () {
@@ -71,7 +71,7 @@ describe('GOVUK.PiiRemover', function () {
     beforeEach(function () {
       pageWantsDatesStripped()
       pageWantsPostcodesStripped()
-      pii = new GOVUK.PiiRemover()
+      pii = new GOVUK.PIIRemover()
     })
 
     it('strips email addresses, postcodes and dates from strings', function () {
@@ -119,7 +119,7 @@ describe('GOVUK.PiiRemover', function () {
   describe('when there is a a govuk:static-analytics:strip-postcodes meta tag present', function () {
     beforeEach(function () {
       pageWantsPostcodesStripped()
-      pii = new GOVUK.PiiRemover()
+      pii = new GOVUK.PIIRemover()
     })
 
     it('observes the meta tag and strips out postcodes', function () {
@@ -142,28 +142,28 @@ describe('GOVUK.PiiRemover', function () {
 
     it('strips specified query strings that are identified in a string', function () {
       pageWantsQueryStringParametersStripped(['strip-parameter-1', 'strip-parameter-2'])
-      pii = new GOVUK.PiiRemover()
+      pii = new GOVUK.PIIRemover()
       var string = pii.stripPII('this is a string with a url /test?strip-parameter-1=secret&strip-parameter-2=more-secret')
       expect(string).toEqual('this is a string with a url /test?strip-parameter-1=[strip-parameter-1]&strip-parameter-2=[strip-parameter-2]')
     })
 
     it('can strip query strings with special characters', function () {
       pageWantsQueryStringParametersStripped(['parameter[]'])
-      pii = new GOVUK.PiiRemover()
+      pii = new GOVUK.PIIRemover()
       var string = pii.stripPII('/url?parameter[]=secret&parameter[]=more-secret')
       expect(string).toEqual('/url?parameter[]=[parameter[]]&parameter[]=[parameter[]]')
     })
 
     it('matches a URL with a fragment', function () {
       pageWantsQueryStringParametersStripped(['parameter'])
-      pii = new GOVUK.PiiRemover()
+      pii = new GOVUK.PIIRemover()
       var string = pii.stripPII('/url?parameter=secret#anchor')
       expect(string).toEqual('/url?parameter=[parameter]#anchor')
     })
 
     it('doesn\'t match params without a query string prefix', function () {
       pageWantsQueryStringParametersStripped(['parameter'])
-      pii = new GOVUK.PiiRemover()
+      pii = new GOVUK.PIIRemover()
       var string = pii.stripPII('parameter=secret')
       expect(string).toEqual('parameter=secret')
     })
@@ -172,7 +172,7 @@ describe('GOVUK.PiiRemover', function () {
   describe('when there is a a govuk:static-analytics:strip-dates meta tag present', function () {
     beforeEach(function () {
       pageWantsDatesStripped()
-      pii = new GOVUK.PiiRemover()
+      pii = new GOVUK.PIIRemover()
     })
 
     it('observes the meta tag and strips out dates', function () {
@@ -186,7 +186,7 @@ describe('GOVUK.PiiRemover', function () {
     beforeEach(function () {
       pageWantsDatesStripped()
       pageWantsPostcodesStripped()
-      pii = new GOVUK.PiiRemover()
+      pii = new GOVUK.PIIRemover()
     })
 
     it('observes the override and strips out emails', function () {


### PR DESCRIPTION
Hi @andysellick 

Would you be able to approve this if all is OK?

Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
This takes the PII removal code from Universal Analytics and moves it to our gtm code. Some modifications to the PII code have been made, which are:
- It now prevents email addresses prepended with a `#` from having the `#` removed in redaction. This was needed as a valid test was failing due to the # unexpectedly being caught in the redaction.
- A function  - `stripPIIWithOverride()` - was added to manually override wether dates and postcodes are stripped. This was added because we are only applying the PII to certain values now. In Universal Analytics, PII was being applied to every value, unless it was wrapped in a `PIISafe` class. Enabling Dates and Postcodes on UA was also done in a way that applied it to every stripPII calls - you weren't easily able to have some values only strip emails, and then other values strip email, postcodes and dates.
- The `PIISafe` class now exists within the `PIIRemover` module - in UA it existed in `GOVUK.Analytics` which created an unnecessary dependancy. Theoretically the `PIIRemover` can be used outside of analytics code now.
- The `referrer` value in Pageview tracking has maximum redaction on it - we'll need to measure the impact of this (if it creates any false positives.)

## Why
<!-- What are the reasons behind this change being made? -->
We need to be able to remove PII from values pushed to GTM. We are removing all the UA code eventually so separate file were created.

## Testing

You could test it by running `static` with a local publishing components, and the GTM environment variables in static's `docker-compose.yml`. You can then view `gem_layout.html.erb` in your browser, and edit the page title in `_gem_base.html.erb` to contain an email address.  You would then see the redaction on the title working if you inspect `window.dataLayer`. 