### PR TITLE
Refactor textarea component print styles

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/_all_components_print.scss
@@ -14,5 +14,4 @@
 @import "components/print/organisation-logo";
 @import "components/print/step-by-step-nav-header";
 @import "components/print/step-by-step-nav";
-@import "components/print/textarea";
 @import "components/print/title";

--- a/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_textarea.scss
@@ -9,3 +9,19 @@
     }
   }
 }
+
+@include govuk-media-query($media-type: print) {
+  .gem-c-textarea {
+    .gem-c-label,
+    .gem-c-error-message,
+    .govuk-hint,
+    .govuk-character-count__message {
+      display: block;
+    }
+
+    .govuk-textarea {
+      width: 400px;
+      height: 40px;
+    }
+  }
+}

--- a/app/assets/stylesheets/govuk_publishing_components/components/print/_textarea.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/print/_textarea.scss
@@ -1,13 +1,1 @@
-.gem-c-textarea {
-  .gem-c-label,
-  .gem-c-error-message,
-  .govuk-hint,
-  .govuk-character-count__message {
-    display: block;
-  }
-
-  .govuk-textarea {
-    width: 400px;
-    height: 40px;
-  }
-}
+// to be removed


### PR DESCRIPTION
## What / why
- we're removing print stylesheets in favour of using print mixins in the screen stylesheet
- reduces requests, simplifies component management, may reduce asset size in some components
- currently only moving styles from print to screen, not deleting print stylesheet as this would be a breaking change

## Visual Changes
None.

Trello card: https://trello.com/c/EHMAHSjh/83-improve-component-print-stylesheets-strategy