### PR TITLE
Fix GA4 analytics language on page views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix GA4 analytics language on page views ([PR #2892](https://github.com/alphagov/govuk_publishing_components/pull/2892))
 * Update GA4 schema to use null instead of 'n/a' for undefined values ([PR #2889](https://github.com/alphagov/govuk_publishing_components/pull/2889))
 * Remove times from GA4 analytics page views ([PR #2891](https://github.com/alphagov/govuk_publishing_components/pull/2891))
 * Remove axe-core workaround test ([PR #2882](https://github.com/alphagov/govuk_publishing_components/pull/2882))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js
@@ -79,8 +79,12 @@
     },
 
     getLanguage: function () {
-      var html = document.querySelector('html')
-      return html.getAttribute('lang') || this.nullValue
+      var content = document.getElementById('content')
+      if (content) {
+        return content.getAttribute('lang') || this.nullValue
+      } else {
+        return this.nullValue
+      }
     },
 
     getHistory: function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.spec.js
@@ -4,11 +4,11 @@ describe('Google Tag Manager page view tracking', function () {
   var GOVUK = window.GOVUK
   var saved = {}
   var expected
+  var nullValue = null
 
   beforeEach(function () {
     saved.title = document.title
     document.title = 'This here page'
-    var nullValue = null
     expected = {
       event: 'page_view',
       page_view: {
@@ -160,10 +160,37 @@ describe('Google Tag Manager page view tracking', function () {
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
-  it('returns a pageview with a language', function () {
-    var html = document.querySelector('html')
-    html.setAttribute('lang', 'wakandan')
-    expected.page_view.language = 'wakandan'
+  describe('returns a pageview with a language', function () {
+    var content
+
+    beforeEach(function () {
+      content = document.createElement('div')
+      content.setAttribute('id', 'content')
+      document.body.appendChild(content)
+    })
+
+    afterEach(function () {
+      document.body.removeChild(content)
+    })
+
+    it('set correctly', function () {
+      content.setAttribute('lang', 'wakandan')
+      expected.page_view.language = 'wakandan'
+
+      GOVUK.Gtm.sendPageView()
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('set incorrectly', function () {
+      expected.page_view.language = nullValue
+
+      GOVUK.Gtm.sendPageView()
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+  })
+
+  it('returns a pageview without a language', function () {
+    expected.page_view.language = nullValue
 
     GOVUK.Gtm.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)


### PR DESCRIPTION
## What
Fix the value for `language` of the page in page views in the GA4 analytics code.

Note that this is only implemented on integration.

## Why
Language was incorrectly being reported as `en` on non English language pages.

## Visual Changes
None.

Trello card: https://trello.com/c/lYTIDjZg/345-content-language-should-not-always-be-en
