### PR TITLE
Minor ecommerce tracking refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update to LUX 305 ([PR #3096](https://github.com/alphagov/govuk_publishing_components/pull/3096))
 * Add the keyboard shim for link buttons ([PR #3027](https://github.com/alphagov/govuk_publishing_components/pull/3027))
 * Remove unused axe-core option from options parameter ([PR #3094](https://github.com/alphagov/govuk_publishing_components/pull/3094))
+* Minor ecommerce tracking refactor ([PR #3098](https://github.com/alphagov/govuk_publishing_components/pull/3098))
 
 ## 33.0.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.js
@@ -50,7 +50,7 @@
       var schema = this.populateEcommerceSchema(searchResultsBlock, false, null)
 
       this.clearPreviousEcommerceObject()
-      window.dataLayer.push(schema)
+      GOVUK.analyticsGa4.core.sendData(schema)
     },
 
     handleClick: function (event) {
@@ -62,7 +62,7 @@
         var schema = this.populateEcommerceSchema(searchResultsBlock, true, searchResult)
 
         this.clearPreviousEcommerceObject()
-        window.dataLayer.push(schema)
+        GOVUK.analyticsGa4.core.sendData(schema)
       }
     },
 
@@ -127,7 +127,7 @@
     },
 
     clearPreviousEcommerceObject: function () {
-      window.dataLayer.push({ search_results: { ecommerce: null } })
+      GOVUK.analyticsGa4.core.sendData({ search_results: { ecommerce: null } })
     },
 
     getResultsCount: function (searchResultsBlock) {


### PR DESCRIPTION
## What
This PR refactors ecommerce tracking to use the `sendData()` function in `ga4-core.js` when pushing to the `dataLayer` (as opposed to calling `window.dataLayer.push()` directly).

## Why
To maintain consistency in how we push data to the `dataLayer`.

## Visual Changes
N/A
