### PR TITLE
Add GA4 analytics tracking to remaining feedback component buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Track clicks on links with child elements ([PR #3042](https://github.com/alphagov/govuk_publishing_components/pull/3042))
 * Fix issue with blue action link arrow svg ([PR #3039](https://github.com/alphagov/govuk_publishing_components/pull/3039))
 * **BREAKING:** Fix referrer bug ([PR #3032](https://github.com/alphagov/govuk_publishing_components/pull/3032))
+* Add GA4 analytics tracking to remaining feedback component buttons ([PR #3036](https://github.com/alphagov/govuk_publishing_components/pull/3036))
 
 ## 31.2.0
 

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -39,25 +39,32 @@
       } %>
 
       <%= render "govuk_publishing_components/components/button", {
-        text: t("components.feedback.send")
+        text: t("components.feedback.send"),
+        data_attributes: {
+          ga4: {
+            event_name: "form_submit",
+            type: "feedback",
+            text: "Send",
+            section: "Help us improve GOV.UK",
+          }
+        }
       } %>
 
-    <button
-      class="govuk-button govuk-button--secondary gem-c-feedback__close gem-c-feedback__js-show js-close-form"
-      data-track-category="Onsite Feedback"
-      data-track-action="GOV.UK Close Form"
-      aria-controls="something-is-wrong"
-      aria-expanded="true">
-      <%= t("components.feedback.close") %>
-    </button>
-
+      <button
+        class="govuk-button govuk-button--secondary gem-c-feedback__close gem-c-feedback__js-show js-close-form"
+        data-track-category="Onsite Feedback"
+        data-track-action="GOV.UK Close Form"
+        aria-controls="something-is-wrong"
+        aria-expanded="true">
+        <%= t("components.feedback.close") %>
+      </button>
     </div>
   </div>
 </form>
 
 <%
-  # I've added the following script inline in case of a scenario where a bot is able to parse the page, 
-  # without downloading any of the external scripts. 
+  # I've added the following script inline in case of a scenario where a bot is able to parse the page,
+  # without downloading any of the external scripts.
   # This seems to be a more reliable way to make sure the script is executed.
 %>
 

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -25,8 +25,16 @@
         describedby: "survey_explanation"
       } %>
 
-       <%= render "govuk_publishing_components/components/button", {
+      <%= render "govuk_publishing_components/components/button", {
         text: t("components.feedback.send_me_survey"),
+        data_attributes: {
+          ga4: {
+            event_name: "form_submit",
+            type: "feedback",
+            text: "Send me the survey",
+            section: "Help us improve GOV.UK",
+          }
+        }
       } %>
 
       <button
@@ -38,7 +46,7 @@
         hidden>
         <%= t("components.feedback.close") %>
       </button>
-      
+
     </div>
   </div>
 </form>

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -39,10 +39,9 @@
     </div>
 
     <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions" hidden>
-      <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV-UK Open Form" aria-controls="something-is-wrong" aria-expanded="false">
+      <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV-UK Open Form" aria-controls="something-is-wrong" aria-expanded="false" data-ga4='{"event_name":"form_submit","type":"feedback","text":"Report a problem with this page", "section": "Is this page useful?"}'>
         <%= t("components.feedback.something_wrong") %>
       </button>
     </div>
-    
   </div>
 </div>


### PR DESCRIPTION
## What
Adds GA4/GTM tracking to the remaining buttons in the feedback component.

## Why
Part of the GA4 migration work.

## Visual Changes
None.

Trello card: https://trello.com/c/EmWLC6DE/379-add-tracking-feedback-remaining-elements
