### PR TITLE
Add helper use to auditing

### DIFF
--- a/app/views/govuk_publishing_components/audit/_components.html.erb
+++ b/app/views/govuk_publishing_components/audit/_components.html.erb
@@ -56,56 +56,19 @@
     }
   %>
 
-  <% if @other_applications %>
-    <% components_by_application = capture do %>
-      <% if @components[:components_by_application].any? %>
-        <dl class="govuk-summary-list">
-          <% @components[:components_by_application].each do |component| %>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                <%= component[:component] %> (<%= pluralize(component[:count], 'use') %>)
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <% component[:locations].each do |application| %>
-                  <% github_link = 'https://github.com/alphagov/' + application[:name] + '/blob/main/' %>
-                  <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
-                    <summary class="govuk-details__summary">
-                      <span class="govuk-details__summary-text">
-                        <%= application[:name] %> (<%= application[:locations].length %>)
-                      </span>
-                    </summary>
-                    <div class="govuk-details__text">
-                      <ul class="govuk-list govuk-list--bullet">
-                        <% application[:locations].each do |location| %>
-                          <li>
-                            <a href="<%= github_link %><%= location %>" class="govuk-link"><%= location %></a>
-                          </li>
-                        <% end %>
-                      </ul>
-                    </div>
-                  </details>
-                <% end %>
-              </dd>
-            </div>
-          <% end %>
-        </dl>
-      <% end %>
-    <% end %>
+  <%= render 'items_in_applications',
+    heading: 'Components by application',
+    summary: 'Shows which applications use each component',
+    content: @components[:components_by_application],
+    items: component_items
+  %>
 
-    <%
-      component_items << {
-        heading: {
-          text: "Components by application",
-        },
-        summary: {
-          text: "Shows which applications use each component",
-        },
-        content: {
-          html: components_by_application
-        },
-      }
-    %>
-  <% end %>
+  <%= render 'items_in_applications',
+    heading: 'Helpers by application',
+    summary: 'Shows any applications that use helper classes from the components gem',
+    content: @components[:helpers_used_by_applications],
+    items: component_items
+  %>
 
   <%= render "govuk_publishing_components/components/accordion", {
     items: component_items

--- a/app/views/govuk_publishing_components/audit/_items_in_applications.html.erb
+++ b/app/views/govuk_publishing_components/audit/_items_in_applications.html.erb
@@ -1,0 +1,50 @@
+<% if @other_applications %>
+  <% accordion_content = capture do %>
+    <% if content.any? %>
+      <dl class="govuk-summary-list">
+        <% content.each do |item| %>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              <%= item[:name] %> (<%= pluralize(item[:count], 'use') %>)
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <% item[:locations].each do |application| %>
+                <% github_link = 'https://github.com/alphagov/' + application[:name] + '/blob/main/' %>
+                <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
+                  <summary class="govuk-details__summary">
+                    <span class="govuk-details__summary-text">
+                      <%= application[:name] %> (<%= application[:locations].length %>)
+                    </span>
+                  </summary>
+                  <div class="govuk-details__text">
+                    <ul class="govuk-list govuk-list--bullet">
+                      <% application[:locations].each do |location| %>
+                        <li>
+                          <a href="<%= github_link %><%= location %>" class="govuk-link"><%= location %></a>
+                        </li>
+                      <% end %>
+                    </ul>
+                  </div>
+                </details>
+              <% end %>
+            </dd>
+          </div>
+        <% end %>
+      </dl>
+    <% end %>
+  <% end %>
+
+  <%
+    items << {
+      heading: {
+        text: heading,
+      },
+      summary: {
+        text: summary,
+      },
+      content: {
+        html: accordion_content
+      },
+    }
+  %>
+<% end %>

--- a/spec/component_guide/audit_applications_spec.rb
+++ b/spec/component_guide/audit_applications_spec.rb
@@ -58,6 +58,12 @@ describe "Auditing the components in applications" do
         tabs: ["app/views/welcome/error_summary.html.erb", "app/views/welcome/tabs_example.html.erb"],
         title: ["app/views/welcome/contextual_navigation.html.erb", "app/views/welcome/error_summary.html.erb", "app/views/welcome/table.html.erb"],
       },
+      helper_references: {
+        BrandHelper: ["lib/test_file_3.rb"],
+        ButtonHelper: ["lib/test_file_3.rb"],
+        SharedHelper: ["lib/test_file_3.rb"],
+        TableHelper: ["app/views/welcome/table.html.erb"],
+      },
     }
 
     expect(application.data).to match(expected)

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -123,6 +123,7 @@ describe "Comparing data from an application with the components" do
         ],
         gem_style_references: [],
         jquery_references: [],
+        helper_references: nil,
       },
     ]
     comparer = GovukPublishingComponents::AuditComparer.new(gem, application)
@@ -180,6 +181,7 @@ describe "Comparing data from an application with the components" do
         gem_style_references: [],
         jquery_references: [],
         component_locations: nil,
+        helper_references: nil,
       },
     ]
 
@@ -309,6 +311,7 @@ describe "Comparing data from an application with the components" do
         gem_style_references: [],
         jquery_references: [],
         component_locations: nil,
+        helper_references: nil,
       },
       {
         name: "static",
@@ -341,6 +344,7 @@ describe "Comparing data from an application with the components" do
         gem_style_references: [],
         jquery_references: [],
         component_locations: nil,
+        helper_references: nil,
       },
     ]
 
@@ -422,6 +426,7 @@ describe "Comparing data from an application with the components" do
         gem_style_references: [],
         jquery_references: [],
         component_locations: nil,
+        helper_references: nil,
       },
     ]
 
@@ -534,9 +539,165 @@ describe "Comparing data from an application with the components" do
           },
         ],
         warning_count: 6,
+        helper_references: nil,
       },
     ]
 
     expect(comparer.applications_data).to match(expected)
+  end
+
+  it "returns a comparison for an application with component and helper references" do
+    application = [
+      {
+        name: "Dummy application",
+        application_found: true,
+        components_found: [
+          {
+            location: "templates",
+            components: [
+              "component one",
+              "component three",
+              "component that does not exist",
+            ],
+          },
+          {
+            location: "stylesheets",
+            components: [
+              "component one",
+              "component two",
+              "component three",
+            ],
+          },
+          {
+            location: "print_stylesheets",
+            components: [],
+          },
+          {
+            location: "javascripts",
+            components: [],
+          },
+          {
+            location: "ruby",
+            components: [
+              "component three",
+            ],
+          },
+        ],
+        gem_style_references: [],
+        jquery_references: [],
+        component_locations: {
+          accordion: ["app/views/welcome/accordion_example.html.erb"],
+        },
+        helper_references: {
+          BrandHelper: ["lib/test_file_3.rb"],
+          ButtonHelper: ["lib/test_file_3.rb"],
+          SharedHelper: ["lib/test_file_3.rb"],
+          TableHelper: ["app/views/welcome/table.html.erb"],
+        },
+      },
+    ]
+
+    gem[:component_listing] = [
+      {
+        name: "accordion",
+      },
+    ]
+
+    comparer = GovukPublishingComponents::AuditComparer.new(gem, application)
+
+    expected = {
+      gem_found: true,
+      name: "govuk_publishing_components",
+      component_code: [
+        "component one",
+        "component two",
+        "component three",
+        "component four",
+      ],
+      component_stylesheets: [
+        "component one",
+        "component two",
+        "component three",
+        "component four",
+      ],
+      component_print_stylesheets: [
+        "component two",
+      ],
+      component_javascripts: [
+        "component one",
+        "component four",
+      ],
+      component_tests: [],
+      component_js_tests: [],
+      components_containing_components: [
+        {
+          component: "component three",
+          sub_components: [
+            "component four",
+          ],
+        },
+      ],
+      component_listing: [
+        {
+          name: "accordion",
+        },
+      ],
+      components_by_application: [
+        {
+          name: "accordion",
+          count: 1,
+          locations: [
+            {
+              name: "Dummy application",
+              locations: ["app/views/welcome/accordion_example.html.erb"],
+            },
+          ],
+        },
+      ],
+      helpers_used_by_applications: [
+        {
+          name: :BrandHelper,
+          count: 1,
+          locations: [
+            {
+              locations: ["lib/test_file_3.rb"],
+              name: "Dummy application",
+            },
+          ],
+        },
+        {
+          name: :ButtonHelper,
+          count: 1,
+          locations: [
+            {
+              locations: ["lib/test_file_3.rb"],
+              name: "Dummy application",
+            },
+          ],
+        },
+        {
+          name: :SharedHelper,
+          count: 1,
+          locations: [
+            {
+              locations: ["lib/test_file_3.rb"],
+              name: "Dummy application",
+            },
+          ],
+        },
+        {
+          name: :TableHelper,
+          count: 1,
+          locations: [
+            {
+              locations: ["app/views/welcome/table.html.erb"],
+              name: "Dummy application",
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(comparer.gem_data).to match(expected)
   end
 end

--- a/spec/dummy/lib/test_file_3.rb
+++ b/spec/dummy/lib/test_file_3.rb
@@ -1,0 +1,5 @@
+# this is a test file used to check component auditing functionality
+
+# shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+# button = GovukPublishingComponents::Presenters::ButtonHelper.new(local_assigns)
+# brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)


### PR DESCRIPTION
## What
Extend the auditing to include details of where applications are referencing code from the gem.

## Why
We've had more than one instance where changing something in the gem has caused an error in an application because the application relied upon that code. This can give developers insight into where gem code is being used outside of the gem, and hopefully avoid similar future errors.

## Visual Changes
Extra bit added to the bottom of the 'components' tab of the auditing page.

![Screenshot 2022-07-26 at 15 22 53](https://user-images.githubusercontent.com/861310/181030082-3c4568a7-0032-4594-8268-a22060095b34.png)

