### PR TITLE
Remove unused classes in intervention component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add GA4 analytics GTM blocklist ([PR #2962](https://github.com/alphagov/govuk_publishing_components/pull/2962))
 * GA4 analytics add single dataLayer push function ([PR #2960](https://github.com/alphagov/govuk_publishing_components/pull/2960))
+* Remove unused classes in intervention component ([PR #2920](https://github.com/alphagov/govuk_publishing_components/pull/2920))
 
 ## 30.5.2
 

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -21,7 +21,7 @@
   dismiss_href = intervention_helper.dismiss_link
 
   suggestion_tag_options = {
-    class: "govuk-link gem-c-intervention__suggestion-link",
+    class: "govuk-link",
     href: suggestion_link_url,
     data: suggestion_data_attributes,
   }
@@ -53,7 +53,7 @@
 
     <% if dismiss_text %>
       <p class="govuk-body">
-        <%= tag.a class: "govuk-link gem-c-intervention__dismiss", href: dismiss_href, data: dismiss_data_attributes do %>
+        <%= tag.a class: "govuk-link", href: dismiss_href, data: dismiss_data_attributes do %>
           <svg class="gem-c-intervention__dismiss-icon"
             width="19" height="19" viewBox="0 0 19 19"
             aria-hidden="true"

--- a/spec/components/intervention_spec.rb
+++ b/spec/components/intervention_spec.rb
@@ -14,8 +14,8 @@ describe "Intervention", type: :view do
     )
 
     assert_select ".gem-c-intervention", text: /You might be interested in/
-    assert_select ".gem-c-intervention__suggestion-link", text: "Travel abroad"
-    assert_select ".gem-c-intervention__dismiss", text: /Hide this suggestion/
+    assert_select ".gem-c-intervention .govuk-link", text: "Travel abroad"
+    assert_select ".gem-c-intervention .govuk-link", text: /Hide this suggestion/
   end
 
   it "renders the component without dismiss button" do
@@ -26,8 +26,8 @@ describe "Intervention", type: :view do
     )
 
     assert_select ".gem-c-intervention", text: /You might be interested in/
-    assert_select ".gem-c-intervention__suggestion-link", text: "Travel abroad"
-    assert_select ".gem-c-intervention__dismiss", false
+    assert_select ".gem-c-intervention .govuk-body:nth-child(1) .govuk-link", text: "Travel abroad"
+    assert_select ".gem-c-intervention .govuk-body:nth-child(2) .govuk-link", false
   end
 
   it "renders the component without suggestion link" do
@@ -37,8 +37,8 @@ describe "Intervention", type: :view do
     )
 
     assert_select ".gem-c-intervention", text: /You might be interested in/
-    assert_select ".gem-c-intervention__suggestion-link", false
-    assert_select ".gem-c-intervention__dismiss", text: /Hide this suggestion/
+    assert_select ".gem-c-intervention .govuk-body:nth-child(1) .govuk-link", false
+    assert_select ".gem-c-intervention .govuk-body:nth-child(2) .govuk-link", text: /Hide this suggestion/
   end
 
   it "renders the right query string when none exists" do


### PR DESCRIPTION
## What
Replace unused classes in intervention component.

## Why
The component has selectors for `govuk-link gem-c-intervention__suggestion-link` and `govuk-link gem-c-intervention__dismiss` which are only used for targeting in tests but has no specific styling.