### PR TITLE
Replace YAML anchor with list to fix VRT action

### DIFF
--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore: &ignore-list
+    paths-ignore: # Until anchors are supported by GitHub Actions, we have to write this list twice.
       - ".github/**"
       - "docs/**"
       - ".gitignore"
@@ -14,7 +14,15 @@ on:
       - "LICENCE.md"
       - "SUPPORT.md"
   pull_request:
-    paths-ignore: *ignore-list
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - ".gitignore"
+      - "startup.sh"
+      - "CHANGELOG.md"
+      - "README.md"
+      - "LICENCE.md"
+      - "SUPPORT.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name || github.run_id }}


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Replace the ignore file list YAML anchor with an actual list.

## Why
<!-- What are the reasons behind this change being made? -->

GitHub Actions doesn't currently support YAML anchors, so this list of files and paths to ignore needs to be written twice - once for the pushes and once  or the pull requests.

This caused the YAML file to halt the running of the workflow - so visual regression tests weren't being run.

![image](https://user-images.githubusercontent.com/1732331/195621746-b73d864b-6e73-4426-852c-89346bc5205f.png)

## Visual Changes
None.
