### PR TITLE
Revert "Include width and height size attributes on image card component"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 
 * GA4 analytics schema rework ([PR #2864](https://github.com/alphagov/govuk_publishing_components/pull/2864))
 * Change colour palette in graphs to match GSS guidance ([PR #2782](https://github.com/alphagov/govuk_publishing_components/pull/2782))
-* Include width and height size attributes on image card component ([PR #2869](https://github.com/alphagov/govuk_publishing_components/pull/2869))
 
 ## 29.15.1
 

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -4,8 +4,6 @@ body: |
   An image and links, meant for use for news articles and people. Includes optional paragraph and additional links.
 
   The component is generally to be used within a grid column but has no grid of its own, so the text and the images in the examples below may not always line up. This will normally look tidier, for example [on pages like this](https://www.gov.uk/government/organisations/attorney-generals-office).
-
-  Images should have an aspect ratio of 3:2.
 accessibility_criteria: |
   The component must:
 

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -46,8 +46,6 @@ module GovukPublishingComponents
               loading: @image_loading,
               sizes: @sizes,
               srcset: @srcset,
-              height: 200,
-              width: 300,
             )
           end
         end


### PR DESCRIPTION
Reverts alphagov/govuk_publishing_components#2869