### PR TITLE
Remove default parameters from ecommerce tracker

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-enhanced-ecommerce-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-enhanced-ecommerce-tracker.js
@@ -59,7 +59,7 @@
       }
     },
 
-    populateEcommerceSchema: function (searchResultsBlock, searchResultClicked = false, searchResult = null) {
+    populateEcommerceSchema: function (searchResultsBlock, searchResultClicked, searchResult) {
       // Limiting to 100 characters to avoid noise from extra long search queries and to stop the size of the payload going over 8k limit.
       var searchQuery = this.PIIRemover.stripPII(searchResultsBlock.getAttribute('data-search-query')).substring(0, 100).toLowerCase()
       var variant = searchResultsBlock.getAttribute('data-ecommerce-variant') || undefined


### PR DESCRIPTION

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Remove the default parameters from a function in the GA4 enhanced ecommerce tracking JavaScript.

Removing the defaults doesn't seem to have an effect as the defaults were
falsely anyway.

## Why
<!-- What are the reasons behind this change being made? -->

We shouldn't be using ES6 in production. This was preventing applications from being deployed as the uglifier/compresser was throwing an error when encountering the default parameters:

```
Uglifier::Error: Unexpected token operator «=», expected punc «,». To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).
```

[Log output from frontend](https://ci.integration.publishing.service.gov.uk/job/frontend/job/set-up-individual-component-css/17/console)

## Visual Changes
None.
