### PR TITLE
Use one button in navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add `id` attribute option to the label component ([PR #3093](https://github.com/alphagov/govuk_publishing_components/pull/3093))
 * Make GA4 event tracker automatically get element text ([PR #3137](https://github.com/alphagov/govuk_publishing_components/pull/3137))
 * Rename taxon parameters ([PR #3139](https://github.com/alphagov/govuk_publishing_components/pull/3139))
+* Use one button in navbar ([PR #3058](https://github.com/alphagov/govuk_publishing_components/pull/3058))
 
 ## 34.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -8,9 +8,9 @@ $search-width-or-height: $black-bar-height;
 $pseudo-underline-height: 3px;
 $button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
 
-$after-link-padding: govuk-spacing(6);
-$after-button-padding-right: govuk-spacing(6);
-$after-button-padding-left: govuk-spacing(5);
+$after-link-padding: govuk-spacing(4);
+$after-button-padding-right: govuk-spacing(4);
+$after-button-padding-left: govuk-spacing(4);
 
 @mixin chevron($colour, $update: false) {
   @if $update == true {
@@ -46,6 +46,7 @@ $after-button-padding-left: govuk-spacing(5);
   left: $left;
   position: absolute;
   right: $right;
+  bottom: 0;
   top: auto;
   @if $width {
     width: $width;
@@ -97,18 +98,18 @@ $after-button-padding-left: govuk-spacing(5);
 }
 
 .gem-c-layout-super-navigation-header__header-logo {
+  display: inline-block;
   height: govuk-spacing(6);
   padding-bottom: govuk-spacing(2);
   padding-top: govuk-spacing(2);
-
-  @include govuk-media-query($from: "desktop") {
-    display: block;
-    float: left;
-  }
 }
 
 .gem-c-layout-super-navigation-header__content {
-  display: block;
+  @include govuk-media-query($until: "tablet") {
+    margin-right: govuk-spacing(-3);
+  }
+
+  display: inline-block;
   float: right;
 }
 
@@ -119,26 +120,14 @@ $after-button-padding-left: govuk-spacing(5);
 // Top level navigation and search.
 .gem-c-layout-super-navigation-header__navigation-items,
 .gem-c-layout-super-navigation-header__search-items {
-  background: govuk-colour("light-grey");
   display: block;
+  float: left;
   list-style: none;
-  margin: 0 (0 - govuk-spacing(3));
   padding: 0;
-
-  @include govuk-media-query($from: "tablet") {
-    margin: 0 (0 - govuk-spacing(6));
-  }
-
-  @include govuk-media-query($from: "desktop") {
-    background: none;
-    float: left;
-    padding: 0;
-    margin: 0;
-  }
+  margin: 0;
 }
 
 .gem-c-layout-super-navigation-header__navigation-items {
-  display: inline-block;
   border-bottom: 1px solid $govuk-border-colour;
 
   .js-module-initialised & {
@@ -157,6 +146,15 @@ $after-button-padding-left: govuk-spacing(5);
   }
 }
 
+.gem-c-layout-super-navigation-header__navigation-item,
+.gem-c-layout-super-navigation-header__search-item {
+  background: govuk-colour("black");
+  display: block;
+  float: left;
+  margin: 0;
+  padding: 0;
+}
+
 // Top level navigation links and search link.
 .gem-c-layout-super-navigation-header__navigation-item-link,
 .gem-c-layout-super-navigation-header__search-item-link {
@@ -168,6 +166,7 @@ $after-button-padding-left: govuk-spacing(5);
   font-size: govuk-px-to-rem(19px);
   font-weight: bold;
   margin: govuk-spacing(3) 0;
+  position: relative;
 
   @include govuk-media-query($from: "desktop") {
     display: block;
@@ -192,6 +191,10 @@ $after-button-padding-left: govuk-spacing(5);
       box-shadow: none;
       color: $govuk-link-colour;
 
+      .gem-c-layout-super-navigation-header__navigation-item-link-inner {
+        border-color: $button-pipe-colour;
+      }
+
       &:hover {
         @include govuk-link-decoration;
         @include govuk-link-hover-decoration;
@@ -201,15 +204,14 @@ $after-button-padding-left: govuk-spacing(5);
 
     &:after {
       @include make-selectable-area-bigger;
+      @include pseudo-underline($left: $after-link-padding, $right: $after-link-padding, $width: calc(100% - $after-button-padding-right));
     }
 
     // stylelint-disable max-nesting-depth
     float: left;
     font-size: 16px;
     font-size: govuk-px-to-rem(16px);
-
     height: govuk-spacing(4);
-    position: relative;
 
     &:before {
       @include chevron(govuk-colour("white"), true);
@@ -226,6 +228,7 @@ $after-button-padding-left: govuk-spacing(5);
     @include focus-and-focus-visible {
       .gem-c-layout-super-navigation-header__navigation-item-link-inner {
         border-color: $govuk-focus-colour;
+        background: $govuk-focus-colour;
       }
 
       &,
@@ -273,10 +276,9 @@ $after-button-padding-left: govuk-spacing(5);
       margin: 0;
 
       &:after {
-        @include pseudo-underline($left: $after-button-padding-left, $right: $after-button-padding-right, $width: calc(100% - $after-button-padding-left));
+        @include pseudo-underline($left: $after-button-padding-left, $right: $after-button-padding-right, $width: 100%);
       }
     }
-
     // stylelint-enable max-nesting-depth
   }
 
@@ -297,79 +299,64 @@ $after-button-padding-left: govuk-spacing(5);
 }
 
 .gem-c-layout-super-navigation-header__navigation-item-link-inner {
-  @include govuk-media-query($from: "desktop") {
-    // links have different left padding to the button as
-    // they do not have the 5px wide caret pseudo element
-    padding: govuk-spacing(1) $after-link-padding;
-  }
-}
-
-.gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
-  @include govuk-media-query($from: "desktop") {
-    display: inline-block;
-    padding: govuk-spacing(1) $after-button-padding-right govuk-spacing(1) $after-button-padding-left;
-  }
+  background-color: govuk-colour("black");
+  border-left: 1px solid $button-pipe-colour;
+  padding: govuk-spacing(1) $after-link-padding;
 }
 
 // Search link and dropdown.
 .gem-c-layout-super-navigation-header__search-item-link {
-  @include govuk-media-query($from: "desktop") {
-    padding: govuk-spacing(3);
+  padding: govuk-spacing(3);
+
+  @include govuk-media-query($until: "desktop") {
+    margin: 0;
   }
 
   &:link,
   &:visited {
-    @include govuk-media-query($from: "desktop") {
-      background: $govuk-brand-colour;
+    background: $govuk-brand-colour;
+
+    &:hover {
+      background: govuk-colour("black");
+
+      &:before {
+        left: 0;
+        right: 0;
+      }
+    }
+
+    &:focus {
+      background: $govuk-focus-colour;
+
+      &:before {
+        content: none;
+      }
+    }
+
+    &:after {
+      left: 0;
+      right: 0;
+      width: 100%;
+    }
+
+    @include focus-not-focus-visible {
+      background: $govuk-link-colour;
 
       &:hover {
         background: govuk-colour("black");
-
-        &:before {
-          left: 0;
-          right: 0;
-        }
-      }
-
-      &:focus {
-        background: $govuk-focus-colour;
-
-        &:before {
-          content: none;
-        }
-      }
-
-      &:after {
-        left: 0;
-        right: 0;
-        width: 100%;
-      }
-
-      @include focus-not-focus-visible {
-        background: $govuk-link-colour;
-
-        &:hover {
-          background: govuk-colour("black");
-        }
-      }
-
-      @include focus-and-focus-visible {
-        &:hover {
-          background: $govuk-focus-colour;
-        }
-
-        &:after,
-        &:hover:after {
-          background: $govuk-focus-colour;
-        }
       }
     }
-  }
-}
 
-.gem-c-layout-super-navigation-header__search-item-link-text {
-  @include govuk-media-query($from: "desktop") {
-    @include govuk-visually-hidden;
+    @include focus-and-focus-visible {
+      &:hover {
+        background: $govuk-focus-colour;
+      }
+
+      &:after,
+      &:hover:after {
+        background: $govuk-focus-colour;
+      }
+    }
   }
 }
 
@@ -378,12 +365,6 @@ $after-button-padding-left: govuk-spacing(5);
   height: $icon-size;
   pointer-events: none;
   width: $icon-size;
-}
-
-.gem-c-layout-super-navigation-header__search-item-link-icon {
-  @include govuk-media-query($until: "desktop") {
-    @include govuk-visually-hidden;
-  }
 }
 
 // Search and popular content dropdown.
@@ -403,6 +384,24 @@ $after-button-padding-left: govuk-spacing(5);
   @include govuk-link-style-no-visited-state;
   @include govuk-link-style-no-underline;
 
+  &:after {
+    @include pseudo-underline($left: $after-button-padding-left, $right: $after-button-padding-right);
+  }
+
+  &:hover {
+    color: govuk-colour("mid-grey");
+
+    &:after {
+      background: govuk-colour("mid-grey");
+    }
+
+    .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+      &:before {
+        border-color: govuk-colour("mid-grey");
+      }
+    }
+  }
+
   font-size: 16px;
   font-size: govuk-px-to-rem(16px);
   font-weight: 700;
@@ -413,19 +412,53 @@ $after-button-padding-left: govuk-spacing(5);
   cursor: pointer;
   height: $black-bar-height;
   padding: 0;
-  margin: 0;
-  position: absolute;
-  right: (($search-width-or-height - govuk-spacing(3)) - 1px); // width of the search button (50px) - 15px - 1px to create an overlap between buttons and stop the border appearing to hang off the buttons when they're focused/open
-  top: 0;
-  z-index: 10;
+  position: relative;
+  margin: 0 -3px 0 0; // overlap with the search button to hide right border on mobile
+  vertical-align: top;
+
+  @include govuk-media-query($from: "desktop") {
+    background: govuk-colour("black");
+    display: block;
+    float: left;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    right: 0;
+  }
+
+  &:focus-visible {
+    &:hover {
+      .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+        color: govuk-colour("black");
+
+        &:after {
+          background: govuk-colour("black");
+        }
+
+        &:before {
+          @include chevron(govuk-colour("black"), true);
+        }
+      }
+    }
+  }
 
   @include focus-and-focus-visible {
     @include govuk-focused-text;
+
     box-shadow: none;
+
+    &:hover {
+      &:after {
+        background-color: govuk-colour("black");
+      }
+    }
+
+    &:after {
+      background-color: govuk-colour("black");
+    }
 
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
       border-color: $govuk-focus-colour;
-      color: govuk-colour("black");
 
       &:before {
         @include chevron(govuk-colour("black"), true);
@@ -438,10 +471,24 @@ $after-button-padding-left: govuk-spacing(5);
   @include focus-not-focus-visible {
     background: none;
     box-shadow: none;
+    color: govuk-colour("white");
+
+    &:hover {
+      .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+        &:before {
+          @include chevron(govuk-colour("mid-grey"), true);
+        }
+
+        color: govuk-colour("mid-grey");
+      }
+
+      &:after {
+        background: govuk-colour("mid-grey");
+      }
+    }
 
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
       border-color: $button-pipe-colour;
-      color: govuk-colour("white");
 
       @include govuk-media-query($from: 360px) {
         &:before {
@@ -459,7 +506,7 @@ $after-button-padding-left: govuk-spacing(5);
       box-shadow: none;
 
       &:after {
-        background-color: $govuk-focus-colour;
+        background-color: govuk-colour("black");
       }
 
       .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
@@ -503,7 +550,11 @@ $after-button-padding-left: govuk-spacing(5);
   border-left: 1px solid govuk-colour("white");
   border-right: 1px solid govuk-colour("white");
   margin: 0;
-  padding: govuk-spacing(2) govuk-spacing(4);
+  padding: govuk-spacing(1) govuk-spacing(4);
+
+  @include govuk-media-query($from: "desktop") {
+    border-right: 0;
+  }
 
   @include govuk-media-query($from: 360px) {
     &:before {
@@ -521,9 +572,7 @@ $after-button-padding-left: govuk-spacing(5);
   cursor: pointer;
   height: $search-width-or-height;
   padding: govuk-spacing(3);
-  position: absolute;
-  right: (0 - govuk-spacing(3));
-  top: 0;
+  position: relative;
   width: $search-width-or-height;
 
   @include focus-and-focus-visible {
@@ -541,6 +590,8 @@ $after-button-padding-left: govuk-spacing(5);
   }
 
   @include govuk-media-query($from: "desktop") {
+    border: 0;
+    margin: 0;
     right: 0;
 
     @include focus-not-focus-visible {
@@ -582,6 +633,7 @@ $after-button-padding-left: govuk-spacing(5);
       background: govuk-colour("light-grey");
       border-bottom-color: govuk-colour("light-grey");
       color: govuk-colour("light-grey");
+      outline: 1px solid govuk-colour("light-grey"); // overlap the border of the nav menu so it won't appear when menu open
     }
   }
 }
@@ -608,11 +660,21 @@ $after-button-padding-left: govuk-spacing(5);
 // Dropdown menu.
 .gem-c-layout-super-navigation-header__navigation-dropdown-menu {
   background: govuk-colour("light-grey");
+  border-bottom: 1px govuk-colour("mid-grey") solid;
+  top: govuk-spacing(8);
+  left: govuk-spacing(-3);
+  padding: 0 govuk-spacing(3);
+  position: absolute;
+  right: govuk-spacing(-3);
+
+  @include govuk-media-query($from: "tablet") {
+    padding: 0 govuk-spacing(6);
+    left: govuk-spacing(-6);
+    right: govuk-spacing(-6);
+  }
 
   @include govuk-media-query($from: "desktop") {
-    border-bottom: 1px govuk-colour("mid-grey") solid;
     left: 0;
-    position: absolute;
     right: 0;
   }
 }
@@ -630,23 +692,27 @@ $after-button-padding-left: govuk-spacing(5);
 // Dropdown menu items.
 .gem-c-layout-super-navigation-header__dropdown-list-item {
   box-sizing: border-box;
-  padding: 0 0 govuk-spacing(4) 0;
+  padding: 0 0 govuk-spacing(5) 0;
   position: relative;
+  @include govuk-media-query($from: "desktop") {
+    padding: 0 0 govuk-spacing(4) 0;
+  }
 }
 
 // Navigation menu items.
 .gem-c-layout-super-navigation-header__navigation-second-items {
+
   list-style: none;
   margin: 0;
-  padding: govuk-spacing(6) govuk-spacing(4);
+  padding: govuk-spacing(3) govuk-spacing(5) govuk-spacing(5) 0;
 
   & > li {
     margin: 0;
   }
 
   @include govuk-media-query($from: "desktop") {
-    margin: 0 (0 - govuk-spacing(3));
-    padding: govuk-spacing(7) 0 govuk-spacing(8) 0;
+    margin: 0 (0 - govuk-spacing(3)) govuk-spacing(9);
+    padding: govuk-spacing(2) 0 0 0;
 
     & > li {
       margin: 0 govuk-spacing(3);
@@ -654,21 +720,21 @@ $after-button-padding-left: govuk-spacing(5);
   }
 }
 
-.gem-c-layout-super-navigation-header__navigation-second-items--topics {
-  @include govuk-media-query($from: "desktop") {
-    @include columns($items: 17, $columns: 2, $selector: "li", $flow: column);
+.gem-c-layout-super-navigation-header__column--government-activity {
+  position: relative;
+
+  @include govuk-media-query($until: "desktop") {
+    margin-top: govuk-spacing(6);
   }
 }
 
-.gem-c-layout-super-navigation-header__navigation-second-items--government-activity {
-  @include govuk-media-query($from: "desktop") {
-    @include columns($items: 6, $columns: 2, $selector: "li", $flow: column);
-    padding-bottom: 0;
+.gem-c-layout-super-navigation-header__navigation-second-items--topics {
+  @include govuk-media-query($until: "desktop") {
+    border-bottom: 1px solid govuk-colour("mid-grey");
+  }
 
-    & > li {
-      box-sizing: border-box;
-      padding-bottom: govuk-spacing(4);
-    }
+  @include govuk-media-query($from: "desktop") {
+    @include columns($items: 17, $columns: 2, $selector: "li", $flow: column);
   }
 }
 
@@ -690,6 +756,11 @@ $after-button-padding-left: govuk-spacing(5);
   font-size: 16px;
   font-size: govuk-px-to-rem(16px);
   font-weight: bold;
+
+  &:after {
+    @include make-selectable-area-bigger;
+    height: calc(100% - 20px);
+  }
 }
 
 .gem-c-layout-super-navigation-header__navigation-second-item-description {
@@ -702,21 +773,22 @@ $after-button-padding-left: govuk-spacing(5);
 
 // Search dropdown.
 .gem-c-layout-super-navigation-header__search-items {
-  background: govuk-colour("light-grey");
-  margin: 0 (0 - govuk-spacing(3));
+  .js-module-initialised & {
+    margin: 0 (0 - govuk-spacing(3));
+    position: absolute;
 
-  @include govuk-media-query($from: "tablet") {
-    margin: 0 (0 - govuk-spacing(6));
+    @include govuk-media-query($from: "tablet") {
+      margin: 0 (0 - govuk-spacing(6));
+    }
   }
+
+  background: govuk-colour("light-grey");
+  left: 0;
+  right: 0;
+  z-index: 999;
 
   @include govuk-media-query($from: "desktop") {
     margin: 0;
-
-    .js-module-initialised & {
-      left: 0;
-      position: absolute;
-      right: 0;
-    }
   }
 }
 
@@ -750,7 +822,17 @@ $after-button-padding-left: govuk-spacing(5);
 .gem-c-layout-super-navigation-header__width-container {
   @include govuk-media-query($until: "desktop") {
     margin: 0;
+    margin-top: govuk-spacing(6);
   }
+
+  @include govuk-media-query($from: "desktop") {
+    margin: govuk-spacing(5) auto 0;
+    max-width: 960px;
+  }
+}
+
+.gem-c-layout-super-navigation-header__column-header {
+  font-size: 24px;
 }
 
 @include govuk-media-query($media-type: print) {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -138,34 +138,7 @@ $after-button-padding-left: govuk-spacing(5);
 }
 
 .gem-c-layout-super-navigation-header__navigation-items {
-  @include govuk-media-query($from: "desktop") {
-    display: inline-block;
-  }
-}
-
-.gem-c-layout-super-navigation-header__navigation-item,
-.gem-c-layout-super-navigation-header__search-item {
-  display: block;
-  margin: 0;
-  padding: govuk-spacing(2) govuk-spacing(3);
-  position: relative;
-
-  @include govuk-media-query($from: "tablet") {
-    margin: 0 govuk-spacing(6);
-    padding: govuk-spacing(2) 0;
-  }
-
-  @include govuk-media-query($from: "desktop") {
-    background: govuk-colour("black");
-    display: block;
-    float: left;
-    margin: 0;
-    padding: 0;
-    position: static;
-  }
-}
-
-.gem-c-layout-super-navigation-header__navigation-item {
+  display: inline-block;
   border-bottom: 1px solid $govuk-border-colour;
 
   .js-module-initialised & {
@@ -180,20 +153,13 @@ $after-button-padding-left: govuk-spacing(5);
 
     &:first-of-type {
       margin-right: -1px;
-
-      .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner,
-      .gem-c-layout-super-navigation-header__navigation-item-link-inner {
-        border-left: 1px solid $button-pipe-colour;
-        border-right: 1px solid $button-pipe-colour;
-      }
     }
   }
 }
 
 // Top level navigation links and search link.
 .gem-c-layout-super-navigation-header__navigation-item-link,
-.gem-c-layout-super-navigation-header__search-item-link,
-.gem-c-layout-super-navigation-header__navigation-second-toggle-button {
+.gem-c-layout-super-navigation-header__search-item-link {
   @include govuk-link-common;
   @include govuk-link-style-no-visited-state;
 
@@ -257,12 +223,6 @@ $after-button-padding-left: govuk-spacing(5);
       }
     }
 
-    &:focus:not(:focus-visible) {
-      .gem-c-layout-super-navigation-header__navigation-item-link-inner {
-        border-color: $button-pipe-colour;
-      }
-    }
-
     @include focus-and-focus-visible {
       .gem-c-layout-super-navigation-header__navigation-item-link-inner {
         border-color: $govuk-focus-colour;
@@ -302,10 +262,6 @@ $after-button-padding-left: govuk-spacing(5);
       }
     }
 
-    &:after {
-      @include pseudo-underline($left: $after-link-padding, $right: $after-link-padding, $width: calc(100% - $after-link-padding));
-    }
-
     .js-module-initialised & {
       // If js is initialised, we are hiding the links and
       // making the buttons visible instead. This means we have
@@ -329,158 +285,13 @@ $after-button-padding-left: govuk-spacing(5);
   }
 }
 
-.gem-c-layout-super-navigation-header__navigation-item-link,
-.gem-c-layout-super-navigation-header__navigation-second-toggle-button {
+.gem-c-layout-super-navigation-header__navigation-item-link {
   @include govuk-media-query($from: "desktop") {
     padding: govuk-spacing(3) 0;
   }
-}
 
-.gem-c-layout-super-navigation-header__navigation-item-link {
   .js-module-initialised & {
     margin-left: govuk-spacing(4);
-    @include govuk-link-style-no-underline;
-  }
-}
-
-.gem-c-layout-super-navigation-header__navigation-second-toggle-button {
-  background: none;
-  border: 0;
-  color: $govuk-link-colour;
-  cursor: pointer;
-  padding: 0;
-
-  @include focus-not-focus-visible {
-    .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
-      &:before {
-        @include chevron($govuk-link-colour);
-      }
-    }
-  }
-
-  @include focus-not-focus-visible {
-    &:hover {
-      .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
-        &:before {
-          @include chevron($govuk-link-hover-colour, true);
-        }
-      }
-    }
-  }
-
-  &:focus {
-    .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
-      &:before {
-        @include chevron($govuk-focus-text-colour, true);
-      }
-    }
-  }
-
-  @include govuk-media-query($from: "desktop") {
-    &:after {
-      @include pseudo-underline($left: govuk-spacing(5), $right: govuk-spacing(6));
-    }
-
-    @include focus-not-focus-visible {
-      color: govuk-colour("white");
-      float: left;
-      font-size: 16px;
-      font-size: govuk-px-to-rem(16px);
-      height: $black-bar-height;
-      position: relative;
-      text-decoration: none;
-
-      .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
-        border-color: $button-pipe-colour;
-
-        &:before {
-          @include chevron(govuk-colour("white"), true);
-        }
-      }
-    }
-    @include focus-not-focus-visible {
-      &:hover {
-        color: govuk-colour("mid-grey");
-        text-decoration: none;
-
-        &:after {
-          background: govuk-colour("mid-grey");
-        }
-
-        .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
-          &:before {
-            @include chevron(govuk-colour("mid-grey"), true);
-          }
-        }
-      }
-    }
-
-    @include focus-and-focus-visible {
-      color: $govuk-focus-text-colour;
-
-      &:after {
-        background: $govuk-focus-text-colour;
-      }
-
-      .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
-        border-color: $govuk-focus-colour;
-
-        &:before {
-          @include chevron($govuk-focus-text-colour, true);
-        }
-      }
-    }
-  }
-
-  &.gem-c-layout-super-navigation-header__open-button {
-    @include focus-not-focus-visible {
-      .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
-        &:before {
-          @include prefixed-transform($rotate: 225deg, $translateY: 1px);
-        }
-      }
-    }
-
-    @include govuk-media-query($from: "desktop") {
-      @include focus-not-focus-visible {
-        background: govuk-colour("light-grey");
-        color: $govuk-link-colour;
-
-        // stylelint-disable max-nesting-depth
-        .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
-          border-color: govuk-colour("light-grey");
-
-          &:before {
-            @include chevron($govuk-link-colour, true);
-          }
-        }
-
-        &:after {
-          background-color: $govuk-link-colour;
-        }
-      }
-
-      @include focus-and-focus-visible {
-        background-color: $govuk-focus-colour;
-        color: $govuk-focus-text-colour;
-
-        .gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner {
-          border-color: $govuk-focus-colour;
-
-          &:before {
-            @include chevron($govuk-focus-text-colour, true);
-          }
-        }
-
-        &:after {
-          background: $govuk-focus-text-colour;
-        }
-      }
-    }
-  }
-  // stylelint-enable max-nesting-depth
-
-  .js-module-initialised & {
     @include govuk-link-style-no-underline;
   }
 }
@@ -865,10 +676,6 @@ $after-button-padding-left: govuk-spacing(5);
   font-size: 16px;
   font-size: govuk-px-to-rem(16px);
 
-  &:after {
-    @include make-selectable-area-bigger;
-  }
-
   @include govuk-media-query($from: "desktop") {
     font-weight: bold;
     padding: 0;
@@ -883,53 +690,6 @@ $after-button-padding-left: govuk-spacing(5);
   font-size: 16px;
   font-size: govuk-px-to-rem(16px);
   font-weight: bold;
-}
-
-// Dropdown menu footer links.
-.gem-c-layout-super-navigation-header__navigation-second-footer-break {
-  @include govuk-media-query($until: "desktop") {
-    display: none;
-  }
-}
-
-.gem-c-layout-super-navigation-header__navigation-second-footer-list {
-  list-style: none;
-  padding: 0 0 govuk-spacing(8) govuk-spacing(4);
-
-  @include govuk-media-query($from: "desktop") {
-    @include columns($items: 2, $columns: 2, $selector: "li");
-    margin: 0 (0 - govuk-spacing(3));
-    padding: govuk-spacing(6) 0 govuk-spacing(7) 0;
-  }
-}
-
-.gem-c-layout-super-navigation-header__navigation-second-footer-item {
-  padding: govuk-spacing(2) 0;
-  position: relative;
-
-  @include govuk-media-query($from: "desktop") {
-    padding: 0 govuk-spacing(3);
-  }
-}
-
-.gem-c-layout-super-navigation-header__navigation-second-footer-link {
-  display: inline-block;
-  font-size: 16px;
-  font-size: govuk-px-to-rem(16px);
-  margin: govuk-spacing(1) 0;
-
-  &:after {
-    @include make-selectable-area-bigger;
-  }
-
-  @include govuk-media-query($from: "desktop") {
-    display: inline;
-    padding: 0;
-
-    &:after {
-      content: none;
-    }
-  }
 }
 
 .gem-c-layout-super-navigation-header__navigation-second-item-description {
@@ -987,8 +747,6 @@ $after-button-padding-left: govuk-spacing(5);
   }
 }
 
-// To be used with .govuk-width-container - we only need the margins from
-// desktop onwards.
 .gem-c-layout-super-navigation-header__width-container {
   @include govuk-media-query($until: "desktop") {
     margin: 0;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -108,10 +108,8 @@ $after-button-padding-left: govuk-spacing(5);
 }
 
 .gem-c-layout-super-navigation-header__content {
-  @include govuk-media-query($from: "desktop") {
-    display: block;
-    float: right;
-  }
+  display: block;
+  float: right;
 }
 
 .gem-c-layout-super-navigation-header__navigation-toggle-wrapper {
@@ -239,16 +237,56 @@ $after-button-padding-left: govuk-spacing(5);
       @include make-selectable-area-bigger;
     }
 
-    @include govuk-media-query($from: "desktop") {
-      // stylelint-disable max-nesting-depth
-      float: left;
-      font-size: 16px;
-      font-size: govuk-px-to-rem(16px);
-      height: govuk-spacing(4);
-      position: relative;
+    // stylelint-disable max-nesting-depth
+    float: left;
+    font-size: 16px;
+    font-size: govuk-px-to-rem(16px);
 
-      &:before {
-        @include chevron(govuk-colour("white"), true);
+    height: govuk-spacing(4);
+    position: relative;
+
+    &:before {
+      @include chevron(govuk-colour("white"), true);
+    }
+
+    &:hover {
+      color: govuk-colour("mid-grey");
+
+      &:after {
+        background: govuk-colour("mid-grey");
+      }
+    }
+
+    &:focus:not(:focus-visible) {
+      .gem-c-layout-super-navigation-header__navigation-item-link-inner {
+        border-color: $button-pipe-colour;
+      }
+    }
+
+    @include focus-and-focus-visible {
+      .gem-c-layout-super-navigation-header__navigation-item-link-inner {
+        border-color: $govuk-focus-colour;
+      }
+
+      &,
+      &:hover {
+        box-shadow: none;
+        color: $govuk-focus-text-colour;
+
+        &:after {
+          background: $govuk-focus-text-colour;
+        }
+      }
+    }
+
+    @include focus-not-focus-visible {
+      &,
+      &:hover {
+        text-decoration: none;
+      }
+
+      & {
+        color: govuk-colour("white");
       }
 
       &:hover {
@@ -259,72 +297,31 @@ $after-button-padding-left: govuk-spacing(5);
         }
       }
 
-      &:focus:not(:focus-visible) {
-        .gem-c-layout-super-navigation-header__navigation-item-link-inner {
-          border-color: $button-pipe-colour;
-        }
+      &:after {
+        background: none;
       }
+    }
 
-      @include focus-and-focus-visible {
-        .gem-c-layout-super-navigation-header__navigation-item-link-inner {
-          border-color: $govuk-focus-colour;
-        }
+    &:after {
+      @include pseudo-underline($left: $after-link-padding, $right: $after-link-padding, $width: calc(100% - $after-link-padding));
+    }
 
-        &,
-        &:hover {
-          box-shadow: none;
-          color: $govuk-focus-text-colour;
+    .js-module-initialised & {
+      // If js is initialised, we are hiding the links and
+      // making the buttons visible instead. This means we have
+      // to remove the padding added to make the links vertically
+      // aligned, as the buttons are styled vertically aligned by
+      // default.
 
-          &:after {
-            background: $govuk-focus-text-colour;
-          }
-        }
-      }
-
-      @include focus-not-focus-visible {
-        &,
-        &:hover {
-          text-decoration: none;
-        }
-
-        & {
-          color: govuk-colour("white");
-        }
-
-        &:hover {
-          color: govuk-colour("mid-grey");
-
-          &:after {
-            background: govuk-colour("mid-grey");
-          }
-        }
-
-        &:after {
-          background: none;
-        }
-      }
+      padding: 0;
+      margin: 0;
 
       &:after {
-        @include pseudo-underline($left: $after-link-padding, $right: $after-link-padding, $width: calc(100% - $after-link-padding));
+        @include pseudo-underline($left: $after-button-padding-left, $right: $after-button-padding-right, $width: calc(100% - $after-button-padding-left));
       }
-
-      .js-module-initialised & {
-        // If js is initialised, we are hiding the links and
-        // making the buttons visible instead. This means we have
-        // to remove the padding added to make the links vertically
-        // aligned, as the buttons are styled vertically aligned by
-        // default.
-
-        padding: 0;
-        margin: 0;
-
-        &:after {
-          @include pseudo-underline($left: $after-button-padding-left, $right: $after-button-padding-right, $width: calc(100% - $after-button-padding-left));
-        }
-      }
-
-      // stylelint-enable max-nesting-depth
     }
+
+    // stylelint-enable max-nesting-depth
   }
 
   &:after {
@@ -619,10 +616,8 @@ $after-button-padding-left: govuk-spacing(5);
       border-color: $govuk-focus-colour;
       color: govuk-colour("black");
 
-      @include govuk-media-query($from: 360px) {
-        &:before {
-          @include chevron(govuk-colour("black"), true);
-        }
+      &:before {
+        @include chevron(govuk-colour("black"), true);
       }
     }
   }

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -102,12 +102,12 @@
           toggle_desktop_group: "top",
           toggle_mobile_group: "top",
           tracking_key: tracking_label,
-          ga4: {
+          ga4_event: {
             event_name: "select_content",
             type: "header menu bar",
             text: link[:label],
-            index: 2,
-            index_total: 3,
+            index: 1,
+            index_total: 2,
             section: link[:label]
           }
         },
@@ -184,12 +184,12 @@
         hidden
         id="super-search-menu-toggle"
         type="button"
-        data-ga4="<%= {
+        data-ga4-event="<%= {
           "event_name": "select_content",
           "type": "header menu bar",
           "text": "Search",
-          "index": 3,
-          "index_total": 3,
+          "index": 2,
+          "index_total": 2,
           "section": "Search"
         }.to_json %>"
       >

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -2,7 +2,7 @@
   logo_link ||= "https://www.gov.uk/"
   logo_link_title ||= t("components.layout_super_navigation_header.logo_link_title")
   logo_text = t("components.layout_super_navigation_header.logo_text")
-  navigation_links = t("components.layout_super_navigation_header.navigation_links")
+  navigation_links_columns = t("components.layout_super_navigation_header.navigation_links_columns")
   navigation_menu_heading = t("components.layout_super_navigation_header.navigation_menu_heading")
   navigation_search_heading = t("components.layout_super_navigation_header.navigation_search_heading")
   navigation_search_subheading = t("components.layout_super_navigation_header.navigation_search_subheading")
@@ -67,12 +67,10 @@
       </h2>
 
       <%
-        has_children = (link[:menu_contents].present? or link[:footer_links].present?)
-        li_classes = %w[gem-c-layout-super-navigation-header__navigation-item]
-        li_classes << "gem-c-layout-super-navigation-header__navigation-item--with-children" if has_children
+        link = t("components.layout_super_navigation_header.navigation_link")
         unique_id = SecureRandom.hex(4)
-        show_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.show", :label => link[:label])
-        hide_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.hide", :label => link[:label])
+        show_menu_text = show_navigation_menu_text
+        hide_menu_text = hide_navigation_menu_text
         tracking_label = link[:label].downcase.gsub(/\s+/, "")
       %>
 
@@ -93,97 +91,89 @@
 
       <%= content_tag(:button, {
         aria: {
-          controls: "super-navigation-menu__section-#{unique_id}",
+          controls: "super-navigation-menu-#{unique_id}",
           expanded: false,
           label: show_menu_text,
         },
-        class: "gem-c-layout-super-navigation-header__navigation-second-toggle-button",
+        class: "gem-c-layout-super-navigation-header__navigation-top-toggle-button",
         data: {
           text_for_hide: hide_menu_text,
           text_for_show: show_menu_text,
           toggle_desktop_group: "top",
-          toggle_mobile_group: "second",
+          toggle_mobile_group: "top",
           tracking_key: tracking_label,
           ga4: {
             event_name: "select_content",
             type: "header menu bar",
             text: link[:label],
-            index: index + 2,
-            index_total: navigation_links.length + 2,
+            index: 2,
+            index_total: 3,
             section: link[:label]
           }
         },
         hidden: true,
-        id: "super-navigation-menu__section-#{unique_id}-toggle",
+        id: "super-navigation-menu-#{unique_id}-toggle",
         type: "button",
       }) do %>
-        <%= tag.span link[:label], class: "gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner" %>
+        <%= tag.span link[:label], class: "gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner" %>
       <% end %>
-      <div
-        hidden
-        class="gem-c-layout-super-navigation-header__navigation-dropdown-menu"
-        id="super-navigation-menu__section-<%= unique_id %>"
-      >
-        <div class="govuk-width-container gem-c-layout-super-navigation-header__width-container">
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-third-from-desktop">
-              <% if link[:description].present? %>
-                <h3 class="govuk-body-l gem-c-layout-super-navigation-header__menu-description">
-                  <%= link[:description] %>
-                </h3>
-              <% end %>
-            </div>
-            <div class="govuk-grid-column-two-thirds-from-desktop">
-              <% if link[:menu_contents].present? %>
-                  <ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--<%= link[:label].parameterize %>">
-                    <% link[:menu_contents].each do | item | %>
-                      <%
-                        has_description = item[:description].present?
-                        link_classes = %w[govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link]
-                        link_classes << "gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" if has_description
-                      %>
-                      <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
-                        <%= link_to item[:label], item[:href], {
-                          class: link_classes,
-                          data: {
-                            track_action: "#{tracking_label}Link",
-                            track_category: "headerClicked",
-                            track_label: item[:href],
-                            track_dimension: item[:label],
-                            track_dimension_index: "29",
-                          }
-                        } %>
-                        <%= tag.p item[:description], class: "gem-c-layout-super-navigation-header__navigation-second-item-description" if has_description %>
-                      </li>
-                    <% end %>
-                  </ul>
-              <% end %>
-              <% if link[:footer_links].present? %>
-                <hr class="gem-c-layout-super-navigation-header__navigation-second-footer-break govuk-section-break govuk-section-break--visible">
-                <ul class="gem-c-layout-super-navigation-header__navigation-second-footer-list">
-                  <% link[:footer_links].each do | item | %>
-                    <li class="gem-c-layout-super-navigation-header__navigation-second-footer-item">
-                      <%= link_to item[:label], item[:href], {
-                        class: [
-                          "govuk-link",
-                          "gem-c-layout-super-navigation-header__navigation-second-footer-link",
-                        ],
-                        data: {
-                          track_action: "#{tracking_label}Link",
-                          track_category: "headerClicked",
-                          track_label: item[:href],
-                          track_dimension: item[:label],
-                          track_dimension_index: "29",
-                        }
-                      } %>
-                    </li>
+        <%= tag.div class: "gem-c-layout-super-navigation-header__navigation-items" do %>
+            <div
+              id="super-navigation-menu-<%= unique_id %>" hidden
+              class="gem-c-layout-super-navigation-header__navigation-dropdown-menu"
+            >
+              <div class="gem-c-layout-super-navigation-header__width-container">
+                <div class="govuk-grid-row">
+
+                  <% navigation_links_columns.each_with_index do | column, index | %>
+                    <%
+                      case column[:size]
+                      when 2
+                        width_class = "govuk-grid-column-two-thirds-from-desktop"
+                      when 3
+                        width_class = "govuk-grid-column-full-from-desktop"
+                      else
+                        width_class = "govuk-grid-column-one-third-from-desktop"
+                      end
+                    %>
+
+                    <div class="<%= width_class %> gem-c-layout-super-navigation-header__column--<%= column[:label].downcase.sub(" ", "-") %>">
+                      <div class="govuk-width-container">
+                        <h3 class="govuk-heading-m gem-c-layout-super-navigation-header__column-header">
+                          <%= column[:label] %>
+                        </h3>
+                      </div>
+                      <div class="govuk-width-container">
+                        <ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--<%= column[:label].downcase.sub(" ", "-") %>">
+                          <% column[:menu_contents].each do | item | %>
+                              <%
+                                has_description = item[:description].present?
+                                link_classes = %w[govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link]
+                                link_classes << "gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" if has_description
+                                tracking_label = column[:label].downcase.gsub(/\s+/, "")
+                              %>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <%= link_to item[:label], item[:href], {
+                                  class: link_classes,
+                                  data: {
+                                    track_action: "#{tracking_label}Link",
+                                    track_category: "headerClicked",
+                                    track_label: item[:href],
+                                    track_dimension: item[:label],
+                                    track_dimension_index: "29",
+                                  }
+                                } %>
+                                <%= tag.p item[:description], class: "gem-c-layout-super-navigation-header__navigation-second-item-description" if has_description %>
+                              </li>
+                          <% end %>
+                        </ul>
+                      </div>
+                    </div>
                   <% end %>
-                </ul>
-              <% end %>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      </div>
+        <% end %>
 
       <button
         aria-controls="super-search-menu"
@@ -198,12 +188,12 @@
         hidden
         id="super-search-menu-toggle"
         type="button"
-        data-ga4-event="<%= {
+        data-ga4="<%= {
           "event_name": "select_content",
           "type": "header menu bar",
           "text": "Search",
-          "index": navigation_links.length + 2,
-          "index_total": navigation_links.length + 2,
+          "index": 3,
+          "index_total": 3,
           "section": "Search"
         }.to_json %>"
       >
@@ -230,7 +220,7 @@
         </h3>
         <div class="gem-c-layout-super-navigation-header__search-item">
           <a class="gem-c-layout-super-navigation-header__search-item-link" href="/search">
-            <span class="gem-c-layout-super-navigation-header__search-item-link-text">
+            <span class="govuk-visually-hidden">
               <%= search_text %>
             </span>
             <svg

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -90,137 +90,100 @@
           <%= link[:label] %>
         </span>
       <% end %>
-      <button
-        aria-controls="super-navigation-menu"
-        aria-expanded="true"
-        aria-label="<%= hide_navigation_menu_text %>"
-        class="gem-c-layout-super-navigation-header__navigation-top-toggle-button"
-        data-text-for-hide="<%= hide_navigation_menu_text %>"
-        data-text-for-show="<%= show_navigation_menu_text %>"
-        data-toggle-desktop-group="hidden"
-        data-toggle-mobile-group="top"
-        data-tracking-key="menu"
+
+      <%= content_tag(:button, {
+        aria: {
+          controls: "super-navigation-menu__section-#{unique_id}",
+          expanded: false,
+          label: show_menu_text,
+        },
+        class: "gem-c-layout-super-navigation-header__navigation-second-toggle-button",
+        data: {
+          text_for_hide: hide_menu_text,
+          text_for_show: show_menu_text,
+          toggle_desktop_group: "top",
+          toggle_mobile_group: "second",
+          tracking_key: tracking_label,
+          ga4: {
+            event_name: "select_content",
+            type: "header menu bar",
+            text: link[:label],
+            index: index + 2,
+            index_total: navigation_links.length + 2,
+            section: link[:label]
+          }
+        },
+        hidden: true,
+        id: "super-navigation-menu__section-#{unique_id}-toggle",
+        type: "button",
+      }) do %>
+        <%= tag.span link[:label], class: "gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner" %>
+      <% end %>
+      <div
         hidden
-        id="super-navigation-menu-toggle"
-        type="button"
-        data-ga4-event="<%= {
-          "event_name": "select_content",
-          "type": "header menu bar",
-          "text": "Menu",
-          "index": 1,
-          "index_total": navigation_links.length + 2,
-          "section": "Menu"
-        }.to_json %>"
+        class="gem-c-layout-super-navigation-header__navigation-dropdown-menu"
+        id="super-navigation-menu__section-<%= unique_id %>"
       >
-        <span class="gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner">
-          Menu
-        </span>
-      </button>
-      <ul id="super-navigation-menu" class="gem-c-layout-super-navigation-header__navigation-items">
-        <% navigation_links.each_with_index do | link, index | %>
-          <%= tag.li class: li_classes do %>
-            <div class="gem-c-layout-super-navigation-header__navigation-toggle-wrapper govuk-clearfix">
-              <% if has_children %>
-                <%= content_tag(:button, {
-                  aria: {
-                    controls: "super-navigation-menu__section-#{unique_id}",
-                    expanded: false,
-                    label: show_menu_text,
-                  },
-                  class: "gem-c-layout-super-navigation-header__navigation-second-toggle-button",
-                  data: {
-                    text_for_hide: hide_menu_text,
-                    text_for_show: show_menu_text,
-                    toggle_desktop_group: "top",
-                    toggle_mobile_group: "second",
-                    tracking_key: tracking_label,
-                    ga4: {
-                      event_name: "select_content",
-                      type: "header menu bar",
-                      text: link[:label],
-                      index: index + 2,
-                      index_total: navigation_links.length + 2,
-                      section: link[:label]
-                    }
-                  },
-                  hidden: true,
-                  id: "super-navigation-menu__section-#{unique_id}-toggle",
-                  type: "button",
-                }) do %>
-                  <%= tag.span link[:label], class: "gem-c-layout-super-navigation-header__navigation-second-toggle-button-inner" %>
-                <% end %>
+        <div class="govuk-width-container gem-c-layout-super-navigation-header__width-container">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-third-from-desktop">
+              <% if link[:description].present? %>
+                <h3 class="govuk-body-l gem-c-layout-super-navigation-header__menu-description">
+                  <%= link[:description] %>
+                </h3>
               <% end %>
             </div>
-            <% if has_children %>
-              <div
-                hidden
-                class="gem-c-layout-super-navigation-header__navigation-dropdown-menu"
-                id="super-navigation-menu__section-<%= unique_id %>"
-              >
-                <div class="govuk-width-container gem-c-layout-super-navigation-header__width-container">
-                  <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-one-third-from-desktop">
-                      <% if link[:description].present? %>
-                        <h3 class="govuk-body-l gem-c-layout-super-navigation-header__menu-description">
-                          <%= link[:description] %>
-                        </h3>
-                      <% end %>
-                    </div>
-                    <div class="govuk-grid-column-two-thirds-from-desktop">
-                      <% if link[:menu_contents].present? %>
-                          <ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--<%= link[:label].parameterize %>">
-                            <% link[:menu_contents].each do | item | %>
-                              <%
-                                has_description = item[:description].present?
-                                link_classes = %w[govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link]
-                                link_classes << "gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" if has_description
-                              %>
-                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
-                                <%= link_to item[:label], item[:href], {
-                                  class: link_classes,
-                                  data: {
-                                    track_action: "#{tracking_label}Link",
-                                    track_category: "headerClicked",
-                                    track_label: item[:href],
-                                    track_dimension: item[:label],
-                                    track_dimension_index: "29",
-                                  }
-                                } %>
-                                <%= tag.p item[:description], class: "gem-c-layout-super-navigation-header__navigation-second-item-description" if has_description %>
-                              </li>
-                            <% end %>
-                          </ul>
-                      <% end %>
-                      <% if link[:footer_links].present? %>
-                        <hr class="gem-c-layout-super-navigation-header__navigation-second-footer-break govuk-section-break govuk-section-break--visible">
-                        <ul class="gem-c-layout-super-navigation-header__navigation-second-footer-list">
-                          <% link[:footer_links].each do | item | %>
-                            <li class="gem-c-layout-super-navigation-header__navigation-second-footer-item">
-                              <%= link_to item[:label], item[:href], {
-                                class: [
-                                  "govuk-link",
-                                  "gem-c-layout-super-navigation-header__navigation-second-footer-link",
-                                ],
-                                data: {
-                                  track_action: "#{tracking_label}Link",
-                                  track_category: "headerClicked",
-                                  track_label: item[:href],
-                                  track_dimension: item[:label],
-                                  track_dimension_index: "29",
-                                }
-                              } %>
-                            </li>
-                          <% end %>
-                        </ul>
-                      <% end %>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            <% end %>
-          <% end %>
-        <% end %>
-      </ul>
+            <div class="govuk-grid-column-two-thirds-from-desktop">
+              <% if link[:menu_contents].present? %>
+                  <ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--<%= link[:label].parameterize %>">
+                    <% link[:menu_contents].each do | item | %>
+                      <%
+                        has_description = item[:description].present?
+                        link_classes = %w[govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link]
+                        link_classes << "gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" if has_description
+                      %>
+                      <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                        <%= link_to item[:label], item[:href], {
+                          class: link_classes,
+                          data: {
+                            track_action: "#{tracking_label}Link",
+                            track_category: "headerClicked",
+                            track_label: item[:href],
+                            track_dimension: item[:label],
+                            track_dimension_index: "29",
+                          }
+                        } %>
+                        <%= tag.p item[:description], class: "gem-c-layout-super-navigation-header__navigation-second-item-description" if has_description %>
+                      </li>
+                    <% end %>
+                  </ul>
+              <% end %>
+              <% if link[:footer_links].present? %>
+                <hr class="gem-c-layout-super-navigation-header__navigation-second-footer-break govuk-section-break govuk-section-break--visible">
+                <ul class="gem-c-layout-super-navigation-header__navigation-second-footer-list">
+                  <% link[:footer_links].each do | item | %>
+                    <li class="gem-c-layout-super-navigation-header__navigation-second-footer-item">
+                      <%= link_to item[:label], item[:href], {
+                        class: [
+                          "govuk-link",
+                          "gem-c-layout-super-navigation-header__navigation-second-footer-link",
+                        ],
+                        data: {
+                          track_action: "#{tracking_label}Link",
+                          track_category: "headerClicked",
+                          track_label: item[:href],
+                          track_dimension: item[:label],
+                          track_dimension_index: "29",
+                        }
+                      } %>
+                    </li>
+                  <% end %>
+                </ul>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
 
       <button
         aria-controls="super-search-menu"

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -65,6 +65,31 @@
       <h2 id="super-navigation-menu-heading" class="govuk-visually-hidden">
         <%= navigation_menu_heading %>
       </h2>
+
+      <%
+        has_children = (link[:menu_contents].present? or link[:footer_links].present?)
+        li_classes = %w[gem-c-layout-super-navigation-header__navigation-item]
+        li_classes << "gem-c-layout-super-navigation-header__navigation-item--with-children" if has_children
+        unique_id = SecureRandom.hex(4)
+        show_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.show", :label => link[:label])
+        hide_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.hide", :label => link[:label])
+        tracking_label = link[:label].downcase.gsub(/\s+/, "")
+      %>
+
+      <%= link_to link[:href], {
+        class: "gem-c-layout-super-navigation-header__navigation-item-link",
+        data: {
+          track_action: "#{tracking_label}Link",
+          track_category: "headerClicked",
+          track_label: link[:href],
+          track_dimension: link[:label],
+          track_dimension_index: "29",
+        }
+      } do %>
+        <span class="gem-c-layout-super-navigation-header__navigation-item-link-inner">
+          <%= link[:label] %>
+        </span>
+      <% end %>
       <button
         aria-controls="super-navigation-menu"
         aria-expanded="true"
@@ -93,31 +118,8 @@
       </button>
       <ul id="super-navigation-menu" class="gem-c-layout-super-navigation-header__navigation-items">
         <% navigation_links.each_with_index do | link, index | %>
-          <%
-            has_children = (link[:menu_contents].present? or link[:footer_links].present?)
-            li_classes = %w[gem-c-layout-super-navigation-header__navigation-item]
-            li_classes << "gem-c-layout-super-navigation-header__navigation-item--with-children" if has_children
-            unique_id = SecureRandom.hex(4)
-            show_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.show", :label => link[:label])
-            hide_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.hide", :label => link[:label])
-            tracking_label = link[:label].downcase.gsub(/\s+/, "")
-          %>
           <%= tag.li class: li_classes do %>
             <div class="gem-c-layout-super-navigation-header__navigation-toggle-wrapper govuk-clearfix">
-              <%= link_to link[:href], {
-                class: "gem-c-layout-super-navigation-header__navigation-item-link",
-                data: {
-                  track_action: "#{tracking_label}Link",
-                  track_category: "headerClicked",
-                  track_label: link[:href],
-                  track_dimension: link[:label],
-                  track_dimension_index: "29",
-                }
-              } do %>
-                <span class="gem-c-layout-super-navigation-header__navigation-item-link-inner">
-                  <%= link[:label] %>
-                </span>
-              <% end %>
               <% if has_children %>
                 <%= content_tag(:button, {
                   aria: {

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -138,36 +138,32 @@
                     %>
 
                     <div class="<%= width_class %> gem-c-layout-super-navigation-header__column--<%= column[:label].downcase.sub(" ", "-") %>">
-                      <div class="govuk-width-container">
-                        <h3 class="govuk-heading-m gem-c-layout-super-navigation-header__column-header">
-                          <%= column[:label] %>
-                        </h3>
-                      </div>
-                      <div class="govuk-width-container">
-                        <ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--<%= column[:label].downcase.sub(" ", "-") %>">
-                          <% column[:menu_contents].each do | item | %>
-                              <%
-                                has_description = item[:description].present?
-                                link_classes = %w[govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link]
-                                link_classes << "gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" if has_description
-                                tracking_label = column[:label].downcase.gsub(/\s+/, "")
-                              %>
-                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
-                                <%= link_to item[:label], item[:href], {
-                                  class: link_classes,
-                                  data: {
-                                    track_action: "#{tracking_label}Link",
-                                    track_category: "headerClicked",
-                                    track_label: item[:href],
-                                    track_dimension: item[:label],
-                                    track_dimension_index: "29",
-                                  }
-                                } %>
-                                <%= tag.p item[:description], class: "gem-c-layout-super-navigation-header__navigation-second-item-description" if has_description %>
-                              </li>
-                          <% end %>
-                        </ul>
-                      </div>
+                      <h3 class="govuk-heading-m gem-c-layout-super-navigation-header__column-header">
+                        <%= column[:label] %>
+                      </h3>
+                      <ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--<%= column[:label].downcase.sub(" ", "-") %>">
+                        <% column[:menu_contents].each do | item | %>
+                            <%
+                              has_description = item[:description].present?
+                              link_classes = %w[govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link]
+                              link_classes << "gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" if has_description
+                              tracking_label = column[:label].downcase.gsub(/\s+/, "")
+                            %>
+                            <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                              <%= link_to item[:label], item[:href], {
+                                class: link_classes,
+                                data: {
+                                  track_action: "#{tracking_label}Link",
+                                  track_category: "headerClicked",
+                                  track_label: item[:href],
+                                  track_dimension: item[:label],
+                                  track_dimension_index: "29",
+                                }
+                              } %>
+                              <%= tag.p item[:description], class: "gem-c-layout-super-navigation-header__navigation-second-item-description" if has_description %>
+                            </li>
+                        <% end %>
+                      </ul>
                     </div>
                   <% end %>
                 </div>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -112,7 +112,10 @@ ar:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -109,7 +109,10 @@ az:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -115,7 +115,10 @@ be:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -113,7 +113,10 @@ bg:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -110,7 +110,10 @@ bn:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -114,7 +114,10 @@ cs:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -113,7 +113,10 @@ cy:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -110,7 +110,10 @@ da:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -113,7 +113,10 @@ de:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -111,7 +111,10 @@ dr:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -109,7 +109,10 @@ el:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,10 +162,12 @@ en:
       menu_toggle_label:
         hide: Hide %{label} menu
         show: Show %{label} menu
-      navigation_links:
-      - label: Topics
+      navigation_link:
         href: "/browse"
-        description: Find information and services
+        label: Menu
+      navigation_links_columns:
+      - label: Topics
+        size: 2
         menu_contents:
         - label: Benefits
           href: "/browse/benefits"
@@ -202,8 +204,7 @@ en:
         - label: Working, jobs and pensions
           href: "/browse/working"
       - label: Government activity
-        href: "/search/news-and-communications"
-        description: Search for a department and find out what the government is doing
+        column_size: 1
         menu_contents:
         - label: Departments
           href: "/government/organisations"
@@ -223,11 +224,6 @@ en:
         - label: Transparency
           href: "/search/transparency-and-freedom-of-information-releases"
           description: Data, Freedom of Information releases and corporate reports
-        footer_links:
-        - label: How government works
-          href: "/government/how-government-works"
-        - label: Get involved
-          href: "/government/get-involved"
       navigation_menu_heading: Navigation menu
       navigation_search_heading: Search and popular pages
       navigation_search_subheading: Search

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -109,7 +109,10 @@ es-419:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -109,7 +109,10 @@ es:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -112,7 +112,10 @@ et:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -108,7 +108,10 @@ fa:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -111,7 +111,10 @@ fi:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -109,7 +109,10 @@ fr:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -111,7 +111,10 @@ gd:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -109,7 +109,10 @@ gu:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -109,7 +109,10 @@ he:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -109,7 +109,10 @@ hi:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -110,7 +110,10 @@ hr:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -112,7 +112,10 @@ hu:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -113,7 +113,10 @@ hy:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -109,7 +109,10 @@ id:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -109,7 +109,10 @@ is:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -109,7 +109,10 @@ it:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -105,7 +105,10 @@ ja:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -112,7 +112,10 @@ ka:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -109,7 +109,10 @@ kk:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -104,7 +104,10 @@ ko:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -114,7 +114,10 @@ lt:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -113,7 +113,10 @@ lv:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -108,7 +108,10 @@ ms:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -111,7 +111,10 @@ mt:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -109,7 +109,10 @@ nl:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -109,7 +109,10 @@
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -105,7 +105,10 @@ pa-pk:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -109,7 +109,10 @@ pa:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -113,7 +113,10 @@ pl:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -106,7 +106,10 @@ ps:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -109,7 +109,10 @@ pt:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -110,7 +110,10 @@ ro:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -113,7 +113,10 @@ ru:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -109,7 +109,10 @@ si:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -114,7 +114,10 @@ sk:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -116,7 +116,10 @@ sl:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -109,7 +109,10 @@ so:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -109,7 +109,10 @@ sq:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -110,7 +110,10 @@ sr:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -109,7 +109,10 @@ sv:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -109,7 +109,10 @@ sw:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -110,7 +110,10 @@ ta:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -107,7 +107,10 @@ th:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -110,7 +110,10 @@ tk:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -110,7 +110,10 @@ tr:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -116,7 +116,10 @@ uk:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -106,7 +106,10 @@ ur:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -111,7 +111,10 @@ uz:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -108,7 +108,10 @@ vi:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -107,7 +107,10 @@ zh-hk:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -107,7 +107,10 @@ zh-tw:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -107,7 +107,10 @@ zh:
       menu_toggle_label:
         hide:
         show:
-      navigation_links:
+      navigation_link:
+        href:
+        label:
+      navigation_links_columns:
       navigation_menu_heading:
       navigation_search_heading:
       navigation_search_subheading:

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -68,7 +68,6 @@ describe "Super navigation header", type: :view do
     render_component({})
 
     assert_select ".gem-c-layout-super-navigation-header__navigation-items", count: 1
-    assert_select ".gem-c-layout-super-navigation-header__navigation-items .gem-c-layout-super-navigation-header__navigation-item", count: 1
   end
 
   it "renders the search menu with links in it" do

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -68,8 +68,7 @@ describe "Super navigation header", type: :view do
     render_component({})
 
     assert_select ".gem-c-layout-super-navigation-header__navigation-items", count: 1
-    assert_select ".gem-c-layout-super-navigation-header__navigation-items .gem-c-layout-super-navigation-header__navigation-item", count: 2
-    assert_select ".gem-c-layout-super-navigation-header__navigation-items .gem-c-layout-super-navigation-header__navigation-item .gem-c-layout-super-navigation-header__navigation-item-link", count: 2
+    assert_select ".gem-c-layout-super-navigation-header__navigation-items .gem-c-layout-super-navigation-header__navigation-item", count: 1
   end
 
   it "renders the search menu with links in it" do

--- a/spec/javascripts/components/layout-super-navigation-header-spec.js
+++ b/spec/javascripts/components/layout-super-navigation-header-spec.js
@@ -11,653 +11,198 @@ describe('The super header navigation', function () {
     container = document.createElement('div')
     container.className = 'js-enabled'
     container.innerHTML =
-      '<nav ' +
-        'aria-labelledby="super-navigation-menu-heading" ' +
-        'class="gem-c-layout-super-navigation-header__content" ' +
-        'data-module="super-navigation-mega-menu" ' +
-        'data-text-for-generic-button="Toggle section" ' +
-        'data-text-for-show-generic="Show section" ' +
-        'data-text-for-hide-generic="Hide section" ' +
-      '>' +
-        '<h2 id="super-navigation-menu-heading" class="govuk-visually-hidden">' +
-          'Navigation menu ' +
-        '</h2>' +
-        '<button ' +
-          'aria-controls="super-navigation-menu" ' +
-          'aria-expanded="true" ' +
-          'aria-label="Hide navigation menu" ' +
-          'class="gem-c-layout-super-navigation-header__navigation-top-toggle-button" ' +
-          'data-text-for-hide="Hide navigation menu" ' +
-          'data-text-for-show="Show navigation menu" ' +
-          'data-toggle-desktop-group="hidden" ' +
-          'data-toggle-mobile-group="top" ' +
-          'data-tracking-key="testing" ' +
-          'hidden ' +
-          'id="super-navigation-menu-toggle" ' +
-          'type="button" ' +
-        '>' +
-          'Menu ' +
-        '</button>' +
-        '<ul ' +
-          'id="super-navigation-menu" ' +
-          'class="gem-c-layout-super-navigation-header__navigation-items" ' +
-        '>' +
-          '<li ' +
-            'class=" ' +
-              'gem-c-layout-super-navigation-header__navigation-item ' +
-              'gem-c-layout-super-navigation-header__navigation-item--with-children ' +
-            '" ' +
-          '>' +
-            '<a ' +
-              'class=" ' +
-                'govuk-header__link ' +
-                'gem-c-layout-super-navigation-header__navigation-item-link ' +
-              '" ' +
-              'href="/browse" ' +
-            '>' +
-              'Topics ' +
-            '</a>' +
-            '<button ' +
-              'aria-controls="super-navigation-menu__section-1b6ef312" ' +
-              'aria-expanded="false" ' +
-              'aria-label="Show Topics section" ' +
-              'class=" ' +
-                'gem-c-layout-super-navigation-header__navigation-second-toggle-button ' +
-              '" ' +
-              'data-text-for-hide="Hide Topics section" ' +
-              'data-text-for-show="Show Topics section" ' +
-              'data-toggle-desktop-group="top" ' +
-              'data-toggle-mobile-group="second" ' +
-              'hidden ' +
-              'id="super-navigation-menu__section-1b6ef312-toggle" ' +
-              'type="button" ' +
-            '>' +
-              'Topics ' +
-            '</button>' +
-            '<div ' +
-              'hidden ' +
-              'class="gem-c-layout-super-navigation-header__navigation-dropdown-menu" ' +
-              'id="super-navigation-menu__section-1b6ef312" ' +
-            '>' +
-              '<ul class="govuk-list">' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/benefits" ' +
-                  '>' +
-                    'Benefits ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/births-deaths-marriages" ' +
-                  '>' +
-                    'Births, death, marriages and care ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/brexit" ' +
-                  '>' +
-                    'Brexit ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/business" ' +
-                  '>' +
-                    'Business and self-employed ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/childcare-parenting" ' +
-                  '>' +
-                    'Childcare and parenting ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/citizenship" ' +
-                  '>' +
-                    'Citizenship and living in the UK ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/coronavirus" ' +
-                  '>' +
-                    'Coronavirus (COVID‑19) ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/justice" ' +
-                  '>' +
-                    'Crime, justice and the law ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/disabilities" ' +
-                  '>' +
-                    'Disabled people ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/driving" ' +
-                  '>' +
-                    'Driving and transport ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/education" ' +
-                  '>' +
-                    'Education and learning ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/employing-people" ' +
-                  '>' +
-                    'Employing people ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/environment-countryside" ' +
-                  '>' +
-                    'Environment and countryside ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/housing-local-services" ' +
-                  '>' +
-                    'Housing and local services ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/tax" ' +
-                  '>' +
-                    'Money and tax ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/abroad" ' +
-                  '>' +
-                    'Passports, travel and living abroad ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/visas-immigration" ' +
-                  '>' +
-                    'Visas and immigration ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/browse/working" ' +
-                  '>' +
-                    'Working, jobs and pensions ' +
-                  '</a>' +
-                '</li>' +
-              '</ul>' +
-            '</div>' +
-          '</li>' +
-          '<li class="gem-c-layout-super-navigation-header__navigation-item">' +
-            '<a ' +
-              'class=" ' +
-                'govuk-header__link ' +
-                'gem-c-layout-super-navigation-header__navigation-item-link ' +
-              '" ' +
-              'href="/government/organisations" ' +
-            '>' +
-              'Departments ' +
-            '</a>' +
-          '</li>' +
-          '<li ' +
-            'class=" ' +
-              'gem-c-layout-super-navigation-header__navigation-item ' +
-              'gem-c-layout-super-navigation-header__navigation-item--with-children ' +
-            '" ' +
-          '>' +
-            '<a ' +
-              'class=" ' +
-                'govuk-header__link ' +
-                'gem-c-layout-super-navigation-header__navigation-item-link ' +
-              '" ' +
-              'href="/search/news-and-communications" ' +
-            '>' +
-              'Government activity ' +
-            '</a>' +
-            '<button ' +
-              'aria-controls="super-navigation-menu__section-7e5c3450" ' +
-              'aria-expanded="false" ' +
-              'aria-label="Show Government activity section" ' +
-              'class=" ' +
-                'gem-c-layout-super-navigation-header__navigation-second-toggle-button ' +
-              '" ' +
-              'data-text-for-hide="Hide Government activity section" ' +
-              'data-text-for-show="Show Government activity section" ' +
-              'data-toggle-desktop-group="top" ' +
-              'data-toggle-mobile-group="second" ' +
-              'hidden ' +
-              'id="super-navigation-menu__section-7e5c3450-toggle" ' +
-              'type="button" ' +
-            '>' +
-              'Government activity ' +
-            '</button>' +
-            '<div ' +
-              'hidden ' +
-              'class="gem-c-layout-super-navigation-header__navigation-dropdown-menu" ' +
-              'id="super-navigation-menu__section-7e5c3450" ' +
-            '>' +
-              '<ul class="govuk-list">' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/search/news-and-communications" ' +
-                  '>' +
-                    'News ' +
-                  '</a>' +
-                  '<p ' +
-                    'class=" ' +
-                      'govuk-body-s ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-description ' +
-                    '" ' +
-                  '>' +
-                    'News stories, speeches, letters and notices ' +
-                  '</p>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/search/guidance-and-regulation" ' +
-                  '>' +
-                    'Guidance and regulation ' +
-                  '</a>' +
-                  '<p ' +
-                    'class=" ' +
-                      'govuk-body-s ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-description ' +
-                    '" ' +
-                  '>' +
-                    'Detailed guidance, regulations and rules ' +
-                  '</p>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/search/research-and-statistics" ' +
-                  '>' +
-                    'Research and statistics ' +
-                  '</a>' +
-                  '<p ' +
-                    'class=" ' +
-                      'govuk-body-s ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-description ' +
-                    '" ' +
-                  '>' +
-                    'Reports, analysis and official statistics ' +
-                  '</p>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/search/policy-papers-and-consultations" ' +
-                  '>' +
-                    'Policy papers and consultation ' +
-                  '</a>' +
-                  '<p ' +
-                    'class=" ' +
-                      'govuk-body-s ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-description ' +
-                    '" ' +
-                  '>' +
-                    'Consultations and strategy ' +
-                  '</p>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/search/transparency-and-freedom-of-information-releases" ' +
-                  '>' +
-                    'Transparency ' +
-                  '</a>' +
-                  '<p ' +
-                    'class=" ' +
-                      'govuk-body-s ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-description ' +
-                    '" ' +
-                  '>' +
-                    'Government data, freedom of information releases and corporate ' +
-                    'reports ' +
-                  '</p>' +
-                '</li>' +
-              '</ul>' +
-              '<ul class="govuk-list">' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/government/how-government-works" ' +
-                  '>' +
-                    'How government works ' +
-                  '</a>' +
-                '</li>' +
-                '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                  '<a ' +
-                    'class=" ' +
-                      'govuk-link ' +
-                      'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                    '" ' +
-                    'href="/government/get-involved" ' +
-                  '>' +
-                    'Get involved ' +
-                  '</a>' +
-                '</li>' +
-              '</ul>' +
-            '</div>' +
-          '</li>' +
-        '</ul>' +
-' ' +
-        '<button ' +
-          'aria-controls="super-search-menu" ' +
-          'aria-expanded="true" ' +
-          'aria-label="Hide search menu" ' +
-          'class="gem-c-layout-super-navigation-header__search-toggle-button" ' +
-          'data-text-for-hide="Hide search menu" ' +
-          'data-text-for-show="Show search menu" ' +
-          'data-toggle-mobile-group="top" ' +
-          'data-toggle-desktop-group="top" ' +
-          'hidden ' +
-          'id="super-search-menu-toggle" ' +
-          'type="button" ' +
-        '>' +
-          '<span ' +
-            'class=" ' +
-              'gem-c-layout-super-navigation-header__search-toggle-button-link-text ' +
-            '" ' +
-            '>Search GOV.UK</span ' +
-          '>' +
-          '<svg ' +
-            'class=" ' +
-              'gem-c-layout-super-navigation-header__search-toggle-button-link-icon ' +
-            '" ' +
-            'width="27" ' +
-            'height="27" ' +
-            'viewBox="0 0 27 27" ' +
-            'fill="none" ' +
-            'xmlns="http://www.w3.org/2000/svg" ' +
-            'aria-hidden="true" ' +
-            'focusable="false" ' +
-          '>' +
-            '<circle ' +
-              'cx="10.0161" ' +
-              'cy="10.0161" ' +
-              'r="8.51613" ' +
-              'stroke="currentColor" ' +
-              'stroke-width="3" ' +
-            '></circle>' +
-            '<line ' +
-              'x1="15.8668" ' +
-              'y1="16.3587" ' +
-              'x2="25.4475" ' +
-              'y2="25.9393" ' +
-              'stroke="currentColor" ' +
-              'stroke-width="3" ' +
-            '></line>' +
-          '</svg>' +
-        '</button>' +
-' ' +
-        '<div ' +
-          'id="super-search-menu" ' +
-          'class="gem-c-layout-super-navigation-header__search-items" ' +
-        '>' +
-          '<h3 ' +
-            'class=" ' +
-              'govuk-visually-hidden ' +
-              'gem-c-layout-super-navigation-header__search-subheading ' +
-            '" ' +
-          '>' +
-            'Search ' +
-          '</h3>' +
-          '<div class="gem-c-layout-super-navigation-header__search-item">' +
-            '<a ' +
-              'class=" ' +
-                'govuk-header__link ' +
-                'gem-c-layout-super-navigation-header__search-item-link ' +
-              '" ' +
-              'href="/search" ' +
-            '>' +
-              '<span ' +
-                'class="gem-c-layout-super-navigation-header__search-item-link-text" ' +
-                '>Search GOV.UK</span ' +
-              '>' +
-              '<svg ' +
-                'class="gem-c-layout-super-navigation-header__search-item-link-icon" ' +
-                'width="27" ' +
-                'height="27" ' +
-                'viewBox="0 0 27 27" ' +
-                'fill="none" ' +
-                'xmlns="http://www.w3.org/2000/svg" ' +
-                'aria-hidden="true" ' +
-                'focusable="false" ' +
-              '>' +
-                '<circle ' +
-                  'cx="10.0161" ' +
-                  'cy="10.0161" ' +
-                  'r="8.51613" ' +
-                  'stroke="currentColor" ' +
-                  'stroke-width="3" ' +
-                '></circle>' +
-                '<line ' +
-                  'x1="15.8668" ' +
-                  'y1="16.3587" ' +
-                  'x2="25.4475" ' +
-                  'y2="25.9393" ' +
-                  'stroke="currentColor" ' +
-                  'stroke-width="3" ' +
-                '></line>' +
-              '</svg>' +
-            '</a>' +
-          '</div>' +
-          '<div class="gem-c-layout-super-navigation-header__search-and-popular">' +
-            '<form ' +
-              'id="search" ' +
-              'action="/search" ' +
-              'method="get" ' +
-              'role="search" ' +
-              'aria-label="Site-wide" ' +
-            '>' +
-              '<div ' +
-                'class=" ' +
-                  'gem-c-search ' +
-                  'govuk-!-display-none-print ' +
-                  'gem-c-search--large ' +
-                  'gem-c-search--on-white ' +
-                  'gem-c-search--separate-label ' +
-                '" ' +
-                'data-module="gem-toggle-input-class-on-focus" ' +
-              '>' +
-                '<label for="search-main-5dfcaa4f" class="gem-c-search__label">' +
-                  'Search GOV.UK ' +
-                '</label>' +
-                '<div class="gem-c-search__item-wrapper">' +
-                  '<input ' +
-                    'class="gem-c-search__item gem-c-search__input js-class-toggle" ' +
-                    'id="search-main-5dfcaa4f" ' +
-                    'name="q" ' +
-                    'title="Search" ' +
-                    'type="search" ' +
-                    'value="" ' +
-                  '/>' +
-                  '<div class="gem-c-search__item gem-c-search__submit-wrapper">' +
-                    '<button ' +
-                      'class="gem-c-search__submit" ' +
-                      'type="submit" ' +
-                      'data-module="gem-track-click" ' +
-                    '>' +
-                      'Search ' +
-                    '</button>' +
+      '<nav aria-labelledby="super-navigation-menu-heading" class="gem-c-layout-super-navigation-header__content" data-module="super-navigation-mega-menu">' +
+          '<h2 id="super-navigation-menu-heading" class="govuk-visually-hidden">' +
+              'Navigation menu' +
+          '</h2>' +
+          '<a class="gem-c-layout-super-navigation-header__navigation-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse" data-track-dimension="Menu" data-track-dimension-index="29" href="/browse" hidden="hidden">' +
+              '<span class="gem-c-layout-super-navigation-header__navigation-item-link-inner">' +
+                  'Menu' +
+              '</span>' +
+          '</a>' +
+          '<button aria-controls="super-navigation-menu__section-eca2a8c8" aria-expanded="false" aria-label="Show Menu menu" class="gem-c-layout-super-navigation-header__navigation-top-toggle-button" data-text-for-hide="Hide Menu menu" data-text-for-show="Show Menu menu" data-toggle-desktop-group="top" data-toggle-mobile-group="second" data-tracking-key="menu" data-ga4="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;type&quot;:&quot;header menu bar&quot;,&quot;text&quot;:&quot;Menu&quot;,&quot;section&quot;:&quot;Menu&quot;}" id="super-navigation-menu__section-eca2a8c8-toggle" type="button">' +
+              '<span class="gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner">Menu</span>' +
+          '</button>' +
+          '<ul id="super-navigation-menu" class="gem-c-layout-super-navigation-header__navigation-items">' +
+              '<li class="gem-c-layout-super-navigation-header__navigation-item">' +
+                  '<!-- this is the nav menu -->' +
+                  '<div hidden="" class="gem-c-layout-super-navigation-header__navigation-dropdown-menu" id="super-navigation-menu__section-eca2a8c8">' +
+                      '<div class="govuk-width-container gem-c-layout-super-navigation-header__width-container">' +
+                          '<div class="govuk-grid-row">' +
+                              '<div class="govuk-grid-column-two-thirds-from-desktop gem-c-layout-super-navigation-header__column--topics">' +
+                                  '<div class="govuk-width-container">' +
+                                      '<h3 class="govuk-heading-m gem-c-layout-super-navigation-header__column-header">' +
+                                          'Topics' +
+                                      '</h3>' +
+                                  '</div>' +
+                                  '<div class="govuk-width-container">' +
+                                      '<ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--topics">' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/benefits" data-track-dimension="Benefits" data-track-dimension-index="29" href="/browse/benefits">Benefits</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/births-deaths-marriages" data-track-dimension="Births, death, marriages and care" data-track-dimension-index="29" href="/browse/births-deaths-marriages">Births, death, marriages and care</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/business" data-track-dimension="Business and self-employed" data-track-dimension-index="29" href="/browse/business">Business and self-employed</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/childcare-parenting" data-track-dimension="Childcare and parenting" data-track-dimension-index="29" href="/browse/childcare-parenting">Childcare and parenting</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/citizenship" data-track-dimension="Citizenship and living in the UK" data-track-dimension-index="29" href="/browse/citizenship">Citizenship and living in the UK</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/cost-of-living" data-track-dimension="Cost of Living support" data-track-dimension-index="29" href="/cost-of-living">Cost of Living support</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/justice" data-track-dimension="Crime, justice and the law" data-track-dimension-index="29" href="/browse/justice">Crime, justice and the law</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/disabilities" data-track-dimension="Disabled people" data-track-dimension-index="29" href="/browse/disabilities">Disabled people</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/driving" data-track-dimension="Driving and transport" data-track-dimension-index="29" href="/browse/driving">Driving and transport</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/education" data-track-dimension="Education and learning" data-track-dimension-index="29" href="/browse/education">Education and learning</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/employing-people" data-track-dimension="Employing people" data-track-dimension-index="29" href="/browse/employing-people">Employing people</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/environment-countryside" data-track-dimension="Environment and countryside" data-track-dimension-index="29" href="/browse/environment-countryside">Environment and countryside</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/housing-local-services" data-track-dimension="Housing and local services" data-track-dimension-index="29" href="/browse/housing-local-services">Housing and local services</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/tax" data-track-dimension="Money and tax" data-track-dimension-index="29" href="/browse/tax">Money and tax</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/abroad" data-track-dimension="Passports, travel and living abroad" data-track-dimension-index="29" href="/browse/abroad">Passports, travel and living abroad</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/visas-immigration" data-track-dimension="Visas and immigration" data-track-dimension-index="29" href="/browse/visas-immigration">Visas and immigration</a>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/working" data-track-dimension="Working, jobs and pensions" data-track-dimension-index="29" href="/browse/working">Working, jobs and pensions</a>' +
+                                          '</li>' +
+                                      '</ul>' +
+                                  '</div>' +
+                              '</div>' +
+                              '<div class="govuk-grid-column-one-third-from-desktop gem-c-layout-super-navigation-header__column--government-activity">' +
+                                  '<div class="govuk-width-container">' +
+                                      '<h3 class="govuk-heading-m gem-c-layout-super-navigation-header__column-header">' +
+                                          'Government activity' +
+                                      '</h3>' +
+                                  '</div>' +
+                                  '<div class="govuk-width-container">' +
+                                      '<ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--government-activity">' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/government/organisations" data-track-dimension="Departments" data-track-dimension-index="29" href="/government/organisations">Departments</a>' +
+                                              '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Departments, agencies and public bodies</p>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/news-and-communications" data-track-dimension="News" data-track-dimension-index="29" href="/search/news-and-communications">News</a>' +
+                                              '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">News stories, speeches, letters and notices</p>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/guidance-and-regulation" data-track-dimension="Guidance and regulation" data-track-dimension-index="29" href="/search/guidance-and-regulation">Guidance and regulation</a>' +
+                                              '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Detailed guidance, regulations and rules</p>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/policy-papers-and-consultations" data-track-dimension="Policy papers and consultations" data-track-dimension-index="29" href="/search/policy-papers-and-consultations">Policy papers and consultations</a>' +
+                                              '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Consultations and strategy</p>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/research-and-statistics" data-track-dimension="Research and statistics" data-track-dimension-index="29" href="/search/research-and-statistics">Research and statistics</a>' +
+                                              '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Reports, analysis and official statistics</p>' +
+                                          '</li>' +
+                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/transparency-and-freedom-of-information-releases" data-track-dimension="Transparency" data-track-dimension-index="29" href="/search/transparency-and-freedom-of-information-releases">Transparency</a>' +
+                                              '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Data, Freedom of Information releases and corporate reports</p>' +
+                                          '</li>' +
+                                      '</ul>' +
+                                  '</div>' +
+                              '</div>' +
+                          '</div>' +
+                      '</div>' +
                   '</div>' +
-                '</div>' +
+              '</li>' +
+          '</ul>' +
+          '<button aria-controls="super-search-menu" aria-expanded="false" aria-label="Show search menu" class="gem-c-layout-super-navigation-header__search-toggle-button" data-text-for-hide="Hide search menu" data-text-for-show="Show search menu" data-toggle-mobile-group="top" data-toggle-desktop-group="top" data-tracking-key="search" id="super-search-menu-toggle" type="button" data-ga4="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;type&quot;:&quot;header menu bar&quot;,&quot;text&quot;:&quot;Search&quot;,&quot;section&quot;:&quot;Search&quot;}">' +
+              '<span class="govuk-visually-hidden">' +
+                  'Search GOV.UK' +
+              '</span>' +
+              '<svg class="gem-c-layout-super-navigation-header__search-toggle-button-link-icon" width="27" height="27" viewBox="0 0 27 27" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">' +
+                  '<circle cx="12.0161" cy="11.0161" r="8.51613" stroke="currentColor" stroke-width="3"></circle>' +
+                  '<line x1="17.8668" y1="17.3587" x2="26.4475" y2="25.9393" stroke="currentColor" stroke-width="3"></line>' +
+              '</svg>' +
+              '<span aria-hidden="true" class="gem-c-layout-super-navigation-header__navigation-top-toggle-close-icon" focusable="false">' +
+                  '×' +
+              '</span>' +
+          '</button>' +
+          '<div id="super-search-menu" class="gem-c-layout-super-navigation-header__search-items" hidden="hidden">' +
+              '<h3 class="govuk-visually-hidden">' +
+                  'Search' +
+              '</h3>' +
+              '<div class="gem-c-layout-super-navigation-header__search-item">' +
+                  '<a class="gem-c-layout-super-navigation-header__search-item-link" href="/search" hidden="hidden">' +
+                      '<span class="gem-c-layout-super-navigation-header__search-item-link-text">' +
+                          'Search GOV.UK' +
+                      '</span>' +
+                      '<svg class="gem-c-layout-super-navigation-header__search-item-link-icon" width="27" height="27" viewBox="0 0 27 27" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">' +
+                          '<circle cx="10.0161" cy="10.0161" r="8.51613" stroke="currentColor" stroke-width="3"></circle>' +
+                          '<line x1="15.8668" y1="16.3587" x2="25.4475" y2="25.9393" stroke="currentColor" stroke-width="3"></line>' +
+                      '</svg>' +
+                  '</a>' +
               '</div>' +
-            '</form>' +
-            '<h3 class="govuk-heading-m">Popular on GOV.UK</h3>' +
-            '<ul class="govuk-list">' +
-              '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                '<a ' +
-                  'class=" ' +
-                    'govuk-link ' +
-                    'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                  '" ' +
-                  'href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do" ' +
-                '>' +
-                  'Coronavirus (COVID-19): rules ' +
-                '</a>' +
-              '</li>' +
-              '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                '<a ' +
-                  'class=" ' +
-                    'govuk-link ' +
-                    'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                  '" ' +
-                  'href="/brexit" ' +
-                '>' +
-                  'Brexit: check what you need to do ' +
-                '</a>' +
-              '</li>' +
-              '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                '<a ' +
-                  'class=" ' +
-                    'govuk-link ' +
-                    'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                  '" ' +
-                  'href="/personal-tax-account" ' +
-                '>' +
-                  'Sign in to your personal tax account ' +
-                '</a>' +
-              '</li>' +
-              '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                '<a ' +
-                  'class=" ' +
-                    'govuk-link ' +
-                    'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                  '" ' +
-                  'href="/find-a-job" ' +
-                '>' +
-                  'Find a job ' +
-                '</a>' +
-              '</li>' +
-              '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                '<a ' +
-                  'class=" ' +
-                    'govuk-link ' +
-                    'gem-c-layout-super-navigation-header__dropdown-list-item-link ' +
-                  '" ' +
-                  'href="/sign-in-universal-credit" ' +
-                '>' +
-                  'Sign in to your Universal Credit account ' +
-                '</a>' +
-              '</li>' +
-            '</ul>' +
+              '<div class="govuk-width-container gem-c-layout-super-navigation-header__search-and-popular">' +
+                  '<div class="govuk-grid-row">' +
+                      '<div class="govuk-grid-column-full">' +
+                          '<form class="gem-c-layout-super-navigation-header__search-form" id="search" action="/search" method="get" role="search" aria-label="Site-wide">' +
+                              '<div class="gem-c-search govuk-!-display-none-print  gem-c-search--large gem-c-search--on-white gem-c-search--separate-label" data-module="gem-toggle-input-class-on-focus">' +
+                                  '<label for="search-main-d6160a6e" class="govuk-label govuk-label--m">Search GOV.UK</label>' +
+                                  '<div class="gem-c-search__item-wrapper">' +
+                                      '<input enterkeyhint="search" class="gem-c-search__item gem-c-search__input js-class-toggle" id="search-main-d6160a6e" name="q" title="Search" type="search" value="">' +
+                                      '<div class="gem-c-search__item gem-c-search__submit-wrapper">' +
+                                          '<button class="gem-c-search__submit" type="submit" data-track-category="headerClicked" data-track-action="searchSubmitted" data-track-label="/search/all" data-track-dimension="Search on GOV.UK" data-track-dimension-index="29" data-module="gem-track-click" enterkeyhint="search">' +
+                                              'Search' +
+                                              '<svg class="gem-c-search__icon" width="27" height="27" viewBox="0 0 27 27" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">' +
+                                                  '<circle cx="12.0161" cy="11.0161" r="8.51613" stroke="currentColor" stroke-width="3"></circle>' +
+                                                  '<line x1="17.8668" y1="17.3587" x2="26.4475" y2="25.9393" stroke="currentColor" stroke-width="3"></line>' +
+                                              '</svg>' +
+                                          '</button> </div>' +
+                                  '</div>' +
+                              '</div>' +
+                          '</form>' +
+                      '</div>' +
+                  '</div>' +
+                  '<div class="govuk-grid-row">' +
+                      '<div class="govuk-grid-column-full">' +
+                          '<h3 class="govuk-heading-m">Popular on GOV.UK</h3>' +
+                          '<ul class="govuk-list">' +
+                              '<li class="gem-c-layout-super-navigation-header__popular-item">' +
+                                  '<a class="govuk-link gem-c-layout-super-navigation-header__popular-link" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/check-benefits-financial-support" data-track-dimension="Check benefits and financial support you can get" data-track-dimension-index="29" href="/check-benefits-financial-support">Check benefits and financial support you can get</a>' +
+                              '</li>' +
+                              '<li class="gem-c-layout-super-navigation-header__popular-item">' +
+                                  '<a class="govuk-link gem-c-layout-super-navigation-header__popular-link" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/government/publications/energy-bills-support/energy-bills-support-factsheet-8-september-2022" data-track-dimension="Limits on energy prices: Energy Price Guarantee" data-track-dimension-index="29" href="/government/publications/energy-bills-support/energy-bills-support-factsheet-8-september-2022">Limits on energy prices: Energy Price Guarantee</a>' +
+                              '</li>' +
+                              '<li class="gem-c-layout-super-navigation-header__popular-item">' +
+                                  '<a class="govuk-link gem-c-layout-super-navigation-header__popular-link" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/find-a-job" data-track-dimension="Find a job" data-track-dimension-index="29" href="/find-a-job">Find a job</a>' +
+                              '</li>' +
+                              '<li class="gem-c-layout-super-navigation-header__popular-item">' +
+                                  '<a class="govuk-link gem-c-layout-super-navigation-header__popular-link" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/coronavirus" data-track-dimension="Coronavirus (COVID-19)" data-track-dimension-index="29" href="/coronavirus">Coronavirus (COVID-19)</a>' +
+                              '</li>' +
+                              '<li class="gem-c-layout-super-navigation-header__popular-item">' +
+                                  '<a class="govuk-link gem-c-layout-super-navigation-header__popular-link" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/sign-in-universal-credit" data-track-dimension="Universal Credit account: sign in" data-track-dimension-index="29" href="/sign-in-universal-credit">Universal Credit account: sign in</a>' +
+                              '</li>' +
+                          '</ul>' +
+                      '</div>' +
+                  '</div>' +
+              '</div>' +
           '</div>' +
-        '</div>' +
       '</nav>'
 
     document.body.appendChild(container)

--- a/spec/javascripts/components/layout-super-navigation-header-spec.js
+++ b/spec/javascripts/components/layout-super-navigation-header-spec.js
@@ -11,7 +11,7 @@ describe('The super header navigation', function () {
     container = document.createElement('div')
     container.className = 'js-enabled'
     container.innerHTML =
-      '<nav aria-labelledby="super-navigation-menu-heading" class="gem-c-layout-super-navigation-header__content" data-module="super-navigation-mega-menu">' +
+      '<nav aria-labelledby="super-navigation-menu-heading" class="gem-c-layout-super-navigation-header__content js-module-initialised" data-module="super-navigation-mega-menu" data-super-navigation-mega-menu-module-started="true" style="margin-bottom: 0px;">' +
           '<h2 id="super-navigation-menu-heading" class="govuk-visually-hidden">' +
               'Navigation menu' +
           '</h2>' +
@@ -20,117 +20,114 @@ describe('The super header navigation', function () {
                   'Menu' +
               '</span>' +
           '</a>' +
-          '<button aria-controls="super-navigation-menu__section-eca2a8c8" aria-expanded="false" aria-label="Show Menu menu" class="gem-c-layout-super-navigation-header__navigation-top-toggle-button" data-text-for-hide="Hide Menu menu" data-text-for-show="Show Menu menu" data-toggle-desktop-group="top" data-toggle-mobile-group="second" data-tracking-key="menu" data-ga4="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;type&quot;:&quot;header menu bar&quot;,&quot;text&quot;:&quot;Menu&quot;,&quot;section&quot;:&quot;Menu&quot;}" id="super-navigation-menu__section-eca2a8c8-toggle" type="button">' +
+          '<button aria-controls="super-navigation-menu" aria-expanded="false" aria-label="Show navigation menu" class="gem-c-layout-super-navigation-header__navigation-top-toggle-button" data-text-for-hide="Hide navigation menu" data-text-for-show="Show navigation menu" data-toggle-desktop-group="top" data-toggle-mobile-group="top" data-tracking-key="testing" data-ga4="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;type&quot;:&quot;header menu bar&quot;,&quot;text&quot;:&quot;Menu&quot;,&quot;section&quot;:&quot;Menu&quot;}" id="super-navigation-menu-toggle" type="button">' +
               '<span class="gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner">Menu</span>' +
           '</button>' +
-          '<ul id="super-navigation-menu" class="gem-c-layout-super-navigation-header__navigation-items">' +
-              '<li class="gem-c-layout-super-navigation-header__navigation-item">' +
-                  '<!-- this is the nav menu -->' +
-                  '<div hidden="" class="gem-c-layout-super-navigation-header__navigation-dropdown-menu" id="super-navigation-menu__section-eca2a8c8">' +
-                      '<div class="govuk-width-container gem-c-layout-super-navigation-header__width-container">' +
-                          '<div class="govuk-grid-row">' +
-                              '<div class="govuk-grid-column-two-thirds-from-desktop gem-c-layout-super-navigation-header__column--topics">' +
-                                  '<div class="govuk-width-container">' +
-                                      '<h3 class="govuk-heading-m gem-c-layout-super-navigation-header__column-header">' +
-                                          'Topics' +
-                                      '</h3>' +
-                                  '</div>' +
-                                  '<div class="govuk-width-container">' +
-                                      '<ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--topics">' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/benefits" data-track-dimension="Benefits" data-track-dimension-index="29" href="/browse/benefits">Benefits</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/births-deaths-marriages" data-track-dimension="Births, death, marriages and care" data-track-dimension-index="29" href="/browse/births-deaths-marriages">Births, death, marriages and care</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/business" data-track-dimension="Business and self-employed" data-track-dimension-index="29" href="/browse/business">Business and self-employed</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/childcare-parenting" data-track-dimension="Childcare and parenting" data-track-dimension-index="29" href="/browse/childcare-parenting">Childcare and parenting</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/citizenship" data-track-dimension="Citizenship and living in the UK" data-track-dimension-index="29" href="/browse/citizenship">Citizenship and living in the UK</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/cost-of-living" data-track-dimension="Cost of Living support" data-track-dimension-index="29" href="/cost-of-living">Cost of Living support</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/justice" data-track-dimension="Crime, justice and the law" data-track-dimension-index="29" href="/browse/justice">Crime, justice and the law</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/disabilities" data-track-dimension="Disabled people" data-track-dimension-index="29" href="/browse/disabilities">Disabled people</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/driving" data-track-dimension="Driving and transport" data-track-dimension-index="29" href="/browse/driving">Driving and transport</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/education" data-track-dimension="Education and learning" data-track-dimension-index="29" href="/browse/education">Education and learning</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/employing-people" data-track-dimension="Employing people" data-track-dimension-index="29" href="/browse/employing-people">Employing people</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/environment-countryside" data-track-dimension="Environment and countryside" data-track-dimension-index="29" href="/browse/environment-countryside">Environment and countryside</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/housing-local-services" data-track-dimension="Housing and local services" data-track-dimension-index="29" href="/browse/housing-local-services">Housing and local services</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/tax" data-track-dimension="Money and tax" data-track-dimension-index="29" href="/browse/tax">Money and tax</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/abroad" data-track-dimension="Passports, travel and living abroad" data-track-dimension-index="29" href="/browse/abroad">Passports, travel and living abroad</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/visas-immigration" data-track-dimension="Visas and immigration" data-track-dimension-index="29" href="/browse/visas-immigration">Visas and immigration</a>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/working" data-track-dimension="Working, jobs and pensions" data-track-dimension-index="29" href="/browse/working">Working, jobs and pensions</a>' +
-                                          '</li>' +
-                                      '</ul>' +
-                                  '</div>' +
+          '<div class="gem-c-layout-super-navigation-header__navigation-item gem-c-layout-super-navigation-header__navigation-items">' +
+              '<div id="super-navigation-menu" class="gem-c-layout-super-navigation-header__navigation-dropdown-menu" hidden="hidden">' +
+                  '<div class="govuk-width-container gem-c-layout-super-navigation-header__width-container">' +
+                      '<div class="govuk-grid-row">' +
+                          '<div class="govuk-grid-column-two-thirds-from-desktop gem-c-layout-super-navigation-header__column--topics">' +
+                              '<div class="govuk-width-container">' +
+                                  '<h3 class="govuk-heading-m gem-c-layout-super-navigation-header__column-header">' +
+                                      'Topics' +
+                                  '</h3>' +
                               '</div>' +
-                              '<div class="govuk-grid-column-one-third-from-desktop gem-c-layout-super-navigation-header__column--government-activity">' +
-                                  '<div class="govuk-width-container">' +
-                                      '<h3 class="govuk-heading-m gem-c-layout-super-navigation-header__column-header">' +
-                                          'Government activity' +
-                                      '</h3>' +
-                                  '</div>' +
-                                  '<div class="govuk-width-container">' +
-                                      '<ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--government-activity">' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/government/organisations" data-track-dimension="Departments" data-track-dimension-index="29" href="/government/organisations">Departments</a>' +
-                                              '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Departments, agencies and public bodies</p>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/news-and-communications" data-track-dimension="News" data-track-dimension-index="29" href="/search/news-and-communications">News</a>' +
-                                              '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">News stories, speeches, letters and notices</p>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/guidance-and-regulation" data-track-dimension="Guidance and regulation" data-track-dimension-index="29" href="/search/guidance-and-regulation">Guidance and regulation</a>' +
-                                              '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Detailed guidance, regulations and rules</p>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/policy-papers-and-consultations" data-track-dimension="Policy papers and consultations" data-track-dimension-index="29" href="/search/policy-papers-and-consultations">Policy papers and consultations</a>' +
-                                              '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Consultations and strategy</p>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/research-and-statistics" data-track-dimension="Research and statistics" data-track-dimension-index="29" href="/search/research-and-statistics">Research and statistics</a>' +
-                                              '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Reports, analysis and official statistics</p>' +
-                                          '</li>' +
-                                          '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
-                                              '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/transparency-and-freedom-of-information-releases" data-track-dimension="Transparency" data-track-dimension-index="29" href="/search/transparency-and-freedom-of-information-releases">Transparency</a>' +
-                                              '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Data, Freedom of Information releases and corporate reports</p>' +
-                                          '</li>' +
-                                      '</ul>' +
-                                  '</div>' +
+                              '<div class="govuk-width-container">' +
+                                  '<ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--topics">' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/benefits" data-track-dimension="Benefits" data-track-dimension-index="29" href="/browse/benefits">Benefits</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/births-deaths-marriages" data-track-dimension="Births, death, marriages and care" data-track-dimension-index="29" href="/browse/births-deaths-marriages">Births, death, marriages and care</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/business" data-track-dimension="Business and self-employed" data-track-dimension-index="29" href="/browse/business">Business and self-employed</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/childcare-parenting" data-track-dimension="Childcare and parenting" data-track-dimension-index="29" href="/browse/childcare-parenting">Childcare and parenting</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/citizenship" data-track-dimension="Citizenship and living in the UK" data-track-dimension-index="29" href="/browse/citizenship">Citizenship and living in the UK</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/cost-of-living" data-track-dimension="Cost of Living support" data-track-dimension-index="29" href="/cost-of-living">Cost of Living support</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/justice" data-track-dimension="Crime, justice and the law" data-track-dimension-index="29" href="/browse/justice">Crime, justice and the law</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/disabilities" data-track-dimension="Disabled people" data-track-dimension-index="29" href="/browse/disabilities">Disabled people</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/driving" data-track-dimension="Driving and transport" data-track-dimension-index="29" href="/browse/driving">Driving and transport</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/education" data-track-dimension="Education and learning" data-track-dimension-index="29" href="/browse/education">Education and learning</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/employing-people" data-track-dimension="Employing people" data-track-dimension-index="29" href="/browse/employing-people">Employing people</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/environment-countryside" data-track-dimension="Environment and countryside" data-track-dimension-index="29" href="/browse/environment-countryside">Environment and countryside</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/housing-local-services" data-track-dimension="Housing and local services" data-track-dimension-index="29" href="/browse/housing-local-services">Housing and local services</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/tax" data-track-dimension="Money and tax" data-track-dimension-index="29" href="/browse/tax">Money and tax</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/abroad" data-track-dimension="Passports, travel and living abroad" data-track-dimension-index="29" href="/browse/abroad">Passports, travel and living abroad</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/visas-immigration" data-track-dimension="Visas and immigration" data-track-dimension-index="29" href="/browse/visas-immigration">Visas and immigration</a>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/browse/working" data-track-dimension="Working, jobs and pensions" data-track-dimension-index="29" href="/browse/working">Working, jobs and pensions</a>' +
+                                      '</li>' +
+                                  '</ul>' +
+                              '</div>' +
+                          '</div>' +
+                          '<div class="govuk-grid-column-one-third-from-desktop gem-c-layout-super-navigation-header__column--government-activity">' +
+                              '<div class="govuk-width-container">' +
+                                  '<h3 class="govuk-heading-m gem-c-layout-super-navigation-header__column-header">' +
+                                      'Government activity' +
+                                  '</h3>' +
+                              '</div>' +
+                              '<div class="govuk-width-container">' +
+                                  '<ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--government-activity">' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/government/organisations" data-track-dimension="Departments" data-track-dimension-index="29" href="/government/organisations">Departments</a>' +
+                                          '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Departments, agencies and public bodies</p>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/news-and-communications" data-track-dimension="News" data-track-dimension-index="29" href="/search/news-and-communications">News</a>' +
+                                          '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">News stories, speeches, letters and notices</p>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/guidance-and-regulation" data-track-dimension="Guidance and regulation" data-track-dimension-index="29" href="/search/guidance-and-regulation">Guidance and regulation</a>' +
+                                          '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Detailed guidance, regulations and rules</p>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/policy-papers-and-consultations" data-track-dimension="Policy papers and consultations" data-track-dimension-index="29" href="/search/policy-papers-and-consultations">Policy papers and consultations</a>' +
+                                          '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Consultations and strategy</p>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/research-and-statistics" data-track-dimension="Research and statistics" data-track-dimension-index="29" href="/search/research-and-statistics">Research and statistics</a>' +
+                                          '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Reports, analysis and official statistics</p>' +
+                                      '</li>' +
+                                      '<li class="gem-c-layout-super-navigation-header__dropdown-list-item">' +
+                                          '<a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-track-action="menuLink" data-track-category="headerClicked" data-track-label="/search/transparency-and-freedom-of-information-releases" data-track-dimension="Transparency" data-track-dimension-index="29" href="/search/transparency-and-freedom-of-information-releases">Transparency</a>' +
+                                          '<p class="gem-c-layout-super-navigation-header__navigation-second-item-description">Data, Freedom of Information releases and corporate reports</p>' +
+                                      '</li>' +
+                                  '</ul>' +
                               '</div>' +
                           '</div>' +
                       '</div>' +
                   '</div>' +
-              '</li>' +
-          '</ul>' +
+              '</div>' +
+          '</div>' +
           '<button aria-controls="super-search-menu" aria-expanded="false" aria-label="Show search menu" class="gem-c-layout-super-navigation-header__search-toggle-button" data-text-for-hide="Hide search menu" data-text-for-show="Show search menu" data-toggle-mobile-group="top" data-toggle-desktop-group="top" data-tracking-key="search" id="super-search-menu-toggle" type="button" data-ga4="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;type&quot;:&quot;header menu bar&quot;,&quot;text&quot;:&quot;Search&quot;,&quot;section&quot;:&quot;Search&quot;}">' +
               '<span class="govuk-visually-hidden">' +
                   'Search GOV.UK' +
@@ -162,10 +159,10 @@ describe('The super header navigation', function () {
                   '<div class="govuk-grid-row">' +
                       '<div class="govuk-grid-column-full">' +
                           '<form class="gem-c-layout-super-navigation-header__search-form" id="search" action="/search" method="get" role="search" aria-label="Site-wide">' +
-                              '<div class="gem-c-search govuk-!-display-none-print  gem-c-search--large gem-c-search--on-white gem-c-search--separate-label" data-module="gem-toggle-input-class-on-focus">' +
-                                  '<label for="search-main-d6160a6e" class="govuk-label govuk-label--m">Search GOV.UK</label>' +
+                              '<div class="gem-c-search govuk-!-display-none-print  gem-c-search--large gem-c-search--on-white gem-c-search--separate-label" data-module="gem-toggle-input-class-on-focus" data-gem-toggle-input-class-on-focus-module-started="true">' +
+                                  '<label for="search-main-7cccf557" class="govuk-label govuk-label--m">Search GOV.UK</label>' +
                                   '<div class="gem-c-search__item-wrapper">' +
-                                      '<input enterkeyhint="search" class="gem-c-search__item gem-c-search__input js-class-toggle" id="search-main-d6160a6e" name="q" title="Search" type="search" value="">' +
+                                      '<input enterkeyhint="search" class="gem-c-search__item gem-c-search__input js-class-toggle" id="search-main-7cccf557" name="q" title="Search" type="search" value="">' +
                                       '<div class="gem-c-search__item gem-c-search__submit-wrapper">' +
                                           '<button class="gem-c-search__submit" type="submit" data-track-category="headerClicked" data-track-action="searchSubmitted" data-track-label="/search/all" data-track-dimension="Search on GOV.UK" data-track-dimension-index="29" data-module="gem-track-click" enterkeyhint="search">' +
                                               'Search' +
@@ -479,18 +476,6 @@ describe('The super header navigation', function () {
       }
 
       thisModule.init()
-    })
-
-    describe('the navigation toggle button', function () {
-      var $button
-
-      beforeEach(function () {
-        $button = document.querySelector('#super-navigation-menu-toggle')
-      })
-
-      it('does have the `hidden` attribute', function () {
-        expect($button).toHaveAttr('hidden')
-      })
     })
 
     describe('the search button', function () {


### PR DESCRIPTION
## What

Change the implementation of the sitewide super navigation header layout component to use one 'Menu' button at all screen sizes with one toggle menu instead of two buttons with two toggle menus. 

Previous implementation was that each of the two toggle buttons would be contained within another toggle dropdown menu on mobile. This has been removed, as there is now only one menu which is not closable.

Increase size of clickable area for links with descriptions to be the height of the link and description.

## Why

Tree testing has shown that users are confused by our current implementation of two buttons on desktop. We have a design proposal that simplifies this for our users and lessen confusion.

[Relevant Trello Card](https://trello.com/c/tsBPaWVM/1403-build-streamlined-menu-iteration-xl)

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

## Before

### Desktop

![Screenshot 2022-11-08 at 16 29 41](https://user-images.githubusercontent.com/3727504/200621809-bd14a7c2-78c0-46a9-b431-6e0d3df7db70.png)

![Screenshot 2022-11-08 at 16 32 56](https://user-images.githubusercontent.com/3727504/200622605-ab6f07d1-7b07-4be1-aabb-67b8d034c888.png)

![image](https://user-images.githubusercontent.com/3727504/200621992-9b4a2006-f7ff-4a47-bb69-3e9a611993b6.png)

### Mobile

![Screenshot 2022-11-08 at 16 33 04](https://user-images.githubusercontent.com/3727504/200622248-f3c0626f-3932-42fe-b33d-6765e3c7f1a9.png)

![Screenshot 2022-11-08 at 16 33 13](https://user-images.githubusercontent.com/3727504/200622256-f14da91d-d929-4554-88e9-bc7752f36975.png)

![Screenshot 2022-11-08 at 16 33 18](https://user-images.githubusercontent.com/3727504/200622259-959030ab-a352-4b6c-8c2c-eea0291be309.png)

## After

### Desktop

![Screenshot 2022-11-08 at 16 30 03](https://user-images.githubusercontent.com/3727504/200621944-a105674f-43be-4f68-9e48-74b73e0e2b20.png)

![Screenshot 2022-11-08 at 16 30 12](https://user-images.githubusercontent.com/3727504/200622758-cf4d20b3-8d7e-46e2-94c8-dd53b886500f.png)

### Mobile

![Screenshot 2022-11-08 at 16 38 07](https://user-images.githubusercontent.com/3727504/200623299-d8595b1a-045e-4752-8ea9-bfa55010dd3b.png)

![Screenshot 2022-11-08 at 16 30 28](https://user-images.githubusercontent.com/3727504/200623094-77b90c17-c696-4b89-bf71-cbcb160af20a.png)
