### PR TITLE
Fix bug when getting target element from URL hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix bug when getting target element from URL hash in accordion component ([PR #2985](https://github.com/alphagov/govuk_publishing_components/pull/2985))
+
 ## 30.7.3
 
 * Lint ga4-core ([PR #2982](https://github.com/alphagov/govuk_publishing_components/pull/2982))

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -59,11 +59,9 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
 
   // Navigate to and open accordions with anchored content on page load if a hash is present
   GemAccordion.prototype.openByAnchorOnLoad = function () {
+    if (!window.location.hash) return
     var splitHash = window.location.hash.split('#')[1]
-
-    if (window.location.hash && document.getElementById(splitHash)) {
-      this.openForAnchor(splitHash)
-    }
+    this.openForAnchor(splitHash)
   }
 
   // Add event listeners for links to open accordion sections when navigated to using said anchor links on the page
@@ -80,7 +78,9 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
 
   // Find the parent accordion section for the given id and open it
   GemAccordion.prototype.openForAnchor = function (hash) {
-    var target = document.getElementById(hash)
+    hash = hash.replace(':', '\\:')
+    var target = this.$module.querySelector('#' + hash)
+    if (!target) return
     var $section = this.getContainingSection(target)
     var $header = $section.querySelector(this.sectionHeader)
     var $expanded = this.getContainingSection($section)

--- a/spec/javascripts/components/accordion-spec.js
+++ b/spec/javascripts/components/accordion-spec.js
@@ -24,6 +24,7 @@ describe('Accordion component', function () {
             '</button>' +
           '</h2>' +
         '</div>' +
+      '</div>' +
       '<div class="govuk-accordion__section">' +
         '<div class="govuk-accordion__section-header">' +
           '<h2 class="govuk-accordion__section-heading">' +


### PR DESCRIPTION
## What
Update the accordion component to only look for a target element within the module itself, not the entire document.

## Why
This fixes a bug when `anchor_navigation` is set to `true` and an ID is passed in for an element that exists on the page, but is not contained within the accordion component.

For example: https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#section-title

## Further Info

Fixes: https://github.com/alphagov/govuk_publishing_components/issues/2086
Trello: https://trello.com/c/q5P6u7id/1507-ps-17-accordion-anchor-link-navigation-breaks-with-invalid-anchor

### Using querySelector when the ID contains a colon
There was also a need to escape the colon character when using `querySelector`, for example `$this.module.querySelector('#fnref:1')` would throw an error [^1]

[^1]: [Bugzilla - querySelector doesn't work if the ID contains a colon (:)](https://bugzilla.mozilla.org/show_bug.cgi?id=883044)
