### PR TITLE
Add `gtm.blocklist` values to GTM snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## UNRELEASED
+
+* Add gtm.blocklist values to GTM snippet ([PR #2922](https://github.com/alphagov/govuk_publishing_components/pull/2922))
+
+
 ## 30.4.1
 
 * Revert addition of `awesome_print` gem ([PR #2943](https://github.com/alphagov/govuk_publishing_components/pull/2943))

--- a/app/views/govuk_publishing_components/components/_google_tag_manager_script.html.erb
+++ b/app/views/govuk_publishing_components/components/_google_tag_manager_script.html.erb
@@ -1,13 +1,19 @@
 <%
   gtm_auth ||= nil
   gtm_preview ||= nil
+  blocklist ||= nil # an array of the form ['customPixels', 'customScripts', 'html', 'nonGoogleScripts']
 
   gtm_attributes = %w(gtm_cookies_win=x)
     gtm_attributes << "gtm_auth=" + gtm_auth if gtm_auth
     gtm_attributes << "gtm_preview=" + gtm_preview if gtm_preview
   gtm_attributes = gtm_attributes.join('&')
 %>
+
 <script>
+<% if blocklist %>
+window.dataLayer = window.dataLayer || []
+window.dataLayer.push({ 'gtm.blocklist' : <%= blocklist %> })
+<% end %>
 var doNotTrack = ( navigator.doNotTrack === '1' || navigator.doNotTrack === 'yes' || navigator.msDoNotTrack === '1' || window.doNotTrack === '1' )
 if (!doNotTrack) {
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/app/views/govuk_publishing_components/components/docs/google_tag_manager_script.yml
+++ b/app/views/govuk_publishing_components/components/docs/google_tag_manager_script.yml
@@ -11,3 +11,7 @@ examples:
   default:
     data:
       gtm_id: GTM-XXXXXXX
+  with_blocklist:
+    data:
+      gtm_id: GTM-XXXXXXX
+      blocklist: "['customPixels', 'customScripts', 'html', 'nonGoogleScripts']"

--- a/spec/components/google_tag_manager_script_spec.rb
+++ b/spec/components/google_tag_manager_script_spec.rb
@@ -5,10 +5,22 @@ describe "Google tag manager script", type: :view do
     "google_tag_manager_script"
   end
 
-  it "renders a script tag" do
+  it "renders a script tag without a blocklist" do
     render_component(gtm_id: "GTM_ID")
 
     assert_select "script"
+    expect(rendered).not_to include "gtm.blocklist"
+    expect(rendered).to include "window,document,'script','dataLayer','GTM_ID'"
+  end
+
+  it "renders a script tag with a blocklist" do
+    render_component(
+      gtm_id: "GTM_ID",
+      blocklist: [],
+    )
+
+    assert_select "script"
+    expect(rendered).to include "gtm.blocklist"
     expect(rendered).to include "window,document,'script','dataLayer','GTM_ID'"
   end
 end


### PR DESCRIPTION
## What

Include the following with the GTM snippet, to add a block list to the dataLayer:

```
dataLayer = [
  { 'gtm.blocklist' : ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] },
]
```

## Why

To prevent anyone from adding custom code through GTM.

## Visual Changes

None

[Trello](https://trello.com/c/G2dyvbZR/97-add-blacklist-to-gtm-snippet)
