### PR TITLE
Remove times from GA4 analytics page views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove times from GA4 analytics page views ([PR #2891](https://github.com/alphagov/govuk_publishing_components/pull/2891))
 * Remove axe-core workaround test ([PR #2882](https://github.com/alphagov/govuk_publishing_components/pull/2882))
 * Move the emergency_banner from static ([PR #2795](https://github.com/alphagov/govuk_publishing_components/pull/2795))
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
@@ -32,9 +32,9 @@
             language: this.getLanguage(),
             history: this.getHistory(),
             withdrawn: this.getWithDrawn(),
-            first_published_at: this.getMetaContent('first-published-at'),
-            updated_at: this.getMetaContent('updated-at'),
-            public_updated_at: this.getMetaContent('public-updated-at'),
+            first_published_at: this.stripTimeFrom(this.getMetaContent('first-published-at')),
+            updated_at: this.stripTimeFrom(this.getMetaContent('updated-at')),
+            public_updated_at: this.stripTimeFrom(this.getMetaContent('public-updated-at')),
             publishing_government: this.getMetaContent('publishing-government'),
             political_status: this.getMetaContent('political-status'),
             primary_publishing_organisation: this.getMetaContent('primary-publishing-organisation'),
@@ -90,6 +90,12 @@
     getWithDrawn: function () {
       var withdrawn = this.getMetaContent('withdrawn')
       return (withdrawn === 'withdrawn') ? 'true' : 'false'
+    },
+
+    // return only the date from given timestamps of the form
+    // 2022-03-28T19:11:00.000+00:00
+    stripTimeFrom: function (value) {
+      return value.split('T')[0]
     }
   }
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
@@ -191,21 +191,21 @@ describe('Google Tag Manager page view tracking', function () {
 
   it('returns a pageview on a page with a first published date', function () {
     createMetaTags('first-published-at', '2022-03-28T19:11:00.000+00:00')
-    expected.page_view.first_published_at = '2022-03-28T19:11:00.000+00:00'
+    expected.page_view.first_published_at = '2022-03-28'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page with a last updated date', function () {
     createMetaTags('updated-at', '2021-03-28T19:11:00.000+00:00')
-    expected.page_view.updated_at = '2021-03-28T19:11:00.000+00:00'
+    expected.page_view.updated_at = '2021-03-28'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page with a last public updated date', function () {
     createMetaTags('public-updated-at', '2020-03-28T19:11:00.000+00:00')
-    expected.page_view.public_updated_at = '2020-03-28T19:11:00.000+00:00'
+    expected.page_view.public_updated_at = '2020-03-28'
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })


### PR DESCRIPTION
## What / why
Remove time from GA4 page view data.

- page views include values for when the page was updated, which are strings of date followed by time, these are taken from the corresponding metatags on each page
- time is not needed, so stripping from the GA4 data

Note that this code is enabled only in integration.

## Visual Changes
None.

Trello card: https://trello.com/c/52O14FNY/346-strip-times-from-date-values-in-pageview-parameters
