### PR TITLE
Version 31.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 31.0.0
 
 * Fix bug when getting target element from URL hash in accordion component ([PR #2985](https://github.com/alphagov/govuk_publishing_components/pull/2985))
 * **BREAKING:** Update GA4 naming conventions ([PR #2987](https://github.com/alphagov/govuk_publishing_components/pull/2987))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (30.7.3)
+    govuk_publishing_components (31.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -228,7 +228,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.4)
-    rack-proxy (0.7.2)
+    rack-proxy (0.7.4)
       rack
     rack-test (2.0.2)
       rack (>= 1.3)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "30.7.3".freeze
+  VERSION = "31.0.0".freeze
 end


### PR DESCRIPTION
## 31.0.0

* Fix bug when getting target element from URL hash in accordion component ([PR #2985](https://github.com/alphagov/govuk_publishing_components/pull/2985))
* **BREAKING:** Update GA4 naming conventions ([PR #2987](https://github.com/alphagov/govuk_publishing_components/pull/2987))
* Stop using .erb for ga4-core ([PR #2984](https://github.com/alphagov/govuk_publishing_components/pull/2984))
