### PR TITLE
Version 29.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 29.14.0
 
 * Add White Arrow to Action Link Options ([PR #2851](https://github.com/alphagov/govuk_publishing_components/pull/2851))
 * Bump govuk-frontend from 4.1.0 to 4.2.0 ([PR #2836](https://github.com/alphagov/govuk_publishing_components/pull/2836))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (29.13.0)
+    govuk_publishing_components (29.14.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "29.13.0".freeze
+  VERSION = "29.14.0".freeze
 end


### PR DESCRIPTION
## 29.14.0

* Add White Arrow to Action Link Options ([PR #2851](https://github.com/alphagov/govuk_publishing_components/pull/2851))
* Bump govuk-frontend from 4.1.0 to 4.2.0 ([PR #2836](https://github.com/alphagov/govuk_publishing_components/pull/2836))
* Add personally identifiable information (PII) remover to GTM ([PR #2842](https://github.com/alphagov/govuk_publishing_components/pull/2842))
* Fix broken preview link for "previous and next navigation" component ([PR #2853](https://github.com/alphagov/govuk_publishing_components/pull/2853))
* Add extra options for show/hide all sections accordion click ([PR #2840](https://github.com/alphagov/govuk_publishing_components/pull/2840))
