### PR TITLE
[DO NOT MERGE] Restructure GA4 link/event tracking

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
@@ -5,5 +5,6 @@
 //= require ./analytics-ga4/ga4-page-views
 //= require ./analytics-ga4/ga4-link-tracker
 //= require ./analytics-ga4/ga4-event-tracker
+//= require ./analytics-ga4/ga4-specialist-link-tracker
 //= require ./analytics-ga4/ga4-ecommerce-tracker
 //= require ./analytics-ga4/init-ga4

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -1,3 +1,4 @@
+//= require ../vendor/polyfills/closest.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
 
@@ -47,6 +48,16 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
 
     getGemVersion: function () {
       return window.GOVUK.analyticsGa4.vars.gem_version || 'not found'
+    },
+
+    trackFunctions: {
+      findTrackingAttributes: function (clicked, trackingTrigger) {
+        if (clicked.hasAttribute('[' + trackingTrigger + ']')) {
+          return clicked
+        } else {
+          return clicked.closest('[' + trackingTrigger + ']')
+        }
+      }
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.js
@@ -97,7 +97,7 @@
         })
 
         ecommerceObject.event_data = {
-          external: GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker.isExternalLink(searchResult.getAttribute('data-ecommerce-path')) ? 'true' : 'false'
+          external: GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker.isExternalLink(searchResult.getAttribute('data-ecommerce-path')) ? 'true' : 'false'
         }
       } else {
         for (var i = 0; i < ecommerceRows.length; i++) {

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
@@ -1,4 +1,4 @@
-// = require govuk/vendor/polyfills/Element/prototype/closest.js
+//= require ../vendor/polyfills/closest.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
@@ -7,7 +7,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   function Ga4EventTracker (module) {
     this.module = module
-    this.trackingTrigger = 'data-ga4' // elements with this attribute get tracked
+    this.trackingTrigger = 'data-ga4-event' // elements with this attribute get tracked
   }
 
   Ga4EventTracker.prototype.init = function () {
@@ -29,7 +29,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   Ga4EventTracker.prototype.trackClick = function (event) {
-    var target = this.findTrackingAttributes(event.target)
+    var target = window.GOVUK.analyticsGa4.core.trackFunctions.findTrackingAttributes(event.target, this.trackingTrigger)
     if (target) {
       var schema = new window.GOVUK.analyticsGa4.Schemas().eventSchema()
 
@@ -85,14 +85,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       window.GOVUK.analyticsGa4.core.sendData(schema)
-    }
-  }
-
-  Ga4EventTracker.prototype.findTrackingAttributes = function (clicked) {
-    if (clicked.hasAttribute('[' + this.trackingTrigger + ']')) {
-      return clicked
-    } else {
-      return clicked.closest('[' + this.trackingTrigger + ']')
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -1,331 +1,91 @@
-// = require govuk/vendor/polyfills/Element/prototype/closest.js
+//= require ../vendor/polyfills/closest.js
 window.GOVUK = window.GOVUK || {}
-window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
-window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analyticsModules || {};
+window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-(function (analyticsModules) {
+(function (Modules) {
   'use strict'
 
-  var Ga4LinkTracker = {
-    init: function (config) {
-      if (window.dataLayer) {
-        config = config || {}
-        this.internalDomains = config.internalDomains || []
-        this.internalDomains.push(this.getHostname())
-        this.appendDomainsWithoutWWW(this.internalDomains)
-        this.internalDownloadPaths = config.internalDownloadPaths || ['/government/uploads/']
-        this.dedicatedDownloadDomains = config.dedicatedDownloadDomains || ['assets.publishing.service.gov.uk']
-        this.appendDomainsWithoutWWW(this.dedicatedDownloadDomains)
-        this.handleClick = this.handleClick.bind(this)
-        this.handleMousedown = this.handleMousedown.bind(this)
+  function Ga4LinkTracker (module) {
+    this.module = module
+    this.trackingTrigger = 'data-ga4' // elements with this attribute get tracked
+    this.trackLinksOnly = this.module.hasAttribute('data-ga4-track-links-only')
+    this.limitToElementClass = this.module.getAttribute('data-ga4-limit-to-element-class')
+  }
 
-        if (!config.disableListeners) {
-          document.querySelector('body').addEventListener('click', this.handleClick)
-          document.querySelector('body').addEventListener('contextmenu', this.handleClick)
-          document.querySelector('body').addEventListener('mousedown', this.handleMousedown)
-        }
-      }
-    },
+  Ga4LinkTracker.prototype.init = function () {
+    var consentCookie = window.GOVUK.getConsentCookie()
 
-    stopTracking: function () {
-      document.querySelector('body').removeEventListener('click', this.handleClick)
-      document.querySelector('body').removeEventListener('contextmenu', this.handleClick)
-      document.querySelector('body').removeEventListener('mousedown', this.handleMousedown)
-    },
-
-    handleClick: function (event) {
-      var element = event.target
-
-      if (element.tagName !== 'A') {
-        element = element.closest('a')
-      }
-
-      if (!element) {
-        return
-      }
-
-      var href = element.getAttribute('href')
-
-      if (!href) {
-        return
-      }
-      var clickData = {}
-      var linkAttributes = element.getAttribute('data-ga4-link')
-      if (linkAttributes) {
-        clickData = JSON.parse(linkAttributes)
-
-        /* Since external links can't be determined in the template, we use populated-via-js as a signal
-        for our JavaScript to determine this value. */
-        if (clickData.external === 'populated-via-js' && clickData.url) {
-          clickData.external = this.isExternalLink(clickData.url) ? 'true' : 'false'
-        }
-
-        if (clickData.method === 'populated-via-js') {
-          clickData.method = this.getClickType(event)
-        }
-
-        if (clickData.index) {
-          clickData.index = parseInt(clickData.index)
-        }
-
-        if (clickData.index_total) {
-          clickData.index_total = parseInt(clickData.index_total)
-        }
-      } else if (this.isMailToLink(href)) {
-        clickData.event_name = 'navigation'
-        clickData.type = 'email'
-        clickData.external = 'true'
-        clickData.url = href
-        clickData.text = this.removeLinesAndExtraSpaces(element.textContent)
-        clickData.method = this.getClickType(event)
-      } else if (this.isDownloadLink(href)) {
-        clickData.event_name = 'file_download'
-        clickData.type = this.isPreviewLink(href) ? 'preview' : 'generic download'
-        clickData.external = this.isExternalLink(href) ? 'true' : 'false'
-        clickData.url = href
-        clickData.text = this.removeLinesAndExtraSpaces(element.textContent)
-        clickData.method = this.getClickType(event)
-      } else if (this.isExternalLink(href)) {
-        clickData.event_name = 'navigation'
-        clickData.type = 'generic link'
-        clickData.external = 'true'
-        clickData.url = href
-        clickData.text = this.removeLinesAndExtraSpaces(element.textContent)
-        clickData.method = this.getClickType(event)
-      }
-
-      if (Object.keys(clickData).length > 0) {
-        if (clickData.url) {
-          clickData.url = this.removeCrossDomainParams(clickData.url)
-          clickData.link_domain = this.populateLinkDomain(clickData.url)
-          clickData.link_path_parts = this.populateLinkPathParts(clickData.url)
-        }
-
-        var schema = new window.GOVUK.analyticsGa4.Schemas().eventSchema()
-        schema.event = 'event_data'
-
-        // get attributes from the clickData object to send to GA
-        // only allow it if it already exists in the schema
-        for (var property in clickData) {
-          if (property in schema.event_data) {
-            schema.event_data[property] = clickData[property]
-          }
-        }
-
-        window.GOVUK.analyticsGa4.core.sendData(schema)
-      }
-    },
-
-    populateLinkPathParts: function (href) {
-      var path = ''
-      if (this.hrefIsRelative(href) || this.isMailToLink(href)) {
-        path = href
-      } else {
-        // This regex matches a protocol and domain name at the start of a string such as https://www.gov.uk, http://gov.uk, //gov.uk
-        path = href.replace(/^(http:||https:)?(\/\/)([^\/]*)/, '') // eslint-disable-line no-useless-escape
-      }
-
-      if (path === '/' || path.length === 0) {
-        return
-      }
-
-      /*
-      This will create an object with 5 keys that are indexes ("1", "2", etc.)
-      The values will be each part of the link path split every 100 characters, or undefined.
-      For example: {"1": "/hello/world/etc...", "2": "/more/path/text...", "3": undefined, "4": undefined, "5": undefined}
-      Undefined values are needed to override the persistent object in GTM so that any values from old pushes are overwritten.
-      */
-      var parts = path.match(/.{1,100}/g)
-      var obj = {}
-      for (var i = 0; i < 5; i++) {
-        obj[(i + 1).toString()] = parts[i]
-      }
-      return obj
-    },
-
-    populateLinkDomain: function (href) {
-      // We always want mailto links to have an undefined link_domain
-      if (this.isMailToLink(href)) {
-        return undefined
-      }
-
-      if (this.hrefIsRelative(href)) {
-        return this.getProtocol() + '//' + this.getHostname()
-      } else {
-        // This regex matches a protocol and domain name at the start of a string such as https://www.gov.uk, http://gov.uk, //gov.uk
-        var domainRegex = /^(http:||https:)?(\/\/)([^\/]*)/ // eslint-disable-line no-useless-escape
-        var domain = domainRegex.exec(href)[0]
-        return domain
-      }
-    },
-
-    appendDomainsWithoutWWW: function (domainsArrays) {
-      // Add domains with www. removed, in case site hrefs are marked up without www. included.
-      for (var i = 0; i < domainsArrays.length; i++) {
-        var domain = domainsArrays[i]
-        if (this.stringStartsWith(domain, 'www.')) {
-          var domainWithoutWww = domain.replace('www.', '')
-          domainsArrays.push(domainWithoutWww)
-        }
-      }
-    },
-
-    removeLinesAndExtraSpaces: function (text) {
-      text = text.trim()
-      text = text.replace(/(\r\n|\n|\r)/gm, ' ') // Replace line breaks with 1 space
-      text = text.replace(/\s+/g, ' ') // Replace instances of 2+ spaces with 1 space
-      return text
-    },
-
-    getClickType: function (event) {
-      switch (event.type) {
-        case 'click':
-          if (event.ctrlKey) {
-            return 'ctrl click'
-          } else if (event.metaKey) {
-            return 'command/win click'
-          } else if (event.shiftKey) {
-            return 'shift click'
-          } else {
-            return 'primary click'
-          }
-        case 'mousedown':
-          return 'middle click'
-        case 'contextmenu':
-          return 'secondary click'
-      }
-    },
-
-    handleMousedown: function (event) {
-      // 1 = middle mouse button
-      if (event.button === 1) {
-        this.handleClick(event)
-      }
-    },
-
-    isMailToLink: function (href) {
-      return href.substring(0, 7) === 'mailto:'
-    },
-
-    isDownloadLink: function (href) {
-      if (this.isInternalLink(href) && this.hrefPointsToDownloadPath(href)) {
-        return true
-      }
-
-      var result = false
-      for (var i = 0; i < this.dedicatedDownloadDomains.length; i++) {
-        var downloadDomain = this.dedicatedDownloadDomains[i]
-        if (this.hrefPointsToDomain(href, downloadDomain)) {
-          result = true
-        }
-      }
-      return result
-    },
-
-    isInternalLink: function (href) {
-      if (this.hrefIsRelative(href) || this.hrefIsAnchor(href)) {
-        return true
-      }
-      var result = false
-      for (var i = 0; i < this.internalDomains.length; i++) {
-        var internalDomain = this.internalDomains[i]
-        if (this.hrefPointsToDomain(href, internalDomain)) {
-          result = true
-        }
-      }
-      return result
-    },
-
-    isExternalLink: function (href) {
-      return !this.isInternalLink(href)
-    },
-
-    isPreviewLink: function (href) {
-      /*  Regex looks for:
-      1. The file extension period (the character '.')
-      2. any alphanumeric characters (so we can match any file type such as jpg, pdf, mp4.)
-      3. the presence of '/preview'.
-      For example, .csv/preview or .mp4/preview will be matched.
-      Regex is used over JS string methods as this should work with anchor links, query string parameters and files that may have 'preview' in their name.
-      */
-      var previewRegex = /\.\w+\/preview/i
-      return previewRegex.test(href)
-    },
-
-    hrefPointsToDomain: function (href, domain) {
-      /* Add a trailing slash to prevent an edge case such
-      as the href www.gov.uk.domain.co.uk being detected as an internal link,
-      if we were checking for 'www.gov.uk' instead of 'www.gov.uk/' */
-      if (domain.substring(domain.length) !== '/') {
-        domain = domain + '/'
-      }
-
-      /* If the href doesn't end in a slash, we add one.
-      This fixes an edge case where the <a href> is exactly `https://www.gov.uk`
-      but these checks would only look for `https://www.gov.uk/` */
-      if (href.substring(href.length) !== '/') {
-        href = href + '/'
-      }
-      var httpDomain = 'http://' + domain
-      var httpsDomain = 'https://' + domain
-      var schemaRelativeDomain = '//' + domain
-      return this.stringStartsWith(href, domain) ||
-      this.stringStartsWith(href, httpDomain) ||
-      this.stringStartsWith(href, httpsDomain) ||
-      this.stringStartsWith(href, schemaRelativeDomain)
-    },
-
-    hrefPointsToDownloadPath: function (href) {
-      var result = false
-      for (var i = 0; i < this.internalDownloadPaths.length; i++) {
-        var internalDownloadPath = this.internalDownloadPaths[i]
-        if (href.indexOf(internalDownloadPath) !== -1) {
-          result = true
-        }
-      }
-      return result
-    },
-
-    stringStartsWith: function (string, stringToFind) {
-      return string.substring(0, stringToFind.length) === stringToFind
-    },
-
-    stringEndsWith: function (string, stringToFind) {
-      return string.substring(string.length - stringToFind.length, string.length) === stringToFind
-    },
-
-    hrefIsRelative: function (href) {
-      // Checks that a link is relative, but is not a protocol relative url
-      return href[0] === '/' && href[1] !== '/'
-    },
-
-    hrefIsAnchor: function (href) {
-      return href[0] === '#'
-    },
-
-    getHostname: function () {
-      return window.location.hostname
-    },
-
-    getProtocol: function () {
-      return window.location.protocol
-    },
-
-    removeCrossDomainParams: function (href) {
-      if (href.indexOf('_ga') !== -1 || href.indexOf('_gl') !== -1) {
-        // _ga & _gl are values needed for cross domain tracking, but we don't want them included in our click tracking.
-        href = href.replaceAll(/_g[al]=([^&]*)/g, '')
-
-        // The following code cleans up inconsistencies such as gov.uk/&&, gov.uk/?&hello=world, gov.uk/?, and gov.uk/&.
-        href = href.replaceAll(/(&&)+/g, '&')
-        href = href.replace('?&', '?')
-        if (this.stringEndsWith(href, '?') || this.stringEndsWith(href, '&')) {
-          href = href.substring(0, href.length - 1)
-        }
-      }
-      return href
+    if (consentCookie && consentCookie.settings) {
+      this.startModule()
+    } else {
+      this.startModule = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.startModule)
     }
   }
 
-  analyticsModules.Ga4LinkTracker = Ga4LinkTracker
-})(window.GOVUK.analyticsGa4.analyticsModules)
+  // triggered by cookie-consent event, which happens when users consent to cookies
+  Ga4LinkTracker.prototype.startModule = function () {
+    if (window.dataLayer) {
+      this.module.addEventListener('click', function (event) {
+        var target = event.target
+        if (!this.trackLinksOnly) {
+          this.trackClick(event)
+        } else if (this.trackLinksOnly && target.closest('a')) {
+          if (!this.limitToElementClass) {
+            this.trackClick(event)
+          } else if (this.limitToElementClass && target.closest('.' + this.limitToElementClass)) {
+            this.trackClick(event)
+          }
+        }
+      }.bind(this), true) // useCapture must be true
+    }
+  }
+
+  Ga4LinkTracker.prototype.trackClick = function (event) {
+    var target = this.findTrackingAttributes(event.target)
+    if (target) {
+      var schema = new window.GOVUK.analyticsGa4.Schemas().eventSchema()
+
+      try {
+        var data = target.getAttribute(this.trackingTrigger)
+        data = JSON.parse(data)
+      } catch (e) {
+        // if there's a problem with the config, don't start the tracker
+        console.error('GA4 configuration error: ' + e.message, window.location)
+        return
+      }
+
+      schema.event = 'event_data'
+      data.text = event.target.textContent
+      data.url = this.findLink(event.target).getAttribute('href')
+      // get attributes from the data attribute to send to GA
+      // only allow it if it already exists in the schema
+      for (var property in data) {
+        if (property in schema.event_data) {
+          schema.event_data[property] = data[property]
+        }
+      }
+
+      window.GOVUK.analyticsGa4.core.sendData(schema)
+    }
+  }
+
+  Ga4LinkTracker.prototype.findLink = function (target) {
+    if (target.tagName === 'A') {
+      return target
+    } else {
+      return target.closest('a')
+    }
+  }
+
+  // FIXME duplicated from the event tracker - move to somewhere shared
+  Ga4LinkTracker.prototype.findTrackingAttributes = function (clicked) {
+    if (clicked.hasAttribute('[' + this.trackingTrigger + ']')) {
+      return clicked
+    } else {
+      return clicked.closest('[' + this.trackingTrigger + ']')
+    }
+  }
+
+  Modules.Ga4LinkTracker = Ga4LinkTracker
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -7,7 +7,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   function Ga4LinkTracker (module) {
     this.module = module
-    this.trackingTrigger = 'data-ga4' // elements with this attribute get tracked
+    this.trackingTrigger = 'data-ga4-link' // elements with this attribute get tracked
     this.trackLinksOnly = this.module.hasAttribute('data-ga4-track-links-only')
     this.limitToElementClass = this.module.getAttribute('data-ga4-limit-to-element-class')
   }
@@ -42,7 +42,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   Ga4LinkTracker.prototype.trackClick = function (event) {
-    var target = this.findTrackingAttributes(event.target)
+    var target = window.GOVUK.analyticsGa4.core.trackFunctions.findTrackingAttributes(event.target, this.trackingTrigger)
     if (target) {
       var schema = new window.GOVUK.analyticsGa4.Schemas().eventSchema()
 
@@ -75,15 +75,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       return target
     } else {
       return target.closest('a')
-    }
-  }
-
-  // FIXME duplicated from the event tracker - move to somewhere shared
-  Ga4LinkTracker.prototype.findTrackingAttributes = function (clicked) {
-    if (clicked.hasAttribute('[' + this.trackingTrigger + ']')) {
-      return clicked
-    } else {
-      return clicked.closest('[' + this.trackingTrigger + ']')
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
@@ -1,0 +1,331 @@
+// = require govuk/vendor/polyfills/Element/prototype/closest.js
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analyticsModules || {};
+
+(function (analyticsModules) {
+  'use strict'
+
+  var Ga4SpecialistLinkTracker = {
+    init: function (config) {
+      if (window.dataLayer) {
+        config = config || {}
+        this.internalDomains = config.internalDomains || []
+        this.internalDomains.push(this.getHostname())
+        this.appendDomainsWithoutWWW(this.internalDomains)
+        this.internalDownloadPaths = config.internalDownloadPaths || ['/government/uploads/']
+        this.dedicatedDownloadDomains = config.dedicatedDownloadDomains || ['assets.publishing.service.gov.uk']
+        this.appendDomainsWithoutWWW(this.dedicatedDownloadDomains)
+        this.handleClick = this.handleClick.bind(this)
+        this.handleMousedown = this.handleMousedown.bind(this)
+
+        if (!config.disableListeners) {
+          document.querySelector('body').addEventListener('click', this.handleClick)
+          document.querySelector('body').addEventListener('contextmenu', this.handleClick)
+          document.querySelector('body').addEventListener('mousedown', this.handleMousedown)
+        }
+      }
+    },
+
+    stopTracking: function () {
+      document.querySelector('body').removeEventListener('click', this.handleClick)
+      document.querySelector('body').removeEventListener('contextmenu', this.handleClick)
+      document.querySelector('body').removeEventListener('mousedown', this.handleMousedown)
+    },
+
+    handleClick: function (event) {
+      var element = event.target
+
+      if (element.tagName !== 'A') {
+        element = element.closest('a')
+      }
+
+      if (!element) {
+        return
+      }
+
+      var href = element.getAttribute('href')
+
+      if (!href) {
+        return
+      }
+      var clickData = {}
+      var linkAttributes = element.getAttribute('data-ga4-link')
+      if (linkAttributes) {
+        clickData = JSON.parse(linkAttributes)
+
+        /* Since external links can't be determined in the template, we use populated-via-js as a signal
+        for our JavaScript to determine this value. */
+        if (clickData.external === 'populated-via-js' && clickData.url) {
+          clickData.external = this.isExternalLink(clickData.url) ? 'true' : 'false'
+        }
+
+        if (clickData.method === 'populated-via-js') {
+          clickData.method = this.getClickType(event)
+        }
+
+        if (clickData.index) {
+          clickData.index = parseInt(clickData.index)
+        }
+
+        if (clickData.index_total) {
+          clickData.index_total = parseInt(clickData.index_total)
+        }
+      } else if (this.isMailToLink(href)) {
+        clickData.event_name = 'navigation'
+        clickData.type = 'email'
+        clickData.external = 'true'
+        clickData.url = href
+        clickData.text = this.removeLinesAndExtraSpaces(element.textContent)
+        clickData.method = this.getClickType(event)
+      } else if (this.isDownloadLink(href)) {
+        clickData.event_name = 'file_download'
+        clickData.type = this.isPreviewLink(href) ? 'preview' : 'generic download'
+        clickData.external = this.isExternalLink(href) ? 'true' : 'false'
+        clickData.url = href
+        clickData.text = this.removeLinesAndExtraSpaces(element.textContent)
+        clickData.method = this.getClickType(event)
+      } else if (this.isExternalLink(href)) {
+        clickData.event_name = 'navigation'
+        clickData.type = 'generic link'
+        clickData.external = 'true'
+        clickData.url = href
+        clickData.text = this.removeLinesAndExtraSpaces(element.textContent)
+        clickData.method = this.getClickType(event)
+      }
+
+      if (Object.keys(clickData).length > 0) {
+        if (clickData.url) {
+          clickData.url = this.removeCrossDomainParams(clickData.url)
+          clickData.link_domain = this.populateLinkDomain(clickData.url)
+          clickData.link_path_parts = this.populateLinkPathParts(clickData.url)
+        }
+
+        var schema = new window.GOVUK.analyticsGa4.Schemas().eventSchema()
+        schema.event = 'event_data'
+
+        // get attributes from the clickData object to send to GA
+        // only allow it if it already exists in the schema
+        for (var property in clickData) {
+          if (property in schema.event_data) {
+            schema.event_data[property] = clickData[property]
+          }
+        }
+
+        window.GOVUK.analyticsGa4.core.sendData(schema)
+      }
+    },
+
+    populateLinkPathParts: function (href) {
+      var path = ''
+      if (this.hrefIsRelative(href) || this.isMailToLink(href)) {
+        path = href
+      } else {
+        // This regex matches a protocol and domain name at the start of a string such as https://www.gov.uk, http://gov.uk, //gov.uk
+        path = href.replace(/^(http:||https:)?(\/\/)([^\/]*)/, '') // eslint-disable-line no-useless-escape
+      }
+
+      if (path === '/' || path.length === 0) {
+        return
+      }
+
+      /*
+      This will create an object with 5 keys that are indexes ("1", "2", etc.)
+      The values will be each part of the link path split every 100 characters, or undefined.
+      For example: {"1": "/hello/world/etc...", "2": "/more/path/text...", "3": undefined, "4": undefined, "5": undefined}
+      Undefined values are needed to override the persistent object in GTM so that any values from old pushes are overwritten.
+      */
+      var parts = path.match(/.{1,100}/g)
+      var obj = {}
+      for (var i = 0; i < 5; i++) {
+        obj[(i + 1).toString()] = parts[i]
+      }
+      return obj
+    },
+
+    populateLinkDomain: function (href) {
+      // We always want mailto links to have an undefined link_domain
+      if (this.isMailToLink(href)) {
+        return undefined
+      }
+
+      if (this.hrefIsRelative(href)) {
+        return this.getProtocol() + '//' + this.getHostname()
+      } else {
+        // This regex matches a protocol and domain name at the start of a string such as https://www.gov.uk, http://gov.uk, //gov.uk
+        var domainRegex = /^(http:||https:)?(\/\/)([^\/]*)/ // eslint-disable-line no-useless-escape
+        var domain = domainRegex.exec(href)[0]
+        return domain
+      }
+    },
+
+    appendDomainsWithoutWWW: function (domainsArrays) {
+      // Add domains with www. removed, in case site hrefs are marked up without www. included.
+      for (var i = 0; i < domainsArrays.length; i++) {
+        var domain = domainsArrays[i]
+        if (this.stringStartsWith(domain, 'www.')) {
+          var domainWithoutWww = domain.replace('www.', '')
+          domainsArrays.push(domainWithoutWww)
+        }
+      }
+    },
+
+    removeLinesAndExtraSpaces: function (text) {
+      text = text.trim()
+      text = text.replace(/(\r\n|\n|\r)/gm, ' ') // Replace line breaks with 1 space
+      text = text.replace(/\s+/g, ' ') // Replace instances of 2+ spaces with 1 space
+      return text
+    },
+
+    getClickType: function (event) {
+      switch (event.type) {
+        case 'click':
+          if (event.ctrlKey) {
+            return 'ctrl click'
+          } else if (event.metaKey) {
+            return 'command/win click'
+          } else if (event.shiftKey) {
+            return 'shift click'
+          } else {
+            return 'primary click'
+          }
+        case 'mousedown':
+          return 'middle click'
+        case 'contextmenu':
+          return 'secondary click'
+      }
+    },
+
+    handleMousedown: function (event) {
+      // 1 = middle mouse button
+      if (event.button === 1) {
+        this.handleClick(event)
+      }
+    },
+
+    isMailToLink: function (href) {
+      return href.substring(0, 7) === 'mailto:'
+    },
+
+    isDownloadLink: function (href) {
+      if (this.isInternalLink(href) && this.hrefPointsToDownloadPath(href)) {
+        return true
+      }
+
+      var result = false
+      for (var i = 0; i < this.dedicatedDownloadDomains.length; i++) {
+        var downloadDomain = this.dedicatedDownloadDomains[i]
+        if (this.hrefPointsToDomain(href, downloadDomain)) {
+          result = true
+        }
+      }
+      return result
+    },
+
+    isInternalLink: function (href) {
+      if (this.hrefIsRelative(href) || this.hrefIsAnchor(href)) {
+        return true
+      }
+      var result = false
+      for (var i = 0; i < this.internalDomains.length; i++) {
+        var internalDomain = this.internalDomains[i]
+        if (this.hrefPointsToDomain(href, internalDomain)) {
+          result = true
+        }
+      }
+      return result
+    },
+
+    isExternalLink: function (href) {
+      return !this.isInternalLink(href)
+    },
+
+    isPreviewLink: function (href) {
+      /*  Regex looks for:
+      1. The file extension period (the character '.')
+      2. any alphanumeric characters (so we can match any file type such as jpg, pdf, mp4.)
+      3. the presence of '/preview'.
+      For example, .csv/preview or .mp4/preview will be matched.
+      Regex is used over JS string methods as this should work with anchor links, query string parameters and files that may have 'preview' in their name.
+      */
+      var previewRegex = /\.\w+\/preview/i
+      return previewRegex.test(href)
+    },
+
+    hrefPointsToDomain: function (href, domain) {
+      /* Add a trailing slash to prevent an edge case such
+      as the href www.gov.uk.domain.co.uk being detected as an internal link,
+      if we were checking for 'www.gov.uk' instead of 'www.gov.uk/' */
+      if (domain.substring(domain.length) !== '/') {
+        domain = domain + '/'
+      }
+
+      /* If the href doesn't end in a slash, we add one.
+      This fixes an edge case where the <a href> is exactly `https://www.gov.uk`
+      but these checks would only look for `https://www.gov.uk/` */
+      if (href.substring(href.length) !== '/') {
+        href = href + '/'
+      }
+      var httpDomain = 'http://' + domain
+      var httpsDomain = 'https://' + domain
+      var schemaRelativeDomain = '//' + domain
+      return this.stringStartsWith(href, domain) ||
+      this.stringStartsWith(href, httpDomain) ||
+      this.stringStartsWith(href, httpsDomain) ||
+      this.stringStartsWith(href, schemaRelativeDomain)
+    },
+
+    hrefPointsToDownloadPath: function (href) {
+      var result = false
+      for (var i = 0; i < this.internalDownloadPaths.length; i++) {
+        var internalDownloadPath = this.internalDownloadPaths[i]
+        if (href.indexOf(internalDownloadPath) !== -1) {
+          result = true
+        }
+      }
+      return result
+    },
+
+    stringStartsWith: function (string, stringToFind) {
+      return string.substring(0, stringToFind.length) === stringToFind
+    },
+
+    stringEndsWith: function (string, stringToFind) {
+      return string.substring(string.length - stringToFind.length, string.length) === stringToFind
+    },
+
+    hrefIsRelative: function (href) {
+      // Checks that a link is relative, but is not a protocol relative url
+      return href[0] === '/' && href[1] !== '/'
+    },
+
+    hrefIsAnchor: function (href) {
+      return href[0] === '#'
+    },
+
+    getHostname: function () {
+      return window.location.hostname
+    },
+
+    getProtocol: function () {
+      return window.location.protocol
+    },
+
+    removeCrossDomainParams: function (href) {
+      if (href.indexOf('_ga') !== -1 || href.indexOf('_gl') !== -1) {
+        // _ga & _gl are values needed for cross domain tracking, but we don't want them included in our click tracking.
+        href = href.replaceAll(/_g[al]=([^&]*)/g, '')
+
+        // The following code cleans up inconsistencies such as gov.uk/&&, gov.uk/?&hello=world, gov.uk/?, and gov.uk/&.
+        href = href.replaceAll(/(&&)+/g, '&')
+        href = href.replace('?&', '?')
+        if (this.stringEndsWith(href, '?') || this.stringEndsWith(href, '&')) {
+          href = href.substring(0, href.length - 1)
+        }
+      }
+      return href
+    }
+  }
+
+  analyticsModules.Ga4SpecialistLinkTracker = Ga4SpecialistLinkTracker
+})(window.GOVUK.analyticsGa4.analyticsModules)

--- a/docs/analytics-ga4/analytics.md
+++ b/docs/analytics-ga4/analytics.md
@@ -54,6 +54,16 @@ When cookie consent is given, `init-ga4.js` looks through the `analyticsModules`
 
 Where analytics code is required as a [GOV.UK JavaScript Module](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/javascript-modules.md), the code structure for the [existing model for deferred loading](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/javascript-modules.md#modules-and-cookie-consent) should be used.
 
+## Link and event tracking
+
+There are several types of user initiated tracking. To distinguish them and simplify the code, we consider them as the following:
+
+- interactions with [internal links](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-track-click.md)
+- interactions with [specialist links](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md), e.g. external links, download links, mailto links
+- interactions with [buttons or other interactive elements](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) e.g. details elements
+
+Each type of tracking is handled by a separate script, but some code is shared between them as they do similar things.
+
 ## Data schemas
 
 All of the data sent to GTM is based on a common schema.

--- a/docs/analytics-ga4/ga4-event-tracker.md
+++ b/docs/analytics-ga4/ga4-event-tracker.md
@@ -1,14 +1,14 @@
-# Google Analytics event tracker
+# Google Analytics 4 event tracker
 
-This is a script to allow event tracking (e.g. clicks) through Google Tag Manager to be added to any element using data attributes.
+This script is intended for adding GA4 tracking to interactive elements such as buttons or details elements. It depends upon the main GA4 analytics code to function.
 
 ## Basic use
 
 ```html
 <div data-module="ga4-event-tracker">
-  <div data-ga4='{"event_name":"select_content", "type":"something", "index":0, "index_total":1, "text":"Click me"}'>
+  <button data-ga4='{ "event_name": "select_content", "type": "something", "index": "0", "index_total": "1", "text": "Click me"}'>
     Click me
-  </div>
+  </button>
 </div>
 ```
 

--- a/docs/analytics-ga4/ga4-link-tracker.md
+++ b/docs/analytics-ga4/ga4-link-tracker.md
@@ -1,116 +1,75 @@
-# Google Analytics link tracker
+# Google Analytics 4 link tracker
 
-A module for tracking link clicks on GOV.UK.
+This script is intended for adding GA4 tracking to links. It depends upon the main GA4 analytics code to function.
 
-When initialised, the JS adds an event listener to the `<body>` of the page with the following listeners:
+## Basic use (single link)
 
-- A `click` listener (for left clicks, control clicks, and "Meta key" clicks - "Meta key" clicks are command + clicks or windows key + clicks.)
-- A `mousedown` listener (for middle clicks.)
-- A `contextmenu` listener (for right clicks / context menu keypresses.)
-
-When one of these listeners are fired, they check if the `event.target` is an `<a>` tag with a `href`. If so, it will then check if the link is:
-
-- A `share` or `follow` link - This allows analysts to track if a page was shared, or if a user clicked on one of our social media channels, which are usually under a 'Follow us' heading. The tracking is added to the component by adding `track_as_share: true` or `track_as_follow: true` to the template import of a share links component. If one of these booleans is set to true, a `data-ga4-link` attribute is added to all the component's `<a>` tags. This `data-ga4-link` attribute houses a stringified JSON, containing the relevant data to push to GTM. The link tracker will always check for `data-ga4-link` first before checking the link matches our other link types. Therefore, this `data-ga4-link` pattern can be expanded to track other types of links, which can't be categorised by simply running checks against the href. Some keys in the JSON cannot be calculated in the template. Therefore, the value of these keys are set to `"populated-via-js"`. This `"populated-via-js"` is detected by the JS, and is subsequently overwritten in JS with the correct value.
-- A `generic download` - This is either a href to `assets.publishing.service.gov.uk` or a href on the `www.gov.uk` domain pointing to the `/government/uploads/` path.
-- A `preview` link - This is either a href to `assets.publishing.service.gov.uk` or a href on the `www.gov.uk` domain pointing to the `/government/uploads/` path which has `/preview` in the URL after the file path.
-- A `mailto` link - This is an email href that starts with `mailto:`.
-- An `generic link`  - This is a href that is not on the internal domains. Internal domains include the current hostname, and any domains passed through to the `init({internalDomains: []})` array.
-    - To calculate this, it checks the start of the href. If we were to use `www.gov.uk` as an example, it would check if the href starts with:
-        - `http://www.gov.uk/`,
-        - `https://www.gov.uk/`,
-        - `//www.gov.uk/`,
-        - `www.gov.uk/`,
-        - (NB: `www.gov.uk/` is technically a relative link, as a href must contain a `/` or http method at the start to be treated as non-relative).
-    - It also checks if a `href` starts with `/` and does not start with `//` to determine if it's a relative link like `/bank-holidays` , but not a protocol relative link such as `//google.com`.
-    - If the `href` does not meet the above criteria, then it is considered an external link.
-
-Events can either have an `event_name` of `navigation`, `file_download`, or `share`. Download and preview links will use the `file_download` value, while generic external links, mailto links, and follow links will use `navigation`. Share links use `share`.
-
-Link URLs are stripped of the `_ga` and `_gl` query parameters. These are only relevant for cross domain tracking and aren't useful for our click tracking. Link text is stripped of multiple lines and multiple spaces, as this causes issues in the analytics dashboards.
-
-GA4 only allows event values to have a maximum character length of 100. This is a problem for tracking URLs, as many of them exceed 100 characters. Therefore, to solve this we have:
-- Added a separate `link_domain` value which captures the protocol and domain of a link, such as `https://www.gov.uk`
-- Created an object called `link_path_parts`, which splits the path into 100 character segments (max 5 segments, or 500 characters). For example, if your link was `https://gov.uk/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili`, your GA4 push would contain:
-     ```JavaScript
-     "link_domain": "https://www.gov.uk",
-     "link_path_parts": {
-          "1": "/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-",
-          "2": "say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili",
-          "3": undefined,
-          "4": undefined,
-          "5": undefined
-        },
-    ```
-- The link is then reconstructed in Data Studio.
-
-## Basic use
-
-```JavaScript
-//= require ./analytics-ga4/ga4-link-tracker
-
-window.GOVUK.analyticsGa4.linkTracker.init()
+```html
+<a
+  href="/link"
+  data-module="ga4-track-click"
+  data-ga4='{ "event_name": "navigation", "type": "home page", "index": 0, "index_total": 1, "section": "name of section", "external": "false" }'>
+    Link
+</a>
 ```
 
-Passing a config object with arrays to `init()` is optional, but passing each array enables extra functionality:
-- Passing an `internalDomains` array allows you to class domains which aren't the current hostname as internal domains. For example, if you were adding tracking and your hostname was `helpforhouseholds.campaign.gov.uk`, `www.gov.uk` links would be classed as external links, unless you add `www.gov.uk` to this array. The link tracker will automatically add the domain with `www.` removed as well (`gov.uk` in this case,) as sometimes `www.` is omitted from `href` values.
-- Passing an `internalDownloadPaths` array allows you to specify paths which should be classified as paths to a downloads route in your internal domains. If the path exists in an internal `href`, it will be treated as a download link.
-- Passing a `dedicatedDownloadDomains` array allows you to specify domains which will always be classed as a download link. For example, `dropbox.com` could be added to always track dropbox links as download links.
-- Passing `disableListeners: true` prevents click listeners from being added to the page on initilisation. This is useful if you'd like use the link detection features elsewhere without adding extra click listeners to the DOM.
+Note that the specific detail of the `data-ga4` attribute will depend on the context of the link.
 
-```JavaScript
-//= require ./analytics-ga4/ga4-link-tracker
+## Basic use (multiple links)
 
-window.GOVUK.analyticsGa4.linkTracker.init({
-    internalDomains: ['www.gov.uk'],
-    internalDownloadPaths: ['/government/uploads/', '/downloads/'],
-    dedicatedDownloadDomains: ['assets.publishing.service.gov.uk', 'dropbox.com'],
-    disableListeners: // true/false
-})
+Specific tracking can be applied to multiple elements within a container, by applying the data module once to the parent element.
 
+```html
+<div data-module="ga4-track-click">
+  <a
+    href="/a-page"
+    data-ga4='{ "event_name": "navigation", "type": "browse", "index": "0", "index_total": "2", "section": "name of section", "external": "false" }'>
+    Link 1
+  </a>
+  <a
+    href="/another-page"
+    data-ga4='{ "event_name": "navigation", "type": "browse", "index": "1", "index_total": "2", "section": "name of section", "external": "false" }'>
+    Link 2
+  </a>
+</div>
 ```
 
-`<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/742746/A_quick_guide_to_govt_healthy_eating_update.pdf">A Quick Guide to the Government’s Healthy Eating Recommendations</a>`
+Note that the specific detail of the `data-ga4` attribute will depend on the context of the link.
 
-In the example above, on a left click of the link, the following would be pushed to the dataLayer, using the `eventSchema` found in `ga4-schemas.js`:
+## Track links within content
 
-```JSON
-{
-    "event": "event_data",
-    "event_data": {
-        "event_name": "file_download",
-        "type": "generic download",
-        "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/742746/A_quick_guide_to_govt_healthy_eating_update.pdf",
-        "text": "A Quick Guide to the Government’s Healthy Eating Recommendations",
-        "index": null,
-        "index_total": null,
-        "section": null,
-        "action": null,
-        "external": "true",
-        "method": "primary click",
-        "link_domain": "https://assets.publishing.service.gov.uk",
-        "link_path_parts": {
-            "1": "/government/uploads/system/uploads/attachment_data/file/742746/A_quick_guide_to_govt_healthy_eating_",
-            "2": "update.pdf"
-        }
-    }
-}
+Where tracking attributes cannot be directly applied to elements, links can be tracked with details applied to the parent. In this configuration the link text and href are automatically determined and included in the event data. This is helpful where page content is not editable, e.g. content comes from the content item or a publishing tool.
+
+The `data-ga4-track-links-only` attribute ensures that only link clicks are tracked (without it, any click inside the element is tracked).
+
+```html
+<div
+  data-module="ga4-track-click"
+  data-ga4='{ "event_name": "navigation", "type": "browse", "section": "name of section", "external": "false" }'
+  data-ga4-track-links-only>
+  <a href="/link1">This link will be tracked</a>
+  <a href="/link2">
+    <span>This link will also be tracked even though it contains child elements</span>
+  </a>
+  <span>This span will not be tracked</span>
+</div>
 ```
 
-Preview links would turn `type` to `preview`.
+Note that in this configuration specific values such as `index` and `index_total` cannot currently be applied to links.
 
-External links would turn `event_name` to `navigation` and `type` to `generic link`.
+## Track links within content within a specific element
 
-Mailto links would turn turn `event_name` to `navigation` and `type` to `email`.
+To apply tracking to links within a specific element within part of a page, use the `data-ga4-limit-to-element-class` alongside the `data-ga4-track-links-only` attribute. This is helpful where page content is not editable, e.g. content comes from the content item or a publishing tool.
 
-Share links would turn `event_name` to `share` and type to `share this page`.
-
-Follow links would turn `event_name` to `navigation` and type to `follow us`
-
-For `method`:
-
-- Left clicks are a `primary click`
-- Right clicks and context menu keypresses are `secondary click`
-- Middle mouse button clicks are `middle click`
-- Meta key clicks are `command/win click`
-- Shift key clicks are `shift click`
-- Control clicks are `ctrl click`
+```html
+<div
+  data-module="ga4-track-click"
+  data-ga4='{ "event_name": "navigation", "type": "browse", "section": "name of section", "external": "false" }'
+  data-ga4-track-links-only
+  data-ga4-limit-to-element-class="demoBox">
+  <a href="/link1">This link will not be tracked</a>
+  <div class="demoBox">
+    <a href="/link2">This link will be tracked</a>
+  </div>
+</div>
+```

--- a/docs/analytics-ga4/ga4-specialist-link-tracker.md
+++ b/docs/analytics-ga4/ga4-specialist-link-tracker.md
@@ -1,0 +1,116 @@
+# Google Analytics Specialist Link Tracker
+
+A module for tracking specific kinds of link interactions on GOV.UK.
+
+When initialised, the JS adds an event listener to the `<body>` of the page with the following listeners:
+
+- A `click` listener (for left clicks, control clicks, and "Meta key" clicks - "Meta key" clicks are command + clicks or windows key + clicks.)
+- A `mousedown` listener (for middle clicks.)
+- A `contextmenu` listener (for right clicks / context menu keypresses.)
+
+When one of these listeners are fired, they check if the `event.target` is an `<a>` tag with a `href`. If so, it will then check if the link is:
+
+- A `share` or `follow` link - This allows analysts to track if a page was shared, or if a user clicked on one of our social media channels, which are usually under a 'Follow us' heading. The tracking is added to the component by adding `track_as_share: true` or `track_as_follow: true` to the template import of a share links component. If one of these booleans is set to true, a `data-ga4-link` attribute is added to all the component's `<a>` tags. This `data-ga4-link` attribute houses a stringified JSON, containing the relevant data to push to GTM. The link tracker will always check for `data-ga4-link` first before checking the link matches our other link types. Therefore, this `data-ga4-link` pattern can be expanded to track other types of links, which can't be categorised by simply running checks against the href. Some keys in the JSON cannot be calculated in the template. Therefore, the value of these keys are set to `"populated-via-js"`. This `"populated-via-js"` is detected by the JS, and is subsequently overwritten in JS with the correct value.
+- A `generic download` - This is either a href to `assets.publishing.service.gov.uk` or a href on the `www.gov.uk` domain pointing to the `/government/uploads/` path.
+- A `preview` link - This is either a href to `assets.publishing.service.gov.uk` or a href on the `www.gov.uk` domain pointing to the `/government/uploads/` path which has `/preview` in the URL after the file path.
+- A `mailto` link - This is an email href that starts with `mailto:`.
+- An `generic link`  - This is a href that is not on the internal domains. Internal domains include the current hostname, and any domains passed through to the `init({internalDomains: []})` array.
+    - To calculate this, it checks the start of the href. If we were to use `www.gov.uk` as an example, it would check if the href starts with:
+        - `http://www.gov.uk/`,
+        - `https://www.gov.uk/`,
+        - `//www.gov.uk/`,
+        - `www.gov.uk/`,
+        - (NB: `www.gov.uk/` is technically a relative link, as a href must contain a `/` or http method at the start to be treated as non-relative).
+    - It also checks if a `href` starts with `/` and does not start with `//` to determine if it's a relative link like `/bank-holidays` , but not a protocol relative link such as `//google.com`.
+    - If the `href` does not meet the above criteria, then it is considered an external link.
+
+Events can either have an `event_name` of `navigation`, `file_download`, or `share`. Download and preview links will use the `file_download` value, while generic external links, mailto links, and follow links will use `navigation`. Share links use `share`.
+
+Link URLs are stripped of the `_ga` and `_gl` query parameters. These are only relevant for cross domain tracking and aren't useful for our click tracking. Link text is stripped of multiple lines and multiple spaces, as this causes issues in the analytics dashboards.
+
+GA4 only allows event values to have a maximum character length of 100. This is a problem for tracking URLs, as many of them exceed 100 characters. Therefore, to solve this we have:
+- Added a separate `link_domain` value which captures the protocol and domain of a link, such as `https://www.gov.uk`
+- Created an object called `link_path_parts`, which splits the path into 100 character segments (max 5 segments, or 500 characters). For example, if your link was `https://gov.uk/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili`, your GA4 push would contain:
+     ```JavaScript
+     "link_domain": "https://www.gov.uk",
+     "link_path_parts": {
+          "1": "/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-",
+          "2": "say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili",
+          "3": undefined,
+          "4": undefined,
+          "5": undefined
+        },
+    ```
+- The link is then reconstructed in Data Studio.
+
+## Basic use
+
+```JavaScript
+//= require ./analytics-ga4/ga4-link-tracker
+
+window.GOVUK.analyticsGa4.linkTracker.init()
+```
+
+Passing a config object with arrays to `init()` is optional, but passing each array enables extra functionality:
+- Passing an `internalDomains` array allows you to class domains which aren't the current hostname as internal domains. For example, if you were adding tracking and your hostname was `helpforhouseholds.campaign.gov.uk`, `www.gov.uk` links would be classed as external links, unless you add `www.gov.uk` to this array. The link tracker will automatically add the domain with `www.` removed as well (`gov.uk` in this case,) as sometimes `www.` is omitted from `href` values.
+- Passing an `internalDownloadPaths` array allows you to specify paths which should be classified as paths to a downloads route in your internal domains. If the path exists in an internal `href`, it will be treated as a download link.
+- Passing a `dedicatedDownloadDomains` array allows you to specify domains which will always be classed as a download link. For example, `dropbox.com` could be added to always track dropbox links as download links.
+- Passing `disableListeners: true` prevents click listeners from being added to the page on initilisation. This is useful if you'd like use the link detection features elsewhere without adding extra click listeners to the DOM.
+
+```JavaScript
+//= require ./analytics-ga4/ga4-link-tracker
+
+window.GOVUK.analyticsGa4.linkTracker.init({
+    internalDomains: ['www.gov.uk'],
+    internalDownloadPaths: ['/government/uploads/', '/downloads/'],
+    dedicatedDownloadDomains: ['assets.publishing.service.gov.uk', 'dropbox.com'],
+    disableListeners: // true/false
+})
+
+```
+
+`<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/742746/A_quick_guide_to_govt_healthy_eating_update.pdf">A Quick Guide to the Government’s Healthy Eating Recommendations</a>`
+
+In the example above, on a left click of the link, the following would be pushed to the dataLayer, using the `eventSchema` found in `ga4-schemas.js`:
+
+```JSON
+{
+    "event": "event_data",
+    "event_data": {
+        "event_name": "file_download",
+        "type": "generic download",
+        "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/742746/A_quick_guide_to_govt_healthy_eating_update.pdf",
+        "text": "A Quick Guide to the Government’s Healthy Eating Recommendations",
+        "index": null,
+        "index_total": null,
+        "section": null,
+        "action": null,
+        "external": "true",
+        "method": "primary click",
+        "link_domain": "https://assets.publishing.service.gov.uk",
+        "link_path_parts": {
+            "1": "/government/uploads/system/uploads/attachment_data/file/742746/A_quick_guide_to_govt_healthy_eating_",
+            "2": "update.pdf"
+        }
+    }
+}
+```
+
+Preview links would turn `type` to `preview`.
+
+External links would turn `event_name` to `navigation` and `type` to `generic link`.
+
+Mailto links would turn turn `event_name` to `navigation` and `type` to `email`.
+
+Share links would turn `event_name` to `share` and type to `share this page`.
+
+Follow links would turn `event_name` to `navigation` and type to `follow us`
+
+For `method`:
+
+- Left clicks are a `primary click`
+- Right clicks and context menu keypresses are `secondary click`
+- Middle mouse button clicks are `middle click`
+- Meta key clicks are `command/win click`
+- Shift key clicks are `shift click`
+- Control clicks are `ctrl click`

--- a/docs/analytics/track-click.md
+++ b/docs/analytics/track-click.md
@@ -79,8 +79,8 @@ Where tracking attributes cannot be applied to elements, links can be tracked wi
   data-track-category="category"
   data-track-action="action"
   data-track-links-only>
-  <a class="first" href="/link1">This link will be tracked</a>
-  <a class="second" href="/link2">
+  <a href="/link1">This link will be tracked</a>
+  <a href="/link2">
     <span>This link will also be tracked even though it contains child elements</span>
   </a>
   <span>This span will not be tracked</span>
@@ -97,9 +97,9 @@ To apply tracking to links within a specific element within part of a page, use 
   data-track-action="action"
   data-track-links-only
   data-limit-to-element-class="demoBox">
-  <a class="first" href="/link1">This link will not be tracked</a>
+  <a href="/link1">This link will not be tracked</a>
   <div class="demoBox">
-    <a class="second" href="/link2">This link will be tracked</a>
+    <a href="/link2">This link will be tracked</a>
   </div>
 </div>
 ```

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.spec.js
@@ -249,8 +249,8 @@ describe('Google Analytics ecommerce tracking', function () {
       }
 
       resultToBeClicked = document.querySelector("[data-ecommerce-path='/foreign-travel-advice']")
-      GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker.internalLinksDomain = 'www.gov.uk/'
-      GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker.internalLinksDomainWithoutWww = 'gov.uk/'
+      GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker.internalLinksDomain = 'www.gov.uk/'
+      GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker.internalLinksDomainWithoutWww = 'gov.uk/'
     })
 
     it('should push a nullified ecommerce object to the dataLayer', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -74,7 +74,7 @@ describe('Google Analytics event tracking', function () {
 
   describe('configuring tracking without any data', function () {
     beforeEach(function () {
-      element.setAttribute('data-ga4', '')
+      element.setAttribute('data-ga4-event', '')
       document.body.appendChild(element)
       new GOVUK.Modules.Ga4EventTracker(element).init()
     })
@@ -87,7 +87,7 @@ describe('Google Analytics event tracking', function () {
 
   describe('configuring tracking with incorrect data', function () {
     beforeEach(function () {
-      element.setAttribute('data-ga4', 'invalid json')
+      element.setAttribute('data-ga4-event', 'invalid json')
       document.body.appendChild(element)
       new GOVUK.Modules.Ga4EventTracker(element).init()
     })
@@ -111,7 +111,7 @@ describe('Google Analytics event tracking', function () {
         type: 'tabs',
         not_a_schema_attribute: 'something'
       }
-      element.setAttribute('data-ga4', JSON.stringify(attributes))
+      element.setAttribute('data-ga4-event', JSON.stringify(attributes))
       document.body.appendChild(element)
       new GOVUK.Modules.Ga4EventTracker(element).init()
     })
@@ -150,10 +150,10 @@ describe('Google Analytics event tracking', function () {
       }
 
       element.innerHTML =
-        '<div data-ga4=\'' + JSON.stringify(attributes1) + '\'' +
+        '<div data-ga4-event=\'' + JSON.stringify(attributes1) + '\'' +
           'class="clickme"' +
         '></div>' +
-        '<div data-ga4=\'' + JSON.stringify(attributes2) + '\'' +
+        '<div data-ga4-event=\'' + JSON.stringify(attributes2) + '\'' +
           'class="clickme"' +
         '></div>'
       document.body.appendChild(element)
@@ -176,7 +176,7 @@ describe('Google Analytics event tracking', function () {
         text: 'some text'
       }
       element.classList.add('gem-c-accordion')
-      element.setAttribute('data-ga4', JSON.stringify(attributes))
+      element.setAttribute('data-ga4-event', JSON.stringify(attributes))
       element.setAttribute('aria-expanded', 'false')
       document.body.appendChild(element)
       new GOVUK.Modules.Ga4EventTracker(element).init()
@@ -211,7 +211,7 @@ describe('Google Analytics event tracking', function () {
         text: 'some text'
       }
       element.innerHTML =
-        '<details data-ga4=\'' + JSON.stringify(attributes) + '\'' +
+        '<details data-ga4-event=\'' + JSON.stringify(attributes) + '\'' +
           'class="clickme"' +
         '>' +
         '</details>'
@@ -249,7 +249,7 @@ describe('Google Analytics event tracking', function () {
         event_name: 'event-name'
       }
       element.innerHTML =
-        '<div data-ga4=\'' + JSON.stringify(attributes) + '\'' +
+        '<div data-ga4-event=\'' + JSON.stringify(attributes) + '\'' +
           'class="gem-c-accordion"' +
         '>' +
           '<button aria-expanded="false">Show</button>' +
@@ -292,7 +292,7 @@ describe('Google Analytics event tracking', function () {
         event_name: 'event-name'
       }
       element.innerHTML =
-        '<details data-ga4=\'' + JSON.stringify(attributes) + '\'' +
+        '<details data-ga4-event=\'' + JSON.stringify(attributes) + '\'' +
           'class="clickme"' +
         '>' +
           '<summary class="nested">Example</summary>' +
@@ -334,7 +334,7 @@ describe('Google Analytics event tracking', function () {
         event_name: 'event-name'
       }
       element.innerHTML =
-        '<div data-ga4=\'' + JSON.stringify(attributes) + '\' class="clickme">' +
+        '<div data-ga4-event=\'' + JSON.stringify(attributes) + '\' class="clickme">' +
           '<div class="content">Content</div>' +
           '<div class="gem-c-accordion">' +
             '<button aria-expanded="false">Show</button>' +
@@ -357,7 +357,7 @@ describe('Google Analytics event tracking', function () {
         event_name: 'event-name'
       }
       element.innerHTML =
-        '<div data-ga4=\'' + JSON.stringify(attributes) + '\' class="clickme">' +
+        '<div data-ga4-event=\'' + JSON.stringify(attributes) + '\' class="clickme">' +
           '<div class="content">Content</div>' +
           '<details>' +
             'Details element' +
@@ -380,7 +380,7 @@ describe('Google Analytics event tracking', function () {
         event_name: 'event-name'
       }
       element.innerHTML =
-        '<div data-ga4=\'' + JSON.stringify(attributes) + '\' class="clickme">' +
+        '<div data-ga4-event=\'' + JSON.stringify(attributes) + '\' class="clickme">' +
           '<div class="gem-c-tabs">' +
               '<ul>' +
               '<li> <a href="#tab-location-1" class="tab-1">Tab 1</a> </li>' +
@@ -423,12 +423,12 @@ describe('Google Analytics event tracking', function () {
       '</div>'
 
       var yesButton = document.createElement('button')
-      yesButton.setAttribute('data-ga4', JSON.stringify(attributes))
+      yesButton.setAttribute('data-ga4-event', JSON.stringify(attributes))
       yesButton.id = 'yesButton'
 
       attributes.text = 'No'
       var noButton = document.createElement('button')
-      noButton.setAttribute('data-ga4', JSON.stringify(attributes))
+      noButton.setAttribute('data-ga4-event', JSON.stringify(attributes))
       noButton.id = 'noButton'
 
       element.appendChild(yesButton)
@@ -487,7 +487,7 @@ describe('Google Analytics event tracking', function () {
       for (var i = 0; i < buttons.length; i++) {
         window.dataLayer = []
         var button = buttons[i]
-        button.setAttribute('data-ga4', JSON.stringify({
+        button.setAttribute('data-ga4-event', JSON.stringify({
           event_name: 'select_content',
           type: 'header menu bar',
           text: button.textContent,

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -1,792 +1,241 @@
 /* eslint-env jasmine */
 
-describe('GOVUK.analyticsGa4.linkTracker', function () {
-  'use strict'
+describe('GA4 click tracker', function () {
   var GOVUK = window.GOVUK
-  var links
+  var element
   var expected
-  var body = document.querySelector('body')
-  var linkTracker
-  var preventDefault = function (e) {
-    e.preventDefault()
+  var attributes
+
+  function initModule (element, click) {
+    new GOVUK.Modules.Ga4LinkTracker(element).init()
+    if (click) {
+      GOVUK.triggerEvent(element, 'click')
+    }
   }
-  var defaultLinkPathParts
+
+  function agreeToCookies () {
+    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+  }
+
+  function denyCookies () {
+    GOVUK.setCookie('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}')
+  }
 
   beforeAll(function () {
     spyOn(GOVUK.analyticsGa4.core, 'getGemVersion').and.returnValue('aVersion')
-    spyOn(GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker, 'getHostname').and.returnValue('www.gov.uk')
-    spyOn(GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker, 'getProtocol').and.returnValue('https:')
-  })
-
-  afterAll(function () {
-    window.dataLayer = []
   })
 
   beforeEach(function () {
-    defaultLinkPathParts = {
-      1: undefined,
-      2: undefined,
-      3: undefined,
-      4: undefined,
-      5: undefined
-    }
+    window.dataLayer = []
+    agreeToCookies()
   })
 
-  describe('External link tracking', function () {
+  afterEach(function () {
+    window.dataLayer = []
+  })
+
+  describe('when the user has a cookie consent choice', function () {
     beforeEach(function () {
-      window.dataLayer = []
+      element = document.createElement('a')
+    })
+
+    it('starts the module if consent has already been given', function () {
+      agreeToCookies()
+      document.body.appendChild(element)
+      var tracker = new GOVUK.Modules.Ga4LinkTracker(element)
+      spyOn(tracker, 'trackClick')
+      tracker.init()
+
+      element.click()
+      expect(tracker.trackClick).toHaveBeenCalled()
+    })
+
+    it('starts the module on the same page as cookie consent is given', function () {
+      denyCookies()
+      document.body.appendChild(element)
+      var tracker = new GOVUK.Modules.Ga4LinkTracker(element)
+      spyOn(tracker, 'trackClick')
+      tracker.init()
+
+      element.click()
+      expect(tracker.trackClick).not.toHaveBeenCalled()
+
+      // page has not been reloaded, user consents to cookies
+      window.GOVUK.triggerEvent(window, 'cookie-consent')
+
+      element.click()
+      expect(tracker.trackClick).toHaveBeenCalled()
+    })
+
+    it('does not do anything if consent is not given', function () {
+      denyCookies()
+      document.body.appendChild(element)
+      var tracker = new GOVUK.Modules.Ga4LinkTracker(element)
+      spyOn(tracker, 'trackClick')
+      tracker.init()
+
+      element.click()
+      expect(tracker.trackClick).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('basic tracking', function () {
+    beforeEach(function () {
+      attributes = {
+        event_name: 'navigation',
+        type: 'a link'
+      }
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.event_name = 'navigation'
-      expected.event_data.type = 'generic link'
-      expected.event_data.method = 'primary click'
-      expected.event_data.external = 'true'
+      expected.event_data.type = 'a link'
       expected.govuk_gem_version = 'aVersion'
-      links = document.createElement('div')
-      /* The link_domain, external and path attributes exist so we can hardcode what the expected value is for each test.
-      The value differs for each link, so we can't hardcode the expected value inside the test itself. */
-      links.innerHTML =
-          '<div class="fully-structured-external-links">' +
-              '<a href="http://www.nationalarchives.gov.uk/1" link_domain="http://www.nationalarchives.gov.uk" path="/1"> National Archives </a>' +
-              '<a href="https://www.nationalarchives.gov.uk/2" link_domain="https://www.nationalarchives.gov.uk" path="/2"></a>' +
-              '<a href="https://www.nationalarchives.gov.uk/3.pdf" link_domain="https://www.nationalarchives.gov.uk" path="/3.pdf">National Archives PDF</a>' +
-            '</div>' +
-            '<div class="www-less-external-links">' +
-              '<a href="http://nationalarchives.gov.uk/1" path="/1" link_domain="http://nationalarchives.gov.uk"> National Archives </a>' +
-              '<a href="https://nationalarchives.gov.uk/2" path="/2" link_domain="https://nationalarchives.gov.uk"></a>' +
-              '<a href="https://nationalarchives.gov.uk/one.pdf" link_domain="https://nationalarchives.gov.uk" path="/one.pdf">National Archives PDF</a>' +
-            '</div>' +
-            '<div class="protocol-relative-external-links">' +
-              '<a href="//nationalarchives.gov.uk"> National Archives </a>' +
-              '<a href="//nationalarchives.gov.uk"></a>' +
-              '<a href="//nationalarchives.gov.uk/one.pdf" path="/one.pdf">National Archives PDF</a>' +
-            '</div>' +
-            '<div class="nested-link">' +
-            '<a href="http://www.nationalarchives.gov.uk"> <img /> </a>' +
-            '</div>' +
-            '<div class="internal-links">' +
-              '<a href="/some-path">Local link</a>' +
-              '<a href="http://www.gov.uk/some-path">Another local link</a>' +
-              '<a href="https://www.gov.uk/some-path">Another local link</a>' +
-              '<a href="https://gov.uk/some-path">Another local link</a>' +
-              '<a href="//gov.uk/some-path">Another local link</a>' +
-            '</div>' +
-            '<div class="anchor-links">' +
-              '<a href="#some-id">Anchor link</a>' +
-              '<a href="#https://www.gov.uk">Another anchor link</a>' +
-              '<a href="#https://www.example.com">Another anchor link</a>' +
-            '</div>'
-
-      body.appendChild(links)
-      body.addEventListener('click', preventDefault)
-
-      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker
-      // Add gov.uk as an internal domain, as our tests are running from localhost
-      linkTracker.init({ internalDomains: ['www.gov.uk'] })
     })
 
-    afterEach(function () {
-      body.removeEventListener('click', preventDefault)
-      links.remove()
-      linkTracker.stopTracking()
+    it('does not track anything without a data-ga4 attribute', function () {
+      element = document.createElement('a')
+      var linkText = 'Should not track'
+      element.textContent = linkText
+      expected.event_data.text = linkText
+
+      initModule(element, true)
+      expect(window.dataLayer[0]).toEqual(undefined)
     })
 
-    it('detects external click events on well structured external links', function () {
-      var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
+    it('tracks clicks on a single link', function () {
+      var link = '#aNormalLink'
+      element = document.createElement('a')
+      element.setAttribute('data-ga4', JSON.stringify(attributes))
+      element.setAttribute('href', link)
+      var linkText = 'A normal link'
+      element.textContent = linkText
+      expected.event_data.text = linkText
+      expected.event_data.url = link
 
-      for (var i = 0; i < linksToTest.length; i++) {
-        var link = linksToTest[i]
-        window.dataLayer = []
-        GOVUK.triggerEvent(link, 'click')
-        expected.event_data.link_domain = link.getAttribute('link_domain')
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.text = link.innerText.trim()
-        var linkPath = link.getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('detects external click events on www. missing external links', function () {
-      var linksToTest = document.querySelectorAll('.www-less-external-links a')
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-
-        expected.event_data.link_domain = link.getAttribute('link_domain')
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.text = link.innerText.trim()
-        var linkPath = link.getAttribute('path')
-        if (linkPath) {
-          expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        }
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('listens to external click events on protocol relative links', function () {
-      var linksToTest = document.querySelectorAll('.protocol-relative-external-links a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-
-        expected.event_data.link_domain = '//nationalarchives.gov.uk'
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.text = link.innerText.trim()
-        var linkPath = link.getAttribute('path')
-        if (linkPath) {
-          expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        }
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('listens to external click events on elements within external links', function () {
-      var nestedImage = document.querySelector('.nested-link a img')
-      var parentLink = nestedImage.closest('a')
-
-      GOVUK.triggerEvent(nestedImage, 'click')
-
-      expected.event_data.link_domain = 'http://www.nationalarchives.gov.uk'
-      expected.event_data.url = parentLink.getAttribute('href')
-      expected.event_data.text = parentLink.innerText.trim()
-
+      initModule(element, true)
       expect(window.dataLayer[0]).toEqual(expected)
     })
 
-    it('ignores external click events on internal links', function () {
-      var linksToTest = document.querySelectorAll('.internal-links a')
+    it('tracks all links with data-ga4 attributes within a container', function () {
+      element = document.createElement('div')
+      element.innerHTML =
+        '<a class="first" href="#link1">Link 1</a>' +
+        '<a href="#link2" class="secondWrapper"><span class="second">Link 2</span></a>' +
+        '<a href="#link3"><span class="third">Link 3</span></a>' +
+        '<span class="nothing"></span>'
 
-      for (var i = 0; i < linksToTest.length; i++) {
-        var link = linksToTest[i]
-        window.dataLayer = []
-        GOVUK.triggerEvent(link, 'click')
-        expect(window.dataLayer).toEqual([])
-      }
-    })
+      element.querySelector('.first').setAttribute('data-ga4', JSON.stringify(attributes))
+      element.querySelector('.secondWrapper').setAttribute('data-ga4', JSON.stringify(attributes))
+      initModule(element, false)
 
-    it('ignores external click events on anchor links', function () {
-      var linksToTest = document.querySelectorAll('.anchor-links a')
+      expected.event_data.text = 'Link 1'
+      expected.event_data.url = '#link1'
+      element.querySelector('.first').click()
+      expect(window.dataLayer[0]).toEqual(expected)
 
-      for (var i = 0; i < linksToTest.length; i++) {
-        var link = linksToTest[i]
-        window.dataLayer = []
-        GOVUK.triggerEvent(link, 'click')
-        expect(window.dataLayer).toEqual([])
-      }
-    })
+      expected.event_data.text = 'Link 2'
+      expected.event_data.url = '#link2'
+      element.querySelector('.second').click()
+      expect(window.dataLayer[1]).toEqual(expected)
 
-    it('detects control click events on external links', function () {
-      var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
+      element.querySelector('.third').click()
+      expect(window.dataLayer[2]).toEqual(undefined)
 
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
-        clickEvent.ctrlKey = true
-        link.dispatchEvent(clickEvent)
-        expected.event_data.link_domain = link.getAttribute('link_domain')
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.text = link.innerText.trim()
-        expected.event_data.method = 'ctrl click'
-        var linkPath = link.getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('detects command click events on external links', function () {
-      var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
-        clickEvent.metaKey = true
-        link.dispatchEvent(clickEvent)
-        expected.event_data.link_domain = link.getAttribute('link_domain')
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.text = link.innerText.trim()
-        expected.event_data.method = 'command/win click'
-        var linkPath = link.getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('detects middle mouse click events on external links', function () {
-      var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        var clickEvent = new window.CustomEvent('mousedown', { cancelable: true, bubbles: true })
-        clickEvent.button = 1
-        link.dispatchEvent(clickEvent)
-        expected.event_data.link_domain = link.getAttribute('link_domain')
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.text = link.innerText.trim()
-        expected.event_data.method = 'middle click'
-        var linkPath = link.getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('detects shift click events on external links', function () {
-      var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
-        clickEvent.shiftKey = true
-        link.dispatchEvent(clickEvent)
-        expected.event_data.link_domain = link.getAttribute('link_domain')
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.text = link.innerText.trim()
-        expected.event_data.method = 'shift click'
-        var linkPath = link.getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('detects right click events on external links', function () {
-      var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'contextmenu')
-        expected.event_data.link_domain = link.getAttribute('link_domain')
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.text = link.innerText.trim()
-        expected.event_data.method = 'secondary click'
-        var linkPath = link.getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
+      element.querySelector('.nothing').click()
+      expect(window.dataLayer[2]).toEqual(undefined)
     })
   })
 
-  describe('Download link tracking', function () {
+  describe('when the track links only feature is enabled', function () {
     beforeEach(function () {
-      window.dataLayer = []
-      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
-      expected.event = 'event_data'
-      expected.event_data.event_name = 'file_download'
-      expected.event_data.type = 'generic download'
-      expected.event_data.method = 'primary click'
-      expected.govuk_gem_version = 'aVersion'
-
-      links = document.createElement('div')
-      /* The link_domain, external and path attributes exist so we can hardcode what the expected value is for each test.
-      The value differs for each link, so we can't hardcode the expected value inside the test itself. */
-      links.innerHTML = '<div class="fully-structured-download-links">' +
-            '<a href="https://assets.publishing.service.gov.uk/one.pdf" path="/one.pdf" external="true" link_domain="https://assets.publishing.service.gov.uk">PDF</a>' +
-            '<a href="https://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link_domain="https://assets.publishing.service.gov.uk">Spreadsheet</a>' +
-            '<a href="https://www.gov.uk/government/uploads/system/three.doc" path="/government/uploads/system/three.doc" external="false" link_domain="https://www.gov.uk">Document</a>' +
-          '</div>' +
-          '<div class="nested-download-links">' +
-            '<a href="https://www.gov.uk/government/uploads/link.png" path="/government/uploads/link.png" external="false" link_domain="https://www.gov.uk"><img src="/img" /></a>' +
-            '<a href="https://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link_domain="https://assets.publishing.service.gov.uk"><div><img src="/img" /></div></a>' +
-          '</div>' +
-          '<div class="http-download-links">' +
-            '<a href="http://assets.publishing.service.gov.uk/one.pdf" path="/one.pdf" external="true" link_domain="http://assets.publishing.service.gov.uk">PDF</a>' +
-            '<a href="http://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link_domain="http://assets.publishing.service.gov.uk">Spreadsheet</a>' +
-            '<a href="http://www.gov.uk/government/uploads/system/three.doc" path="/government/uploads/system/three.doc" external="false" link_domain="http://www.gov.uk">Document</a>' +
-            '<a href="http://www.gov.uk/government/uploads/link.png" path="/government/uploads/link.png" external="false" link_domain="http://www.gov.uk">Image</a>' +
-          '</div>' +
-          '<div class="www-less-download-links">' +
-            '<a href="http://gov.uk/government/uploads/system/three.doc" link_domain="http://gov.uk" path="/government/uploads/system/three.doc">Document</a>' +
-            '<a href="https://gov.uk/government/uploads/link.png" link_domain="https://gov.uk" path="/government/uploads/link.png">Image</a>' +
-          '</div>' +
-          '<div class="internal-links">' +
-            '<a href="https://www.gov.uk/normal-link">Normal link</a>' +
-            '<a href="https://www.gov.uk/another-link">Another link</a>' +
-          '</div>' +
-          '<div class="external-download-links">' +
-            '<a href="https://example.com/one.pdf" path="/one.pdf" link_domain="https://example.com">External download link</a>' +
-            '<a href="https://www.nationalarchives.gov.uk/government/uploads/logo.png" path="/government/uploads/logo.png" link_domain="https://www.nationalarchives.gov.uk">External download link with false positive path</a>' +
-            '<a href="https://www.nationalarchives.gov.uk/download&fileName=assets.publishing.service.gov.uk.pdf" path="/download&fileName=assets.publishing.service.gov.uk.pdf" link_domain="https://www.nationalarchives.gov.uk">External PDF link with false positive name</a>' +
-          '</div>' +
-          '<div class="relative-download-links">' +
-            '<a href="/government/uploads/one.pdf" path="/government/uploads/one.pdf">Relative PDF link</a>' +
-            '<a href="/government/uploads/two.xslt" path="/government/uploads/two.xslt">Relative Spreadsheet link</a>' +
-          '</div>' +
-          '<div class="preview-download-links">' +
-            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" path="/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link_domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
-            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" path="/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link_domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
-          '</div>' +
-          '<div class="not-a-preview-link">' +
-            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" link_domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
-            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" link_domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
-          '</div>'
-
-      body.appendChild(links)
-      body.addEventListener('click', preventDefault)
-
-      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker
-      // Add gov.uk as an internal domain, as our tests are running from localhost
-      linkTracker.init({ internalDomains: ['www.gov.uk'] })
-    })
-
-    afterEach(function () {
-      body.removeEventListener('click', preventDefault)
-      links.remove()
-      linkTracker.stopTracking()
-    })
-
-    it('detects download clicks on fully structured gov.uk download links', function () {
-      var linksToTest = document.querySelectorAll('.fully-structured-download-links a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-
-        expected.event_data.link_domain = link.getAttribute('link_domain')
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.type = 'generic download'
-        expected.event_data.text = link.innerText.trim()
-        expected.event_data.external = link.getAttribute('external')
-        var linkPath = link.getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        expect(window.dataLayer[0]).toEqual(expected)
+      attributes = {
+        event_name: 'navigation',
+        type: 'a link'
       }
-    })
-
-    it('listens to download clicks on nested elements in download links', function () {
-      var linksToTest = document.querySelectorAll('.nested-download-links a img')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-        expected.event_data.link_domain = link.closest('a').getAttribute('link_domain')
-        expected.event_data.url = link.closest('a').getAttribute('href')
-        expected.event_data.text = link.closest('a').innerText.trim()
-        expected.event_data.type = 'generic download'
-        expected.event_data.external = link.closest('a').getAttribute('external')
-        var linkPath = link.closest('a').getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('detects download clicks on download links that have http:// in the href', function () {
-      var linksToTest = document.querySelectorAll('.http-download-links a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-        expected.event_data.link_domain = link.getAttribute('link_domain')
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.type = 'generic download'
-        expected.event_data.text = link.innerText.trim()
-        expected.event_data.external = link.getAttribute('external')
-        var linkPath = link.getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('detects download clicks on download links without www. in the href', function () {
-      var linksToTest = document.querySelectorAll('.www-less-download-links a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-        expected.event_data.link_domain = link.getAttribute('link_domain')
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.type = 'generic download'
-        expected.event_data.text = link.innerText.trim()
-        expected.event_data.external = 'false'
-        var linkPath = link.getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('ignores internal links from being treated as download links', function () {
-      var linksToTest = document.querySelectorAll('.internal-links a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-        expect(window.dataLayer).toEqual([])
-      }
-    })
-
-    it('treats external files as external links', function () {
-      var linksToTest = document.querySelectorAll('.external-download-links a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-
-        expected.event_data.link_domain = link.getAttribute('link_domain')
-        expected.event_data.event_name = 'navigation'
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.text = link.innerText.trim()
-        expected.event_data.type = 'generic link'
-        expected.govuk_gem_version = 'aVersion'
-        expected.event_data.external = 'true'
-        var linkPath = link.getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('detects download clicks on relative gov.uk download links', function () {
-      var linksToTest = document.querySelectorAll('.relative-download-links a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-        expected.event_data.link_domain = 'https://www.gov.uk'
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.type = 'generic download'
-        expected.event_data.text = link.innerText.trim()
-        expected.event_data.external = 'false'
-        var linkPath = link.getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('detects preview clicks on gov.uk download preview links', function () {
-      var linksToTest = document.querySelectorAll('.preview-download-links a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-        expected.event_data.link_domain = link.getAttribute('link_domain')
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.type = 'preview'
-        expected.event_data.text = link.innerText.trim()
-        expected.event_data.external = 'true'
-        var linkPath = link.getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-
-    it('detects files with preview in their filename as download links instead of preview links', function () {
-      var linksToTest = document.querySelectorAll('.not-a-preview-link a')
-
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-        expected.event_data.link_domain = link.getAttribute('link_domain')
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.type = 'generic download'
-        expected.event_data.text = link.innerText.trim()
-        expected.event_data.external = 'true'
-        var linkPath = link.getAttribute('path')
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-  })
-
-  describe('Mailto link tracking', function () {
-    beforeEach(function () {
-      window.dataLayer = []
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.event_name = 'navigation'
-      expected.event_data.type = 'email'
-      expected.event_data.method = 'primary click'
-      expected.event_data.external = 'true'
-
-      links = document.createElement('div')
-      links.innerHTML =
-          '<div class="mail-to-links">' +
-              '<a href="mailto:example@gov.uk"> National Archives </a>' +
-              '<span>This is not a mailto link</span>' +
-            '</div>' +
-            '<div class="invalid-links">' +
-              '<a href="https://gov.uk/mailto:example@gov.uk"> mailto:example@gov.uk </a>' +
-            '</div>'
-
-      body.appendChild(links)
-      body.addEventListener('click', preventDefault)
-
-      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker
-      // Add gov.uk as an internal domain, as our tests are running from localhost
-      linkTracker.init({ internalDomains: ['www.gov.uk'] })
+      expected.event_data.type = 'a link'
+      expected.govuk_gem_version = 'aVersion'
     })
 
-    afterEach(function () {
-      body.removeEventListener('click', preventDefault)
-      links.remove()
-      linkTracker.stopTracking()
-    })
+    it('tracks only links within a container', function () {
+      element = document.createElement('div')
+      element.innerHTML =
+        '<a class="first" href="#link1">Link 1</a>' +
+        '<a class="second" href="#link2">Link 2</a>' +
+        '<a href="#link3"><span class="third">Link 3</span></a>' +
+        '<span class="nothing"></span>'
 
-    it('detects email events on mailto links', function () {
-      var linksToTest = document.querySelectorAll('.mail-to-links a')
+      element.setAttribute('data-ga4-track-links-only', '')
+      element.setAttribute('data-ga4', JSON.stringify(attributes))
+      initModule(element, false)
 
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.text = link.innerText.trim()
-        expected.govuk_gem_version = 'aVersion'
-        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: 'mailto:example@gov.uk' })
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
+      expected.event_data.text = 'Link 1'
+      expected.event_data.url = '#link1'
+      element.querySelector('.first').click()
+      expect(window.dataLayer[0]).toEqual(expected)
 
-    it('ignores email events on non-mailto links', function () {
-      var linksToTest = document.querySelectorAll('.invalid-links a')
+      expected.event_data.text = 'Link 2'
+      expected.event_data.url = '#link2'
+      element.querySelector('.second').click()
+      expect(window.dataLayer[1]).toEqual(expected)
 
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-        expect(window.dataLayer).toEqual([])
-      }
+      expected.event_data.text = 'Link 3'
+      expected.event_data.url = '#link3'
+      element.querySelector('.third').click()
+      expect(window.dataLayer[2]).toEqual(expected)
+
+      element.querySelector('.nothing').click()
+      expect(window.dataLayer[3]).toEqual(undefined)
     })
   })
 
-  describe('Share and follow link tracking', function () {
+  describe('when the limit to element class feature is enabled', function () {
     beforeEach(function () {
-      window.dataLayer = []
+      attributes = {
+        event_name: 'navigation',
+        type: 'a link'
+      }
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
+      expected.event_data.event_name = 'navigation'
+      expected.event_data.type = 'a link'
       expected.govuk_gem_version = 'aVersion'
-
-      links = document.createElement('div')
-      /* The link_domain, external and path attributes exist so we can hardcode what the expected value is for each test.
-      The value differs for each link, so we can't hardcode the expected value inside the test itself. */
-      links.innerHTML =
-          '<div class="share-links">' +
-              '<a href="example.com" data-ga4-link=\'' + JSON.stringify({ event_name: 'share', type: 'share this page', index: '1', index_total: '1', text: 'myspace', method: 'populated-via-js' }) + '\'>Share</a>' +
-          '</div>' +
-          '<div class="follow-links">' +
-              '<a href="https://example.com" link_domain="https://example.com" external="true" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '1', index_total: '2', text: 'Follow us', url: 'https://example.com', external: 'populated-via-js', method: 'populated-via-js' }) + '\'>Follow us</a>' +
-              '<a href="https://www.gov.uk" link_domain="https://www.gov.uk" external="false" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '2', index_total: '2', text: 'Follow me', url: 'https://www.gov.uk', external: 'populated-via-js', method: 'populated-via-js' }) + '\'>Follow me</a>' +
-          '</div>'
-
-      body.appendChild(links)
-      body.addEventListener('click', preventDefault)
-
-      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker
-      // Add gov.uk as an internal domain, as our tests are running from localhost
-      linkTracker.init({ internalDomains: ['www.gov.uk'] })
     })
 
-    afterEach(function () {
-      body.removeEventListener('click', preventDefault)
-      links.remove()
-      linkTracker.stopTracking()
-    })
+    it('tracks only links within the given class', function () {
+      element = document.createElement('div')
+      element.innerHTML =
+        '<a class="first" href="#link1">Link 1</a>' +
+        '<div class="trackme">' +
+          '<a class="second" href="#link2">Link 2</a>' +
+          '<a href="#link3"><span class="third">Link 3</span></a>' +
+          '<span class="nothing"></span>' +
+        '</div>'
 
-    it('detects clicks on share links', function () {
-      var linksToTest = document.querySelectorAll('.share-links a')
+      element.setAttribute('data-ga4-track-links-only', '')
+      element.setAttribute('data-ga4-limit-to-element-class', 'trackme')
+      element.setAttribute('data-ga4', JSON.stringify(attributes))
+      initModule(element, false)
 
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-        var shareLinkAttributes = link.getAttribute('data-ga4-link')
-        shareLinkAttributes = JSON.parse(shareLinkAttributes)
-        expected.event_data.event_name = shareLinkAttributes.event_name
-        expected.event_data.type = shareLinkAttributes.type
-        expected.event_data.text = shareLinkAttributes.text
-        expected.event_data.index = parseInt(shareLinkAttributes.index)
-        expected.event_data.index_total = parseInt(shareLinkAttributes.index_total)
-        expected.event_data.method = 'primary click'
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
+      expected.event_data.text = 'Link 1'
+      expected.event_data.url = '#link1'
+      element.querySelector('.first').click()
+      expect(window.dataLayer[0]).toEqual(undefined)
 
-    it('detects clicks on follow links', function () {
-      var linksToTest = document.querySelectorAll('.follow-links a')
+      expected.event_data.text = 'Link 2'
+      expected.event_data.url = '#link2'
+      element.querySelector('.second').click()
+      expect(window.dataLayer[0]).toEqual(expected)
 
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-        var shareLinkAttributes = link.getAttribute('data-ga4-link')
-        shareLinkAttributes = JSON.parse(shareLinkAttributes)
-        expected.event_data.event_name = shareLinkAttributes.event_name
-        expected.event_data.type = shareLinkAttributes.type
-        expected.event_data.text = link.textContent.trim()
-        expected.event_data.index = parseInt(shareLinkAttributes.index)
-        expected.event_data.index_total = parseInt(shareLinkAttributes.index_total)
-        expected.event_data.url = link.getAttribute('href')
-        expected.event_data.external = link.getAttribute('external')
-        expected.event_data.method = 'primary click'
-        expected.event_data.link_domain = link.getAttribute('link_domain')
-        expect(window.dataLayer[0]).toEqual(expected)
-      }
-    })
-  })
-  describe('Helper function tracking', function () {
-    beforeEach(function () {
-      window.dataLayer = []
-      links = document.createElement('div')
-      body.appendChild(links)
-      body.addEventListener('click', preventDefault)
-    })
+      expected.event_data.text = 'Link 3'
+      expected.event_data.url = '#link3'
+      element.querySelector('.third').click()
+      expect(window.dataLayer[1]).toEqual(expected)
 
-    afterEach(function () {
-      body.removeEventListener('click', preventDefault)
-      links.remove()
-      linkTracker.stopTracking()
-    })
-
-    it('adds "gov.uk" to the internal domain list after "www.gov.uk" was added as an internal domain', function () {
-      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker
-      // Add gov.uk as an internal domain, as our tests are running from localhost
-      linkTracker.init({ internalDomains: ['www.gov.uk'] })
-      expect(linkTracker.internalDomains).toContain('www.gov.uk')
-      expect(linkTracker.internalDomains).toContain('gov.uk')
-    })
-
-    it('does not detect clicks when disableListeners is true', function () {
-      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker
-      // Add gov.uk as an internal domain, as our tests are running from localhost
-      linkTracker.init({ internalDomains: ['www.gov.uk'], disableListeners: true })
-      links.innerHTML = '<a href="http://www.nationalarchives1.gov.uk" id="clickme"> National Archives </a>'
-      var link = links.querySelector('#clickme')
-      GOVUK.triggerEvent(link, 'click')
-      expect(window.dataLayer).toEqual([])
-    })
-
-    it('removes _ga and _gl from href query parameters', function () {
-      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker
-      linkTracker.init({ internalDomains: ['www.gov.uk'] })
-
-      links.innerHTML = '<div class="query-param-links">' +
-      '<a href="https://nationalarchives.gov.uk/test?_ga=2.179870689.471678113.1662373341-1606126050.1639392506">_ga only link</a>' +
-      '<a href="https://nationalarchives.gov.uk/test?_gl=2.179870689.471678113.1662373341-1606126050.1639392506">_gl only link</a>' +
-      '<a href="https://nationalarchives.gov.uk/test?hello=world&_ga=2.179870689.471678113.1662373341-1606126050.1639392506&_gl=2.179870689.471678113.1662373341-1606126050.1639392506">_ga & _gl link</a>' +
-      '<a href="https://nationalarchives.gov.uk/test?hello=world&_ga=example&another=one&_gl=example&goodbye=true">other query params nested around _ga and _gl</a>' +
-      '<a href="https://nationalarchives.gov.uk/test?_ga=example&_gl=example&search=%26&order=relevance">keep the search query params that contains a &</a>' +
-      '<a href="https://nationalarchives.gov.uk/test?_gaa=example&_gll=example">query params similar to _ga and _gl</a>' +
-
-      '</div>'
-
-      var expectedLinks = [
-        'https://nationalarchives.gov.uk/test',
-        'https://nationalarchives.gov.uk/test',
-        'https://nationalarchives.gov.uk/test?hello=world',
-        'https://nationalarchives.gov.uk/test?hello=world&another=one&goodbye=true',
-        'https://nationalarchives.gov.uk/test?search=%26&order=relevance',
-        'https://nationalarchives.gov.uk/test?_gaa=example&_gll=example']
-
-      var queryParamLinks = document.querySelectorAll('.query-param-links a')
-      for (var i = 0; i < queryParamLinks.length; i++) {
-        window.dataLayer = []
-        var link = queryParamLinks[i]
-        GOVUK.triggerEvent(link, 'click')
-        expect(window.dataLayer[0].event_data.url).toEqual(expectedLinks[i])
-      }
-    })
-
-    it('cleans up link text with multiple lines and spaces', function () {
-      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker
-      linkTracker.init({ internalDomains: ['www.gov.uk'] })
-
-      links.innerHTML = '<div class="messy-text">' +
-      '<a href="https://example.com">\nI \nam \non \nmultiple \n\n\n lines</a>' +
-      '<a href="https://www.gov.uk/government/uploads/example.pdf">I     have     lots   of    spaces</a>' +
-      '<a href="mailto:hello@example.com">I     have     lots   of    spaces \n and \n\n many \n\n\n lines</a>' +
-    '</div>'
-
-      var linksToTest = document.querySelectorAll('.messy-text a')
-
-      var expectedText = [
-        'I am on multiple lines',
-        'I have lots of spaces',
-        'I have lots of spaces and many lines'
-      ]
-      for (var i = 0; i < linksToTest.length; i++) {
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-        expect(window.dataLayer[0].event_data.text).toEqual(expectedText[i])
-      }
-    })
-
-    it('splits hrefs longer than 100 characters into an object of parts', function () {
-      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker
-      linkTracker.init({ internalDomains: ['www.gov.uk'] })
-
-      links.innerHTML = '<div class="long-links">' +
-      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-">100 char path</a>' +
-      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili">200 char path</a>' +
-      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-so">500 char path</a>' +
-      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious">Over 500 char path</a>' +
-      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui/https://example.com/test">check regex replace only replaces first domain match</a>' +
-      '<a href="https://assets.publishing.service.gov.uk/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui">check regex replace works with a long subdomain </a>' +
-      '<a href="//assets.publishing.service.gov.uk/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui">check regex replace works with protocal relative domain </a>' +
-      '</div>'
-
-      var expectedLinkPathParts = [
-        {
-          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-'
-        },
-        {
-          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-',
-          2: 'say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili'
-        },
-        {
-          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-',
-          2: 'say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili',
-          3: 'sticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enoug',
-          4: 'h-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidociou',
-          5: 's-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-so'
-        },
-        {
-          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-',
-          2: 'say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili',
-          3: 'sticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enoug',
-          4: 'h-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidociou',
-          5: 's-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-so'
-        },
-        {
-          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui/https://example.com',
-          2: '/test'
-        },
-        {
-          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui'
-        },
-        {
-          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui'
-        }
-      ]
-
-      var linksToTest = document.querySelectorAll('.long-links a')
-      for (var i = 0; i < linksToTest.length; i++) {
-        defaultLinkPathParts = {
-          1: undefined,
-          2: undefined,
-          3: undefined,
-          4: undefined,
-          5: undefined
-        }
-        window.dataLayer = []
-        var link = linksToTest[i]
-        GOVUK.triggerEvent(link, 'click')
-        var expectedObject = window.GOVUK.extendObject(defaultLinkPathParts, expectedLinkPathParts[i])
-        expect(window.dataLayer[0].event_data.link_path_parts).toEqual(expectedObject)
-      }
+      element.querySelector('.nothing').click()
+      expect(window.dataLayer[2]).toEqual(undefined)
     })
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -105,7 +105,7 @@ describe('GA4 click tracker', function () {
     it('tracks clicks on a single link', function () {
       var link = '#aNormalLink'
       element = document.createElement('a')
-      element.setAttribute('data-ga4', JSON.stringify(attributes))
+      element.setAttribute('data-ga4-link', JSON.stringify(attributes))
       element.setAttribute('href', link)
       var linkText = 'A normal link'
       element.textContent = linkText
@@ -124,8 +124,8 @@ describe('GA4 click tracker', function () {
         '<a href="#link3"><span class="third">Link 3</span></a>' +
         '<span class="nothing"></span>'
 
-      element.querySelector('.first').setAttribute('data-ga4', JSON.stringify(attributes))
-      element.querySelector('.secondWrapper').setAttribute('data-ga4', JSON.stringify(attributes))
+      element.querySelector('.first').setAttribute('data-ga4-link', JSON.stringify(attributes))
+      element.querySelector('.secondWrapper').setAttribute('data-ga4-link', JSON.stringify(attributes))
       initModule(element, false)
 
       expected.event_data.text = 'Link 1'
@@ -168,7 +168,7 @@ describe('GA4 click tracker', function () {
         '<span class="nothing"></span>'
 
       element.setAttribute('data-ga4-track-links-only', '')
-      element.setAttribute('data-ga4', JSON.stringify(attributes))
+      element.setAttribute('data-ga4-link', JSON.stringify(attributes))
       initModule(element, false)
 
       expected.event_data.text = 'Link 1'
@@ -216,7 +216,7 @@ describe('GA4 click tracker', function () {
 
       element.setAttribute('data-ga4-track-links-only', '')
       element.setAttribute('data-ga4-limit-to-element-class', 'trackme')
-      element.setAttribute('data-ga4', JSON.stringify(attributes))
+      element.setAttribute('data-ga4-link', JSON.stringify(attributes))
       initModule(element, false)
 
       expected.event_data.text = 'Link 1'

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
@@ -1,0 +1,792 @@
+/* eslint-env jasmine */
+
+describe('GA4 specialist link tracker', function () {
+  'use strict'
+  var GOVUK = window.GOVUK
+  var links
+  var expected
+  var body = document.querySelector('body')
+  var linkTracker
+  var preventDefault = function (e) {
+    e.preventDefault()
+  }
+  var defaultLinkPathParts
+
+  beforeAll(function () {
+    spyOn(GOVUK.analyticsGa4.core, 'getGemVersion').and.returnValue('aVersion')
+    spyOn(GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker, 'getHostname').and.returnValue('www.gov.uk')
+    spyOn(GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker, 'getProtocol').and.returnValue('https:')
+  })
+
+  afterAll(function () {
+    window.dataLayer = []
+  })
+
+  beforeEach(function () {
+    defaultLinkPathParts = {
+      1: undefined,
+      2: undefined,
+      3: undefined,
+      4: undefined,
+      5: undefined
+    }
+  })
+
+  describe('External link tracking', function () {
+    beforeEach(function () {
+      window.dataLayer = []
+      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      expected.event = 'event_data'
+      expected.event_data.event_name = 'navigation'
+      expected.event_data.type = 'generic link'
+      expected.event_data.method = 'primary click'
+      expected.event_data.external = 'true'
+      expected.govuk_gem_version = 'aVersion'
+      links = document.createElement('div')
+      /* The link_domain, external and path attributes exist so we can hardcode what the expected value is for each test.
+      The value differs for each link, so we can't hardcode the expected value inside the test itself. */
+      links.innerHTML =
+          '<div class="fully-structured-external-links">' +
+              '<a href="http://www.nationalarchives.gov.uk/1" link_domain="http://www.nationalarchives.gov.uk" path="/1"> National Archives </a>' +
+              '<a href="https://www.nationalarchives.gov.uk/2" link_domain="https://www.nationalarchives.gov.uk" path="/2"></a>' +
+              '<a href="https://www.nationalarchives.gov.uk/3.pdf" link_domain="https://www.nationalarchives.gov.uk" path="/3.pdf">National Archives PDF</a>' +
+            '</div>' +
+            '<div class="www-less-external-links">' +
+              '<a href="http://nationalarchives.gov.uk/1" path="/1" link_domain="http://nationalarchives.gov.uk"> National Archives </a>' +
+              '<a href="https://nationalarchives.gov.uk/2" path="/2" link_domain="https://nationalarchives.gov.uk"></a>' +
+              '<a href="https://nationalarchives.gov.uk/one.pdf" link_domain="https://nationalarchives.gov.uk" path="/one.pdf">National Archives PDF</a>' +
+            '</div>' +
+            '<div class="protocol-relative-external-links">' +
+              '<a href="//nationalarchives.gov.uk"> National Archives </a>' +
+              '<a href="//nationalarchives.gov.uk"></a>' +
+              '<a href="//nationalarchives.gov.uk/one.pdf" path="/one.pdf">National Archives PDF</a>' +
+            '</div>' +
+            '<div class="nested-link">' +
+            '<a href="http://www.nationalarchives.gov.uk"> <img /> </a>' +
+            '</div>' +
+            '<div class="internal-links">' +
+              '<a href="/some-path">Local link</a>' +
+              '<a href="http://www.gov.uk/some-path">Another local link</a>' +
+              '<a href="https://www.gov.uk/some-path">Another local link</a>' +
+              '<a href="https://gov.uk/some-path">Another local link</a>' +
+              '<a href="//gov.uk/some-path">Another local link</a>' +
+            '</div>' +
+            '<div class="anchor-links">' +
+              '<a href="#some-id">Anchor link</a>' +
+              '<a href="#https://www.gov.uk">Another anchor link</a>' +
+              '<a href="#https://www.example.com">Another anchor link</a>' +
+            '</div>'
+
+      body.appendChild(links)
+      body.addEventListener('click', preventDefault)
+
+      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker
+      // Add gov.uk as an internal domain, as our tests are running from localhost
+      linkTracker.init({ internalDomains: ['www.gov.uk'] })
+    })
+
+    afterEach(function () {
+      body.removeEventListener('click', preventDefault)
+      links.remove()
+      linkTracker.stopTracking()
+    })
+
+    it('detects external click events on well structured external links', function () {
+      var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        var link = linksToTest[i]
+        window.dataLayer = []
+        GOVUK.triggerEvent(link, 'click')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.text = link.innerText.trim()
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('detects external click events on www. missing external links', function () {
+      var linksToTest = document.querySelectorAll('.www-less-external-links a')
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.text = link.innerText.trim()
+        var linkPath = link.getAttribute('path')
+        if (linkPath) {
+          expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        }
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('listens to external click events on protocol relative links', function () {
+      var linksToTest = document.querySelectorAll('.protocol-relative-external-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+
+        expected.event_data.link_domain = '//nationalarchives.gov.uk'
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.text = link.innerText.trim()
+        var linkPath = link.getAttribute('path')
+        if (linkPath) {
+          expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        }
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('listens to external click events on elements within external links', function () {
+      var nestedImage = document.querySelector('.nested-link a img')
+      var parentLink = nestedImage.closest('a')
+
+      GOVUK.triggerEvent(nestedImage, 'click')
+
+      expected.event_data.link_domain = 'http://www.nationalarchives.gov.uk'
+      expected.event_data.url = parentLink.getAttribute('href')
+      expected.event_data.text = parentLink.innerText.trim()
+
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('ignores external click events on internal links', function () {
+      var linksToTest = document.querySelectorAll('.internal-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        var link = linksToTest[i]
+        window.dataLayer = []
+        GOVUK.triggerEvent(link, 'click')
+        expect(window.dataLayer).toEqual([])
+      }
+    })
+
+    it('ignores external click events on anchor links', function () {
+      var linksToTest = document.querySelectorAll('.anchor-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        var link = linksToTest[i]
+        window.dataLayer = []
+        GOVUK.triggerEvent(link, 'click')
+        expect(window.dataLayer).toEqual([])
+      }
+    })
+
+    it('detects control click events on external links', function () {
+      var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
+        clickEvent.ctrlKey = true
+        link.dispatchEvent(clickEvent)
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.method = 'ctrl click'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('detects command click events on external links', function () {
+      var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
+        clickEvent.metaKey = true
+        link.dispatchEvent(clickEvent)
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.method = 'command/win click'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('detects middle mouse click events on external links', function () {
+      var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        var clickEvent = new window.CustomEvent('mousedown', { cancelable: true, bubbles: true })
+        clickEvent.button = 1
+        link.dispatchEvent(clickEvent)
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.method = 'middle click'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('detects shift click events on external links', function () {
+      var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        var clickEvent = new window.CustomEvent('click', { cancelable: true, bubbles: true })
+        clickEvent.shiftKey = true
+        link.dispatchEvent(clickEvent)
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.method = 'shift click'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('detects right click events on external links', function () {
+      var linksToTest = document.querySelectorAll('.fully-structured-external-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'contextmenu')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.method = 'secondary click'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+  })
+
+  describe('Download link tracking', function () {
+    beforeEach(function () {
+      window.dataLayer = []
+      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      expected.event = 'event_data'
+      expected.event_data.event_name = 'file_download'
+      expected.event_data.type = 'generic download'
+      expected.event_data.method = 'primary click'
+      expected.govuk_gem_version = 'aVersion'
+
+      links = document.createElement('div')
+      /* The link_domain, external and path attributes exist so we can hardcode what the expected value is for each test.
+      The value differs for each link, so we can't hardcode the expected value inside the test itself. */
+      links.innerHTML = '<div class="fully-structured-download-links">' +
+            '<a href="https://assets.publishing.service.gov.uk/one.pdf" path="/one.pdf" external="true" link_domain="https://assets.publishing.service.gov.uk">PDF</a>' +
+            '<a href="https://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link_domain="https://assets.publishing.service.gov.uk">Spreadsheet</a>' +
+            '<a href="https://www.gov.uk/government/uploads/system/three.doc" path="/government/uploads/system/three.doc" external="false" link_domain="https://www.gov.uk">Document</a>' +
+          '</div>' +
+          '<div class="nested-download-links">' +
+            '<a href="https://www.gov.uk/government/uploads/link.png" path="/government/uploads/link.png" external="false" link_domain="https://www.gov.uk"><img src="/img" /></a>' +
+            '<a href="https://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link_domain="https://assets.publishing.service.gov.uk"><div><img src="/img" /></div></a>' +
+          '</div>' +
+          '<div class="http-download-links">' +
+            '<a href="http://assets.publishing.service.gov.uk/one.pdf" path="/one.pdf" external="true" link_domain="http://assets.publishing.service.gov.uk">PDF</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/two.xslt" path="/two.xslt" external="true" link_domain="http://assets.publishing.service.gov.uk">Spreadsheet</a>' +
+            '<a href="http://www.gov.uk/government/uploads/system/three.doc" path="/government/uploads/system/three.doc" external="false" link_domain="http://www.gov.uk">Document</a>' +
+            '<a href="http://www.gov.uk/government/uploads/link.png" path="/government/uploads/link.png" external="false" link_domain="http://www.gov.uk">Image</a>' +
+          '</div>' +
+          '<div class="www-less-download-links">' +
+            '<a href="http://gov.uk/government/uploads/system/three.doc" link_domain="http://gov.uk" path="/government/uploads/system/three.doc">Document</a>' +
+            '<a href="https://gov.uk/government/uploads/link.png" link_domain="https://gov.uk" path="/government/uploads/link.png">Image</a>' +
+          '</div>' +
+          '<div class="internal-links">' +
+            '<a href="https://www.gov.uk/normal-link">Normal link</a>' +
+            '<a href="https://www.gov.uk/another-link">Another link</a>' +
+          '</div>' +
+          '<div class="external-download-links">' +
+            '<a href="https://example.com/one.pdf" path="/one.pdf" link_domain="https://example.com">External download link</a>' +
+            '<a href="https://www.nationalarchives.gov.uk/government/uploads/logo.png" path="/government/uploads/logo.png" link_domain="https://www.nationalarchives.gov.uk">External download link with false positive path</a>' +
+            '<a href="https://www.nationalarchives.gov.uk/download&fileName=assets.publishing.service.gov.uk.pdf" path="/download&fileName=assets.publishing.service.gov.uk.pdf" link_domain="https://www.nationalarchives.gov.uk">External PDF link with false positive name</a>' +
+          '</div>' +
+          '<div class="relative-download-links">' +
+            '<a href="/government/uploads/one.pdf" path="/government/uploads/one.pdf">Relative PDF link</a>' +
+            '<a href="/government/uploads/two.xslt" path="/government/uploads/two.xslt">Relative Spreadsheet link</a>' +
+          '</div>' +
+          '<div class="preview-download-links">' +
+            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" path="/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link_domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" path="/government/uploads/system/uploads/attachment_data/file/444468/moj-hq.csv/preview" link_domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
+          '</div>' +
+          '<div class="not-a-preview-link">' +
+            '<a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.mp4" link_domain="https://assets.publishing.service.gov.uk">Preview link</a>' +
+            '<a href="http://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" path="/government/uploads/system/uploads/attachment_data/file/444468/preview.jpg&preview=false" link_domain="http://assets.publishing.service.gov.uk">Relative Spreadsheet link</a>' +
+          '</div>'
+
+      body.appendChild(links)
+      body.addEventListener('click', preventDefault)
+
+      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker
+      // Add gov.uk as an internal domain, as our tests are running from localhost
+      linkTracker.init({ internalDomains: ['www.gov.uk'] })
+    })
+
+    afterEach(function () {
+      body.removeEventListener('click', preventDefault)
+      links.remove()
+      linkTracker.stopTracking()
+    })
+
+    it('detects download clicks on fully structured gov.uk download links', function () {
+      var linksToTest = document.querySelectorAll('.fully-structured-download-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.type = 'generic download'
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.external = link.getAttribute('external')
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('listens to download clicks on nested elements in download links', function () {
+      var linksToTest = document.querySelectorAll('.nested-download-links a img')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        expected.event_data.link_domain = link.closest('a').getAttribute('link_domain')
+        expected.event_data.url = link.closest('a').getAttribute('href')
+        expected.event_data.text = link.closest('a').innerText.trim()
+        expected.event_data.type = 'generic download'
+        expected.event_data.external = link.closest('a').getAttribute('external')
+        var linkPath = link.closest('a').getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('detects download clicks on download links that have http:// in the href', function () {
+      var linksToTest = document.querySelectorAll('.http-download-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.type = 'generic download'
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.external = link.getAttribute('external')
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('detects download clicks on download links without www. in the href', function () {
+      var linksToTest = document.querySelectorAll('.www-less-download-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.type = 'generic download'
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.external = 'false'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('ignores internal links from being treated as download links', function () {
+      var linksToTest = document.querySelectorAll('.internal-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        expect(window.dataLayer).toEqual([])
+      }
+    })
+
+    it('treats external files as external links', function () {
+      var linksToTest = document.querySelectorAll('.external-download-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.event_name = 'navigation'
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.type = 'generic link'
+        expected.govuk_gem_version = 'aVersion'
+        expected.event_data.external = 'true'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('detects download clicks on relative gov.uk download links', function () {
+      var linksToTest = document.querySelectorAll('.relative-download-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        expected.event_data.link_domain = 'https://www.gov.uk'
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.type = 'generic download'
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.external = 'false'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('detects preview clicks on gov.uk download preview links', function () {
+      var linksToTest = document.querySelectorAll('.preview-download-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.type = 'preview'
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.external = 'true'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('detects files with preview in their filename as download links instead of preview links', function () {
+      var linksToTest = document.querySelectorAll('.not-a-preview-link a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.type = 'generic download'
+        expected.event_data.text = link.innerText.trim()
+        expected.event_data.external = 'true'
+        var linkPath = link.getAttribute('path')
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: linkPath })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+  })
+
+  describe('Mailto link tracking', function () {
+    beforeEach(function () {
+      window.dataLayer = []
+      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      expected.event = 'event_data'
+      expected.event_data.event_name = 'navigation'
+      expected.event_data.type = 'email'
+      expected.event_data.method = 'primary click'
+      expected.event_data.external = 'true'
+
+      links = document.createElement('div')
+      links.innerHTML =
+          '<div class="mail-to-links">' +
+              '<a href="mailto:example@gov.uk"> National Archives </a>' +
+              '<span>This is not a mailto link</span>' +
+            '</div>' +
+            '<div class="invalid-links">' +
+              '<a href="https://gov.uk/mailto:example@gov.uk"> mailto:example@gov.uk </a>' +
+            '</div>'
+
+      body.appendChild(links)
+      body.addEventListener('click', preventDefault)
+
+      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker
+      // Add gov.uk as an internal domain, as our tests are running from localhost
+      linkTracker.init({ internalDomains: ['www.gov.uk'] })
+    })
+
+    afterEach(function () {
+      body.removeEventListener('click', preventDefault)
+      links.remove()
+      linkTracker.stopTracking()
+    })
+
+    it('detects email events on mailto links', function () {
+      var linksToTest = document.querySelectorAll('.mail-to-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.text = link.innerText.trim()
+        expected.govuk_gem_version = 'aVersion'
+        expected.event_data.link_path_parts = window.GOVUK.extendObject(defaultLinkPathParts, { 1: 'mailto:example@gov.uk' })
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('ignores email events on non-mailto links', function () {
+      var linksToTest = document.querySelectorAll('.invalid-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        expect(window.dataLayer).toEqual([])
+      }
+    })
+  })
+
+  describe('Share and follow link tracking', function () {
+    beforeEach(function () {
+      window.dataLayer = []
+      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      expected.event = 'event_data'
+      expected.govuk_gem_version = 'aVersion'
+
+      links = document.createElement('div')
+      /* The link_domain, external and path attributes exist so we can hardcode what the expected value is for each test.
+      The value differs for each link, so we can't hardcode the expected value inside the test itself. */
+      links.innerHTML =
+          '<div class="share-links">' +
+              '<a href="example.com" data-ga4-link=\'' + JSON.stringify({ event_name: 'share', type: 'share this page', index: '1', index_total: '1', text: 'myspace', method: 'populated-via-js' }) + '\'>Share</a>' +
+          '</div>' +
+          '<div class="follow-links">' +
+              '<a href="https://example.com" link_domain="https://example.com" external="true" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '1', index_total: '2', text: 'Follow us', url: 'https://example.com', external: 'populated-via-js', method: 'populated-via-js' }) + '\'>Follow us</a>' +
+              '<a href="https://www.gov.uk" link_domain="https://www.gov.uk" external="false" data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'follow us', index: '2', index_total: '2', text: 'Follow me', url: 'https://www.gov.uk', external: 'populated-via-js', method: 'populated-via-js' }) + '\'>Follow me</a>' +
+          '</div>'
+
+      body.appendChild(links)
+      body.addEventListener('click', preventDefault)
+
+      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker
+      // Add gov.uk as an internal domain, as our tests are running from localhost
+      linkTracker.init({ internalDomains: ['www.gov.uk'] })
+    })
+
+    afterEach(function () {
+      body.removeEventListener('click', preventDefault)
+      links.remove()
+      linkTracker.stopTracking()
+    })
+
+    it('detects clicks on share links', function () {
+      var linksToTest = document.querySelectorAll('.share-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        var shareLinkAttributes = link.getAttribute('data-ga4-link')
+        shareLinkAttributes = JSON.parse(shareLinkAttributes)
+        expected.event_data.event_name = shareLinkAttributes.event_name
+        expected.event_data.type = shareLinkAttributes.type
+        expected.event_data.text = shareLinkAttributes.text
+        expected.event_data.index = parseInt(shareLinkAttributes.index)
+        expected.event_data.index_total = parseInt(shareLinkAttributes.index_total)
+        expected.event_data.method = 'primary click'
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+
+    it('detects clicks on follow links', function () {
+      var linksToTest = document.querySelectorAll('.follow-links a')
+
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        var shareLinkAttributes = link.getAttribute('data-ga4-link')
+        shareLinkAttributes = JSON.parse(shareLinkAttributes)
+        expected.event_data.event_name = shareLinkAttributes.event_name
+        expected.event_data.type = shareLinkAttributes.type
+        expected.event_data.text = link.textContent.trim()
+        expected.event_data.index = parseInt(shareLinkAttributes.index)
+        expected.event_data.index_total = parseInt(shareLinkAttributes.index_total)
+        expected.event_data.url = link.getAttribute('href')
+        expected.event_data.external = link.getAttribute('external')
+        expected.event_data.method = 'primary click'
+        expected.event_data.link_domain = link.getAttribute('link_domain')
+        expect(window.dataLayer[0]).toEqual(expected)
+      }
+    })
+  })
+  describe('Helper function tracking', function () {
+    beforeEach(function () {
+      window.dataLayer = []
+      links = document.createElement('div')
+      body.appendChild(links)
+      body.addEventListener('click', preventDefault)
+    })
+
+    afterEach(function () {
+      body.removeEventListener('click', preventDefault)
+      links.remove()
+      linkTracker.stopTracking()
+    })
+
+    it('adds "gov.uk" to the internal domain list after "www.gov.uk" was added as an internal domain', function () {
+      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker
+      // Add gov.uk as an internal domain, as our tests are running from localhost
+      linkTracker.init({ internalDomains: ['www.gov.uk'] })
+      expect(linkTracker.internalDomains).toContain('www.gov.uk')
+      expect(linkTracker.internalDomains).toContain('gov.uk')
+    })
+
+    it('does not detect clicks when disableListeners is true', function () {
+      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker
+      // Add gov.uk as an internal domain, as our tests are running from localhost
+      linkTracker.init({ internalDomains: ['www.gov.uk'], disableListeners: true })
+      links.innerHTML = '<a href="http://www.nationalarchives1.gov.uk" id="clickme"> National Archives </a>'
+      var link = links.querySelector('#clickme')
+      GOVUK.triggerEvent(link, 'click')
+      expect(window.dataLayer).toEqual([])
+    })
+
+    it('removes _ga and _gl from href query parameters', function () {
+      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker
+      linkTracker.init({ internalDomains: ['www.gov.uk'] })
+
+      links.innerHTML = '<div class="query-param-links">' +
+      '<a href="https://nationalarchives.gov.uk/test?_ga=2.179870689.471678113.1662373341-1606126050.1639392506">_ga only link</a>' +
+      '<a href="https://nationalarchives.gov.uk/test?_gl=2.179870689.471678113.1662373341-1606126050.1639392506">_gl only link</a>' +
+      '<a href="https://nationalarchives.gov.uk/test?hello=world&_ga=2.179870689.471678113.1662373341-1606126050.1639392506&_gl=2.179870689.471678113.1662373341-1606126050.1639392506">_ga & _gl link</a>' +
+      '<a href="https://nationalarchives.gov.uk/test?hello=world&_ga=example&another=one&_gl=example&goodbye=true">other query params nested around _ga and _gl</a>' +
+      '<a href="https://nationalarchives.gov.uk/test?_ga=example&_gl=example&search=%26&order=relevance">keep the search query params that contains a &</a>' +
+      '<a href="https://nationalarchives.gov.uk/test?_gaa=example&_gll=example">query params similar to _ga and _gl</a>' +
+
+      '</div>'
+
+      var expectedLinks = [
+        'https://nationalarchives.gov.uk/test',
+        'https://nationalarchives.gov.uk/test',
+        'https://nationalarchives.gov.uk/test?hello=world',
+        'https://nationalarchives.gov.uk/test?hello=world&another=one&goodbye=true',
+        'https://nationalarchives.gov.uk/test?search=%26&order=relevance',
+        'https://nationalarchives.gov.uk/test?_gaa=example&_gll=example']
+
+      var queryParamLinks = document.querySelectorAll('.query-param-links a')
+      for (var i = 0; i < queryParamLinks.length; i++) {
+        window.dataLayer = []
+        var link = queryParamLinks[i]
+        GOVUK.triggerEvent(link, 'click')
+        expect(window.dataLayer[0].event_data.url).toEqual(expectedLinks[i])
+      }
+    })
+
+    it('cleans up link text with multiple lines and spaces', function () {
+      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker
+      linkTracker.init({ internalDomains: ['www.gov.uk'] })
+
+      links.innerHTML = '<div class="messy-text">' +
+      '<a href="https://example.com">\nI \nam \non \nmultiple \n\n\n lines</a>' +
+      '<a href="https://www.gov.uk/government/uploads/example.pdf">I     have     lots   of    spaces</a>' +
+      '<a href="mailto:hello@example.com">I     have     lots   of    spaces \n and \n\n many \n\n\n lines</a>' +
+    '</div>'
+
+      var linksToTest = document.querySelectorAll('.messy-text a')
+
+      var expectedText = [
+        'I am on multiple lines',
+        'I have lots of spaces',
+        'I have lots of spaces and many lines'
+      ]
+      for (var i = 0; i < linksToTest.length; i++) {
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        expect(window.dataLayer[0].event_data.text).toEqual(expectedText[i])
+      }
+    })
+
+    it('splits hrefs longer than 100 characters into an object of parts', function () {
+      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker
+      linkTracker.init({ internalDomains: ['www.gov.uk'] })
+
+      links.innerHTML = '<div class="long-links">' +
+      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-">100 char path</a>' +
+      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili">200 char path</a>' +
+      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-so">500 char path</a>' +
+      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-sound-precocious">Over 500 char path</a>' +
+      '<a href="https://example.com/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui/https://example.com/test">check regex replace only replaces first domain match</a>' +
+      '<a href="https://assets.publishing.service.gov.uk/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui">check regex replace works with a long subdomain </a>' +
+      '<a href="//assets.publishing.service.gov.uk/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui">check regex replace works with protocal relative domain </a>' +
+      '</div>'
+
+      var expectedLinkPathParts = [
+        {
+          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-'
+        },
+        {
+          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-',
+          2: 'say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili'
+        },
+        {
+          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-',
+          2: 'say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili',
+          3: 'sticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enoug',
+          4: 'h-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidociou',
+          5: 's-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-so'
+        },
+        {
+          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-',
+          2: 'say-it-loud-enough-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragili',
+          3: 'sticexpialidocious-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enoug',
+          4: 'h-youll-always-sound-precocious-supercalifragilisticexpialidocious-supercalifragilisticexpialidociou',
+          5: 's-even-though-the-sound-of-it-is-something-quite-atrocious-if-you-say-it-loud-enough-youll-always-so'
+        },
+        {
+          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui/https://example.com',
+          2: '/test'
+        },
+        {
+          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui'
+        },
+        {
+          1: '/supercalifragilisticexpialidocious-even-though-the-sound-of-it-is-something-qui'
+        }
+      ]
+
+      var linksToTest = document.querySelectorAll('.long-links a')
+      for (var i = 0; i < linksToTest.length; i++) {
+        defaultLinkPathParts = {
+          1: undefined,
+          2: undefined,
+          3: undefined,
+          4: undefined,
+          5: undefined
+        }
+        window.dataLayer = []
+        var link = linksToTest[i]
+        GOVUK.triggerEvent(link, 'click')
+        var expectedObject = window.GOVUK.extendObject(defaultLinkPathParts, expectedLinkPathParts[i])
+        expect(window.dataLayer[0].event_data.link_path_parts).toEqual(expectedObject)
+      }
+    })
+  })
+})

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
@@ -4,7 +4,7 @@ describe('Initialising GA4', function () {
   var GOVUK = window.GOVUK
 
   afterEach(function () {
-    GOVUK.analyticsGa4.analyticsModules.Ga4LinkTracker.stopTracking()
+    GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker.stopTracking()
     window.dataLayer = []
     window.removeEventListener('cookie-consent', window.GOVUK.analyticsGa4.init)
   })


### PR DESCRIPTION
**PR has now been superseded by: https://github.com/alphagov/govuk_publishing_components/pull/3057**

## What
Restructure our code for link and event tracking in Google Analytics 4, making the following changes:

- rename the existing link tracker (which automatically tracks external links, mailto links, download links etc.) to specialist link tracker
- add a new link tracker, based on the functionality of https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics/track-click.md
- update documentation to explain the change

The PR's a bit hard to read (sorry) because I renamed one file then created another one with the same name, so github thinks it's a massive change to one file. Might work better to be reviewed per commit.

TODO:

- implement code sharing between the three
- implement link part path on the new link tracker

## Why

We want to clarify both the intent and the code structure for link and event tracking in different situations. Despite the overlap, it feels sensible to have specific scripts for tracking interactive elements like buttons (event tracking), regular links (link tracking) and other kinds of links (specialist link tracking).

Event tracking and link tracking are applied manually to elements using data attributes. Specialist link tracking acts automatically.

## Visual Changes
None.

Trello card: https://trello.com/c/PHlfJHou/324-add-tracking-header-menu-bar
