### PR TITLE
Ensure tab clicks grab the tabs href for gtm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Expand print link component ([PR #2900](https://github.com/alphagov/govuk_publishing_components/pull/2900))
 * Add link click tracking ([PR #2904](https://github.com/alphagov/govuk_publishing_components/pull/2904))
+* Ensure tab clicks grab the tabs href for gtm ([PR #2884](https://github.com/alphagov/govuk_publishing_components/pull/2884))
 
 ## 30.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
@@ -58,6 +58,19 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           var openAttribute = detailsElement.getAttribute('open')
           schema.event_data.action = (openAttribute == null) ? 'opened' : 'closed'
         }
+
+        /* If a tab was clicked, grab the href of the clicked tab (usually an anchor # link) */
+        var tabElement = event.target.closest('.gem-c-tabs')
+        if (tabElement) {
+          var aTag = event.target.closest('a')
+          if (aTag) {
+            var href = aTag.getAttribute('href')
+            if (href) {
+              schema.event_data.url = href
+            }
+          }
+        }
+
         window.dataLayer.push(schema)
       }
     }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
@@ -307,4 +307,40 @@ describe('Google Tag Manager click tracking', function () {
       expect(window.dataLayer[0].event_data.action).toEqual(null)
     })
   })
+
+  describe('doing tracking on tab clicks', function () {
+    beforeEach(function () {
+      var attributes = {
+        event_name: 'event-name'
+      }
+      element.innerHTML =
+        '<div data-ga4=\'' + JSON.stringify(attributes) + '\' class="clickme">' +
+          '<div class="gem-c-tabs">' +
+              '<ul>' +
+              '<li> <a href="#tab-location-1" class="tab-1">Tab 1</a> </li>' +
+              '<li> <a href="#tab-location-2" class="tab-2">Tab 2</a> </li>' +
+              '<li> <p class="random-list-item">Not a link</p> </li>' +
+              '</ul>' +
+          '</div>' +
+        '</div>'
+      document.body.appendChild(element)
+      new GOVUK.Modules.GtmClickTracking(element).init()
+    })
+
+    it('should track tab click url locations', function () {
+      var clickOn = element.querySelector('.tab-1')
+      clickOn.click()
+      expect(window.dataLayer[0].event_data.url).toEqual('#tab-location-1')
+
+      window.dataLayer = []
+      clickOn = element.querySelector('.tab-2')
+      clickOn.click()
+      expect(window.dataLayer[0].event_data.url).toEqual('#tab-location-2')
+
+      window.dataLayer = []
+      clickOn = element.querySelector('.random-list-item')
+      clickOn.click()
+      expect(window.dataLayer[0].event_data.url).toEqual('n/a')
+    })
+  })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
@@ -340,7 +340,7 @@ describe('Google Tag Manager click tracking', function () {
       window.dataLayer = []
       clickOn = element.querySelector('.random-list-item')
       clickOn.click()
-      expect(window.dataLayer[0].event_data.url).toEqual('n/a')
+      expect(window.dataLayer[0].event_data.url).toEqual(null)
     })
   })
 })


### PR DESCRIPTION
Hi @andysellick 

Would you be able to approve this? Though, I'm wondering if we should let our new dev James review it first as a task, and if there any requested changes we can see if he would like to make them. Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
This makes it so our GTM event click tracker grabs the `href` of a tab when it is clicked. For example, if a 'More information' tab is clicked, the value of the url key should be: `url: #more-information` 

This uses `event.target` to ensure that an `<a>` tag was clicked on. You can't use the existing `target` variable as this has already traversed up the DOM due to the use of `.closest`, so it wouldn't let us know if what was clicked on was the tab itself - it just gives us the element with `data-ga4` on it.

## Why
<!-- What are the reasons behind this change being made? -->
When clicking tabs, the `url` value in our GTM schema was passing through the current browser URL. This is an issue because our click tracking runs first, before the tab has changed. Therefore it was grabbing the browser URL before the tab had changed, so it was outdated. For example if you were on `/coronavirus` and clicked on the `More information` tab, our tracking should track either `#more-information` or `/coronavirus#more-information` as this is useful to the analytics. However because we were grabbing the page URL, it was always being displayed as `/coronavirus` as our GTM code runs before the tab code which changes the URL.


## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.