### PR TITLE
Rename gtm click tracking.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Expand print link component ([PR #2900](https://github.com/alphagov/govuk_publishing_components/pull/2900))
+* **BREAKING:** Rename instances of `gtm-click-tracking`/`GtmClickTracking` to `gtm-event-click-tracker`/`GtmEventClickTracker` ([PR #2901](https://github.com/alphagov/govuk_publishing_components/pull/2901))
 
 ## 30.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
@@ -2,6 +2,6 @@
 //= require ./analytics-ga4/gtm-schemas
 //= require ./analytics-ga4/pii-remover
 //= require ./analytics-ga4/gtm-page-views
-//= require ./analytics-ga4/gtm-click-tracking
+//= require ./analytics-ga4/gtm-event-click-tracker
 
 window.GOVUK.Gtm.sendPageView() // this will need integrating with cookie consent before production

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-event-click-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-event-click-tracker.js
@@ -5,16 +5,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   'use strict'
 
-  function GtmClickTracking (module) {
+  function GtmEventClickTracker (module) {
     this.module = module
     this.trackingTrigger = 'data-ga4' // elements with this attribute get tracked
   }
 
-  GtmClickTracking.prototype.init = function () {
+  GtmEventClickTracker.prototype.init = function () {
     this.module.addEventListener('click', this.trackClick.bind(this), true) // useCapture must be true
   }
 
-  GtmClickTracking.prototype.trackClick = function (event) {
+  GtmEventClickTracker.prototype.trackClick = function (event) {
     if (window.dataLayer) {
       var target = this.findTrackingAttributes(event.target)
       if (target) {
@@ -63,7 +63,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
   }
 
-  GtmClickTracking.prototype.findTrackingAttributes = function (clicked) {
+  GtmEventClickTracker.prototype.findTrackingAttributes = function (clicked) {
     if (clicked.hasAttribute('[' + this.trackingTrigger + ']')) {
       return clicked
     } else {
@@ -72,7 +72,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   // check if an attribute exists or contains the attribute
-  GtmClickTracking.prototype.getClosestAttribute = function (clicked, attribute) {
+  GtmEventClickTracker.prototype.getClosestAttribute = function (clicked, attribute) {
     var isAttributeOnElement = clicked.getAttribute(attribute)
     var containsAttribute = clicked.querySelector('[' + attribute + ']')
 
@@ -83,5 +83,5 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
   }
 
-  Modules.GtmClickTracking = GtmClickTracking
+  Modules.GtmEventClickTracker = GtmEventClickTracker
 })(window.GOVUK.Modules)

--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -187,7 +187,7 @@ examples:
 
       The `data_attributes` option applies attributes to the outermost element in the accordion. Each item can also have a `data_attributes` hash, which are placed on the `button` that triggers the opening and closing - useful for differentiating between each section of the accordion.
 
-      Data attributes can be added to the 'Show/hide all' link using the `data_attributes_show_all` option, primarily where custom tracking is required. These attributes are read from the accordion markup and then added to the link by JavaScript (which is how the link is created). More details on how this can be used with the GA4 click tracking can be found in the 'Advanced' section of the [click tracking documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-gtm/gtm-click-tracking.md).
+      Data attributes can be added to the 'Show/hide all' link using the `data_attributes_show_all` option, primarily where custom tracking is required. These attributes are read from the accordion markup and then added to the link by JavaScript (which is how the link is created). More details on how this can be used with the GA4 click tracking can be found in the 'Advanced' section of the [click tracking documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-gtm/gtm-event-click-tracker.md).
 
       If `track_options` within `data_attributes_show_all` is set, then it is possible to pass a custom dimension when 'Show/Hide all' is clicked.
     data:

--- a/docs/analytics-gtm/analytics.md
+++ b/docs/analytics-gtm/analytics.md
@@ -35,7 +35,7 @@ All of the data sent to GTM is based on a common schema.
 
 `page` is defined in the [gtm-page-views script](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-page-views.js).
 
-`event_data` is defined in the [gtm-schemas script](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-schemas.js) and used in the [gtm-click-tracking script](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-click-tracking.js).
+`event_data` is defined in the [gtm-schemas script](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-schemas.js) and used in the [gtm-event-click-tracker script](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/gtm-event-click-tracker.js).
 
 `search_results` has not been implemented yet.
 

--- a/docs/analytics-gtm/gtm-event-click-tracker.md
+++ b/docs/analytics-gtm/gtm-event-click-tracker.md
@@ -5,7 +5,7 @@ This is a script to allow click tracking through Google Tag Manager to be added 
 ## Basic use
 
 ```html
-<div data-module="gtm-click-tracking">
+<div data-module="gtm-event-click-tracker">
   <div data-ga4='{"event_name":"select_content", "type":"something", "index":0, "index_total":1, "text":"Click me"}'>
     Click me
   </div>
@@ -56,7 +56,7 @@ To track clicks on the 'Show/hide all sections' accordion link, pass data to the
     # other attributes
   }
 %>
-<div data-module="gtm-click-tracking">
+<div data-module="gtm-event-click-tracker">
   <%= render 'govuk_publishing_components/components/accordion', {
     data_attributes_show_all: {
       "ga4": ga4_attributes.to_json

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-event-click-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/gtm-event-click-tracker.spec.js
@@ -18,7 +18,7 @@ describe('Google Tag Manager click tracking', function () {
     beforeEach(function () {
       element.setAttribute('data-ga4', '')
       document.body.appendChild(element)
-      new GOVUK.Modules.GtmClickTracking(element).init()
+      new GOVUK.Modules.GtmEventClickTracker(element).init()
     })
 
     it('does not cause an error or fire an event', function () {
@@ -31,7 +31,7 @@ describe('Google Tag Manager click tracking', function () {
     beforeEach(function () {
       element.setAttribute('data-ga4', 'invalid json')
       document.body.appendChild(element)
-      new GOVUK.Modules.GtmClickTracking(element).init()
+      new GOVUK.Modules.GtmEventClickTracker(element).init()
     })
 
     it('does not cause an error', function () {
@@ -54,7 +54,7 @@ describe('Google Tag Manager click tracking', function () {
       }
       element.setAttribute('data-ga4', JSON.stringify(attributes))
       document.body.appendChild(element)
-      new GOVUK.Modules.GtmClickTracking(element).init()
+      new GOVUK.Modules.GtmEventClickTracker(element).init()
     })
 
     it('pushes gtm attributes to the dataLayer', function () {
@@ -98,7 +98,7 @@ describe('Google Tag Manager click tracking', function () {
           'class="clickme"' +
         '></div>'
       document.body.appendChild(element)
-      new GOVUK.Modules.GtmClickTracking(element).init()
+      new GOVUK.Modules.GtmEventClickTracker(element).init()
     })
 
     it('pushes gtm attributes to the dataLayer', function () {
@@ -120,7 +120,7 @@ describe('Google Tag Manager click tracking', function () {
       element.setAttribute('data-ga4', JSON.stringify(attributes))
       element.setAttribute('aria-expanded', 'false')
       document.body.appendChild(element)
-      new GOVUK.Modules.GtmClickTracking(element).init()
+      new GOVUK.Modules.GtmEventClickTracker(element).init()
     })
 
     it('includes the expanded state in the gtm attributes', function () {
@@ -156,7 +156,7 @@ describe('Google Tag Manager click tracking', function () {
         '>' +
         '</details>'
       document.body.appendChild(element)
-      new GOVUK.Modules.GtmClickTracking(element).init()
+      new GOVUK.Modules.GtmEventClickTracker(element).init()
     })
 
     it('includes the open state in the gtm attributes', function () {
@@ -193,7 +193,7 @@ describe('Google Tag Manager click tracking', function () {
           '<button aria-expanded="false">Show</button>' +
         '</div>'
       document.body.appendChild(element)
-      new GOVUK.Modules.GtmClickTracking(element).init()
+      new GOVUK.Modules.GtmEventClickTracker(element).init()
     })
 
     it('includes the expanded state in the gtm attributes', function () {
@@ -234,7 +234,7 @@ describe('Google Tag Manager click tracking', function () {
           '<summary class="nested">Example</summary>' +
         '</details>'
       document.body.appendChild(element)
-      new GOVUK.Modules.GtmClickTracking(element).init()
+      new GOVUK.Modules.GtmEventClickTracker(element).init()
     })
 
     it('includes the open state in the gtm attributes', function () {
@@ -275,7 +275,7 @@ describe('Google Tag Manager click tracking', function () {
           '</div>' +
         '</div>'
       document.body.appendChild(element)
-      new GOVUK.Modules.GtmClickTracking(element).init()
+      new GOVUK.Modules.GtmEventClickTracker(element).init()
     })
 
     it('should not track the aria-expanded state', function () {
@@ -298,7 +298,7 @@ describe('Google Tag Manager click tracking', function () {
           '</details>' +
         '</div>'
       document.body.appendChild(element)
-      new GOVUK.Modules.GtmClickTracking(element).init()
+      new GOVUK.Modules.GtmEventClickTracker(element).init()
     })
 
     it('should not track the open/closed state', function () {


### PR DESCRIPTION
## What
This PR changes all instances of `gtm-click-tracking`/`GtmClickTracking` to `gtm-event-click-tracker`/`GtmEventClickTracker`.

This will have a knock-on effect in applications where `gtm-click-tracking` is still used as a data attribute. Therefore, these changes are breaking and will need to be fixed in applications where `gtm-click-tracking` appears (such as `collections` and `frontend`).

## Why
Prior to these changes, some of our analytics modules had similar names e.g. `gtm-click-tracking.js` and `gtm-link-click-tracker.js`. In order to improve the differentiation between these modules (and also to provide consistency in naming conventions i.e. using `tracker` instead of `tracking`), these changes have been made.

## Visual Changes
None.