### PR TITLE
Fix intervention dismiss

### DIFF
--- a/app/assets/javascripts/component_guide/application.js
+++ b/app/assets/javascripts/component_guide/application.js
@@ -2,4 +2,5 @@
 //= require_tree .
 //= require ../govuk_publishing_components/dependencies
 //= require ../govuk_publishing_components/components/accordion
+//= require ../govuk_publishing_components/components/intervention
 //= require ../govuk_publishing_components/components/tabs

--- a/app/assets/javascripts/govuk_publishing_components/components/intervention.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/intervention.js
@@ -1,0 +1,28 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function Intervention ($module) {
+    this.$module = $module
+    this.$banner = this.$module.querySelector('.gem-c-intervention')
+    this.$closeLink = this.$module.querySelector('.gem-c-intervention__dismiss-link')
+  }
+
+  Intervention.prototype.init = function () {
+    this.$module.close = this.handleClose.bind(this)
+
+    if (this.$closeLink) {
+      this.$closeLink.addEventListener('click', this.$module.close)
+    }
+  }
+
+  Intervention.prototype.handleClose = function (event) {
+    if (event) {
+      event.preventDefault()
+    }
+
+    this.$module.style.display = 'none'
+  }
+
+  Modules.Intervention = Intervention
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/components/intervention.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/intervention.js
@@ -4,23 +4,64 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   function Intervention ($module) {
     this.$module = $module
-    this.$banner = this.$module.querySelector('.gem-c-intervention')
-    this.$closeLink = this.$module.querySelector('.gem-c-intervention__dismiss-link')
+    this.$closeLink = this.$module.querySelector('.js-dismiss-link')
+    this.$campaignName = this.$module.getAttribute('data-intervention-name')
+    this.$campaignCookie = window.GOVUK.cookie('intervention_campaign') || ''
   }
 
   Intervention.prototype.init = function () {
-    this.$module.close = this.handleClose.bind(this)
+    this.$cookieHasCampaign = this.cookieHasCampaign()
 
     if (this.$closeLink) {
+      this.$module.close = this.handleClose.bind(this)
       this.$closeLink.addEventListener('click', this.$module.close)
+    }
+
+    if (this.$cookieHasCampaign) {
+      this.hideBanner()
     }
   }
 
   Intervention.prototype.handleClose = function (event) {
-    if (event) {
-      event.preventDefault()
+    event.preventDefault()
+
+    if (this.$cookieHasCampaign) {
+      this.setCookies()
+    }
+    this.hideBanner()
+  }
+
+  Intervention.prototype.cookieHasCampaign = function () {
+    if (this.$campaignCookie) {
+      return this.cookieValues().includes(this.$campaignName)
+    }
+    return false
+  }
+
+  Intervention.prototype.cookieValues = function () {
+    if (this.$campaignCookie !== null && this.$campaignCookie.length > 0) {
+      return this.$campaignCookie.split(',')
+    }
+  }
+
+  Intervention.prototype.appendCookieValues = function () {
+    return this.$campaignCookie + ',' + this.$campaignName
+  }
+
+  Intervention.prototype.setCookies = function () {
+    if (this.$campaignCookie) {
+      window.GOVUK.setCookie('intervention_campaign', this.appendCookieValues(), { days: 30 })
+    } else {
+      window.GOVUK.setCookie('intervention_campaign', this.$campaignName, { days: 30 })
+    }
+  }
+
+  Intervention.prototype.hideBanner = function () {
+    if (!this.$cookieHasCampaign) {
+      this.setCookies()
     }
 
+    this.$module.hidden = true
     this.$module.style.display = 'none'
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+++ b/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
@@ -17,6 +17,7 @@
     cookie_preferences_set: 'essential',
     cookies_preferences_set: 'essential',
     '_email-alert-frontend_session': 'essential',
+    intervention_campaign: 'essential',
     licensing_session: 'essential',
     govuk_contact_referrer: 'essential',
     multivariatetest_cohort_coronavirus_extremely_vulnerable_rate_limit: 'essential',

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -15,12 +15,15 @@
   aria_attributes ||= {}
   aria_attributes[:label] = 'Intervention'
 
-  local_assigns[:query_string] ||= request.query_string
-  local_assigns[:suggestion_text] = suggestion_text
-  local_assigns[:suggestion_link_text] = suggestion_link_text
-  local_assigns[:suggestion_link_url] = suggestion_link_url
+  options = {
+    params: request.params,
+    query_string: request.query_string,
+    suggestion_text: suggestion_text,
+    suggestion_link_text: suggestion_link_text,
+    suggestion_link_url: suggestion_link_url,
+  }
 
-  intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new(local_assigns)
+  intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new(options)
   dismiss_href = intervention_helper.dismiss_link
 
   suggestion_tag_options = {

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -1,6 +1,7 @@
 <%
   add_gem_component_stylesheet("intervention")
 
+  name ||= ""
   dismiss_text ||= false
   suggestion_link_text ||= false
   suggestion_link_url ||= false
@@ -10,6 +11,8 @@
 
   data_attributes ||= {}
   suggestion_data_attributes ||= {}
+  data_attributes[:module] = "intervention"
+  data_attributes["intervention-name"] = name
 
   aria_attributes ||= {}
   aria_attributes[:label] = 'Intervention'
@@ -40,8 +43,6 @@
     suggestion_link_text = intervention_helper.accessible_text
   end
 
-  data_attributes[:module] = "intervention"
-
   section_options = {
     class: "gem-c-intervention",
     role: "region", aria: aria_attributes,
@@ -60,7 +61,7 @@
 
     <% if dismiss_text %>
       <p class="govuk-body">
-        <%= tag.a class: "govuk-link gem-c-intervention__dismiss-link", href: dismiss_href do %>
+        <%= tag.a class: "govuk-link js-dismiss-link", href: dismiss_href do %>
           <svg class="gem-c-intervention__dismiss-icon"
             width="19" height="19" viewBox="0 0 19 19"
             aria-hidden="true"

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -10,7 +10,6 @@
 
   data_attributes ||= {}
   suggestion_data_attributes ||= {}
-  dismiss_data_attributes ||= {}
 
   aria_attributes ||= {}
   aria_attributes[:label] = 'Intervention'
@@ -41,6 +40,8 @@
     suggestion_link_text = intervention_helper.accessible_text
   end
 
+  data_attributes[:module] = "intervention"
+
   section_options = {
     class: "gem-c-intervention",
     role: "region", aria: aria_attributes,
@@ -59,7 +60,7 @@
 
     <% if dismiss_text %>
       <p class="govuk-body">
-        <%= tag.a class: "govuk-link", href: dismiss_href, data: dismiss_data_attributes do %>
+        <%= tag.a class: "govuk-link gem-c-intervention__dismiss-link", href: dismiss_href do %>
           <svg class="gem-c-intervention__dismiss-icon"
             width="19" height="19" viewBox="0 0 19 19"
             aria-hidden="true"

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -16,6 +16,7 @@
   aria_attributes[:label] = 'Intervention'
 
   local_assigns[:query_string] ||= request.query_string
+  local_assigns[:suggestion_text] = suggestion_text
   local_assigns[:suggestion_link_text] = suggestion_link_text
   local_assigns[:suggestion_link_url] = suggestion_link_url
 
@@ -44,7 +45,7 @@
   }
   section_options.merge!({ hidden: true }) if hide
 %>
-<% if suggestion_text || (suggestion_link_text && suggestion_link_url) %>
+<% if intervention_helper.show? %>
   <%= tag.section **section_options do %>
     <p class="govuk-body">
       <%= tag.span suggestion_text, class: "gem-c-intervention__textwrapper" if suggestion_text %>

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -18,6 +18,8 @@
   aria_attributes[:label] = 'Intervention'
 
   options = {
+    name: name,
+    dismiss_text: dismiss_text,
     params: request.params,
     query_string: request.query_string,
     suggestion_text: suggestion_text,

--- a/app/views/govuk_publishing_components/components/docs/intervention.yml
+++ b/app/views/govuk_publishing_components/components/docs/intervention.yml
@@ -6,7 +6,10 @@ body: |
   that would be useful to them. This component would be used to add this personalised content and would
   indicate to the user that this is not normally part of the page, but has been added for them specifically.
 
-  The dismiss link points to the current URL with the "hide-intervention" query string parameter set to "true". The backend should check for this string in order to render the same page without the intervention.
+  The dismiss link works without Javascript by pointing to the current URL with the "hide-intervention" 
+  query string parameter set to "true". It's progressively enhanced and sets a cookie to remember that 
+  the user has dismissed the banner before. The cookie requires a "name" parameter, the value of which 
+  is stored in the cookie to distinguish which campaign banner the user has dismissed.
 
 accessibility_criteria: |
   The intervention component must:
@@ -33,9 +36,11 @@ examples:
     data:
       suggestion_text: You should renew your permit every 6 months.
       dismiss_text: Hide this suggestion
+      name: campaign-name
 
   with_suggestion_link_only:
     data:
+      suggestion_text: You should renew your permit every 6 months.
       suggestion_link_text: You can now apply for a permit online.
       suggestion_link_url: /permit
 
@@ -44,6 +49,7 @@ examples:
       This example is for when we want to hide by default and display to the user based on some logic,
       either in the backend or with Javascript.
     data:
+      suggestion_text: You should renew your permit every 6 months.
       suggestion_link_text: You may be invited to fill in a questionnaire
       suggestion_link_url: /questionnaire
       hide: true
@@ -55,6 +61,7 @@ examples:
       Link text should tell the user that the link opens in a new tab.
       Note: "(opens in a new tab)" is added to link text if the phrase isn't included.
     data:
+      suggestion_text: You should renew your permit every 6 months.
       suggestion_link_text: You can now apply for a permit online
       suggestion_link_url: www.google.com/permit
       new_tab: true
@@ -76,6 +83,7 @@ examples:
         track-dimension-index: 29
         track-label: clicked suggestion
       dismiss_text: Hide this suggestion
+      name: another-campaign-name
       dismiss_data_attributes:
         track-category: interventionBanner
         track-action: interventionDismissed

--- a/app/views/govuk_publishing_components/components/docs/intervention.yml
+++ b/app/views/govuk_publishing_components/components/docs/intervention.yml
@@ -33,6 +33,9 @@ examples:
       suggestion_link_url: /travel-abroad
 
   with_dismiss_link:
+    description: | 
+      Name is required in order to set a cookie. The name value should be distinct to the campaign for the banner, 
+      so that other banners using this component are not hidden by accident.
     data:
       suggestion_text: You should renew your permit every 6 months.
       dismiss_text: Hide this suggestion

--- a/app/views/govuk_publishing_components/components/docs/intervention.yml
+++ b/app/views/govuk_publishing_components/components/docs/intervention.yml
@@ -38,12 +38,6 @@ examples:
       dismiss_text: Hide this suggestion
       name: campaign-name
 
-  with_suggestion_link_only:
-    data:
-      suggestion_text: You should renew your permit every 6 months.
-      suggestion_link_text: You can now apply for a permit online.
-      suggestion_link_url: /permit
-
   with_hide:
     description: |
       This example is for when we want to hide by default and display to the user based on some logic,

--- a/lib/govuk_publishing_components/presenters/intervention_helper.rb
+++ b/lib/govuk_publishing_components/presenters/intervention_helper.rb
@@ -4,6 +4,7 @@ module GovukPublishingComponents
       def initialize(local_assigns)
         @accessible_text_suffix = I18n.t("components.intervention.accessible_link_text_suffix")
         @query_string = local_assigns[:query_string]
+        @suggestion_text = local_assigns[:suggestion_text]
         @suggestion_link_text = local_assigns[:suggestion_link_text]
         @suggestion_link_url = local_assigns[:suggestion_link_url]
       end
@@ -29,9 +30,13 @@ module GovukPublishingComponents
         rel
       end
 
+      def show?
+        @suggestion_text || (@suggestion_link_text && @suggestion_link_url)
+      end
+
     private
 
-      attr_reader :accessible_text_suffix, :query_string, :suggestion_link_text, :suggestion_link_url
+      attr_reader :accessible_text_suffix, :query_string, :suggestion_text, :suggestion_link_text, :suggestion_link_url
     end
   end
 end

--- a/lib/govuk_publishing_components/presenters/intervention_helper.rb
+++ b/lib/govuk_publishing_components/presenters/intervention_helper.rb
@@ -1,12 +1,13 @@
 module GovukPublishingComponents
   module Presenters
     class InterventionHelper
-      def initialize(local_assigns)
+      def initialize(options = {})
         @accessible_text_suffix = I18n.t("components.intervention.accessible_link_text_suffix")
-        @query_string = local_assigns[:query_string]
-        @suggestion_text = local_assigns[:suggestion_text]
-        @suggestion_link_text = local_assigns[:suggestion_link_text]
-        @suggestion_link_url = local_assigns[:suggestion_link_url]
+        @params = options[:params] || nil
+        @query_string = options[:query_string] || nil
+        @suggestion_text = options[:suggestion_text]
+        @suggestion_link_text = options[:suggestion_link_text]
+        @suggestion_link_url = options[:suggestion_link_url]
       end
 
       def accessible_text
@@ -31,12 +32,14 @@ module GovukPublishingComponents
       end
 
       def show?
+        return false if params["hide-intervention"] == "true"
+
         @suggestion_text || (@suggestion_link_text && @suggestion_link_url)
       end
 
     private
 
-      attr_reader :accessible_text_suffix, :query_string, :suggestion_text, :suggestion_link_text, :suggestion_link_url
+      attr_reader :accessible_text_suffix, :query_string, :params, :suggestion_text, :suggestion_link_text, :suggestion_link_url
     end
   end
 end

--- a/lib/govuk_publishing_components/presenters/intervention_helper.rb
+++ b/lib/govuk_publishing_components/presenters/intervention_helper.rb
@@ -2,6 +2,8 @@ module GovukPublishingComponents
   module Presenters
     class InterventionHelper
       def initialize(options = {})
+        @name = options[:name]
+        @dismiss_text = options[:dismiss_text]
         @accessible_text_suffix = I18n.t("components.intervention.accessible_link_text_suffix")
         @params = options[:params]
         @query_string = options[:query_string]
@@ -33,6 +35,7 @@ module GovukPublishingComponents
 
       def show?
         return false if params["hide-intervention"] == "true"
+        return false if @dismiss_text && @name.blank?
 
         @suggestion_text || (@suggestion_link_text && @suggestion_link_url)
       end

--- a/lib/govuk_publishing_components/presenters/intervention_helper.rb
+++ b/lib/govuk_publishing_components/presenters/intervention_helper.rb
@@ -3,8 +3,8 @@ module GovukPublishingComponents
     class InterventionHelper
       def initialize(options = {})
         @accessible_text_suffix = I18n.t("components.intervention.accessible_link_text_suffix")
-        @params = options[:params] || nil
-        @query_string = options[:query_string] || nil
+        @params = options[:params]
+        @query_string = options[:query_string]
         @suggestion_text = options[:suggestion_text]
         @suggestion_link_text = options[:suggestion_link_text]
         @suggestion_link_url = options[:suggestion_link_url]

--- a/spec/components/intervention_spec.rb
+++ b/spec/components/intervention_spec.rb
@@ -54,10 +54,15 @@ describe "Intervention", type: :view do
     assert_empty render_component({})
   end
 
+  it "doesn't render anything if no suggestion text is provided" do
+    assert_empty render_component(dismiss_text: "Hide this suggestion")
+  end
+
   describe "hide" do
     it "hides the banner if specified" do
       render_component(
-        suggestion_link_text: "Travel abroad",
+        suggestion_text: "Based on your browsing you might be interested in",
+        suggestion_link_text: "Travel abroad: step by step",
         suggestion_link_url: "/travel-abroad",
         hide: true,
       )
@@ -69,7 +74,8 @@ describe "Intervention", type: :view do
   describe "new tab" do
     it "renders with target=_'blank' with new_tab option" do
       render_component(
-        suggestion_link_text: "Travel abroad",
+        suggestion_text: "Based on your browsing you might be interested in",
+        suggestion_link_text: "Travel abroad: step by step",
         suggestion_link_url: "/travel-abroad",
         new_tab: true,
       )
@@ -79,7 +85,8 @@ describe "Intervention", type: :view do
 
     it "renders with security attributes" do
       render_component(
-        suggestion_link_text: "Travel abroad",
+        suggestion_text: "Based on your browsing you might be interested in",
+        suggestion_link_text: "Travel abroad: step by step",
         suggestion_link_url: "/travel-abroad",
         new_tab: true,
       )
@@ -89,7 +96,8 @@ describe "Intervention", type: :view do
 
     it "renders with security attributes for external links" do
       render_component(
-        suggestion_link_text: "Travel abroad",
+        suggestion_text: "Based on your browsing you might be interested in",
+        suggestion_link_text: "Travel back in time",
         suggestion_link_url: "https://https://www.nationalarchives.gov.uk/",
         new_tab: true,
       )
@@ -99,7 +107,8 @@ describe "Intervention", type: :view do
 
     it "renders no target attribute without the new_tab option" do
       render_component(
-        suggestion_link_text: "Travel abroad",
+        suggestion_text: "Based on your browsing you might be interested in",
+        suggestion_link_text: "Travel abroad: step by step",
         suggestion_link_url: "/travel-abroad",
       )
 
@@ -108,22 +117,24 @@ describe "Intervention", type: :view do
 
     it "appends accesible link text" do
       render_component(
+        suggestion_text: "See the world.",
         suggestion_link_text: "Travel abroad",
         suggestion_link_url: "/travel-abroad",
         new_tab: true,
       )
 
-      assert_select ".gem-c-intervention", text: "Travel abroad (opens in a new tab)"
+      assert_select ".gem-c-intervention", text: /See the world.\s+Travel abroad \(opens in a new tab\)/
     end
 
     it "doesn't append accessible link text if link text is already included" do
       render_component(
+        suggestion_text: "See the world.",
         suggestion_link_text: "Travel abroad (opens in a new tab) guidance",
         suggestion_link_url: "/travel-abroad",
         new_tab: true,
       )
 
-      assert_select ".gem-c-intervention", text: "Travel abroad (opens in a new tab) guidance"
+      assert_select ".gem-c-intervention", text: /See the world.\s+Travel abroad \(opens in a new tab\) guidance/
     end
   end
 end

--- a/spec/components/intervention_spec.rb
+++ b/spec/components/intervention_spec.rb
@@ -50,16 +50,6 @@ describe "Intervention", type: :view do
     assert_select "a[href='?hide-intervention=true']"
   end
 
-  it "renders the right query string when one exists already" do
-    render_component(
-      suggestion_text: "You might be interested in",
-      dismiss_text: "Hide this suggestion",
-      query_string: "?a=b&c=d",
-    )
-
-    assert_select "a[href='?a=b&c=d&hide-intervention=true']"
-  end
-
   it "doesn't render anything if no parameter is passed" do
     assert_empty render_component({})
   end

--- a/spec/components/intervention_spec.rb
+++ b/spec/components/intervention_spec.rb
@@ -7,6 +7,7 @@ describe "Intervention", type: :view do
 
   it "renders the component" do
     render_component(
+      name: "test-campaign",
       suggestion_text: "You might be interested in",
       suggestion_link_text: "Travel abroad",
       suggestion_link_url: "/travel-abroad",
@@ -32,6 +33,7 @@ describe "Intervention", type: :view do
 
   it "renders the component without suggestion link" do
     render_component(
+      name: "test-campaign",
       suggestion_text: "You might be interested in",
       dismiss_text: "Hide this suggestion",
     )
@@ -43,6 +45,7 @@ describe "Intervention", type: :view do
 
   it "renders the right query string when none exists" do
     render_component(
+      name: "test-campaign",
       suggestion_text: "You might be interested in",
       dismiss_text: "Hide this suggestion",
     )
@@ -56,6 +59,13 @@ describe "Intervention", type: :view do
 
   it "doesn't render anything if no suggestion text is provided" do
     assert_empty render_component(dismiss_text: "Hide this suggestion")
+  end
+
+  it "doesn't render anything if a dismiss link is given but without a name for the campaign" do
+    assert_empty render_component(
+      suggestion_text: "You might be interested in",
+      dismiss_text: "Hide this suggestion",
+    )
   end
 
   describe "hide" do

--- a/spec/javascripts/components/intervention-spec.js
+++ b/spec/javascripts/components/intervention-spec.js
@@ -6,27 +6,80 @@ describe('Intervention banner component', function () {
 
   var container
 
-  beforeEach(function () {
+  var initWithCookie = function (setCookie) {
+    if (setCookie) {
+      GOVUK.setCookie('intervention_campaign', 'existing-value', { days: 1 })
+    }
+
     container = document.createElement('div')
     container.innerHTML =
-      '<section class="gem-c-intervention" data-module="intervention"><a class="govuk-link gem-c-intervention__dismiss-link">Dismiss</a></section>'
+      '<section class="gem-c-intervention" data-module="intervention" data-intervention-name="test-intervention-name"><a class="govuk-link js-dismiss-link">Dismiss</a></section>'
 
     document.body.appendChild(container)
     var element = document.querySelector('[data-module="intervention"]')
     new GOVUK.Modules.Intervention(element).init()
-  })
+
+    window.GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+  }
 
   afterEach(function () {
+    GOVUK.deleteCookie('intervention_campaign')
     document.body.removeChild(container)
   })
 
   describe('close banner', function () {
+    beforeEach(function () {
+      initWithCookie(false)
+    })
+
     it('should hide intervention banner', function () {
       var banner = document.querySelector('.gem-c-intervention')
-      var close = document.querySelector('.gem-c-intervention__dismiss-link')
+      var close = document.querySelector('.js-dismiss-link')
+      expect(banner).toBeVisible()
+
       close.click()
 
       expect(banner).toBeHidden()
+    })
+
+    it('sets a cookie value', function () {
+      spyOn(GOVUK, 'cookie').and.callThrough()
+      var close = document.querySelector('.js-dismiss-link')
+      close.click()
+
+      expect(GOVUK.cookie).toHaveBeenCalled()
+      var bannerCookie = GOVUK.cookie('intervention_campaign')
+      expect(bannerCookie).toEqual('test-intervention-name')
+    })
+  })
+
+  describe('when cookies are already set', function () {
+    beforeEach(function () {
+      initWithCookie(false)
+    })
+
+    it('does not display the banner', function () {
+      GOVUK.setCookie('intervention_campaign', 'test-intervention-name', { days: 1 })
+      var element = document.querySelector('[data-module="intervention"]')
+      new GOVUK.Modules.Intervention(element).init()
+
+      var banner = document.querySelector('.gem-c-intervention')
+
+      expect(banner).toBeHidden()
+    })
+  })
+
+  describe('there is another concurrent campaign banner', function () {
+    beforeEach(function () {
+      initWithCookie(true)
+    })
+
+    it('appends campaign value to the cookie', function () {
+      var close = document.querySelector('.js-dismiss-link')
+      close.click()
+
+      var updatedCookie = GOVUK.cookie('intervention_campaign')
+      expect(updatedCookie).toEqual('existing-value,test-intervention-name')
     })
   })
 })

--- a/spec/javascripts/components/intervention-spec.js
+++ b/spec/javascripts/components/intervention-spec.js
@@ -1,0 +1,32 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+describe('Intervention banner component', function () {
+  'use strict'
+
+  var container
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML =
+      '<section class="gem-c-intervention" data-module="intervention"><a class="govuk-link gem-c-intervention__dismiss-link">Dismiss</a></section>'
+
+    document.body.appendChild(container)
+    var element = document.querySelector('[data-module="intervention"]')
+    new GOVUK.Modules.Intervention(element).init()
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
+  describe('close banner', function () {
+    it('should hide intervention banner', function () {
+      var banner = document.querySelector('.gem-c-intervention')
+      var close = document.querySelector('.gem-c-intervention__dismiss-link')
+      close.click()
+
+      expect(banner).toBeHidden()
+    })
+  })
+})

--- a/spec/lib/govuk_publishing_components/components/intervention_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/intervention_helper_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe GovukPublishingComponents::Presenters::InterventionHelper do
       end
     end
 
+    describe ".show?" do
+      it "returns falsey value when no params are passed" do
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({})
+
+        expect(intervention_helper.show?).to be_falsey
+      end
+    end
+
     describe ".security_attr" do
       it "returns default security attributes for new tab links" do
         intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", suggestion_link_url: "/path-to-page" })

--- a/spec/lib/govuk_publishing_components/components/intervention_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/intervention_helper_spec.rb
@@ -8,9 +8,10 @@ RSpec.describe GovukPublishingComponents::Presenters::InterventionHelper do
         expect(default_dismiss_link).to eql("?hide-intervention=true")
       end
 
-      it "adds the dismiss query string parameter" do
-        existing_query_string = "?a=b"
-        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ query_string: existing_query_string })
+      it "appends the dismiss query string parameter" do
+        query_string = "?a=b"
+
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new(query_string: query_string)
         new_query_string = intervention_helper.dismiss_link
 
         expect(new_query_string).to eql("?a=b&hide-intervention=true")
@@ -18,7 +19,9 @@ RSpec.describe GovukPublishingComponents::Presenters::InterventionHelper do
 
       it "returns the default query string if the one passed is empty" do
         existing_query_string = ""
-        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ query_string: existing_query_string })
+        request = Rack::Utils.parse_nested_query(existing_query_string)
+
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new(request: request)
         new_query_string = intervention_helper.dismiss_link
 
         expect(new_query_string).to eql("?hide-intervention=true")
@@ -26,23 +29,44 @@ RSpec.describe GovukPublishingComponents::Presenters::InterventionHelper do
     end
 
     describe ".show?" do
-      it "returns falsey value when no params are passed" do
-        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({})
+      it "returns falsey value when no banner data args are passed" do
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ params: {} })
 
         expect(intervention_helper.show?).to be_falsey
+      end
+
+      it "returns falsey value when only some of required params are passed" do
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", params: {} })
+
+        expect(intervention_helper.show?).to be_falsey
+      end
+
+      it "returns falsey value when required params and hide query param is passed" do
+        params = {
+          "hide-intervention" => "true",
+        }
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", suggestion_link_url: "/path-to-page", params: params })
+
+        expect(intervention_helper.show?).to be_falsey
+      end
+
+      it "returns true when required params are passed" do
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", suggestion_link_url: "/path-to-page", params: {} })
+
+        expect(intervention_helper.show?).to be_truthy
       end
     end
 
     describe ".security_attr" do
       it "returns default security attributes for new tab links" do
-        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", suggestion_link_url: "/path-to-page" })
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", suggestion_link_url: "/path-to-page", params: {} })
         security_attrs = intervention_helper.security_attr
 
         expect(security_attrs).to eql("noopener noreferrer")
       end
 
       it "returns appends external attribute for new tab external links" do
-        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", suggestion_link_url: "https://www.nationalarchives.gov.uk" })
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", suggestion_link_url: "https://www.nationalarchives.gov.uk", params: {} })
         security_attrs = intervention_helper.security_attr
 
         expect(security_attrs).to eql("noopener noreferrer external")
@@ -51,14 +75,14 @@ RSpec.describe GovukPublishingComponents::Presenters::InterventionHelper do
 
     describe ".accessible_link_text" do
       it "appends text to make new tab link accessible" do
-        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", suggestion_link_url: "/path-to-page" })
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Text", suggestion_link_url: "/path-to-page", params: {} })
         link_text = intervention_helper.accessible_text
 
         expect(link_text).to eq("Text (opens in a new tab)")
       end
 
       it "doesn't append text if link text is already accessible" do
-        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Travel abroad (opens in a new tab) guidance", suggestion_link_url: "/path-to-page" })
+        intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new({ suggestion_link_text: "Travel abroad (opens in a new tab) guidance", suggestion_link_url: "/path-to-page", params: {} })
         link_text = intervention_helper.accessible_text
 
         expect(link_text).to eq("Travel abroad (opens in a new tab) guidance")


### PR DESCRIPTION
## What

The dismiss feature was never working on the intervention button. This PR adds that missing functionality.

See https://components-gem-pr-3101.herokuapp.com/component-guide/intervention/with_dismiss_link/preview

Fixes https://github.com/alphagov/govuk_publishing_components/issues/3097

[Trello](https://trello.com/c/MIwoWClW/1514-bug-fix-dismiss-button-on-intervention-banner-component-for-research-panel-recruitment-banner-m)

Fixes https://github.com/alphagov/govuk_publishing_components/issues/3097

## Visual Changes
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

https://user-images.githubusercontent.com/424772/211383759-d25f1045-3ea3-4966-9afb-07ec278a6366.mov


### After

https://user-images.githubusercontent.com/424772/211383925-994944de-7097-4503-8d8c-0abc75fea583.mov

### Cookies

https://user-images.githubusercontent.com/424772/219225646-e03a8db1-c64c-4cbc-a0ef-56d12d46a043.mov


