### PR TITLE
Version 30.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 30.4.1
 
 * Revert addition of `awesome_print` gem ([PR #2943](https://github.com/alphagov/govuk_publishing_components/pull/2943))
 * Resolve visual differences in navbar when JS not enabled ([PR #2756](https://github.com/alphagov/govuk_publishing_components/pull/2756))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (30.4.0)
+    govuk_publishing_components (30.4.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -125,10 +125,12 @@ GEM
       rest-client (~> 2.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    govuk_app_config (4.8.0)
+    govuk_app_config (4.9.0)
       logstasher (~> 2.1)
+      plek (~> 4)
       prometheus_exporter (~> 2.0)
       puma (~> 5.6)
+      rack-proxy (~> 0.7)
       sentry-rails (~> 5.3)
       sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
@@ -226,6 +228,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.4)
+    rack-proxy (0.7.2)
+      rack
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.3.1)
@@ -346,7 +350,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
-    strscan (3.0.3)
+    strscan (3.0.4)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)
@@ -403,4 +407,4 @@ RUBY VERSION
    ruby 2.7.6
 
 BUNDLED WITH
-   2.3.6
+   2.3.19

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "30.4.0".freeze
+  VERSION = "30.4.1".freeze
 end


### PR DESCRIPTION
## 30.4.1

* Revert addition of `awesome_print` gem ([PR #2943](https://github.com/alphagov/govuk_publishing_components/pull/2943))
* Resolve visual differences in navbar when JS not enabled ([PR #2756](https://github.com/alphagov/govuk_publishing_components/pull/2756))
