### PR TITLE
Add tracking to super navigation header dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Feedback component visual updates ([PR #2894](https://github.com/alphagov/govuk_publishing_components/pull/2894))
+* Add tracking to super navigation header dropdowns ([PR #3024](https://github.com/alphagov/govuk_publishing_components/pull/3024))
 
 ## 31.1.2
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
@@ -51,8 +51,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
       }
 
-      // Ensure it only tracks aria-expanded in an accordion/super navigation header element, instead of in any child of the clicked element
-      if (target.closest('.gem-c-accordion') || target.closest('.gem-c-layout-super-navigation-header')) {
+      /* Ensure it only tracks aria-expanded in an accordion or element with data-ga4-expandable on it. */
+      if (target.closest('.gem-c-accordion') || target.closest('[data-ga4-expandable]')) {
         var ariaExpanded = this.getClosestAttribute(target, 'aria-expanded')
       }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
@@ -51,8 +51,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
       }
 
-      // Ensure it only tracks aria-expanded in an accordion element, instead of in any child of the clicked element
-      if (target.closest('.gem-c-accordion')) {
+      // Ensure it only tracks aria-expanded in an accordion/super navigation header element, instead of in any child of the clicked element
+      if (target.closest('.gem-c-accordion') || target.closest('.gem-c-layout-super-navigation-header')) {
         var ariaExpanded = this.getClosestAttribute(target, 'aria-expanded')
       }
 

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -15,7 +15,7 @@
   hide_navigation_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.hide", :label => "navigation")
   show_navigation_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.show", :label => "navigation")
 %>
-<header role="banner" class="gem-c-layout-super-navigation-header" data-module="gem-track-click ga4-event-tracker" data-track-links-only>
+<header role="banner" class="gem-c-layout-super-navigation-header" data-module="gem-track-click ga4-event-tracker" data-track-links-only data-ga4-expandable>
   <div class="gem-c-layout-super-navigation-header__container govuk-width-container govuk-clearfix">
     <div class="gem-c-layout-super-navigation-header__header-logo">
       <a
@@ -80,10 +80,11 @@
         type="button"
         data-ga4="<%= {
           "event_name": "select_content",
-          "type": "super navigation header",
+          "type": "header menu bar",
           "text": "Menu",
           "index": 1,
-          "index_total": navigation_links.length + 2
+          "index_total": navigation_links.length + 2,
+          "section": "Menu"
         }.to_json %>"
       >
         <span class="gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner">
@@ -133,10 +134,11 @@
                     tracking_key: tracking_label,
                     ga4: {
                       event_name: "select_content",
-                      type: "super navigation header",
+                      type: "header menu bar",
                       text: link[:label],
                       index: index + 2,
-                      index_total: navigation_links.length + 2
+                      index_total: navigation_links.length + 2,
+                      section: link[:label]
                     }
                   },
                   hidden: true,
@@ -231,12 +233,13 @@
         hidden
         id="super-search-menu-toggle"
         type="button"
-       data-ga4="<%= {
+        data-ga4="<%= {
           "event_name": "select_content",
-          "type": "super navigation header",
+          "type": "header menu bar",
           "text": "Search",
           "index": navigation_links.length + 2,
-          "index_total": navigation_links.length + 2
+          "index_total": navigation_links.length + 2,
+          "section": "Search"
         }.to_json %>"
       >
         <span class="govuk-visually-hidden">

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -15,7 +15,7 @@
   hide_navigation_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.hide", :label => "navigation")
   show_navigation_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.show", :label => "navigation")
 %>
-<header role="banner" class="gem-c-layout-super-navigation-header" data-module="gem-track-click" data-track-links-only>
+<header role="banner" class="gem-c-layout-super-navigation-header" data-module="gem-track-click ga4-event-tracker" data-track-links-only>
   <div class="gem-c-layout-super-navigation-header__container govuk-width-container govuk-clearfix">
     <div class="gem-c-layout-super-navigation-header__header-logo">
       <a
@@ -78,6 +78,13 @@
         hidden
         id="super-navigation-menu-toggle"
         type="button"
+        data-ga4="<%= {
+          "event_name": "select_content",
+          "type": "super navigation header",
+          "text": "Menu",
+          "index": 1,
+          "index_total": navigation_links.length + 2
+        }.to_json %>"
       >
         <span class="gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner">
           Menu
@@ -124,6 +131,13 @@
                     toggle_desktop_group: "top",
                     toggle_mobile_group: "second",
                     tracking_key: tracking_label,
+                    ga4: {
+                      event_name: "select_content",
+                      type: "super navigation header",
+                      text: link[:label],
+                      index: index + 2,
+                      index_total: navigation_links.length + 2
+                    }
                   },
                   hidden: true,
                   id: "super-navigation-menu__section-#{unique_id}-toggle",
@@ -217,6 +231,13 @@
         hidden
         id="super-search-menu-toggle"
         type="button"
+       data-ga4="<%= {
+          "event_name": "select_content",
+          "type": "super navigation header",
+          "text": "Search",
+          "index": navigation_links.length + 2,
+          "index_total": navigation_links.length + 2
+        }.to_json %>"
       >
         <span class="govuk-visually-hidden">
           <%= search_text %>

--- a/docs/analytics-ga4/ga4-event-tracker.md
+++ b/docs/analytics-ga4/ga4-event-tracker.md
@@ -81,7 +81,7 @@ It is also complicated by the fact that the JavaScript that creates this element
   - in the example above, the result will be `data-ga4="{ "event_name": "select_content", "type": "accordion" }"`
 - wrap the accordion in the event tracking script
   - tracking will be activated by clicks on elements with a `data-ga4` attribute
-  - it checks for an `aria-expanded` attribute, either on the clicked element or a child of the clicked element, and sets the `action` of the GA data accordingly
+  - it checks for an `aria-expanded` attribute if the clicked element or parent element contains a `data-ga4-expandable` value or the `gem-c-accordion` class. If it detects one of those, it sets the `action` of the GA data accordingly.
   - the current text of the clicked element is also recorded (this can be overridden to a non-dynamic value by including `text` in the attributes if required)
 
 When a user clicks 'Show all sections' the following information is pushed to the dataLayer.

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -463,9 +463,9 @@ describe('Google Analytics event tracking', function () {
     })
   })
 
-  describe('doing tracking on the super navigation header', function () {
+  describe('doing tracking on an data-ga4-expandable element', function () {
     beforeEach(function () {
-      element.innerHTML = '<header data-module="ga4-event-tracker" class="gem-c-layout-super-navigation-header"><nav>' +
+      element.innerHTML = '<header data-module="ga4-event-tracker" data-ga4-expandable><nav>' +
       '<button aria-expanded="false">Menu</button>' +
       '<ul><li><button aria-expanded="false"">Topics</button></li>' +
       '<li><button aria-expanded="false">Government activity</button></li></ul>' +
@@ -475,11 +475,11 @@ describe('Google Analytics event tracking', function () {
       new GOVUK.Modules.Ga4EventTracker(element).init()
     })
 
-    it('tracks expanding/collapsing menu sections and search', function () {
+    it('tracks expanding/collapsing sections under the data-ga4-expandable attribute', function () {
       var expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.event_name = 'select_content'
-      expected.event_data.type = 'super navigation header'
+      expected.event_data.type = 'header menu bar'
       expected.govuk_gem_version = 'aVersion'
       var buttons = document.querySelectorAll('button')
       expected.event_data.index_total = buttons.length
@@ -489,8 +489,9 @@ describe('Google Analytics event tracking', function () {
         var button = buttons[i]
         button.setAttribute('data-ga4', JSON.stringify({
           event_name: 'select_content',
-          type: 'super navigation header',
+          type: 'header menu bar',
           text: button.textContent,
+          section: button.textContent,
           index: i + 1,
           index_total: buttons.length
         }))
@@ -498,6 +499,7 @@ describe('Google Analytics event tracking', function () {
         button.click()
         expected.event_data.action = 'opened'
         expected.event_data.text = button.textContent
+        expected.event_data.section = button.textContent
         expected.event_data.index = i + 1
         expect(window.dataLayer[0]).toEqual(expected)
         button.setAttribute('aria-expanded', 'true')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -462,4 +462,49 @@ describe('Google Analytics event tracking', function () {
       expect(window.dataLayer[0]).toEqual(expected)
     })
   })
+
+  describe('doing tracking on the super navigation header', function () {
+    beforeEach(function () {
+      element.innerHTML = '<header data-module="ga4-event-tracker" class="gem-c-layout-super-navigation-header"><nav>' +
+      '<button aria-expanded="false">Menu</button>' +
+      '<ul><li><button aria-expanded="false"">Topics</button></li>' +
+      '<li><button aria-expanded="false">Government activity</button></li></ul>' +
+      '<button aria-expanded="false">Search</button>' +
+      '</nav></header>'
+      document.body.appendChild(element)
+      new GOVUK.Modules.Ga4EventTracker(element).init()
+    })
+
+    it('tracks expanding/collapsing menu sections and search', function () {
+      var expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      expected.event = 'event_data'
+      expected.event_data.event_name = 'select_content'
+      expected.event_data.type = 'super navigation header'
+      expected.govuk_gem_version = 'aVersion'
+      var buttons = document.querySelectorAll('button')
+      expected.event_data.index_total = buttons.length
+
+      for (var i = 0; i < buttons.length; i++) {
+        window.dataLayer = []
+        var button = buttons[i]
+        button.setAttribute('data-ga4', JSON.stringify({
+          event_name: 'select_content',
+          type: 'super navigation header',
+          text: button.textContent,
+          index: i + 1,
+          index_total: buttons.length
+        }))
+
+        button.click()
+        expected.event_data.action = 'opened'
+        expected.event_data.text = button.textContent
+        expected.event_data.index = i + 1
+        expect(window.dataLayer[0]).toEqual(expected)
+        button.setAttribute('aria-expanded', 'true')
+        expected.event_data.action = 'closed'
+        button.click()
+        expect(window.dataLayer[1]).toEqual(expected)
+      }
+    })
+  })
 })


### PR DESCRIPTION
Hi @andysellick / @JamesCGDS 

Would one of you (or both) be able to review this? Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds tracking to the dropdown menus of the GOV.UK super navigation header. These are the dropdowns for `Topics`, `Government Activity`, the `Search` button, and the `Menu` button on mobile (the `Menu` button  expands and collapses the whole menu on mobile.)
- This uses `ga4-event-tracker` which listens for a click on all `ga4-event-tracker` modules, then checks for a `data-ga4` data attribute JSON on the `event.target` and pushes it to GTM if it exists.

This is the element in question:

Desktop:
<img width="423" alt="image" src="https://user-images.githubusercontent.com/8880610/196174990-788e4c31-281c-4fbe-9a96-b2b9cfc6c4bf.png">

Mobile:
<img width="272" alt="image" src="https://user-images.githubusercontent.com/8880610/196175044-21535b6d-e636-4cee-802f-5267ceb440c8.png">


The GTM object which is output when clicking one of these dropdowns looks like this:
```JSON
{
    "event": "event_data",
    "event_data": {
        "event_name": "select_content",
        "type": "super navigation header",
        "text": "Topics",
        "index": 2,
        "index_total": 4,
        "action": "opened"
    },
    "govuk_gem_version": "31.1.1"
}
```



## Why
<!-- What are the reasons behind this change being made? -->

- This is a high priority interaction to add. 
- I've had to do a bit of maths (just some addition) to make the `index` and `index_total` conform to what the Performance Analyst's want.  This is why I'm doing things like `"index_total": navigation_links.length + 2` because this makes the indexes correct across the elements. The order is:
    - Mobile 'Menu' dropdown (index 1)
    - Topics dropdown (index 2)
    - Government activity dropdown (index 3)
    - Search button (index 4)
    - The index_total is 4 across all of them

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
