### PR TITLE
Update GA4 schema to use null instead of 'n/a' for undefined values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update GA4 schema to use null instead of 'n/a' for undefined values ([PR #2889](https://github.com/alphagov/govuk_publishing_components/pull/2889))
 * Remove times from GA4 analytics page views ([PR #2891](https://github.com/alphagov/govuk_publishing_components/pull/2891))
 * Remove axe-core workaround test ([PR #2882](https://github.com/alphagov/govuk_publishing_components/pull/2882))
 * Move the emergency_banner from static ([PR #2795](https://github.com/alphagov/govuk_publishing_components/pull/2795))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js
@@ -33,7 +33,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         // get attributes from the data attribute to send to GA
         // only allow it if it already exists in the schema
         for (var property in data) {
-          if (schema.event_data[property]) {
+          if (property in schema.event_data) {
             schema.event_data[property] = data[property]
           }
         }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
@@ -5,6 +5,7 @@
 
   GOVUK.Gtm = {
     PIIRemover: new GOVUK.analyticsGA4.PIIRemover(), // imported in analytics-ga4.js
+    nullValue: null,
 
     sendPageView: function () {
       if (window.dataLayer) {
@@ -73,13 +74,13 @@
       if (tag) {
         return tag.getAttribute('content')
       } else {
-        return 'n/a'
+        return this.nullValue
       }
     },
 
     getLanguage: function () {
       var html = document.querySelector('html')
-      return html.getAttribute('lang') || 'n/a'
+      return html.getAttribute('lang') || this.nullValue
     },
 
     getHistory: function () {
@@ -95,7 +96,11 @@
     // return only the date from given timestamps of the form
     // 2022-03-28T19:11:00.000+00:00
     stripTimeFrom: function (value) {
-      return value.split('T')[0]
+      if (value !== null) {
+        return value.split('T')[0]
+      } else {
+        return this.nullValue
+      }
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-schemas.js
@@ -4,7 +4,7 @@
   var GOVUK = global.GOVUK || {}
 
   var Schemas = function () {
-    this.null = 'n/a'
+    this.null = null
   }
 
   Schemas.prototype.eventSchema = function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.spec.js
@@ -281,7 +281,7 @@ describe('Google Tag Manager click tracking', function () {
     it('should not track the aria-expanded state', function () {
       var clickOn = element.querySelector('.clickme')
       clickOn.click()
-      expect(window.dataLayer[0].event_data.action).toEqual('n/a')
+      expect(window.dataLayer[0].event_data.action).toEqual(null)
     })
   })
 
@@ -304,7 +304,7 @@ describe('Google Tag Manager click tracking', function () {
     it('should not track the open/closed state', function () {
       var clickOn = element.querySelector('.clickme')
       clickOn.click()
-      expect(window.dataLayer[0].event_data.action).toEqual('n/a')
+      expect(window.dataLayer[0].event_data.action).toEqual(null)
     })
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
@@ -8,6 +8,7 @@ describe('Google Tag Manager page view tracking', function () {
   beforeEach(function () {
     saved.title = document.title
     document.title = 'This here page'
+    var nullValue = null
     expected = {
       event: 'page_view',
       page_view: {
@@ -16,30 +17,30 @@ describe('Google Tag Manager page view tracking', function () {
         title: 'This here page',
         status_code: '200',
 
-        document_type: 'n/a',
-        publishing_app: 'n/a',
-        rendering_app: 'n/a',
-        schema_name: 'n/a',
-        content_id: 'n/a',
+        document_type: nullValue,
+        publishing_app: nullValue,
+        rendering_app: nullValue,
+        schema_name: nullValue,
+        content_id: nullValue,
 
-        section: 'n/a',
-        taxon_slug: 'n/a',
-        taxon_id: 'n/a',
-        themes: 'n/a',
-        taxon_slugs: 'n/a',
-        taxon_ids: 'n/a',
+        section: nullValue,
+        taxon_slug: nullValue,
+        taxon_id: nullValue,
+        themes: nullValue,
+        taxon_slugs: nullValue,
+        taxon_ids: nullValue,
 
-        language: 'n/a',
+        language: nullValue,
         history: 'false',
         withdrawn: 'false',
-        first_published_at: 'n/a',
-        updated_at: 'n/a',
-        public_updated_at: 'n/a',
-        publishing_government: 'n/a',
-        political_status: 'n/a',
-        primary_publishing_organisation: 'n/a',
-        organisations: 'n/a',
-        world_locations: 'n/a'
+        first_published_at: nullValue,
+        updated_at: nullValue,
+        public_updated_at: nullValue,
+        publishing_government: nullValue,
+        political_status: nullValue,
+        primary_publishing_organisation: nullValue,
+        organisations: nullValue,
+        world_locations: nullValue
       }
     }
     window.dataLayer = []


### PR DESCRIPTION
## What
Change the GA4 tracking code so that empty values passed to GA4 are now `null` and not `n/a`.

Had a brief thought about using `undefined` instead of `null` but decided on `null` on the basis that null is an assignment value, meant for assigning to a variable as a representation of no value (apparently).

Note that this code is only enabled on integration.

## Why
Currently we're sending `n/a` values for any event_data parameters that don't have a value in order to nullify previously passed data. We believe that GA4 will automatically return `(not set)` for any dimensions that don't have a value. So we think it's safe to not track a value at all, rather than tracking `n/a`.

## Visual Changes
None.

Trello card: https://trello.com/c/HoDiZaWd/348-push-null-values-rather-than-n-a-in-eventdata-parameters
