### PR TITLE
Update link for alpha phase to avoid redirect

### DIFF
--- a/app/views/govuk_publishing_components/components/_phase_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_phase_banner.html.erb
@@ -8,7 +8,7 @@ unless message.present?
   if phase == "beta"
     message = raw("This part of GOV.UK is being rebuilt &ndash; <a class=\"govuk-link\" href=\"/help/beta\">find out what beta means</a>")
   elsif phase == "alpha"
-    message = raw("This part of GOV.UK is being built &ndash; <a class=\"govuk-link\" href=\"/service-manual/phases/ideal-alphas\">find out what alpha means</a>")
+    message = raw("This part of GOV.UK is being built &ndash; <a class=\"govuk-link\" href=\"/service-manual/agile-delivery/how-the-alpha-phase-works\">find out what alpha means</a>")
   end
 end
 


### PR DESCRIPTION
## What

The URL `/service-manual/phases/ideal-alphas` refers to [a page from the original Service Manual][1] before the content was migrated in 2016.

Since the content was migrated, that URL now redirects to `/service-manual/agile-delivery/how-the-alpha-phase-works`.

Update the link in the alpha banner to point to the same place.

[1]: https://github.com/alphagov/government-service-design-manual/blob/master/service-manual/phases/ideal-alphas.md

## Why

Avoids an unnecessary redirect.