### PR TITLE
Update sendPageView object location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add link click tracking ([PR #2904](https://github.com/alphagov/govuk_publishing_components/pull/2904))
 * Ensure tab clicks grab the tabs href for gtm ([PR #2884](https://github.com/alphagov/govuk_publishing_components/pull/2884))
 * Update gtm naming conventions ([PR #2906](https://github.com/alphagov/govuk_publishing_components/pull/2906))
+* Update sendPageView object location ([PR #2909](https://github.com/alphagov/govuk_publishing_components/pull/2909))
 
 ## 30.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
@@ -5,5 +5,5 @@
 //= require ./analytics-ga4/ga4-link-tracker
 //= require ./analytics-ga4/ga4-event-tracker
 
-window.GOVUK.Gtm.sendPageView() // this will need integrating with cookie consent before production
+window.GOVUK.analyticsGA4.pageViewTracker.sendPageView() // this will need integrating with cookie consent before production
 window.GOVUK.analyticsGA4.linkTracker.trackLinkClicks()

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -2,8 +2,9 @@
   'use strict'
 
   var GOVUK = global.GOVUK || {}
+  GOVUK.analyticsGA4 = GOVUK.analyticsGA4 || {}
 
-  GOVUK.Gtm = {
+  GOVUK.analyticsGA4.pageViewTracker = {
     PIIRemover: new GOVUK.analyticsGA4.PIIRemover(), // imported in analytics-ga4.js
     nullValue: null,
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -66,14 +66,14 @@ describe('Google Tag Manager page view tracking', function () {
   }
 
   it('returns a standard page view', function () {
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a page view with a specific status code', function () {
     window.httpStatusCode = 404
     expected.page_view.status_code = '404'
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
@@ -112,7 +112,7 @@ describe('Google Tag Manager page view tracking', function () {
       expected.page_view[tag.gtmName] = tag.value
     }
 
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
@@ -156,7 +156,7 @@ describe('Google Tag Manager page view tracking', function () {
       expected.page_view[tag.gtmName] = tag.value
     }
 
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
@@ -177,14 +177,14 @@ describe('Google Tag Manager page view tracking', function () {
       content.setAttribute('lang', 'wakandan')
       expected.page_view.language = 'wakandan'
 
-      GOVUK.Gtm.sendPageView()
+      GOVUK.analyticsGA4.pageViewTracker.sendPageView()
       expect(window.dataLayer[0]).toEqual(expected)
     })
 
     it('set incorrectly', function () {
       expected.page_view.language = nullValue
 
-      GOVUK.Gtm.sendPageView()
+      GOVUK.analyticsGA4.pageViewTracker.sendPageView()
       expect(window.dataLayer[0]).toEqual(expected)
     })
   })
@@ -192,84 +192,84 @@ describe('Google Tag Manager page view tracking', function () {
   it('returns a pageview without a language', function () {
     expected.page_view.language = nullValue
 
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview with history', function () {
     createMetaTags('content-has-history', 'true')
     expected.page_view.history = 'true'
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview without history', function () {
     createMetaTags('content-has-history', 'banana')
     expected.page_view.history = 'false'
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a withdrawn page', function () {
     createMetaTags('withdrawn', 'withdrawn')
     expected.page_view.withdrawn = 'true'
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page with a first published date', function () {
     createMetaTags('first-published-at', '2022-03-28T19:11:00.000+00:00')
     expected.page_view.first_published_at = '2022-03-28'
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page with a last updated date', function () {
     createMetaTags('updated-at', '2021-03-28T19:11:00.000+00:00')
     expected.page_view.updated_at = '2021-03-28'
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page with a last public updated date', function () {
     createMetaTags('public-updated-at', '2020-03-28T19:11:00.000+00:00')
     expected.page_view.public_updated_at = '2020-03-28'
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page marked with a publishing government', function () {
     createMetaTags('publishing-government', 'labour')
     expected.page_view.publishing_government = 'labour'
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page marked with a political status', function () {
     createMetaTags('political-status', 'ongoing')
     expected.page_view.political_status = 'ongoing'
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page marked with a primary publishing organisation', function () {
     createMetaTags('primary-publishing-organisation', 'Home Office')
     expected.page_view.primary_publishing_organisation = 'Home Office'
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page marked with ids for contributing organisations', function () {
     createMetaTags('analytics:organisations', 'some organisations')
     expected.page_view.organisations = 'some organisations'
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
   it('returns a pageview on a page marked with world locations', function () {
     createMetaTags('analytics:world-locations', 'some world locations')
     expected.page_view.world_locations = 'some world locations'
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
@@ -294,7 +294,7 @@ describe('Google Tag Manager page view tracking', function () {
     linkForURLMock.href = '#example@gov.uk'
     linkForURLMock.click()
 
-    GOVUK.Gtm.sendPageView()
+    GOVUK.analyticsGA4.pageViewTracker.sendPageView()
 
     // Reset the page location for other tests
     linkForURLMock.href = '#'


### PR DESCRIPTION
## What
The `sendPageView` object has been moved into the `analyticsGA4` object to make the structure of our analytics modules more consistent.

## Why
To improve consistency across tracking module implementations.

## Visual Changes
None.
