### PR TITLE
Add Cost of Living hub links to side wide navbar and footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Modify GTM values for download links in response to analyst review ([PR #2923](https://github.com/alphagov/govuk_publishing_components/pull/2923/))
+* Add Cost of Living hub links to side wide navbar and footer ([PR #2939](https://github.com/alphagov/govuk_publishing_components/pull/2939))
 
 ## 30.3.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-footer.scss
@@ -12,3 +12,10 @@
 .gem-c-layout-footer .govuk-footer__list {
   padding-bottom: govuk-spacing(7);
 }
+
+.gem-c-layout-footer .govuk-footer__list-item:nth-child(odd):last-child {
+  // If there are an uneven number of links in the
+  // footer this ensures the left column has more links than the
+  // the right column.
+  margin-bottom: 20px;
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -811,7 +811,7 @@ $button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
 
 .gem-c-layout-super-navigation-header__navigation-second-items--topics {
   @include govuk-media-query($from: "desktop") {
-    @include columns($items: 16, $columns: 2, $selector: "li", $flow: column);
+    @include columns($items: 17, $columns: 2, $selector: "li", $flow: column);
   }
 }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,8 @@ en:
           href: "/browse/childcare-parenting"
         - text: Citizenship and living in the UK
           href: "/browse/citizenship"
+        - text: Cost of living support
+          href: "/cost-of-living"
         - text: Crime, justice and the law
           href: "/browse/justice"
         - text: Disabled people
@@ -175,6 +177,8 @@ en:
           href: "/browse/childcare-parenting"
         - label: Citizenship and living in the UK
           href: "/browse/citizenship"
+        - label: Cost of living support
+          href: "/cost-of-living"
         - label: Crime, justice and the law
           href: "/browse/justice"
         - label: Disabled people


### PR DESCRIPTION
## What

New links to the Cost of living hub have been added to the navbar and to the footer. Both of these elements were designed with a specific number of children in mind so therefore minor stylistic adjustments had to be made.

The number of rows in the navbar topics toggle menu has had to be increased to avoid the splitting of the grid into three columns.

A new selector has been added to the layout footer which ensures that the number of items in each column is correctly balanced when there is an odd number of links.

## Why

The Cost of living hub has recently been added to the homepage and we want links to it on the sidewide navbar and footer.

### Before
![Screenshot 2022-09-02 at 13 03 10](https://user-images.githubusercontent.com/3727504/188138984-4a30a9be-2461-4377-9e20-46ac475c20b5.png)

![Screenshot 2022-09-02 at 13 03 14](https://user-images.githubusercontent.com/3727504/188138991-2e7eee81-ab23-41ed-a4b0-9cbff443a639.png)


### After

![Screenshot 2022-09-02 at 12 58 46](https://user-images.githubusercontent.com/3727504/188138798-f0ddb8ff-ba36-42d9-b32c-5c4a90f463d6.png)

![Screenshot 2022-09-02 at 12 58 40](https://user-images.githubusercontent.com/3727504/188138818-9cdeb9aa-4c9a-4165-aee5-f7e68e421802.png)