### PR TITLE
Change the way we generate pretty print data for our documentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Modify GTM values for download links in response to analyst review ([PR #2923](https://github.com/alphagov/govuk_publishing_components/pull/2923/))
 * Add Cost of Living hub links to side wide navbar and footer ([PR #2939](https://github.com/alphagov/govuk_publishing_components/pull/2939))
+* Change the way we generate pretty print data for our documentations ([PR #2934](https://github.com/alphagov/govuk_publishing_components/pull/2934))
 
 ## 30.3.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    awesome_print (1.9.2)
     better_html (1.0.16)
       actionview (>= 4.0)
       activesupport (>= 4.0)
@@ -381,6 +382,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  awesome_print
   capybara
   faker
   gds-api-adapters

--- a/app/models/govuk_publishing_components/component_example.rb
+++ b/app/models/govuk_publishing_components/component_example.rb
@@ -1,4 +1,5 @@
 require "rouge"
+require "awesome_print"
 
 module GovukPublishingComponents
   class ComponentExample
@@ -29,8 +30,8 @@ module GovukPublishingComponents
     end
 
     def pretty_data
-      json_key_regex = /"(\w*)":/ # matches quoted keys ending with a colon, i.e. "key":
-      output = JSON.pretty_generate(data).gsub('\\n', "\n    ").gsub(json_key_regex, '\1:')
+      json_key_regex = /"(\w*)"\s*:/ # matches quoted keys ending with a colon, i.e. "key":
+      output = data.awesome_inspect(indent: -2, index: false, plain: true).gsub("=>", ":").gsub(json_key_regex, '\1:')
 
       quoted_string_regex = /"((?:[^"\\]|\\.)*)"/ # matches "some text" - ignores escaped quotes, i.e. \"
       output.gsub(quoted_string_regex) do |group|

--- a/govuk_publishing_components.gemspec
+++ b/govuk_publishing_components.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rouge"
   s.add_dependency "sprockets", ">= 3"
 
+  s.add_development_dependency "awesome_print"
   s.add_development_dependency "capybara"
   s.add_development_dependency "faker"
   s.add_development_dependency "gds-api-adapters"

--- a/spec/component_guide/component_example_spec.rb
+++ b/spec/component_guide/component_example_spec.rb
@@ -5,7 +5,7 @@ describe "Component example" do
     visit "/component-guide/test-component"
 
     expect(body).to include("How to call this component")
-    expect(page).to have_content('<%= render "components/test-component", { } %>')
+    expect(page).to have_content('<%= render "components/test-component", {} %>')
   end
 
   it "includes the component partial" do
@@ -139,5 +139,12 @@ describe "Component example" do
     visit "/component-guide/test-component-with-no-accessibility-criteria"
     expect(page).to have_selector(".component-violation")
     expect(body).to include("This component is not valid")
+  end
+
+  it "component with hash key is rendered correctly" do
+    visit "/component-guide/test-component-with-hash-key"
+
+    expect(body).to include("How to call this component")
+    expect(page).to have_content('<%= render "components/test-component-with-hash-key", { items: [ { name: "john" }, :or, { name: "smith" } ] } %>')
   end
 end

--- a/spec/dummy/app/views/components/_test-component-with-hash-key.html.erb
+++ b/spec/dummy/app/views/components/_test-component-with-hash-key.html.erb
@@ -1,0 +1,1 @@
+<div class="test-component-with-hash-key">Test component with hash key</div>

--- a/spec/dummy/app/views/components/docs/test-component-with-hash-key.yml
+++ b/spec/dummy/app/views/components/docs/test-component-with-hash-key.yml
@@ -1,0 +1,11 @@
+name: Test component with hash key
+description: A test component for the dummy app
+accessibility_criteria: |
+  * This is some criteria in a list
+examples:
+  default:
+    data:
+      items:
+        - name: "john"
+        - :or
+        - name: "smith"


### PR DESCRIPTION
## What
This change adds the awesome_print package to pretty print the rails code. This is a more stable solution and allows us to use things like `:or` keys.

## Why
We found that the pretty_data function was changing `:or` keys to `"or"` strings. This caused copy and pasting of the code to fail as "or" would cause the component to throw an error.

## Visual Changes

https://components-gem-pr-2934.herokuapp.com/public

### Before

<img width="1062" alt="Screenshot 2022-08-31 at 3 00 04 pm" src="https://user-images.githubusercontent.com/4599889/187697167-4f737da6-2030-45be-8850-975331e55958.png">

### After

<img width="1133" alt="Screenshot 2022-08-31 at 3 00 27 pm" src="https://user-images.githubusercontent.com/4599889/187697202-e49890ee-c57b-49d0-81a0-482e1f91c01f.png">
