### PR TITLE
Use Google snippet for GTM in analytics JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use Google snippet for GTM in analytics JavaScript ([PR #2951](https://github.com/alphagov/govuk_publishing_components/pull/2951))
+
 ## 30.5.1
 
 * Update popular links for London Bridge ([PR #2952](https://github.com/alphagov/govuk_publishing_components/pull/2952))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
@@ -1,4 +1,5 @@
 // The following modules are imported in a specific order
+//= require ./analytics-ga4/ga4-core
 //= require ./analytics-ga4/ga4-schemas
 //= require ./analytics-ga4/pii-remover
 //= require ./analytics-ga4/ga4-page-views

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -1,0 +1,20 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.analyticsGA4 = window.GOVUK.analyticsGA4 || {};
+
+(function (analytics) {
+  'use strict'
+
+  var core = {
+    load: function () {
+      /* eslint-disable */
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=' + window.GOVUK.analyticsGA4.vars.auth + '&gtm_preview=' + window.GOVUK.analyticsGA4.vars.preview + '&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer',window.GOVUK.analyticsGA4.vars.id);
+      /* eslint-enable */
+    }
+  }
+
+  analytics.core = core
+})(window.GOVUK.analyticsGA4)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
@@ -7,6 +7,8 @@ var initFunction = function () {
   var consentCookie = window.GOVUK.getConsentCookie()
 
   if (consentCookie && consentCookie.usage) {
+    window.GOVUK.analyticsGA4.core.load()
+
     var analyticsModules = window.GOVUK.analyticsGA4.analyticsModules
     for (var property in analyticsModules) {
       var module = analyticsModules[property]
@@ -14,7 +16,6 @@ var initFunction = function () {
         module.init()
       }
     }
-    // to be added: attach JS from Google to the DOM and execute
     // to be added: cross domain tracking code
   } else {
     window.addEventListener('cookie-consent', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -1,0 +1,21 @@
+/* eslint-env jasmine */
+
+describe('GA4 core', function () {
+  var GOVUK = window.GOVUK
+
+  beforeEach(function () {
+    window.dataLayer = []
+  })
+
+  afterAll(function () {
+    window.dataLayer = []
+  })
+
+  it('loads the GTM snippet', function () {
+    GOVUK.analyticsGA4.core.load()
+
+    expect(window.dataLayer.length).toEqual(1)
+    expect(Object.keys(window.dataLayer[0])).toContain('gtm.start')
+    expect(Object.keys(window.dataLayer[0])).toContain('event')
+  })
+})

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -23,6 +23,10 @@ describe('Google Analytics event tracking', function () {
     document.body.removeChild(element)
   })
 
+  afterAll(function () {
+    window.dataLayer = []
+  })
+
   describe('when the user has a cookie consent choice', function () {
     it('starts the module if consent has already been given', function () {
       agreeToCookies()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -10,6 +10,11 @@ describe('GOVUK.analyticsGA4.linkTracker', function () {
   var preventDefault = function (e) {
     e.preventDefault()
   }
+
+  afterAll(function () {
+    window.dataLayer = []
+  })
+
   describe('External link tracking', function () {
     beforeEach(function () {
       window.dataLayer = []

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -58,6 +58,10 @@ describe('Google Tag Manager page view tracking', function () {
     html.removeAttribute('lang')
   })
 
+  afterAll(function () {
+    window.dataLayer = []
+  })
+
   function createMetaTags (key, value) {
     var metatag = document.createElement('meta')
     metatag.setAttribute('name', 'govuk:' + key)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
@@ -12,6 +12,10 @@ describe('Initialising GA4', function () {
     GOVUK.analyticsGA4 = analyticsGA4Save
   })
 
+  afterAll(function () {
+    window.dataLayer = []
+  })
+
   describe('when consent is given', function () {
     var test = {
       functionThatMightBeCalled: function () {}

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -5,6 +5,12 @@ beforeAll(function () {
   window.GOVUK.analyticsVars.gaProperty = "UA-11111111-11"
   window.GOVUK.analyticsVars.gaPropertyCrossDomain = "UA-222222222-2"
   window.GOVUK.analyticsVars.linkedDomains = ['www.gov.uk']
+
+  window.GOVUK.analyticsGA4.vars = window.GOVUK.analyticsGA4.vars || {}
+  window.GOVUK.analyticsGA4.vars.id = 'GTM-test'
+  window.GOVUK.analyticsGA4.vars.auth = 'test'
+  window.GOVUK.analyticsGA4.vars.preview = 'env-test'
+
   delete ga
   window.GOVUK.analyticsInit()
 })


### PR DESCRIPTION
## What
- include the code snippet from Google in our code for running GTM as part of our new analytics code
- note that this will not work without the id, auth and preview values, which have to be created separately before the analytics code is called in `static`

Note that none of this code will be executed in production yet. This also depends upon the correct environment variables being set for the GTM code variables (see related PR, not ready yet).

How this works:

- `static` includes `analytics-ga4.js` (only on integration)
- `static` gets the GTM variables for `id`, `auth` and `preview` from environment variables using the functionality available through `js.erb` and sets them as JS variables inside the `window.analyticsGA4.vars` object
- `static` then calls `window.GOVUK.analyticsGA4.init()` (`init-ga4.js` in the gem)
- the analytics code is set up and configured, beginning first with the `core.load` function in `ga4-core.js`, which runs the Google code snippet, inserting the variables for `id`, `auth` and `preview` from the `window.analyticsGA4.vars` object

A few thoughts on this:

- I'm not sure what tests can be written for `ga4-core.js` as all it currently does is run the code snippet from Google, but I'm open to suggestions
- 'core' was the best name I could think of for this code, but I'm not sure I like it, so again any suggestions welcome
- core seems a bit empty at the moment, but I'm planning for it to be the home for more code, specifically the generic 'push things to the dataLayer' function

## Why
We're moving to integrate this analytics code fully with the cookie consent mechanism, which means no code from Google will be called unless users consent to cookies.

## Visual Changes
None.

Trello card: https://trello.com/c/vrMj18et/353-integrate-gtm-with-cookie-consent-mechanism
