### PR TITLE
Version 30.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 30.6.0
 
 * Add GA4 analytics GTM blocklist ([PR #2962](https://github.com/alphagov/govuk_publishing_components/pull/2962))
 * GA4 analytics add single dataLayer push function ([PR #2960](https://github.com/alphagov/govuk_publishing_components/pull/2960))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (30.5.2)
+    govuk_publishing_components (30.6.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "30.5.2".freeze
+  VERSION = "30.6.0".freeze
 end


### PR DESCRIPTION
## 30.6.0

* Add GA4 analytics GTM blocklist ([PR #2962](https://github.com/alphagov/govuk_publishing_components/pull/2962))
* GA4 analytics add single dataLayer push function ([PR #2960](https://github.com/alphagov/govuk_publishing_components/pull/2960))
* Remove unused classes in intervention component ([PR #2920](https://github.com/alphagov/govuk_publishing_components/pull/2920))
* Include size attributes on image card component ([PR #2895](https://github.com/alphagov/govuk_publishing_components/pull/2895))
