### PR TITLE
Lint ga4-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Lint ga4-core ([PR #2982](https://github.com/alphagov/govuk_publishing_components/pull/2982))
+
 ## 30.7.2
 
 * Refactor analytics code snippets ([PR #2980](https://github.com/alphagov/govuk_publishing_components/pull/2980))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js.erb
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js.erb
@@ -1,3 +1,5 @@
+// note that because this file is .js.erb it is not linted
+// temporarily rename to .js to check with the linter
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.analyticsGA4 = window.GOVUK.analyticsGA4 || {};
 
@@ -6,28 +8,29 @@ window.GOVUK.analyticsGA4 = window.GOVUK.analyticsGA4 || {};
 
   var core = {
     load: function () {
+      var firstScript
+      var newScript
+
       if (window.GOVUK.analyticsGA4.vars.gtag_id) {
         // initialise gtag
         window.dataLayer = window.dataLayer || []
-        function gtag() { dataLayer.push(arguments) }
+        var gtag = function () { window.dataLayer.push(arguments) }
         gtag('js', new Date())
         gtag('config', window.GOVUK.analyticsGA4.vars.gtag_id)
 
-        var firstScript = document.getElementsByTagName('script')[0]
-        var newScript = document.createElement('script')
-        var dl = 'dataLayer' != 'dataLayer' ? '&l=' + 'dataLayer' : ''
+        firstScript = document.getElementsByTagName('script')[0]
+        newScript = document.createElement('script')
 
         newScript.async = true
-        newScript.src = '//www.googletagmanager.com/gtag/js?id=' + window.GOVUK.analyticsGA4.vars.gtag_id + dl
+        newScript.src = '//www.googletagmanager.com/gtag/js?id=' + window.GOVUK.analyticsGA4.vars.gtag_id
         firstScript.parentNode.insertBefore(newScript, firstScript)
       } else {
         // initialise GTM
         window.dataLayer = window.dataLayer || []
         window.dataLayer.push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
 
-        var firstScript = document.getElementsByTagName('script')[0]
-        var newScript = document.createElement('script')
-        var dl = 'dataLayer' != 'dataLayer' ? '&l=' + 'dataLayer' : ''
+        firstScript = document.getElementsByTagName('script')[0]
+        newScript = document.createElement('script')
 
         var auth = window.GOVUK.analyticsGA4.vars.auth || ''
         var preview = window.GOVUK.analyticsGA4.vars.preview || ''
@@ -39,10 +42,10 @@ window.GOVUK.analyticsGA4 = window.GOVUK.analyticsGA4 || {};
         }
 
         newScript.async = true
-        this.googleSrc = 'https://www.googletagmanager.com/gtm.js?id=' + window.GOVUK.analyticsGA4.vars.id + dl + auth + preview
+        this.googleSrc = 'https://www.googletagmanager.com/gtm.js?id=' + window.GOVUK.analyticsGA4.vars.id + auth + preview
         newScript.src = this.googleSrc
         firstScript.parentNode.insertBefore(newScript, firstScript)
-        window.dataLayer.push({ 'gtm.blocklist' : ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] })
+        window.dataLayer.push({ 'gtm.blocklist': ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] })
       }
     },
 


### PR DESCRIPTION
## What
Fix up some linting issues in GA4-core.

- because this file is a .js.erb it was ignored by our linter
- but it turns out it had some linting problems, which were only picked up later when the gem with this code in was installed in an application and included, built and then linted, causing errors
- linting issues addressed

## Why
Just tried to build `static` with the gem containing this unlinted code and it broke 😞 

## Visual Changes
None.

Trello card: https://trello.com/c/zpERINGm/223-rewrite-google-snippets
