### PR TITLE
Version 30.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 30.0.0
 
 * **BREAKING:** Remove the "PrimaryLinks" JS Module and related tests ([PR #2866](https://github.com/alphagov/govuk_publishing_components/pull/2866))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (29.15.3)
+    govuk_publishing_components (30.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "29.15.3".freeze
+  VERSION = "30.0.0".freeze
 end


### PR DESCRIPTION
## 30.0.0

* **BREAKING:** Remove the "PrimaryLinks" JS Module and related tests ([PR #2866](https://github.com/alphagov/govuk_publishing_components/pull/2866))