### PR TITLE
[DO NOT MERGE] Refactor title component print styles

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -15,4 +15,3 @@
 @import "components/print/step-by-step-nav-header";
 @import "components/print/step-by-step-nav";
 @import "components/print/textarea";
-@import "components/print/title";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_title.scss
@@ -28,3 +28,13 @@
 .gem-c-title__text {
   margin: 0;
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-title__context {
+    margin: 0;
+  }
+
+  .gem-c-title__text {
+    margin-top: 0;
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_title.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_title.scss
@@ -1,7 +1,1 @@
-.gem-c-title__context {
-  margin: 0;
-}
-
-.gem-c-title__text {
-  margin-top: 0;
-}
+// to be removed


### PR DESCRIPTION
## What / why
- we're removing print stylesheets in favour of using print mixins in the screen stylesheet
- reduces requests, simplifies component management, may reduce asset size in some components
- currently only moving styles from print to screen, not deleting print stylesheet as this would be a breaking change

## Visual Changes
None.

Trello card: https://trello.com/c/EHMAHSjh/83-improve-component-print-stylesheets-strategy