### PR TITLE
Extend the `input` and `textarea` components to use the `dir` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Support Rails Content Security Policy nonce on inline JavaScript ([PR #3173](https://github.com/alphagov/govuk_publishing_components/pull/3173))
 * Restyle subscription link ([PR #3177](https://github.com/alphagov/govuk_publishing_components/pull/3177))
 * Change "+" to "Show" in related navigation and metadata block components ([PR #3038](https://github.com/alphagov/govuk_publishing_components/pull/3038))
+* Extend the `input` and `textarea` components to use the `dir` attribute ([PR #3081](https://github.com/alphagov/govuk_publishing_components/pull/3081))
 
 ## 34.2.0
 

--- a/app/views/govuk_publishing_components/components/_error_message.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_message.html.erb
@@ -4,12 +4,13 @@
   css_classes = %w( gem-c-error-message govuk-error-message )
   css_classes << classes if classes
   items ||= []
+  right_to_left ||= false
 
   if items.any?
     errors = items.map { |item| capture { item[:text] } }
     text = raw(errors.join("<br />"))
   end
 %>
-<%= tag.p id: id, class: css_classes do %>
+<%= tag.p id: id, class: css_classes, dir: right_to_left ? "rtl" : nil do %>
   <span class="govuk-visually-hidden">Error:</span> <%= text %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_hint.html.erb
+++ b/app/views/govuk_publishing_components/components/_hint.html.erb
@@ -1,11 +1,12 @@
 <%
   id ||= "hint-#{SecureRandom.hex(4)}"
+  right_to_left ||= false
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   css_classes = %w( gem-c-hint govuk-hint )
   css_classes << shared_helper.get_margin_bottom
 %>
 
-<%= tag.div id: id, class: css_classes do %>
+<%= tag.div id: id, class: css_classes, dir: right_to_left ? "rtl" : nil do %>
   <%= text %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_input.html.erb
+++ b/app/views/govuk_publishing_components/components/_input.html.erb
@@ -31,6 +31,8 @@
   heading_level ||= nil
   prefix ||= nil
   suffix ||= nil
+  right_to_left ||= false
+  right_to_left_help = right_to_left_help.nil? ? right_to_left : right_to_left_help
 
   css_classes = %w(gem-c-input govuk-input)
   css_classes << "govuk-input--error" if has_error
@@ -70,7 +72,8 @@
     <% label_markup = capture do %>
       <%= render "govuk_publishing_components/components/label", {
         html_for: id,
-        heading_size: heading_size
+        heading_size: heading_size,
+        right_to_left: right_to_left_help
       }.merge(label.symbolize_keys) %>
     <% end %>
 
@@ -86,7 +89,8 @@
   <% if hint %>
     <%= render "govuk_publishing_components/components/hint", {
       id: hint_id,
-      text: hint
+      text: hint,
+      right_to_left: right_to_left_help
     } %>
   <% end %>
 
@@ -95,6 +99,7 @@
       id: error_id,
       text: error_message,
       items: error_items,
+      right_to_left: right_to_left_help
     } %>
   <% end %>
 
@@ -107,6 +112,7 @@
     autofocus: autofocus,
     class: css_classes,
     data: data,
+    dir: right_to_left ? "rtl" : nil,
     enterkeyhint: checked_enterkeyhint,
     id: id,
     inputmode: inputmode,

--- a/app/views/govuk_publishing_components/components/_label.html.erb
+++ b/app/views/govuk_publishing_components/components/_label.html.erb
@@ -7,6 +7,7 @@
   bold ||= false
   heading_size = false unless shared_helper.valid_heading_size?(heading_size)
   is_page_heading ||= false
+  right_to_left ||= false
 
   css_classes = %w[gem-c-label govuk-label]
   css_classes << "govuk-label--s" if bold
@@ -19,14 +20,14 @@
 
 <% if is_page_heading %>
   <%= tag.h1 text, class: "govuk-label-wrapper" do %>
-    <%= tag.label text, id: id, for: html_for, class: css_classes %>
+    <%= tag.label text, id: id, for: html_for, class: css_classes, dir: right_to_left ? "rtl" : nil %>
   <% end %>
 <% else %>
-  <%= tag.label text, id: id, for: html_for, class: css_classes %>
+  <%= tag.label text, id: id, for: html_for, class: css_classes, dir: right_to_left ? "rtl" : nil %>
 <% end %>
 
 <% if hint_text.present? %>
-  <%= tag.span id: hint_id, class: hint_text_css_classes do %>
+  <%= tag.div id: hint_id, class: hint_text_css_classes, dir: right_to_left ? "rtl" : nil do %>
     <%= hint_text %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_textarea.html.erb
+++ b/app/views/govuk_publishing_components/components/_textarea.html.erb
@@ -17,6 +17,8 @@
   hint_id = "hint-#{SecureRandom.hex(4)}"
   has_error ||= error_message || error_items.any?
   error_id = "error-#{SecureRandom.hex(4)}"
+  right_to_left ||= false
+  right_to_left_help = right_to_left_help.nil? ? right_to_left : right_to_left_help
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
@@ -39,13 +41,17 @@
 
 <%= content_tag :div, class: form_group_css_classes do %>
   <% if label %>
-    <%= render "govuk_publishing_components/components/label", { html_for: id }.merge(label.symbolize_keys) %>
+    <%= render "govuk_publishing_components/components/label", {
+      html_for: id,
+      right_to_left: right_to_left_help
+    }.merge(label.symbolize_keys) %>
   <% end %>
 
   <% if hint %>
     <%= render "govuk_publishing_components/components/hint", {
       id: hint_id,
-      text: hint
+      text: hint,
+      right_to_left: right_to_left_help
     } %>
   <% end %>
 
@@ -54,11 +60,13 @@
       id: error_id,
       text: error_message,
       items: error_items,
+      right_to_left: right_to_left_help
     } %>
   <% end %>
 
   <%= tag.textarea name: name,
     class: css_classes,
+    dir: right_to_left ? "rtl" : nil,
     id: id,
     rows: rows,
     maxlength: maxlength,

--- a/app/views/govuk_publishing_components/components/docs/error_message.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_message.yml
@@ -21,3 +21,16 @@ examples:
       items:
         - text: Error 1
         - text: Error 2
+  with_dir_attribute:
+    description: Allows the correct display of right to left languages
+    data:
+      text: "An error message displayed right to left"
+      id: "error_id_2"
+      right_to_left: true
+  with_items_and_dir_attribute:
+    description: To allow the correct display of right to left languages on error items
+    data:
+      right_to_left: true
+      items:
+        - text: Error 1 displayed right to left
+        - text: Error 2 displayed right to left

--- a/app/views/govuk_publishing_components/components/docs/hint.yml
+++ b/app/views/govuk_publishing_components/components/docs/hint.yml
@@ -19,3 +19,9 @@ examples:
     data:
       text: "You qualify if you were born in the UK before June 1960."
       margin_bottom: 9
+  with_dir_attribute:
+    description: |
+      Allows the correct display of right to left languages.
+    data:
+      text: "العربيَّة"
+      right_to_left: true

--- a/app/views/govuk_publishing_components/components/docs/input.yml
+++ b/app/views/govuk_publishing_components/components/docs/input.yml
@@ -183,3 +183,35 @@ examples:
         text: "Given name"
       name: given-name
       enterkeyhint: "next"
+  with_dir_attribute:
+    description: |
+      Allows the correct display of right to left languages.
+
+      By default the input element and the label both display text in a left to right direction.
+
+      When the `right_to_left` parameter of the input component is set to `true` both the input and the label, hint and error message display their content in a right to left direction. 
+    data:
+      label:
+        text: "Some input text to be displayed right to left with a label that displays in the same direction"
+      hint: "Some hint text that displays in the same text direction as the label"
+      error_message: "An error message that displays in the same text direction as the label"
+      name: rtl-input-text
+      value: "العربيَّة"
+      right_to_left: true
+
+  with_separate_dir_attributes_for_field_and_help_text:
+    description: |
+      Allows the correct display of right to left languages.
+
+      By default the input element and the label both display text in a left to right direction.
+
+      If the input field and the help text (label, hint and error messages) are required to display in different directions the `right_to_left_help` attribute can be set as false to override the `right_to_left` attribute.
+    data:
+      label:
+        text: "Some input text that displays right to left with a label that displays left to right"
+      hint: "Some hint text that displays in the same text direction as the label"
+      name: rtl-input-text
+      value: "العربيَّة"
+      right_to_left: true
+      right_to_left_help: false
+      error_message: "An error message that displays in the same text direction as the label"

--- a/app/views/govuk_publishing_components/components/docs/label.yml
+++ b/app/views/govuk_publishing_components/components/docs/label.yml
@@ -65,3 +65,14 @@ examples:
       text: "Label with an ID"
       id: "id-for-the-label"
       html_for: "id-that-matches-input-6"
+  with_dir_attribute:
+    description: |
+      To allow the correct display of right to left languages.
+
+      When the `right_to_left` parameter is set to `true` any hint text displays in the same text direction as the label.
+    data:
+      text: "العربيَّة"
+      html_for: "id-that-matches-input-7"
+      hint_id: "should-match-aria-describedby-input"
+      hint_text: "Hint text displayed right to left"
+      right_to_left: true

--- a/app/views/govuk_publishing_components/components/docs/textarea.yml
+++ b/app/views/govuk_publishing_components/components/docs/textarea.yml
@@ -110,3 +110,34 @@ examples:
       name: "with_data_attrbutes"
       data:
         module: "some-awesome-module-here"
+  with_dir_attribute:
+    description: |
+      Allows the correct display of right to left languages.
+
+      By default the textarea element and the label both display text in a left to right direction.
+
+      When the `right_to_left` parameter of the textarea component is set to `true` all text desplays in a right to left direction.
+    data:
+      label:
+        text: "Some textarea text that displays right to left with a label that displays in the same direction"
+      hint: "Some hint text that displays in the same text direction as the label"
+      error_message: "An error message that displays in the same text direction as the label"
+      name: "rtl-textarea-text"
+      value: "العربيَّة"
+      right_to_left: true
+  with_separate_dir_attributes_for_field_and_help_text:
+    description: |
+      Allows the correct display of right to left languages.
+
+      By default the textarea element and the label both display text in a left to right direction.
+
+      If the textarea field and the help text (label, hint and error messages) are required to display in different directions the right_to_left_help attribute can be set as false to override the right_to_left attribute.
+    data:
+      label:
+        text: "Some textarea text that displays right to left with a label that displays left to right"
+      hint: "Some hint text that displays in the same text direction as the label"
+      error_message: "An error message that displays in the same text direction as the label"
+      name: rtl-textarea-text
+      value: "العربيَّة"
+      right_to_left: true
+      right_to_left_help: false

--- a/spec/components/error_message_spec.rb
+++ b/spec/components/error_message_spec.rb
@@ -26,4 +26,13 @@ describe "Error message", type: :view do
     assert_select("p.govuk-error-message", html: %r{Error where HTML is &lt;strong&gt;escaped&lt;/strong&gt;})
     assert_select("p.govuk-error-message", html: %r{Error where HTML is <strong>maintained</strong>})
   end
+
+  it "renders error message with a value for the `dir` attribute" do
+    render_component(
+      text: "Error:An error message that displays right to left",
+      right_to_left: true,
+    )
+
+    assert_select("p.govuk-error-message[dir='rtl']")
+  end
 end

--- a/spec/components/hint_spec.rb
+++ b/spec/components/hint_spec.rb
@@ -28,4 +28,13 @@ describe "Hint", type: :view do
 
     assert_select '.govuk-hint.govuk-\!-margin-bottom-3'
   end
+
+  it "renders the component with the correct `dir` attribute" do
+    render_component(
+      text: "العربيَّة",
+      right_to_left: true,
+    )
+
+    assert_select ".govuk-hint[dir='rtl']"
+  end
 end

--- a/spec/components/input_spec.rb
+++ b/spec/components/input_spec.rb
@@ -285,4 +285,37 @@ describe "Input", type: :view do
 
     assert_no_selector ".govuk-input[enterkeyhint='chocolate']"
   end
+
+  it "renders the input and label with the correct `dir` attribute when the input is set to 'right_to_left: true'" do
+    render_component(
+      name: "rtl-input-text",
+      value: "العربيَّة",
+      right_to_left: true,
+      label: {
+        text: "Some label text that displays right to left",
+      },
+    )
+
+    assert_select ".govuk-input[dir='rtl']"
+    assert_select ".govuk-label[dir='rtl']"
+  end
+
+  it "renders the input and help text (label, hint and error messages) with the correct `dir` attribute when `right_to_left` is set to true and `right_to_left_help` is set to false" do
+    render_component(
+      name: "rtl-input-text",
+      value: "العربيَّة",
+      hint: "Some hint text that is displayed left to right",
+      right_to_left: true,
+      right_to_left_help: false,
+      error_message: "An error message that is displayed left to right",
+      label: {
+        text: "Some label text that displays left to right",
+      },
+    )
+
+    assert_select ".govuk-input[dir='rtl']"
+    assert_no_selector ".govuk-label[dir='rtl']"
+    assert_no_selector ".govuk-hint[dir='rtl']"
+    assert_no_selector ".govuk-error-message[dir='rtl']"
+  end
 end

--- a/spec/components/label_spec.rb
+++ b/spec/components/label_spec.rb
@@ -101,4 +101,17 @@ describe "Label", type: :view do
       text: "Label with ID",
     )
   end
+
+  it "renders label with the correct `dir` attribute" do
+    render_component(
+      text: "العربيَّة",
+      html_for: "id-that-matches-input",
+      hint_id: "should-match-aria-describedby-input",
+      hint_text: "Hint text displayed right to left",
+      right_to_left: true,
+    )
+
+    assert_select ".govuk-label[dir='rtl']"
+    assert_select ".govuk-hint[dir='rtl']"
+  end
 end

--- a/spec/components/textarea_spec.rb
+++ b/spec/components/textarea_spec.rb
@@ -198,4 +198,37 @@ describe "Textarea", type: :view do
       assert_select ".govuk-textarea[aria-describedby='#{error_id}']"
     end
   end
+
+  it "renders the textarea and label with the correct `dir` attribute when the textarea is set to 'right_to_left: true'" do
+    render_component(
+      name: "rtl-textarea-text",
+      value: "العربيَّة",
+      right_to_left: true,
+      label: {
+        text: "Some label text that displays right to left",
+      },
+    )
+
+    assert_select ".govuk-textarea[dir='rtl']"
+    assert_select ".govuk-label[dir='rtl']"
+  end
+
+  it "renders the textarea and help text (label, hint and error messages) with the correct `dir` attribute when `right_to_left` is set to true and `right_to_left_help` is set to false" do
+    render_component(
+      name: "rtl-textarea-text",
+      value: "العربيَّة",
+      hint: "Some hint text that is displayed left to right",
+      right_to_left: true,
+      right_to_left_help: false,
+      error_message: "An error message that is displayed left to right",
+      label: {
+        text: "Some label text that displays left to right",
+      },
+    )
+
+    assert_select ".govuk-textarea[dir='rtl']"
+    assert_no_selector ".govuk-label[dir='rtl']"
+    assert_no_selector ".govuk-hint[dir='rtl']"
+    assert_no_selector ".govuk-error-message[dir='rtl']"
+  end
 end


### PR DESCRIPTION
## What
Extends input and textarea components to accept a value for the `dir` attribute

## Why
In a previous piece of work (see[ Add RTL support for attachments](https://trello.com/c/RT5RbtmT/896-add-rtl-support-for-attachments)) we added support for right-to-left languages to the attachments pages on the Whitehall publishing app. This was done by adding a class to the parent of the `input` and `textarea` elements that would be used by CSS to render the text correctly. It became clear that it would be a more elegant and semantic solution to achieve this by use of the `dir` attribute of the elements. In addition this is recommended practice for instances where CSS is not loaded. 

Currently these components do not accept a value for that attribute so the changes here update these components accordingly. 

As part of this work it was also necessary to update the hint, label and error message components so that the correct value for the `dir` element can also be displayed on those elements. Another concern is to enable the element (`input` or `textarea`) and its corresponding `hint`, `label` and `error messages` to be able to render with different values for the `dir` attribute. This is for the specific use of the component in the Whitehall publishing app where a language is specified for a document. 

To this end the input and textarea components are considered with the following in mind: 
- the `dir` attribute is not set by default
- the `dir` attribute is set to the same value on both the `input`/`textarea` elements and their associated hint, label and error messages by default via the `right_to_left` boolean attribute of the component
- the `dir` attribute of the hint, label and error messages can optionally be set separately via the `right_to_left_field` boolean (for `input` or `textarea`) and `right_to_left_help` boolean (for hint, label and error messages) attributes of the component.

### Updated components

|element|example|
|---|---|
|hint|![Screenshot 2023-01-05 at 12 31 18](https://user-images.githubusercontent.com/6080548/210780908-5c06c0c0-eddf-4486-96ea-50d1fec43a68.png)|
|label|![Screenshot 2023-01-05 at 12 44 42](https://user-images.githubusercontent.com/6080548/210783849-b116a3ab-c9e4-4eac-93e0-c81645b11c26.png)|
|error message|![Screenshot 2023-01-05 at 12 50 42](https://user-images.githubusercontent.com/6080548/210784144-6b365dc4-e97a-46bc-8f29-b7dcaf3ee371.png)|
|error items|![Screenshot 2023-01-05 at 12 51 43](https://user-images.githubusercontent.com/6080548/210784312-01271be0-2b31-4438-b8ec-b765710c6967.png)|
|input|![Screenshot 2023-01-05 at 14 16 26](https://user-images.githubusercontent.com/6080548/210800817-4f6b73fb-0258-4efe-b4db-b58dfa6fb4e7.png)|
|input with separate `dir` attributes|![Screenshot 2023-01-05 at 14 22 16](https://user-images.githubusercontent.com/6080548/210802044-aaef06a5-b130-4d01-960a-1d216d1531c1.png)|
|textarea|![Screenshot 2023-01-05 at 14 18 19](https://user-images.githubusercontent.com/6080548/210801213-791720ab-8677-4c75-bd85-3b75597f4818.png)|
|textarea with separate `dir` attributes|![Screenshot 2023-01-05 at 14 19 09](https://user-images.githubusercontent.com/6080548/210801345-aa6c8252-95f6-4c7a-85b1-2783f2c350e7.png)|
