### PR TITLE
Rename section and themes property names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Set attributes for single page notification button based on Account API response ([PR #3071](https://github.com/alphagov/govuk_publishing_components/pull/3071))
 * Support custom text for the single page notification button component ([PR #2935](https://github.com/alphagov/govuk_publishing_components/pull/2935))
 * Simplify the way ga4 tracking is added to accordions ([PR #3082](https://github.com/alphagov/govuk_publishing_components/pull/3082))
+* Rename section and themes property names ([PR #3092](https://github.com/alphagov/govuk_publishing_components/pull/3092))
 
 ## 32.1.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -27,10 +27,10 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             schema_name: this.getMetaContent('schema-name'),
             content_id: this.getMetaContent('content-id'),
 
-            section: this.getMetaContent('section'),
+            browse_topic: this.getMetaContent('section'),
             taxon_slug: this.getMetaContent('taxon-slug'),
             taxon_id: this.getMetaContent('taxon-id'),
-            themes: this.getMetaContent('themes'),
+            taxonomy_level1: this.getMetaContent('themes'),
             taxon_slugs: this.getMetaContent('taxon-slugs'),
             taxon_ids: this.getMetaContent('taxon-ids'),
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -27,10 +27,10 @@ describe('Google Tag Manager page view tracking', function () {
         schema_name: undefined,
         content_id: undefined,
 
-        section: undefined,
+        browse_topic: undefined,
         taxon_slug: undefined,
         taxon_id: undefined,
-        themes: undefined,
+        taxonomy_level1: undefined,
         taxon_slugs: undefined,
         taxon_ids: undefined,
 
@@ -129,7 +129,7 @@ describe('Google Tag Manager page view tracking', function () {
   it('returns a page view with specific taxonomy information', function () {
     var tags = [
       {
-        gtmName: 'section',
+        gtmName: 'browse_topic',
         tagName: 'section',
         value: 'this section'
       },
@@ -144,7 +144,7 @@ describe('Google Tag Manager page view tracking', function () {
         value: 'this taxon id'
       },
       {
-        gtmName: 'themes',
+        gtmName: 'taxonomy_level1',
         tagName: 'themes',
         value: 'this theme'
       },


### PR DESCRIPTION
## What
This PR renames `page_view.section` and `page_view.themes` to `page_view.browse_topic` and `page_view.taxonomy_level1` respectively.

For now, these properties will be set by meta tags using the old values (i.e. `<meta name="govuk:section">` and `<meta name="govuk:themes">`) because updating the meta tags at this time will cause the UA tracking to break. Therefore, the meta tags will be updated after UA has been removed.

## Why
This change has been requested by PA's.

Trello card for renaming `section` to `browse_topic`: https://trello.com/c/bCtjIIL7/340-rename-section-to-browsetopic
Trello card for renaming `themes` to `taxonomy_level1`: https://trello.com/c/vaOo3M8D/341-rename-themes-to-taxonomylevel1

## Visual Changes
N/A
