### PR TITLE
Expand print link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Expand print link component ([PR #2900](https://github.com/alphagov/govuk_publishing_components/pull/2900))
+
 ## 30.1.0
 
 * Fix GA4 analytics language on page views ([PR #2892](https://github.com/alphagov/govuk_publishing_components/pull/2892))

--- a/app/views/govuk_publishing_components/component_guide/example.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/example.html.erb
@@ -7,6 +7,10 @@
 
 <%= render 'govuk_publishing_components/components/title', title: @component_example.name, context: "#{@component_doc.name} example", margin_top: 0 %>
 
+<% code_example = capture do %>
+  <%= render partial: "govuk_publishing_components/component_guide/component_doc/call", locals: { component_doc: @component_doc, example: @component_example } %>
+<% end %>
+
 <div class="component-show">
   <div class="component-doc">
     <div class="component-markdown">
@@ -19,6 +23,6 @@
     <%= render partial: "govuk_publishing_components/component_guide/component_doc/preview", locals: { component_doc: @component_doc, example: @component_example } %>
 
     <h2 class="component-doc-h2">How to call this example</h2>
-    <%= render partial: "govuk_publishing_components/component_guide/component_doc/call", locals: { component_doc: @component_doc, example: @component_example } %>
+    <%= code_example %>
   </div>
 </div>

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -74,8 +74,11 @@
           <div class="component-markdown">
             <%= raw(example.html_description) %>
           </div>
+          <% code_example = capture do %>
+            <%= render "govuk_publishing_components/component_guide/component_doc/call", component_doc: @component_doc, example: example %>
+          <% end %>
           <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, example: example %>
-          <%= render "govuk_publishing_components/component_guide/component_doc/call", component_doc: @component_doc, example: example %>
+          <%= code_example %>
         </div>
       <% end %>
     </div>

--- a/app/views/govuk_publishing_components/components/_print_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_print_link.html.erb
@@ -6,7 +6,7 @@
   margin_top ||= 3
   margin_bottom ||= 3
 
-  data_attributes[:module] = require_js ? "print-link" : "button"
+  ((data_attributes[:module] ||= "") << " " << (require_js ? "print-link" : "button")).strip!
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new({
     margin_top: margin_top,

--- a/app/views/govuk_publishing_components/components/docs/print_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/print_link.yml
@@ -26,6 +26,11 @@ examples:
         track-category: "printButton"
         track-action: "clicked"
         track-label: "Print this page"
+  with_custom_data_module:
+    description: The component includes its own `data-module` but others can be passed in addition if required, for example to apply tracking to an element. This will be included along with the components own `data-module`.
+    data:
+      data_attributes:
+        module: "gem-track-click"
   with_custom_margins:
     description: The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having margin level `3` on top and bottom.
     data:

--- a/spec/components/print_link_spec.rb
+++ b/spec/components/print_link_spec.rb
@@ -12,7 +12,7 @@ describe "Print link", type: :view do
     assert_select ".gem-c-print-link.govuk-\\!-margin-top-3"
     assert_select ".gem-c-print-link.govuk-\\!-margin-bottom-3"
     assert_select(
-      "button.gem-c-print-link__button",
+      "button.gem-c-print-link__button[data-module='print-link']",
       text: "Print this page",
     )
   end
@@ -36,7 +36,7 @@ describe "Print link", type: :view do
 
     assert_select ".gem-c-print-link"
     assert_select(
-      'a.gem-c-print-link__link[href="/print"]',
+      'a.gem-c-print-link__link[href="/print"][data-module="button"]',
       text: "Print this page",
     )
   end
@@ -54,5 +54,15 @@ describe "Print link", type: :view do
       "button.gem-c-print-link__button",
       text: "Print this page",
     )
+  end
+
+  it "displays data attributes" do
+    render_component({
+      data_attributes: {
+        snow: "patrol",
+      },
+    })
+
+    assert_select ".gem-c-print-link button[data-snow='patrol']"
   end
 end

--- a/spec/components/print_link_spec.rb
+++ b/spec/components/print_link_spec.rb
@@ -65,4 +65,25 @@ describe "Print link", type: :view do
 
     assert_select ".gem-c-print-link button[data-snow='patrol']"
   end
+
+  it "accepts an additional passed data module when rendering as a button" do
+    render_component({
+      data_attributes: {
+        module: "gem-track-click",
+      },
+    })
+
+    assert_select ".gem-c-print-link button[data-module='gem-track-click print-link']"
+  end
+
+  it "accepts an additional passed data module when rendering as a link" do
+    render_component({
+      href: "/print",
+      data_attributes: {
+        module: "gem-track-click",
+      },
+    })
+
+    assert_select ".gem-c-print-link a[data-module='gem-track-click button']"
+  end
 end


### PR DESCRIPTION
## What
Allow a `data-module` to be passed to the print link component. This is required for adding a tracking module to the component. This change ensures that the `data-module` set by the component is preserved, and adds missing tests for the passing of data attributes in general.

Also fixes an issue in the component guide where the options shown for components where data attributes can be passed were being unnecessarily inflated by those options also set in the component itself i.e. example might have one data attribute passed, but also include data attributes set in the component template itself, leading to misleading example code snippets.

## Why
We're adding tracking to the print link component, which currently requires wrapping it in a DIV with a data module on it, would be simpler to pass the data module to the component.

Fixes https://github.com/alphagov/govuk_publishing_components/issues/2897

## Visual Changes
Component guide fix. Note how before the `data-module` value (set in the component but not in the example YML) is displayed. This is even more obvious in the accordion component (2nd example) where many more options are set in the accordion template.

Before | After
------ | -------
<img width="705" alt="Screenshot 2022-08-10 at 07 56 55" src="https://user-images.githubusercontent.com/861310/183835507-6af3524d-a46c-425f-90db-79c8af076bca.png"> |  <img width="720" alt="Screenshot 2022-08-10 at 07 57 16" src="https://user-images.githubusercontent.com/861310/183835540-d6def153-7e10-48a6-8e1e-3da60bcb1227.png">
<img width="955" alt="Screenshot 2022-08-10 at 07 58 59" src="https://user-images.githubusercontent.com/861310/183835839-2d042eb5-7f64-4e79-a39c-57b18bd47c80.png"> | <img width="940" alt="Screenshot 2022-08-10 at 07 59 22" src="https://user-images.githubusercontent.com/861310/183835876-9c4e5015-193b-4c74-8c92-f9ab2ab9882e.png">

