### PR TITLE
Fix changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+* Calculate viewport width correctly for navbar in Chrome and Firefox when Mac scrollbars are enabled ([PR #3016](https://github.com/alphagov/govuk_publishing_components/pull/3016))
+
 ## 32.0.0
 
 * Track clicks on links with child elements ([PR #3042](https://github.com/alphagov/govuk_publishing_components/pull/3042))
@@ -60,7 +63,6 @@
 * Change GTM push of unset values from 'null' to 'undefined' ([PR #2971](https://github.com/alphagov/govuk_publishing_components/pull/2971))
 * Add click tracking to Yes/No buttons on feedback component ([PR #2964](https://github.com/alphagov/govuk_publishing_components/pull/2964))
 * Update popular links on search bar ([PR #2972](https://github.com/alphagov/govuk_publishing_components/pull/2972))
-* Calculate viewport width correctly for navbar in Chrome and Firefox when Mac scrollbars are enabled ([PR #3016](https://github.com/alphagov/govuk_publishing_components/pull/3016))
 
 ## 30.6.1
 


### PR DESCRIPTION
The changelog entry for https://github.com/alphagov/govuk_publishing_components/pull/3016 wasn't correct, this fixes it.
