### PR TITLE
[DO NOT MERGE] Fix intermittently failing test

### DIFF
--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -444,10 +444,11 @@ describe "Contextual navigation" do
   end
 
   def then_i_see_the_topic_breadcrumb
+    markup = find("//.gem-c-contextual-breadcrumbs")
+    puts markup.native.inner_html
     within ".gem-c-breadcrumbs" do
-      puts page.html
-      expect(page).to have_link("Home")
-      expect(page).to have_link(topic_item["title"])
+      expect(page).to have_link("Home") # this passes
+      expect(page).to have_link(topic_item["title"]) # this is the 'oil and gas' link that occasionally can't be found
     end
   end
 

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -445,6 +445,7 @@ describe "Contextual navigation" do
 
   def then_i_see_the_topic_breadcrumb
     within ".gem-c-breadcrumbs" do
+      puts page.html
       expect(page).to have_link("Home")
       expect(page).to have_link(topic_item["title"])
     end

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -444,7 +444,7 @@ describe "Contextual navigation" do
   end
 
   def then_i_see_the_topic_breadcrumb
-    markup = find("//.gem-c-contextual-breadcrumbs")
+    markup = find("//.gem-c-breadcrumbs")
     puts markup.native.inner_html
     within ".gem-c-breadcrumbs" do
       expect(page).to have_link("Home") # this passes

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -446,6 +446,8 @@ describe "Contextual navigation" do
   def then_i_see_the_topic_breadcrumb
     markup = find("//.gem-c-breadcrumbs")
     puts markup.native.inner_html
+    puts "topic_item title is:"
+    puts topic_item["title"]
     within ".gem-c-breadcrumbs" do
       expect(page).to have_link("Home") # this passes
       expect(page).to have_link(topic_item["title"]) # this is the 'oil and gas' link that occasionally can't be found


### PR DESCRIPTION
## What
(attempt to) fix an intermittently failing test with the contextual navigation component. The failing test can be run on the command line using:

```
bundle exec rspec ./spec/features/contextual_navigation_spec.rb
```

The test should result in a page containing this:

```html
<div class="gem-c-contextual-breadcrumbs">
  <script type="application/ld+json">
    {
      "@context": "http://schema.org",
      "@type": "BreadcrumbList",
      "itemListElement": [
      {
        "@type": "ListItem",
        "position": 1,
        "item": {
          "name": "Home",
          "@id": "http://www.dev.gov.uk/"
        }
      },
      {
        "@type": "ListItem",
        "position": 2,
        "item": {
          "name": "Oil and gas",
          "@id": "http://www.dev.gov.uk/topic/oil-and-gas"
        }
      }
      ]
    }
  </script>
  
  <div class="gem-c-breadcrumbs govuk-breadcrumbs govuk-breadcrumbs--collapse-on-mobile" data-module="gem-track-click">
    <ol class="govuk-breadcrumbs__list">
      <li class="govuk-breadcrumbs__list-item">
        <a data-track-category="homeLinkClicked" data-track-action="homeBreadcrumb" data-track-label="" data-track-options="{}" class="govuk-breadcrumbs__link" href="/">Home</a>
      </li>
      <li class="govuk-breadcrumbs__list-item">
        <a data-track-category="breadcrumbClicked" data-track-action="2" data-track-label="/topic/oil-and-gas" data-track-options="{&quot;dimension28&quot;:&quot;2&quot;,&quot;dimension29&quot;:&quot;Oil and gas&quot;}" class="govuk-breadcrumbs__link" href="/topic/oil-and-gas">Oil and gas</a>
      </li>
    </ol>
  </div>
</div>
```

...but occasionally for some reason that I haven't been able to figure out yet, it's missing the second content item part, and only produces this:

```html
<div class="gem-c-contextual-breadcrumbs">    
  <script type="application/ld+json">
    {
      "@context": "http://schema.org",
      "@type": "BreadcrumbList",
      "itemListElement": [
      {
        "@type": "ListItem",
        "position": 1,
        "item": {
          "name": "Home",
          "@id": "http://www.dev.gov.uk/"
        }
      }
      ]
    }
  </script>
  
  <div class="gem-c-breadcrumbs govuk-breadcrumbs govuk-breadcrumbs--collapse-on-mobile" data-module="gem-track-click">
    <ol class="govuk-breadcrumbs__list">
      <li class="govuk-breadcrumbs__list-item">
        <a data-track-category="homeLinkClicked" data-track-action="homeBreadcrumb" data-track-label="" data-track-options="{}" class="govuk-breadcrumbs__link" href="/">Home</a>
      </li>
    </ol>
  </div>
</div>
```

## Why
It keeps popping up and temporarily blocking PRs, which is annoying.

## Visual Changes
None.
