### PR TITLE
Version 30.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 30.2.0
 
 * Allow accordion to accept custom data module ([PR #2908](https://github.com/alphagov/govuk_publishing_components/pull/2908))
 * Expand print link component ([PR #2900](https://github.com/alphagov/govuk_publishing_components/pull/2900))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (30.1.0)
+    govuk_publishing_components (30.2.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "30.1.0".freeze
+  VERSION = "30.2.0".freeze
 end


### PR DESCRIPTION
## 30.2.0

* Allow accordion to accept custom data module ([PR #2908](https://github.com/alphagov/govuk_publishing_components/pull/2908))
* Expand print link component ([PR #2900](https://github.com/alphagov/govuk_publishing_components/pull/2900))
* Add link click tracking ([PR #2904](https://github.com/alphagov/govuk_publishing_components/pull/2904))
* Ensure tab clicks grab the tabs href for gtm ([PR #2884](https://github.com/alphagov/govuk_publishing_components/pull/2884))
* Update gtm naming conventions ([PR #2906](https://github.com/alphagov/govuk_publishing_components/pull/2906))
* Update sendPageView object location ([PR #2909](https://github.com/alphagov/govuk_publishing_components/pull/2909))
