### PR TITLE
Remove usage of default parameters

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-enhanced-ecommerce-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-enhanced-ecommerce-tracker.js
@@ -9,7 +9,7 @@
     PIIRemover: new GOVUK.analyticsGA4.PIIRemover(),
     DEFAULT_LIST_TITLE: 'Site search results',
 
-    init: function (isNewPageLoad = true) {
+    init: function (isNewPageLoad) {
       if (window.dataLayer) {
         this.searchResultsBlocks = document.querySelectorAll('[data-ga4-ecommerce]')
         this.isNewPageLoad = isNewPageLoad

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-enhanced-ecommerce-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-enhanced-ecommerce-tracker.spec.js
@@ -92,7 +92,7 @@ describe('Google Analytics ecommerce tracking', function () {
 
   describe('on page load', function () {
     it('should push a nullified ecommerce object to the dataLayer', function () {
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       expect(window.dataLayer[0].search_results.ecommerce).toBe(null)
     })
@@ -100,7 +100,7 @@ describe('Google Analytics ecommerce tracking', function () {
     it('should get the search query', function () {
       onPageLoadExpected.search_results.term = 'coronavirus'
       searchResultsParentEl.setAttribute('data-search-query', 'coronavirus')
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       expect(window.dataLayer[1].search_results.term).toBe(onPageLoadExpected.search_results.term)
     })
@@ -108,7 +108,7 @@ describe('Google Analytics ecommerce tracking', function () {
     it('should remove PII from search query', function () {
       onPageLoadExpected.search_results.term = '[email]'
       searchResultsParentEl.setAttribute('data-search-query', 'email@example.com')
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       expect(window.dataLayer[1].search_results.term).toBe(onPageLoadExpected.search_results.term)
     })
@@ -116,7 +116,7 @@ describe('Google Analytics ecommerce tracking', function () {
     it('should get the variant', function () {
       onPageLoadExpected.search_results.sort = 'Relevance'
       searchResultsParentEl.setAttribute('data-ecommerce-variant', 'Relevance')
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       expect(window.dataLayer[1].search_results.sort).toBe(onPageLoadExpected.search_results.sort)
     })
@@ -124,19 +124,19 @@ describe('Google Analytics ecommerce tracking', function () {
     it('should set the variant to undefined when the data-ecommerce-variant does not exist', function () {
       onPageLoadExpected.search_results.sort = undefined
       searchResultsParentEl.removeAttribute('data-ecommerce-variant')
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       expect(window.dataLayer[1].search_results.sort).toBe(onPageLoadExpected.search_results.sort)
     })
 
     it('should get the number of search results i.e. 12345 search results in this test case', function () {
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       expect(window.dataLayer[1].search_results.results).toBe(onPageLoadExpected.search_results.results)
     })
 
     it('should get the item id for each search result', function () {
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       var searchResults = window.dataLayer[1].search_results.ecommerce.items
       for (var i = 0; i < searchResults.length; i++) {
@@ -145,7 +145,7 @@ describe('Google Analytics ecommerce tracking', function () {
     })
 
     it('should get the item list name for each search result', function () {
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       var searchResults = window.dataLayer[1].search_results.ecommerce.items
       for (var i = 0; i < searchResults.length; i++) {
@@ -159,7 +159,7 @@ describe('Google Analytics ecommerce tracking', function () {
       }
       searchResultsParentEl.removeAttribute('data-list-title')
 
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       var searchResults = window.dataLayer[1].search_results.ecommerce.items
       for (var j = 0; j < searchResults.length; j++) {
@@ -168,7 +168,7 @@ describe('Google Analytics ecommerce tracking', function () {
     })
 
     it('should get the index for each search result using the data-ecommerce-index attribute', function () {
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       var searchResults = window.dataLayer[1].search_results.ecommerce.items
 
@@ -183,7 +183,7 @@ describe('Google Analytics ecommerce tracking', function () {
         ecommerceRows[i].removeAttribute('data-ecommerce-index')
       }
 
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       var searchResults = window.dataLayer[1].search_results.ecommerce.items
       for (var j = 0; j < searchResults.length; j++) {
@@ -194,9 +194,9 @@ describe('Google Analytics ecommerce tracking', function () {
 
   describe('when a new page isn\'t loaded e.g. when the user selects a filter', function () {
     it('should push a nullified ecommerce object to the dataLayer', function () {
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(false)
 
-      expect(window.dataLayer[0].search_results.ecommerce).toBe(null)
+      expect(window.dataLayer[1].search_results.ecommerce).toBe(null)
     })
 
     it('should push a pageView object to the dataLayer', function () {
@@ -255,7 +255,7 @@ describe('Google Analytics ecommerce tracking', function () {
     })
 
     it('should push a nullified ecommerce object to the dataLayer', function () {
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       expect(window.dataLayer[0].search_results.ecommerce).toBe(null)
     })
@@ -264,21 +264,21 @@ describe('Google Analytics ecommerce tracking', function () {
       var tracker = GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker
 
       spyOn(tracker, 'handleClick')
-      tracker.init()
+      tracker.init(true)
 
       resultToBeClicked.click()
       expect(tracker.handleClick).toHaveBeenCalled()
     })
 
     it('should push 1 search result to the dataLayer (i.e. the clicked search result)', function () {
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       resultToBeClicked.click()
       expect(window.dataLayer[3].search_results.ecommerce.items.length).toBe(1)
     })
 
     it('should add the event_data property to the object and set it appropriately', function () {
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       resultToBeClicked.click()
       expect(window.dataLayer[3].event_data).not.toBe(null)
@@ -286,7 +286,7 @@ describe('Google Analytics ecommerce tracking', function () {
     })
 
     it('should set the remaining properties appropriately', function () {
-      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init()
+      GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(true)
 
       resultToBeClicked.click()
       expect(window.dataLayer[3].event).toBe(onSearchResultClickExpected.event)


### PR DESCRIPTION
## What
When initialising ecommerce tracking, the `Ga4EnhancedEcommerceTracker.init()` function relies on a default parameter being set to a boolean. As this is an ES6 feature, it has been removed.

## Why
Using ES6 features can cause compatibility issues with older browsers and so it has been removed.

## Visual Changes
N/A
