### PR TITLE
Modify GTM values for download links in response to analyst review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Modify GTM values for download links in response to analyst review ([PR #2923](https://github.com/alphagov/govuk_publishing_components/pull/2923/))
+
 ## 30.3.0
 
 * Remove GOV.UK specific code for handling exclusive checkboxes ([PR #2896](https://github.com/alphagov/govuk_publishing_components/pull/2896))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -44,18 +44,20 @@
       }
 
       if (this.isMailToLink(href)) {
+        clickData.event_name = 'navigation'
         clickData.type = 'email'
         clickData.external = 'true'
       } else if (this.isDownloadLink(href)) {
-        clickData.type = 'download'
-        clickData.external = 'false'
+        clickData.event_name = 'file_download'
+        clickData.type = this.isPreviewLink(href) ? 'preview' : 'generic download'
+        clickData.external = 'true'
       } else if (this.isExternalLink(href)) {
+        clickData.event_name = 'navigation'
         clickData.type = 'generic link'
         clickData.external = 'true'
       }
 
       if (Object.keys(clickData).length > 0) {
-        clickData.event_name = 'navigation'
         clickData.text = element.textContent.trim()
         clickData.url = href
         clickData.link_method = this.getClickType(event)
@@ -127,6 +129,18 @@
       if (!isInternalLink && !this.hrefIsRelative(href) && !this.hrefIsAnchor(href)) {
         return true
       }
+    },
+
+    isPreviewLink: function (href) {
+      /*  Regex looks for:
+      1. The file extension period (the character '.')
+      2. any alphanumeric characters (so we can match any file type such as jpg, pdf, mp4.)
+      3. the presence of '/preview'.
+      For example, .csv/preview or .mp4/preview will be matched.
+      Regex is used over JS string methods as this should work with anchor links, query string parameters and files that may have 'preview' in their name.
+      */
+      var previewRegex = /\.\w+\/preview/i
+      return previewRegex.test(href)
     },
 
     hrefPointsToDomain: function (href, domain) {

--- a/docs/analytics-gtm/ga4-link-tracker.md
+++ b/docs/analytics-gtm/ga4-link-tracker.md
@@ -10,12 +10,15 @@ When initialised, the JS adds an event listener to the `<body>` of the page with
 
 When one of these listeners are fired, they check if the `event.target` is an `<a>` tag with a `href`. If so, it will then check if the link is:
 
-- A `download` link - This is either a href to `assets.publishing.service.gov.uk` or a href on the `www.gov.uk` domain pointing to the `/government/uploads/` path.
+- A `generic download` - This is either a href to `assets.publishing.service.gov.uk` or a href on the `www.gov.uk` domain pointing to the `/government/uploads/` path.
+- A `preview` link - This is either a href to `assets.publishing.service.gov.uk` or a href on the `www.gov.uk` domain pointing to the `/government/uploads/` path which has `/preview` in the URL after the file path.
 - A `mailto` link - This is an email href that starts with `mailto:`.
-- An `external` link - This is a href that is not on the `www.gov.uk` domain. 
+- An `generic link`  - This is a href that is not on the `www.gov.uk` domain.
     - To calculate this, it checks if the href starts with `http://www.gov.uk/`, `https://www.gov.uk/`, `//www.gov.uk/`, `www.gov.uk/`, `http://gov.uk/`, `https://gov.uk/`, `//gov.uk`, or `gov.uk/` (NB: `gov.uk/` and `www./` are technically relative links as a href must contain a `/` or http method at the start to be treated as non-relative).
-    - It also checks if a `href` starts with `/` and does not start with `//` to determine if it's a relative link like `/bank-holidays` , but not a protocol relative link `//google.com`
+    - It also checks if a `href` starts with `/` and does not start with `//` to determine if it's a relative link like `/bank-holidays` , but not a protocol relative link such as `//google.com`.
     - If the `href` does not meet both of these criteria, then it is considered an external link.
+
+Events can either have an `event_name` of `navigation` or `file_download`. Download and preview links will use the `file_download` value, while generic external links and mailto links will use `navigation`.
 
 ## Basic use
 
@@ -25,10 +28,10 @@ In the example above, on a left click of the link, the following would be pushed
 
 ```
 {
-    "event": "analytics",
+    "event": "event_data",
     "event_data": {
-        "event_name": "navigation",
-        "type": "download",
+        "event_name": "file_download",
+        "type": "generic download",
         "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/742746/A_quick_guide_to_govt_healthy_eating_update.pdf",
         "text": "A Quick Guide to the Government’s Healthy Eating Recommendations",
         "index": null,

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -229,10 +229,10 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
 
       expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
       expected.event = 'event_data'
-      expected.event_data.event_name = 'navigation'
-      expected.event_data.type = 'download'
+      expected.event_data.event_name = 'file_download'
+      expected.event_data.type = 'generic download'
       expected.event_data.link_method = 'primary click'
-      expected.event_data.external = 'false'
+      expected.event_data.external = 'true'
 
       links = document.createElement('div')
       links.innerHTML = '<div class="fully-structured-download-links">' +
@@ -276,6 +276,16 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
           '<div class="relative-download-links">' +
             '<a href="/government/uploads/one.pdf">Relative PDF link</a>' +
             '<a href="/government/uploads/two.xslt">Relative Spreadsheet link</a>' +
+          '</div>' +
+          '<div class="preview-download-links">' +
+            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview">Preview link</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview">Relative Spreadsheet link</a>' +
+            '<a href="assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview">Relative Spreadsheet link</a>' +
+          '</div>' +
+          '<div class="not-a-preview-link">' +
+            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4">Preview link</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false">Relative Spreadsheet link</a>' +
+            '<a href="assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.csv">Relative Spreadsheet link</a>' +
           '</div>'
 
       body.appendChild(links)
@@ -299,8 +309,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
         expected.event_data.url = link.getAttribute('href')
-        expected.event_data.type = 'download'
-        expected.event_data.external = 'false'
+        expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
         expect(window.dataLayer[0]).toEqual(expected)
       }
@@ -315,8 +324,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         GOVUK.triggerEvent(link, 'click')
         expected.event_data.url = link.closest('a').getAttribute('href')
         expected.event_data.text = link.closest('a').innerText.trim()
-        expected.event_data.type = 'download'
-        expected.event_data.external = 'false'
+        expected.event_data.type = 'generic download'
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -329,8 +337,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
         expected.event_data.url = link.getAttribute('href')
-        expected.event_data.type = 'download'
-        expected.event_data.external = 'false'
+        expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
         expect(window.dataLayer[0]).toEqual(expected)
       }
@@ -344,8 +351,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
         expected.event_data.url = link.getAttribute('href')
-        expected.event_data.type = 'download'
-        expected.event_data.external = 'false'
+        expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
         expect(window.dataLayer[0]).toEqual(expected)
       }
@@ -359,8 +365,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
         expected.event_data.url = link.getAttribute('href')
-        expected.event_data.type = 'download'
-        expected.event_data.external = 'false'
+        expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
         expect(window.dataLayer[0]).toEqual(expected)
       }
@@ -384,10 +389,10 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
+        expected.event_data.event_name = 'navigation'
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.event_data.type = 'generic link'
-        expected.event_data.external = 'true'
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -400,8 +405,35 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
         expected.event_data.url = link.getAttribute('href')
-        expected.event_data.type = 'download'
-        expected.event_data.external = 'false'
+        expected.event_data.type = 'generic download'
+        expected.event_data.text = link.innerText.trim()
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('detects preview clicks on gov.uk download preview links', function () {
+      var linksToTest = document.querySelectorAll('.preview-download-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.type = 'preview'
+        expected.event_data.text = link.innerText.trim()
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('detects files with preview in their filename as download links instead of preview links', function () {
+      var linksToTest = document.querySelectorAll('.not-a-preview-link a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
         expect(window.dataLayer[0]).toEqual(expected)
       }


### PR DESCRIPTION
Hi @andysellick,

Would you be able to merge this PR if everything looks OK? Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
This branch updates the values sent to GTM when clicking our download links. This branch:

- Changes the `event_name` value to `file_download`.
- Changes the `type` value to `generic download`.
- Makes download links `external: true` instead of `false`.
- Adds the ability to detect download `/preview` links, and pushes them with the `type: preview` value. This uses regex, instead of a generic check for the presence of `/preview` in the string, or `/preview` being the last characters in the string. This should prevent a false positive if the file itself has the word `preview` in it - a valid download URL could contain `/preview-of-something.pdf` - and loose checking for `/preview` in this case wouldn't incorrectly class this as a preview link.

## Why
<!-- What are the reasons behind this change being made? -->
These changes were requested in the analyst review of this trello card: https://trello.com/c/vyvSCGWx/315-add-tracking-download-links

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
