### PR TITLE
Include the words 'opens in new tab' as part of the share link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 * Calculate viewport width correctly for navbar in Chrome and Firefox when Mac scrollbars are enabled ([PR #3016](https://github.com/alphagov/govuk_publishing_components/pull/3016))
+* Include the words 'opens in new tab' as part of the share link ([PR #3028](https://github.com/alphagov/govuk_publishing_components/pull/3028)) 
 
 ## 32.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_share-links.scss
@@ -26,12 +26,6 @@ $share-button-height: 30px;
   @include govuk-template-link-focus-override;
 }
 
-.gem-c-share-links__title {
-  @include govuk-text-colour;
-  @include govuk-font($size: 16, $line-height: 1.5);
-  margin: 0 0 govuk-spacing(2) 0;
-}
-
 .gem-c-share-links__link-icon {
   position: absolute;
   top: 0;

--- a/app/views/govuk_publishing_components/components/_share_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_share_links.html.erb
@@ -20,9 +20,11 @@
 <% if links.any? %>
   <%= tag.div(class: classes, data: data_attributes) do %>
     <% if title %>
-      <h2 class="gem-c-share-links__title"><%= title %></h2>
+      <h2 class="govuk-heading-s"><%= title %></h2>
     <% end %>
-
+    <p class="govuk-body-s">
+      <%= t('components.share_links.all_opens_in_new_tab') %>
+    </p>
     <ul class="gem-c-share-links__list">
       <% links.each_with_index do |link, index| %>
         <% link_text = capture do %>
@@ -34,6 +36,9 @@
             <% end %>
           </span>
           <%= link[:text] %>
+          <span class="govuk-visually-hidden">
+            <%= t('components.share_links.opens_in_new_tab') %>
+          </span>
         <% end %>
         <li class="gem-c-share-links__list-item">
           <%

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -167,13 +167,16 @@ ar:
         link_text: تحقق مما تحتاج إلى القيام به
         title: برِيكْسِت
       ukraine:
-        title:
         links:
+        title:
       world_locations: المواقع العالمية
     search_box:
       input_title: بحث
       label: بحث على GOV.UK
       search_button: بحث
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: كلمة مرورك مخفيَّة
       announce_show: كلمة مرورك معروضة

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -163,13 +163,16 @@ az:
         link_text: Nələri etməli olduğunuzu yoxlayın
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Dünya üzrə yerləri
     search_box:
       input_title: Axtar
       label: GOV.UK-də axtar
       search_button: Axtar
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Şifrəniz gizlədilib
       announce_show: Şifrəniz göstərilir

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -170,13 +170,16 @@ be:
         link_text: Праверце, што вам трэба зрабіць
         title: Брэкзiт
       ukraine:
-        title:
         links:
+        title:
       world_locations: Мы ў свеце
     search_box:
       input_title: Пошук
       label: Шукаць на GOV.UK
       search_button: Пошук
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Ваш пароль схаваны
       announce_show: Ваш пароль адлюстроўваецца

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -168,13 +168,16 @@ bg:
         link_text: Проверете какво трябва да направите
         title: Брекзит
       ukraine:
-        title:
         links:
+        title:
       world_locations: Местоположения по света
     search_box:
       input_title: Търсене
       label: Търсене в GOV.UK
       search_button: Търсене
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Вашата парола е скрита
       announce_show: Вашата парола е видима

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -165,13 +165,16 @@ bn:
         link_text: আপনার যা করা প্রয়োজন তা দেখুন
         title: ব্রেক্সিট
       ukraine:
-        title:
         links:
+        title:
       world_locations: বিশ্বের অবস্থানসমূহ
     search_box:
       input_title: খুঁজুন
       label: GOV.UK-এ অনুসন্ধান করুন
       search_button: খুঁজুন
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: আপনার পাসওয়ার্ড লুকানো
       announce_show: আপনার পাসওয়ার্ড দেখানো হয়েছে

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -169,13 +169,16 @@ cs:
         link_text: Zkontrolujte, co je třeba udělat
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Místa ve světě
     search_box:
       input_title: Vyhledávání
       label: Vyhledávání na GOV.UK
       search_button: Vyhledávání
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Vaše heslo je skryté
       announce_show: Zobrazí se vaše heslo

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -168,13 +168,16 @@ cy:
         link_text: Gwiriwch beth mae angen i chi wneud
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Lleoliadau byd-eang
     search_box:
       input_title: Chwilio
       label: Chwilio ar GOV.UK
       search_button: Chwilio
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Mae eich cyfrinair wedi'i guddio
       announce_show: Mae eich cyfrinair yn cael ei ddangos

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -165,13 +165,16 @@ da:
         link_text: Tjek hvad du skal gøre
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Verden Placeringer
     search_box:
       input_title: Søge
       label: Søg i GOV.UK
       search_button: Søge
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Din adgangskode er skjult
       announce_show: Din adgangskode vises

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -168,13 +168,16 @@ de:
         link_text: Prüfen Sie, was Sie machen müssen
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Weltweite Standorte
     search_box:
       input_title: Suche
       label: Auf GOV.UK suchen
       search_button: Suche
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Ihr Passwort ist ausgeblendet
       announce_show: Ihr Passwort ist eingeblendet

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -166,13 +166,16 @@ dr:
         link_text: بیبینید که چه کاری باید انجام دهید
         title: برکست
       ukraine:
-        title:
         links:
+        title:
       world_locations: موقعیت هایی جهان
     search_box:
       input_title: جستجو نمایید
       label: در GOV.UK جستجو نمایید
       search_button: جستجو نمایید
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: رمز عبور شما مخفی شده است
       announce_show: رمز عبور شما نشان داده شده است

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -164,13 +164,16 @@ el:
         link_text: Ελέγξτε τι πρέπει να κάνετε
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Παγκόσμιες τοποθεσίες
     search_box:
       input_title: Αναζήτηση
       label: Αναζήτηση στο GOV.UK
       search_button: Αναζήτηση
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Ο κωδικός πρόσβασής σας είναι κρυμμένος
       announce_show: Ο κωδικός πρόσβασής σας εμφανίζεται

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -232,16 +232,16 @@ en:
       navigation_search_heading: Search and popular pages
       navigation_search_subheading: Search
       popular_links:
-      - label: 'Check benefits and financial support you can get'
-        href: '/check-benefits-financial-support'
+      - label: Check benefits and financial support you can get
+        href: "/check-benefits-financial-support"
       - label: 'Limits on energy prices: Energy Price Guarantee'
-        href: '/government/publications/energy-bills-support/energy-bills-support-factsheet-8-september-2022'
-      - label: 'Find a job'
-        href: '/find-a-job'
-      - label: 'Coronavirus (COVID-19)'
-        href: '/coronavirus'
+        href: "/government/publications/energy-bills-support/energy-bills-support-factsheet-8-september-2022"
+      - label: Find a job
+        href: "/find-a-job"
+      - label: Coronavirus (COVID-19)
+        href: "/coronavirus"
       - label: 'Universal Credit account: sign in'
-        href: '/sign-in-universal-credit'
+        href: "/sign-in-universal-credit"
       popular_links_heading: Popular on GOV.UK
       search_text: Search GOV.UK
     metadata:
@@ -292,21 +292,24 @@ en:
         link_text: Check what you need to do
         title: Brexit
       ukraine:
-        title: Invasion of Ukraine
         links:
-        - label: "UK visa support for Ukrainian nationals"
-          href:  "https://www.gov.uk/guidance/support-for-family-members-of-british-nationals-in-ukraine-and-ukrainian-nationals-in-ukraine-and-the-uk"
-        - label: "Move to the UK if you're coming from Ukraine"
-          href:  "https://www.gov.uk/guidance/move-to-the-uk-if-youre-from-ukraine"
-        - label: "Homes for Ukraine: record your interest"
-          href:  "https://www.gov.uk/register-interest-homes-ukraine"
-        - label: "Find out about the UK’s response"
-          href:  "https://ukstandswithukraine.campaign.gov.uk/"
+        - label: UK visa support for Ukrainian nationals
+          href: https://www.gov.uk/guidance/support-for-family-members-of-british-nationals-in-ukraine-and-ukrainian-nationals-in-ukraine-and-the-uk
+        - label: Move to the UK if you're coming from Ukraine
+          href: https://www.gov.uk/guidance/move-to-the-uk-if-youre-from-ukraine
+        - label: 'Homes for Ukraine: record your interest'
+          href: https://www.gov.uk/register-interest-homes-ukraine
+        - label: Find out about the UK’s response
+          href: https://ukstandswithukraine.campaign.gov.uk/
+        title: Invasion of Ukraine
       world_locations: World locations
     search_box:
       input_title: Search
       label: Search on GOV.UK
       search_button: Search
+    share_links:
+      all_opens_in_new_tab: Sharing will open the page in a new tab
+      opens_in_new_tab: "(opens in new tab)"
     show_password:
       announce_hide: Your password is hidden
       announce_show: Your password is shown

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -164,13 +164,16 @@ es-419:
         link_text: Verifique lo que debe hacer
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Ubicaciones en el mundo
     search_box:
       input_title: Buscar
       label: Buscar en GOV.UK
       search_button: Buscar
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Su contraseña está oculta
       announce_show: Se muestra su contraseña

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -164,13 +164,16 @@ es:
         link_text: Compruebe lo que necesita hacer
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Ubicaciones mundiales
     search_box:
       input_title: Buscar
       label: Buscar en GOV.UK
       search_button: Buscar
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: La contraseña está oculta
       announce_show: Se muestra su contraseña

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -167,13 +167,16 @@ et:
         link_text: Kontrollige, mida peate tegema
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Maailma asukohad
     search_box:
       input_title: Otsing
       label: Otsige saidilt GOV.UK
       search_button: Otsing
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Teie parool on peidetud
       announce_show: Teie parooli kuvatakse

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -162,13 +162,16 @@ fa:
         link_text: آنچه را باید انجام دهید، بررسی کنید
         title: برگزیت
       ukraine:
-        title:
         links:
+        title:
       world_locations: مکان‌های جهانی
     search_box:
       input_title: جستجو
       label: جستجو در GOV.UK
       search_button: جستجو
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: رمز عبور شما مخفی شده است
       announce_show: رمز عبور شما نمایش داده شده است

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -166,13 +166,16 @@ fi:
         link_text: Tarkista, mitä sinun on tehtävä
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Maailman sijainnit
     search_box:
       input_title: Hae
       label: Hae osoitteesta GOV.UK
       search_button: Hae
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Salasanasi on piilotettu
       announce_show: Salasanasi näytetään

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -164,13 +164,16 @@ fr:
         link_text: Vérifiez ce que vous devez faire
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Emplacements dans le monde
     search_box:
       input_title: Rechercher
       label: Rechercher sur GOV.UK
       search_button: Rechercher
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Votre mot de passe est masqué
       announce_show: Votre mot de passe est affiché

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -166,13 +166,16 @@ gd:
         link_text: Seiceáil cad is gá duit aird a thabhairt air
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Áit ar domhan
     search_box:
       input_title: Taighde
       label: Cuardaigh ar GOV.UK
       search_button: Taighde
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Tá do chuid focal i bhfolach
       announce_show: Taispeántar do chuid focal

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -164,13 +164,16 @@ gu:
         link_text: તમારે શું કરવું પડશે તે તપાસો
         title: બ્રેક્ઝિટ
       ukraine:
-        title:
         links:
+        title:
       world_locations: વૈશ્વિક લોકેશન્સ
     search_box:
       input_title: શોધો
       label: GOV.UK પર શોધો
       search_button: શોધો
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: તમારો પાસવર્ડ હાઈડ કરેલ છે
       announce_show: તમારો પાસવર્ડ દર્શાવ્યો છે

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -164,13 +164,16 @@ he:
         link_text: בדוק מה אתה צריך לעשות
         title: " ברקזיט"
       ukraine:
-        title:
         links:
+        title:
       world_locations: מיקומים גלובאליים
     search_box:
       input_title: 'חפש '
       label: 'חפש ב- GOV.UK '
       search_button: חפש
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: הסיסמה שלך מוסתרת
       announce_show: הסיסמה שלך מוצגת

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -164,13 +164,16 @@ hi:
         link_text: जांचें कि आपको क्या करना है
         title: ब्रेक्सिट
       ukraine:
-        title:
         links:
+        title:
       world_locations: वैश्विक स्थान
     search_box:
       input_title: खोजें
       label: GOV.UK खोजें
       search_button: खोजें
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: आपका पासवर्ड छिपा है
       announce_show: आपका पासवर्ड प्रदर्शित है

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -165,13 +165,16 @@ hr:
         link_text: Provjerite što trebate učiniti
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Svjetske lokacije
     search_box:
       input_title: Pretraga
       label: Pretražujte na GOV.UK
       search_button: Pretraga
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Vaša lozinka je skrivena
       announce_show: Vaša se lozinka prikazuje

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -167,13 +167,16 @@ hu:
         link_text: Nézze meg, hogy mit kell tennie
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Helyszínek a világban
     search_box:
       input_title: Keresés
       label: Keresés a GOV.UK-n
       search_button: Keresés
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: A jelszava rejtett
       announce_show: A jelszava látható

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -168,13 +168,16 @@ hy:
         link_text: Իմացեք, թե ինչ պետք է անեք
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Գտնվելու վայրերը
     search_box:
       input_title: Որոնում
       label: Որոնել GOV.UK կայքում
       search_button: Որոնում
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Ձեր գաղտնաբառը թաքցրած է
       announce_show: Ձեր գաղտնաբառը ցուցադրված է

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -164,13 +164,16 @@ id:
         link_text: Periksa apa yang Anda harus lakukan
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Lokasi dunia
     search_box:
       input_title: Cari
       label: Cari di GOV.UK
       search_button: Cari
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Kata sandi Anda tersembunyi
       announce_show: Kata sandi Anda tampak

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -164,13 +164,16 @@ is:
         link_text: Athugaðu hvað þú þarft að gera
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Staðsetningar úti um allan heim
     search_box:
       input_title: Leita
       label: Leita á GOV.UK
       search_button: Leita
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Lykilorðið þitt er falið
       announce_show: Lykilorðið þitt er sýnt

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -164,13 +164,16 @@ it:
         link_text: Controlla cosa devi fare
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Località del mondo
     search_box:
       input_title: Cerca
       label: Cerca su GOV.UK
       search_button: Cerca
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: La tua password è nascosta
       announce_show: La tua password è mostrata

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -160,13 +160,16 @@ ja:
         link_text: あなたがする必要があることを確認してください
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: 世界の場所
     search_box:
       input_title: 検索
       label: GOV.UKで検索
       search_button: 検索
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: パスワードは非表示です
       announce_show: パスワードが表示されています

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -167,13 +167,16 @@ ka:
         link_text: შეამოწმეთ თუ რა უნდა გააკეთოთ
         title: ბრექსითის შემოწმება
       ukraine:
-        title:
         links:
+        title:
       world_locations: მსოფლიო ლოკაციები
     search_box:
       input_title: ძიება
       label: ძიება GOV.UK-ზე
       search_button: ძიება
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: თქვენი პაროლი დაფარულია
       announce_show: თქვენი პაროლი ჩანს

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -164,13 +164,16 @@ kk:
         link_text: Не істеу керек екенін қараңыз
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Әлемдегі орындар
     search_box:
       input_title: Іздеу
       label: GOV.UK веб-сайтында іздеу
       search_button: Іздеу
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Құпиясөзіңіз жасырылған
       announce_show: Құпиясөзіңіз көрсетілген

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -159,13 +159,16 @@ ko:
         link_text:
         title:
       ukraine:
-        title:
         links:
+        title:
       world_locations:
     search_box:
       input_title:
       label:
       search_button:
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide:
       announce_show:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -169,13 +169,16 @@ lt:
         link_text: Pažiūrėkite, ką turite daryti
         title: "„Brexitas“ "
       ukraine:
-        title:
         links:
+        title:
       world_locations: Pasaulio vietos
     search_box:
       input_title: Ieškoti
       label: Ieškoti GOV.UK
       search_button: Ieškoti
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Jūsų slaptažodis paslėptas
       announce_show: Jūsų slaptažodis rodomas

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -168,13 +168,16 @@ lv:
         link_text: Noskaidrojiet, kas jums jāpaveic
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Atrašanās vietas pasaulē
     search_box:
       input_title: Meklēt
       label: Meklēt GOV.UK
       search_button: Meklēt
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Jūsu parole ir paslēpta
       announce_show: Jūsu parole ir redzama

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -163,13 +163,16 @@ ms:
         link_text: Periksa apa yang perlu anda lakukan
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Lokasi dunia
     search_box:
       input_title: Carian
       label: Carian di GOV.UK
       search_button: Carian
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Kata laluan anda disorokkan
       announce_show: Kata laluan anda ditunjukkan

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -166,13 +166,16 @@ mt:
         link_text: Iċċekkja x'għandek bżonn tagħmel
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Postijiet fid-dinja
     search_box:
       input_title: Fittex
       label: Fittex fuq GOV.UK
       search_button: Fittex
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Il-password tiegħek hija moħbija
       announce_show: Il-password tiegħek qed tidher

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -164,13 +164,16 @@ nl:
         link_text: Controleer wat u moet doen
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Locaties in de wereld
     search_box:
       input_title: Zoeken
       label: Zoeken op GOV.UK
       search_button: Zoeken
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Uw wachtwoord is verborgen
       announce_show: Uw wachtwoord wordt getoond

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -164,13 +164,16 @@
         link_text: Sjekk hva du må gjøre
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Steder i verden
     search_box:
       input_title: Søk
       label: Søk på GOV.UK
       search_button: Søk
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Passordet ditt er skjult
       announce_show: Passordet ditt vises

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -160,13 +160,16 @@ pa-pk:
         link_text: دیکھو جو تہانوں کرن دی لوڑ اے
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: دُنیا دیاں تھاواں
     search_box:
       input_title: کھوج
       label: GOV.UK اُتے کھوج کرو
       search_button: کھوج
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: تہاڈا پاس ورڈ لُکیا ہویا اے
       announce_show: تہاڈا پاس ورڈ دکھائی دِتا اے

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -164,13 +164,16 @@ pa:
         link_text: ਜਾਂਚ ਕਰੋ ਕਿ ਤੁਹਾਨੂੰ ਕੀ ਕਰਨ ਦੀ ਜ਼ਰੂਰਤ ਹੈ
         title: ਬ੍ਰੈਕਸਿਟ
       ukraine:
-        title:
         links:
+        title:
       world_locations: ਵਿਸ਼ਵ ਸਥਾਨ
     search_box:
       input_title: ਖੋਜ
       label: GOV.UK ਤੇ ਖੋਜ ਕਰੋ
       search_button: ਖੋਜ
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: ਤੁਹਾਡਾ ਪਾਸਵਰਡ ਲੁਕਿਆ ਹੋਇਆ ਹੈ
       announce_show: ਤੁਹਾਡਾ ਪਾਸਵਰਡ ਦਿਖਾਇਆ ਗਿਆ ਹੈ

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -168,13 +168,16 @@ pl:
         link_text: Sprawdź, co musisz zrobić
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Miejsca na świecie
     search_box:
       input_title: Szukaj
       label: Szukaj na GOV.UK
       search_button: Szukaj
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Twoje hasło jest ukryte
       announce_show: Twoje hasło jest wyświetlane

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -161,13 +161,16 @@ ps:
         link_text: وګورئ چې تاسو څه کولو ته اړتیا لرئ
         title: بریکسیټ
       ukraine:
-        title:
         links:
+        title:
       world_locations: د نړۍ موقعیتونه
     search_box:
       input_title: لټون
       label: په GOV.UK کې لټون وکړئ
       search_button: لټون
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: ستاسو رمز پټ دی
       announce_show: ستاسو رمز ښودل شوی

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -164,13 +164,16 @@ pt:
         link_text: Verifique o que precisa de fazer
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Locais mundiais
     search_box:
       input_title: Pesquisar
       label: Pesquisar em GOV.UK
       search_button: Pesquisar
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: A sua palavra-passe é ocultada
       announce_show: A sua palavra-passe é mostrada

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -165,13 +165,16 @@ ro:
         link_text: Verificați ce trebuie să faceți
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Locații pe glob
     search_box:
       input_title: Căutați
       label: Căutați pe GOV.UK
       search_button: Căutați
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Parola dvs. este ascunsă
       announce_show: Parola dvs. este afișată

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -168,13 +168,16 @@ ru:
         link_text: Проверьте, что вам нужно сделать
         title: Брексит
       ukraine:
-        title:
         links:
+        title:
       world_locations: Места нахождения по миру
     search_box:
       input_title: Поиск
       label: Поиск на GOV.UK
       search_button: Поиск
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Ваш пароль скрыт
       announce_show: Ваш пароль показан

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -164,13 +164,16 @@ si:
         link_text: ඔබ කළ යුතු දේ පරීක්ෂා කරන්න
         title: බ්රෙක්සිට්
       ukraine:
-        title:
         links:
+        title:
       world_locations: ලෝක ස්ථාන
     search_box:
       input_title: සොයන්න
       label: GOV.UK මත සොයන්න
       search_button: සොයන්න
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: ඔබගේ මුරපදය සඟවා ඇත
       announce_show: ඔබගේ මුරපදය පෙන්වා ඇත

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -169,13 +169,16 @@ sk:
         link_text: Skontrolujte, čo je potrebné urobiť
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Svetové lokality
     search_box:
       input_title: Vyhľadávanie
       label: Vyhľadávanie na GOV.UK
       search_button: Vyhľadávanie
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Vaše heslo je skryté
       announce_show: Vaše heslo sa zobrazuje.

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -171,13 +171,16 @@ sl:
         link_text: Preverite, kaj morate storiti
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Lokacije po svetu
     search_box:
       input_title: Iskanje
       label: Iskanje po GOV.UK
       search_button: Iskanje
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Vaše geslo je skrito
       announce_show: Vaše geslo je prikazano

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -164,13 +164,16 @@ so:
         link_text: Hubi waxaad u baahantahay inaad qabato
         title: Ka bixitaanka Ingiriiska
       ukraine:
-        title:
         links:
+        title:
       world_locations: Goobaha Dunida
     search_box:
       input_title: Baadh
       label: Baadh GOV.UK
       search_button: Baadh
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Fure sireedkaagu wuu qarsoonayhay
       announce_show: Fure sireedkaagu wuu muuqdaa

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -164,13 +164,16 @@ sq:
         link_text: Kontrolloni se çfarë duhet të bëni
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Vendndodhjet globale
     search_box:
       input_title: Kërko
       label: Kërko në GOV.UK
       search_button: Kërko
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Fjalëkalimi juaj është fshehur
       announce_show: Fjalëkalimi juaj është treguar

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -165,13 +165,16 @@ sr:
         link_text: Proverite šta treba da uradite
         title: Bregzit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Globalne lokacije
     search_box:
       input_title: Pretraži
       label: Pretraži na GOV.UK
       search_button: Pretraži
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Lozinka je sakrivena
       announce_show: Lozinka je prikazana

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -164,13 +164,16 @@ sv:
         link_text: Kontrollera vad du behöver göra
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Platser i världen
     search_box:
       input_title: Sök på
       label: Sök på GOV.UK
       search_button: Sök på
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Ditt lösenord är dolt
       announce_show: Ditt lösenord visas

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -164,13 +164,16 @@ sw:
         link_text: Angalia unachopaswa kufanya
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Maeneo ya kimataifa
     search_box:
       input_title: Tafuta
       label: Tafuta kwenye tovuti ya GOV.UK
       search_button: Tafuta
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Nenosiri lako limefichwa
       announce_show: Nenosiri lako limeonyeshwa

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -165,13 +165,16 @@ ta:
         link_text: நீங்கள் செய்யவேண்டியது என்ன என்று பாருங்கள்
         title: பிரெக்சிட்
       ukraine:
-        title:
         links:
+        title:
       world_locations: உலக இருப்பிடங்கள்
     search_box:
       input_title: தேடு
       label: GOV.UK-யில் தேடுக
       search_button: தேடு
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: உங்கள் கடவுச்சொல் மறைக்கப்பட்டுள்ளது
       announce_show: உங்கள் கடவுச்சொல் காட்டப்படுகிறது

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -162,13 +162,16 @@ th:
         link_text: ตรวจสอบสิ่งที่คุณต้องทำ
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: สถานที่ทั่วโลก
     search_box:
       input_title: ค้นหา
       label: ค้นหาใน GOV.UK
       search_button: ค้นหา
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: รหัสผ่านของคุณถูกซ่อน
       announce_show: รหัสผ่านของคุณถูกแสดง

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -165,13 +165,16 @@ tk:
         link_text: Näme etmelidigiňizi belläň
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Dünýä ýerleri
     search_box:
       input_title: Gözlemek
       label: GOV.UK-de gözle
       search_button: Gözlemek
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Açar sözüňiz gizlenen
       announce_show: Açar sözüňiz görkezilen

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -165,13 +165,16 @@ tr:
         link_text: Ne yapmaya ihtiyacınız olduğunu kontrol edin
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Dünya geneli konumlar
     search_box:
       input_title: Ara
       label: GOV.UK adresini ara
       search_button: Ara
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Şifreniz gizli
       announce_show: Şifreniz gösteriliyor

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -171,13 +171,16 @@ uk:
         link_text: Перевірте, що вам потрібно зробити
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Світові локації
     search_box:
       input_title: Пошук
       label: Пошук на GOV.UK
       search_button: Пошук
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Ваш пароль приховано
       announce_show: Ваш пароль показано

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -161,13 +161,16 @@ ur:
         link_text: پڑتال کریں کہ آپ کو کیا کرنے کی ضرورت ہے
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: عالمی مقامات
     search_box:
       input_title: تلاش
       label: GOV.UK پر تلاش کریں
       search_button: تلاش
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: آپ کا پاس ورڈ پوشیدہ ہے
       announce_show: آپ کا پاس ورڈ دکھائی دے رہا ہے

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -166,13 +166,16 @@ uz:
         link_text: Нима қилиш зарурлигини текшириш
         title: Брексит
       ukraine:
-        title:
         links:
+        title:
       world_locations: Жаҳондаги жойлашиш жойи
     search_box:
       input_title: Излаш
       label: GOV.UKда излаш
       search_button: Излаш
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Сизнинг пароль яширилган
       announce_show: Сизнинг пароль акс эттирилган

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -163,13 +163,16 @@ vi:
         link_text: Kiểm tra những gì bạn cần làm
         title: Brexit
       ukraine:
-        title:
         links:
+        title:
       world_locations: Các vị trí trên thế giới
     search_box:
       input_title: Tìm kiếm
       label: Tìm kiếm trên GOV.UK
       search_button: Tìm kiếm
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: Mật khẩu của bạn bị ẩn
       announce_show: Mật khẩu của bạn được hiển thị

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -162,13 +162,16 @@ zh-hk:
         link_text: 查看您需要做的事
         title: 英國脫歐
       ukraine:
-        title:
         links:
+        title:
       world_locations: 全世界之地點
     search_box:
       input_title: 搜尋
       label: 搜尋 GOV.UK
       search_button: 搜尋
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: 您的密碼已隱藏
       announce_show: 您的密碼已顯示

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -162,13 +162,16 @@ zh-tw:
         link_text: 確認你需要：
         title: 脫歐
       ukraine:
-        title:
         links:
+        title:
       world_locations: 世界地點
     search_box:
       input_title: 搜尋
       label: 在英國政府網站上搜尋
       search_button: 搜尋
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: 隱藏你的密碼
       announce_show: 顯示你的密碼

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -162,13 +162,16 @@ zh:
         link_text: 检查您需要做的事情
         title: 英国脱欧
       ukraine:
-        title:
         links:
+        title:
       world_locations: 世界地点
     search_box:
       input_title: 搜索
       label: 搜索GOV.UK
       search_button: 搜索
+    share_links:
+      all_opens_in_new_tab:
+      opens_in_new_tab:
     show_password:
       announce_hide: 您的密码已隐藏
       announce_show: 您的密码已显示

--- a/spec/components/share_links_spec.rb
+++ b/spec/components/share_links_spec.rb
@@ -33,7 +33,7 @@ describe "ShareLinks", type: :view do
 
   it "renders a custom title" do
     render_component(links: links, title: "Share this page")
-    assert_select ".gem-c-share-links__title", text: "Share this page"
+    assert_select ".gem-c-share-links .govuk-heading-s", text: "Share this page"
   end
 
   it "renders a share link if only one share link provided" do


### PR DESCRIPTION
## What

Include the words ‘opens in new tab’ as part of the share link

https://trello.com/c/PhMa7my6/1578-include-the-words-opens-in-new-tab-as-part-of-the-share-link

**Review URL**
- See https://components-gem-pr-3028.herokuapp.com/component-guide/share_links

## Why

- The 'Share on...' links open in a new tab without informing the user. This can be disorientating for screen reader users who may not know that the window has opened 
- Also, to follow the Design System guidance here: https://design-system.service.gov.uk/styles/typography/#opening-links-in-a-new-tab

## Visual changes

## Before (component only with "Sharing will open the page in a new tab" text)

<a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/199773690-ad01526f-8971-4441-a6e4-3d4914f092a6.png"><img src="https://user-images.githubusercontent.com/87758239/199773690-ad01526f-8971-4441-a6e4-3d4914f092a6.png" width="600" style="max-width: 100%;"></a>

## After (component only "Sharing will open the page in a new tab" text)

<a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/199773681-c8a6ef15-6c45-4512-848c-f4789e9c9b17.png"><img src="https://user-images.githubusercontent.com/87758239/199773681-c8a6ef15-6c45-4512-848c-f4789e9c9b17.png" width="600" style="max-width: 100%;"></a>

## Before (component with "Sharing..." text and title)

<a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/199773693-92d2dc23-35f4-4745-9e42-62edd91e2f76.png"><img src="https://user-images.githubusercontent.com/87758239/199773693-92d2dc23-35f4-4745-9e42-62edd91e2f76.png" width="600" style="max-width: 100%;"></a>

## After (component with "Sharing..." text and title)

<a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/199773686-ce48c111-a22c-427e-ab94-68cf8a118e91.png"><img src="https://user-images.githubusercontent.com/87758239/199773686-ce48c111-a22c-427e-ab94-68cf8a118e91.png" width="600" style="max-width: 100%;"></a>

## Before (news article page with component)

<a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/199776186-d7130707-41f6-43da-b6aa-5839838baaa9.png"><img src="https://user-images.githubusercontent.com/87758239/199776186-d7130707-41f6-43da-b6aa-5839838baaa9.png" width="800" style="max-width: 100%;"></a>

## After (news article page with component)

<a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/199776174-04eddb36-1798-49ae-8be7-59546ca411f5.png"><img src="https://user-images.githubusercontent.com/87758239/199776174-04eddb36-1798-49ae-8be7-59546ca411f5.png" width="800" style="max-width: 100%;"></a>