### PR TITLE
Change GTM push of unset values from 'null' to 'undefined'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change GTM push of unset values from 'null' to 'undefined' ([PR #2971](https://github.com/alphagov/govuk_publishing_components/pull/2971))
+
 ## 30.6.1
 
 * Add require version ([PR #2965](https://github.com/alphagov/govuk_publishing_components/pull/2965))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -7,7 +7,7 @@ window.GOVUK.analyticsGA4.analyticsModules = window.GOVUK.analyticsGA4.analytics
 
   var PageViewTracker = {
     PIIRemover: new window.GOVUK.analyticsGA4.PIIRemover(), // imported in analytics-ga4.js
-    nullValue: null,
+    nullValue: undefined,
 
     init: function () {
       if (window.dataLayer) {
@@ -102,7 +102,7 @@ window.GOVUK.analyticsGA4.analyticsModules = window.GOVUK.analyticsGA4.analytics
     // return only the date from given timestamps of the form
     // 2022-03-28T19:11:00.000+00:00
     stripTimeFrom: function (value) {
-      if (value !== null) {
+      if (value !== undefined) {
         return value.split('T')[0]
       } else {
         return this.nullValue

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
@@ -4,24 +4,24 @@
   var GOVUK = global.GOVUK || {}
 
   var Schemas = function () {
-    this.null = null
+    this.undefined = undefined
   }
 
   Schemas.prototype.eventSchema = function () {
     return {
-      event: this.null,
+      event: this.undefined,
 
       event_data: {
-        event_name: this.null,
-        type: this.null,
-        url: this.null,
-        text: this.null,
-        index: this.null,
-        index_total: this.null,
-        section: this.null,
-        action: this.null,
-        external: this.null,
-        link_method: this.null
+        event_name: this.undefined,
+        type: this.undefined,
+        url: this.undefined,
+        text: this.undefined,
+        index: this.undefined,
+        index_total: this.undefined,
+        section: this.undefined,
+        action: this.undefined,
+        external: this.undefined,
+        link_method: this.undefined
       }
     }
   }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -350,7 +350,7 @@ describe('Google Analytics event tracking', function () {
     it('should not track the aria-expanded state', function () {
       var clickOn = element.querySelector('.clickme')
       clickOn.click()
-      expect(window.dataLayer[0].event_data.action).toEqual(null)
+      expect(window.dataLayer[0].event_data.action).toEqual(undefined)
     })
   })
 
@@ -373,7 +373,7 @@ describe('Google Analytics event tracking', function () {
     it('should not track the open/closed state', function () {
       var clickOn = element.querySelector('.clickme')
       clickOn.click()
-      expect(window.dataLayer[0].event_data.action).toEqual(null)
+      expect(window.dataLayer[0].event_data.action).toEqual(undefined)
     })
   })
 
@@ -409,7 +409,7 @@ describe('Google Analytics event tracking', function () {
       window.dataLayer = []
       clickOn = element.querySelector('.random-list-item')
       clickOn.click()
-      expect(window.dataLayer[0].event_data.url).toEqual(null)
+      expect(window.dataLayer[0].event_data.url).toEqual(undefined)
     })
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -4,7 +4,6 @@ describe('Google Tag Manager page view tracking', function () {
   var GOVUK = window.GOVUK
   var saved = {}
   var expected
-  var nullValue = null
 
   beforeAll(function () {
     spyOn(GOVUK.analyticsGA4.core, 'getGemVersion').and.returnValue('aVersion')
@@ -22,30 +21,30 @@ describe('Google Tag Manager page view tracking', function () {
         title: 'This here page',
         status_code: '200',
 
-        document_type: nullValue,
-        publishing_app: nullValue,
-        rendering_app: nullValue,
-        schema_name: nullValue,
-        content_id: nullValue,
+        document_type: undefined,
+        publishing_app: undefined,
+        rendering_app: undefined,
+        schema_name: undefined,
+        content_id: undefined,
 
-        section: nullValue,
-        taxon_slug: nullValue,
-        taxon_id: nullValue,
-        themes: nullValue,
-        taxon_slugs: nullValue,
-        taxon_ids: nullValue,
+        section: undefined,
+        taxon_slug: undefined,
+        taxon_id: undefined,
+        themes: undefined,
+        taxon_slugs: undefined,
+        taxon_ids: undefined,
 
-        language: nullValue,
+        language: undefined,
         history: 'false',
         withdrawn: 'false',
-        first_published_at: nullValue,
-        updated_at: nullValue,
-        public_updated_at: nullValue,
-        publishing_government: nullValue,
-        political_status: nullValue,
-        primary_publishing_organisation: nullValue,
-        organisations: nullValue,
-        world_locations: nullValue
+        first_published_at: undefined,
+        updated_at: undefined,
+        public_updated_at: undefined,
+        publishing_government: undefined,
+        political_status: undefined,
+        primary_publishing_organisation: undefined,
+        organisations: undefined,
+        world_locations: undefined
       }
     }
     window.dataLayer = []
@@ -191,7 +190,7 @@ describe('Google Tag Manager page view tracking', function () {
     })
 
     it('set incorrectly', function () {
-      expected.page_view.language = nullValue
+      expected.page_view.language = undefined
 
       GOVUK.analyticsGA4.analyticsModules.PageViewTracker.init()
       expect(window.dataLayer[0]).toEqual(expected)
@@ -199,7 +198,7 @@ describe('Google Tag Manager page view tracking', function () {
   })
 
   it('returns a pageview without a language', function () {
-    expected.page_view.language = nullValue
+    expected.page_view.language = undefined
 
     GOVUK.analyticsGA4.analyticsModules.PageViewTracker.init()
     expect(window.dataLayer[0]).toEqual(expected)


### PR DESCRIPTION
Hi @andysellick 

Would you be able to approve this? Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- This will make our GA4 code push any unset values as `undefined` instead of `null`.

## Why
<!-- What are the reasons behind this change being made? -->
- This should now display unset values as `(not set)` instead of `""` in the GA4 dashboard.
- I had to remove `var nullValue` from the page view tests, as `standardx` didn't like us setting a `var` to `undefined`
- Ecommerce has not been touched, because `we should set any missing values to undefined rather than null - except for the ecommerce parameters (and any other edge cases where [Jeff] may recommend against it.)`

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.