### PR TITLE
Add ecommerce tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * GA4 analytics add single dataLayer push function ([PR #2960](https://github.com/alphagov/govuk_publishing_components/pull/2960))
 * Remove unused classes in intervention component ([PR #2920](https://github.com/alphagov/govuk_publishing_components/pull/2920))
 * Include size attributes on image card component ([PR #2895](https://github.com/alphagov/govuk_publishing_components/pull/2895))
+* Add ecommerce tracking ([PR #2955](https://github.com/alphagov/govuk_publishing_components/pull/2955))
 
 ## 30.5.2
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
@@ -5,4 +5,5 @@
 //= require ./analytics-ga4/ga4-page-views
 //= require ./analytics-ga4/ga4-link-tracker
 //= require ./analytics-ga4/ga4-event-tracker
+//= require ./analytics-ga4/ga4-enhanced-ecommerce-tracker
 //= require ./analytics-ga4/init-ga4

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-enhanced-ecommerce-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-enhanced-ecommerce-tracker.js
@@ -1,0 +1,141 @@
+// = require govuk/vendor/polyfills/Element/prototype/closest.js
+;(function (global) {
+  'use strict'
+
+  var GOVUK = global.GOVUK || {}
+  GOVUK.analyticsGA4 = GOVUK.analyticsGA4 || {}
+
+  GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker = {
+    PIIRemover: new GOVUK.analyticsGA4.PIIRemover(),
+    DEFAULT_LIST_TITLE: 'Site search results',
+
+    init: function (isNewPageLoad = true) {
+      if (window.dataLayer) {
+        this.searchResultsBlocks = document.querySelectorAll('[data-ga4-ecommerce]')
+        this.isNewPageLoad = isNewPageLoad
+
+        if (!this.searchResultsBlocks.length === 0) {
+          return
+        }
+
+        /* If the results are updated by JS, the URL of the page will change and this needs to be visible to PA's,
+        hence the pageView object push to the dataLayer. We do not need to send a pageView object on page load as
+        this is handled elsewhere. */
+        if (!this.isNewPageLoad) {
+          var pageViewTracker = window.GOVUK.analyticsGA4.analyticsModules.PageViewTracker
+
+          if (pageViewTracker) {
+            pageViewTracker.init()
+          }
+        }
+
+        for (var i = 0; i < this.searchResultsBlocks.length; i++) {
+          this.trackSearchResults(this.searchResultsBlocks[i])
+
+          if (this.isNewPageLoad) {
+            this.searchResultsBlocks[i].addEventListener('click', this.handleClick.bind(this))
+          }
+        }
+      }
+    },
+
+    trackSearchResults: function (searchResultsBlock) {
+      var schema = this.populateEcommerceSchema(searchResultsBlock)
+
+      this.clearPreviousEcommerceObject()
+      window.dataLayer.push(schema)
+    },
+
+    handleClick: function (event) {
+      var searchResultsBlock = event.target.closest('[data-ga4-ecommerce]')
+      var isSearchResult = event.target.getAttribute('data-ecommerce-path')
+
+      if (isSearchResult) {
+        var searchResult = event.target
+        var schema = this.populateEcommerceSchema(searchResultsBlock, true, searchResult)
+
+        this.clearPreviousEcommerceObject()
+        window.dataLayer.push(schema)
+      }
+    },
+
+    populateEcommerceSchema: function (searchResultsBlock, searchResultClicked = false, searchResult = null) {
+      // Limiting to 100 characters to avoid noise from extra long search queries and to stop the size of the payload going over 8k limit.
+      var searchQuery = this.PIIRemover.stripPII(searchResultsBlock.getAttribute('data-search-query')).substring(0, 100).toLowerCase()
+      var variant = searchResultsBlock.getAttribute('data-ecommerce-variant') || undefined
+      var ecommerceRows = searchResultsBlock.querySelectorAll('[data-ecommerce-row]')
+      var listTitle = searchResultsBlock.getAttribute('data-list-title') || this.DEFAULT_LIST_TITLE
+      var startPosition = parseInt(searchResultsBlock.getAttribute('data-ecommerce-start-index'), 10)
+
+      var ecommerceObject = {
+        event: 'search_results',
+        search_results: {
+          event_name: searchResultClicked && searchResult ? 'select_item' : 'view_item_list',
+          term: searchQuery,
+          sort: variant,
+          results: this.getResultsCount(searchResultsBlock),
+          ecommerce: {
+            items: []
+          }
+        }
+      }
+
+      // Populate items array
+      if (searchResultClicked && searchResult) {
+        ecommerceObject.search_results.ecommerce.items.push({
+          item_id: searchResult.getAttribute('data-ecommerce-path'),
+          item_name: searchResult.textContent,
+          item_list_name: listTitle,
+          index: this.getIndex(searchResult, startPosition)
+        })
+
+        ecommerceObject.event_data = {
+          external: GOVUK.analyticsGA4.analyticsModules.Ga4LinkTracker.isExternalLink(searchResult.getAttribute('data-ecommerce-path')) ? 'true' : 'false'
+        }
+      } else {
+        for (var i = 0; i < ecommerceRows.length; i++) {
+          var ecommerceRow = ecommerceRows[i]
+          var path = ecommerceRow.getAttribute('data-ecommerce-path')
+
+          /* If the element does not have a data-ecommerce-index attribute, we set one so that we can use it later when setting the index property
+          on the ecommerce object. This for loop will always run on page load and so data-ecommerce-index will be available when we use it in the
+          initial if block above that checks if a search result has been clicked. */
+          if (!ecommerceRow.getAttribute('data-ecommerce-index')) {
+            ecommerceRow.setAttribute('data-ecommerce-index', i + 1)
+          }
+
+          ecommerceObject.search_results.ecommerce.items.push({
+            item_id: path,
+            item_list_name: listTitle,
+            index: this.getIndex(ecommerceRow, startPosition)
+          })
+        }
+      }
+
+      return ecommerceObject
+    },
+
+    getIndex: function (element, startPosition) {
+      return parseInt(element.getAttribute('data-ecommerce-index')) + startPosition - 1
+    },
+
+    clearPreviousEcommerceObject: function () {
+      window.dataLayer.push({ search_results: { ecommerce: null } })
+    },
+
+    getResultsCount: function (searchResultsBlock) {
+      // This returns a string e.g. '12,345 results'. Therefore to extract the number, we need to remove the comma and split the string at the space
+      var resultsCount = searchResultsBlock.querySelector('#js-result-count')
+
+      if (!resultsCount) {
+        return null
+      }
+
+      resultsCount = resultsCount.textContent.replace(',', '')
+      resultsCount = resultsCount.split(' ')[0]
+      return parseInt(resultsCount)
+    }
+  }
+
+  global.GOVUK = GOVUK
+})(window)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-enhanced-ecommerce-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-enhanced-ecommerce-tracker.spec.js
@@ -1,0 +1,296 @@
+/* eslint-env jasmine */
+
+describe('Google Analytics ecommerce tracking', function () {
+  var GOVUK = window.GOVUK
+  var searchResultsParentEl
+  var searchResults
+  var searchResultsHeading
+  var resultToBeClicked
+  var onPageLoadExpected
+  var onSearchResultClickExpected
+  var pageViewExpected
+
+  function agreeToCookies () {
+    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+  }
+
+  beforeEach(function () {
+    searchResultsHeading = document.createElement('h2')
+    searchResultsHeading.id = 'js-result-count'
+    searchResultsHeading.innerHTML = '12,345 results'
+
+    searchResultsParentEl = document.createElement('div')
+    searchResultsParentEl.setAttribute('data-ga4-ecommerce', '')
+    searchResultsParentEl.setAttribute('data-search-query', 'test-search-query')
+    searchResultsParentEl.setAttribute('data-module', 'ga4-enhanced-ecommerce-tracker')
+    searchResultsParentEl.setAttribute('data-ecommerce-variant', 'test-ecommerce-variant')
+    searchResultsParentEl.setAttribute('data-list-title', 'test-list-title')
+    searchResultsParentEl.setAttribute('data-ecommerce-start-index', '1')
+
+    searchResults = document.createElement('div')
+    searchResults.innerHTML =
+      '<a data-ecommerce-path="/coronavirus" data-ecommerce-row="1" data-ecommerce-index="1" href="/coronavirus">Coronavirus (COVID-19): guidance and support</a>' +
+
+      '<a data-ecommerce-path="/guidance/travel-abroad-from-england-during-coronavirus-covid-19" data-ecommerce-row="1" data-ecommerce-index="2" href="/guidance/travel-abroad">Travel abroad</a>' +
+
+      '<a data-ecommerce-path="/guidance/people-with-symptoms-of-a-respiratory-infection-including-covid-19" data-ecommerce-row="1" data-ecommerce-index="3" href="/guidance/people">People</a>' +
+
+      '<a data-ecommerce-path="/foreign-travel-advice" onclick="event.preventDefault()" data-ecommerce-row="1" data-ecommerce-index="4" href="/foreign-travel-advice">Foreign travel advice</a>' +
+
+      '<a data-ecommerce-path="/guidance/living-safely-with-respiratory-infections-including-covid-19" data-ecommerce-row="1" data-ecommerce-index="5" href="/guidance/living-safely">Living safely</a>'
+
+    onPageLoadExpected = {
+      event: 'search_results',
+      search_results: {
+        event_name: 'view_item_list',
+        term: 'test-search-query',
+        sort: 'test-ecommerce-variant',
+        results: 12345,
+        ecommerce: {
+          items: [
+            {
+              item_id: '/coronavirus',
+              item_list_name: 'test-list-title',
+              index: 1
+            },
+            {
+              item_id: '/guidance/travel-abroad-from-england-during-coronavirus-covid-19',
+              item_list_name: 'test-list-title',
+              index: 2
+            },
+            {
+              item_id: '/guidance/people-with-symptoms-of-a-respiratory-infection-including-covid-19',
+              item_list_name: 'test-list-title',
+              index: 3
+            },
+            {
+              item_id: '/foreign-travel-advice',
+              item_list_name: 'test-list-title',
+              index: 4
+            },
+            {
+              item_id: '/guidance/living-safely-with-respiratory-infections-including-covid-19',
+              item_list_name: 'test-list-title',
+              index: 5
+            }
+          ]
+        }
+      }
+    }
+
+    window.dataLayer = []
+    searchResultsParentEl.appendChild(searchResults)
+    searchResultsParentEl.appendChild(searchResultsHeading)
+    document.body.appendChild(searchResultsParentEl)
+    agreeToCookies()
+  })
+
+  afterEach(function () {
+    window.dataLayer = []
+    document.body.removeChild(searchResultsParentEl)
+  })
+
+  describe('on page load', function () {
+    it('should push a nullified ecommerce object to the dataLayer', function () {
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      expect(window.dataLayer[0].search_results.ecommerce).toBe(null)
+    })
+
+    it('should get the search query', function () {
+      onPageLoadExpected.search_results.term = 'coronavirus'
+      searchResultsParentEl.setAttribute('data-search-query', 'coronavirus')
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      expect(window.dataLayer[1].search_results.term).toBe(onPageLoadExpected.search_results.term)
+    })
+
+    it('should remove PII from search query', function () {
+      onPageLoadExpected.search_results.term = '[email]'
+      searchResultsParentEl.setAttribute('data-search-query', 'email@example.com')
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      expect(window.dataLayer[1].search_results.term).toBe(onPageLoadExpected.search_results.term)
+    })
+
+    it('should get the variant', function () {
+      onPageLoadExpected.search_results.sort = 'Relevance'
+      searchResultsParentEl.setAttribute('data-ecommerce-variant', 'Relevance')
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      expect(window.dataLayer[1].search_results.sort).toBe(onPageLoadExpected.search_results.sort)
+    })
+
+    it('should set the variant to undefined when the data-ecommerce-variant does not exist', function () {
+      onPageLoadExpected.search_results.sort = undefined
+      searchResultsParentEl.removeAttribute('data-ecommerce-variant')
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      expect(window.dataLayer[1].search_results.sort).toBe(onPageLoadExpected.search_results.sort)
+    })
+
+    it('should get the number of search results i.e. 12345 search results in this test case', function () {
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      expect(window.dataLayer[1].search_results.results).toBe(onPageLoadExpected.search_results.results)
+    })
+
+    it('should get the item id for each search result', function () {
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      var searchResults = window.dataLayer[1].search_results.ecommerce.items
+      for (var i = 0; i < searchResults.length; i++) {
+        expect(searchResults[i].item_id).toBe(onPageLoadExpected.search_results.ecommerce.items[i].item_id)
+      }
+    })
+
+    it('should get the item list name for each search result', function () {
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      var searchResults = window.dataLayer[1].search_results.ecommerce.items
+      for (var i = 0; i < searchResults.length; i++) {
+        expect(searchResults[i].item_list_name).toBe(onPageLoadExpected.search_results.ecommerce.items[i].item_list_name)
+      }
+    })
+
+    it('should set the item list name to \'Site search results\' when the data-list-title does not exist', function () {
+      for (var i = 0; i < onPageLoadExpected.search_results.ecommerce.items.length; i++) {
+        onPageLoadExpected.search_results.ecommerce.items[i].item_list_name = 'Site search results'
+      }
+      searchResultsParentEl.removeAttribute('data-list-title')
+
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      var searchResults = window.dataLayer[1].search_results.ecommerce.items
+      for (var j = 0; j < searchResults.length; j++) {
+        expect(searchResults[j].item_list_name).toBe(onPageLoadExpected.search_results.ecommerce.items[j].item_list_name)
+      }
+    })
+
+    it('should get the index for each search result using the data-ecommerce-index attribute', function () {
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      var searchResults = window.dataLayer[1].search_results.ecommerce.items
+
+      for (var i = 0; i < searchResults.length; i++) {
+        expect(searchResults[i].index).toBe(onPageLoadExpected.search_results.ecommerce.items[i].index)
+      }
+    })
+
+    it('should get the index for each search result using the for loop index if the data-ecommerce-index attribute does not exist', function () {
+      var ecommerceRows = document.querySelectorAll('[data-ecommerce-row]')
+      for (var i = 0; i < ecommerceRows.length; i++) {
+        ecommerceRows[i].removeAttribute('data-ecommerce-index')
+      }
+
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      var searchResults = window.dataLayer[1].search_results.ecommerce.items
+      for (var j = 0; j < searchResults.length; j++) {
+        expect(searchResults[j].index).toBe(onPageLoadExpected.search_results.ecommerce.items[j].index)
+      }
+    })
+  })
+
+  describe('when a new page isn\'t loaded e.g. when the user selects a filter', function () {
+    it('should push a nullified ecommerce object to the dataLayer', function () {
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      expect(window.dataLayer[0].search_results.ecommerce).toBe(null)
+    })
+
+    it('should push a pageView object to the dataLayer', function () {
+      spyOnProperty(document, 'referrer', 'get').and.returnValue('https://gov.uk/')
+
+      // We can't spy on location, so instead we use an anchor link to change the URL
+      var linkForURLMock = document.createElement('a')
+      linkForURLMock.href = '#'
+      linkForURLMock.click()
+      var location = document.location.href
+
+      pageViewExpected = {
+        event: 'page_view',
+        page_view: {
+          location: location,
+          referrer: 'https://gov.uk/'
+        }
+      }
+
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(false)
+
+      expect(window.dataLayer[0].event).toBe(pageViewExpected.event)
+      expect(window.dataLayer[0].page_view.location).toBe(pageViewExpected.page_view.location)
+      expect(window.dataLayer[0].page_view.referrer).toBe(pageViewExpected.page_view.referrer)
+    })
+  })
+
+  describe('when the user clicks on a search result', function () {
+    beforeEach(function () {
+      onSearchResultClickExpected = {
+        event: 'search_results',
+        event_data: {
+          external: 'false'
+        },
+        search_results: {
+          event_name: 'select_item',
+          term: 'test-search-query',
+          sort: 'test-ecommerce-variant',
+          results: 12345,
+          ecommerce: {
+            items: [
+              {
+                item_id: '/foreign-travel-advice',
+                item_name: 'Foreign travel advice',
+                item_list_name: 'test-list-title',
+                index: 4
+              }
+            ]
+          }
+        }
+      }
+
+      resultToBeClicked = document.querySelector("[data-ecommerce-path='/foreign-travel-advice']")
+      GOVUK.analyticsGA4.analyticsModules.Ga4LinkTracker.internalLinksDomain = 'www.gov.uk/'
+      GOVUK.analyticsGA4.analyticsModules.Ga4LinkTracker.internalLinksDomainWithoutWww = 'gov.uk/'
+    })
+
+    it('should push a nullified ecommerce object to the dataLayer', function () {
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      expect(window.dataLayer[0].search_results.ecommerce).toBe(null)
+    })
+
+    it('should call the handleClick function', function () {
+      var tracker = GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker
+
+      spyOn(tracker, 'handleClick')
+      tracker.init()
+
+      resultToBeClicked.click()
+      expect(tracker.handleClick).toHaveBeenCalled()
+    })
+
+    it('should push 1 search result to the dataLayer (i.e. the clicked search result)', function () {
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      resultToBeClicked.click()
+      expect(window.dataLayer[3].search_results.ecommerce.items.length).toBe(1)
+    })
+
+    it('should add the event_data property to the object and set it appropriately', function () {
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      resultToBeClicked.click()
+      expect(window.dataLayer[3].event_data).not.toBe(null)
+      expect(window.dataLayer[3].event_data.external).toBe(onSearchResultClickExpected.event_data.external)
+    })
+
+    it('should set the remaining properties appropriately', function () {
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+
+      resultToBeClicked.click()
+      expect(window.dataLayer[3].event).toBe(onSearchResultClickExpected.event)
+      expect(window.dataLayer[3].search_results).toEqual(onSearchResultClickExpected.search_results)
+    })
+  })
+})


### PR DESCRIPTION
## What

This PR adds enhanced ecommerce tracking scripts that will gather data on pages such as search and push this data to the `dataLayer` where it can be accessed by Performance Analysts.

Caveat: on lines `90` and `91`, `internalLinksDomain` and `internalLinksDomainWithoutWww` are set directly because otherwise `isExternalLink` will return an error. This implementation is temporary and will be fixed following a refactor of the `ga4-link-tracker` code by @AshGDS (https://github.com/alphagov/govuk_publishing_components/pull/2961).

## Why

These changes are being made as part of our migration to GA4.

## Visual Changes

N/A
