### PR TITLE
Version 31.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 31.1.2
 
 * Move the GTM blocklist code ([PR #3011](https://github.com/alphagov/govuk_publishing_components/pull/3011))
 * Fix issues with GA4 link tracking identified by performance analysts ([PR #3004](https://github.com/alphagov/govuk_publishing_components/pull/3004))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (31.1.1)
+    govuk_publishing_components (31.1.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "31.1.1".freeze
+  VERSION = "31.1.2".freeze
 end


### PR DESCRIPTION
## 31.1.2
* Move the GTM blocklist code ([PR #3011](https://github.com/alphagov/govuk_publishing_components/pull/3011))
* Fix issues with GA4 link tracking identified by performance analysts ([PR #3004](https://github.com/alphagov/govuk_publishing_components/pull/3004))