### PR TITLE
Fix issues with GA4 link tracking identified by performance analysts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Move the GTM blocklist code ([PR #3011](https://github.com/alphagov/govuk_publishing_components/pull/3011))
+* Fix issues with GA4 link tracking identified by performance analysts ([PR #3004](https://github.com/alphagov/govuk_publishing_components/pull/3004))
 
 ## 31.1.1
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -61,8 +61,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
           clickData.external = this.isExternalLink(clickData.url) ? 'true' : 'false'
         }
 
-        if (clickData.link_method === 'populated-via-js') {
-          clickData.link_method = this.getClickType(event)
+        if (clickData.method === 'populated-via-js') {
+          clickData.method = this.getClickType(event)
         }
 
         if (clickData.index) {
@@ -78,21 +78,21 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
         clickData.external = 'true'
         clickData.url = href
         clickData.text = element.textContent.trim()
-        clickData.link_method = this.getClickType(event)
+        clickData.method = this.getClickType(event)
       } else if (this.isDownloadLink(href)) {
         clickData.event_name = 'file_download'
         clickData.type = this.isPreviewLink(href) ? 'preview' : 'generic download'
         clickData.external = this.isExternalLink(href) ? 'true' : 'false'
         clickData.url = href
         clickData.text = element.textContent.trim()
-        clickData.link_method = this.getClickType(event)
+        clickData.method = this.getClickType(event)
       } else if (this.isExternalLink(href)) {
         clickData.event_name = 'navigation'
         clickData.type = 'generic link'
         clickData.external = 'true'
         clickData.url = href
         clickData.text = element.textContent.trim()
-        clickData.link_method = this.getClickType(event)
+        clickData.method = this.getClickType(event)
       }
 
       if (Object.keys(clickData).length > 0) {

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -97,6 +97,10 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       }
 
       if (Object.keys(clickData).length > 0) {
+        if (clickData.url) {
+          clickData.url = this.removeCrossDomainParams(clickData.url)
+        }
+
         var schema = new window.GOVUK.analyticsGa4.Schemas().eventSchema()
         schema.event = 'event_data'
 
@@ -236,6 +240,13 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       return string.substring(0, stringToFind.length) === stringToFind
     },
 
+    stringEndsWith: function (string, stringToFind) {
+      if (stringToFind.length > string.length) {
+        return false
+      }
+      return string.substring(string.length - stringToFind.length, string.length) === stringToFind
+    },
+
     hrefIsRelative: function (href) {
       // Checks that a link is relative, but is not a protocol relative url
       return href[0] === '/' && href[1] !== '/'
@@ -247,6 +258,22 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
 
     getHostname: function () {
       return window.location.hostname
+    },
+
+    removeCrossDomainParams: function (url) {
+      if (url.indexOf('_ga') !== -1 || url.indexOf('_gl') !== -1) {
+        // _ga & _gl are values needed for cross domain tracking, but we don't want them included in our click tracking.
+        url = url.replace(/_ga=([^&]*)/, '')
+        url = url.replace(/_gl=([^&]*)/, '')
+
+        // The following code cleans up inconsistencies such as gov.uk/&&, gov.uk/?&hello=world, gov.uk/?, and gov.uk/&.
+        url = url.replaceAll(/(&&)+/g, '&')
+        url = url.replace('?&', '?')
+        if (this.stringEndsWith(url, '?') || this.stringEndsWith(url, '&')) {
+          url = url.substring(0, url.length - 1)
+        }
+      }
+      return url
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -77,21 +77,21 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
         clickData.type = 'email'
         clickData.external = 'true'
         clickData.url = href
-        clickData.text = element.textContent.trim()
+        clickData.text = this.removeLinesAndExtraSpaces(element.textContent.trim())
         clickData.method = this.getClickType(event)
       } else if (this.isDownloadLink(href)) {
         clickData.event_name = 'file_download'
         clickData.type = this.isPreviewLink(href) ? 'preview' : 'generic download'
         clickData.external = this.isExternalLink(href) ? 'true' : 'false'
         clickData.url = href
-        clickData.text = element.textContent.trim()
+        clickData.text = this.removeLinesAndExtraSpaces(element.textContent.trim())
         clickData.method = this.getClickType(event)
       } else if (this.isExternalLink(href)) {
         clickData.event_name = 'navigation'
         clickData.type = 'generic link'
         clickData.external = 'true'
         clickData.url = href
-        clickData.text = element.textContent.trim()
+        clickData.text = this.removeLinesAndExtraSpaces(element.textContent.trim())
         clickData.method = this.getClickType(event)
       }
 
@@ -187,6 +187,12 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
           domainsArrays.push(domainWithoutWww)
         }
       }
+    },
+
+    removeLinesAndExtraSpaces: function (text) {
+      text = text.replace(/(\r\n|\n|\r)/gm, ' ') // Replace line breaks with 1 space
+      text = text.replace(/\s+/g, ' ') // Replace instances of 2+ spaces with 1 space
+      return text
     },
 
     getClickType: function (event) {

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
@@ -22,7 +22,8 @@
         action: this.undefined,
         external: this.undefined,
         link_method: this.undefined,
-        link_domain: this.undefined
+        link_domain: this.undefined,
+        link_path_parts: this.undefined
       }
     }
   }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
@@ -21,7 +21,7 @@
         section: this.undefined,
         action: this.undefined,
         external: this.undefined,
-        link_method: this.undefined,
+        method: this.undefined,
         link_domain: this.undefined,
         link_path_parts: this.undefined
       }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
@@ -21,7 +21,8 @@
         section: this.undefined,
         action: this.undefined,
         external: this.undefined,
-        link_method: this.undefined
+        link_method: this.undefined,
+        link_domain: this.undefined
       }
     }
   }

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -49,7 +49,7 @@
                 'index': index + 1,
                 'index_total': links.length,
                 'text': link[:icon],
-                'link_method': 'populated-via-js'
+                'method': 'populated-via-js'
               }
             end
             if track_as_follow
@@ -61,7 +61,7 @@
                 'text': link[:text],
                 'external': 'populated-via-js',
                 'url': link[:href],
-                'link_method': 'populated-via-js'
+                'method': 'populated-via-js'
               }
             end
           %>

--- a/docs/analytics-ga4/ga4-link-tracker.md
+++ b/docs/analytics-ga4/ga4-link-tracker.md
@@ -26,6 +26,23 @@ When one of these listeners are fired, they check if the `event.target` is an `<
 
 Events can either have an `event_name` of `navigation`, `file_download`, or `share`. Download and preview links will use the `file_download` value, while generic external links, mailto links, and follow links will use `navigation`. Share links use `share`.
 
+Link URLs are stripped of the `_ga` and `_gl` query parameters. These are only relevant for cross domain tracking and aren't useful for our click tracking. Link text is stripped of multiple lines and multiple spaces, as this causes issues in the analytics dashboards.
+
+GA4 only allows event values to have a maximum character length of 100. This is a problem for tracking URLs, as many of them exceed 100 characters. Therefore, to solve this we have:
+- Added a separate `link_domain` value which captures the protocol and domain of a link, such as `https://www.gov.uk`
+- Created an object called `link_path_parts`, which splits the path into 100 character segments (max 5 segments, or 500 characters). For example, if your link was `https://gov.uk/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili`, your GA4 push would contain:
+     ```JavaScript
+     "link_domain": "https://www.gov.uk",
+     "link_path_parts": {
+          "1": "/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-",
+          "2": "say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili",
+          "3": undefined,
+          "4": undefined,
+          "5": undefined
+        },
+    ```
+- The link is then reconstructed in Data Studio.
+
 ## Basic use
 
 ```JavaScript
@@ -69,7 +86,12 @@ In the example above, on a left click of the link, the following would be pushed
         "section": null,
         "action": null,
         "external": "true",
-        "link_method": "primary click"
+        "method": "primary click",
+        "link_domain": "https://assets.publishing.service.gov.uk",
+        "link_path_parts": {
+            "1": "/government/uploads/system/uploads/attachment_data/file/742746/A_quick_guide_to_govt_healthy_eating_",
+            "2": "update.pdf"
+        }
     }
 }
 ```
@@ -84,7 +106,7 @@ Share links would turn `event_name` to `share` and type to `share this page`.
 
 Follow links would turn `event_name` to `navigation` and type to `follow us`
 
-For `link_method`:
+For `method`:
 
 - Left clicks are a `primary click`
 - Right clicks and context menu keypresses are `secondary click`

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -719,6 +719,31 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
       }
     })
 
+    it('cleans up link text with multiple lines and spaces', function () {
+      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker
+      linkTracker.init({ internalDomains: ['www.gov.uk'] })
+
+      links.innerHTML = '<div class="messy-text">' +
+      '<a href="https://example.com">\nI \nam \non \nmultiple \n\n\n lines</a>' +
+      '<a href="https://www.gov.uk/government/uploads/example.pdf">I     have     lots   of    spaces</a>' +
+      '<a href="mailto:hello@example.com">I     have     lots   of    spaces \n and \n\n many \n\n\n lines</a>' +
+    '</div>'
+
+      var linksToTest = document.querySelectorAll('.messy-text a')
+
+      var expectedText = [
+        'I am on multiple lines',
+        'I have lots of spaces',
+        'I have lots of spaces and many lines'
+      ]
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        expect(window.dataLayer[0].event_data.text).toEqual(expectedText[i])
+      }
+    })
+
     it('splits hrefs longer than 100 characters into an object of parts', function () {
       linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker
       linkTracker.init({ internalDomains: ['www.gov.uk'] })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -10,6 +10,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
   var preventDefault = function (e) {
     e.preventDefault()
   }
+  var defaultLinkPathParts
 
   beforeAll(function () {
     spyOn(GOVUK.analyticsGa4.core, 'getGemVersion').and.returnValue('aVersion')
@@ -24,6 +25,13 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
   describe('External link tracking', function () {
     beforeEach(function () {
       window.dataLayer = []
+      defaultLinkPathParts = {
+        1: undefined,
+        2: undefined,
+        3: undefined,
+        4: undefined,
+        5: undefined
+      }
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.event_name = 'navigation'
@@ -34,19 +42,19 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
       links = document.createElement('div')
       links.innerHTML =
           '<div class="fully-structured-external-links">' +
-              '<a href="http://www.nationalarchives.gov.uk/1" link_domain="http://www.nationalarchives.gov.uk"> National Archives </a>' +
-              '<a href="https://www.nationalarchives.gov.uk/2" link_domain="https://www.nationalarchives.gov.uk"></a>' +
-              '<a href="https://www.nationalarchives.gov.uk/3.pdf" link_domain="https://www.nationalarchives.gov.uk">National Archives PDF</a>' +
+              '<a href="http://www.nationalarchives.gov.uk/1" link_domain="http://www.nationalarchives.gov.uk" path="/1"> National Archives </a>' +
+              '<a href="https://www.nationalarchives.gov.uk/2" link_domain="https://www.nationalarchives.gov.uk" path="/2"></a>' +
+              '<a href="https://www.nationalarchives.gov.uk/3.pdf" link_domain="https://www.nationalarchives.gov.uk" path="/3.pdf">National Archives PDF</a>' +
             '</div>' +
             '<div class="www-less-external-links">' +
               '<a href="http://nationalarchives.gov.uk" link_domain="http://nationalarchives.gov.uk"> National Archives </a>' +
               '<a href="https://nationalarchives.gov.uk" link_domain="https://nationalarchives.gov.uk"></a>' +
-              '<a href="https://nationalarchives.gov.uk/one.pdf" link_domain="https://nationalarchives.gov.uk">National Archives PDF</a>' +
+              '<a href="https://nationalarchives.gov.uk/one.pdf" link_domain="https://nationalarchives.gov.uk" path="/one.pdf">National Archives PDF</a>' +
             '</div>' +
             '<div class="protocol-relative-external-links">' +
               '<a href="//nationalarchives.gov.uk"> National Archives </a>' +
               '<a href="//nationalarchives.gov.uk"></a>' +
-              '<a href="//nationalarchives.gov.uk/one.pdf">National Archives PDF</a>' +
+              '<a href="//nationalarchives.gov.uk/one.pdf" path="/one.pdf">National Archives PDF</a>' +
             '</div>' +
             '<div class="nested-link">' +
             '<a href="http://www.nationalarchives.gov.uk"> <img /> </a>' +
@@ -88,6 +96,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -102,6 +112,10 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
+        var linkPath = link.getAttribute('path')
+        if (linkPath) {
+          expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        }
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -117,6 +131,10 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.link_domain = '//nationalarchives.gov.uk'
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
+        var linkPath = link.getAttribute('path')
+        if (linkPath) {
+          expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        }
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -169,6 +187,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.event_data.link_method = 'ctrl click'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -186,6 +206,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.event_data.link_method = 'command/win click'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -203,6 +225,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.event_data.link_method = 'middle click'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -220,6 +244,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.event_data.link_method = 'shift click'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -235,6 +261,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.event_data.link_method = 'secondary click'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -243,6 +271,13 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
   describe('Download link tracking', function () {
     beforeEach(function () {
       window.dataLayer = []
+      defaultLinkPathParts = {
+        1: undefined,
+        2: undefined,
+        3: undefined,
+        4: undefined,
+        5: undefined
+      }
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.event_name = 'file_download'
@@ -252,44 +287,44 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
 
       links = document.createElement('div')
       links.innerHTML = '<div class="fully-structured-download-links">' +
-            '<a href="https://assets.publishing.service.gov.uk/one.pdf" external="true" link-domain="https://assets.publishing.service.gov.uk">PDF</a>' +
-            '<a href="https://assets.publishing.service.gov.uk/two.xslt" external="true" link-domain="https://assets.publishing.service.gov.uk">Spreadsheet</a>' +
-            '<a href="https://www.gov.uk/government/uploads/system/three.doc" external="false" link-domain="https://www.gov.uk">Document</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/one.pdf" path="/one.pdf" external="true" link-domain="https://assets.publishing.service.gov.uk">PDF</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link-domain="https://assets.publishing.service.gov.uk">Spreadsheet</a>' +
+            '<a href="https://www.gov.uk/government/uploads/system/three.doc" path="/government/uploads/system/three.doc" external="false" link-domain="https://www.gov.uk">Document</a>' +
           '</div>' +
           '<div class="nested-download-links">' +
-            '<a href="https://www.gov.uk/government/uploads/link.png" external="false" link-domain="https://www.gov.uk"><img src="/img" /></a>' +
-            '<a href="https://assets.publishing.service.gov.uk/two.xslt" external="true" link-domain="https://assets.publishing.service.gov.uk"><div><img src="/img" /></div></a>' +
+            '<a href="https://www.gov.uk/government/uploads/link.png" path="/government/uploads/link.png" external="false" link-domain="https://www.gov.uk"><img src="/img" /></a>' +
+            '<a href="https://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link-domain="https://assets.publishing.service.gov.uk"><div><img src="/img" /></div></a>' +
           '</div>' +
           '<div class="http-download-links">' +
-            '<a href="http://assets.publishing.service.gov.uk/one.pdf" external="true" link-domain="http://assets.publishing.service.gov.uk">PDF</a>' +
-            '<a href="http://assets.publishing.service.gov.uk/two.xslt" external="true" link-domain="http://assets.publishing.service.gov.uk">Spreadsheet</a>' +
-            '<a href="http://www.gov.uk/government/uploads/system/three.doc" external="false" link-domain="http://www.gov.uk">Document</a>' +
-            '<a href="http://www.gov.uk/government/uploads/link.png" external="false" link-domain="http://www.gov.uk">Image</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/one.pdf" path="/one.pdf" external="true" link-domain="http://assets.publishing.service.gov.uk">PDF</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link-domain="http://assets.publishing.service.gov.uk">Spreadsheet</a>' +
+            '<a href="http://www.gov.uk/government/uploads/system/three.doc" path="/government/uploads/system/three.doc" external="false" link-domain="http://www.gov.uk">Document</a>' +
+            '<a href="http://www.gov.uk/government/uploads/link.png" path="/government/uploads/link.png" external="false" link-domain="http://www.gov.uk">Image</a>' +
           '</div>' +
           '<div class="www-less-download-links">' +
-            '<a href="http://gov.uk/government/uploads/system/three.doc" link-domain="http://gov.uk">Document</a>' +
-            '<a href="https://gov.uk/government/uploads/link.png" link-domain="https://gov.uk">Image</a>' +
+            '<a href="http://gov.uk/government/uploads/system/three.doc" link-domain="http://gov.uk" path="/government/uploads/system/three.doc">Document</a>' +
+            '<a href="https://gov.uk/government/uploads/link.png" link-domain="https://gov.uk" path="/government/uploads/link.png">Image</a>' +
           '</div>' +
           '<div class="internal-links">' +
             '<a href="https://www.gov.uk/normal-link">Normal link</a>' +
             '<a href="https://www.gov.uk/another-link">Another link</a>' +
           '</div>' +
           '<div class="external-download-links">' +
-            '<a href="https://example.com/one.pdf" link-domain="https://example.com">External download link</a>' +
-            '<a href="https://www.nationalarchives.gov.uk/government/uploads/logo.png" link-domain="https://www.nationalarchives.gov.uk">External download link with false positive path</a>' +
-            '<a href="https://www.nationalarchives.gov.uk/download&fileName=assets.publishing.service.gov.uk.pdf" link-domain="https://www.nationalarchives.gov.uk">External PDF link with false positive name</a>' +
+            '<a href="https://example.com/one.pdf" path="/one.pdf" link-domain="https://example.com">External download link</a>' +
+            '<a href="https://www.nationalarchives.gov.uk/government/uploads/logo.png" path="/government/uploads/logo.png" link-domain="https://www.nationalarchives.gov.uk">External download link with false positive path</a>' +
+            '<a href="https://www.nationalarchives.gov.uk/download&fileName=assets.publishing.service.gov.uk.pdf" path="/download&fileName=assets.publishing.service.gov.uk.pdf" link-domain="https://www.nationalarchives.gov.uk">External PDF link with false positive name</a>' +
           '</div>' +
           '<div class="relative-download-links">' +
-            '<a href="/government/uploads/one.pdf">Relative PDF link</a>' +
-            '<a href="/government/uploads/two.xslt">Relative Spreadsheet link</a>' +
+            '<a href="/government/uploads/one.pdf" path="/government/uploads/one.pdf">Relative PDF link</a>' +
+            '<a href="/government/uploads/two.xslt" path="/government/uploads/two.xslt">Relative Spreadsheet link</a>' +
           '</div>' +
           '<div class="preview-download-links">' +
-            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link-domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
-            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link-domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" path="/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link-domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" path="/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link-domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
           '</div>' +
           '<div class="not-a-preview-link">' +
-            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" link-domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
-            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" link-domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" link-domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" link-domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
           '</div>'
 
       body.appendChild(links)
@@ -319,6 +354,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
         expected.event_data.external = link.getAttribute('external')
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -335,6 +372,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.text = link.closest('a').innerText.trim()
         expected.event_data.type = 'generic download'
         expected.event_data.external = link.closest('a').getAttribute('external')
+        var linkPath = link.closest('a').getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -351,6 +390,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
         expected.event_data.external = link.getAttribute('external')
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -367,6 +408,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
         expected.event_data.external = 'false'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -397,6 +440,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.type = 'generic link'
         expected.govuk_gem_version = 'aVersion'
         expected.event_data.external = 'true'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -413,6 +458,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
         expected.event_data.external = 'false'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -429,6 +476,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.type = 'preview'
         expected.event_data.text = link.innerText.trim()
         expected.event_data.external = 'true'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -445,6 +494,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
         expected.event_data.external = 'true'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -453,6 +504,13 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
   describe('Mailto link tracking', function () {
     beforeEach(function () {
       window.dataLayer = []
+      defaultLinkPathParts = {
+        1: undefined,
+        2: undefined,
+        3: undefined,
+        4: undefined,
+        5: undefined
+      }
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.event_name = 'navigation'
@@ -463,11 +521,11 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
       links = document.createElement('div')
       links.innerHTML =
           '<div class="mail-to-links">' +
-              '<a href="mailto:example@gov.uk"> National Archives </a>' +
+              '<a href="mailto:example@gov.uk" path="mailto:example@gov.uk"> National Archives </a>' +
               '<span>This is not a mailto link</span>' +
             '</div>' +
             '<div class="invalid-links">' +
-              '<a href="https://gov.uk/mailto:example@gov.uk"> mailto:example@gov.uk </a>' +
+              '<a href="https://gov.uk/mailto:example@gov.uk" path="mailto:example@gov.uk"> mailto:example@gov.uk </a>' +
             '</div>'
 
       body.appendChild(links)
@@ -494,6 +552,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.govuk_gem_version = 'aVersion'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -513,6 +573,13 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
   describe('Share and follow link tracking', function () {
     beforeEach(function () {
       window.dataLayer = []
+      defaultLinkPathParts = {
+        1: undefined,
+        2: undefined,
+        3: undefined,
+        4: undefined,
+        5: undefined
+      }
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.govuk_gem_version = 'aVersion'
@@ -585,6 +652,13 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
   describe('Helper function tracking', function () {
     beforeEach(function () {
       window.dataLayer = []
+      defaultLinkPathParts = {
+        1: undefined,
+        2: undefined,
+        3: undefined,
+        4: undefined,
+        5: undefined
+      }
       links = document.createElement('div')
       body.appendChild(links)
       body.addEventListener('click', preventDefault)
@@ -642,6 +716,71 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         var link = queryParamLinks[i]
         GOVUK.triggerEvent(link, 'click')
         expect(window.dataLayer[0].event_data.url).toEqual(expectedLinks[i])
+      }
+    })
+
+    it('splits hrefs longer than 100 characters into an object of parts', function () {
+      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker
+      linkTracker.init({ internalDomains: ['www.gov.uk'] })
+
+      links.innerHTML = '<div class="long-links">' +
+      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-">100 char path</a>' +
+      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili">200 char path</a>' +
+      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-so">500 char path</a>' +
+      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious">Over 500 char path</a>' +
+      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui/https://example.com/test">check regex replace only replaces first domain match</a>' +
+      '<a href="https://assets.publishing.service.gov.uk/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui">check regex replace works with a long subdomain </a>' +
+      '<a href="//assets.publishing.service.gov.uk/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui">check regex replace works with protocal relative domain </a>' +
+      '</div>'
+
+      var expectedLinkPathParts = [
+        {
+          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-'
+        },
+        {
+          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-',
+          2: 'say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili'
+        },
+        {
+          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-',
+          2: 'say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili',
+          3: 'sticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enoug',
+          4: 'h-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidociou',
+          5: 's-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-so'
+        },
+        {
+          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-',
+          2: 'say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili',
+          3: 'sticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enoug',
+          4: 'h-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidociou',
+          5: 's-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-so'
+        },
+        {
+          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui/https://example.com',
+          2: '/test'
+        },
+        {
+          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui'
+        },
+        {
+          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui'
+        }
+      ]
+
+      var linksToTest = document.querySelectorAll('.long-links a')
+      for (var i = 0; i < linksToTest.length; i++) {
+        defaultLinkPathParts = {
+          1: undefined,
+          2: undefined,
+          3: undefined,
+          4: undefined,
+          5: undefined
+        }
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        var expectedObject = window.GOVUK.extendObject(defaultLinkPathParts, expectedLinkPathParts[i])
+        expect(window.dataLayer[0].event_data.link_path_parts).toEqual(expectedObject)
       }
     })
   })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -22,16 +22,19 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
     window.dataLayer = []
   })
 
+  beforeEach(function () {
+    defaultLinkPathParts = {
+      1: undefined,
+      2: undefined,
+      3: undefined,
+      4: undefined,
+      5: undefined
+    }
+  })
+
   describe('External link tracking', function () {
     beforeEach(function () {
       window.dataLayer = []
-      defaultLinkPathParts = {
-        1: undefined,
-        2: undefined,
-        3: undefined,
-        4: undefined,
-        5: undefined
-      }
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.event_name = 'navigation'
@@ -40,6 +43,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
       expected.event_data.external = 'true'
       expected.govuk_gem_version = 'aVersion'
       links = document.createElement('div')
+      /* The link_domain, external and path attributes exist so we can hardcode what the expected value is for each test.
+      The value differs for each link, so we can't hardcode the expected value inside the test itself. */
       links.innerHTML =
           '<div class="fully-structured-external-links">' +
               '<a href="http://www.nationalarchives.gov.uk/1" link_domain="http://www.nationalarchives.gov.uk" path="/1"> National Archives </a>' +
@@ -47,8 +52,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
               '<a href="https://www.nationalarchives.gov.uk/3.pdf" link_domain="https://www.nationalarchives.gov.uk" path="/3.pdf">National Archives PDF</a>' +
             '</div>' +
             '<div class="www-less-external-links">' +
-              '<a href="http://nationalarchives.gov.uk" link_domain="http://nationalarchives.gov.uk"> National Archives </a>' +
-              '<a href="https://nationalarchives.gov.uk" link_domain="https://nationalarchives.gov.uk"></a>' +
+              '<a href="http://nationalarchives.gov.uk/1" path="/1" link_domain="http://nationalarchives.gov.uk"> National Archives </a>' +
+              '<a href="https://nationalarchives.gov.uk/2" path="/2" link_domain="https://nationalarchives.gov.uk"></a>' +
               '<a href="https://nationalarchives.gov.uk/one.pdf" link_domain="https://nationalarchives.gov.uk" path="/one.pdf">National Archives PDF</a>' +
             '</div>' +
             '<div class="protocol-relative-external-links">' +
@@ -271,13 +276,6 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
   describe('Download link tracking', function () {
     beforeEach(function () {
       window.dataLayer = []
-      defaultLinkPathParts = {
-        1: undefined,
-        2: undefined,
-        3: undefined,
-        4: undefined,
-        5: undefined
-      }
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.event_name = 'file_download'
@@ -286,45 +284,47 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
       expected.govuk_gem_version = 'aVersion'
 
       links = document.createElement('div')
+      /* The link_domain, external and path attributes exist so we can hardcode what the expected value is for each test.
+      The value differs for each link, so we can't hardcode the expected value inside the test itself. */
       links.innerHTML = '<div class="fully-structured-download-links">' +
-            '<a href="https://assets.publishing.service.gov.uk/one.pdf" path="/one.pdf" external="true" link-domain="https://assets.publishing.service.gov.uk">PDF</a>' +
-            '<a href="https://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link-domain="https://assets.publishing.service.gov.uk">Spreadsheet</a>' +
-            '<a href="https://www.gov.uk/government/uploads/system/three.doc" path="/government/uploads/system/three.doc" external="false" link-domain="https://www.gov.uk">Document</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/one.pdf" path="/one.pdf" external="true" link_domain="https://assets.publishing.service.gov.uk">PDF</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link_domain="https://assets.publishing.service.gov.uk">Spreadsheet</a>' +
+            '<a href="https://www.gov.uk/government/uploads/system/three.doc" path="/government/uploads/system/three.doc" external="false" link_domain="https://www.gov.uk">Document</a>' +
           '</div>' +
           '<div class="nested-download-links">' +
-            '<a href="https://www.gov.uk/government/uploads/link.png" path="/government/uploads/link.png" external="false" link-domain="https://www.gov.uk"><img src="/img" /></a>' +
-            '<a href="https://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link-domain="https://assets.publishing.service.gov.uk"><div><img src="/img" /></div></a>' +
+            '<a href="https://www.gov.uk/government/uploads/link.png" path="/government/uploads/link.png" external="false" link_domain="https://www.gov.uk"><img src="/img" /></a>' +
+            '<a href="https://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link_domain="https://assets.publishing.service.gov.uk"><div><img src="/img" /></div></a>' +
           '</div>' +
           '<div class="http-download-links">' +
-            '<a href="http://assets.publishing.service.gov.uk/one.pdf" path="/one.pdf" external="true" link-domain="http://assets.publishing.service.gov.uk">PDF</a>' +
-            '<a href="http://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link-domain="http://assets.publishing.service.gov.uk">Spreadsheet</a>' +
-            '<a href="http://www.gov.uk/government/uploads/system/three.doc" path="/government/uploads/system/three.doc" external="false" link-domain="http://www.gov.uk">Document</a>' +
-            '<a href="http://www.gov.uk/government/uploads/link.png" path="/government/uploads/link.png" external="false" link-domain="http://www.gov.uk">Image</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/one.pdf" path="/one.pdf" external="true" link_domain="http://assets.publishing.service.gov.uk">PDF</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link_domain="http://assets.publishing.service.gov.uk">Spreadsheet</a>' +
+            '<a href="http://www.gov.uk/government/uploads/system/three.doc" path="/government/uploads/system/three.doc" external="false" link_domain="http://www.gov.uk">Document</a>' +
+            '<a href="http://www.gov.uk/government/uploads/link.png" path="/government/uploads/link.png" external="false" link_domain="http://www.gov.uk">Image</a>' +
           '</div>' +
           '<div class="www-less-download-links">' +
-            '<a href="http://gov.uk/government/uploads/system/three.doc" link-domain="http://gov.uk" path="/government/uploads/system/three.doc">Document</a>' +
-            '<a href="https://gov.uk/government/uploads/link.png" link-domain="https://gov.uk" path="/government/uploads/link.png">Image</a>' +
+            '<a href="http://gov.uk/government/uploads/system/three.doc" link_domain="http://gov.uk" path="/government/uploads/system/three.doc">Document</a>' +
+            '<a href="https://gov.uk/government/uploads/link.png" link_domain="https://gov.uk" path="/government/uploads/link.png">Image</a>' +
           '</div>' +
           '<div class="internal-links">' +
             '<a href="https://www.gov.uk/normal-link">Normal link</a>' +
             '<a href="https://www.gov.uk/another-link">Another link</a>' +
           '</div>' +
           '<div class="external-download-links">' +
-            '<a href="https://example.com/one.pdf" path="/one.pdf" link-domain="https://example.com">External download link</a>' +
-            '<a href="https://www.nationalarchives.gov.uk/government/uploads/logo.png" path="/government/uploads/logo.png" link-domain="https://www.nationalarchives.gov.uk">External download link with false positive path</a>' +
-            '<a href="https://www.nationalarchives.gov.uk/download&fileName=assets.publishing.service.gov.uk.pdf" path="/download&fileName=assets.publishing.service.gov.uk.pdf" link-domain="https://www.nationalarchives.gov.uk">External PDF link with false positive name</a>' +
+            '<a href="https://example.com/one.pdf" path="/one.pdf" link_domain="https://example.com">External download link</a>' +
+            '<a href="https://www.nationalarchives.gov.uk/government/uploads/logo.png" path="/government/uploads/logo.png" link_domain="https://www.nationalarchives.gov.uk">External download link with false positive path</a>' +
+            '<a href="https://www.nationalarchives.gov.uk/download&fileName=assets.publishing.service.gov.uk.pdf" path="/download&fileName=assets.publishing.service.gov.uk.pdf" link_domain="https://www.nationalarchives.gov.uk">External PDF link with false positive name</a>' +
           '</div>' +
           '<div class="relative-download-links">' +
             '<a href="/government/uploads/one.pdf" path="/government/uploads/one.pdf">Relative PDF link</a>' +
             '<a href="/government/uploads/two.xslt" path="/government/uploads/two.xslt">Relative Spreadsheet link</a>' +
           '</div>' +
           '<div class="preview-download-links">' +
-            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" path="/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link-domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
-            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" path="/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link-domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" path="/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link_domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" path="/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link_domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
           '</div>' +
           '<div class="not-a-preview-link">' +
-            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" link-domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
-            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" link-domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" link_domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" link_domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
           '</div>'
 
       body.appendChild(links)
@@ -349,7 +349,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
 
-        expected.event_data.link_domain = link.getAttribute('link-domain')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
@@ -367,7 +367,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
-        expected.event_data.link_domain = link.closest('a').getAttribute('link-domain')
+        expected.event_data.link_domain = link.closest('a').getAttribute('link_domain')
         expected.event_data.url = link.closest('a').getAttribute('href')
         expected.event_data.text = link.closest('a').innerText.trim()
         expected.event_data.type = 'generic download'
@@ -385,7 +385,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
-        expected.event_data.link_domain = link.getAttribute('link-domain')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
@@ -403,7 +403,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
-        expected.event_data.link_domain = link.getAttribute('link-domain')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
@@ -433,7 +433,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
 
-        expected.event_data.link_domain = link.getAttribute('link-domain')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.event_name = 'navigation'
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
@@ -471,7 +471,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
-        expected.event_data.link_domain = link.getAttribute('link-domain')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'preview'
         expected.event_data.text = link.innerText.trim()
@@ -489,7 +489,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
-        expected.event_data.link_domain = link.getAttribute('link-domain')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
@@ -504,13 +504,6 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
   describe('Mailto link tracking', function () {
     beforeEach(function () {
       window.dataLayer = []
-      defaultLinkPathParts = {
-        1: undefined,
-        2: undefined,
-        3: undefined,
-        4: undefined,
-        5: undefined
-      }
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.event_name = 'navigation'
@@ -521,11 +514,11 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
       links = document.createElement('div')
       links.innerHTML =
           '<div class="mail-to-links">' +
-              '<a href="mailto:example@gov.uk" path="mailto:example@gov.uk"> National Archives </a>' +
+              '<a href="mailto:example@gov.uk"> National Archives </a>' +
               '<span>This is not a mailto link</span>' +
             '</div>' +
             '<div class="invalid-links">' +
-              '<a href="https://gov.uk/mailto:example@gov.uk" path="mailto:example@gov.uk"> mailto:example@gov.uk </a>' +
+              '<a href="https://gov.uk/mailto:example@gov.uk"> mailto:example@gov.uk </a>' +
             '</div>'
 
       body.appendChild(links)
@@ -552,8 +545,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.govuk_gem_version = 'aVersion'
-        var linkPath = link.getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: 'mailto:example@gov.uk' })
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -573,25 +565,20 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
   describe('Share and follow link tracking', function () {
     beforeEach(function () {
       window.dataLayer = []
-      defaultLinkPathParts = {
-        1: undefined,
-        2: undefined,
-        3: undefined,
-        4: undefined,
-        5: undefined
-      }
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.govuk_gem_version = 'aVersion'
 
       links = document.createElement('div')
+      /* The link_domain, external and path attributes exist so we can hardcode what the expected value is for each test.
+      The value differs for each link, so we can't hardcode the expected value inside the test itself. */
       links.innerHTML =
           '<div class="share-links">' +
               '<a href="example.com" data-ga4-link=\'' + JSON.stringify({ event_name: 'share', type: 'share this page', index: '1', index_total: '1', text: 'myspace', method: 'populated-via-js' }) + '\'>Share</a>' +
           '</div>' +
           '<div class="follow-links">' +
-              '<a href="https://example.com" link-domain="https://example.com" external="true" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '1', index_total: '2', text: 'Follow us', url: 'https://example.com', external: 'populated-via-js', method: 'populated-via-js' }) + '\'>Follow us</a>' +
-              '<a href="https://www.gov.uk" link-domain="https://www.gov.uk" external="false" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '2', index_total: '2', text: 'Follow me', url: 'https://www.gov.uk', external: 'populated-via-js', method: 'populated-via-js' }) + '\'>Follow me</a>' +
+              '<a href="https://example.com" link_domain="https://example.com" external="true" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '1', index_total: '2', text: 'Follow us', url: 'https://example.com', external: 'populated-via-js', method: 'populated-via-js' }) + '\'>Follow us</a>' +
+              '<a href="https://www.gov.uk" link_domain="https://www.gov.uk" external="false" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '2', index_total: '2', text: 'Follow me', url: 'https://www.gov.uk', external: 'populated-via-js', method: 'populated-via-js' }) + '\'>Follow me</a>' +
           '</div>'
 
       body.appendChild(links)
@@ -644,7 +631,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.external = link.getAttribute('external')
         expected.event_data.method = 'primary click'
-        expected.event_data.link_domain = link.getAttribute('link-domain')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -652,13 +639,6 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
   describe('Helper function tracking', function () {
     beforeEach(function () {
       window.dataLayer = []
-      defaultLinkPathParts = {
-        1: undefined,
-        2: undefined,
-        3: undefined,
-        4: undefined,
-        5: undefined
-      }
       links = document.createElement('div')
       body.appendChild(links)
       body.addEventListener('click', preventDefault)
@@ -694,7 +674,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
 
       links.innerHTML = '<div class="query-param-links">' +
       '<a href="https://nationalarchives.gov.uk/test?_ga=2.179870689.471678113.1662373341-1606126050.1639392506">_ga only link</a>' +
-      '<a href="https://nationalarchives.gov.uk/test?_ga=2.179870689.471678113.1662373341-1606126050.1639392506">_gl only link</a>' +
+      '<a href="https://nationalarchives.gov.uk/test?_gl=2.179870689.471678113.1662373341-1606126050.1639392506">_gl only link</a>' +
       '<a href="https://nationalarchives.gov.uk/test?hello=world&_ga=2.179870689.471678113.1662373341-1606126050.1639392506&_gl=2.179870689.471678113.1662373341-1606126050.1639392506">_ga & _gl link</a>' +
       '<a href="https://nationalarchives.gov.uk/test?hello=world&_ga=example&another=one&_gl=example&goodbye=true">other query params nested around _ga and _gl</a>' +
       '<a href="https://nationalarchives.gov.uk/test?_ga=example&_gl=example&search=%26&order=relevance">keep the search query params that contains a &</a>' +
@@ -804,6 +784,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
+        console.log(window.dataLayer)
         var expectedObject = window.GOVUK.extendObject(defaultLinkPathParts, expectedLinkPathParts[i])
         expect(window.dataLayer[0].event_data.link_path_parts).toEqual(expectedObject)
       }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -13,6 +13,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
 
   beforeAll(function () {
     spyOn(GOVUK.analyticsGa4.core, 'getGemVersion').and.returnValue('aVersion')
+    spyOn(GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker, 'getHostname').and.returnValue('www.gov.uk')
+    spyOn(GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker, 'getProtocol').and.returnValue('https:')
   })
 
   afterAll(function () {
@@ -32,34 +34,28 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
       links = document.createElement('div')
       links.innerHTML =
           '<div class="fully-structured-external-links">' +
-              '<a href="http://www.nationalarchives1.gov.uk"> National Archives </a>' +
-              '<a href="https://www.nationalarchives2.gov.uk"></a>' +
-              '<a href="https://www.nationalarchives3.gov.uk/one.pdf">National Archives PDF</a>' +
+              '<a href="http://www.nationalarchives.gov.uk/1" link_domain="http://www.nationalarchives.gov.uk"> National Archives </a>' +
+              '<a href="https://www.nationalarchives.gov.uk/2" link_domain="https://www.nationalarchives.gov.uk"></a>' +
+              '<a href="https://www.nationalarchives.gov.uk/3.pdf" link_domain="https://www.nationalarchives.gov.uk">National Archives PDF</a>' +
             '</div>' +
             '<div class="www-less-external-links">' +
-              '<a href="http://nationalarchives1.gov.uk"> National Archives </a>' +
-              '<a href="https://nationalarchives2.gov.uk"></a>' +
-              '<a href="https://nationalarchives3.gov.uk/one.pdf">National Archives PDF</a>' +
-            '</div>' +
-            '<div class="http-less-external-links">' +
-              '<a href="nationalarchives1.gov.uk"> National Archives </a>' +
-              '<a href="nationalarchives2.gov.uk"></a>' +
-              '<a href="nationalarchives3.gov.uk/one.pdf">National Archives PDF</a>' +
+              '<a href="http://nationalarchives.gov.uk" link_domain="http://nationalarchives.gov.uk"> National Archives </a>' +
+              '<a href="https://nationalarchives.gov.uk" link_domain="https://nationalarchives.gov.uk"></a>' +
+              '<a href="https://nationalarchives.gov.uk/one.pdf" link_domain="https://nationalarchives.gov.uk">National Archives PDF</a>' +
             '</div>' +
             '<div class="protocol-relative-external-links">' +
-              '<a href="//nationalarchives1.gov.uk"> National Archives </a>' +
-              '<a href="//nationalarchives2.gov.uk"></a>' +
-              '<a href="//nationalarchives3.gov.uk/one.pdf">National Archives PDF</a>' +
+              '<a href="//nationalarchives.gov.uk"> National Archives </a>' +
+              '<a href="//nationalarchives.gov.uk"></a>' +
+              '<a href="//nationalarchives.gov.uk/one.pdf">National Archives PDF</a>' +
             '</div>' +
             '<div class="nested-link">' +
-            '<a href="http://www.nationalarchives1.gov.uk"> <img /> </a>' +
+            '<a href="http://www.nationalarchives.gov.uk"> <img /> </a>' +
             '</div>' +
             '<div class="internal-links">' +
               '<a href="/some-path">Local link</a>' +
               '<a href="http://www.gov.uk/some-path">Another local link</a>' +
               '<a href="https://www.gov.uk/some-path">Another local link</a>' +
               '<a href="https://gov.uk/some-path">Another local link</a>' +
-              '<a href="gov.uk/some-path">Another local link</a>' +
               '<a href="//gov.uk/some-path">Another local link</a>' +
             '</div>' +
             '<div class="anchor-links">' +
@@ -89,7 +85,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         var link = linksToTest[i]
         window.dataLayer = []
         GOVUK.triggerEvent(link, 'click')
-
+        expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expect(window.dataLayer[0]).toEqual(expected)
@@ -103,20 +99,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
 
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.text = link.innerText.trim()
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('detects external click events on missing http/https external links', function () {
-      var linksToTest = document.querySelectorAll('.http-less-external-links a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-
+        expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expect(window.dataLayer[0]).toEqual(expected)
@@ -131,6 +114,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
 
+        expected.event_data.link_domain = '//nationalarchives.gov.uk'
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expect(window.dataLayer[0]).toEqual(expected)
@@ -143,6 +127,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
 
       GOVUK.triggerEvent(nestedImage, 'click')
 
+      expected.event_data.link_domain = 'http://www.nationalarchives.gov.uk'
       expected.event_data.url = parentLink.getAttribute('href')
       expected.event_data.text = parentLink.innerText.trim()
 
@@ -180,6 +165,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
         clickEvent.ctrlKey = true
         link.dispatchEvent(clickEvent)
+        expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.event_data.link_method = 'ctrl click'
@@ -196,6 +182,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
         clickEvent.metaKey = true
         link.dispatchEvent(clickEvent)
+        expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.event_data.link_method = 'command/win click'
@@ -212,6 +199,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         var clickEvent = new window.CustomEvent('mousedown', { cancelable: true, bubbles: true })
         clickEvent.button = 1
         link.dispatchEvent(clickEvent)
+        expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.event_data.link_method = 'middle click'
@@ -228,6 +216,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
         clickEvent.shiftKey = true
         link.dispatchEvent(clickEvent)
+        expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.event_data.link_method = 'shift click'
@@ -242,6 +231,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'contextmenu')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
         expected.event_data.link_method = 'secondary click'
@@ -253,7 +243,6 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
   describe('Download link tracking', function () {
     beforeEach(function () {
       window.dataLayer = []
-
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.event_name = 'file_download'
@@ -263,56 +252,44 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
 
       links = document.createElement('div')
       links.innerHTML = '<div class="fully-structured-download-links">' +
-            '<a href="https://assets.publishing.service.gov.uk/one.pdf" external="true">PDF</a>' +
-            '<a href="https://assets.publishing.service.gov.uk/two.xslt" external="true">Spreadsheet</a>' +
-            '<a href="https://www.gov.uk/government/uploads/system/three.doc" external="false">Document</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/one.pdf" external="true" link-domain="https://assets.publishing.service.gov.uk">PDF</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/two.xslt" external="true" link-domain="https://assets.publishing.service.gov.uk">Spreadsheet</a>' +
+            '<a href="https://www.gov.uk/government/uploads/system/three.doc" external="false" link-domain="https://www.gov.uk">Document</a>' +
           '</div>' +
           '<div class="nested-download-links">' +
-            '<a href="https://www.gov.uk/government/uploads/link.png" external="false"><img src="/img" /></a>' +
-            '<a href="https://assets.publishing.service.gov.uk/two.xslt" external="true"><div><img src="/img" /></div></a>' +
+            '<a href="https://www.gov.uk/government/uploads/link.png" external="false" link-domain="https://www.gov.uk"><img src="/img" /></a>' +
+            '<a href="https://assets.publishing.service.gov.uk/two.xslt" external="true" link-domain="https://assets.publishing.service.gov.uk"><div><img src="/img" /></div></a>' +
           '</div>' +
           '<div class="http-download-links">' +
-            '<a href="http://assets.publishing.service.gov.uk/one.pdf" external="true">PDF</a>' +
-            '<a href="http://assets.publishing.service.gov.uk/two.xslt" external="true">Spreadsheet</a>' +
-            '<a href="http://www.gov.uk/government/uploads/system/three.doc" external="false">Document</a>' +
-            '<a href="http://www.gov.uk/government/uploads/link.png" external="false">Image</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/one.pdf" external="true" link-domain="http://assets.publishing.service.gov.uk">PDF</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/two.xslt" external="true" link-domain="http://assets.publishing.service.gov.uk">Spreadsheet</a>' +
+            '<a href="http://www.gov.uk/government/uploads/system/three.doc" external="false" link-domain="http://www.gov.uk">Document</a>' +
+            '<a href="http://www.gov.uk/government/uploads/link.png" external="false" link-domain="http://www.gov.uk">Image</a>' +
           '</div>' +
           '<div class="www-less-download-links">' +
-            '<a href="http://gov.uk/government/uploads/system/three.doc">Document</a>' +
-            '<a href="https://gov.uk/government/uploads/link.png">Image</a>' +
-          '</div>' +
-          '<div class="http-less-download-links">' +
-            '<a href="gov.uk/government/uploads/system/three.doc" external="false">Document</a>' +
-            '<a href="www.gov.uk/government/uploads/link.png" external="false">Image</a>' +
-            '<a href="assets.publishing.service.gov.uk/one.pdf" external="true">PDF</a>' +
-            '<a href="assets.publishing.service.gov.uk/two.xslt" external="true">Spreadsheet</a>' +
+            '<a href="http://gov.uk/government/uploads/system/three.doc" link-domain="http://gov.uk">Document</a>' +
+            '<a href="https://gov.uk/government/uploads/link.png" link-domain="https://gov.uk">Image</a>' +
           '</div>' +
           '<div class="internal-links">' +
             '<a href="https://www.gov.uk/normal-link">Normal link</a>' +
             '<a href="https://www.gov.uk/another-link">Another link</a>' +
           '</div>' +
           '<div class="external-download-links">' +
-            '<a href="https://example.com/one.pdf">External download link</a>' +
-            '<a href="example.com/one.pdf">External download link</a>' +
-            '<a href="example.com/one.pdf">External download link</a>' +
-            '<a href="https://www.nationalarchives.gov.uk/government/uploads/logo.png">External download link with false positive path</a>' +
-            '<a href="https://www.nationalarchives.gov.uk/download&fileName=assets.publishing.service.gov.uk.pdf">External PDF link with false positive name</a>' +
-            '<a href="nationalarchives.gov.uk/government/uploads/logo.png">External download link with false positive path</a>' +
-            '<a href="www.nationalarchives.gov.uk/government/uploads/logo.png">External download link with false positive path</a>' +
+            '<a href="https://example.com/one.pdf" link-domain="https://example.com">External download link</a>' +
+            '<a href="https://www.nationalarchives.gov.uk/government/uploads/logo.png" link-domain="https://www.nationalarchives.gov.uk">External download link with false positive path</a>' +
+            '<a href="https://www.nationalarchives.gov.uk/download&fileName=assets.publishing.service.gov.uk.pdf" link-domain="https://www.nationalarchives.gov.uk">External PDF link with false positive name</a>' +
           '</div>' +
           '<div class="relative-download-links">' +
             '<a href="/government/uploads/one.pdf">Relative PDF link</a>' +
             '<a href="/government/uploads/two.xslt">Relative Spreadsheet link</a>' +
           '</div>' +
           '<div class="preview-download-links">' +
-            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview">Preview link</a>' +
-            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview">Relative Spreadsheet link</a>' +
-            '<a href="assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview">Relative Spreadsheet link</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link-domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link-domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
           '</div>' +
           '<div class="not-a-preview-link">' +
-            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4">Preview link</a>' +
-            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false">Relative Spreadsheet link</a>' +
-            '<a href="assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.csv">Relative Spreadsheet link</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" link-domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" link-domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
           '</div>'
 
       body.appendChild(links)
@@ -336,6 +313,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
+
+        expected.event_data.link_domain = link.getAttribute('link-domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
@@ -351,6 +330,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
+        expected.event_data.link_domain = link.closest('a').getAttribute('link-domain')
         expected.event_data.url = link.closest('a').getAttribute('href')
         expected.event_data.text = link.closest('a').innerText.trim()
         expected.event_data.type = 'generic download'
@@ -366,6 +346,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
+        expected.event_data.link_domain = link.getAttribute('link-domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
@@ -381,25 +362,11 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
+        expected.event_data.link_domain = link.getAttribute('link-domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
         expected.event_data.external = 'false'
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('detects download clicks on download links without http:// or https:// in the href', function () {
-      var linksToTest = document.querySelectorAll('.http-less-download-links a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.type = 'generic download'
-        expected.event_data.text = link.innerText.trim()
-        expected.event_data.external = link.getAttribute('external')
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -422,6 +389,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
+
+        expected.event_data.link_domain = link.getAttribute('link-domain')
         expected.event_data.event_name = 'navigation'
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
@@ -439,6 +408,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
+        expected.event_data.link_domain = 'https://www.gov.uk'
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
@@ -454,6 +424,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
+        expected.event_data.link_domain = link.getAttribute('link-domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'preview'
         expected.event_data.text = link.innerText.trim()
@@ -469,6 +440,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         window.dataLayer = []
         var link = linksToTest[i]
         GOVUK.triggerEvent(link, 'click')
+        expected.event_data.link_domain = link.getAttribute('link-domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.type = 'generic download'
         expected.event_data.text = link.innerText.trim()
@@ -551,8 +523,8 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
               '<a href="example.com" data-ga4-link=\'' + JSON.stringify({ event_name: 'share', type: 'share this page', index: '1', index_total: '1', text: 'myspace', link_method: 'populated-via-js' }) + '\'>Share</a>' +
           '</div>' +
           '<div class="follow-links">' +
-              '<a href="https://example.com" external="true" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '1', index_total: '2', text: 'Follow us', url: 'https://example.com', external: 'populated-via-js', link_method: 'populated-via-js' }) + '\'>Follow us</a>' +
-              '<a href="https://www.gov.uk" external="false" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '2', index_total: '2', text: 'Follow me', url: 'https://www.gov.uk', external: 'populated-via-js', link_method: 'populated-via-js' }) + '\'>Follow me</a>' +
+              '<a href="https://example.com" link-domain="https://example.com" external="true" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '1', index_total: '2', text: 'Follow us', url: 'https://example.com', external: 'populated-via-js', link_method: 'populated-via-js' }) + '\'>Follow us</a>' +
+              '<a href="https://www.gov.uk" link-domain="https://www.gov.uk" external="false" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '2', index_total: '2', text: 'Follow me', url: 'https://www.gov.uk', external: 'populated-via-js', link_method: 'populated-via-js' }) + '\'>Follow me</a>' +
           '</div>'
 
       body.appendChild(links)
@@ -605,6 +577,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.external = link.getAttribute('external')
         expected.event_data.link_method = 'primary click'
+        expected.event_data.link_domain = link.getAttribute('link-domain')
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -637,7 +610,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
       linkTracker.init({ internalDomains: ['www.gov.uk'], disableListeners: true })
       links.innerHTML = '<a href="http://www.nationalarchives1.gov.uk" id="clickme"> National Archives </a>'
       var link = links.querySelector('#clickme')
-      link.click()
+      GOVUK.triggerEvent(link, 'click')
       expect(window.dataLayer).toEqual([])
     })
 
@@ -667,7 +640,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
       for (var i = 0; i < queryParamLinks.length; i++) {
         window.dataLayer = []
         var link = queryParamLinks[i]
-        link.click()
+        GOVUK.triggerEvent(link, 'click')
         expect(window.dataLayer[0].event_data.url).toEqual(expectedLinks[i])
       }
     })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -36,7 +36,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
       expected.event = 'event_data'
       expected.event_data.event_name = 'navigation'
       expected.event_data.type = 'generic link'
-      expected.event_data.link_method = 'primary click'
+      expected.event_data.method = 'primary click'
       expected.event_data.external = 'true'
       expected.govuk_gem_version = 'aVersion'
       links = document.createElement('div')
@@ -186,7 +186,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
-        expected.event_data.link_method = 'ctrl click'
+        expected.event_data.method = 'ctrl click'
         var linkPath = link.getAttribute('path')
         expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
@@ -205,7 +205,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
-        expected.event_data.link_method = 'command/win click'
+        expected.event_data.method = 'command/win click'
         var linkPath = link.getAttribute('path')
         expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
@@ -224,7 +224,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
-        expected.event_data.link_method = 'middle click'
+        expected.event_data.method = 'middle click'
         var linkPath = link.getAttribute('path')
         expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
@@ -243,7 +243,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
-        expected.event_data.link_method = 'shift click'
+        expected.event_data.method = 'shift click'
         var linkPath = link.getAttribute('path')
         expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
@@ -260,7 +260,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.link_domain = link.getAttribute('link_domain')
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.text = link.innerText.trim()
-        expected.event_data.link_method = 'secondary click'
+        expected.event_data.method = 'secondary click'
         var linkPath = link.getAttribute('path')
         expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
         expect(window.dataLayer[0]).toEqual(expected)
@@ -282,7 +282,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
       expected.event = 'event_data'
       expected.event_data.event_name = 'file_download'
       expected.event_data.type = 'generic download'
-      expected.event_data.link_method = 'primary click'
+      expected.event_data.method = 'primary click'
       expected.govuk_gem_version = 'aVersion'
 
       links = document.createElement('div')
@@ -515,7 +515,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
       expected.event = 'event_data'
       expected.event_data.event_name = 'navigation'
       expected.event_data.type = 'email'
-      expected.event_data.link_method = 'primary click'
+      expected.event_data.method = 'primary click'
       expected.event_data.external = 'true'
 
       links = document.createElement('div')
@@ -587,11 +587,11 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
       links = document.createElement('div')
       links.innerHTML =
           '<div class="share-links">' +
-              '<a href="example.com" data-ga4-link=\'' + JSON.stringify({ event_name: 'share', type: 'share this page', index: '1', index_total: '1', text: 'myspace', link_method: 'populated-via-js' }) + '\'>Share</a>' +
+              '<a href="example.com" data-ga4-link=\'' + JSON.stringify({ event_name: 'share', type: 'share this page', index: '1', index_total: '1', text: 'myspace', method: 'populated-via-js' }) + '\'>Share</a>' +
           '</div>' +
           '<div class="follow-links">' +
-              '<a href="https://example.com" link-domain="https://example.com" external="true" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '1', index_total: '2', text: 'Follow us', url: 'https://example.com', external: 'populated-via-js', link_method: 'populated-via-js' }) + '\'>Follow us</a>' +
-              '<a href="https://www.gov.uk" link-domain="https://www.gov.uk" external="false" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '2', index_total: '2', text: 'Follow me', url: 'https://www.gov.uk', external: 'populated-via-js', link_method: 'populated-via-js' }) + '\'>Follow me</a>' +
+              '<a href="https://example.com" link-domain="https://example.com" external="true" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '1', index_total: '2', text: 'Follow us', url: 'https://example.com', external: 'populated-via-js', method: 'populated-via-js' }) + '\'>Follow us</a>' +
+              '<a href="https://www.gov.uk" link-domain="https://www.gov.uk" external="false" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '2', index_total: '2', text: 'Follow me', url: 'https://www.gov.uk', external: 'populated-via-js', method: 'populated-via-js' }) + '\'>Follow me</a>' +
           '</div>'
 
       body.appendChild(links)
@@ -622,7 +622,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.text = shareLinkAttributes.text
         expected.event_data.index = parseInt(shareLinkAttributes.index)
         expected.event_data.index_total = parseInt(shareLinkAttributes.index_total)
-        expected.event_data.link_method = 'primary click'
+        expected.event_data.method = 'primary click'
         expect(window.dataLayer[0]).toEqual(expected)
       }
     })
@@ -643,7 +643,7 @@ describe('GOVUK.analyticsGa4.linkTracker', function () {
         expected.event_data.index_total = parseInt(shareLinkAttributes.index_total)
         expected.event_data.url = link.getAttribute('href')
         expected.event_data.external = link.getAttribute('external')
-        expected.event_data.link_method = 'primary click'
+        expected.event_data.method = 'primary click'
         expected.event_data.link_domain = link.getAttribute('link-domain')
         expect(window.dataLayer[0]).toEqual(expected)
       }


### PR DESCRIPTION
Hi @andysellick / @JamesCGDS - would either (or both) of you be able to approve this PR? 

Also, do you think this is too many changes in one branch? I like to tackle multiple tickets at a time, but I appreciate that some people would treat each commit as a separate PR.

Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Strips out `_gl` and `_ga` query parameters from being pushed with link clicks
- Adds a `link_domain` field which tracks what protocol and domain the clicked link is pointing to (e.g. `https://www.gov.uk` or `https://example.com`)
- Adds a `link_path_parts` object which stores strings. These are the clicked link's path, split at every 100 characters.
- Changes the `link_method` key to just be `method`.
- Strips line breaks and multiple spaces in link text before being pushed to the dataLayer.
- Updates the docs to reflect the above changes.

## Why
<!-- What are the reasons behind this change being made? -->
- The `_gl` and `_ga` query parameters are used for cross domain tracking to identify a user across domains. It isn't useful for the link click tracking as it won't tell us anything, and they are long query parameters which is wasting precious space.
- Adds ` link_domain` value. This was requested by the PAs as it will be useful for them to see which domains are being clicked. It will also be needed to reconstruct long URLs in Data Studio that have been split up - related to the next point: 
- Adds a `link_path_parts` object. GA4 only allows event values to be a maximum of 100 characters. Therefore, a lot of the link URLs were being cut off after 100 characters, which means we are pushing incomplete data to GA4. To solve this, we have created an object which dynamically adds the path of the URL, split every 100 characters. We have set a limit of splitting it into a maximum of 5 parts (500 characters) - this can be changed if the analysts want. The analysts also requested we add the link path to this object, even when the whole link is under 100 characters.
- Changes the `link_method` key to just be `method` because GA4 already has a `method` key configured, so there was no point in having our own key called `link_method`.
- We strip line breaks and multiple spaces in link text as this was causing visual issues in the GA4 dashboard.

## Visual Changes
None.
