### PR TITLE
Rename GA4 analytics attribute state to action

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
@@ -40,11 +40,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
         if (ariaExpanded) {
           data.ui.text = data.ui.text || target.innerText
-          data.ui.state = (ariaExpanded === 'false') ? 'opened' : 'closed'
+          data.ui.action = (ariaExpanded === 'false') ? 'opened' : 'closed'
         } else if (detailsElement) {
           data.ui.text = data.ui.text || detailsElement.textContent
           var openAttribute = detailsElement.getAttribute('open')
-          data.ui.state = (openAttribute == null) ? 'opened' : 'closed'
+          data.ui.action = (openAttribute == null) ? 'opened' : 'closed'
         }
 
         window.dataLayer.push(data)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
@@ -160,7 +160,7 @@ describe('Google Tag Manager click tracking', function () {
         ui: {
           'test-3-1': 'test 3-1 value',
           'test-3-2': 'test 3-2 value',
-          state: 'opened',
+          action: 'opened',
           text: 'some text'
         }
       }
@@ -173,7 +173,7 @@ describe('Google Tag Manager click tracking', function () {
         ui: {
           'test-3-1': 'test 3-1 value',
           'test-3-2': 'test 3-2 value',
-          state: 'closed',
+          action: 'closed',
           text: 'some text'
         }
       }
@@ -211,7 +211,7 @@ describe('Google Tag Manager click tracking', function () {
         ui: {
           'test-3-1': 'test 3-1 value',
           'test-3-2': 'test 3-2 value',
-          state: 'opened',
+          action: 'opened',
           text: 'some text'
         }
       }
@@ -224,7 +224,7 @@ describe('Google Tag Manager click tracking', function () {
         ui: {
           'test-3-1': 'test 3-1 value',
           'test-3-2': 'test 3-2 value',
-          state: 'closed',
+          action: 'closed',
           text: 'some text'
         }
       }
@@ -262,7 +262,7 @@ describe('Google Tag Manager click tracking', function () {
         ui: {
           'test-3-1': 'test 3-1 value',
           'test-3-2': 'test 3-2 value',
-          state: 'opened',
+          action: 'opened',
           text: 'Show'
         }
       }
@@ -275,7 +275,7 @@ describe('Google Tag Manager click tracking', function () {
         ui: {
           'test-3-1': 'test 3-1 value',
           'test-3-2': 'test 3-2 value',
-          state: 'closed',
+          action: 'closed',
           text: 'Hide'
         }
       }
@@ -314,7 +314,7 @@ describe('Google Tag Manager click tracking', function () {
         ui: {
           'test-3-1': 'test 3-1 value',
           'test-3-2': 'test 3-2 value',
-          state: 'opened',
+          action: 'opened',
           text: 'Example'
         }
       }
@@ -327,7 +327,7 @@ describe('Google Tag Manager click tracking', function () {
         ui: {
           'test-3-1': 'test 3-1 value',
           'test-3-2': 'test 3-2 value',
-          state: 'closed',
+          action: 'closed',
           text: 'Example'
         }
       }
@@ -354,7 +354,7 @@ describe('Google Tag Manager click tracking', function () {
     it('should not track the aria-expanded state', function () {
       var clickOn = element.querySelector('.clickme')
       clickOn.click()
-      expect(window.dataLayer[0].ui.state).toEqual(undefined)
+      expect(window.dataLayer[0].ui.action).toEqual(undefined)
     })
   })
 
@@ -374,7 +374,7 @@ describe('Google Tag Manager click tracking', function () {
     it('should not track the open/closed state', function () {
       var clickOn = element.querySelector('.clickme')
       clickOn.click()
-      expect(window.dataLayer[0].ui.state).toEqual(undefined)
+      expect(window.dataLayer[0].ui.action).toEqual(undefined)
     })
   })
 })


### PR DESCRIPTION
## What / why
Changes the name of the state attribute in the new GA4 code to action.

- rename is to avoid ambiguity
- will also need updating in applications where data attributes are passed

## Visual Changes
None.

Trello card: https://trello.com/c/BRyCFCVf/334-uistate-should-be-uiaction
