### PR TITLE
Fix axe-core false positives for `color-contrast` tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix axe-core false positives for color-contrast tests ([PR #3007](https://github.com/alphagov/govuk_publishing_components/pull/3007))
+
 ## 31.1.0
 
 * Resolve Plek.current deprecations ([PR #3000](https://github.com/alphagov/govuk_publishing_components/pull/3000))

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -132,18 +132,6 @@ $gem-guide-border-width: 1px;
   &.component-output {
     padding: 0;
   }
-
-  &:before {
-    @include govuk-font($size: 14);
-    content: attr(data-content);
-    position: absolute;
-    top: 0;
-    left: 0;
-    padding: .2105em .7894em;
-    background: $govuk-border-colour;
-    color: govuk-colour("black");
-    font-weight: bold;
-  }
 }
 
 .component-guide-preview--simple {
@@ -190,6 +178,16 @@ $gem-guide-border-width: 1px;
 
   .selector {
     font-style: italic;
+  }
+
+  &:before {
+    @include govuk-font($size: 14);
+    content: attr(data-content);
+    position: absolute;
+    top: 0;
+    left: 0;
+    padding: .2105em .7894em;
+    font-weight: bold;
   }
 }
 

--- a/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/component_doc/_component.html.erb
@@ -2,6 +2,6 @@
             <% if example.right_to_left? %>direction-rtl<% end %>
             <% if example.dark_background? %>dark-background<% end %>
             <% if example.black_background? %>black-background<% end %>
-            <% if preview_page %>component-guide-preview--simple<% end %>" data-content="EXAMPLE">
+            <% if preview_page %>component-guide-preview--simple<% end %>">
   <%= render "govuk_publishing_components/component_guide/component_doc/component_output", example: example, component_doc: component_doc %>
 </div>


### PR DESCRIPTION
## What
Remove the "Example" grey box from component previews. The :before pseudo class is now only used by `.component-guide-preview--violation` and `.component-guide-preview--warning`

## Why
The "Example" grey box shown for each component preview was causing the axe-core colour-contrast check to report as "incomplete". We would then advise that the component needs to be manually checked.

The "Example" grey box was being nested within the component itself, so was also being included as part of the accessibility test. The accessibility test would then report as incomplete, because the "Example" element uses the :before pseudo class to set both the `color` and `background-color` which cannot be tested using axe-core.

This change reduces the number of manual checks required overall, for example on the [Action Links component](https://components.publishing.service.gov.uk/component-guide/action_link), the number of manual checks reported would go from 15 to 0.

## Visual Changes

### Before
<img width="1047" alt="color-contrast-before" src="https://user-images.githubusercontent.com/28779939/195059364-7f27e365-cf9c-4c3c-a6b2-24cacb728cc0.png">

### After
<img width="989" alt="color-contrast-after" src="https://user-images.githubusercontent.com/28779939/195070782-ba73b796-51fa-4075-826c-bb9ce6a36906.png">