### PR TITLE
Include size attributes on image card component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add GA4 analytics GTM blocklist ([PR #2962](https://github.com/alphagov/govuk_publishing_components/pull/2962))
 * GA4 analytics add single dataLayer push function ([PR #2960](https://github.com/alphagov/govuk_publishing_components/pull/2960))
 * Remove unused classes in intervention component ([PR #2920](https://github.com/alphagov/govuk_publishing_components/pull/2920))
+* Include size attributes on image card component ([PR #2895](https://github.com/alphagov/govuk_publishing_components/pull/2895))
 
 ## 30.5.2
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -55,7 +55,8 @@
 
 .gem-c-image-card__image {
   display: block;
-  max-width: 100%;
+  height: auto;
+  width: 100%;
   border-top: 1px solid $govuk-border-colour;
   border-left: none;
   border-right: none;

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -4,6 +4,8 @@ body: |
   An image and links, meant for use for news articles and people. Includes optional paragraph and additional links.
 
   The component is generally to be used within a grid column but has no grid of its own, so the text and the images in the examples below may not always line up. This will normally look tidier, for example [on pages like this](https://www.gov.uk/government/organisations/attorney-generals-office).
+
+  Images should have an aspect ratio of 3:2.
 accessibility_criteria: |
   The component must:
 
@@ -12,6 +14,10 @@ accessibility_criteria: |
   - if the contents of the component are in a different language than the rest of the document, include an appropriate `lang` attribute to correctly identify the language used in the component
 shared_accessibility_criteria:
   - link
+embed: |
+  <div class="govuk-!-width-one-third">
+    <%= component %>
+  </div>
 examples:
   default:
     data:
@@ -195,6 +201,10 @@ examples:
         text: "Announcement"
       heading_text: "Something has happened nearby possibly"
       description: "Following a news report that something has happened, further details are emerging of the thing that has happened and what that means for you."
+    embed: |
+      <div class="govuk-!-width-full">
+        <%= component %>
+      </div>
   with_data_attributes:
     description: Data attributes can be applied as required. Note that the component does not include built in tracking. If this is required consider using the [track click script](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics/track-click.md).
     data:
@@ -283,3 +293,7 @@ examples:
         /assets/govuk_publishing_components/image-card-srcset/cop26-320.jpg: 320w
         /assets/govuk_publishing_components/image-card-srcset/cop26-240.jpg: 240w
         /assets/govuk_publishing_components/image-card-srcset/cop26-170.jpg: 170w
+    embed: |
+      <div class="govuk-!-width-full">
+        <%= component %>
+      </div>

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -46,6 +46,8 @@ module GovukPublishingComponents
               loading: @image_loading,
               sizes: @sizes,
               srcset: @srcset,
+              height: 200,
+              width: 300,
             )
           end
         end


### PR DESCRIPTION
## What
https://trello.com/c/iz7WJaeG/1404-include-width-and-height-size-attributes-on-image-card-component-2869

Include width and height size attributes on image card component

- https://components-gem-pr-2895.herokuapp.com/component-guide/image_card
- https://components-gem-pr-2895.herokuapp.com/component-guide/image_card/large_version

## Why
See https://github.com/alphagov/govuk_publishing_components/issues/2863

## Visual changes

### CLS (before)

https://user-images.githubusercontent.com/87758239/183419165-41224472-c3b2-4bb2-bf3a-3e786f6b190f.mov

### CLS (after)

https://user-images.githubusercontent.com/87758239/183419124-d9d54a1b-3a6c-4e23-b06d-772eefce2f3b.mov

## Testing

https://www.integration.publishing.service.gov.uk/government/organisations/attorney-generals-office (which includes the image component with `large` and standard options) in -

- [x] Internet Explorer 11 on Windows 10 
- [x] Edge 103 on Windows 10 
- [x] Chrome 104 on Windows 10 
- [x] Chrome 104 on macOS Monterey
- [x] Safari 15.3 on macOS Monterey
- [x] Firefox 103 on macOS Big Sur
- [x] Chrome on Galaxy S22
- [x] Safari on iPhone 13