### PR TITLE
Remove GOV.UK specific code for handling exclusive checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 - Don't include changes that are purely internal. The CHANGELOG should be a
   useful summary for people upgrading their application, not a replication
   of the commit log.
-  
+
 ## Unreleased
 
+* Remove GOV.UK specific code for handling exclusive checkboxes ([PR #2896](https://github.com/alphagov/govuk_publishing_components/pull/2896))
 * Add links and sections count tracking for Cost of living hub ([PR #2921](https://github.com/alphagov/govuk_publishing_components/pull/2921))
 * Fix bugs with gtm external link tracking ([PR #2916](https://github.com/alphagov/govuk_publishing_components/pull/2916))
 

--- a/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/checkboxes.js
@@ -9,7 +9,6 @@ window.GOVUK.Modules.GovukCheckboxes = window.GOVUKFrontend.Checkboxes;
     this.$module = $module
     this.$checkboxes = this.$module.querySelectorAll('input[type=checkbox]')
     this.$nestedCheckboxes = this.$module.querySelectorAll('[data-nested=true] input[type=checkbox]')
-    this.$exclusiveCheckboxes = this.$module.querySelectorAll('[data-exclusive=true] input[type=checkbox]')
   }
 
   GemCheckboxes.prototype.init = function () {
@@ -21,10 +20,6 @@ window.GOVUK.Modules.GovukCheckboxes = window.GOVUKFrontend.Checkboxes;
 
     for (i = 0; i < this.$nestedCheckboxes.length; i++) {
       this.$nestedCheckboxes[i].addEventListener('change', this.handleNestedCheckboxChange.bind(this))
-    }
-
-    for (i = 0; i < this.$exclusiveCheckboxes.length; i++) {
-      this.$exclusiveCheckboxes[i].addEventListener('change', this.handleExclusiveCheckboxChange)
     }
   }
 
@@ -92,23 +87,6 @@ window.GOVUK.Modules.GovukCheckboxes = window.GOVUKFrontend.Checkboxes;
       $parent.checked = true
     } else {
       $parent.checked = false
-    }
-  }
-
-  GemCheckboxes.prototype.handleExclusiveCheckboxChange = function (event) {
-    var $currentCheckbox = event.target
-    var $checkboxes = $currentCheckbox.closest('.govuk-checkboxes')
-    var $exclusiveOption = $checkboxes.querySelector('input[type=checkbox][data-exclusive]')
-    var $nonExclusiveOptions = $checkboxes.querySelectorAll('input[type=checkbox]:not([data-exclusive])')
-
-    if ($currentCheckbox.getAttribute('data-exclusive') === 'true' && $currentCheckbox.checked === true) {
-      for (var i = 0; i < $nonExclusiveOptions.length; i++) {
-        $nonExclusiveOptions[i].checked = false
-      }
-    } else if ($currentCheckbox.getAttribute('data-exclusive') !== 'true' && $currentCheckbox.checked === true) {
-      if ($exclusiveOption) {
-        $exclusiveOption.checked = false
-      }
     }
   }
 

--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -24,8 +24,7 @@
 
         <%= tag.ul class: cb_helper.list_classes, data: {
           module: ('govuk-checkboxes' if cb_helper.has_conditional),
-          nested: ('true' if cb_helper.has_nested),
-          exclusive: ('true' if cb_helper.has_exclusive)
+          nested: ('true' if cb_helper.has_nested)
         } do %>
           <% cb_helper.items.each_with_index do |item, index| %>
             <% if item === :or %>

--- a/app/views/govuk_publishing_components/components/_checkboxes.html.erb
+++ b/app/views/govuk_publishing_components/components/_checkboxes.html.erb
@@ -4,7 +4,7 @@
   id = cb_helper.id
 %>
 
-<%= tag.div id: id, class: cb_helper.css_classes, data: { module: "gem-checkboxes" } do %>
+<%= tag.div id: id, class: cb_helper.css_classes, data: { module: "gem-checkboxes govuk-checkboxes" } do %>
   <% if cb_helper.should_have_fieldset %>
     <% if cb_helper.heading_markup %>
       <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": cb_helper.fieldset_describedby do %>

--- a/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
+++ b/lib/govuk_publishing_components/presenters/checkboxes_helper.rb
@@ -14,8 +14,7 @@ module GovukPublishingComponents
                   :id,
                   :hint_text,
                   :description,
-                  :heading_caption,
-                  :has_exclusive
+                  :heading_caption
 
       def initialize(options)
         @items = options[:items] || []
@@ -29,7 +28,6 @@ module GovukPublishingComponents
 
         # check if any item is set as being conditional
         @has_conditional = options[:items].any? { |item| item.is_a?(Hash) && item[:conditional] }
-        @has_exclusive = options[:items].any? { |item| item.is_a?(Hash) && item[:exclusive] }
         @has_nested = options[:items].any? { |item| item.is_a?(Hash) && item[:items] }
 
         @id = options[:id] || "checkboxes-#{SecureRandom.hex(4)}"
@@ -97,7 +95,7 @@ module GovukPublishingComponents
         data = checkbox[:data_attributes] || {}
         data[:controls] = controls
         data["aria-controls"] = aria_controls
-        data[:exclusive] = checkbox[:exclusive]
+        data[:behaviour] = "exclusive" if checkbox[:exclusive]
 
         capture do
           concat check_box_tag checkbox_name, checkbox[:value], checked, class: "govuk-checkboxes__input", id: checkbox_id, data: data

--- a/spec/components/checkboxes_spec.rb
+++ b/spec/components/checkboxes_spec.rb
@@ -326,8 +326,7 @@ describe "Checkboxes", type: :view do
         { label: "Other", value: "other", exclusive: true },
       ],
     )
-    assert_select ".govuk-checkboxes[data-exclusive=true]"
-    assert_select ".govuk-checkboxes__input[value=other][data-exclusive=true]"
+    assert_select ".govuk-checkboxes__input[value=other][data-behaviour=exclusive]"
     assert_select ".gem-c-checkboxes__divider", text: "or"
   end
 

--- a/spec/javascripts/components/checkboxes-spec.js
+++ b/spec/javascripts/components/checkboxes-spec.js
@@ -13,9 +13,9 @@ describe('Checkboxes component', function () {
            '<h1 class="govuk-fieldset__heading">What is your favourite colour?</h1>' +
         '</legend>' +
         '<span id="checkboxes-1ac8e5cf-hint" class="govuk-hint">Select all that apply.</span>' +
-        '<ul class="govuk-checkboxes gem-c-checkboxes__list" data-nested="true" data-exclusive="true">' +
+        '<ul class="govuk-checkboxes gem-c-checkboxes__list" data-nested="true">' +
            '<li class="govuk-checkboxes__item">' +
-              '<input id="checkboxes-1ac8e5cf-0" name="favourite_colour" type="checkbox" value="red" class="govuk-checkboxes__input" data-track-category="choseFavouriteColour" data-track-action="favourite-color" data-track-label="red" data-track-value="1" data-track-options=\'{"dimension28": "wubbalubbadubdub","dimension29": "Pickle Rick"}\'>' +
+              '<input id="checkboxes-1ac8e5cf-0" name="favourite_colour" type="checkbox" value="red" class="govuk-checkboxes__input" data-track-category="choseFavouriteColour" data-track-action="favourite-color" data-track-label="red" data-track-value="1" data-track-options=\'{"dimension28": "wubbalubbadubdub","dimension29": "Pickle Rick"}\' data-test-exclusive>' +
               '<label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-0">Red</label>' +
               '<ul id="checkboxes-1ac8e5cf-nested-0" class="govuk-checkboxes govuk-checkboxes--nested" data-parent="checkboxes-1ac8e5cf-0">' +
                 '<li class="govuk-checkboxes__item">' +
@@ -29,7 +29,7 @@ describe('Checkboxes component', function () {
               '</ul>' +
            '</li>' +
            '<li class="govuk-checkboxes__item">' +
-              '<input id="checkboxes-1ac8e5cf-1" name="favourite_colour" type="checkbox" value="blue" class="govuk-checkboxes__input" data-track-category="choseFavouriteColour" data-uncheck-track-category="unselectedFavouriteColour" data-track-action="favourite-color" data-track-label="blue" data-track-value="2" data-track-options=\'{"dimension28":"Get schwifty","dimension29":"Squanch"}\'>' +
+              '<input id="checkboxes-1ac8e5cf-1" name="favourite_colour" type="checkbox" value="blue" class="govuk-checkboxes__input" data-track-category="choseFavouriteColour" data-uncheck-track-category="unselectedFavouriteColour" data-track-action="favourite-color" data-track-label="blue" data-track-value="2" data-track-options=\'{"dimension28":"Get schwifty","dimension29":"Squanch"}\' data-test-exclusive>' +
               '<label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-1">Blue</label>' +
               '<ul id="checkboxes-1ac8e5cf-nested-1" class="govuk-checkboxes govuk-checkboxes--nested" data-parent="checkboxes-1ac8e5cf-1">' +
                 '<li class="govuk-checkboxes__item">' +
@@ -43,7 +43,7 @@ describe('Checkboxes component', function () {
               '</ul>' +
            '</li>' +
            '<li class="govuk-checkboxes__item">' +
-              '<input id="checkboxes-1ac8e5cf-2" name="favourite_colour" type="checkbox" value="other" class="govuk-checkboxes__input" data-exclusive="true">' +
+              '<input id="checkboxes-1ac8e5cf-2" name="favourite_colour" type="checkbox" value="other" class="govuk-checkboxes__input" data-behaviour="exclusive">' +
               '<label class="govuk-label govuk-checkboxes__label" for="checkboxes-1ac8e5cf-2">Other</label>' +
            '</li>' +
         '</ul>' +
@@ -67,8 +67,8 @@ describe('Checkboxes component', function () {
     $parentCheckbox = $parentCheckboxWrapper.find('> .govuk-checkboxes__input')
     $nestedChildren = $parentCheckboxWrapper.find('.govuk-checkboxes--nested .govuk-checkboxes__input')
     $checkboxesWrapper = $('.gem-c-checkboxes')
-    $exclusiveOption = $checkboxesWrapper.find('input[type=checkbox][data-exclusive]')
-    $nonExclusiveOptions = $checkboxesWrapper.find('input[type=checkbox]:not([data-exclusive])')
+    $exclusiveOption = $checkboxesWrapper.find('input[type=checkbox][data-test-exclusive]')
+    $nonExclusiveOptions = $checkboxesWrapper.find('input[type=checkbox][data-behaviour="exclusive"]')
     expectedRedOptions = { label: 'red', value: '1', dimension28: 'wubbalubbadubdub', dimension29: 'Pickle Rick' }
     expectedBlueOptions = { label: 'blue', value: '2', dimension28: 'Get schwifty', dimension29: 'Squanch' }
 


### PR DESCRIPTION
## What
Remove GOV.UK specific code for handling the [exclusive checkboxes option](https://components.publishing.service.gov.uk/component-guide/checkboxes/checkbox_with_exclusive_item).

## Why
This is already included in `govuk-frontend` as of v.3.13.0.

Fixes https://github.com/alphagov/govuk_publishing_components/issues/2167

## Visual Changes
None.
