### PR TITLE
Add GA4 analytics GTM blocklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add GA4 analytics GTM blocklist ([PR #2962](https://github.com/alphagov/govuk_publishing_components/pull/2962))
 * GA4 analytics add single dataLayer push function ([PR #2960](https://github.com/alphagov/govuk_publishing_components/pull/2960))
 
 ## 30.5.2

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js.erb
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js.erb
@@ -12,6 +12,7 @@ window.GOVUK.analyticsGA4 = window.GOVUK.analyticsGA4 || {};
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=' + window.GOVUK.analyticsGA4.vars.auth + '&gtm_preview=' + window.GOVUK.analyticsGA4.vars.preview + '&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer',window.GOVUK.analyticsGA4.vars.id);
+      window.dataLayer.push({ 'gtm.blocklist' : ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] })
       /* eslint-enable */
     },
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -14,9 +14,11 @@ describe('GA4 core', function () {
   it('loads the GTM snippet', function () {
     GOVUK.analyticsGA4.core.load()
 
-    expect(window.dataLayer.length).toEqual(1)
+    expect(window.dataLayer.length).toEqual(2)
     expect(Object.keys(window.dataLayer[0])).toContain('gtm.start')
     expect(Object.keys(window.dataLayer[0])).toContain('event')
+    expect(Object.keys(window.dataLayer[1])).toContain('gtm.blocklist')
+    expect(window.dataLayer[1]['gtm.blocklist']).toEqual(['customPixels', 'customScripts', 'html', 'nonGoogleScripts'])
   })
 
   it('pushes data to the dataLayer', function () {


### PR DESCRIPTION
## What / why
Adds a blocklist to the Google Tag Manager initialisation. This is a custom blocklist for GOV.UK that should prevent anyone from adding custom code through GTM's web interface

## Visual Changes
None.

Trello card: https://trello.com/c/vrMj18et/353-integrate-gtm-with-cookie-consent-mechanism