### PR TITLE
Fix bugs with gtm external link tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Don't include changes that are purely internal. The CHANGELOG should be a
   useful summary for people upgrading their application, not a replication
   of the commit log.
+  
+## Unreleased
+* Fix bugs with gtm external link tracking ([PR #2916](https://github.com/alphagov/govuk_publishing_components/pull/2916))
 
 ## 30.2.1
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -61,7 +61,7 @@
         clickData.link_method = this.getClickType(event)
 
         var schema = new window.GOVUK.analyticsGA4.Schemas().eventSchema()
-        schema.event = 'analytics'
+        schema.event = 'event_data'
 
         // get attributes from the clickData object to send to GA
         // only allow it if it already exists in the schema

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -124,7 +124,7 @@
 
     isExternalLink: function (href) {
       var isInternalLink = this.hrefPointsToDomain(href, this.internalLinksDomain) || this.hrefPointsToDomain(href, this.internalLinksDomainWithoutWww)
-      if (!isInternalLink && !this.hrefIsRelative(href)) {
+      if (!isInternalLink && !this.hrefIsRelative(href) && !this.hrefIsAnchor(href)) {
         return true
       }
     },
@@ -146,6 +146,10 @@
     hrefIsRelative: function (href) {
       // Checks that a link is relative, but is not a protocol relative url
       return href[0] === '/' && href[1] !== '/'
+    },
+
+    hrefIsAnchor: function (href) {
+      return href[0] === '#'
     }
   }
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -52,7 +52,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
               '<a href="gov.uk/some-path">Another local link</a>' +
               '<a href="//gov.uk/some-path">Another local link</a>' +
             '</div>' +
-            '<div class="internal-links">' +
+            '<div class="anchor-links">' +
               '<a href="#some-id">Anchor link</a>' +
               '<a href="#https://www.gov.uk">Another anchor link</a>' +
               '<a href="#https://www.example.com">Another anchor link</a>' +

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -51,6 +51,11 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
               '<a href="https://gov.uk/some-path">Another local link</a>' +
               '<a href="gov.uk/some-path">Another local link</a>' +
               '<a href="//gov.uk/some-path">Another local link</a>' +
+            '</div>' +
+            '<div class="internal-links">' +
+              '<a href="#some-id">Anchor link</a>' +
+              '<a href="#https://www.gov.uk">Another anchor link</a>' +
+              '<a href="#https://www.example.com">Another anchor link</a>' +
             '</div>'
 
       body.appendChild(links)
@@ -135,6 +140,17 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
 
     it('ignores external click events on internal links', function () {
       var linksToTest = document.querySelectorAll('.internal-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        var link = linksToTest[i]
+        window.dataLayer = []
+        GOVUK.triggerEvent(link, 'click')
+        expect(window.dataLayer).toEqual([])
+      }
+    })
+
+    it('ignores external click events on anchor links', function () {
+      var linksToTest = document.querySelectorAll('.anchor-links a')
 
       for (var i = 0; i < linksToTest.length; i++) {
         var link = linksToTest[i]

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -14,7 +14,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
     beforeEach(function () {
       window.dataLayer = []
       expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
-      expected.event = 'analytics'
+      expected.event = 'event_data'
       expected.event_data.event_name = 'navigation'
       expected.event_data.type = 'generic link'
       expected.event_data.link_method = 'primary click'
@@ -212,7 +212,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
       window.dataLayer = []
 
       expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
-      expected.event = 'analytics'
+      expected.event = 'event_data'
       expected.event_data.event_name = 'navigation'
       expected.event_data.type = 'download'
       expected.event_data.link_method = 'primary click'
@@ -396,7 +396,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
     beforeEach(function () {
       window.dataLayer = []
       expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
-      expected.event = 'analytics'
+      expected.event = 'event_data'
       expected.event_data.event_name = 'navigation'
       expected.event_data.type = 'email'
       expected.event_data.link_method = 'primary click'


### PR DESCRIPTION
Hi @JamesCGDS - would you be able to look at this PR? Thanks :+1:

## What
- Changes `event: analytics` to `event: event_data` in the external link tracking GTM object (as requested by analysts.)
- Makes sure that anchor links (jump links), such as `#other-ways-to-apply` are not treated as external links.

## Why
- The `event` key was changed so that the data is properly tracking the the analytics dashboard.
- The anchor links should not be treated as external links, as they just jump to a location on the same page you're already on.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
None. 
