### PR TITLE
Resolve Plek.current deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Resolve Plek.current deprecations ([PR #3000](https://github.com/alphagov/govuk_publishing_components/pull/3000))
 * Add ecommerce tracking documentation ([PR #2997](https://github.com/alphagov/govuk_publishing_components/pull/2997))
 * Use section for emergency banner ([PR #2973](https://github.com/alphagov/govuk_publishing_components/pull/2973))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       ast (~> 2.4.1)
     percy-capybara (5.0.0)
       capybara (>= 3)
-    plek (4.0.0)
+    plek (4.1.0)
     prometheus_exporter (2.0.3)
       webrick
     pry (0.14.1)

--- a/lib/govuk_publishing_components/presenters/machine_readable/creative_work_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/creative_work_schema.rb
@@ -50,7 +50,7 @@ module GovukPublishingComponents
           "author" => {
             "@type" => "Organization",
             "name" => publishing_organisation["title"],
-            "url" => Plek.current.website_root + publishing_organisation["base_path"],
+            "url" => Plek.new.website_root + publishing_organisation["base_path"],
           },
         }
       end

--- a/lib/govuk_publishing_components/presenters/machine_readable/page.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/page.rb
@@ -12,7 +12,7 @@ module GovukPublishingComponents
       end
 
       def canonical_url
-        local_assigns[:canonical_url] || (Plek.current.website_root + content_item["base_path"])
+        local_assigns[:canonical_url] || (Plek.new.website_root + content_item["base_path"])
       end
 
       def body

--- a/lib/govuk_publishing_components/presenters/machine_readable/potential_search_action_schema.rb
+++ b/lib/govuk_publishing_components/presenters/machine_readable/potential_search_action_schema.rb
@@ -5,7 +5,7 @@ module GovukPublishingComponents
     class PotentialSearchActionSchema
       attr_reader :facet_params, :description
 
-      BASE_SEARCH_URL = "#{Plek.current.website_root}/search/all?keywords={query}&order=relevance".freeze
+      BASE_SEARCH_URL = "#{Plek.new.website_root}/search/all?keywords={query}&order=relevance".freeze
 
       def initialize(facet_params, description)
         @facet_params = facet_params


### PR DESCRIPTION
Plek 4.1 [1] deprecates the Plek.current method. This resolves this gem emitting deprecation warnings.

This also updates the Gemfile.lock of this gem to use the new version.

[1]: https://github.com/alphagov/plek/pull/92

