### PR TITLE
Remove unused axe-core option from options parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Update to LUX 305 ([PR #3096](https://github.com/alphagov/govuk_publishing_components/pull/3096))
 * Add the keyboard shim for link buttons ([PR #3027](https://github.com/alphagov/govuk_publishing_components/pull/3027))
+* Remove unused axe-core option from options parameter ([PR #3094](https://github.com/alphagov/govuk_publishing_components/pull/3094))
 
 ## 33.0.0
 

--- a/app/assets/javascripts/component_guide/accessibility-test.js
+++ b/app/assets/javascripts/component_guide/accessibility-test.js
@@ -24,7 +24,6 @@
     })
 
     var axeOptions = {
-      include: [selector],
       rules: axeRules
     }
 


### PR DESCRIPTION
## What
Remove unused `include: [selector]`, from option from axe-core options parameter

## Why
See https://github.com/alphagov/govuk_publishing_components/issues/3020