### PR TITLE
Match content item with heading label

### DIFF
--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -34,7 +34,7 @@
         content_items = [
           {
             href: "#default",
-            text: "Default",
+            text: "How it looks",
           }
         ]
 


### PR DESCRIPTION
## What
This matches the default contents item with the heading text.

## Why
The reference to default doesn't really exist anywhere, this matches the whole list of contents with the headings.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

<img width="379" alt="Screenshot 2022-09-01 at 3 21 07 pm" src="https://user-images.githubusercontent.com/4599889/187938072-10cd0f7a-7c06-46a4-86e3-a6515d3e357c.png">

### After

<img width="569" alt="Screenshot 2022-09-01 at 3 21 19 pm" src="https://user-images.githubusercontent.com/4599889/187938112-e0d29d83-dc88-4d6c-91b4-43ff13c7b4ec.png">
