### PR TITLE
Add `id` attribute option to the label component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Add `aria-controls` and `aria-describedby` attribute options to the button component ([PR #3088](https://github.com/alphagov/govuk_publishing_components/pull/3088))
 * Simplify the way ga4 tracking is added to accordions ([PR #3082](https://github.com/alphagov/govuk_publishing_components/pull/3082))
 * Rename section and themes property names ([PR #3092](https://github.com/alphagov/govuk_publishing_components/pull/3092))
-
+* Add `id` attribute option to the label component ([PR #3093](https://github.com/alphagov/govuk_publishing_components/pull/3093))
 
 ## 32.1.0
 

--- a/app/views/govuk_publishing_components/components/_label.html.erb
+++ b/app/views/govuk_publishing_components/components/_label.html.erb
@@ -2,6 +2,7 @@
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   hint_text ||= ""
+  id ||= nil
   is_radio_label ||= false
   bold ||= false
   heading_size = false unless shared_helper.valid_heading_size?(heading_size)
@@ -18,10 +19,10 @@
 
 <% if is_page_heading %>
   <%= tag.h1 text, class: "govuk-label-wrapper" do %>
-    <%= tag.label text, for: html_for, class: css_classes %>
+    <%= tag.label text, id: id, for: html_for, class: css_classes %>
   <% end %>
 <% else %>
-  <%= tag.label text, for: html_for, class: css_classes %>
+  <%= tag.label text, id: id, for: html_for, class: css_classes %>
 <% end %>
 
 <% if hint_text.present? %>

--- a/app/views/govuk_publishing_components/components/docs/label.yml
+++ b/app/views/govuk_publishing_components/components/docs/label.yml
@@ -59,3 +59,9 @@ examples:
       html_for: "id-radio"
       hint_id: "id-radio"
       hint_text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+  with_id:
+    description: 
+    data:
+      text: "Label with an ID"
+      id: "id-for-the-label"
+      html_for: "id-that-matches-input-6"

--- a/spec/components/label_spec.rb
+++ b/spec/components/label_spec.rb
@@ -88,4 +88,17 @@ describe "Label", type: :view do
     assert_select ".gem-c-label.govuk-label.govuk-radios__label"
     assert_select ".govuk-hint.govuk-radios__hint"
   end
+
+  it "renders label with id" do
+    render_component(
+      text: "Label with ID",
+      id: "test-id",
+      html_for: "label-with-id",
+    )
+
+    assert_select(
+      ".govuk-label[id='test-id'][for='label-with-id']",
+      text: "Label with ID",
+    )
+  end
 end


### PR DESCRIPTION
## What
[Trello ticket link](https://trello.com/c/oGsq2F3m/828-add-accessibility-improvements-to-preview-govspeak-component)
Add the `id` attribute option to the label component
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
Part of a body of work to improve accessibility of the [Preview Govspeak](https://github.com/alphagov/whitehall/blob/main/app/views/components/_govspeak-editor.html.erb) component in Whitehall (see [this PR](https://github.com/alphagov/whitehall/pull/7104)). In order for the Preview button to reference the label with `aria-describedby` the label must have an `id` attribute.
<!-- What are the reasons behind this change being made? -->
