### PR TITLE
GA4 analytics schema rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* GA4 analytics schema rework ([PR #2864](https://github.com/alphagov/govuk_publishing_components/pull/2864))
+
 ## 29.15.1
 
 * Removes additional id argument from table_helper ([PR #2862](https://github.com/alphagov/govuk_publishing_components/pull/2862))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
@@ -1,4 +1,5 @@
 // The following modules are imported in a specific order
+//= require ./analytics-ga4/gtm-schemas
 //= require ./analytics-ga4/pii-remover
 //= require ./analytics-ga4/gtm-page-views
 //= require ./analytics-ga4/gtm-click-tracking

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
@@ -29,8 +29,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           return
         }
 
-        schema.event = 'analytics'
-        schema.location = window.location.href.substring(window.location.origin.length)
+        schema.event = 'event_data'
         // get attributes from the data attribute to send to GA
         // only allow it if it already exists in the schema
         for (var property in data) {

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
@@ -7,7 +7,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   function GtmClickTracking (module) {
     this.module = module
-    this.trackingTrigger = 'data-gtm-event-name' // elements with this attribute get tracked
+    this.trackingTrigger = 'data-ga4' // elements with this attribute get tracked
   }
 
   GtmClickTracking.prototype.init = function () {
@@ -18,12 +18,25 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (window.dataLayer) {
       var target = this.findTrackingAttributes(event.target)
       if (target) {
-        var data = {
-          event: 'analytics',
-          event_name: target.getAttribute('data-gtm-event-name'),
-          // get entire URL apart from domain
-          link_url: window.location.href.substring(window.location.origin.length),
-          ui: JSON.parse(target.getAttribute('data-gtm-attributes')) || {}
+        var schema = new window.GOVUK.analyticsGA4.Schemas().eventSchema()
+
+        try {
+          var data = target.getAttribute(this.trackingTrigger)
+          data = JSON.parse(data)
+        } catch (e) {
+          // if there's a problem with the config, don't start the tracker
+          console.error('GA4 configuration error: ' + e.message, window.location)
+          return
+        }
+
+        schema.event = 'analytics'
+        schema.location = window.location.href.substring(window.location.origin.length)
+        // get attributes from the data attribute to send to GA
+        // only allow it if it already exists in the schema
+        for (var property in data) {
+          if (schema.event_data[property]) {
+            schema.event_data[property] = data[property]
+          }
         }
 
         // Ensure it only tracks aria-expanded in an accordion element, instead of in any child of the clicked element
@@ -39,15 +52,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var detailsElement = target.closest('details')
 
         if (ariaExpanded) {
-          data.ui.text = data.ui.text || target.innerText
-          data.ui.action = (ariaExpanded === 'false') ? 'opened' : 'closed'
+          schema.event_data.text = data.text || target.innerText
+          schema.event_data.action = (ariaExpanded === 'false') ? 'opened' : 'closed'
         } else if (detailsElement) {
-          data.ui.text = data.ui.text || detailsElement.textContent
+          schema.event_data.text = data.text || detailsElement.textContent
           var openAttribute = detailsElement.getAttribute('open')
-          data.ui.action = (openAttribute == null) ? 'opened' : 'closed'
+          schema.event_data.action = (openAttribute == null) ? 'opened' : 'closed'
         }
-
-        window.dataLayer.push(data)
+        window.dataLayer.push(schema)
       }
     }
   }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
@@ -62,9 +62,9 @@
     // https://github.com/alphagov/static/blob/main/app/views/root/_error_page.html.erb#L32
     getStatusCode: function () {
       if (window.httpStatusCode) {
-        return window.httpStatusCode
+        return window.httpStatusCode.toString()
       } else {
-        return 200
+        return '200'
       }
     },
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
@@ -9,7 +9,7 @@
     sendPageView: function () {
       if (window.dataLayer) {
         var data = {
-          event: 'config_ready',
+          event: 'page_view',
           page: {
             location: this.getLocation(),
             referrer: this.getReferrer(),

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
@@ -14,24 +14,21 @@
             location: this.getLocation(),
             referrer: this.getReferrer(),
             title: this.getTitle(),
-            status_code: this.getStatusCode()
-          },
-          publishing: {
+            status_code: this.getStatusCode(),
+
             document_type: this.getMetaContent('format'),
             publishing_app: this.getMetaContent('publishing-app'),
             rendering_app: this.getMetaContent('rendering-app'),
             schema_name: this.getMetaContent('schema-name'),
-            content_id: this.getMetaContent('content-id')
-          },
-          taxonomy: {
+            content_id: this.getMetaContent('content-id'),
+
             section: this.getMetaContent('section'),
             taxon_slug: this.getMetaContent('taxon-slug'),
             taxon_id: this.getMetaContent('taxon-id'),
             themes: this.getMetaContent('themes'),
             taxon_slugs: this.getMetaContent('taxon-slugs'),
-            taxon_ids: this.getMetaContent('taxon-ids')
-          },
-          content: {
+            taxon_ids: this.getMetaContent('taxon-ids'),
+
             language: this.getLanguage(),
             history: this.getHistory(),
             withdrawn: this.getWithDrawn(),

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-schemas.js
@@ -10,18 +10,16 @@
   Schemas.prototype.eventSchema = function () {
     return {
       event: this.null,
-      location: this.null,
 
       event_data: {
         event_name: this.null,
         type: this.null,
-        location: this.null,
+        url: this.null,
         text: this.null,
         index: this.null,
         index_total: this.null,
         section: this.null,
         action: this.null,
-        href: this.null,
         external: this.null
       }
     }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-schemas.js
@@ -1,0 +1,34 @@
+;(function (global) {
+  'use strict'
+
+  var GOVUK = global.GOVUK || {}
+
+  var Schemas = function () {
+    this.null = 'n/a'
+  }
+
+  Schemas.prototype.eventSchema = function () {
+    return {
+      event: this.null,
+      location: this.null,
+
+      event_data: {
+        event_name: this.null,
+        type: this.null,
+        location: this.null,
+        text: this.null,
+        index: this.null,
+        index_total: this.null,
+        section: this.null,
+        action: this.null,
+        href: this.null,
+        external: this.null
+      }
+    }
+  }
+
+  GOVUK.analyticsGA4 = GOVUK.analyticsGA4 || {}
+  GOVUK.analyticsGA4.Schemas = Schemas
+
+  global.GOVUK = GOVUK
+})(window)

--- a/docs/analytics-gtm/analytics.md
+++ b/docs/analytics-gtm/analytics.md
@@ -1,0 +1,59 @@
+# Google Analytics 4 and Google Tag Manager
+
+This document describes the use of Google Tag Manager (GTM) with Google Analytics 4 (GA4) on GOV.UK Publishing.
+
+No analytics code is initialised and no data is gathered without user consent.
+
+## General approach
+
+We pass three types of data to GA4.
+
+- page views
+- events
+- search data
+
+Page views happen when a page loads.
+
+Events happen when a user interacts with certain things, for example clicking on an accordion, tab, or link.
+
+Search data is gathered when users perform a search.
+
+## Data schemas
+
+All of the data sent to GTM is based on a common schema.
+
+```
+{
+  event: '',
+  page: {},
+  event_data: {},
+  search_results: {}
+}
+```
+
+`event` must have a specific value to activate the right trigger in GTM.
+
+`page` is defined in the [gtm-page-views script](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js).
+
+`event_data` is defined in the [gtm-schemas script](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-schemas.js) and used in the [gtm-click-tracking script](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js).
+
+`search_results` has not been implemented yet.
+
+## How the dataLayer works
+
+GTM's dataLayer has two elements - an array and an object. `window.dataLayer = []` is executed when the page loads.
+
+GOV.UK JavaScript (JS) pushes objects to the dataLayer array when certain things happen e.g. when the page loads, or a user clicks on a certain type of link. Once that happens GTM takes over. It reads the latest object in the array and passes the data found into the dataLayer object. Importantly, it only adds to the object, so data can persist from previous array pushes.
+
+For example:
+
+- an event happens and JS pushes `{ a: 1 }` to the dataLayer array
+- GTM adds this to the dataLayer object, which is now `{ a: 1 }`
+- another event happens and JS pushes `{ b: 1 }` to the array
+- GTM adds this to the dataLayer object, which is now `{ a: 1, b: 1 }`
+
+If data shouldn't persist it can be erased in a following push, for example by sending `{ a: 1, b: false }`, but often this overall behaviour is desirable - for example, page view data will persist in events that happen on that page, providing more context for analysts.
+
+If the data given to GTM contains a recognised `event` attribute value, GTM then sends that data on to GA4.
+
+The dataLayer is recreated when a user navigates to another page, so no data in the dataLayer will persist between pages.

--- a/docs/analytics-gtm/gtm-click-tracking.md
+++ b/docs/analytics-gtm/gtm-click-tracking.md
@@ -1,14 +1,12 @@
 # Google Tag Manager click tracking
 
-This is an experimental script to allow click tracking through Google Tag Manager to be added to any element using data attributes.
+This is a script to allow click tracking through Google Tag Manager to be added to any element using data attributes.
 
 ## Basic use
 
 ```html
 <div data-module="gtm-click-tracking">
-  <div
-    data-gtm-event-name="anything"
-    data-gtm-attributes='{"type":"something","index":0,"index-total":1,"section":"n/a","text":"Click me"}'>
+  <div data-ga4='{"event_name":"select_content", "type":"something", "index":0, "index_total":1, "text":"Click me"}'>
     Click me
   </div>
 </div>
@@ -16,22 +14,26 @@ This is an experimental script to allow click tracking through Google Tag Manage
 
 The module is initialised on the parent element, but tracking only occurs when clicks happen:
 
-- on child elements that have a `data-gtm-event-name` attribute
-- on the parent if it has a `data-gtm-event-name` attribute
+- on child elements that have a valid `data-ga4` attribute
+- on the parent if it has a valid `data-ga4` attribute
 
-The contents of `data-gtm-attributes` are parsed as a JSON object and included in the information passed to GTM. In the example above, the following would be pushed to the dataLayer. Note that the `link_url` attribute is automatically populated with the current page path.
+A valid `data-ga4` attribute is a JSON string that can be parsed into an object, that contains a recognised value for `event_name`. Pushes to the dataLayer that do not include a valid `event_name` attribute will be ignored by Tag Manager.
+
+In the example above, the following would be pushed to the dataLayer. Note that the schema automatically populates empty values, and that attributes not in the schema are ignored.
 
 ```
 {
-  'event': 'analytics',
-  'event_name': 'anything',
-  'link_url': '/government/publications/cheese',
-  'ui': {
+  'event': 'event_data',
+  'event_data': {
+    'event_name': 'select_content',
     'type': 'something',
+    'url': 'n/a',
+    'text': 'Click me',
     'index': '0',
-    'index-total': '1',
+    'index_total': '1',
     'section': 'n/a',
-    'text': 'Click me'
+    'action': 'n/a',
+    'external': 'n/a'
   }
 }
 ```
@@ -46,16 +48,16 @@ This is handled using the following approach.
 <div data-module="gtm-click-tracking">
   <%
     show_all_attributes = {
+      event_name: "select_content",
       type: "accordion",
       index: 0,
-      "index-total": 5,
+      index_total: 5,
       section: "n/a"
     }
   %>
   <%= render 'govuk_publishing_components/components/accordion', {
     data_attributes_show_all: {
-      "gtm-event-name": "select_content",
-      "gtm-attributes": show_all_attributes.to_json
+      "ga4": show_all_attributes.to_json
     },
     items: []
   } %>
@@ -68,22 +70,23 @@ This works as follows.
 - `GtmClickTracking` can now be triggered because the accordion is wrapped in the module and its 'Show/hide all' link has a `gtm-event-name` attribute
 - `GtmClickTracking` checks for the presence of an `aria-expanded` attribute, either on the clicked element or a child of the clicked element
 - if it finds one, it sets the `state` attribute of `ui` to either 'opened' or 'closed' depending on the value of `aria-expanded`
-- if `data-gtm-attributes` does not include `text`, `GtmClickTracking` automatically uses the text of the clicked element
+- if `data-ga4` does not include `text`, `GtmClickTracking` automatically uses the text of the clicked element
 
 When a user clicks 'Show all sections' the following information is pushed to the dataLayer.
 
 ```
 {
-  'event': 'analytics',
-  'event_name': 'select_content',
-  'link_url': '/government/publications/cheese',
-  'ui': {
+  'event': 'event_data',
+  'event_data': {
+    'event_name': 'select_content',
     'type': 'accordion',
+    'url': 'n/a',
+    'text': 'Show all sections',
     'index': '0',
     'index-total': '5',
     'section': 'n/a',
-    'text': 'Show all sections',
-    'state': 'opened'
+    'action': 'opened',
+    'external': 'n/a'
   }
 }
 ```
@@ -92,16 +95,17 @@ When a user clicks 'Hide all sections' the following information is pushed to th
 
 ```
 {
-  'event': 'analytics',
-  'event_name': 'select_content',
-  'link_url': '/government/publications/cheese',
-  'ui': {
+  'event': 'event_data',
+  'event_data': {
+    'event_name': 'select_content',
     'type': 'accordion',
+    'url': 'n/a',
+    'text': 'Hide all sections',
     'index': '0',
     'index-total': '5',
     'section': 'n/a',
-    'text': 'Hide all sections',
-    'state': 'closed'
+    'action': 'closed',
+    'external': 'n/a'
   }
 }
 ```

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
@@ -12,7 +12,6 @@ describe('Google Tag Manager click tracking', function () {
 
   afterEach(function () {
     document.body.removeChild(element)
-    window.location.hash = ''
   })
 
   describe('configuring tracking without any data', function () {
@@ -44,7 +43,7 @@ describe('Google Tag Manager click tracking', function () {
   describe('doing simple tracking on a single element', function () {
     beforeEach(function () {
       expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
-      expected.event = 'analytics'
+      expected.event = 'event_data'
       expected.event_data.event_name = 'select_content'
       expected.event_data.type = 'tabs'
 
@@ -60,22 +59,6 @@ describe('Google Tag Manager click tracking', function () {
 
     it('pushes gtm attributes to the dataLayer', function () {
       element.click()
-      expected.location = window.location.href.substring(window.location.origin.length)
-      expect(window.dataLayer[0]).toEqual(expected)
-    })
-
-    it('gets the full URL including a hash', function () {
-      var currentUrl = window.location.href.substring(window.location.origin.length)
-      // fix a bug where running the test in a browser more than once left a
-      // dangling # that broke the expected URL - would be (url)##myhash
-      var lastChar = currentUrl.substr(currentUrl.length - 1)
-      if (lastChar === '#') {
-        currentUrl = currentUrl.slice(0, -1)
-      }
-      window.location.hash = 'myhash'
-
-      element.click()
-      expected.location = currentUrl + '#myhash'
       expect(window.dataLayer[0]).toEqual(expected)
     })
 
@@ -91,13 +74,11 @@ describe('Google Tag Manager click tracking', function () {
 
     beforeEach(function () {
       expected1 = new GOVUK.analyticsGA4.Schemas().eventSchema()
-      expected1.event = 'analytics'
-      expected1.location = window.location.href.substring(window.location.origin.length)
+      expected1.event = 'event_data'
       expected1.event_data.event_name = 'event1-name'
 
       expected2 = new GOVUK.analyticsGA4.Schemas().eventSchema()
-      expected2.event = 'analytics'
-      expected2.location = window.location.href.substring(window.location.origin.length)
+      expected2.event = 'event_data'
       expected2.event_data.event_name = 'event2-name'
 
       var attributes1 = {
@@ -146,16 +127,14 @@ describe('Google Tag Manager click tracking', function () {
       element.click()
 
       expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
-      expected.event = 'analytics'
-      expected.location = window.location.href.substring(window.location.origin.length)
+      expected.event = 'event_data'
       expected.event_data.action = 'opened'
       expected.event_data.text = 'some text'
 
       expect(window.dataLayer[0]).toEqual(expected)
 
       expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
-      expected.event = 'analytics'
-      expected.location = window.location.href.substring(window.location.origin.length)
+      expected.event = 'event_data'
       expected.event_data.action = 'closed'
       expected.event_data.text = 'some text'
 
@@ -185,16 +164,14 @@ describe('Google Tag Manager click tracking', function () {
       clickOn.click()
 
       expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
-      expected.event = 'analytics'
-      expected.location = window.location.href.substring(window.location.origin.length)
+      expected.event = 'event_data'
       expected.event_data.action = 'opened'
       expected.event_data.text = 'some text'
 
       expect(window.dataLayer[0]).toEqual(expected)
 
       expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
-      expected.event = 'analytics'
-      expected.location = window.location.href.substring(window.location.origin.length)
+      expected.event = 'event_data'
       expected.event_data.action = 'closed'
       expected.event_data.text = 'some text'
 
@@ -224,8 +201,7 @@ describe('Google Tag Manager click tracking', function () {
       clickOn.click()
 
       expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
-      expected.event = 'analytics'
-      expected.location = window.location.href.substring(window.location.origin.length)
+      expected.event = 'event_data'
       expected.event_data.action = 'opened'
       expected.event_data.event_name = 'event-name'
       expected.event_data.text = 'Show'
@@ -233,8 +209,7 @@ describe('Google Tag Manager click tracking', function () {
       expect(window.dataLayer[0]).toEqual(expected)
 
       expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
-      expected.event = 'analytics'
-      expected.location = window.location.href.substring(window.location.origin.length)
+      expected.event = 'event_data'
       expected.event_data.action = 'closed'
       expected.event_data.event_name = 'event-name'
       expected.event_data.text = 'Hide'
@@ -267,8 +242,7 @@ describe('Google Tag Manager click tracking', function () {
       clickOn.click()
 
       expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
-      expected.event = 'analytics'
-      expected.location = window.location.href.substring(window.location.origin.length)
+      expected.event = 'event_data'
       expected.event_data.action = 'opened'
       expected.event_data.event_name = 'event-name'
       expected.event_data.text = 'Example'
@@ -276,8 +250,7 @@ describe('Google Tag Manager click tracking', function () {
       expect(window.dataLayer[0]).toEqual(expected)
 
       expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
-      expected.event = 'analytics'
-      expected.location = window.location.href.substring(window.location.origin.length)
+      expected.event = 'event_data'
       expected.event_data.action = 'closed'
       expected.event_data.event_name = 'event-name'
       expected.event_data.text = 'Example'

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
@@ -9,7 +9,7 @@ describe('Google Tag Manager page view tracking', function () {
     saved.title = document.title
     document.title = 'This here page'
     expected = {
-      event: 'config_ready',
+      event: 'page_view',
       page: {
         location: document.location.href,
         referrer: document.referrer,

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
@@ -14,7 +14,7 @@ describe('Google Tag Manager page view tracking', function () {
         location: document.location.href,
         referrer: document.referrer,
         title: 'This here page',
-        status_code: 200,
+        status_code: '200',
 
         document_type: 'n/a',
         publishing_app: 'n/a',
@@ -71,7 +71,7 @@ describe('Google Tag Manager page view tracking', function () {
 
   it('returns a page view with a specific status code', function () {
     window.httpStatusCode = 404
-    expected.page.status_code = 404
+    expected.page.status_code = '404'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
@@ -14,24 +14,21 @@ describe('Google Tag Manager page view tracking', function () {
         location: document.location.href,
         referrer: document.referrer,
         title: 'This here page',
-        status_code: 200
-      },
-      publishing: {
+        status_code: 200,
+
         document_type: 'n/a',
         publishing_app: 'n/a',
         rendering_app: 'n/a',
         schema_name: 'n/a',
-        content_id: 'n/a'
-      },
-      taxonomy: {
+        content_id: 'n/a',
+
         section: 'n/a',
         taxon_slug: 'n/a',
         taxon_id: 'n/a',
         themes: 'n/a',
         taxon_slugs: 'n/a',
-        taxon_ids: 'n/a'
-      },
-      content: {
+        taxon_ids: 'n/a',
+
         language: 'n/a',
         history: 'false',
         withdrawn: 'false',
@@ -111,7 +108,7 @@ describe('Google Tag Manager page view tracking', function () {
     for (var i = 0; i < tags.length; i++) {
       var tag = tags[i]
       createMetaTags(tag.tagName, tag.value)
-      expected.publishing[tag.gtmName] = tag.value
+      expected.page[tag.gtmName] = tag.value
     }
 
     GOVUK.Gtm.sendPageView()
@@ -155,7 +152,7 @@ describe('Google Tag Manager page view tracking', function () {
     for (var i = 0; i < tags.length; i++) {
       var tag = tags[i]
       createMetaTags(tag.tagName, tag.value)
-      expected.taxonomy[tag.gtmName] = tag.value
+      expected.page[tag.gtmName] = tag.value
     }
 
     GOVUK.Gtm.sendPageView()
@@ -165,7 +162,7 @@ describe('Google Tag Manager page view tracking', function () {
   it('returns a pageview with a language', function () {
     var html = document.querySelector('html')
     html.setAttribute('lang', 'wakandan')
-    expected.content.language = 'wakandan'
+    expected.page.language = 'wakandan'
 
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
@@ -173,77 +170,77 @@ describe('Google Tag Manager page view tracking', function () {
 
   it('returns a pageview with history', function () {
     createMetaTags('content-has-history', 'true')
-    expected.content.history = 'true'
+    expected.page.history = 'true'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview without history', function () {
     createMetaTags('content-has-history', 'banana')
-    expected.content.history = 'false'
+    expected.page.history = 'false'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a withdrawn page', function () {
     createMetaTags('withdrawn', 'withdrawn')
-    expected.content.withdrawn = 'true'
+    expected.page.withdrawn = 'true'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page with a first published date', function () {
     createMetaTags('first-published-at', '2022-03-28T19:11:00.000+00:00')
-    expected.content.first_published_at = '2022-03-28T19:11:00.000+00:00'
+    expected.page.first_published_at = '2022-03-28T19:11:00.000+00:00'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page with a last updated date', function () {
     createMetaTags('updated-at', '2021-03-28T19:11:00.000+00:00')
-    expected.content.updated_at = '2021-03-28T19:11:00.000+00:00'
+    expected.page.updated_at = '2021-03-28T19:11:00.000+00:00'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page with a last public updated date', function () {
     createMetaTags('public-updated-at', '2020-03-28T19:11:00.000+00:00')
-    expected.content.public_updated_at = '2020-03-28T19:11:00.000+00:00'
+    expected.page.public_updated_at = '2020-03-28T19:11:00.000+00:00'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page marked with a publishing government', function () {
     createMetaTags('publishing-government', 'labour')
-    expected.content.publishing_government = 'labour'
+    expected.page.publishing_government = 'labour'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page marked with a political status', function () {
     createMetaTags('political-status', 'ongoing')
-    expected.content.political_status = 'ongoing'
+    expected.page.political_status = 'ongoing'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page marked with a primary publishing organisation', function () {
     createMetaTags('primary-publishing-organisation', 'Home Office')
-    expected.content.primary_publishing_organisation = 'Home Office'
+    expected.page.primary_publishing_organisation = 'Home Office'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page marked with ids for contributing organisations', function () {
     createMetaTags('analytics:organisations', 'some organisations')
-    expected.content.organisations = 'some organisations'
+    expected.page.organisations = 'some organisations'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page marked with world locations', function () {
     createMetaTags('analytics:world-locations', 'some world locations')
-    expected.content.world_locations = 'some world locations'
+    expected.page.world_locations = 'some world locations'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })


### PR DESCRIPTION
## What
Rework the code based on changes to the GA4 schema. This includes:

- the creation of a new file that contains the schema for events, which is then used by the event click tracking script (hopefully we can use it for other schemas as well)
- restructuring of the page view data
- some new documentation
- miscellaneous other changes (see commit messages for details)

## Why
We're redesigning the data schema for events.

## Visual Changes
None.

Trello card: https://trello.com/c/obytEbqo/153-update-existing-code-with-schema-changes