### PR TITLE
Version 30.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 30.5.1
+
+* Update popular links for London Bridge ([PR #2952](https://github.com/alphagov/govuk_publishing_components/pull/2952))
+
 ## 30.5.0
 
 * Fix underline on organisation logo component ([PR #2949](https://github.com/alphagov/govuk_publishing_components/pull/2949))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (30.5.0)
+    govuk_publishing_components (30.5.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "30.5.0".freeze
+  VERSION = "30.5.1".freeze
 end


### PR DESCRIPTION
## 30.5.1

* Update popular links for London Bridge ([PR #3366](https://github.com/alphagov/frontend/pull/3366))