### PR TITLE
Add optional gtag snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add optional gtag snippet ([PR #2979](https://github.com/alphagov/govuk_publishing_components/pull/2979))
+
 ## 30.7.1
 
 * Add new cookies set by gtag ([PR #2975](https://github.com/alphagov/govuk_publishing_components/pull/2975))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js.erb
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js.erb
@@ -6,14 +6,29 @@ window.GOVUK.analyticsGA4 = window.GOVUK.analyticsGA4 || {};
 
   var core = {
     load: function () {
-      /* eslint-disable */
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=' + window.GOVUK.analyticsGA4.vars.auth + '&gtm_preview=' + window.GOVUK.analyticsGA4.vars.preview + '&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer',window.GOVUK.analyticsGA4.vars.id);
-      window.dataLayer.push({ 'gtm.blocklist' : ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] })
-      /* eslint-enable */
+      if (window.GOVUK.analyticsGA4.vars.gtag_id) { // initialise gtag
+        (function (id) {
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', window.GOVUK.analyticsGA4.vars.gtag_id);
+          var firstScript = document.getElementsByTagName('script')[0];
+          var newScript = document.createElement('script');
+          var dl = 'dataLayer' != 'dataLayer' ? '&l=' + 'dataLayer' : '';
+          newScript.async = true;
+          newScript.src = '//www.googletagmanager.com/gtag/js?id=' + id + dl;
+          firstScript.parentNode.insertBefore(newScript, firstScript);
+        })(window.GOVUK.analyticsGA4.vars.gtag_id);
+      } else { // initialise GTM
+        /* eslint-disable */
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=' + window.GOVUK.analyticsGA4.vars.auth + '&gtm_preview=' + window.GOVUK.analyticsGA4.vars.preview + '&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer',window.GOVUK.analyticsGA4.vars.id);
+        window.dataLayer.push({ 'gtm.blocklist' : ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] })
+        /* eslint-enable */
+      }
     },
 
     sendData: function (data) {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -8,6 +8,7 @@ describe('GA4 core', function () {
   })
 
   afterEach(function () {
+    window.GOVUK.analyticsGA4.vars.gtag_id = null
     window.dataLayer = []
   })
 
@@ -19,6 +20,15 @@ describe('GA4 core', function () {
     expect(Object.keys(window.dataLayer[0])).toContain('event')
     expect(Object.keys(window.dataLayer[1])).toContain('gtm.blocklist')
     expect(window.dataLayer[1]['gtm.blocklist']).toEqual(['customPixels', 'customScripts', 'html', 'nonGoogleScripts'])
+  })
+
+  it('loads the GTAG snippet', function () {
+    window.GOVUK.analyticsGA4.vars.gtag_id = 'fake'
+    GOVUK.analyticsGA4.core.load()
+
+    expect(window.dataLayer.length).toEqual(2)
+    expect(window.dataLayer[0]).toContain('js')
+    expect(window.dataLayer[1]).toContain('config')
   })
 
   it('pushes data to the dataLayer', function () {


### PR DESCRIPTION
## What
Add the ability to switch GA4 from GTM to Gtag.

- if an environment variable for gtag has been set in static and passed as a variable attached to the window.GOVUK.analyticsGA4.vars object, use gtag instead of GTM
- this is for testing on integration, we will only add the gtag env var on there for now
- note that this code snippet for gtag is adapted from the GTM one, since the gtag one from Google involves <script> tags, rather than the convenience of a self executing function that creates the <script> tags and appends them to the DOM. However, both original snippets do essentially the same thing, so the GTM one has been adapted to suit and should perform exactly the same task as the original gtag snippet recommended by Google

Corresponding PR to use this in `static` is here: https://github.com/alphagov/static/pull/2886

## Why
We want to see if we can make Gtag work as intended. Note that this code will not work on any environment unless the correct env vars are set - initially we will only test this on integration.

## Visual Changes
None.

Trello card: https://trello.com/c/Oo0T8ZCa/178-spike-into-back-out-plan-from-gtm-to-gtag