### PR TITLE
Allow accordion to accept custom data module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Allow accordion to accept custom data module ([PR #2908](https://github.com/alphagov/govuk_publishing_components/pull/2908))
 * Expand print link component ([PR #2900](https://github.com/alphagov/govuk_publishing_components/pull/2900))
 * Add link click tracking ([PR #2904](https://github.com/alphagov/govuk_publishing_components/pull/2904))
 * Ensure tab clicks grab the tabs href for gtm ([PR #2884](https://github.com/alphagov/govuk_publishing_components/pull/2884))

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -22,7 +22,7 @@
   locales = {}
 
   data_attributes ||= {}
-  data_attributes[:module] = 'govuk-accordion gem-accordion'
+  ((data_attributes[:module] ||= "") << " " << "govuk-accordion gem-accordion").strip!
   data_attributes[:anchor_navigation] = anchor_navigation
   data_attributes[:track_show_all_clicks] = track_show_all_clicks
   data_attributes[:track_sections] = track_sections

--- a/app/views/govuk_publishing_components/components/docs/accordion.yml
+++ b/app/views/govuk_publishing_components/components/docs/accordion.yml
@@ -222,6 +222,20 @@ examples:
             html: <p class="govuk-body">This is the content for How people read.</p>
           data_attributes:
             custom_data_attr: custom-data-attr-accordion-item-4
+  with_custom_data_module:
+    description: The component includes its own `data-module` but others can be passed in addition if required, for example to apply tracking to an element. This will be included along with the components own `data-module`.
+    data:
+      data_attributes:
+        module: gem-track-click
+      items:
+        - heading:
+            text: Writing well for the web
+          content:
+            html: <p class="govuk-body">This is the content for Writing well for the web.</p>
+        - heading:
+            text: Writing well for specialists
+          content:
+            html: <p class="govuk-body">This is the content for Writing well for specialists.</p>
   different_heading_level:
     description: This will alter the level of the heading, not the appearance of the heading.
     data:

--- a/spec/components/accordion_spec.rb
+++ b/spec/components/accordion_spec.rb
@@ -243,6 +243,23 @@ describe "Accordion", type: :view do
     assert_select "[data-accordion='first']", count: 1
   end
 
+  it "allows a custom data module to be included" do
+    test_data = {
+      id: "test-for-module-data-attributes",
+      data_attributes: {
+        module: "gem-track-click",
+      },
+      items: [
+        {
+          heading: { text: "Heading 1" },
+          content: { html: "<p>Content 1.</p>" },
+        },
+      ],
+    }
+    render_component(test_data)
+    assert_select "[data-module='gem-track-click govuk-accordion gem-accordion']", count: 1
+  end
+
   it "section has class added when expanded flag is present" do
     test_data = {
       id: "test-for-expanded-layout",


### PR DESCRIPTION
## What
Allow the accordion to be passed a custom value for `data-module`. The accordion already fills this in with its own module, so this must be preserved alongside whatever is passed.

## Why
Because we want to add tracking to accordions without having to wrap them in extra elements just to add the `data-module` attribute. Also because I already told @gclssvglx accordions can do this and it turns out they couldn't.

## Visual Changes
None.
