### PR TITLE
Fix underline on organisation logo component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix underline on organisation logo component ([PR #2949](https://github.com/alphagov/govuk_publishing_components/pull/2949))
 * Integrate GA4 analytics code with cookie consent mechanism ([PR #2915](https://github.com/alphagov/govuk_publishing_components/pull/2915))
 
 ## 30.4.1

--- a/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_organisation-logo.scss
@@ -37,11 +37,11 @@
 .gem-c-organisation-logo__crest {
   // Default brand colour
   border-left: 2px solid govuk-colour("black");
-  padding-top: 20px;
+  padding-top: 23px;
   padding-left: 6px;
 
   @include govuk-media-query($from: tablet) {
-    padding-top: 25px;
+    padding-top: 28px;
     padding-left: 7px;
   }
 
@@ -53,8 +53,6 @@
 }
 
 .gem-c-organisation-logo__name {
-  position: relative;
-  top: 3px;
   font-family: HelveticaNeue, "Helvetica Neue", Arial, Helvetica, sans-serif;
 }
 


### PR DESCRIPTION
## What
Fix the underline on the organisation logo component.

## Why
This appears to be being caused by a [bug in Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1359501&q=underline&can=2) related to the use of `position: relative` and `top: 3px` - the underline on the element is not adjusted, meaning that the text is pushed down 3px, slightly overlapping the underline (if you increase the value for `top` you can make the underline eventually appear above the text).

The bug has only been recently reported but we don't really need to have this CSS on this element - the same effect can be achieved by increasing the padding above the element by 3px.

## Visual Changes
Tested in various Chromes and Chrome on mobile.

Before | After
------ | ------
![Screenshot 2022-09-09 at 09 36 32](https://user-images.githubusercontent.com/861310/189308751-879fce90-e0e1-40d8-8132-031e9f909dcc.png) | ![Screenshot 2022-09-09 at 09 36 37](https://user-images.githubusercontent.com/861310/189308795-0d1c9dbc-aea6-46c0-8414-d5dac36e2bc7.png)

