### PR TITLE
Allow customisation of single page notification button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Share links allow data attributes ([PR #3072](https://github.com/alphagov/govuk_publishing_components/pull/3072))
 * Update to LUX 304 ([PR #3070](https://github.com/alphagov/govuk_publishing_components/pull/3070))
 * Set attributes for single page notification button based on Account API response ([PR #3071](https://github.com/alphagov/govuk_publishing_components/pull/3071))
+* Support custom text for the single page notification button component ([PR #2935](https://github.com/alphagov/govuk_publishing_components/pull/2935))
 
 ## 32.1.0
 

--- a/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
+++ b/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
@@ -49,3 +49,11 @@ examples:
       base_path: '/current-page-path'
       js_enhancement: true
       button_location: 'top'
+  with_custom_button_text:
+    description: The component accepts custom button text, provided that both subscribe and unsubscribe text is provided.
+    data:
+      base_path: '/current-page-path'
+      js_enhancement: true
+      button_text:
+        subscribe: 'Subscribe to this page of things'
+        unsubscribe: 'Unsubscribe to this page of things'

--- a/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb
@@ -13,6 +13,8 @@ module GovukPublishingComponents
         @button_type = @local_assigns[:already_subscribed] ? "Unsubscribe" : "Subscribe"
         @classes = %w[gem-c-single-page-notification-button]
         @classes << "js-personalisation-enhancement" if js_enhancement
+        @button_text_subscribe = custom_button_text_is_valid? ? custom_subscribe_text : default_subscribe_text
+        @button_text_unsubscribe = custom_button_text_is_valid? ? custom_unsubscribe_text : default_unsubscribe_text
       end
 
       def data
@@ -24,8 +26,8 @@ module GovukPublishingComponents
         @data_attributes[:track_category] = "Single-page-notification-button"
         # This attribute is passed through to the personalisation API to ensure when a new button is returned from the API, it has the same button_location
         @data_attributes[:button_location] = button_location
-        @data_attributes[:button_text_subscribe] = button_text_subscribe
-        @data_attributes[:button_text_unsubscribe] = button_text_unsubscribe
+        @data_attributes[:button_text_subscribe] = @button_text_subscribe
+        @data_attributes[:button_text_unsubscribe] = @button_text_unsubscribe
         @data_attributes
       end
 
@@ -34,14 +36,26 @@ module GovukPublishingComponents
       end
 
       def button_text
-        @already_subscribed ? button_text_unsubscribe : button_text_subscribe
+        @already_subscribed ? @button_text_unsubscribe : @button_text_subscribe
       end
 
-      def button_text_subscribe
+      def custom_button_text_is_valid?
+        custom_subscribe_text.present? && custom_unsubscribe_text.present?
+      end
+
+      def custom_subscribe_text
+        @local_assigns.dig(:button_text, :subscribe)
+      end
+
+      def custom_unsubscribe_text
+        @local_assigns.dig(:button_text, :unsubscribe)
+      end
+
+      def default_subscribe_text
         I18n.t("components.single_page_notification_button.subscribe_text")
       end
 
-      def button_text_unsubscribe
+      def default_unsubscribe_text
         I18n.t("components.single_page_notification_button.unsubscribe_text")
       end
     end

--- a/spec/components/single_page_notification_button_spec.rb
+++ b/spec/components/single_page_notification_button_spec.rb
@@ -26,6 +26,30 @@ describe "Single page notification button", type: :view do
     assert_select ".gem-c-single-page-notification-button", text: "Stop getting emails about this page"
   end
 
+  it "shows custom subscribe text if button_text:subscribe and button_text:unsubscribe are provided" do
+    local_assigns = {
+      base_path: "/the-current-page",
+      button_text: {
+        subscribe: "Start getting emails about this stuff",
+        unsubscribe: "Stop getting emails about this stuff",
+      },
+    }
+    render_component(local_assigns)
+    assert_select ".gem-c-single-page-notification-button", text: "Start getting emails about this stuff"
+  end
+
+  it "does not show custom text unless both button_text:subscribe and button_text:unsubscribe are provided" do
+    local_assigns = {
+      base_path: "/the-current-page",
+      already_subscribed: true,
+      button_text: {
+        unsubscribe: "Stop getting emails about this stuff",
+      },
+    }
+    render_component(local_assigns)
+    assert_select ".gem-c-single-page-notification-button", text: "Stop getting emails about this page"
+  end
+
   it "has data attributes if data_attributes is specified" do
     render_component({ base_path: "/the-current-page", data_attributes: { custom_attribute: "kaboom!" } })
     assert_select ".gem-c-single-page-notification-button[data-custom-attribute='kaboom!']"


### PR DESCRIPTION
## What
Allow the single page notification button to accept custom subscribe and unsubscribe text.

Trello : https://trello.com/c/gpch42Uc/1456-enable-custom-text-for-the-single-page-notification-button-component-l

## Why
There is some initial User Research which suggests the default text of "Get emails about this page" is confusing if the button is added to a document collection, which is a collection of pages.

## Visual Changes

### Before
<img width="1017" alt="Screenshot 2022-08-31 at 16 55 48" src="https://user-images.githubusercontent.com/17908089/187724116-593b5bda-94c5-4556-a75d-f46d99b9a928.png">

### After
<img width="1069" alt="Screenshot 2022-08-31 at 16 56 41" src="https://user-images.githubusercontent.com/17908089/187724108-ad7596b9-fcc1-4289-a8fa-92fbc8972e14.png">

https://trello.com/c/CLaB78Qh/1280-spike-adding-single-page-notifications-with-custom-button-text-to-collections-time-box-2-days