### PR TITLE
Improve GTM analytics click tracking docs

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -185,15 +185,15 @@ examples:
     description: |
       Adds custom data attributes to each section of the accordion. Accepts a hash, so multiple attributes can be added.
 
-      The `data_attributes` hash is for the outermost element in the accordion.
+      The `data_attributes` option applies attributes to the outermost element in the accordion. Each item can also have a `data_attributes` hash, which are placed on the `button` that triggers the opening and closing - useful for differentiating between each section of the accordion.
 
-      Each item can also have a `data_attributes` hash. These `data_attributes` are placed on the `button` that triggers the opening and closing - useful for differentiating between each section of the accordion.
+      Data attributes can be added to the 'Show/hide all' link using the `data_attributes_show_all` option, primarily where custom tracking is required. These attributes are read from the accordion markup and then added to the link by JavaScript (which is how the link is created). More details on how this can be used with the GA4 click tracking can be found in the 'Advanced' section of the [click tracking documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-gtm/gtm-click-tracking.md).
 
-      Data attributes can also be added to the 'Show/hide all' link using the `data_attributes_show_all` option, primarily where custom tracking is required. These attributes are read from the accordion markup and then added to the link by JavaScript (which is how the link is created). If `track_options` within `data_attributes_show_all` is set, then it is possible to pass a custom dimension when 'Show/Hide all' is clicked.
+      If `track_options` within `data_attributes_show_all` is set, then it is possible to pass a custom dimension when 'Show/Hide all' is clicked.
     data:
       data_attributes:
-          gtm: gtm-accordion
-          ga: ga-accordion
+        gtm: gtm-accordion
+        ga: ga-accordion
       data_attributes_show_all:
         gtm-event-name: example
         gtm-attributes: "{ 'ui': { 'type': 'type value', 'section': 'section value' } }"


### PR DESCRIPTION
## What / why
Rewrite the documentation for applying click tracking to accordion 'show all sections' links. This in response to https://github.com/alphagov/collections/pull/2886, where the need for better documentation was identified.

## Visual Changes
None.

Trello card: https://trello.com/c/L9L67OKk/339-fix-accordion-example-and-json-parsing-in-publishing-components
