### PR TITLE
Include width and height size attributes on image card component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * GA4 analytics schema rework ([PR #2864](https://github.com/alphagov/govuk_publishing_components/pull/2864))
 * Change colour palette in graphs to match GSS guidance ([PR #2782](https://github.com/alphagov/govuk_publishing_components/pull/2782))
+* Include width and height size attributes on image card component ([PR #2869](https://github.com/alphagov/govuk_publishing_components/pull/2869))
 
 ## 29.15.1
 

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -4,6 +4,8 @@ body: |
   An image and links, meant for use for news articles and people. Includes optional paragraph and additional links.
 
   The component is generally to be used within a grid column but has no grid of its own, so the text and the images in the examples below may not always line up. This will normally look tidier, for example [on pages like this](https://www.gov.uk/government/organisations/attorney-generals-office).
+
+  Images should have an aspect ratio of 3:2.
 accessibility_criteria: |
   The component must:
 

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -46,6 +46,8 @@ module GovukPublishingComponents
               loading: @image_loading,
               sizes: @sizes,
               srcset: @srcset,
+              height: 200,
+              width: 300,
             )
           end
         end


### PR DESCRIPTION
## What
https://trello.com/c/iz7WJaeG/1404-include-width-and-height-size-attributes-on-image-card-component-2869

Include width and height size attributes on image card component

## Why
See https://github.com/alphagov/govuk_publishing_components/issues/2863

## Visual changes

### Before

https://user-images.githubusercontent.com/87758239/180429698-4196bf45-9d87-4918-8da0-c8cf0e50aa9f.mov

### After

https://user-images.githubusercontent.com/87758239/180429818-c858cddb-a3c6-4c80-8123-672b6c2b9623.mov