### PR TITLE
Add file locations to component audits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * Add White Arrow to Action Link Options ([PR #2851](https://github.com/alphagov/govuk_publishing_components/pull/2851))
 * Bump govuk-frontend from 4.1.0 to 4.2.0 ([PR #2836](https://github.com/alphagov/govuk_publishing_components/pull/2836))
+* Add file locations to component audits ([PR #2849](https://github.com/alphagov/govuk_publishing_components/pull/2849))
 * Add personally identifiable information (PII) remover to GTM ([PR #2842](https://github.com/alphagov/govuk_publishing_components/pull/2842))
 * Fix broken preview link for "previous and next navigation" component ([PR #2853](https://github.com/alphagov/govuk_publishing_components/pull/2853))
 * Add extra options for show/hide all sections accordion click ([PR #2840](https://github.com/alphagov/govuk_publishing_components/pull/2840))

--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -6,6 +6,7 @@ module GovukPublishingComponents
       @path = path
       application_found = application_exists(path)
       components_found = []
+      @component_locations = {}
       @gem_style_references = []
       @jquery_references = []
 
@@ -25,15 +26,15 @@ module GovukPublishingComponents
         @find_all_javascripts = /\/\/ *= require govuk_publishing_components\/all_components/
         find_javascripts = /(?<=require govuk_publishing_components\/components\/)[a-zA-Z_-]+/
 
-        components_in_templates = find_components(templates, find_components, "templates") || []
-        components_in_stylesheets = find_components(stylesheets, find_stylesheets, "stylesheets") || []
-        components_in_print_stylesheets = find_components(stylesheets, find_print_stylesheets, "print_stylesheets") || []
-        components_in_javascripts = find_components(javascripts, find_javascripts, "javascripts") || []
+        components_in_templates = find_components(templates, find_components, "templates", true) || []
+        components_in_stylesheets = find_components(stylesheets, find_stylesheets, "stylesheets", false) || []
+        components_in_print_stylesheets = find_components(stylesheets, find_print_stylesheets, "print_stylesheets", false) || []
+        components_in_javascripts = find_components(javascripts, find_javascripts, "javascripts", false) || []
 
         ruby_paths = %w[/app/helpers/ /app/presenters/ /lib/]
         components_in_ruby = []
         ruby_paths.each do |ruby_path|
-          components_in_ruby << find_components(Dir["#{path}#{ruby_path}**/*.{rb,erb}"], find_components, "ruby") || []
+          components_in_ruby << find_components(Dir["#{path}#{ruby_path}**/*.{rb,erb}"], find_components, "ruby", true) || []
         end
         components_in_ruby = components_in_ruby.flatten.uniq
 
@@ -67,17 +68,32 @@ module GovukPublishingComponents
         components_found: components_found,
         gem_style_references: @gem_style_references.flatten.uniq.sort,
         jquery_references: @jquery_references.flatten.uniq.sort,
+        component_locations: @component_locations,
       }
     end
 
   private
 
-    def find_components(files, find, type)
+    def find_components(files, find, type, keep_locations)
       components_found = []
 
       files.each do |file|
         src = File.read(file)
-        components_found << find_match(find, src, type)
+
+        if keep_locations
+          components = find_match(find, src, type)
+          if components.any?
+            components_found << components
+            components.each do |component|
+              component_sym = component.to_sym
+              @component_locations[component_sym] = [] unless @component_locations[component_sym]
+              @component_locations[component_sym] << clean_file_path(file)
+              @component_locations[component_sym].sort!
+            end
+          end
+        else
+          components_found << find_match(find, src, type)
+        end
 
         if type == "javascripts"
           jquery_references = find_code_references(file, src, /\$\(/)
@@ -93,12 +109,16 @@ module GovukPublishingComponents
       components_found.flatten.uniq.sort
     end
 
+    # looks for components in the given src of a file
+    # returns an array of component names or an empty array
     def find_match(find, src, type)
       return %w[all] if src.match(@find_all_stylesheets) && type == "stylesheets"
       return %w[all] if src.match(@find_all_print_stylesheets) && type == "print_stylesheets"
       return %w[all] if src.match(@find_all_javascripts) && type == "javascripts"
 
       matches = src.scan(find)
+      return [] unless matches.any?
+
       all_matches = []
       matches.each do |match|
         all_matches << clean_file_name(match.tr('[])\'"', ""))
@@ -108,9 +128,11 @@ module GovukPublishingComponents
     end
 
     def find_code_references(file, src, regex)
-      clean_file_path = /(?<=#{Regexp.escape(@path.to_s)}\/)[\/a-zA-Z_-]+.[a-zA-Z.]+/
+      return clean_file_path(file) if regex.match?(src)
+    end
 
-      return file[clean_file_path] if regex.match?(src)
+    def clean_file_path(file)
+      file[/(?<=#{Regexp.escape(@path.to_s)}\/)[\/a-zA-Z_-]+.[a-zA-Z.]+/]
     end
 
     def clean_file_name(name)

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -106,6 +106,7 @@ module GovukPublishingComponents
             warning_count: warnings.length,
             gem_style_references: result[:gem_style_references],
             jquery_references: result[:jquery_references],
+            component_locations: result[:component_locations],
           }
         else
           data << {
@@ -244,28 +245,33 @@ module GovukPublishingComponents
       (haystack - needle).flatten.sort
     end
 
+    # returns details of component inclusion by applications
     def get_components_by_application
       results = []
       found_something = false
 
       @gem_data[:component_listing].each do |component|
-        found_in_applications = []
+        component_name = component[:name]
+        locations = []
 
         @applications_data.each do |application|
-          next unless application[:application_found]
+          next unless application[:application_found] && application[:component_locations][component_name.to_sym]
 
-          name = application[:name]
+          application_name = application[:name]
           found_something = true
 
-          application[:summary].each do |item|
-            found_in_applications << name if item[:value].include?(component[:name])
-          end
+          locations << {
+            name: application_name,
+            locations: application[:component_locations][component_name.to_sym],
+          }
         end
 
+        locations = locations.flatten
+
         results << {
-          component: component[:name],
-          count: found_in_applications.uniq.length,
-          list: found_in_applications.uniq.join(", "),
+          component: component_name,
+          count: locations.length,
+          locations: locations,
         }
       end
 

--- a/app/views/govuk_publishing_components/audit/_components.html.erb
+++ b/app/views/govuk_publishing_components/audit/_components.html.erb
@@ -63,10 +63,28 @@
           <% @components[:components_by_application].each do |component| %>
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                <%= component[:component] %> (<%= component[:count] %>)
+                <%= component[:component] %> (<%= pluralize(component[:count], 'use') %>)
               </dt>
               <dd class="govuk-summary-list__value">
-                <%= component[:list] %>
+                <% component[:locations].each do |application| %>
+                  <% github_link = 'https://github.com/alphagov/' + application[:name] + '/blob/main/' %>
+                  <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        <%= application[:name] %> (<%= application[:locations].length %>)
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <ul class="govuk-list govuk-list--bullet">
+                        <% application[:locations].each do |location| %>
+                          <li>
+                            <a href="<%= github_link %><%= location %>" class="govuk-link"><%= location %></a>
+                          </li>
+                        <% end %>
+                      </ul>
+                    </div>
+                  </details>
+                <% end %>
               </dd>
             </div>
           <% end %>

--- a/spec/component_guide/audit_applications_spec.rb
+++ b/spec/component_guide/audit_applications_spec.rb
@@ -38,6 +38,26 @@ describe "Auditing the components in applications" do
       jquery_references: [
         "app/assets/javascripts/some-jquery.js",
       ],
+      component_locations: {
+        accordion: ["app/views/welcome/accordion_example.html.erb"],
+        "back link": ["app/views/welcome/public_example.html.erb"],
+        button: ["lib/test_file_2.erb"],
+        "contextual breadcrumbs": ["app/views/step_nav/show.html.erb", "app/views/welcome/contextual_navigation.html.erb"],
+        "contextual footer": ["app/views/step_nav/show.html.erb", "app/views/welcome/contextual_navigation.html.erb"],
+        "contextual sidebar": ["app/views/step_nav/show.html.erb", "app/views/welcome/contextual_navigation.html.erb"],
+        "error summary": ["app/views/welcome/error_summary.html.erb"],
+        feedback: ["app/views/layouts/application.html.erb"],
+        govspeak: ["app/views/welcome/contextual_navigation.html.erb", "lib/test_file_1.rb"],
+        input: ["app/views/welcome/error_summary.html.erb", "app/views/welcome/error_summary.html.erb"],
+        "layout footer": ["app/views/layouts/dummy_admin_layout.html.erb"],
+        "layout for admin": ["app/views/layouts/dummy_admin_layout.html.erb"],
+        "layout for public": ["app/views/layouts/dummy_public_layout.html.erb"],
+        "layout header": ["app/views/layouts/dummy_admin_layout.html.erb"],
+        "print link": ["lib/test_file_2.erb"],
+        "skip link": ["app/views/layouts/dummy_admin_layout.html.erb"],
+        tabs: ["app/views/welcome/error_summary.html.erb", "app/views/welcome/tabs_example.html.erb"],
+        title: ["app/views/welcome/contextual_navigation.html.erb", "app/views/welcome/error_summary.html.erb", "app/views/welcome/table.html.erb"],
+      },
     }
 
     expect(application.data).to match(expected)

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -179,6 +179,7 @@ describe "Comparing data from an application with the components" do
         warning_count: 5,
         gem_style_references: [],
         jquery_references: [],
+        component_locations: nil,
       },
     ]
 
@@ -307,6 +308,7 @@ describe "Comparing data from an application with the components" do
         warning_count: 3,
         gem_style_references: [],
         jquery_references: [],
+        component_locations: nil,
       },
       {
         name: "static",
@@ -338,6 +340,7 @@ describe "Comparing data from an application with the components" do
         warning_count: 0,
         gem_style_references: [],
         jquery_references: [],
+        component_locations: nil,
       },
     ]
 
@@ -418,6 +421,7 @@ describe "Comparing data from an application with the components" do
         warning_count: 1,
         gem_style_references: [],
         jquery_references: [],
+        component_locations: nil,
       },
     ]
 
@@ -473,6 +477,7 @@ describe "Comparing data from an application with the components" do
       {
         name: "Dummy application",
         application_found: true,
+        component_locations: nil,
         uses_static: false,
         summary: [
           {


### PR DESCRIPTION
## What
Adds links to the file locations of components included in applications to the auditing pages of the component guide, in the 'Components' tab.

- previously the 'components by application' section of the auditing listed the components, how many applications used them, and the names of those applications
- now lists the above, plus links to the specific files where the components are used (in github)
- also updates this part of the auditing to only match applications where the component is included in ruby or templates, previously matched for any instance (which meant false positives e.g. would say an application was using a component even if it only included the component asset)

## Why
I think this is going to be useful.

## Visual Changes

### Before
![Screenshot 2022-07-05 at 10 10 14](https://user-images.githubusercontent.com/861310/177293594-c516ca9b-cc45-4aa2-9612-1f831e055967.png)

### After
![Screenshot 2022-07-05 at 10 09 41](https://user-images.githubusercontent.com/861310/177293624-a77e1619-97e1-4a78-8755-99c4b013c582.png)
