### PR TITLE
Version 30.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 30.1.0
 
 * Fix GA4 analytics language on page views ([PR #2892](https://github.com/alphagov/govuk_publishing_components/pull/2892))
 * Update GA4 schema to use null instead of 'n/a' for undefined values ([PR #2889](https://github.com/alphagov/govuk_publishing_components/pull/2889))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (30.0.0)
+    govuk_publishing_components (30.1.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "30.0.0".freeze
+  VERSION = "30.1.0".freeze
 end


### PR DESCRIPTION
## 30.1.0

* Fix GA4 analytics language on page views ([PR #2892](https://github.com/alphagov/govuk_publishing_components/pull/2892))
* Update GA4 schema to use null instead of 'n/a' for undefined values ([PR #2889](https://github.com/alphagov/govuk_publishing_components/pull/2889))
* Remove times from GA4 analytics page views ([PR #2891](https://github.com/alphagov/govuk_publishing_components/pull/2891))
* Remove axe-core workaround test ([PR #2882](https://github.com/alphagov/govuk_publishing_components/pull/2882))
* Move the emergency_banner from static ([PR #2795](https://github.com/alphagov/govuk_publishing_components/pull/2795))