### PR TITLE
Re-add tracking to next and previous pagination link clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove axe-core workaround test ([PR #2882](https://github.com/alphagov/govuk_publishing_components/pull/2882))
+* Re-add tracking to next and previous pagination links ([PR #2885](https://github.com/alphagov/govuk_publishing_components/pull/2885))
 
 ## 30.0.0
 

--- a/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
@@ -10,9 +10,9 @@
         link_text_classes = %w[govuk-pagination__link-title]
         link_text_classes << "govuk-pagination__link-title--decorated" unless previous_page[:label].present?
       %>
-      <div class="govuk-pagination__prev">
-        <a class="govuk-link govuk-pagination__link" 
-          href="<%= previous_page[:url] %>" 
+      <div class="govuk-pagination__prev" data-module="gem-track-click">
+        <a class="govuk-link govuk-pagination__link"
+          href="<%= previous_page[:url] %>"
           rel="prev"
           data-track-category="contentsClicked"
           data-track-action="previous"
@@ -38,9 +38,9 @@
         link_text_classes = %w[govuk-pagination__link-title]
         link_text_classes << "govuk-pagination__link-title--decorated" unless next_page[:label].present?
       %>
-      <div class="govuk-pagination__next">
-        <a class="govuk-link govuk-pagination__link" 
-          href="<%= next_page[:url] %>" 
+      <div class="govuk-pagination__next" data-module="gem-track-click">
+        <a class="govuk-link govuk-pagination__link"
+          href="<%= next_page[:url] %>"
           rel="next"
           data-track-category="contentsClicked"
           data-track-action="next"


### PR DESCRIPTION
The data-module was removed when .gem-c-pagination was replaced with .govuk-pagination [1].

This caused smokey tests to fail [2] when Finder Frontend was bumped to govuk_publishing_components 30.0.0 [3].

The tests were failing due to ‘Step: [FAIL] Then the "contentsClicked" event is reported’. This commit re-adds data-module="gem-track-click" and the contentsClicked event now fires as expected.

![Screenshot 2022-08-01 at 17 27 00](https://user-images.githubusercontent.com/5963488/182205888-c0e9ef89-d84e-42e2-b7be-5f44711409d3.png)
^ Tracking in Finder Frontend


[1](https://github.com/alphagov/govuk_publishing_components/commit/dbcc6977f24b7da98c8399bcfcfc8a7e39587ffd#diff-faf8d214f3533285c10c2c77f2ea3db12f3c22463bb53a2e3587a4494fc79bc1L7)

[2](https://alert.production.govuk.digital/cgi-bin/icinga/extinfo.cgi?type=2&host=ip-10-13-5-163.eu-west-1.compute.internal&service=Smokey+loop+for+apps%2Ffinder_frontend&scroll=299)

[3](https://github.com/alphagov/finder-frontend/pull/2838)

