### PR TITLE
Delete removed `restoreScroll` Axe API option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 * Calculate viewport width correctly for navbar in Chrome and Firefox when Mac scrollbars are enabled ([PR #3016](https://github.com/alphagov/govuk_publishing_components/pull/3016))
 * Include the words 'opens in new tab' as part of the share link ([PR #3028](https://github.com/alphagov/govuk_publishing_components/pull/3028)) 
+* Delete removed `restoreScroll` Axe API option ([PR #3029](https://github.com/alphagov/govuk_publishing_components/pull/3029))
 
 ## 32.0.0
 

--- a/app/assets/javascripts/component_guide/accessibility-test.js
+++ b/app/assets/javascripts/component_guide/accessibility-test.js
@@ -24,7 +24,6 @@
     })
 
     var axeOptions = {
-      restoreScroll: true,
       include: [selector],
       rules: axeRules
     }

--- a/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
+++ b/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js
@@ -84,22 +84,6 @@ describe('AccessibilityTest', function () {
     })
   })
 
-  it('should not scroll the page', function (done) {
-    var bigElement = '<div style="height: 1000px; width: 100px;"></div>'
-
-    addToDom(
-      bigElement + '<a href="#">Low contrast</a>' + bigElement,
-      'a { background: white; color: #ddd }'
-    )
-
-    expect(window.scrollY).toBe(0, 'should start at top of the page')
-
-    AccessibilityTest(TEST_SELECTOR, function () {
-      expect(window.scrollY).toBe(0, 'should end at top of the page')
-      done()
-    })
-  })
-
   it('should throw if there\'s a contrast issue', function (done) {
     addToDom('<a href="#">Low contrast</a>', 'a { background: white; color: #ddd }')
 


### PR DESCRIPTION
## What

Delete removed `restoreScroll` Axe API option.

## Why

The option has been removed. See https://github.com/dequelabs/axe-core/issues/2388.