### PR TITLE
Update feedback component tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update feedback component tracking ([PR #3099](https://github.com/alphagov/govuk_publishing_components/pull/3099))
 * Update to LUX 305 ([PR #3096](https://github.com/alphagov/govuk_publishing_components/pull/3096))
 * Add the keyboard shim for link buttons ([PR #3027](https://github.com/alphagov/govuk_publishing_components/pull/3027))
 * Remove unused axe-core option from options parameter ([PR #3094](https://github.com/alphagov/govuk_publishing_components/pull/3094))

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -41,7 +41,7 @@
       <%= render "govuk_publishing_components/components/button", {
         text: t("components.feedback.send"),
         data_attributes: {
-          ga4: {
+          ga4_event: {
             event_name: "form_submit",
             type: "feedback",
             text: "Send",

--- a/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_survey_signup_form.html.erb
@@ -28,7 +28,7 @@
       <%= render "govuk_publishing_components/components/button", {
         text: t("components.feedback.send_me_survey"),
         data_attributes: {
-          ga4: {
+          ga4_event: {
             event_name: "form_submit",
             type: "feedback",
             text: "Send me the survey",


### PR DESCRIPTION
## What / why
Update the tracking attributes in the feedback component following a recent change to `ga4-event-tracker`, `data-ga4` attributes should now be called `data-ga4-event`.

## Visual Changes
None.
