### PR TITLE
Move the GTM blocklist code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Move the GTM blocklist code ([PR #3011](https://github.com/alphagov/govuk_publishing_components/pull/3011))
+
 ## 31.1.1
 
 * Update to LUX 302 ([PR #3009](https://github.com/alphagov/govuk_publishing_components/pull/3009))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -22,6 +22,7 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
       } else {
         // initialise GTM
         window.dataLayer = window.dataLayer || []
+        window.dataLayer.push({ 'gtm.blocklist': ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] })
         window.dataLayer.push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
 
         var auth = window.GOVUK.analyticsGa4.vars.auth || ''
@@ -36,7 +37,6 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
         this.googleSrc = 'https://www.googletagmanager.com/gtm.js?id=' + window.GOVUK.analyticsGa4.vars.id + auth + preview
         newScript.src = this.googleSrc
         firstScript.parentNode.insertBefore(newScript, firstScript)
-        window.dataLayer.push({ 'gtm.blocklist': ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] })
       }
     },
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -21,10 +21,10 @@ describe('GA4 core', function () {
     GOVUK.analyticsGa4.core.load()
 
     expect(window.dataLayer.length).toEqual(2)
-    expect(Object.keys(window.dataLayer[0])).toContain('gtm.start')
-    expect(Object.keys(window.dataLayer[0])).toContain('event')
-    expect(Object.keys(window.dataLayer[1])).toContain('gtm.blocklist')
-    expect(window.dataLayer[1]['gtm.blocklist']).toEqual(['customPixels', 'customScripts', 'html', 'nonGoogleScripts'])
+    expect(Object.keys(window.dataLayer[0])).toContain('gtm.blocklist')
+    expect(Object.keys(window.dataLayer[1])).toContain('gtm.start')
+    expect(Object.keys(window.dataLayer[1])).toContain('event')
+    expect(window.dataLayer[0]['gtm.blocklist']).toEqual(['customPixels', 'customScripts', 'html', 'nonGoogleScripts'])
   })
 
   describe('calls the right URL from Google', function () {


### PR DESCRIPTION
## What / why
Discovered this problem during testing. The blocklist has to come first or it doesn't work.

- make it so that the blocklist is the very first thing that is added to the dataLayer when GTM initialises
- otherwise it doesn't work

## Visual Changes
None.
