### PR TITLE
Use the base path for World Location related links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Use base path to form URLs for related World Location links ([PR #3102](https://github.com/alphagov/govuk_publishing_components/pull/3102))
+
 ## 34.7.0
 
 * Add GA4 modules error checking ([PR #3228](https://github.com/alphagov/govuk_publishing_components/pull/3228))

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -12,9 +12,6 @@ module GovukPublishingComponents
         world_locations
         statistical_data_sets
       ].freeze
-      WORLD_LOCATION_SPECIAL_CASES = {
-        "UK Mission to the European Union" => "uk-mission-to-the-eu",
-      }.freeze
 
       def initialize(options = {})
         @content_item = options.fetch(:content_item) { raise ArgumentError, "missing argument: content_item" }
@@ -115,10 +112,6 @@ module GovukPublishingComponents
 
       def related_world_locations
         content_item_links_for("world_locations")
-          .map do |link|
-            slug = WORLD_LOCATION_SPECIAL_CASES[link[:text]] || link[:text].parameterize
-            link.merge(path: "/world/#{slug}/news")
-          end
       end
 
       def related_statistical_data_sets

--- a/spec/components/contextual_footer_spec.rb
+++ b/spec/components/contextual_footer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "Contextual footer", type: :view do
       # If this item is a part of a step nav or secondary step nav this component might not render
       payload["links"].delete("part_of_step_navs")
       payload["links"].delete("secondary_to_step_navs")
+      payload["links"].delete("world_locations")
       payload
     end
 

--- a/spec/components/related_navigation_spec.rb
+++ b/spec/components/related_navigation_spec.rb
@@ -71,20 +71,11 @@ describe "Related navigation", type: :view do
 
   it "renders world locations section when passed world location items" do
     content_item = {}
-    content_item["links"] = construct_links("world_locations", "/world/usa/news", "USA")
+    content_item["links"] = construct_links("world_locations", "/world/usa", "USA")
     render_component(content_item: content_item)
 
     assert_select ".gem-c-related-navigation__sub-heading", text: "World locations"
-    assert_select ".gem-c-related-navigation__section-link[href=\"/world/usa/news\"]", text: "USA"
-  end
-
-  it "renders world locations section when passed special case world location items" do
-    content_item = {}
-    content_item["links"] = construct_links("world_locations", nil, "UK Mission to the European Union")
-    render_component(content_item: content_item)
-
-    assert_select ".gem-c-related-navigation__sub-heading", text: "World locations"
-    assert_select ".gem-c-related-navigation__section-link[href=\"/world/uk-mission-to-the-eu/news\"]", text: "UK Mission to the European Union"
+    assert_select ".gem-c-related-navigation__section-link[href=\"/world/usa\"]", text: "USA"
   end
 
   it "renders collection section when passed collection items" do
@@ -161,24 +152,24 @@ describe "Related navigation", type: :view do
   it "adds a show more toggle link to long sections" do
     content_item = { "links" => { "world_locations" => [] } }
     %w[USA Wales Fiji Iceland Sweden Mauritius Brazil].each do |country|
-      content_item["links"]["world_locations"] << { "title" => country }
+      content_item["links"]["world_locations"] << { "title" => country, "base_path" => "/world/#{country.downcase}" }
     end
     render_component(content_item: content_item)
 
-    assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales/news\"]", text: "Wales"
+    assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales\"]", text: "Wales"
     assert_select ".gem-c-related-navigation__link.toggle-wrap", text: "Show 2 more"
-    assert_select "#toggle_world_locations .gem-c-related-navigation__section-link[href=\"/world/mauritius/news\"]", text: "Mauritius"
-    assert_select "#toggle_world_locations .gem-c-related-navigation__section-link[href=\"/world/brazil/news\"]", text: "Brazil"
+    assert_select "#toggle_world_locations .gem-c-related-navigation__section-link[href=\"/world/mauritius\"]", text: "Mauritius"
+    assert_select "#toggle_world_locations .gem-c-related-navigation__section-link[href=\"/world/brazil\"]", text: "Brazil"
   end
 
   it "does not use a Show More for only one link above the max per section" do
     content_item = { "links" => { "world_locations" => [] } }
     %w[USA Wales Fiji Iceland Sweden Mauritius].each do |country|
-      content_item["links"]["world_locations"] << { "title" => country }
+      content_item["links"]["world_locations"] << { "title" => country, "base_path" => "/world/#{country.downcase}" }
     end
     render_component(content_item: content_item)
 
-    assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales/news\"]", text: "Wales"
+    assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales\"]", text: "Wales"
     assert_select ".gem-c-related-navigation__link.toggle-wrap", false, "Progressive disclosure should not display for only 1 link"
   end
 

--- a/spec/lib/govuk_publishing_components/presenters/related_navigation_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/related_navigation_helper_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
               "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
               "title" => "World, ~ (@Location)",
               "locale" => "en",
+              "base_path" => "/world/somewhere",
             },
           ],
         },
@@ -126,7 +127,7 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
         "related_contacts" => [],
         "related_external_links" => [],
         "topical_events" => [{ locale: "en", path: "/related-topical-event", text: "related topical event" }],
-        "world_locations" => [{ locale: "en", path: "/world/world-location/news", text: "World, ~ (@Location)" }],
+        "world_locations" => [{ locale: "en", path: "/world/somewhere", text: "World, ~ (@Location)" }],
         "statistical_data_sets" => [],
       }
 


### PR DESCRIPTION
## What
We are currently creating the URL of World Location related links by using the World Location's name.

However there are multiple examples where the name does not match the slug (e.g. an acronym in the slug, but spelt out in full in the name).

This was attempted to be solved by hardcoding a list of special cases, but that list has now become out of date.

Since the content item already includes the base path (which will always be up-to-date), we should use that and remove the list of exceptions.

## Why
There are currently broken related links on documents that link to World Locations.

## Visual Changes
No visual changes.

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
