### PR TITLE
Add example for passing data attributes to textarea

### DIFF
--- a/app/views/govuk_publishing_components/components/docs/textarea.yml
+++ b/app/views/govuk_publishing_components/components/docs/textarea.yml
@@ -103,3 +103,10 @@ examples:
       name: "described"
       rows: 2
       describedby: "contextual-guidance"
+  with_data_attributes:
+    data:
+      label:
+        text: "This textarea has a data attribute"
+      name: "with_data_attrbutes"
+      data:
+        module: "some-awesome-module-here"


### PR DESCRIPTION
## What
This adds an example of how to pass data attributes to text areas.

## Why
The option is available but isn't documented.
