### PR TITLE
Add links and sections count tracking for Cost of living hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   of the commit log.
   
 ## Unreleased
+
+* Add links and sections count tracking for Cost of living hub ([PR #2921](https://github.com/alphagov/govuk_publishing_components/pull/2921))
 * Fix bugs with gtm external link tracking ([PR #2916](https://github.com/alphagov/govuk_publishing_components/pull/2916))
 
 ## 30.2.1

--- a/app/assets/javascripts/govuk_publishing_components/analytics/page-content.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/page-content.js
@@ -17,6 +17,8 @@
         // if there are no accordion sections on the browse level 2 page
         // then it is a default page with one or two lists
         return document.querySelectorAll('[data-track-count="accordionSection"]').length || document.querySelectorAll('main .govuk-list').length
+      case isCostOfLivingHub():
+        return document.querySelectorAll('[data-track-count="accordionSection"]').length
       case isNewBrowsePage():
         return document.querySelectorAll('[data-track-count="cardList"]').length
       case isMainstreamBrowsePage():
@@ -51,6 +53,7 @@
       case isDocumentCollectionPage():
         return document.querySelectorAll('.document-collection .group-document-list li a').length
       case isNewBrowsePageLevelTwo():
+      case isCostOfLivingHub():
         return document.querySelectorAll('[data-track-count="contentLink"]').length
       case isNewBrowsePage():
         return document.querySelectorAll('[data-track-count="cardLink"]').length
@@ -106,6 +109,11 @@
   function isNewBrowsePageLevelTwo () {
     return getMetaAttribute(metaApplicationSelector) === 'collections' &&
       getMetaAttribute(metaNavigationTypeSelector) === 'browse level 2'
+  }
+
+  function isCostOfLivingHub () {
+    return getMetaAttribute(metaApplicationSelector) === 'collections' &&
+      getMetaAttribute(metaNavigationTypeSelector) === 'cost of living hub'
   }
 
   function isNewBrowsePage () {

--- a/spec/javascripts/govuk_publishing_components/analytics/page-content.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/page-content.spec.js
@@ -446,6 +446,29 @@ describe('Page content', function () {
     })
   })
 
+  describe('in cost of living hub', function () {
+    beforeEach(function () {
+      createMetaTags('rendering-application', 'collections')
+      createMetaTags('navigation-page-type', 'cost of living hub')
+    })
+
+    it('gets the number of accordion sections', function () {
+      for (var i = 1; i <= 4; i++) {
+        createDummyElement('div', false, false, 'data-track-count', 'accordionSection')
+      }
+      var result = window.GOVUK.PageContent.getNumberOfSections()
+      expect(result).toEqual(4)
+    })
+
+    it('gets the number of links', function () {
+      for (var i = 1; i <= 4; i++) {
+        createDummyElement('a', false, false, 'data-track-count', 'contentLink')
+      }
+      var result = window.GOVUK.PageContent.getNumberOfLinks()
+      expect(result).toEqual(4)
+    })
+  })
+
   describe('by default', function () {
     it('gets the number of sidebar sections', function () {
       for (var p = 1; p <= 4; p++) {


### PR DESCRIPTION
## What
Add links and sections count tracking for Cost of living hub

## Why
We need to add tracing to populate custom dimensions 26 (number of sections) and 27 (number of links) on the Cost of living hub pages as requested by a performance analyst.

`data-track-count="accordionSection"` is already added to the accordion sections https://github.com/alphagov/collections/blob/241b33a/app/views/cost_of_living_landing_page/show.html.erb#L22

`data-track-count="contentLink"` will be added to links within accordions and links within inset text on the page.

Meta tag `navigation-page-type` will be added to the Cost of living page.

[Trello](https://trello.com/c/0pjp3DgK/1288-add-meta-tags-that-power-custom-dimensions-m)

## Visual Changes
n/a