### PR TITLE
Calculate viewport width correctly for navbar in Chrome and Firefox when Mac scrollbars are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Change GTM push of unset values from 'null' to 'undefined' ([PR #2971](https://github.com/alphagov/govuk_publishing_components/pull/2971))
 * Add click tracking to Yes/No buttons on feedback component ([PR #2964](https://github.com/alphagov/govuk_publishing_components/pull/2964))
 * Update popular links on search bar ([PR #2972](https://github.com/alphagov/govuk_publishing_components/pull/2972))
+* Calculate viewport width correctly for navbar in Chrome and Firefox when Mac scrollbars are enabled ([PR #3016](https://github.com/alphagov/govuk_publishing_components/pull/3016))
 
 ## 30.6.1
 

--- a/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/layout-super-navigation-header.js
@@ -98,13 +98,22 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     return $menu.querySelectorAll('button[aria-expanded="true"]').length > 0
   }
 
-  // Returns what screen size the window is currently. Returns a string of
-  // either `desktop` or `mobile` so it can be interpolated to access the
+  // Detect the current viewport width. Return the string `desktop` or `mobile` so it can be interpolated to access the
   // `data-toggle-{desktop|mobile}-group` attribute.
+  //
+  // Use `matchedia` which mitigates issues in modern browsers when scrollbars are forced in MacOS (using `document.documentElement.clientWidth`
+  // for viewport width detection has issues in Chrome and Firefox, and `window.innerWidth` has issues in Safari).
+  //
+  //  Fall back to `document.documentElement.clientWidth` for legacy browsers.
   var windowSize = function () {
-    return document.documentElement.clientWidth >= SETTINGS.breakpoint.desktop ? 'desktop' : 'mobile'
+    var viewport = false
+    if (typeof window.matchMedia === 'function') {
+      viewport = window.matchMedia('(min-width:' + SETTINGS.breakpoint.desktop + 'px)').matches
+    } else {
+      viewport = document.documentElement.clientWidth >= SETTINGS.breakpoint.desktop
+    }
+    return viewport ? 'desktop' : 'mobile'
   }
-
   function SuperNavigationMegaMenu ($module) {
     this.$module = $module
     this.$navigationToggle = this.$module.querySelector('#super-navigation-menu-toggle')


### PR DESCRIPTION
## What
When the user sets scrollbars to always show in MacOS at system level ('System Preferences' > 'General' > 'Show scroll bars': 'Always'), the super navigation header doesn't calculate the viewport width correctly in Chrome and Firefox.

This is because `document.documentElement.clientWidth` which is used to calculate the viewport width and switch styles on/off doesn't account for the forced Mac scrollbar in Chrome and Firefox, leading to the component rendering incorrectly in when the viewport is ~768-784px wide. The same calculation had previously used `window.innerWidth` but [this was found to have caused issues in Safari](https://github.com/alphagov/govuk_publishing_components/issues/2430). Hence it was replaced by `document.documentElement.clientWidth` but this is now causing the above mentioned issue in Chrome and Firefox.

Instead of using `document.documentElement.clientWidth` to calculate viewport width, switch to using `matchMedia` which mitigates the above issue and works correctly in Safari, Chrome and Firefox.

Fall back to using `document.documentElement.clientWidth` for legacy browsers that don't support `matchMedia` (falling back to using `window.innerWidth` which the component originally used would have probably worked equally well, but stick with `document.documentElement.clientWidth` as it's currently in use on production, without any issues reported in legacy browsers).

## Why
The component should render correctly on all viewport sizes. 

<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

*All on MacOS, with scrollbars always set to show

### Before (Chrome 106)
![chrome-before-2](https://user-images.githubusercontent.com/5007934/195664567-bbdf4107-79e2-4f95-ae6c-590275f564e7.png)

### After (Chrome 106)

![chrome-after2](https://user-images.githubusercontent.com/5007934/195664578-e8622570-4493-4f65-a298-058b71cd70a1.png)

### Before (FF 105)

![ff-before-2](https://user-images.githubusercontent.com/5007934/195664538-a4dcb661-746a-4765-9261-15e8f9e35b6e.png)

### After (FF 105)
![ff-after-2](https://user-images.githubusercontent.com/5007934/195664558-165f7e79-72b3-4e86-b553-e801ccda06f6.png)

## Further detail
The change was tested in all the supported browsers/devices, and with the scrollbars setting switched both on and off on MacOS. See [Trello](https://trello.com/c/Q3Pn5yIN/1099-bug-investigate-and-fix-header-menu-button-behaviour-at-width-768px-and-784px-m) for details. I would have liked to force scrollbars on Windows too (you can do this by going  to 'Windows Settings' > 'Accessibility' > 'Visual effects' > 'Always show scrollbars') but Browserstack won't let you toggle on that setting. However it seems quite unlikely that modern browsers like Chrome and Firefox which support `matchMedia` wouldn't work correctly on Windows (and older browsers fall back to `document.documentElement.clientWidth` which we already use on production) but we could find a virtual machine for testing on Windows.

I found a [bug on the super nav in Safari when zooming in or out ](https://trello.com/c/WXSSNrNZ/744-navigation-header-can-break-in-safari-when-the-window-is-zoomed)- I can replicate the same bug on production (intermittently, it's an edge case resulting from a JS race condition it seems) so it wasn't introduced by the change in this PR. But it might be good to sense check how this change works on Safari when zooming in or out (as well as generally sense checking in other browsers and especially in Mac with the scrollbars switched on and off).

## How to test
Go to Mac's 'System Preferences' > 'General' > 'Show scroll bars': 'Always'. I was using `/component-guide/layout_super_navigation_header/default/preview` to view the change.

~Note that this PR contains a _debugging commit_ that helps with testing the change by removing the extra margins added by the gem preview app so that the component can render full-width and adding some page content to the blank layout so that the page is tall enough to have scrollbars - this commit must be removed before merging, hence the draft PR and the `do-not-merge` label. **The tests are also failing because of this commit.**~ now deleted

Fixes https://trello.com/c/Q3Pn5yIN/1099-bug-investigate-and-fix-header-menu-button-behaviour-at-width-768px-and-784px-m
