### PR TITLE
Refactor ga4-link-tracker and add new features

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
@@ -6,4 +6,4 @@
 //= require ./analytics-ga4/ga4-event-tracker
 
 window.GOVUK.analyticsGA4.pageViewTracker.sendPageView() // this will need integrating with cookie consent before production
-window.GOVUK.analyticsGA4.linkTracker.trackLinkClicks()
+window.GOVUK.analyticsGA4.linkTracker.trackLinkClicks({ internalDownloadPaths: ['/government/uploads/'], dedicatedDownloadDomains: ['assets.publishing.service.gov.uk'] })

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -2,6 +2,7 @@
   links ||= []
   title ||= false
   track_as_sharing ||= false
+  track_as_follow ||= false
   stacked ||= false
   columns ||= false
 
@@ -23,7 +24,7 @@
     <% end %>
 
     <ul class="gem-c-share-links__list">
-      <% links.each do |link| %>
+      <% links.each_with_index do |link, index| %>
         <% link_text = capture do %>
           <span class="govuk-visually-hidden">
             <% if link[:hidden_text] %>
@@ -42,6 +43,22 @@
                 'socialNetwork': link[:icon],
                 'socialTarget': link[:href]
               }
+              ga4_link_data = {
+                'event_name': 'share',
+                'type': 'share this page',
+                'index': index + 1,
+                'index_total': links.length,
+                'text': link[:icon],
+              }
+            end
+            if track_as_follow
+              ga4_link_data = {
+                'event_name': 'navigation',
+                'type': 'follow us',
+                'index': index + 1,
+                'index_total': links.length,
+                'text': link[:icon],
+              }
             end
           %>
           <%= link_to link[:href],
@@ -50,7 +67,8 @@
             data: {
               'track-category': 'social media',
               'track-action': link[:icon],
-              'track-options': track_options
+              'track-options': track_options,
+              'ga4-link': ga4_link_data
             },
             class: "govuk-link govuk-link--no-underline gem-c-share-links__link #{brand_helper.color_class}" do %>
             <span class="gem-c-share-links__link-icon">

--- a/app/views/govuk_publishing_components/components/docs/share_links.yml
+++ b/app/views/govuk_publishing_components/components/docs/share_links.yml
@@ -45,13 +45,24 @@ examples:
     context:
       right_to_left: true
   track_as_sharing_links:
-    description: Where the component is used to allow users to share content on social media, tracking can be added that uses [Social Interactions](https://developers.google.com/analytics/devguides/collection/analyticsjs/social-interactions). If this option is not included, it is assumed the component is simply linking to social media pages and the extra options are omitted from the tracking call.
+    description: Where the component is used to allow users to share content on social media, tracking can be added that uses [Social Interactions](https://developers.google.com/analytics/devguides/collection/analyticsjs/social-interactions) in UA. If this option is not included, it is assumed the component is simply linking to social media pages and the extra options are omitted from the tracking call in UA. In GA4, when this is set to true, a 'share' event is pushed with values defined in the .erb template.
     data:
       track_as_sharing: true
       links: [
         {
           href: 'share',
           text: 'Share on Facebook',
+          icon: 'facebook'
+        }
+      ]
+  track_as_follow_links:
+    description: Where the component is used to allow users to follow us on social media, tracking can be added. When this is set to true, a navigation event is pushed with values defined in the .erb template.
+    data:
+      track_as_follow: true
+      links: [
+        {
+          href: 'follow',
+          text: 'Follow us on Facebook',
           icon: 'facebook'
         }
       ]

--- a/docs/analytics-gtm/ga4-link-tracker.md
+++ b/docs/analytics-gtm/ga4-link-tracker.md
@@ -10,17 +10,38 @@ When initialised, the JS adds an event listener to the `<body>` of the page with
 
 When one of these listeners are fired, they check if the `event.target` is an `<a>` tag with a `href`. If so, it will then check if the link is:
 
+- A `share` or `follow` link - This allows analysts to track if a page was shared, or if a user clicked on one of our social media channels, which are usually under a 'Follow us' heading. The tracking is added to the component by adding `track_as_share: true` or `track_as_follow: true` to the template import of a share links component. If one of these booleans are true, a `data-ga4-link` attribute is added to all the component's `<a>` tags. This `data-ga4-link` attribute houses a stringified JSON, containing the relevant data to push to GTM. The link tracker will always check for `data-ga4-link` first before checking the link matches our other link types. Therefore, this `data-ga4-link` pattern can be expanded to track other types of links, which can't be categorised by simply running checks against the href.
 - A `generic download` - This is either a href to `assets.publishing.service.gov.uk` or a href on the `www.gov.uk` domain pointing to the `/government/uploads/` path.
 - A `preview` link - This is either a href to `assets.publishing.service.gov.uk` or a href on the `www.gov.uk` domain pointing to the `/government/uploads/` path which has `/preview` in the URL after the file path.
 - A `mailto` link - This is an email href that starts with `mailto:`.
-- An `generic link`  - This is a href that is not on the `www.gov.uk` domain.
-    - To calculate this, it checks if the href starts with `http://www.gov.uk/`, `https://www.gov.uk/`, `//www.gov.uk/`, `www.gov.uk/`, `http://gov.uk/`, `https://gov.uk/`, `//gov.uk`, or `gov.uk/` (NB: `gov.uk/` and `www./` are technically relative links as a href must contain a `/` or http method at the start to be treated as non-relative).
+- An `generic link`  - This is a href that is not on the internal domains. Internal domains include the current hostname, and any domains passed through to the `trackLinkClicks({internalDomains: []})` array.
+    - To calculate this, it checks the start of the href. If we were to use `www.gov.uk` as an example, it would check if the href starts with:
+        - `http://www.gov.uk/`,
+        - `https://www.gov.uk/`,
+        - `//www.gov.uk/`,
+        - `www.gov.uk/`,
+        - (NB: `www.gov.uk/` is technically a relative link, as a href must contain a `/` or http method at the start to be treated as non-relative).
     - It also checks if a `href` starts with `/` and does not start with `//` to determine if it's a relative link like `/bank-holidays` , but not a protocol relative link such as `//google.com`.
-    - If the `href` does not meet both of these criteria, then it is considered an external link.
+    - If the `href` does not meet the above criteria, then it is considered an external link.
 
-Events can either have an `event_name` of `navigation` or `file_download`. Download and preview links will use the `file_download` value, while generic external links and mailto links will use `navigation`.
+Events can either have an `event_name` of `navigation`, `file_download`, or `share`. Download and preview links will use the `file_download` value, while generic external links, mailto links, and follow links will use `navigation`. Share links use `share`.
 
 ## Basic use
+
+```
+//= require ./analytics-ga4/ga4-link-tracker
+
+window.GOVUK.analyticsGA4.linkTracker.trackLinkClicks({
+     internalDomains: ['www.gov.uk']
+     internalDownloadPaths: ['/government/uploads/'],
+     dedicatedDownloadDomains: ['assets.publishing.service.gov.uk']
+     })
+```
+
+Passing an object with arrays to `trackLinkClicks()` is optional, but passing each array enables extra functionality:
+- Passing an `internalDomains` array allows you to class domains which aren't the current hostname as internal domains. For example, if you were adding tracking and your hostname was `helpforhouseholds.campaign.gov.uk`, you could add `www.gov.uk` to this array, classing any link clicks to those domains as internal clicks. The link tracker will automatically add the domain with `www.` removed as well (`gov.uk` in this case,) as sometimes `www.` is omitted from `href` values.
+- Passing an `internalDownloadPaths` array allows you to specify paths which should be classified as paths to a downloads route. If the path exists in a `href` will be treated as a download link.
+- Passing a `dedicatedDownloadDomains` array allows you to specify domains which will class any click to that domain as a download link. For example, `dl.dropbox.com` could be added to track dropbox downloads as download links.
 
 `<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/742746/A_quick_guide_to_govt_healthy_eating_update.pdf">A Quick Guide to the Government’s Healthy Eating Recommendations</a>`
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -62,7 +62,8 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
       body.addEventListener('click', preventDefault)
 
       linkTracker = GOVUK.analyticsGA4.linkTracker
-      linkTracker.trackLinkClicks()
+      // Add gov.uk as an internal domain, as our tests are running from localhost
+      linkTracker.trackLinkClicks({ internalDomains: ['www.gov.uk'], internalDownloadPaths: ['/government/uploads'], dedicatedDownloadDomains: ['assets.publishing.service.gov.uk'] })
     })
 
     afterEach(function () {
@@ -192,6 +193,22 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
       }
     })
 
+    it('detects shift click events on external links', function () {
+      var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
+        clickEvent.shiftKey = true
+        link.dispatchEvent(clickEvent)
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.link_method = 'shift click'
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
     it('detects middle mouse click events on external links', function () {
       var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
 
@@ -232,33 +249,32 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
       expected.event_data.event_name = 'file_download'
       expected.event_data.type = 'generic download'
       expected.event_data.link_method = 'primary click'
-      expected.event_data.external = 'true'
 
       links = document.createElement('div')
       links.innerHTML = '<div class="fully-structured-download-links">' +
-            '<a href="https://assets.publishing.service.gov.uk/one.pdf">PDF</a>' +
-            '<a href="https://assets.publishing.service.gov.uk/two.xslt">Spreadsheet</a>' +
-            '<a href="https://www.gov.uk/government/uploads/system/three.doc">Document</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/one.pdf" external="true">PDF</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/two.xslt" external="true">Spreadsheet</a>' +
+            '<a href="https://www.gov.uk/government/uploads/system/three.doc" external="false">Document</a>' +
           '</div>' +
           '<div class="nested-download-links">' +
-            '<a href="https://www.gov.uk/government/uploads/link.png"><img src="/img" /></a>' +
-            '<a href="https://assets.publishing.service.gov.uk/two.xslt"><div><img src="/img" /></div></a>' +
+            '<a href="https://www.gov.uk/government/uploads/link.png" external="false"><img src="/img" /></a>' +
+            '<a href="https://assets.publishing.service.gov.uk/two.xslt" external="true"><div><img src="/img" /></div></a>' +
           '</div>' +
           '<div class="http-download-links">' +
-            '<a href="http://assets.publishing.service.gov.uk/one.pdf">PDF</a>' +
-            '<a href="http://assets.publishing.service.gov.uk/two.xslt">Spreadsheet</a>' +
-            '<a href="http://www.gov.uk/government/uploads/system/three.doc">Document</a>' +
-            '<a href="http://www.gov.uk/government/uploads/link.png">Image</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/one.pdf" external="true">PDF</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/two.xslt" external="true">Spreadsheet</a>' +
+            '<a href="http://www.gov.uk/government/uploads/system/three.doc" external="false">Document</a>' +
+            '<a href="http://www.gov.uk/government/uploads/link.png" external="false">Image</a>' +
           '</div>' +
           '<div class="www-less-download-links">' +
             '<a href="http://gov.uk/government/uploads/system/three.doc">Document</a>' +
             '<a href="https://gov.uk/government/uploads/link.png">Image</a>' +
           '</div>' +
           '<div class="http-less-download-links">' +
-            '<a href="gov.uk/government/uploads/system/three.doc">Document</a>' +
-            '<a href="www.gov.uk/government/uploads/link.png">Image</a>' +
-            '<a href="assets.publishing.service.gov.uk/one.pdf">PDF</a>' +
-            '<a href="assets.publishing.service.gov.uk/two.xslt">Spreadsheet</a>' +
+            '<a href="gov.uk/government/uploads/system/three.doc" external="false">Document</a>' +
+            '<a href="www.gov.uk/government/uploads/link.png" external="false">Image</a>' +
+            '<a href="assets.publishing.service.gov.uk/one.pdf" external="true">PDF</a>' +
+            '<a href="assets.publishing.service.gov.uk/two.xslt" external="true">Spreadsheet</a>' +
           '</div>' +
           '<div class="internal-links">' +
             '<a href="https://www.gov.uk/normal-link">Normal link</a>' +
@@ -292,7 +308,8 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
       body.addEventListener('click', preventDefault)
 
       linkTracker = GOVUK.analyticsGA4.linkTracker
-      linkTracker.trackLinkClicks()
+      // Add gov.uk as an internal domain, as our tests are running from localhost
+      linkTracker.trackLinkClicks({ internalDomains: ['www.gov.uk'], internalDownloadPaths: ['/government/uploads'], dedicatedDownloadDomains: ['assets.publishing.service.gov.uk'] })
     })
 
     afterEach(function () {
@@ -311,6 +328,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
+        expected.event_data.external = link.getAttribute('external')
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -325,6 +343,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         expected.event_data.url = link.closest('a').getAttribute('href')
         expected.event_data.text = link.closest('a').innerText.trim()
         expected.event_data.type = 'generic download'
+        expected.event_data.external = link.closest('a').getAttribute('external')
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -339,6 +358,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
+        expected.event_data.external = link.getAttribute('external')
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -353,6 +373,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
+        expected.event_data.external = 'false'
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -367,6 +388,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
+        expected.event_data.external = link.getAttribute('external')
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -393,6 +415,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.event_data.type = 'generic link'
+        expected.event_data.external = 'true'
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -407,6 +430,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
+        expected.event_data.external = 'false'
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -421,6 +445,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'preview'
         expected.event_data.text = link.innerText.trim()
+        expected.event_data.external = 'true'
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -435,6 +460,7 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
+        expected.event_data.external = 'true'
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -464,7 +490,8 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
       body.addEventListener('click', preventDefault)
 
       linkTracker = GOVUK.analyticsGA4.linkTracker
-      linkTracker.trackLinkClicks()
+      // Add gov.uk as an internal domain, as our tests are running from localhost
+      linkTracker.trackLinkClicks({ internalDomains: ['www.gov.uk'], internalDownloadPaths: ['/government/uploads'], dedicatedDownloadDomains: ['assets.publishing.service.gov.uk'] })
     })
 
     afterEach(function () {
@@ -494,6 +521,72 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
         expect(window.dataLayer).toEqual([])
+      }
+    })
+  })
+
+  describe('Share and follow link tracking', function () {
+    beforeEach(function () {
+      window.dataLayer = []
+      expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
+      expected.event = 'event_data'
+
+      links = document.createElement('div')
+      links.innerHTML =
+          '<div class="share-links">' +
+              '<a href="example.com" data-ga4-link=\'' + JSON.stringify({ event_name: 'share', type: 'share this page', index: '1', index_total: '1', text: 'myspace' }) + '\'>Share</a>' +
+          '</div>' +
+          '<div class="follow-links">' +
+              '<a href="example.com" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '1', index_total: '1', text: 'myspace' }) + '\'>Follow us</a>' +
+          '</div>'
+
+      body.appendChild(links)
+      body.addEventListener('click', preventDefault)
+
+      linkTracker = GOVUK.analyticsGA4.linkTracker
+      // Add gov.uk as an internal domain, as our tests are running from localhost
+      linkTracker.trackLinkClicks({ internalDomains: ['www.gov.uk'], internalDownloadPaths: ['/government/uploads/'], dedicatedDownloadDomains: ['assets.publishing.service.gov.uk'] })
+    })
+
+    afterEach(function () {
+      body.removeEventListener('click', preventDefault)
+      links.remove()
+      linkTracker.stopTracking()
+    })
+
+    it('detects clicks on share links', function () {
+      var linksToTest = document.querySelectorAll('.share-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        var shareLinkAttributes = link.getAttribute('data-ga4-link')
+        shareLinkAttributes = JSON.parse(shareLinkAttributes)
+        expected.event_data.event_name = shareLinkAttributes.event_name
+        expected.event_data.type = shareLinkAttributes.type
+        expected.event_data.text = shareLinkAttributes.text
+        expected.event_data.index = parseInt(shareLinkAttributes.index)
+        expected.event_data.index_total = parseInt(shareLinkAttributes.index_total)
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('detects clicks on follow links', function () {
+      var linksToTest = document.querySelectorAll('.follow-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        var shareLinkAttributes = link.getAttribute('data-ga4-link')
+        shareLinkAttributes = JSON.parse(shareLinkAttributes)
+        expected.event_data.event_name = shareLinkAttributes.event_name
+        expected.event_data.type = shareLinkAttributes.type
+        expected.event_data.text = shareLinkAttributes.text
+        expected.event_data.index = parseInt(shareLinkAttributes.index)
+        expected.event_data.index_total = parseInt(shareLinkAttributes.index_total)
+        expect(window.dataLayer[0]).toEqual(expected)
       }
     })
   })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
1. Allows shift clicks to be tracked, using `event.shiftKey`.
2. Allows share and follow link clicks to be tracked, using a `data-ga4-link` attribute on `_share_links.html.erb`.
3. Tracks internal download paths (e.g. `/government/uploads`) as internal links instead of external at the request of the analysts.
4. Adds the current hostname as an internal domain when tracking links.
5. Removes hard coding of www.gov.uk as an internal domain.
6. Removes hard coding of assets.publishing.gov.uk as a download domain.
7. Removes hard coding of /government/uploads/ as a download path.
8. Allows the developer to specify arrays for the internal domains to detect, download domains to detect, and internal domain download paths to check. This makes the code more suitable for domains that aren't www.gov.uk.

## Why
<!-- What are the reasons behind this change being made? -->
1. Shift clicks were added at the request of the analysts.
2. Share and follow link click tracking was added at the request of the analysts.
3. Tracking internal download paths (e.g. `/government/uploads`) as internal links instead of external was made at the request of the analysts.
4. Adds the current hostname as an internal domain when tracking links. This allows this code to be used on different domains - as previously the internal domain was hard coded as `www.gov.uk`
5. Removes hard coding of www.gov.uk as an internal domain to make the code more generic.
6. Removes hard coding of assets.publishing.gov.uk as a download domain to make the code more generic.
7. Removes hard coding of /government/uploads/ as a download path to make the code more generic.
8. When running `trackLinkClicks()`, it allows the developer to specify arrays which internal domains to detect, download domains to detect, and download paths to check. This makes the code more suitable for running on domains that aren't www.gov.uk. The code can be used on different domains, without any hardcoded `www.gov.uk` specific values in the code. 
It can now be decided what domains in hrefs are classed as internal domains - for example `helpforhouseholds.campaign.gov.uk` could be classed as an internal domain now. It can now be decided what domains are classed as a 'dedicated download' domains (a domain name which will always be a file download, such as `assets.publishing.service.gov.uk` or `dropbox.com`). It can now be decided what URL paths are classed as internal download paths, such as `/government/uploads` or `/government/another-new-download-path`. 

## Visual changes

None.