### PR TITLE
Change "+" to "Show" in related navigation and metadata block components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Support Rails Content Security Policy nonce on inline JavaScript ([PR #3173](https://github.com/alphagov/govuk_publishing_components/pull/3173))
 * Restyle subscription link ([PR #3177](https://github.com/alphagov/govuk_publishing_components/pull/3177))
+* Change "+" to "Show" in related navigation and metadata block components ([PR #3038](https://github.com/alphagov/govuk_publishing_components/pull/3038))
 
 ## 34.2.0
 

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -12,8 +12,8 @@
   accordion_classes << (shared_helper.get_margin_bottom)
 
   translations = {
-    show_text: "components.accordion.show",
-    hide_text: "components.accordion.hide",
+    show_text: "common.show",
+    hide_text: "common.hide",
     show_all_text: "components.accordion.show_all",
     hide_all_text: "components.accordion.hide_all",
     this_section_visually_hidden: "components.accordion.this_section_visually_hidden",

--- a/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
+++ b/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
@@ -14,7 +14,9 @@
        data-controls="toggle-<%= toggle_id %>"
        data-expanded="false"
        data-toggled-text="<%= t("components.metadata.toggle_less") %>">
-        <%= t("components.metadata.toggle_more", number: remaining.length) %>
+        <%= t("components.metadata.toggle_more",
+          show: t('components.accordion.show'),
+          number: remaining.length) %>
     </a>
   </div>
   <span id="toggle-<%= toggle_id %>" class="gem-c-metadata__toggle-items js-hidden"><%= remaining.to_sentence.html_safe %></span>

--- a/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
+++ b/app/views/govuk_publishing_components/components/metadata/_sentence.html.erb
@@ -13,9 +13,9 @@
        class="gem-c-metadata__definition-link govuk-!-display-none-print"
        data-controls="toggle-<%= toggle_id %>"
        data-expanded="false"
-       data-toggled-text="<%= t("components.metadata.toggle_less") %>">
-        <%= t("components.metadata.toggle_more",
-          show: t('components.accordion.show'),
+       data-toggled-text="<%= t("common.toggle_less") %>">
+        <%= t("common.toggle_more",
+          show: t('common.show'),
           number: remaining.length) %>
     </a>
   </div>

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -54,9 +54,9 @@
           class="gem-c-related-navigation__toggle"
           data-controls="toggle_<%= section_title %>"
           data-expanded="false"
-          data-toggled-text="<%= t("components.metadata.toggle_less") %>">
-          <%= t("components.metadata.toggle_more",
-            show: t('components.accordion.show'),
+          data-toggled-text="<%= t("common.toggle_less") %>">
+          <%= t("common.toggle_more",
+            show: t('common.show'),
             number: related_nav_helper.remaining_link_count(links)) %>
         </a>
       </li>

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -56,8 +56,8 @@
           data-expanded="false"
           data-toggled-text="<%= t("components.metadata.toggle_less") %>">
           <%= t("components.metadata.toggle_more",
-                number: related_nav_helper.remaining_link_count(links),
-                default: "+ #{related_nav_helper.remaining_link_count(links)} more") %>
+            show: t('components.accordion.show'),
+            number: related_nav_helper.remaining_link_count(links)) %>
         </a>
       </li>
 

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1,12 +1,14 @@
 ---
 ar:
   common:
+    hide: إخفاء
+    show: إظهار
+    toggle_less: عرض أقل
+    toggle_more: زيادة بمقدار %{show} %{number}
     translations: الترجمات
   components:
     accordion:
-      hide: إخفاء
       hide_all: إخفاء كل الأقسام
-      show: إظهار
       show_all: إظهار كل الأقسام
       this_section_visually_hidden: " هذا القسم"
     article_schema:
@@ -129,8 +131,6 @@ ar:
       part_of: جزء من
       published: منشورة
       see_all_updates: اطلع على كل التحديثات
-      toggle_less: عرض أقل
-      toggle_more: زيادة بمقدار %{show} %{number}
     modal_dialogue:
       close_modal: إغلاق مربع الحوار المشروط
     notice:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -130,7 +130,7 @@ ar:
       published: منشورة
       see_all_updates: اطلع على كل التحديثات
       toggle_less: عرض أقل
-      toggle_more: زيادة بمقدار + %{number}
+      toggle_more: زيادة بمقدار %{show} %{number}
     modal_dialogue:
       close_modal: إغلاق مربع الحوار المشروط
     notice:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -127,7 +127,7 @@ az:
       published: Dərc edilib
       see_all_updates: Bütün yeniləmələrə baxın
       toggle_less: Daha azını göstər
-      toggle_more: "+ %{number} daha çox"
+      toggle_more: "%{show} %{number} daha çox"
     modal_dialogue:
       close_modal: Modal dialoqu bağla
     notice:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -1,12 +1,14 @@
 ---
 az:
   common:
+    hide: Gizlət
+    show: Göstər
+    toggle_less: Daha azını göstər
+    toggle_more: "%{show} %{number} daha çox"
     translations: Tərcümələr
   components:
     accordion:
-      hide: Gizlət
       hide_all: Bütün bölmələri gizlət
-      show: Göstər
       show_all: Bütün bölmələri göstər
       this_section_visually_hidden: " bu bölmə"
     article_schema:
@@ -126,8 +128,6 @@ az:
       part_of: Hissə
       published: Dərc edilib
       see_all_updates: Bütün yeniləmələrə baxın
-      toggle_less: Daha azını göstər
-      toggle_more: "%{show} %{number} daha çox"
     modal_dialogue:
       close_modal: Modal dialoqu bağla
     notice:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -133,7 +133,7 @@ be:
       published: Апублікаваны
       see_all_updates: Паглядзець усе абнаўленні
       toggle_less: Паказаць меньш
-      toggle_more: "+ %{number} болей"
+      toggle_more: "%{show} %{number} болей"
     modal_dialogue:
       close_modal: Зачыніць мадальны дыялог
     notice:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -1,12 +1,14 @@
 ---
 be:
   common:
+    hide: Схаваць
+    show: Паказаць
+    toggle_less: Паказаць меньш
+    toggle_more: "%{show} %{number} болей"
     translations: Пераклады
   components:
     accordion:
-      hide: Схаваць
       hide_all: Схаваць усе секцыi
-      show: Паказаць
       show_all: Паказаць усе секцыi
       this_section_visually_hidden: " гэта секцыя"
     article_schema:
@@ -132,8 +134,6 @@ be:
       part_of: Частка
       published: Апублікаваны
       see_all_updates: Паглядзець усе абнаўленні
-      toggle_less: Паказаць меньш
-      toggle_more: "%{show} %{number} болей"
     modal_dialogue:
       close_modal: Зачыніць мадальны дыялог
     notice:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -131,7 +131,7 @@ bg:
       published: Публикуван
       see_all_updates: Вижте всички актуализации
       toggle_less: Показване на по-малко
-      toggle_more: "+ %{number} повече"
+      toggle_more: "%{show} %{number} повече"
     modal_dialogue:
       close_modal: Затваряне на модалния диалог
     notice:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -1,12 +1,14 @@
 ---
 bg:
   common:
+    hide: Скриване
+    show: Показване
+    toggle_less: Показване на по-малко
+    toggle_more: "%{show} %{number} повече"
     translations: Translations
   components:
     accordion:
-      hide: Скриване
       hide_all: Скриване на всички раздели
-      show: Показване
       show_all: Показване на всички раздели
       this_section_visually_hidden: " този раздел"
     article_schema:
@@ -130,8 +132,6 @@ bg:
       part_of: Част от
       published: Публикуван
       see_all_updates: Вижте всички актуализации
-      toggle_less: Показване на по-малко
-      toggle_more: "%{show} %{number} повече"
     modal_dialogue:
       close_modal: Затваряне на модалния диалог
     notice:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -128,7 +128,7 @@ bn:
       published: প্রকাশিত হয়েছে
       see_all_updates: সকল আপডেট দেখুন
       toggle_less: অল্প দেখান
-      toggle_more: আরও + %{number}
+      toggle_more: আরও %{show} %{number}
     modal_dialogue:
       close_modal: ক্লোজ মোডাল ডায়ালগ
     notice:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -1,12 +1,14 @@
 ---
 bn:
   common:
+    hide: লুকিয়ে রাখুন
+    show: দেখান
+    toggle_less: অল্প দেখান
+    toggle_more: আরও %{show} %{number}
     translations: অনুবাদসমূহ
   components:
     accordion:
-      hide: লুকিয়ে রাখুন
       hide_all: সকল অংশ লুকিয়ে রাখুন
-      show: দেখান
       show_all: সকল অংশ দেখান
       this_section_visually_hidden: " এই অংশ"
     article_schema:
@@ -127,8 +129,6 @@ bn:
       part_of: এর অংশ
       published: প্রকাশিত হয়েছে
       see_all_updates: সকল আপডেট দেখুন
-      toggle_less: অল্প দেখান
-      toggle_more: আরও %{show} %{number}
     modal_dialogue:
       close_modal: ক্লোজ মোডাল ডায়ালগ
     notice:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -132,7 +132,7 @@ cs:
       published: Zveřejněno
       see_all_updates: Vidět všechny aktualizace
       toggle_less: Zobrazit méně
-      toggle_more: "+ %{number} více"
+      toggle_more: "%{show} %{number} více"
     modal_dialogue:
       close_modal: Zavření modálního dialogu
     notice:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,12 +1,14 @@
 ---
 cs:
   common:
+    hide: Skrýt
+    show: Zobrazit
+    toggle_less: Zobrazit méně
+    toggle_more: "%{show} %{number} více"
     translations: Překlady
   components:
     accordion:
-      hide: Skrýt
       hide_all: Skrýt všechny sekce
-      show: Zobrazit
       show_all: Zobrazit všechny sekce
       this_section_visually_hidden: " tento oddíl"
     article_schema:
@@ -131,8 +133,6 @@ cs:
       part_of: Část
       published: Zveřejněno
       see_all_updates: Vidět všechny aktualizace
-      toggle_less: Zobrazit méně
-      toggle_more: "%{show} %{number} více"
     modal_dialogue:
       close_modal: Zavření modálního dialogu
     notice:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -131,7 +131,7 @@ cy:
       published: Cyhoeddwyd
       see_all_updates: Gweld pob diweddariad
       toggle_less: Dangos llai
-      toggle_more: "+ %{number} arall"
+      toggle_more: "%{show} %{number} arall"
     modal_dialogue:
       close_modal: Cau'r ddeialog foddol
     notice:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1,12 +1,14 @@
 ---
 cy:
   common:
+    hide: Cuddio
+    show: Dangos
+    toggle_less: Dangos llai
+    toggle_more: "%{show} %{number} arall"
     translations: Cyfieithiadau
   components:
     accordion:
-      hide: Cuddio
       hide_all: Cuddio pob adran
-      show: Dangos
       show_all: Dangos pob adran
       this_section_visually_hidden: " yr adran hon"
     article_schema:
@@ -130,8 +132,6 @@ cy:
       part_of: Rhan o
       published: Cyhoeddwyd
       see_all_updates: Gweld pob diweddariad
-      toggle_less: Dangos llai
-      toggle_more: "%{show} %{number} arall"
     modal_dialogue:
       close_modal: Cau'r ddeialog foddol
     notice:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -128,7 +128,7 @@ da:
       published: offentliggjort
       see_all_updates: se alle opdateringer
       toggle_less: Vis færre
-      toggle_more: "+ %{number} mere"
+      toggle_more: "%{show} %{number} mere"
     modal_dialogue:
       close_modal: Luk den modale dialog
     notice:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -1,12 +1,14 @@
 ---
 da:
   common:
+    hide: Skjul
+    show: vise
+    toggle_less: Vis færre
+    toggle_more: "%{show} %{number} mere"
     translations: Oversættelser
   components:
     accordion:
-      hide: Skjul
       hide_all: Skjul alle sektioner
-      show: vise
       show_all: Vise alle sektioner
       this_section_visually_hidden: " denne sektion"
     article_schema:
@@ -127,8 +129,6 @@ da:
       part_of: del af
       published: offentliggjort
       see_all_updates: se alle opdateringer
-      toggle_less: Vis færre
-      toggle_more: "%{show} %{number} mere"
     modal_dialogue:
       close_modal: Luk den modale dialog
     notice:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -131,7 +131,7 @@ de:
       published: Veröffentlicht
       see_all_updates: Alle Aktualisierungen ansehen
       toggle_less: Weniger anzeigen
-      toggle_more: "+ %{number} weitere"
+      toggle_more: "%{show} %{number} weitere"
     modal_dialogue:
       close_modal: Dialog schließen
     notice:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,12 +1,14 @@
 ---
 de:
   common:
+    hide: Ausblenden
+    show: Anzeigen
+    toggle_less: Weniger anzeigen
+    toggle_more: "%{show} %{number} weitere"
     translations: Übersetzungen
   components:
     accordion:
-      hide: Ausblenden
       hide_all: Alle Rubriken ausblenden
-      show: Anzeigen
       show_all: Alle Rubriken anzeigen
       this_section_visually_hidden: " diese Rubrik"
     article_schema:
@@ -130,8 +132,6 @@ de:
       part_of: Teil von
       published: Veröffentlicht
       see_all_updates: Alle Aktualisierungen ansehen
-      toggle_less: Weniger anzeigen
-      toggle_more: "%{show} %{number} weitere"
     modal_dialogue:
       close_modal: Dialog schließen
     notice:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -1,12 +1,14 @@
 ---
 dr:
   common:
+    hide: مخفی کردن
+    show: نمایش دادن
+    toggle_less: کمتر نمایش دهید
+    toggle_more: "%{show} %{number} بیشتر"
     translations: ترجمه ها
   components:
     accordion:
-      hide: مخفی کردن
       hide_all: مخفی کردن همه بخش ها
-      show: نمایش دادن
       show_all: نمایش دادن همه بخش ها
       this_section_visually_hidden: " این بخش"
     article_schema:
@@ -128,8 +130,6 @@ dr:
       part_of: بخشی از
       published: منتشر شده است
       see_all_updates: تمام آپدیت ها را مشاهده نمایید
-      toggle_less: کمتر نمایش دهید
-      toggle_more: "%{show} %{number} بیشتر"
     modal_dialogue:
       close_modal: دیالوگ کیفی را بسته نمایید
     notice:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -129,7 +129,7 @@ dr:
       published: منتشر شده است
       see_all_updates: تمام آپدیت ها را مشاهده نمایید
       toggle_less: کمتر نمایش دهید
-      toggle_more: "+ %{number} بیشتر"
+      toggle_more: "%{show} %{number} بیشتر"
     modal_dialogue:
       close_modal: دیالوگ کیفی را بسته نمایید
     notice:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -1,12 +1,14 @@
 ---
 el:
   common:
+    hide: Απόκρυψη
+    show: Εμφάνιση
+    toggle_less: Εμφάνιση λιγότερων
+    toggle_more: "%{show} %{number} ακόμη"
     translations: Μεταφράσεις
   components:
     accordion:
-      hide: Απόκρυψη
       hide_all: Απόκρυψη όλων των ενοτήτων
-      show: Εμφάνιση
       show_all: Εμφάνιση όλων των ενοτήτων
       this_section_visually_hidden: " αυτή η ενότητα"
     article_schema:
@@ -126,8 +128,6 @@ el:
       part_of: Μέρος του
       published: Δημοσιεύθηκε
       see_all_updates: Δείτε όλες τις ενημερώσεις
-      toggle_less: Εμφάνιση λιγότερων
-      toggle_more: "%{show} %{number} ακόμη"
     modal_dialogue:
       close_modal: Κλείσιμο παράθυρου διαλόγου
     notice:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -127,7 +127,7 @@ el:
       published: Δημοσιεύθηκε
       see_all_updates: Δείτε όλες τις ενημερώσεις
       toggle_less: Εμφάνιση λιγότερων
-      toggle_more: "+ %{number} ακόμη"
+      toggle_more: "%{show} %{number} ακόμη"
     modal_dialogue:
       close_modal: Κλείσιμο παράθυρου διαλόγου
     notice:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,7 +248,7 @@ en:
       published: Published
       see_all_updates: See all updates
       toggle_less: Show fewer
-      toggle_more: "+ %{number} more"
+      toggle_more: "%{show} %{number} more"
     modal_dialogue:
       close_modal: Close modal dialogue
     notice:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,12 +1,14 @@
 ---
 en:
   common:
+    hide: Hide
+    show: Show
+    toggle_less: Show fewer
+    toggle_more: "%{show} %{number} more"
     translations: Translations
   components:
     accordion:
-      hide: Hide
       hide_all: Hide all sections
-      show: Show
       show_all: Show all sections
       this_section_visually_hidden: " this section"
     article_schema:
@@ -247,8 +249,6 @@ en:
       part_of: Part of
       published: Published
       see_all_updates: See all updates
-      toggle_less: Show fewer
-      toggle_more: "%{show} %{number} more"
     modal_dialogue:
       close_modal: Close modal dialogue
     notice:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -127,7 +127,7 @@ es-419:
       published: Publicado
       see_all_updates: Ver todas las novedades
       toggle_less: Mostrar menos
-      toggle_more: "+ %{number} más"
+      toggle_more: "%{show} %{number} más"
     modal_dialogue:
       close_modal: Cerrar diálogo modal
     notice:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -1,12 +1,14 @@
 ---
 es-419:
   common:
+    hide: Ocultar
+    show: Mostrar
+    toggle_less: Mostrar menos
+    toggle_more: "%{show} %{number} más"
     translations: Traducciones
   components:
     accordion:
-      hide: Ocultar
       hide_all: Ocultar todas las secciones
-      show: Mostrar
       show_all: Mostrar todas las secciones
       this_section_visually_hidden: esta sección
     article_schema:
@@ -126,8 +128,6 @@ es-419:
       part_of: Parte de
       published: Publicado
       see_all_updates: Ver todas las novedades
-      toggle_less: Mostrar menos
-      toggle_more: "%{show} %{number} más"
     modal_dialogue:
       close_modal: Cerrar diálogo modal
     notice:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -127,7 +127,7 @@ es:
       published: Publicado
       see_all_updates: Ver todas las actualizaciones
       toggle_less: Mostrar menos
-      toggle_more: "+ %{number} más"
+      toggle_more: "%{show} %{number} más"
     modal_dialogue:
       close_modal: Cierre el cuadro de diálogo modal
     notice:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,12 +1,14 @@
 ---
 es:
   common:
+    hide: Ocultar
+    show: Mostrar
+    toggle_less: Mostrar menos
+    toggle_more: "%{show} %{number} más"
     translations: Traducciones
   components:
     accordion:
-      hide: Ocultar
       hide_all: Ocultar todas las secciones
-      show: Mostrar
       show_all: Mostrar todas las secciones
       this_section_visually_hidden: " esta sección"
     article_schema:
@@ -126,8 +128,6 @@ es:
       part_of: Parte de
       published: Publicado
       see_all_updates: Ver todas las actualizaciones
-      toggle_less: Mostrar menos
-      toggle_more: "%{show} %{number} más"
     modal_dialogue:
       close_modal: Cierre el cuadro de diálogo modal
     notice:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -130,7 +130,7 @@ et:
       published: Avaldatud
       see_all_updates: Vt kõiki värskendusi
       toggle_less: Kuva vähem
-      toggle_more: "+ %{number} veel"
+      toggle_more: "%{show} %{number} veel"
     modal_dialogue:
       close_modal: Sule modaalne dialoog
     notice:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -1,12 +1,14 @@
 ---
 et:
   common:
+    hide: Peida
+    show: Kuva
+    toggle_less: Kuva vähem
+    toggle_more: "%{show} %{number} veel"
     translations: Tõlked
   components:
     accordion:
-      hide: Peida
       hide_all: Peida kõik jaotised
-      show: Kuva
       show_all: Kuva kõik jaotised
       this_section_visually_hidden: " see jaotis"
     article_schema:
@@ -129,8 +131,6 @@ et:
       part_of: Osa
       published: Avaldatud
       see_all_updates: Vt kõiki värskendusi
-      toggle_less: Kuva vähem
-      toggle_more: "%{show} %{number} veel"
     modal_dialogue:
       close_modal: Sule modaalne dialoog
     notice:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -1,12 +1,14 @@
 ---
 fa:
   common:
+    hide: مخفی کردن
+    show: نمایش
+    toggle_less: نمایش کمتر
+    toggle_more: "%{show} %{number} بیشتر"
     translations: ترجمه
   components:
     accordion:
-      hide: مخفی کردن
       hide_all: مخفی کردن تمام بخش‌ها
-      show: نمایش
       show_all: نمایش تمام بخش‌ها
       this_section_visually_hidden: " این بخش"
     article_schema:
@@ -125,8 +127,6 @@ fa:
       part_of: بخشی از
       published: منتشر شده
       see_all_updates: مشاهده تمام بروزرسانی‌ها
-      toggle_less: نمایش کمتر
-      toggle_more: "%{show} %{number} بیشتر"
     modal_dialogue:
       close_modal: بستن گفتگوی مودال
     notice:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -126,7 +126,7 @@ fa:
       published: منتشر شده
       see_all_updates: مشاهده تمام بروزرسانی‌ها
       toggle_less: نمایش کمتر
-      toggle_more: "+ %{number} بیشتر"
+      toggle_more: "%{show} %{number} بیشتر"
     modal_dialogue:
       close_modal: بستن گفتگوی مودال
     notice:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1,12 +1,14 @@
 ---
 fi:
   common:
+    hide: Piilottaa
+    show: Näytä
+    toggle_less: Näytä vähemmän
+    toggle_more: "%{show} %{number} lisää"
     translations: Käännökset
   components:
     accordion:
-      hide: Piilottaa
       hide_all: Piilota kaikki osiot
-      show: Näytä
       show_all: Näytä kaikki osiot
       this_section_visually_hidden: " Tämä jakso"
     article_schema:
@@ -128,8 +130,6 @@ fi:
       part_of: Osa
       published: Julkaistu
       see_all_updates: Katso kaikki palvelut
-      toggle_less: Näytä vähemmän
-      toggle_more: "%{show} %{number} lisää"
     modal_dialogue:
       close_modal: Sulje modaalinen vuoropuhelu
     notice:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -129,7 +129,7 @@ fi:
       published: Julkaistu
       see_all_updates: Katso kaikki palvelut
       toggle_less: Näytä vähemmän
-      toggle_more: "+ %{number} lisää"
+      toggle_more: "%{show} %{number} lisää"
     modal_dialogue:
       close_modal: Sulje modaalinen vuoropuhelu
     notice:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,12 +1,14 @@
 ---
 fr:
   common:
+    hide: Masquer
+    show: Afficher
+    toggle_less: Afficher moins
+    toggle_more: "%{show} %{number} plus"
     translations: Traductions
   components:
     accordion:
-      hide: Masquer
       hide_all: Masquer toutes les sections
-      show: Afficher
       show_all: Afficher toutes les sections
       this_section_visually_hidden: " cette section"
     article_schema:
@@ -126,8 +128,6 @@ fr:
       part_of: Fait partie de
       published: Publié
       see_all_updates: Afficher toutes les mises à jour
-      toggle_less: Afficher moins
-      toggle_more: "%{show} %{number} plus"
     modal_dialogue:
       close_modal: Fermer le dialogue modal
     notice:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -127,7 +127,7 @@ fr:
       published: Publié
       see_all_updates: Afficher toutes les mises à jour
       toggle_less: Afficher moins
-      toggle_more: "+ %{number} plus"
+      toggle_more: "%{show} %{number} plus"
     modal_dialogue:
       close_modal: Fermer le dialogue modal
     notice:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -1,12 +1,14 @@
 ---
 gd:
   common:
+    hide: Cheilt
+    show: Taispeántas
+    toggle_less: Taispeáin níos lú
+    toggle_more: "%{show} %{number} níos mó"
     translations: Aistriúchán
   components:
     accordion:
-      hide: Cheilt
       hide_all: Scrios gach cuid
-      show: Taispeántas
       show_all: Taispeáin gach cuid
       this_section_visually_hidden: " An chuid seo"
     article_schema:
@@ -128,8 +130,6 @@ gd:
       part_of: Chuid
       published: Arna chur suas
       see_all_updates: Féach gach nuashonrú
-      toggle_less: Taispeáin níos lú
-      toggle_more: "%{show} %{number} níos mó"
     modal_dialogue:
       close_modal: Dún an dialóg módúil
     notice:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -129,7 +129,7 @@ gd:
       published: Arna chur suas
       see_all_updates: Féach gach nuashonrú
       toggle_less: Taispeáin níos lú
-      toggle_more: " + %{number} níos mó"
+      toggle_more: "%{show} %{number} níos mó"
     modal_dialogue:
       close_modal: Dún an dialóg módúil
     notice:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -127,7 +127,7 @@ gu:
       published: પ્રકાશિત
       see_all_updates: તમામ અપડેટ્સ જુઓ
       toggle_less: થોડા ઓછા દર્શાવો
-      toggle_more: "+ %{number} વધુ"
+      toggle_more: "%{show} %{number} વધુ"
     modal_dialogue:
       close_modal: મોડલ ડાયલોગ બંધ કરો
     notice:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -1,12 +1,14 @@
 ---
 gu:
   common:
+    hide: હાઇડ કરો
+    show: દર્શાવો
+    toggle_less: થોડા ઓછા દર્શાવો
+    toggle_more: "%{show} %{number} વધુ"
     translations: અનુવાદ
   components:
     accordion:
-      hide: હાઇડ કરો
       hide_all: તમામ સેક્શન હાઈડ કરો
-      show: દર્શાવો
       show_all: તમામ સેક્શન દર્શાવો
       this_section_visually_hidden: " આ સેક્શન"
     article_schema:
@@ -126,8 +128,6 @@ gu:
       part_of: નો ભાગ
       published: પ્રકાશિત
       see_all_updates: તમામ અપડેટ્સ જુઓ
-      toggle_less: થોડા ઓછા દર્શાવો
-      toggle_more: "%{show} %{number} વધુ"
     modal_dialogue:
       close_modal: મોડલ ડાયલોગ બંધ કરો
     notice:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -127,7 +127,7 @@ he:
       published: פורסם
       see_all_updates: ראה כל העדכונים
       toggle_less: הצג פחות
-      toggle_more: " + %{number} עוד"
+      toggle_more: "%{show} %{number} עוד"
     modal_dialogue:
       close_modal: סגור דיאלוג מודאלי
     notice:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1,12 +1,14 @@
 ---
 he:
   common:
+    hide: הסתר
+    show: הצג
+    toggle_less: הצג פחות
+    toggle_more: "%{show} %{number} עוד"
     translations: תרגומים
   components:
     accordion:
-      hide: הסתר
       hide_all: הסתר כל המקטעים
-      show: הצג
       show_all: הצג כל המקטעים
       this_section_visually_hidden: מקטע זה
     article_schema:
@@ -126,8 +128,6 @@ he:
       part_of: חלק של
       published: פורסם
       see_all_updates: ראה כל העדכונים
-      toggle_less: הצג פחות
-      toggle_more: "%{show} %{number} עוד"
     modal_dialogue:
       close_modal: סגור דיאלוג מודאלי
     notice:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -127,7 +127,7 @@ hi:
       published: प्रकाशित
       see_all_updates: सभी अपडेट देखें
       toggle_less: कम दिखाएं
-      toggle_more: "+ %{number} और"
+      toggle_more: "%{show} %{number} और"
     modal_dialogue:
       close_modal: मॉडल संवाद बंद करें
     notice:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -1,12 +1,14 @@
 ---
 hi:
   common:
+    hide: छिपाएं
+    show: दिखाएं
+    toggle_less: कम दिखाएं
+    toggle_more: "%{show} %{number} और"
     translations: अनुवादन
   components:
     accordion:
-      hide: छिपाएं
       hide_all: सभी अनुभाग छुपाएं
-      show: दिखाएं
       show_all: सभी अनुभाग दिखाएं
       this_section_visually_hidden: " यह अनुभाग"
     article_schema:
@@ -126,8 +128,6 @@ hi:
       part_of: का भाग
       published: प्रकाशित
       see_all_updates: सभी अपडेट देखें
-      toggle_less: कम दिखाएं
-      toggle_more: "%{show} %{number} और"
     modal_dialogue:
       close_modal: मॉडल संवाद बंद करें
     notice:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -1,12 +1,14 @@
 ---
 hr:
   common:
+    hide: Sakrij
+    show: Prikaži
+    toggle_less: Pokaži manje
+    toggle_more: "%{show} %{number} more"
     translations: Prijevodi
   components:
     accordion:
-      hide: Sakrij
       hide_all: Sakrij sve odjeljke
-      show: Prikaži
       show_all: Prikaži sve odjeljke
       this_section_visually_hidden: " ovaj odjeljak"
     article_schema:
@@ -127,8 +129,6 @@ hr:
       part_of: Dio
       published: Objavljeno
       see_all_updates: Pogledajte sva ažuriranja
-      toggle_less: Pokaži manje
-      toggle_more: "%{show} %{number} more"
     modal_dialogue:
       close_modal: Zatvorite modalni dijalog
     notice:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -128,7 +128,7 @@ hr:
       published: Objavljeno
       see_all_updates: Pogledajte sva ažuriranja
       toggle_less: Pokaži manje
-      toggle_more: "+ %{number} more"
+      toggle_more: "%{show} %{number} more"
     modal_dialogue:
       close_modal: Zatvorite modalni dijalog
     notice:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -130,7 +130,7 @@ hu:
       published: Közzététel időpontja
       see_all_updates: Minden frissítés megtekintése
       toggle_less: Kevesebb mutatása
-      toggle_more: " + %{number} több"
+      toggle_more: "%{show} %{number} több"
     modal_dialogue:
       close_modal: Modális párbeszédpanel bezárása
     notice:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -1,12 +1,14 @@
 ---
 hu:
   common:
+    hide: Elrejtés
+    show: Megmutatás
+    toggle_less: Kevesebb mutatása
+    toggle_more: "%{show} %{number} több"
     translations: Fordítások
   components:
     accordion:
-      hide: Elrejtés
       hide_all: Minden szekció elrejtése
-      show: Megmutatás
       show_all: Minden szekció megmutatása
       this_section_visually_hidden: " a jelen szekció"
     article_schema:
@@ -129,8 +131,6 @@ hu:
       part_of: 'Része a következőnek:'
       published: Közzététel időpontja
       see_all_updates: Minden frissítés megtekintése
-      toggle_less: Kevesebb mutatása
-      toggle_more: "%{show} %{number} több"
     modal_dialogue:
       close_modal: Modális párbeszédpanel bezárása
     notice:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -131,7 +131,7 @@ hy:
       published: Հրապարակված
       see_all_updates: Դիտել բոլոր թարմացումները
       toggle_less: Ցույց տալ ավելի քիչ
-      toggle_more: "+ %{number} հատ ավել"
+      toggle_more: "%{show} %{number} հատ ավել"
     modal_dialogue:
       close_modal: Փակել մոդալ պատուհանը
     notice:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -1,12 +1,14 @@
 ---
 hy:
   common:
+    hide: Թաքցնել
+    show: Ցուցադրել
+    toggle_less: Ցույց տալ ավելի քիչ
+    toggle_more: "%{show} %{number} հատ ավել"
     translations: Թարգմանություններ
   components:
     accordion:
-      hide: Թաքցնել
       hide_all: Թաքցնել բոլոր բաժինները
-      show: Ցուցադրել
       show_all: Ցուցադրել բոլոր բաժինները
       this_section_visually_hidden: " այս բաժինը"
     article_schema:
@@ -130,8 +132,6 @@ hy:
       part_of: Մաս է՝
       published: Հրապարակված
       see_all_updates: Դիտել բոլոր թարմացումները
-      toggle_less: Ցույց տալ ավելի քիչ
-      toggle_more: "%{show} %{number} հատ ավել"
     modal_dialogue:
       close_modal: Փակել մոդալ պատուհանը
     notice:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1,12 +1,14 @@
 ---
 id:
   common:
+    hide: Sembunyikan
+    show: Tampilkan
+    toggle_less: Lihat lebih sedikit
+    toggle_more: "%{show} %{number} lagi"
     translations: Terjemahan
   components:
     accordion:
-      hide: Sembunyikan
       hide_all: Sembunyikan semua bagian
-      show: Tampilkan
       show_all: Tampilkan semua bagian
       this_section_visually_hidden: " bagian ini"
     article_schema:
@@ -126,8 +128,6 @@ id:
       part_of: Bagian dari
       published: Diterbitkan
       see_all_updates: Lihat semua pembaruan
-      toggle_less: Lihat lebih sedikit
-      toggle_more: "%{show} %{number} lagi"
     modal_dialogue:
       close_modal: Tutup dialog
     notice:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -127,7 +127,7 @@ id:
       published: Diterbitkan
       see_all_updates: Lihat semua pembaruan
       toggle_less: Lihat lebih sedikit
-      toggle_more: "+ %{number} lagi"
+      toggle_more: "%{show} %{number} lagi"
     modal_dialogue:
       close_modal: Tutup dialog
     notice:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -1,12 +1,14 @@
 ---
 is:
   common:
+    hide: Fela
+    show: Sýna
+    toggle_less: Sýna færri
+    toggle_more: "%{show} %{number} fleiri"
     translations: Þýðingar
   components:
     accordion:
-      hide: Fela
       hide_all: Fela alla hluta
-      show: Sýna
       show_all: Sýna alla hluta
       this_section_visually_hidden: " þessi hluti"
     article_schema:
@@ -126,8 +128,6 @@ is:
       part_of: Hluti af
       published: Birt
       see_all_updates: Sjá allar uppfærslur
-      toggle_less: Sýna færri
-      toggle_more: "%{show} %{number} fleiri"
     modal_dialogue:
       close_modal: Loka glugga
     notice:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -127,7 +127,7 @@ is:
       published: Birt
       see_all_updates: Sjá allar uppfærslur
       toggle_less: Sýna færri
-      toggle_more: "+ %{number} fleiri"
+      toggle_more: "%{show} %{number} fleiri"
     modal_dialogue:
       close_modal: Loka glugga
     notice:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -127,7 +127,7 @@ it:
       published: Pubblicato
       see_all_updates: Vedi tutti gli aggiornamenti
       toggle_less: Mostra meno
-      toggle_more: "+ %{number} più"
+      toggle_more: "%{show} %{number} più"
     modal_dialogue:
       close_modal: Chiudi dialogo modale
     notice:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,12 +1,14 @@
 ---
 it:
   common:
+    hide: Nascondi
+    show: Mostra
+    toggle_less: Mostra meno
+    toggle_more: "%{show} %{number} più"
     translations: Traduzioni
   components:
     accordion:
-      hide: Nascondi
       hide_all: Nascondi tutte le sezioni
-      show: Mostra
       show_all: Mostra tutte le sezioni
       this_section_visually_hidden: " questa sezione"
     article_schema:
@@ -126,8 +128,6 @@ it:
       part_of: Parte di
       published: Pubblicato
       see_all_updates: Vedi tutti gli aggiornamenti
-      toggle_less: Mostra meno
-      toggle_more: "%{show} %{number} più"
     modal_dialogue:
       close_modal: Chiudi dialogo modale
     notice:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,12 +1,14 @@
 ---
 ja:
   common:
+    hide: 非表示
+    show: 表示
+    toggle_less: 一部を表示
+    toggle_more: さらに ％{number}
     translations: 翻訳
   components:
     accordion:
-      hide: 非表示
       hide_all: すべてのセクションを非表示
-      show: 表示
       show_all: すべてのセクションを表示
       this_section_visually_hidden: " このセクション"
     article_schema:
@@ -122,8 +124,6 @@ ja:
       part_of: 一部の
       published: 公開済み
       see_all_updates: すべての更新を表示
-      toggle_less: 一部を表示
-      toggle_more: さらに ％{number}
     modal_dialogue:
       close_modal: 特殊ウインドウを閉じる
     notice:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -1,12 +1,14 @@
 ---
 ka:
   common:
+    hide: დამალვა
+    show: ჩვენება
+    toggle_less: ნაკლების ჩვენება
+    toggle_more: "%{show} %{number} more"
     translations: თარგმანები
   components:
     accordion:
-      hide: დამალვა
       hide_all: ყველა სექციის დამალვა
-      show: ჩვენება
       show_all: ყველა სექციის ჩვენება
       this_section_visually_hidden: " ეს სექცია"
     article_schema:
@@ -129,8 +131,6 @@ ka:
       part_of: ნაწილი
       published: პუბლიკაცია
       see_all_updates: ყველა განახლების ნახვა
-      toggle_less: ნაკლების ჩვენება
-      toggle_more: "%{show} %{number} more"
     modal_dialogue:
       close_modal: მოდალური დიალოგის გამორთვა
     notice:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -130,7 +130,7 @@ ka:
       published: პუბლიკაცია
       see_all_updates: ყველა განახლების ნახვა
       toggle_less: ნაკლების ჩვენება
-      toggle_more: "+ %{number} more"
+      toggle_more: "%{show} %{number} more"
     modal_dialogue:
       close_modal: მოდალური დიალოგის გამორთვა
     notice:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -127,7 +127,7 @@ kk:
       published: Жарияланды
       see_all_updates: Барлық жаңартуларды қарау
       toggle_less: Азырақ көрсету
-      toggle_more: "+ %{number} көп"
+      toggle_more: "%{show} %{number} көп"
     modal_dialogue:
       close_modal: Жабық модальды диалог
     notice:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -1,12 +1,14 @@
 ---
 kk:
   common:
+    hide: Жасыру
+    show: Көрсету
+    toggle_less: Азырақ көрсету
+    toggle_more: "%{show} %{number} көп"
     translations: Аудармалар
   components:
     accordion:
-      hide: Жасыру
       hide_all: Барлық бөлімдерді жасыру
-      show: Көрсету
       show_all: Барлық бөлімдерді көрсету
       this_section_visually_hidden: " бұл бөлім"
     article_schema:
@@ -126,8 +128,6 @@ kk:
       part_of: Бөлігі
       published: Жарияланды
       see_all_updates: Барлық жаңартуларды қарау
-      toggle_less: Азырақ көрсету
-      toggle_more: "%{show} %{number} көп"
     modal_dialogue:
       close_modal: Жабық модальды диалог
     notice:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,12 +1,14 @@
 ---
 ko:
   common:
+    hide:
+    show:
+    toggle_less:
+    toggle_more:
     translations:
   components:
     accordion:
-      hide:
       hide_all:
-      show:
       show_all:
       this_section_visually_hidden:
     article_schema:
@@ -121,8 +123,6 @@ ko:
       part_of:
       published:
       see_all_updates:
-      toggle_less:
-      toggle_more:
     modal_dialogue:
       close_modal:
     notice:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -132,7 +132,7 @@ lt:
       published: Publikuota
       see_all_updates: Matyti visą naujausią informaciją
       toggle_less: Rodyti mažiau
-      toggle_more: "+% {number} daugiau"
+      toggle_more: "%{show} %{number} daugiau"
     modal_dialogue:
       close_modal: Uždaryti modalinį dialogo langą
     notice:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -1,12 +1,14 @@
 ---
 lt:
   common:
+    hide: Slėpti
+    show: Rodyti
+    toggle_less: Rodyti mažiau
+    toggle_more: "%{show}% {number} daugiau"
     translations: Vertimai
   components:
     accordion:
-      hide: Slėpti
       hide_all: Slėpti visas skiltis
-      show: Rodyti
       show_all: Rodyti visas skiltis
       this_section_visually_hidden: " ši skiltis"
     article_schema:
@@ -131,8 +133,6 @@ lt:
       part_of: Dalis
       published: Publikuota
       see_all_updates: Matyti visą naujausią informaciją
-      toggle_less: Rodyti mažiau
-      toggle_more: "%{show} %{number} daugiau"
     modal_dialogue:
       close_modal: Uždaryti modalinį dialogo langą
     notice:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -131,7 +131,7 @@ lv:
       published: Publicēts
       see_all_updates: Skatīt visus atjauninājumus
       toggle_less: Rādīt mazāk
-      toggle_more: "+ %{number} vairāk"
+      toggle_more: "%{show} %{number} vairāk"
     modal_dialogue:
       close_modal: Aizvērt modālo dialogu
     notice:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -1,12 +1,14 @@
 ---
 lv:
   common:
+    hide: Paslēpt
+    show: Rādīt
+    toggle_less: Rādīt mazāk
+    toggle_more: "%{show} %{number} vairāk"
     translations: Tulkojumi
   components:
     accordion:
-      hide: Paslēpt
       hide_all: Paslēpt visas sadaļas
-      show: Rādīt
       show_all: Rādīt visas sadaļas
       this_section_visually_hidden: " šī sadaļa"
     article_schema:
@@ -130,8 +132,6 @@ lv:
       part_of: Daļa no
       published: Publicēts
       see_all_updates: Skatīt visus atjauninājumus
-      toggle_less: Rādīt mazāk
-      toggle_more: "%{show} %{number} vairāk"
     modal_dialogue:
       close_modal: Aizvērt modālo dialogu
     notice:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -126,7 +126,7 @@ ms:
       published: Diterbitkan
       see_all_updates: Lihat semua kemas kini
       toggle_less: Tunjuk sedikit
-      toggle_more: "+ %{number} lagi"
+      toggle_more: "%{show} %{number} lagi"
     modal_dialogue:
       close_modal: Tutup dialog mod
     notice:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -1,12 +1,14 @@
 ---
 ms:
   common:
+    hide: Sorok
+    show: Tunjuk
+    toggle_less: Tunjuk sedikit
+    toggle_more: "%{show} %{number} lagi"
     translations: Terjemahan
   components:
     accordion:
-      hide: Sorok
       hide_all: Sorok semua bahagian
-      show: Tunjuk
       show_all: Tunjuk semua bahagian
       this_section_visually_hidden: " bahagian ini"
     article_schema:
@@ -125,8 +127,6 @@ ms:
       part_of: Sebahagian daripada
       published: Diterbitkan
       see_all_updates: Lihat semua kemas kini
-      toggle_less: Tunjuk sedikit
-      toggle_more: "%{show} %{number} lagi"
     modal_dialogue:
       close_modal: Tutup dialog mod
     notice:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -129,7 +129,7 @@ mt:
       published: Ippubblikat
       see_all_updates: Ara l-aġġornamenti kollha
       toggle_less: Ara inqas
-      toggle_more: "+ %{number}"
+      toggle_more: "%{show} %{number}"
     modal_dialogue:
       close_modal: Agħlaq id-djalogu modali
     notice:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -1,12 +1,14 @@
 ---
 mt:
   common:
+    hide: Aħbi
+    show: Uri
+    toggle_less: Ara inqas
+    toggle_more: "%{show} %{number}"
     translations: Traduzzjonijiet
   components:
     accordion:
-      hide: Aħbi
       hide_all: Aħbi s-sezzjonijiet kollha
-      show: Uri
       show_all: Uri s-sezzjonijiet kollha
       this_section_visually_hidden: " din is-sezzjoni"
     article_schema:
@@ -128,8 +130,6 @@ mt:
       part_of: Parti minn
       published: Ippubblikat
       see_all_updates: Ara l-aġġornamenti kollha
-      toggle_less: Ara inqas
-      toggle_more: "%{show} %{number}"
     modal_dialogue:
       close_modal: Agħlaq id-djalogu modali
     notice:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,12 +1,14 @@
 ---
 nl:
   common:
+    hide: Verberg
+    show: Toon
+    toggle_less: Toon minder
+    toggle_more: "%{show} %{number} meer"
     translations: Vertalingen
   components:
     accordion:
-      hide: Verberg
       hide_all: Verberg alle secties
-      show: Toon
       show_all: Toon alle secties
       this_section_visually_hidden: " deze sectie"
     article_schema:
@@ -126,8 +128,6 @@ nl:
       part_of: Deel van
       published: Gepubliceerd
       see_all_updates: Bekijk alle updates
-      toggle_less: Toon minder
-      toggle_more: "%{show} %{number} meer"
     modal_dialogue:
       close_modal: Modale dialoog sluiten
     notice:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -127,7 +127,7 @@ nl:
       published: Gepubliceerd
       see_all_updates: Bekijk alle updates
       toggle_less: Toon minder
-      toggle_more: "+ %{number} meer"
+      toggle_more: "%{show} %{number} meer"
     modal_dialogue:
       close_modal: Modale dialoog sluiten
     notice:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -127,7 +127,7 @@
       published: Publisert
       see_all_updates: Se alle oppdateringer
       toggle_less: Vis færre
-      toggle_more: " + %{number} mer"
+      toggle_more: "%{show} %{number} mer"
     modal_dialogue:
       close_modal: Lukk modal dialog
     notice:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -1,12 +1,14 @@
 ---
 'no':
   common:
+    hide: Skjul
+    show: Vis
+    toggle_less: Vis færre
+    toggle_more: "%{show} %{number} mer"
     translations: Oversettelser
   components:
     accordion:
-      hide: Skjul
       hide_all: Skjul alle seksjoner
-      show: Vis
       show_all: Vis alle seksjoner
       this_section_visually_hidden: " denne seksjonen"
     article_schema:
@@ -126,8 +128,6 @@
       part_of: Del av
       published: Publisert
       see_all_updates: Se alle oppdateringer
-      toggle_less: Vis færre
-      toggle_more: "%{show} %{number} mer"
     modal_dialogue:
       close_modal: Lukk modal dialog
     notice:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -1,12 +1,14 @@
 ---
 pa-pk:
   common:
+    hide: چھپاؤ
+    show: وکھاؤ
+    toggle_less: کُج گھٹ دکھاؤ
+    toggle_more: ہور {number}% %{show}
     translations: ترجمے
   components:
     accordion:
-      hide: چھپاؤ
       hide_all: سارے حصے چھپاؤ
-      show: وکھاؤ
       show_all: سارے حصے وکھاؤ
       this_section_visually_hidden: " اِک حصہ"
     article_schema:
@@ -122,8 +124,6 @@ pa-pk:
       part_of: ایندا حصہ
       published: شائع کیتا گیا
       see_all_updates: ساریاں نویاں چیزاں دیکھو
-      toggle_less: کُج گھٹ دکھاؤ
-      toggle_more: ہور {number}% %{show}
     modal_dialogue:
       close_modal: موڈیل ڈائیلاگ نوں بند کرو
     notice:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -123,7 +123,7 @@ pa-pk:
       published: شائع کیتا گیا
       see_all_updates: ساریاں نویاں چیزاں دیکھو
       toggle_less: کُج گھٹ دکھاؤ
-      toggle_more: ہور {number}%+
+      toggle_more: ہور {number}% %{show}
     modal_dialogue:
       close_modal: موڈیل ڈائیلاگ نوں بند کرو
     notice:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -127,7 +127,7 @@ pa:
       published: ਪ੍ਰਕਾਸ਼ਿਤ
       see_all_updates: ਸਾਰੇ ਅਪਡੇਟਸ ਵੇਖੋ
       toggle_less: ਘੱਟ ਦਿਖਾਉ
-      toggle_more: "+ %{number} ਹੋਰ"
+      toggle_more: "%{show} %{number} ਹੋਰ"
     modal_dialogue:
       close_modal: ਮਾਡਲ ਸੰਵਾਦ ਬੰਦ ਕਰੋ
     notice:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -1,12 +1,14 @@
 ---
 pa:
   common:
+    hide: ਓਹਲੇ
+    show: ਦਿਖਾਉ
+    toggle_less: ਘੱਟ ਦਿਖਾਉ
+    toggle_more: "%{show} %{number} ਹੋਰ"
     translations: ਅਨੁਵਾਦ
   components:
     accordion:
-      hide: ਓਹਲੇ
       hide_all: ਸਾਰੇ ਭਾਗ ਲੁਕਾਓ
-      show: ਦਿਖਾਉ
       show_all: ਸਾਰੇ ਭਾਗ ਦਿਖਾਓ
       this_section_visually_hidden: " ਇਹ ਭਾਗ"
     article_schema:
@@ -126,8 +128,6 @@ pa:
       part_of: ਦਾ ਹਿੱਸਾ
       published: ਪ੍ਰਕਾਸ਼ਿਤ
       see_all_updates: ਸਾਰੇ ਅਪਡੇਟਸ ਵੇਖੋ
-      toggle_less: ਘੱਟ ਦਿਖਾਉ
-      toggle_more: "%{show} %{number} ਹੋਰ"
     modal_dialogue:
       close_modal: ਮਾਡਲ ਸੰਵਾਦ ਬੰਦ ਕਰੋ
     notice:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -131,7 +131,7 @@ pl:
       published: Opublikowano
       see_all_updates: Zobacz wszystkie aktualizacje
       toggle_less: Pokaż mniej
-      toggle_more: "+ %{number} więcej"
+      toggle_more: "%{show} %{number} więcej"
     modal_dialogue:
       close_modal: Zamknij okno modalne
     notice:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1,12 +1,14 @@
 ---
 pl:
   common:
+    hide: Ukryj
+    show: Pokaż
+    toggle_less: Pokaż mniej
+    toggle_more: "%{show} %{number} więcej"
     translations: Tłumaczenia
   components:
     accordion:
-      hide: Ukryj
       hide_all: Ukryj wszystkie części
-      show: Pokaż
       show_all: Pokaż wszystkie części
       this_section_visually_hidden: " ta część"
     article_schema:
@@ -130,8 +132,6 @@ pl:
       part_of: Część
       published: Opublikowano
       see_all_updates: Zobacz wszystkie aktualizacje
-      toggle_less: Pokaż mniej
-      toggle_more: "%{show} %{number} więcej"
     modal_dialogue:
       close_modal: Zamknij okno modalne
     notice:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -124,7 +124,7 @@ ps:
       published: خپور شوی
       see_all_updates: ټول تازه معلومات وګورئ
       toggle_less: لږ ښودل
-      toggle_more: " + %{number} نور"
+      toggle_more: "%{show} %{number} نور"
     modal_dialogue:
       close_modal: موډل ډیالوګ بند کړئ
     notice:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -1,12 +1,14 @@
 ---
 ps:
   common:
+    hide: پټول
+    show: ښودل
+    toggle_less: لږ ښودل
+    toggle_more: "%{show} %{number} نور"
     translations: ژباړې
   components:
     accordion:
-      hide: پټول
       hide_all: ټولې برخې پټې کړئ
-      show: ښودل
       show_all: ټولې برخې وښایاست
       this_section_visually_hidden: " دا برخه"
     article_schema:
@@ -123,8 +125,6 @@ ps:
       part_of: برخه
       published: خپور شوی
       see_all_updates: ټول تازه معلومات وګورئ
-      toggle_less: لږ ښودل
-      toggle_more: "%{show} %{number} نور"
     modal_dialogue:
       close_modal: موډل ډیالوګ بند کړئ
     notice:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,12 +1,14 @@
 ---
 pt:
   common:
+    hide: Ocultar
+    show: Mostrar
+    toggle_less: Mostrar menos
+    toggle_more: mais de %{number} a mais
     translations: Traduções
   components:
     accordion:
-      hide: Ocultar
       hide_all: Ocultar todas as secções
-      show: Mostrar
       show_all: Mostrar todas as secções
       this_section_visually_hidden: " Esta secção"
     article_schema:
@@ -126,8 +128,6 @@ pt:
       part_of: Parte de
       published: Publicado em
       see_all_updates: Ver todas as atualizações
-      toggle_less: Mostrar menos
-      toggle_more: mais de %{number} a mais
     modal_dialogue:
       close_modal: Fechar diálogo modal
     notice:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -128,7 +128,7 @@ ro:
       published: Publicat
       see_all_updates: Vedeți toate actualizările
       toggle_less: Afișați mai puține
-      toggle_more: "+ încă %{number}"
+      toggle_more: "%{show} încă %{number}"
     modal_dialogue:
       close_modal: Închideți dialogul modal
     notice:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,12 +1,14 @@
 ---
 ro:
   common:
+    hide: Ascundeți
+    show: Afișați
+    toggle_less: Afișați mai puține
+    toggle_more: "%{show} încă %{number}"
     translations: Traduceri
   components:
     accordion:
-      hide: Ascundeți
       hide_all: Ascundeți toate secțiunile
-      show: Afișați
       show_all: Afișați toate secțiunile
       this_section_visually_hidden: " această secțiune"
     article_schema:
@@ -127,8 +129,6 @@ ro:
       part_of: Parte din
       published: Publicat
       see_all_updates: Vedeți toate actualizările
-      toggle_less: Afișați mai puține
-      toggle_more: "%{show} încă %{number}"
     modal_dialogue:
       close_modal: Închideți dialogul modal
     notice:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,12 +1,14 @@
 ---
 ru:
   common:
+    hide: Скрыть
+    show: Показать
+    toggle_less: Показать меньше
+    toggle_more: "%{show} %{number} больше"
     translations: Переводы
   components:
     accordion:
-      hide: Скрыть
       hide_all: Скрыть все секции
-      show: Показать
       show_all: Показать все секции
       this_section_visually_hidden: 'данная секция '
     article_schema:
@@ -130,8 +132,6 @@ ru:
       part_of: Является частью
       published: Опубликовано
       see_all_updates: Посмотреть все обновления
-      toggle_less: Показать меньше
-      toggle_more: "%{show} %{number} больше"
     modal_dialogue:
       close_modal: Закрыть модальное диалоговое окно
     notice:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -131,7 +131,7 @@ ru:
       published: Опубликовано
       see_all_updates: Посмотреть все обновления
       toggle_less: Показать меньше
-      toggle_more: "+ %{number} больше"
+      toggle_more: "%{show} %{number} больше"
     modal_dialogue:
       close_modal: Закрыть модальное диалоговое окно
     notice:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -1,12 +1,14 @@
 ---
 si:
   common:
+    hide: සඟවන්න
+    show: පෙන්වන්න
+    toggle_less: අඩුවෙන් පෙන්වන්න
+    toggle_more: තවත් %{show} %{number}
     translations: පරිවර්තන
   components:
     accordion:
-      hide: සඟවන්න
       hide_all: සියලුම කොටස් සඟවන්න
-      show: පෙන්වන්න
       show_all: සියලු කොටස් පෙන්වන්න
       this_section_visually_hidden: " මෙම කොටස"
     article_schema:
@@ -126,8 +128,6 @@ si:
       part_of: කොටසක්
       published: පළ කළේ
       see_all_updates: සියලුම යාවත්කාලීනයන් බලන්න
-      toggle_less: අඩුවෙන් පෙන්වන්න
-      toggle_more: තවත් %{show} %{number}
     modal_dialogue:
       close_modal: ආදර්ශ සංවාදය වසන්න
     notice:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -127,7 +127,7 @@ si:
       published: පළ කළේ
       see_all_updates: සියලුම යාවත්කාලීනයන් බලන්න
       toggle_less: අඩුවෙන් පෙන්වන්න
-      toggle_more: තවත් + %{number}
+      toggle_more: තවත් %{show} %{number}
     modal_dialogue:
       close_modal: ආදර්ශ සංවාදය වසන්න
     notice:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,12 +1,14 @@
 ---
 sk:
   common:
+    hide: Skryť
+    show: Zobraziť
+    toggle_less: Zobraziť menej
+    toggle_more: "%{show} %{number} viac"
     translations: Preklady
   components:
     accordion:
-      hide: Skryť
       hide_all: Skryť všetky sekcie
-      show: Zobraziť
       show_all: Zobraziť všetky časti
       this_section_visually_hidden: " táto časť"
     article_schema:
@@ -131,8 +133,6 @@ sk:
       part_of: Časť
       published: Zverejnené na
       see_all_updates: Zobraziť všetky aktualizácie
-      toggle_less: Zobraziť menej
-      toggle_more: "%{show} %{number} viac"
     modal_dialogue:
       close_modal: Zavrieť modálny dialóg
     notice:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -132,7 +132,7 @@ sk:
       published: Zverejnené na
       see_all_updates: Zobraziť všetky aktualizácie
       toggle_less: Zobraziť menej
-      toggle_more: "+ %{number} viac"
+      toggle_more: "%{show} %{number} viac"
     modal_dialogue:
       close_modal: Zavrieť modálny dialóg
     notice:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -134,7 +134,7 @@ sl:
       published: Objavljeno
       see_all_updates: Poglej vse posodobitve
       toggle_less: Pokaži manj
-      toggle_more: "+ %{number} več"
+      toggle_more: "%{show} %{number} več"
     modal_dialogue:
       close_modal: Zapri modalno okno
     notice:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -1,12 +1,14 @@
 ---
 sl:
   common:
+    hide: Skrij
+    show: Prikaži
+    toggle_less: Pokaži manj
+    toggle_more: "%{show} %{number} več"
     translations: Prevodi
   components:
     accordion:
-      hide: Skrij
       hide_all: Skrij vse razdelke
-      show: Prikaži
       show_all: Prikaži vse razdelke
       this_section_visually_hidden: " ta razdelek"
     article_schema:
@@ -133,8 +135,6 @@ sl:
       part_of: Del
       published: Objavljeno
       see_all_updates: Poglej vse posodobitve
-      toggle_less: Pokaži manj
-      toggle_more: "%{show} %{number} več"
     modal_dialogue:
       close_modal: Zapri modalno okno
     notice:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -127,7 +127,7 @@ so:
       published: Daabacaada
       see_all_updates: Eeg dhamaan cusboonaysiinaha
       toggle_less: Muuji waxyar
-      toggle_more: "+ %{number} badan"
+      toggle_more: "%{show} %{number} badan"
     modal_dialogue:
       close_modal: Kusoo dhawoow wada hadal dhex dhexaad ah
     notice:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -1,12 +1,14 @@
 ---
 so:
   common:
+    hide: Qari
+    show: Muuji
+    toggle_less: Muuji waxyar
+    toggle_more: "%{show} %{number} badan"
     translations: Turjumaanada
   components:
     accordion:
-      hide: Qari
       hide_all: Qari dhamaan qaybaha
-      show: Muuji
       show_all: Muuji dhamaan qaybaha
       this_section_visually_hidden: " Qaybtan"
     article_schema:
@@ -126,8 +128,6 @@ so:
       part_of: Ka qeyba
       published: Daabacaada
       see_all_updates: Eeg dhamaan cusboonaysiinaha
-      toggle_less: Muuji waxyar
-      toggle_more: "%{show} %{number} badan"
     modal_dialogue:
       close_modal: Kusoo dhawoow wada hadal dhex dhexaad ah
     notice:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -127,7 +127,7 @@ sq:
       published: Publikuar
       see_all_updates: Shih të gjitha përditësimet
       toggle_less: Shfaq më pak
-      toggle_more: "+ %{number} më tepër"
+      toggle_more: "%{show} %{number} më tepër"
     modal_dialogue:
       close_modal: Mbyll dialogun modal
     notice:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -1,12 +1,14 @@
 ---
 sq:
   common:
+    hide: Fshih
+    show: Shfaq
+    toggle_less: Shfaq më pak
+    toggle_more: "%{show} %{number} më tepër"
     translations: Përkthimet
   components:
     accordion:
-      hide: Fshih
       hide_all: Fshih të gjitha seksionet
-      show: Shfaq
       show_all: Shfaq të gjitha seksionet
       this_section_visually_hidden: " këtë seksion"
     article_schema:
@@ -126,8 +128,6 @@ sq:
       part_of: Pjesë e
       published: Publikuar
       see_all_updates: Shih të gjitha përditësimet
-      toggle_less: Shfaq më pak
-      toggle_more: "%{show} %{number} më tepër"
     modal_dialogue:
       close_modal: Mbyll dialogun modal
     notice:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -1,12 +1,14 @@
 ---
 sr:
   common:
+    hide: Sakrij
+    show: Prikaži
+    toggle_less: Prikaži manje
+    toggle_more: još %{number}
     translations: Prevodi
   components:
     accordion:
-      hide: Sakrij
       hide_all: Sakrij sve odeljke
-      show: Prikaži
       show_all: Prikaži sve odeljke
       this_section_visually_hidden: " ovaj odeljak"
     article_schema:
@@ -127,8 +129,6 @@ sr:
       part_of: Deo
       published: Objavljeno
       see_all_updates: Pogledajte sva ažuriranja
-      toggle_less: Prikaži manje
-      toggle_more: još %{number}
     modal_dialogue:
       close_modal: Zatvori modalni dijalog
     notice:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,12 +1,14 @@
 ---
 sv:
   common:
+    hide: Dölj
+    show: Visa
+    toggle_less: Visa färre
+    toggle_more: "%{show} %{number} mer"
     translations: Översättningar
   components:
     accordion:
-      hide: Dölj
       hide_all: Dölj alla avsnitt
-      show: Visa
       show_all: Visa alla avsnitt
       this_section_visually_hidden: " detta avsnitt"
     article_schema:
@@ -126,8 +128,6 @@ sv:
       part_of: Del av
       published: Publicerad
       see_all_updates: Se alla uppdateringar
-      toggle_less: Visa färre
-      toggle_more: "%{show} %{number} mer"
     modal_dialogue:
       close_modal: Stäng den modala dialogen
     notice:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -127,7 +127,7 @@ sv:
       published: Publicerad
       see_all_updates: Se alla uppdateringar
       toggle_less: Visa färre
-      toggle_more: "+ %{number} mer"
+      toggle_more: "%{show} %{number} mer"
     modal_dialogue:
       close_modal: Stäng den modala dialogen
     notice:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -1,12 +1,14 @@
 ---
 sw:
   common:
+    hide: Ficha
+    show: Onyesha
+    toggle_less: Onyesha chache
+    toggle_more: "%{show} %{number} zaidi"
     translations: Tafsiri
   components:
     accordion:
-      hide: Ficha
       hide_all: Ficha sehemu zote
-      show: Onyesha
       show_all: Onyesha sehemu zote
       this_section_visually_hidden: " sehemu hii"
     article_schema:
@@ -126,8 +128,6 @@ sw:
       part_of: Sehemu ya
       published: Ilichapishwa
       see_all_updates: Angalia taarifa zote
-      toggle_less: Onyesha chache
-      toggle_more: "%{show} %{number} zaidi"
     modal_dialogue:
       close_modal: Funga dirisha ibukizi
     notice:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -127,7 +127,7 @@ sw:
       published: Ilichapishwa
       see_all_updates: Angalia taarifa zote
       toggle_less: Onyesha chache
-      toggle_more: "+ %{number} zaidi"
+      toggle_more: "%{show} %{number} zaidi"
     modal_dialogue:
       close_modal: Funga dirisha ibukizi
     notice:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -128,7 +128,7 @@ ta:
       published: வெளியிடப்பட்டது
       see_all_updates: அனைத்து புதுப்பித்தல்களையும் பார்
       toggle_less: குறைவாகக் காட்டு
-      toggle_more: மேலும் + %{number}
+      toggle_more: மேலும் %{show} %{number}
     modal_dialogue:
       close_modal: மாதிரி உரையாடலை மூடு
     notice:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -1,12 +1,14 @@
 ---
 ta:
   common:
+    hide: மறை
+    show: காட்டு
+    toggle_less: குறைவாகக் காட்டு
+    toggle_more: மேலும் %{show} %{number}
     translations: மொழிபெயர்ப்புகள்
   components:
     accordion:
-      hide: மறை
       hide_all: அனைத்துப் பிரிவுகளையும் மறை
-      show: காட்டு
       show_all: அனைத்துப் பிரிவுகளையும் காட்டு
       this_section_visually_hidden: " இந்தப் பிரிவு"
     article_schema:
@@ -127,8 +129,6 @@ ta:
       part_of: பகுதி
       published: வெளியிடப்பட்டது
       see_all_updates: அனைத்து புதுப்பித்தல்களையும் பார்
-      toggle_less: குறைவாகக் காட்டு
-      toggle_more: மேலும் %{show} %{number}
     modal_dialogue:
       close_modal: மாதிரி உரையாடலை மூடு
     notice:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -1,12 +1,14 @@
 ---
 th:
   common:
+    hide: ซ่อน
+    show: แสดง
+    toggle_less: แสดงน้อยลง
+    toggle_more: เพิ่มเติม %{show} %{number} รายการ
     translations: ข้อความแปล
   components:
     accordion:
-      hide: ซ่อน
       hide_all: ซ่อนทุกส่วน
-      show: แสดง
       show_all: แสดงส่วนทั้งหมด
       this_section_visually_hidden: " ส่วนนี้"
     article_schema:
@@ -124,8 +126,6 @@ th:
       part_of: ส่วนหนึ่งของ
       published: เผยแพร่แล้ว
       see_all_updates: ดูอัปเดตทั้งหมด
-      toggle_less: แสดงน้อยลง
-      toggle_more: เพิ่มเติม %{show} %{number} รายการ
     modal_dialogue:
       close_modal: ปิดการสนทนาโมดอล
     notice:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -125,7 +125,7 @@ th:
       published: เผยแพร่แล้ว
       see_all_updates: ดูอัปเดตทั้งหมด
       toggle_less: แสดงน้อยลง
-      toggle_more: เพิ่มเติม + %{number} รายการ
+      toggle_more: เพิ่มเติม %{show} %{number} รายการ
     modal_dialogue:
       close_modal: ปิดการสนทนาโมดอล
     notice:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -1,12 +1,14 @@
 ---
 tk:
   common:
+    hide: Gizle
+    show: görkez
+    toggle_less: Azrak görkez
+    toggle_more: "%{show} %{number} köpeltmek üçin"
     translations: Terjimeler
   components:
     accordion:
-      hide: Gizle
       hide_all: Ähli bölümleri gizle
-      show: görkez
       show_all: Ähli bölümleri görkez
       this_section_visually_hidden: " Bu bölüm"
     article_schema:
@@ -127,8 +129,6 @@ tk:
       part_of: Bir bölegi
       published: Çap edilen
       see_all_updates: Ähli täzelenmelere serediň
-      toggle_less: Azrak görkez
-      toggle_more: "%{show} %{number} köpeltmek üçin"
     modal_dialogue:
       close_modal: Modal gepleşikleri tamamlamak
     notice:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -128,7 +128,7 @@ tk:
       published: Çap edilen
       see_all_updates: Ähli täzelenmelere serediň
       toggle_less: Azrak görkez
-      toggle_more: "+ %{number} köpeltmek üçin"
+      toggle_more: "%{show} %{number} köpeltmek üçin"
     modal_dialogue:
       close_modal: Modal gepleşikleri tamamlamak
     notice:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,12 +1,14 @@
 ---
 tr:
   common:
+    hide: Gizle
+    show: Göster
+    toggle_less: Daha az göster
+    toggle_more: "%{show} %{number} daha fazla"
     translations: Tercümeler
   components:
     accordion:
-      hide: Gizle
       hide_all: Tüm bölümleri gizle
-      show: Göster
       show_all: Tüm bölümleri göster
       this_section_visually_hidden: " Bu bölüm"
     article_schema:
@@ -127,8 +129,6 @@ tr:
       part_of: Şunun kısmı
       published: Yayınlanan
       see_all_updates: Tüm güncellemeleri görün
-      toggle_less: Daha az göster
-      toggle_more: "%{show} %{number} daha fazla"
     modal_dialogue:
       close_modal: Model diyaloğu kapat
     notice:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -128,7 +128,7 @@ tr:
       published: Yayınlanan
       see_all_updates: Tüm güncellemeleri görün
       toggle_less: Daha az göster
-      toggle_more: "+ %{number} daha fazla"
+      toggle_more: "%{show} %{number} daha fazla"
     modal_dialogue:
       close_modal: Model diyaloğu kapat
     notice:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1,12 +1,14 @@
 ---
 uk:
   common:
+    hide: Приховати
+    show: Показати
+    toggle_less: Показати менше
+    toggle_more: "%{show} %{number} більше"
     translations: Переклади
   components:
     accordion:
-      hide: Приховати
       hide_all: приховати всі розділи
-      show: Показати
       show_all: Показати всі розділи
       this_section_visually_hidden: " цей розділ"
     article_schema:
@@ -133,8 +135,6 @@ uk:
       part_of: Частина
       published: Опубліковано
       see_all_updates: Переглянути всі оновлення
-      toggle_less: Показати менше
-      toggle_more: "%{show} %{number} більше"
     modal_dialogue:
       close_modal: Закрити модальний діалог
     notice:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -134,7 +134,7 @@ uk:
       published: Опубліковано
       see_all_updates: Переглянути всі оновлення
       toggle_less: Показати менше
-      toggle_more: "+ %{number} більше"
+      toggle_more: "%{show} %{number} більше"
     modal_dialogue:
       close_modal: Закрити модальний діалог
     notice:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -124,7 +124,7 @@ ur:
       published: شائع کردہ
       see_all_updates: تمام اپ ڈیٹس دیکھیں
       toggle_less: کم دکھائیں
-      toggle_more: "+ %{number} مزید"
+      toggle_more: "%{show} %{number} مزید"
     modal_dialogue:
       close_modal: محدود موڈل ڈائیلاگ
     notice:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -1,12 +1,14 @@
 ---
 ur:
   common:
+    hide: پوشیدہ کریں
+    show: دکھائی
+    toggle_less: کم دکھائیں
+    toggle_more: "%{show} %{number} مزید"
     translations: تراجم
   components:
     accordion:
-      hide: پوشیدہ کریں
       hide_all: تمام سیکشنز کو پوشیدہ کریں
-      show: دکھائی
       show_all: تمام سیکشنز دکھائیں
       this_section_visually_hidden: " یہ سیکشن"
     article_schema:
@@ -123,8 +125,6 @@ ur:
       part_of: حصہ از
       published: شائع کردہ
       see_all_updates: تمام اپ ڈیٹس دیکھیں
-      toggle_less: کم دکھائیں
-      toggle_more: "%{show} %{number} مزید"
     modal_dialogue:
       close_modal: محدود موڈل ڈائیلاگ
     notice:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -1,12 +1,14 @@
 ---
 uz:
   common:
+    hide: Яшириш
+    show: Кўрсатиш
+    toggle_less: Камроқ кўрсатиш
+    toggle_more: "%{show} %{number} кўпроқ"
     translations: Таржималар
   components:
     accordion:
-      hide: Яшириш
       hide_all: Бўлимларни барчасини яшириш
-      show: Кўрсатиш
       show_all: Бўлимларни барчасини кўрсатиш
       this_section_visually_hidden: " ушбу бўлим"
     article_schema:
@@ -128,8 +130,6 @@ uz:
       part_of: Қисм
       published: Нашр қилинган
       see_all_updates: Барча янгиланишларни кўриш
-      toggle_less: Камроқ кўрсатиш
-      toggle_more: "%{show} %{number} кўпроқ"
     modal_dialogue:
       close_modal: Модал мулоқотни ёпиш
     notice:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -129,7 +129,7 @@ uz:
       published: Нашр қилинган
       see_all_updates: Барча янгиланишларни кўриш
       toggle_less: Камроқ кўрсатиш
-      toggle_more: "+ %{number} кўпроқ"
+      toggle_more: "%{show} %{number} кўпроқ"
     modal_dialogue:
       close_modal: Модал мулоқотни ёпиш
     notice:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -126,7 +126,7 @@ vi:
       published: Đã xuất bản
       see_all_updates: Xem tất cả nội dung cập nhật
       toggle_less: Ẩn bớt
-      toggle_more: "+ thêm %{number}"
+      toggle_more: "%{show} thêm %{number}"
     modal_dialogue:
       close_modal: Đóng đối thoại phương thức
     notice:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1,12 +1,14 @@
 ---
 vi:
   common:
+    hide: Ẩn
+    show: Hiển thị
+    toggle_less: Ẩn bớt
+    toggle_more: "%{show} thêm %{number}"
     translations: Bản dịch
   components:
     accordion:
-      hide: Ẩn
       hide_all: Ẩn tất cả các phần
-      show: Hiển thị
       show_all: Hiển thị tất cả các phần
       this_section_visually_hidden: " phần này"
     article_schema:
@@ -125,8 +127,6 @@ vi:
       part_of: Một phần của
       published: Đã xuất bản
       see_all_updates: Xem tất cả nội dung cập nhật
-      toggle_less: Ẩn bớt
-      toggle_more: "%{show} thêm %{number}"
     modal_dialogue:
       close_modal: Đóng đối thoại phương thức
     notice:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -125,7 +125,7 @@ zh-hk:
       published: 已發佈
       see_all_updates: 查閱所有更新項
       toggle_less: 顯示更少內容
-      toggle_more: "+ %{number} more"
+      toggle_more: "%{show} %{number} more"
     modal_dialogue:
       close_modal: 關閉互動視窗對話
     notice:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -1,12 +1,14 @@
 ---
 zh-hk:
   common:
+    hide: 隱藏
+    show: 顯示
+    toggle_less: 顯示更少內容
+    toggle_more: "%{show} %{number} more"
     translations: 譯文
   components:
     accordion:
-      hide: 隱藏
       hide_all: 隱藏所有部份
-      show: 顯示
       show_all: 顯示所有部份
       this_section_visually_hidden: 此部份
     article_schema:
@@ -124,8 +126,6 @@ zh-hk:
       part_of: 部份
       published: 已發佈
       see_all_updates: 查閱所有更新項
-      toggle_less: 顯示更少內容
-      toggle_more: "%{show} %{number} more"
     modal_dialogue:
       close_modal: 關閉互動視窗對話
     notice:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -125,7 +125,7 @@ zh-tw:
       published: 發布
       see_all_updates: 查看所有更新
       toggle_less: 顯示部分
-      toggle_more: "+ %{number}更多"
+      toggle_more: "%{show} %{number}更多"
     modal_dialogue:
       close_modal: 關閉模態對話
     notice:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -1,12 +1,14 @@
 ---
 zh-tw:
   common:
+    hide: 隱藏
+    show: 展開
+    toggle_less: 顯示部分
+    toggle_more: "%{show} %{number}更多"
     translations: 翻譯
   components:
     accordion:
-      hide: 隱藏
       hide_all: 隱藏所有區段
-      show: 展開
       show_all: 展開所有區段
       this_section_visually_hidden: " 這個區段"
     article_schema:
@@ -124,8 +126,6 @@ zh-tw:
       part_of: 部分
       published: 發布
       see_all_updates: 查看所有更新
-      toggle_less: 顯示部分
-      toggle_more: "%{show} %{number}更多"
     modal_dialogue:
       close_modal: 關閉模態對話
     notice:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -125,7 +125,7 @@ zh:
       published: 已发布
       see_all_updates: 查看全部更新
       toggle_less: 显示更少
-      toggle_more: "+ %{number}更多"
+      toggle_more: "%{show} %{number}更多"
     modal_dialogue:
       close_modal: 关闭模态对话
     notice:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1,12 +1,14 @@
 ---
 zh:
   common:
+    hide: 隐藏
+    show: 显示
+    toggle_less: 显示更少
+    toggle_more: "%{show} %{number}更多"
     translations: 翻译
   components:
     accordion:
-      hide: 隐藏
       hide_all: 隐藏所有小节
-      show: 显示
       show_all: 显示所有小节
       this_section_visually_hidden: " 本小节"
     article_schema:
@@ -124,8 +126,6 @@ zh:
       part_of: 一部分
       published: 已发布
       see_all_updates: 查看全部更新
-      toggle_less: 显示更少
-      toggle_more: "%{show} %{number}更多"
     modal_dialogue:
       close_modal: 关闭模态对话
     notice:

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -210,7 +210,7 @@ describe "Metadata", type: :view do
     assert_select ".gem-c-metadata__toggle-items", count: 1
     assert_select ".gem-c-metadata__definition > a", count: limit
     assert_select ".gem-c-metadata__definition .gem-c-metadata__toggle-items a", count: length - limit
-    assert_select "a[href=\"#\"]", text: t("components.metadata.toggle_more", number: length - limit)
+    assert_select "a[href=\"#\"]", text: t("components.metadata.toggle_more", show: t("components.accordion.show"), number: length - limit)
   end
 
   def assert_no_truncation(length)

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -210,7 +210,7 @@ describe "Metadata", type: :view do
     assert_select ".gem-c-metadata__toggle-items", count: 1
     assert_select ".gem-c-metadata__definition > a", count: limit
     assert_select ".gem-c-metadata__definition .gem-c-metadata__toggle-items a", count: length - limit
-    assert_select "a[href=\"#\"]", text: t("components.metadata.toggle_more", show: t("components.accordion.show"), number: length - limit)
+    assert_select "a[href=\"#\"]", text: t("common.toggle_more", show: t("common.show"), number: length - limit)
   end
 
   def assert_no_truncation(length)

--- a/spec/components/related_navigation_spec.rb
+++ b/spec/components/related_navigation_spec.rb
@@ -166,7 +166,7 @@ describe "Related navigation", type: :view do
     render_component(content_item: content_item)
 
     assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales/news\"]", text: "Wales"
-    assert_select ".gem-c-related-navigation__link.toggle-wrap", text: "+ 2 more"
+    assert_select ".gem-c-related-navigation__link.toggle-wrap", text: "Show 2 more"
     assert_select "#toggle_world_locations .gem-c-related-navigation__section-link[href=\"/world/mauritius/news\"]", text: "Mauritius"
     assert_select "#toggle_world_locations .gem-c-related-navigation__section-link[href=\"/world/brazil/news\"]", text: "Brazil"
   end


### PR DESCRIPTION
## What
The "**+ 3 more**" / "**show fewer**" button text from the [related navigation component](https://components.publishing.service.gov.uk/component-guide/related_navigation) and [metadata block component](https://components.publishing.service.gov.uk/component-guide/metadata/extensive_country_list/) is not descriptive enough to identify its function or purpose when navigating out of context.

Change "**+**" to "**Show**".

**Example URLs:**

- https://www.gov.uk/check-uk-visa
- https://www.gov.uk/cymraeg

**Review URL:**

- [related navigation component example - with extensive world locations](https://components-gem-pr-3038.herokuapp.com/component-guide/related_navigation/with_extensive_world_locations/preview)
- [metadata block component example - with extensive country list](https://components-gem-pr-3038.herokuapp.com/component-guide/related_navigation/with_extensive_world_locations/preview)

## Why
WCAG fail and the button text is confusing for users (especially for screen reader users).

## Anything else
- ~~I decided against including any HTML in the locale file based on this [issue: several Instances of HTML in locale files](https://github.com/alphagov/govuk_publishing_components/issues/2780)~~
- A [similar issue - affecting the primaryLinks" JS Module](https://github.com/alphagov/govuk_publishing_components/pull/2866) was previously fixed by removing the disclosure functionality. I've not applied the same fix since the related navigation component is used more widely and similar changes would have a bigger impact. Also, the component does not have the same problems e.g. lack of communication to screen reader users on changes or that the "**+ more**" button is removed when clicked