### PR TITLE
[DO NOT MERGE] Refactor cards component print styles

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -5,7 +5,6 @@
 
 @import "components/print/accordion";
 @import "components/print/button";
-@import "components/print/cards";
 @import "components/print/contents-list";
 @import "components/print/emergency-banner";
 @import "components/print/govspeak-html-publication";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -107,3 +107,10 @@
 .gem-c-cards__description {
   margin: 0 govuk-spacing(-6) 0 0;
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-cards__sub-heading {
+    margin-top: govuk-spacing(6);
+    margin-bottom: govuk-spacing(1);
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_cards.scss
@@ -1,4 +1,1 @@
-.gem-c-cards__sub-heading {
-  margin-top: govuk-spacing(6);
-  margin-bottom: govuk-spacing(1);
-}
+// to be removed


### PR DESCRIPTION
## What / why
- we're removing print stylesheets in favour of using print mixins in the screen stylesheet
- reduces requests, simplifies component management, may reduce asset size in some components
- currently only moving styles from print to screen, not deleting print stylesheet as this would be a breaking change

## Visual Changes
None.

Trello card: https://trello.com/c/EHMAHSjh/83-improve-component-print-stylesheets-strategy