### PR TITLE
Release version 32.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 32.0.1
+
 * Calculate viewport width correctly for navbar in Chrome and Firefox when Mac scrollbars are enabled ([PR #3016](https://github.com/alphagov/govuk_publishing_components/pull/3016))
 * Include the words 'opens in new tab' as part of the share link ([PR #3028](https://github.com/alphagov/govuk_publishing_components/pull/3028)) 
 * Delete removed `restoreScroll` Axe API option ([PR #3029](https://github.com/alphagov/govuk_publishing_components/pull/3029))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (32.0.0)
+    govuk_publishing_components (32.0.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -399,4 +399,4 @@ RUBY VERSION
    ruby 2.7.6
 
 BUNDLED WITH
-   2.3.19
+   2.3.25

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "32.0.0".freeze
+  VERSION = "32.0.1".freeze
 end


### PR DESCRIPTION
## 32.0.1

* Calculate viewport width correctly for navbar in Chrome and Firefox when Mac scrollbars are enabled ([PR #3016](https://github.com/alphagov/govuk_publishing_components/pull/3016))
* Include the words 'opens in new tab' as part of the share link ([PR #3028](https://github.com/alphagov/govuk_publishing_components/pull/3028)) 
* Delete removed `restoreScroll` Axe API option ([PR #3029](https://github.com/alphagov/govuk_publishing_components/pull/3029))