### PR TITLE
Fix intermittent failing analytics test

### DIFF
--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -3,11 +3,7 @@
 describe('GA4 core', function () {
   var GOVUK = window.GOVUK
 
-  beforeEach(function () {
-    window.dataLayer = []
-  })
-
-  afterAll(function () {
+  afterEach(function () {
     window.dataLayer = []
   })
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
@@ -2,17 +2,9 @@
 
 describe('Initialising GA4', function () {
   var GOVUK = window.GOVUK
-  var analyticsGA4Save
-
-  beforeEach(function () {
-    analyticsGA4Save = GOVUK.analyticsGA4
-  })
 
   afterEach(function () {
-    GOVUK.analyticsGA4 = analyticsGA4Save
-  })
-
-  afterAll(function () {
+    GOVUK.analyticsGA4.analyticsModules.Ga4LinkTracker.stopTracking()
     window.dataLayer = []
   })
 


### PR DESCRIPTION
## What / why
- sometimes the core test would fail because window.dataLayer was already full of things when the test was run, when it was expecting it to start empty
- the reason for this was the init GA4 tests, which were repeatedly initialising the link tracker code, which adds event listeners to the DOM
- when other tests ran and clicked anywhere, those event listeners were firing and adding things to window.dataLayer
- the link tests already cleaned up after themselves by shutting down the event listeners, so the fix was to repeat that in the init GA4 tests
- note that these tests were already passing because we were cleaning out window.dataLayer manually, but this is better because it avoids potential similar problems in the future with other new tests

## Visual Changes
None.
