### PR TITLE
Refactor analytics code snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Refactor analytics code snippets ([PR #2980](https://github.com/alphagov/govuk_publishing_components/pull/2980))
 * Add optional gtag snippet ([PR #2979](https://github.com/alphagov/govuk_publishing_components/pull/2979))
 
 ## 30.7.1

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js.erb
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js.erb
@@ -6,28 +6,33 @@ window.GOVUK.analyticsGA4 = window.GOVUK.analyticsGA4 || {};
 
   var core = {
     load: function () {
-      if (window.GOVUK.analyticsGA4.vars.gtag_id) { // initialise gtag
-        (function (id) {
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', window.GOVUK.analyticsGA4.vars.gtag_id);
-          var firstScript = document.getElementsByTagName('script')[0];
-          var newScript = document.createElement('script');
-          var dl = 'dataLayer' != 'dataLayer' ? '&l=' + 'dataLayer' : '';
-          newScript.async = true;
-          newScript.src = '//www.googletagmanager.com/gtag/js?id=' + id + dl;
-          firstScript.parentNode.insertBefore(newScript, firstScript);
-        })(window.GOVUK.analyticsGA4.vars.gtag_id);
-      } else { // initialise GTM
-        /* eslint-disable */
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=' + window.GOVUK.analyticsGA4.vars.auth + '&gtm_preview=' + window.GOVUK.analyticsGA4.vars.preview + '&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer',window.GOVUK.analyticsGA4.vars.id);
+      if (window.GOVUK.analyticsGA4.vars.gtag_id) {
+        // initialise gtag
+        window.dataLayer = window.dataLayer || []
+        function gtag() { dataLayer.push(arguments) }
+        gtag('js', new Date())
+        gtag('config', window.GOVUK.analyticsGA4.vars.gtag_id)
+
+        var firstScript = document.getElementsByTagName('script')[0]
+        var newScript = document.createElement('script')
+        var dl = 'dataLayer' != 'dataLayer' ? '&l=' + 'dataLayer' : ''
+
+        newScript.async = true
+        newScript.src = '//www.googletagmanager.com/gtag/js?id=' + window.GOVUK.analyticsGA4.vars.gtag_id + dl
+        firstScript.parentNode.insertBefore(newScript, firstScript)
+      } else {
+        // initialise GTM
+        window.dataLayer = window.dataLayer || []
+        window.dataLayer.push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+
+        var firstScript = document.getElementsByTagName('script')[0]
+        var newScript = document.createElement('script')
+        var dl = 'dataLayer' != 'dataLayer' ? '&l=' + 'dataLayer' : ''
+
+        newScript.async = true
+        newScript.src = 'https://www.googletagmanager.com/gtm.js?id=' + window.GOVUK.analyticsGA4.vars.id + dl + '&gtm_auth=' + window.GOVUK.analyticsGA4.vars.auth + '&gtm_preview=' + window.GOVUK.analyticsGA4.vars.preview + '&gtm_cookies_win=x'
+        firstScript.parentNode.insertBefore(newScript, firstScript)
         window.dataLayer.push({ 'gtm.blocklist' : ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] })
-        /* eslint-enable */
       }
     },
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js.erb
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js.erb
@@ -29,8 +29,18 @@ window.GOVUK.analyticsGA4 = window.GOVUK.analyticsGA4 || {};
         var newScript = document.createElement('script')
         var dl = 'dataLayer' != 'dataLayer' ? '&l=' + 'dataLayer' : ''
 
+        var auth = window.GOVUK.analyticsGA4.vars.auth || ''
+        var preview = window.GOVUK.analyticsGA4.vars.preview || ''
+        if (auth) {
+          auth = '&gtm_auth=' + auth
+        }
+        if (preview) {
+          preview = '&gtm_preview=' + preview + '&gtm_cookies_win=x'
+        }
+
         newScript.async = true
-        newScript.src = 'https://www.googletagmanager.com/gtm.js?id=' + window.GOVUK.analyticsGA4.vars.id + dl + '&gtm_auth=' + window.GOVUK.analyticsGA4.vars.auth + '&gtm_preview=' + window.GOVUK.analyticsGA4.vars.preview + '&gtm_cookies_win=x'
+        this.googleSrc = 'https://www.googletagmanager.com/gtm.js?id=' + window.GOVUK.analyticsGA4.vars.id + dl + auth + preview
+        newScript.src = this.googleSrc
         firstScript.parentNode.insertBefore(newScript, firstScript)
         window.dataLayer.push({ 'gtm.blocklist' : ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] })
       }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -4,11 +4,12 @@ describe('GA4 core', function () {
   var GOVUK = window.GOVUK
 
   beforeEach(function () {
+    window.GOVUK.analyticsGA4.vars = {}
     window.dataLayer = []
   })
 
   afterEach(function () {
-    window.GOVUK.analyticsGA4.vars.gtag_id = null
+    window.GOVUK.analyticsGA4.vars = null
     window.dataLayer = []
   })
 
@@ -20,6 +21,24 @@ describe('GA4 core', function () {
     expect(Object.keys(window.dataLayer[0])).toContain('event')
     expect(Object.keys(window.dataLayer[1])).toContain('gtm.blocklist')
     expect(window.dataLayer[1]['gtm.blocklist']).toEqual(['customPixels', 'customScripts', 'html', 'nonGoogleScripts'])
+  })
+
+  describe('calls the right URL from Google', function () {
+    it('if all three env vars are present', function () {
+      window.GOVUK.analyticsGA4.vars.id = 'myId'
+      window.GOVUK.analyticsGA4.vars.auth = 'myAuth'
+      window.GOVUK.analyticsGA4.vars.preview = 'myPreview'
+      GOVUK.analyticsGA4.core.load()
+
+      expect(GOVUK.analyticsGA4.core.googleSrc).toEqual('https://www.googletagmanager.com/gtm.js?id=myId&gtm_auth=myAuth&gtm_preview=myPreview&gtm_cookies_win=x')
+    })
+
+    it('if only id is present', function () {
+      window.GOVUK.analyticsGA4.vars.id = 'myId'
+      GOVUK.analyticsGA4.core.load()
+
+      expect(GOVUK.analyticsGA4.core.googleSrc).toEqual('https://www.googletagmanager.com/gtm.js?id=myId')
+    })
   })
 
   it('loads the GTAG snippet', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
@@ -3,6 +3,10 @@
 describe('Initialising GA4', function () {
   var GOVUK = window.GOVUK
 
+  beforeEach(function () {
+    window.GOVUK.analyticsGA4.vars = window.GOVUK.analyticsGA4.vars || {}
+  })
+
   afterEach(function () {
     GOVUK.analyticsGA4.analyticsModules.Ga4LinkTracker.stopTracking()
     window.dataLayer = []


### PR DESCRIPTION
## What
Rewrite the code from Google that pulls in Tag Manager, so that if the `auth` and `preview` variables are not present, we don't pass them as part of the script URL.

## Why
Apparently the snippet with the extra bits in should never be used in a live site, because environments (the snippet we were using) are expensive in terms of performance, so we should avoid sending too much traffic to them - environment endpoints can become overloaded and shut down.

## Visual Changes
None.

Trello card: https://trello.com/c/zpERINGm/223-rewrite-google-snippets