### PR TITLE
Add all headings to content list

### DIFF
--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -28,41 +28,42 @@
     </div>
   </div>
 
-  <% if @component_doc.other_examples.any? %>
-    <div class="component-doc__content-list">
-      <%
-        content_items = [
-          {
-            href: "#default",
-            text: "How it looks",
-          }
-        ]
+  <div class="component-doc__content-list">
+    <%
+      content_items = [
+        { href: "#how-it-looks", text: "How it looks" },
+        { href: "#how-to-call-this-component", text: "How to call this component" },
+        ({ href: "#govuk-design-system", text: "GOV.UK Design System" } if @component_doc.govuk_frontend_components.any?),
+        ({ href: "#accessibility-acceptance-criteria", text: "Accessibility acceptance criteria" } if @component_doc.accessibility_criteria.present?),
+        ({
+          href: "#other-examples",
+          text: "Other examples",
+          items: @component_doc.other_examples.map do | example |
+            {
+              href: "##{example.id}",
+              text: example.name
+            }
+          end
+        } if @component_doc.other_examples.any?),
+      ].compact
+    %>
+    <%= render "govuk_publishing_components/components/contents_list", {
+      contents: content_items
+    } %>
+  </div>
 
-        @component_doc.other_examples.each do | example |
-          content_items << {
-            href: "##{example.id}",
-            text: example.name
-          }
-        end
-      %>
-      <%= render "govuk_publishing_components/components/contents_list", {
-        contents: content_items
-      } %>
-    </div>
-  <% end %>
-
-  <h2 class="component-doc-h2" id="default">
+  <h2 class="component-doc-h2" id="how-it-looks">
     <a href="<%= component_example_path(@component_doc.id, "default") %>" class="govuk-link">How it looks</a>
     <small>(<a href="<%= component_preview_path(@component_doc.id, "default") %>" class="govuk-link">preview</a>)</small>
     <small>(<a href="<%= component_preview_all_path(@component_doc.id) %>" class="govuk-link">preview all</a>)</small>
   </h2>
   <%= render "govuk_publishing_components/component_guide/component_doc/preview", component_doc: @component_doc, example: @component_doc.example %>
 
-  <h2 class="component-doc-h2">How to call this component</h2>
+  <h2 class="component-doc-h2" id="how-to-call-this-component">How to call this component</h2>
   <%= render "govuk_publishing_components/component_guide/component_doc/call", component_doc: @component_doc, example: @component_doc.example %>
 
   <% if @component_doc.govuk_frontend_components.any? %>
-    <h2 class="component-doc-h2">GOV.UK Design System</h2>
+    <h2 class="component-doc-h2" id="govuk-design-system">GOV.UK Design System</h2>
     <div class="component-markdown">
       <p>This component incorporates components from the <%= link_to "GOV.UK Design System", "https://design-system.service.gov.uk" %>:</p>
 
@@ -75,7 +76,7 @@
   <% end %>
 
   <% if @component_doc.accessibility_criteria.present? %>
-    <div class="govuk-grid-row component-accessibility-criteria">
+    <div class="govuk-grid-row component-accessibility-criteria" id="accessibility-acceptance-criteria">
       <div class="govuk-grid-column-two-thirds">
         <h2 class="component-doc-h2">Accessibility acceptance criteria</h2>
         <div class="component-markdown">
@@ -87,7 +88,7 @@
 
   <% if @component_doc.other_examples.any? %>
     <div class="examples">
-      <h2 class="component-doc-h2">Other examples</h2>
+      <h2 class="component-doc-h2" id="other-examples">Other examples</h2>
 
       <% @component_doc.other_examples.each do |example| %>
         <div class="component-example" id="<%= example.id %>">

--- a/spec/component_guide/component_example_spec.rb
+++ b/spec/component_guide/component_example_spec.rb
@@ -18,6 +18,16 @@ describe "Component example" do
     end
   end
 
+  it "includes the content list" do
+    visit "/component-guide/test-component"
+
+    within ".component-doc__content-list", match: :first do
+      expect(page).to have_selector(".gem-c-contents-list")
+      expect(page).to have_selector(".gem-c-contents-list .gem-c-contents-list__title", text: "Contents")
+      expect(page).to have_selector(".gem-c-contents-list .gem-c-contents-list__list .gem-c-contents-list__list-item", match: :first, text: "How it looks")
+    end
+  end
+
   it "includes the application stylesheet for an application component" do
     visit "/component-guide/test-component"
 


### PR DESCRIPTION
## What
This change adds all headings in the page as part of the content list

## Why
This allows users to have a whole page structural overview rather than just a list of components.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

<img width="291" alt="Screenshot 2022-09-01 at 4 16 07 pm" src="https://user-images.githubusercontent.com/4599889/187950320-4cc7961a-9145-457d-828f-33f0c8474ce3.png">

### After

<img width="367" alt="Screenshot 2022-09-01 at 4 15 43 pm" src="https://user-images.githubusercontent.com/4599889/187950362-f06c5e08-c553-4733-ad13-612c0826a8aa.png">
