### PR TITLE
Version 30.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 30.4.0
 
 * Modify GTM values for download links in response to analyst review ([PR #2923](https://github.com/alphagov/govuk_publishing_components/pull/2923/))
 * Add Cost of Living hub links to side wide navbar and footer ([PR #2939](https://github.com/alphagov/govuk_publishing_components/pull/2939))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (30.3.0)
+    govuk_publishing_components (30.4.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "30.3.0".freeze
+  VERSION = "30.4.0".freeze
 end


### PR DESCRIPTION
## 30.4.0

* Modify GTM values for download links in response to analyst review ([PR #2923](https://github.com/alphagov/govuk_publishing_components/pull/2923/))
* Add Cost of Living hub links to side wide navbar and footer ([PR #2939](https://github.com/alphagov/govuk_publishing_components/pull/2939))
* Change the way we generate pretty print data for our documentations ([PR #2934](https://github.com/alphagov/govuk_publishing_components/pull/2934))

