### PR TITLE
Bumps gem version to 29.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 29.15.1
 
 * Removes additional id argument from table_helper ([PR #2862](https://github.com/alphagov/govuk_publishing_components/pull/2862))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (29.15.0)
+    govuk_publishing_components (29.15.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "29.15.0".freeze
+  VERSION = "29.15.1".freeze
 end


### PR DESCRIPTION
Removes additional id argument from table_helper ([PR #2862](https://github.com/alphagov/govuk_publishing_components/pull/2862))