### PR TITLE
Add option for blue bar on full width public layout

### DIFF
--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -21,6 +21,10 @@
   omit_account_navigation ||= false
   omit_account_phase_banner ||= false
 
+  # if blue bar not set, then default behaviour is to hide
+  # when using a full width layout
+  blue_bar ||= !full_width
+
 # This is a hack - but it's the only way I can find to not have two blue bars on
 # constrained width layouts.
 #
@@ -39,7 +43,7 @@
 # height, making the two blue bars overlap and appear as one. The class is added
 # when a) there's content for the emergency or global banner *and* b) when using
 # the contrained width layout.
-  blue_bar_dedupe = !full_width && global_bar.present?
+  blue_bar_dedupe = (blue_bar && global_bar.present?)
   body_css_classes = %w(gem-c-layout-for-public govuk-template__body)
   body_css_classes << "draft" if draft_watermark
 -%>
@@ -112,7 +116,7 @@
 
     <%= raw(emergency_banner) %>
 
-    <% unless full_width %>
+    <% if blue_bar %>
       <div class="gem-c-layout-for-public__blue-bar govuk-width-container"></div>
     <% end %>
 

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -23,6 +23,13 @@ examples:
       full_width: true
       block: |
         <h1>Page content goes here</h1>
+  full_width_with_blue_bar:
+    description: Full width layout but with the blue bar from the default layout still present.
+    data:
+      full_width: true
+      blue_bar: true
+      block: |
+        <h1>Page content goes here</h1>
   omit_header:
     description: This allows the header to be omitted which is currently used when rendering CSV previews from Whitehall
     data:

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -123,6 +123,12 @@ describe "Layout for public", type: :view do
     assert_select ".gem-c-layout-for-public__blue-bar"
   end
 
+  it "has blue bar when using the full width layout if specified" do
+    render_component(full_width: true, blue_bar: true)
+
+    assert_select ".gem-c-layout-for-public__blue-bar", false
+  end
+
   it "has no blue bar when using the full width layout" do
     render_component(full_width: true)
 


### PR DESCRIPTION
## What

Add option to add blue bar to full width layouts.

## Why

For[ Browse pages in collections](https://www.gov.uk/browse), we need to use a full width layout for the header to fit the width of the entire page. The design of the page also still includes the blue bar underneath the navbar. Previously, this was disabled in full width layout with no option to override. This meant that in collections, a bespoke implementation of the blue bar was implemented which had styling discrepancies to the blue bar that appears as part of public layout. This commit adds an option to have a blue bar in the full width layout so we can remove the custom blue bar on collections.

Once this has merged, need to merge https://github.com/alphagov/static/pull/2898