### PR TITLE
Use a large image for the large example

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -190,7 +190,7 @@ examples:
     data:
       large: true
       href: "/still-not-a-page"
-      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62756/s300_courts-of-justice.JPG"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/91397/s712_SG_Swear_in_1_.jpg"
       image_alt: "some meaningful alt text please"
       context:
         date: 2017-06-14 11:30:00


### PR DESCRIPTION
## What / why
- the image used for the large image card configuration example wasn't large, so didn't clearly show what the intent of the option was
- adding a large image to make better use of the space

## Visual Changes

Before | After
------- | ------
![Screenshot 2022-07-25 at 14 49 59](https://user-images.githubusercontent.com/861310/180793444-241f43d1-c703-416f-b13d-b669204a8abd.png) | ![Screenshot 2022-07-25 at 14 50 05](https://user-images.githubusercontent.com/861310/180793514-c59b312a-752d-4da8-a226-e102f384f181.png)

