### PR TITLE
Add click tracking to Yes/No buttons on feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Change GTM push of unset values from 'null' to 'undefined' ([PR #2971](https://github.com/alphagov/govuk_publishing_components/pull/2971))
+* Add click tracking to Yes/No buttons on feedback component ([PR #2964](https://github.com/alphagov/govuk_publishing_components/pull/2964))
 
 ## 30.6.1
 

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -8,7 +8,7 @@
   path_without_pii = utf_encode(request.fullpath.gsub(email_regex, '[email]'))
 %>
 
-<div class="gem-c-feedback govuk-!-display-none-print" data-module="feedback">
+<div class="gem-c-feedback govuk-!-display-none-print" data-module="feedback ga4-event-tracker">
   <%= render "govuk_publishing_components/components/feedback/yes_no_banner" %>
   <%= render "govuk_publishing_components/components/feedback/problem_form", url_without_pii: url_without_pii %>
   <%= render "govuk_publishing_components/components/feedback/survey_signup_form", path_without_pii: path_without_pii %>

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -20,12 +20,12 @@
         <% end %>
       </li>
       <li class="gem-c-feedback__option-list-item">
-        <button class="govuk-button gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">
+        <button class="govuk-button gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick" data-ga4='{"event_name":"form_submit","type":"feedback","text":"Yes", "section": "Is this page useful?"}'>
           <%= t("components.feedback.yes") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_useful") %></span>
         </button>
       </li>
       <li class="gem-c-feedback__option-list-item">
-        <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">
+        <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false" data-ga4='{"event_name":"form_submit","type":"feedback","text":"No", "section": "Is this page useful?"}'>
           <%= t("components.feedback.no") %> <span class="govuk-visually-hidden"><%= t("components.feedback.is_not_useful") %></span>
         </button>
       </li>

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -412,4 +412,65 @@ describe('Google Analytics event tracking', function () {
       expect(window.dataLayer[0].event_data.url).toEqual(undefined)
     })
   })
+
+  describe('doing tracking on the feedback component', function () {
+    beforeEach(function () {
+      var attributes = {
+        event_name: 'form_submit',
+        type: 'feedback',
+        text: 'Yes',
+        section: 'Is this page useful?'
+      }
+      element.innerHTML =
+        '<div data-module="ga4-event-tracker">' +
+      '</div>'
+
+      var yesButton = document.createElement('button')
+      yesButton.setAttribute('data-ga4', JSON.stringify(attributes))
+      yesButton.id = 'yesButton'
+
+      attributes.text = 'No'
+      var noButton = document.createElement('button')
+      noButton.setAttribute('data-ga4', JSON.stringify(attributes))
+      noButton.id = 'noButton'
+
+      element.appendChild(yesButton)
+      element.appendChild(noButton)
+
+      document.body.appendChild(element)
+      new GOVUK.Modules.Ga4EventTracker(element).init()
+
+      window.dataLayer = []
+    })
+
+    it('should track "Yes" button clicks', function () {
+      expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
+
+      expected.event = 'event_data'
+      expected.event_data.event_name = 'form_submit'
+      expected.event_data.type = 'feedback'
+      expected.event_data.text = 'Yes'
+      expected.event_data.section = 'Is this page useful?'
+      expected.govuk_gem_version = 'aVersion'
+
+      var yesButton = document.querySelector('#yesButton')
+      yesButton.click()
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('should track "No" button clicks', function () {
+      expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
+
+      expected.event = 'event_data'
+      expected.event_data.event_name = 'form_submit'
+      expected.event_data.type = 'feedback'
+      expected.event_data.text = 'No'
+      expected.event_data.section = 'Is this page useful?'
+      expected.govuk_gem_version = 'aVersion'
+
+      var noButton = document.querySelector('#noButton')
+      noButton.click()
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+  })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -441,17 +441,16 @@ describe('Google Analytics event tracking', function () {
       new GOVUK.Modules.Ga4EventTracker(element).init()
 
       window.dataLayer = []
-    })
-
-    it('should track "Yes" button clicks', function () {
       expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
-
       expected.event = 'event_data'
       expected.event_data.event_name = 'form_submit'
       expected.event_data.type = 'feedback'
-      expected.event_data.text = 'Yes'
       expected.event_data.section = 'Is this page useful?'
       expected.govuk_gem_version = 'aVersion'
+    })
+
+    it('should track "Yes" button clicks', function () {
+      expected.event_data.text = 'Yes'
 
       var yesButton = document.querySelector('#yesButton')
       yesButton.click()
@@ -459,14 +458,7 @@ describe('Google Analytics event tracking', function () {
     })
 
     it('should track "No" button clicks', function () {
-      expected = new GOVUK.analyticsGA4.Schemas().eventSchema()
-
-      expected.event = 'event_data'
-      expected.event_data.event_name = 'form_submit'
-      expected.event_data.type = 'feedback'
       expected.event_data.text = 'No'
-      expected.event_data.section = 'Is this page useful?'
-      expected.govuk_gem_version = 'aVersion'
 
       var noButton = document.querySelector('#noButton')
       noButton.click()


### PR DESCRIPTION
Hi @andysellick @JamesCGDS 

Would you be able to approve this PR if all is OK?

Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds `data-module="ga4-event-tracker"` to the feedback component parent `<div>`
- Adds a `data-ga4` JSON to the feedback component Yes/No buttons so that they are tracked on click by `ga4-event-tracker.js`

## Why
<!-- What are the reasons behind this change being made? -->
- They are needed to fulfil the MVP requirement of tracking the clicks on the Yes/No buttons
- I've hard coded the English versions of "Yes" "No" and "Is this page useful?" in the `JSON`. In the live feedback component, these strings are potentially translated into 60+ other languages, depending on what language the user's browser is set to. I'm assuming we should always send English to GA4, otherwise the analysts would have to collate all these different languages in the dashboard just to see wether Yes/No was clicked.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
