### PR TITLE
WIP Add option to turn headings into anchor link headings

### DIFF
--- a/app/views/govuk_publishing_components/components/_heading.html.erb
+++ b/app/views/govuk_publishing_components/components/_heading.html.erb
@@ -1,6 +1,7 @@
 <%
   brand ||= false
   lang = local_assigns[:lang].presence
+  is_anchor = local_assigns[:is_anchor] || false
 
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
   heading_helper = GovukPublishingComponents::Presenters::HeadingHelper.new(local_assigns)
@@ -17,3 +18,9 @@
   id: heading_helper.id,
   lang: lang
 ) %>
+<% if is_anchor %>
+<a href="#<%= heading_helper.id %>">
+  <span aria-hidden="true">#</span>
+  <span class="govuk-visually-hidden">Section titled #{text}</span>
+</a>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/heading.yml
+++ b/app/views/govuk_publishing_components/components/docs/heading.yml
@@ -85,3 +85,10 @@ examples:
     data:
       text: "Ein gweinidogion"
       lang: "cy"
+  with_anchor:
+    description: |
+      Turns the heading into an anchor link heading, so that users can easily retrieve the link to this specific section.
+    data:
+      text: "Heading"
+      id: "heading"
+      is_anchor: true

--- a/spec/components/heading_spec.rb
+++ b/spec/components/heading_spec.rb
@@ -118,4 +118,12 @@ describe "Heading", type: :view do
     render_component(text: "Inverted", inverse: true)
     assert_select ".gem-c-heading.gem-c-heading--inverse"
   end
+
+  it "augments heading with anchor link" do
+    render_component(text: "Heading", heading_level: 2, id: "heading", is_anchor: true)
+    assert_select "h2#heading"
+    assert_select "h2#heading + a[href='#heading']"
+    assert_select "h2#heading + a[href='#heading'] span[aria-hidden='true']"
+    assert_select "h2#heading + a[href='#heading'] span.govuk-visually-hidden"
+  end
 end


### PR DESCRIPTION
## What

Defines a new `is_anchor` parameter which, when set to `true`, enhances the heading into an anchor link heading. This is a POC while frontend devs evaluate a few different UX approaches.

We still need to consider a couple of points:

1. CSS and JS
2. Do all frontend apps have govuk_publishing_components installed, and specifically the 'heading' component?

## Why
For GIFT week, we're exploring making it easier for users to share links to specific sections on GOV.UK pages, in a similar style to GitHub ([example](https://github.com/alphagov/govuk-developer-docs#before-running-the-app)).

Trello: https://trello.com/c/Gz6dirLk/36-turn-headings-into-anchor-links

## Visual Changes
TBC

<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before


### After
