### PR TITLE
Remove the redundant region role from the cookie banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Update component auditing following print style changes ([PR #3128](https://github.com/alphagov/govuk_publishing_components/pull/3128))
+* Remove the redundant region role from the cookie banner ([PR #3075](https://github.com/alphagov/govuk_publishing_components/pull/3075))
 
 ## 34.1.0
 

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -29,8 +29,8 @@
   css_classes = %w(gem-c-cookie-banner govuk-clearfix)
   css_classes << "gem-c-cookie-banner--services" if services_cookies
 %>
-<div id="<%= id %>" class="<%= css_classes.join(' ') %>" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet>
-  <div class="govuk-cookie-banner js-banner-wrapper" role="region" aria-label="<%= title %>">
+<div id="<%= id %>" class="<%= css_classes.join(' ') %>" data-module="cookie-banner" data-nosnippet role="region" aria-label="<%= title %>">
+  <div class="govuk-cookie-banner js-banner-wrapper">
     <div class="gem-c-cookie-banner__message govuk-cookie-banner__message govuk-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## What
The cookie banner is currently nested in two very similar regions:
```
<div id="global-cookie-message" role="region" aria-label="cookie banner" [...]>
  <div class="govuk-cookie-banner js-banner-wrapper" role="region" aria-label="Cookies on GOV.UK">
```
That means there is a region announced as “cookie banner” which includes the another region called “Cookies on GOV.UK”.

## Why
This is confusing to screen reader users. Landmarks should be used sparingly and reflect the structure of the page. This structure should only be announced as one region.

## How
By removing the `region` and `aria-label` from the outer element, we retain the full functionality of the component without needing to change the structure itself. Now only one region will be announced.