### PR TITLE
Removes additional `id` argument from `table_helper`

### DIFF
--- a/app/views/govuk_publishing_components/components/_table.html.erb
+++ b/app/views/govuk_publishing_components/components/_table.html.erb
@@ -13,10 +13,11 @@
 %>
 
 <% @table = capture do %>
-  <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, caption, table_id, {
+  <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, caption, {
       sortable: sortable,
       filterable: filterable,
-      caption_classes: caption_classes
+      caption_classes: caption_classes, 
+      table_id: table_id
     }) do |t| %>
 
     <% if head.any? %>

--- a/lib/govuk_publishing_components/app_helpers/table_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/table_helper.rb
@@ -1,7 +1,7 @@
 module GovukPublishingComponents
   module AppHelpers
     class TableHelper
-      def self.helper(context, caption = nil, id = nil, opt = {})
+      def self.helper(context, caption = nil, opt = {})
         builder = TableBuilder.new(context.tag)
 
         classes = %w[gem-c-table govuk-table]
@@ -10,7 +10,7 @@ module GovukPublishingComponents
         caption_classes = %w[govuk-table__caption]
         caption_classes << opt[:caption_classes] if opt[:caption_classes]
 
-        context.tag.table class: classes, id: id do
+        context.tag.table class: classes, id: opt[:table_id] do
           context.concat context.tag.caption caption, class: caption_classes
           yield(builder)
         end


### PR DESCRIPTION
## What
The changes in this PR removes an argument in the `table_helper` that had been added in a previous piece of work, and was intended to allow a value for an `id` parameter to be passed to the table component. This value is now added to the `opt` argument instead.

## Why
While the initial change was not problematic within this repo, the Table Helper is also used outside the repo. When calls are made to it from elsewhere only two arguments are assumed leading to unexpected results in the table component there.

## Visual Changes
There should be no visual changes to the table component. The important check is that the table retains an `id` parameter in the mark-up.

![Screenshot 2022-07-15 at 11 38 31](https://user-images.githubusercontent.com/6080548/179207701-dc319782-518e-4407-abf2-d2253aa7a8b3.png)

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
