### PR TITLE
Fix auditing path cleaning

### DIFF
--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -150,7 +150,7 @@ module GovukPublishingComponents
     end
 
     def clean_file_path(file)
-      file[/(?<=#{Regexp.escape(@path.to_s)}\/)[\/a-zA-Z_-]+.[a-zA-Z.]+/]
+      file[/(?<=#{Regexp.escape(@path.to_s)}\/)[\/a-zA-Z_-]+.[a-zA-Z+.]+/]
     end
 
     def clean_file_name(name)


### PR DESCRIPTION
## What
Fixes a bug in the component auditing, in the section that shows where components are used in applications.

- fixes a bug where file paths that contained a + character were being cut short, resulting in incorrect links to component references in applications
- example was `guide.html+print.erb` in government-frontend, which was incorrectly coming out as `guide.html`

## Why
Was generating links to files that didn't exist.

## Visual Changes
None.
