### PR TITLE
Fix cookie-consent events breaking GA4 tests

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
@@ -18,9 +18,7 @@ var initFunction = function () {
     }
     // to be added: cross domain tracking code
   } else {
-    window.addEventListener('cookie-consent', function () {
-      window.GOVUK.analyticsGA4.init()
-    })
+    window.addEventListener('cookie-consent', window.GOVUK.analyticsGA4.init)
   }
 }
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
@@ -6,6 +6,7 @@ describe('Initialising GA4', function () {
   afterEach(function () {
     GOVUK.analyticsGA4.analyticsModules.Ga4LinkTracker.stopTracking()
     window.dataLayer = []
+    window.removeEventListener('cookie-consent', window.GOVUK.analyticsGA4.init)
   })
 
   describe('when consent is given', function () {


### PR DESCRIPTION
Hi @andysellick - would you be able to approve this when you get a chance? Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Ensures the `cookie-consent` event listener is removed after the `init-ga4.spec.js` tests.
## Why
<!-- What are the reasons behind this change being made? -->
We were adding a `cookie-consent` listener in our tests, which initialises our GA4 modules when the event is fired. However `cookie-functions-spec.js` fires `cookie-consent` events, which caused multiple instances of GTM to be initialised, breaking our tests as multiple click listeners/page view listeners were active.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
