### PR TITLE
Remove jasmine jquery from tests 1

### DIFF
--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -64,7 +64,7 @@ describe('Cookie banner', function () {
     var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
 
     expect(element.offsetWidth > 0 || element.offsetHeight > 0).toBeTruthy()
-    expect(cookieBannerMain.offsetWidth > 0 || cookieBannerMain.offsetHeight > 0 ).toBeTruthy()
+    expect(cookieBannerMain.offsetWidth > 0 || cookieBannerMain.offsetHeight > 0).toBeTruthy()
     expect(cookieBannerConfirmation).toBeHidden()
   })
 

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -63,8 +63,8 @@ describe('Cookie banner', function () {
     var cookieBannerMain = document.querySelector('.js-banner-wrapper')
     var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
 
-    expect(element).toBeVisible()
-    expect(cookieBannerMain).toBeVisible()
+    expect(element.offsetWidth > 0 || element.offsetHeight > 0).toBeTruthy()
+    expect(cookieBannerMain.offsetWidth > 0 || cookieBannerMain.offsetHeight > 0 ).toBeTruthy()
     expect(cookieBannerConfirmation).toBeHidden()
   })
 
@@ -77,8 +77,8 @@ describe('Cookie banner', function () {
     var cookieBannerMain = document.querySelector('.js-banner-wrapper')
     var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
 
-    expect(element).toBeVisible()
-    expect(cookieBannerMain).toBeVisible()
+    expect(element.offsetWidth > 0 || element.offsetHeight > 0).toBeTruthy()
+    expect(cookieBannerMain.offsetWidth > 0 || cookieBannerMain.offsetHeight > 0).toBeTruthy()
     expect(cookieBannerConfirmation).toBeHidden()
   })
 
@@ -164,13 +164,13 @@ describe('Cookie banner', function () {
     var mainCookieBanner = document.querySelector('.gem-c-cookie-banner__message')
     var confirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
 
-    expect(mainCookieBanner).toBeVisible()
+    expect(mainCookieBanner.offsetWidth > 0 || mainCookieBanner.offsetHeight > 0).toBeTruthy()
     expect(confirmationMessage).toBeHidden()
 
     acceptCookiesButton.click()
 
     expect(mainCookieBanner).toBeHidden()
-    expect(confirmationMessage).toBeVisible()
+    expect(confirmationMessage.offsetWidth > 0 || confirmationMessage.offsetHeight > 0).toBeTruthy()
   })
 
   it('set cookies_preferences_set cookie, and re-set cookies_policy expiration date when rejecting cookies', function () {

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -63,8 +63,8 @@ describe('Cookie banner', function () {
     var cookieBannerMain = document.querySelector('.js-banner-wrapper')
     var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
 
-    expect(element.offsetWidth > 0 || element.offsetHeight > 0).toBeTruthy()
-    expect(cookieBannerMain.offsetWidth > 0 || cookieBannerMain.offsetHeight > 0).toBeTruthy()
+    expect(window.isElementVisible(element)).toBeTruthy()
+    expect(window.isElementVisible(cookieBannerMain)).toBeTruthy()
     expect(cookieBannerConfirmation).toBeHidden()
   })
 
@@ -77,8 +77,8 @@ describe('Cookie banner', function () {
     var cookieBannerMain = document.querySelector('.js-banner-wrapper')
     var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
 
-    expect(element.offsetWidth > 0 || element.offsetHeight > 0).toBeTruthy()
-    expect(cookieBannerMain.offsetWidth > 0 || cookieBannerMain.offsetHeight > 0).toBeTruthy()
+    expect(window.isElementVisible(element)).toBeTruthy()
+    expect(window.isElementVisible(cookieBannerMain)).toBeTruthy()
     expect(cookieBannerConfirmation).toBeHidden()
   })
 
@@ -164,13 +164,13 @@ describe('Cookie banner', function () {
     var mainCookieBanner = document.querySelector('.gem-c-cookie-banner__message')
     var confirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
 
-    expect(mainCookieBanner.offsetWidth > 0 || mainCookieBanner.offsetHeight > 0).toBeTruthy()
+    expect(window.isElementVisible(mainCookieBanner)).toBeTruthy()
     expect(confirmationMessage).toBeHidden()
 
     acceptCookiesButton.click()
 
     expect(mainCookieBanner).toBeHidden()
-    expect(confirmationMessage.offsetWidth > 0 || confirmationMessage.offsetHeight > 0).toBeTruthy()
+    expect(window.isElementVisible(confirmationMessage)).toBeTruthy()
   })
 
   it('set cookies_preferences_set cookie, and re-set cookies_policy expiration date when rejecting cookies', function () {

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -575,7 +575,7 @@ describe('Feedback component', function () {
           responseText: '{"errors": {"path": ["can\'t be blank"], "another": ["weird error"]}}'
         })
 
-        expect($('#something-is-wrong .js-errors').html()).toContainText(
+        expect(document.querySelector('#something-is-wrong .js-errors').textContent).toBe(
           'Sorry, we’re unable to receive your message right now. ' +
           'If the problem persists, we have other ways for you to provide ' +
           'feedback on the contact page.'
@@ -645,7 +645,7 @@ describe('Feedback component', function () {
           responseText: '{"errors": {"path": ["can\'t be blank"], "another": ["weird error"]}}'
         })
 
-        expect($('#page-is-not-useful .js-errors').html()).toContainText(
+        expect(document.querySelector('#page-is-not-useful .js-errors').textContent).toBe(
           'Sorry, we’re unable to receive your message right now. ' +
           'If the problem persists, we have other ways for you to provide ' +
           'feedback on the contact page.'
@@ -687,12 +687,12 @@ describe('Feedback component', function () {
       })
 
       it('displays the generic error message in place of the less helpful "email survey sign up failure"', function () {
-        expect($('.gem-c-feedback__error-summary').html()).toContainText(
+        expect(document.querySelector('.gem-c-feedback__error-summary').textContent).toBe(
           'Sorry, we’re unable to receive your message right now. ' +
           'If the problem persists, we have other ways for you to provide ' +
           'feedback on the contact page.'
         )
-        expect($('.gem-c-feedback__error-summary').html()).not.toContainText('email survey sign up failure')
+        expect(document.querySelector('.gem-c-feedback__error-summary').textContent).not.toBe('email survey sign up failure')
       })
     })
 
@@ -715,7 +715,7 @@ describe('Feedback component', function () {
       })
 
       it('displays a generic error message', function () {
-        expect($('.gem-c-feedback__error-summary').html()).toContainText(
+        expect(document.querySelector('.gem-c-feedback__error-summary').textContent).toBe(
           'Sorry, we’re unable to receive your message right now. ' +
           'If the problem persists, we have other ways for you to provide ' +
           'feedback on the contact page.'
@@ -748,7 +748,7 @@ describe('Feedback component', function () {
       })
 
       it('displays a generic error message', function () {
-        expect($('.gem-c-feedback__error-summary').html()).toContainText(
+        expect(document.querySelector('.gem-c-feedback__error-summary').textContent).toBe(
           'Sorry, we’re unable to receive your message right now. ' +
           'If the problem persists, we have other ways for you to provide ' +
           'feedback on the contact page.'

--- a/spec/javascripts/components/layout-super-navigation-header-spec.js
+++ b/spec/javascripts/components/layout-super-navigation-header-spec.js
@@ -709,20 +709,20 @@ describe('The super header navigation', function () {
       })
 
       it('does not have the `hidden` attribute', function () {
-        expect($button).not.toHaveAttr('hidden')
+        expect($button.getAttribute('hidden')).toBe(null)
       })
 
       describe('has the correct ARIA attributes', function () {
         it('has `aria-controls` set to "super-navigation-menu"', function () {
-          expect($button).toHaveAttr('aria-controls', 'super-navigation-menu')
+          expect($button.getAttribute('aria-controls')).toBe('super-navigation-menu')
         })
 
         it('has `aria-label` set to "Show navigation menu"', function () {
-          expect($button).toHaveAttr('aria-label', 'Show navigation menu')
+          expect($button.getAttribute('aria-label')).toBe('Show navigation menu')
         })
 
         it('has `aria-expanded` set to false', function () {
-          expect($button).toHaveAttr('aria-expanded', 'false')
+          expect($button.getAttribute('aria-expanded')).toBe('false')
         })
       })
 
@@ -738,16 +738,16 @@ describe('The super header navigation', function () {
         })
 
         it('opens the menu', function () {
-          expect($menu).not.toHaveAttr('hidden')
+          expect($menu.getAttribute('hidden')).toBe(null)
         })
 
         it('updates the button’s `aria-expanded` attribute to true', function () {
-          expect($button).toHaveAttr('aria-expanded', 'true')
+          expect($button.getAttribute('aria-expanded')).toBe('true')
         })
 
         it('updates the button’s `aria-label`', function () {
           var hideLabel = $button.getAttribute('data-text-for-hide')
-          expect($button).toHaveAttr('aria-label', hideLabel)
+          expect($button.getAttribute('aria-label')).toBe(hideLabel)
         })
 
         it('triggers the correct google analytics custom event', function () {
@@ -769,21 +769,21 @@ describe('The super header navigation', function () {
         })
 
         it('opens and then closes the menu', function () {
-          expect($menu).not.toHaveAttr('hidden')
+          expect($menu.getAttribute('hidden')).toBe(null)
           $button.click()
-          expect($menu).toHaveAttr('hidden')
+          expect($menu.getAttribute('hidden')).toBeTruthy()
         })
 
         it('sets the button’s `aria-expanded` attribute to true, then false', function () {
-          expect($button).toHaveAttr('aria-expanded', 'true')
+          expect($button.getAttribute('aria-expanded')).toBe('true')
           $button.click()
-          expect($button).toHaveAttr('aria-expanded', 'false')
+          expect($button.getAttribute('aria-expanded')).toBe('false')
         })
 
         it('sets the button’s `aria-label` attribute to "Hide navigation menu", then "Show navigation menu"', function () {
-          expect($button).toHaveAttr('aria-label', 'Hide navigation menu')
+          expect($button.getAttribute('aria-label')).toBe('Hide navigation menu')
           $button.click()
-          expect($button).toHaveAttr('aria-label', 'Show navigation menu')
+          expect($button.getAttribute('aria-label')).toBe('Show navigation menu')
         })
 
         it('triggers the correct google analytics custom event', function () {
@@ -800,21 +800,21 @@ describe('The super header navigation', function () {
 
         $button.click()
 
-        expect($searchButton).toHaveAttr('aria-expanded', 'false')
-        expect($searchButton).toHaveAttr('aria-label', 'Show search menu')
-        expect($searchMenu).toHaveAttr('hidden')
+        expect($searchButton.getAttribute('aria-expanded')).toBe('false')
+        expect($searchButton.getAttribute('aria-label')).toBe('Show search menu')
+        expect($searchMenu.getAttribute('hidden')).toBeTruthy()
 
         $searchButton.click()
 
-        expect($searchButton).toHaveAttr('aria-expanded', 'true')
-        expect($searchButton).toHaveAttr('aria-label', 'Hide search menu')
-        expect($searchMenu).not.toHaveAttr('hidden')
+        expect($searchButton.getAttribute('aria-expanded')).toBe('true')
+        expect($searchButton.getAttribute('aria-label')).toBe('Hide search menu')
+        expect($searchMenu.getAttribute('hidden')).toBe(null)
 
         $button.click()
 
-        expect($searchButton).toHaveAttr('aria-expanded', 'false')
-        expect($searchButton).toHaveAttr('aria-label', 'Show search menu')
-        expect($searchMenu).toHaveAttr('hidden')
+        expect($searchButton.getAttribute('aria-expanded')).toBe('false')
+        expect($searchButton.getAttribute('aria-label')).toBe('Show search menu')
+        expect($searchMenu.getAttribute('hidden')).toBeTruthy()
       })
     })
 
@@ -826,20 +826,20 @@ describe('The super header navigation', function () {
       })
 
       it('does not have the `hidden` attribute', function () {
-        expect($button).not.toHaveAttr('hidden')
+        expect($button.getAttribute('hidden')).toBe(null)
       })
 
       describe('has the correct ARIA attributes', function () {
         it('has `aria-controls` set to "super-search-menu"', function () {
-          expect($button).toHaveAttr('aria-controls', 'super-search-menu')
+          expect($button.getAttribute('aria-controls')).toBe('super-search-menu')
         })
 
         it('has `aria-label` set to "Show search menu"', function () {
-          expect($button).toHaveAttr('aria-label', 'Show search menu')
+          expect($button.getAttribute('aria-label')).toBe('Show search menu')
         })
 
         it('has `aria-expanded` set to false', function () {
-          expect($button).toHaveAttr('aria-expanded', 'false')
+          expect($button.getAttribute('aria-expanded')).toBe('false')
         })
       })
 
@@ -855,16 +855,16 @@ describe('The super header navigation', function () {
         })
 
         it('opens the menu', function () {
-          expect($menu).not.toHaveAttr('hidden')
+          expect($menu.getAttribute('hidden')).toBe(null)
         })
 
         it('updates the button’s `aria-expanded` attribute to true', function () {
-          expect($button).toHaveAttr('aria-expanded', 'true')
+          expect($button.getAttribute('aria-expanded')).toBe('true')
         })
 
         it('updates the button’s `aria-label`', function () {
           var hideLabel = $button.getAttribute('data-text-for-hide')
-          expect($button).toHaveAttr('aria-label', hideLabel)
+          expect($button.getAttribute('aria-label')).toBe(hideLabel)
         })
       })
 
@@ -880,21 +880,21 @@ describe('The super header navigation', function () {
         })
 
         it('opens and then closes the menu', function () {
-          expect($menu).not.toHaveAttr('hidden')
+          expect($menu.getAttribute('hidden')).toBe(null)
           $button.click()
-          expect($menu).toHaveAttr('hidden')
+          expect($menu.getAttribute('hidden')).toBeTruthy()
         })
 
         it('sets the button’s `aria-expanded` attribute to true, then false', function () {
-          expect($button).toHaveAttr('aria-expanded', 'true')
+          expect($button.getAttribute('aria-expanded')).toBe('true')
           $button.click()
-          expect($button).toHaveAttr('aria-expanded', 'false')
+          expect($button.getAttribute('aria-expanded')).toBe('false')
         })
 
         it('sets the button’s `aria-label` attribute to "Hide search menu", then "Show search menu"', function () {
-          expect($button).toHaveAttr('aria-label', 'Hide search menu')
+          expect($button.getAttribute('aria-label')).toBe('Hide search menu')
           $button.click()
-          expect($button).toHaveAttr('aria-label', 'Show search menu')
+          expect($button.getAttribute('aria-label')).toBe('Show search menu')
         })
       })
 
@@ -904,21 +904,21 @@ describe('The super header navigation', function () {
 
         $button.click()
 
-        expect($navigationButton).toHaveAttr('aria-expanded', 'false')
-        expect($navigationButton).toHaveAttr('aria-label', 'Show navigation menu')
-        expect($navigationMenu).toHaveAttr('hidden')
+        expect($navigationButton.getAttribute('aria-expanded')).toBe('false')
+        expect($navigationButton.getAttribute('aria-label')).toBe('Show navigation menu')
+        expect($navigationMenu.getAttribute('hidden')).toBeTruthy()
 
         $navigationButton.click()
 
-        expect($navigationButton).toHaveAttr('aria-expanded', 'true')
-        expect($navigationButton).toHaveAttr('aria-label', 'Hide navigation menu')
-        expect($navigationMenu).not.toHaveAttr('hidden')
+        expect($navigationButton.getAttribute('aria-expanded')).toBe('true')
+        expect($navigationButton.getAttribute('aria-label')).toBe('Hide navigation menu')
+        expect($navigationMenu.getAttribute('hidden')).toBe(null)
 
         $button.click()
 
-        expect($navigationButton).toHaveAttr('aria-expanded', 'false')
-        expect($navigationButton).toHaveAttr('aria-label', 'Show navigation menu')
-        expect($navigationMenu).toHaveAttr('hidden')
+        expect($navigationButton.getAttribute('aria-expanded')).toBe('false')
+        expect($navigationButton.getAttribute('aria-label')).toBe('Show navigation menu')
+        expect($navigationMenu.getAttribute('hidden')).toBeTruthy()
       })
     })
   })
@@ -944,7 +944,7 @@ describe('The super header navigation', function () {
       })
 
       it('does have the `hidden` attribute', function () {
-        expect($button).toHaveAttr('hidden')
+        expect($button.getAttribute('hidden')).toBeTruthy()
       })
     })
 
@@ -956,20 +956,20 @@ describe('The super header navigation', function () {
       })
 
       it('does not have the `hidden` attribute', function () {
-        expect($button).not.toHaveAttr('hidden')
+        expect($button.getAttribute('hidden')).toBe(null)
       })
 
       describe('has the correct ARIA attributes', function () {
         it('has `aria-controls` set to "super-search-menu"', function () {
-          expect($button).toHaveAttr('aria-controls', 'super-search-menu')
+          expect($button.getAttribute('aria-controls')).toBe('super-search-menu')
         })
 
         it('has `aria-label` set to "Show search menu"', function () {
-          expect($button).toHaveAttr('aria-label', 'Show search menu')
+          expect($button.getAttribute('aria-label')).toBe('Show search menu')
         })
 
         it('has `aria-expanded` set to false', function () {
-          expect($button).toHaveAttr('aria-expanded', 'false')
+          expect($button.getAttribute('aria-expanded')).toBe('false')
         })
       })
     })

--- a/spec/javascripts/components/modal-dialogue-spec.js
+++ b/spec/javascripts/components/modal-dialogue-spec.js
@@ -50,7 +50,7 @@ describe('Modal dialogue component', function () {
 
     it('should show the modal dialogue', function () {
       var modal = document.querySelector('.gem-c-modal-dialogue')
-      expect(modal.offsetWidth > 0 || modal.offsetHeight > 0).toBeTruthy()
+      expect(window.isElementVisible(modal)).toBeTruthy()
     })
   })
 
@@ -108,7 +108,7 @@ describe('Modal dialogue component', function () {
 
     it('should show the modal dialogue', function () {
       var modal = document.querySelector('.gem-c-modal-dialogue')
-      expect(modal.offsetWidth > 0 || modal.offsetHeight > 0).toBeTruthy()
+      expect(window.isElementVisible(modal)).toBeTruthy()
     })
 
     it('should focus the modal dialogue', function () {

--- a/spec/javascripts/components/modal-dialogue-spec.js
+++ b/spec/javascripts/components/modal-dialogue-spec.js
@@ -50,7 +50,7 @@ describe('Modal dialogue component', function () {
 
     it('should show the modal dialogue', function () {
       var modal = document.querySelector('.gem-c-modal-dialogue')
-      expect(modal).toBeVisible()
+      expect(modal.offsetWidth > 0 || modal.offsetHeight > 0).toBeTruthy()
     })
   })
 
@@ -108,7 +108,7 @@ describe('Modal dialogue component', function () {
 
     it('should show the modal dialogue', function () {
       var modal = document.querySelector('.gem-c-modal-dialogue')
-      expect(modal).toBeVisible()
+      expect(modal.offsetWidth > 0 || modal.offsetHeight > 0).toBeTruthy()
     })
 
     it('should focus the modal dialogue', function () {

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -188,13 +188,18 @@ describe('A stepnav module', function () {
   })
 
   it('adds a show/hide element to each step', function () {
-    var $stepHeader = $element.find('.js-toggle-panel')
-    expect($stepHeader).toContainElement('.gem-c-step-nav__toggle-link-focus')
-    $stepHeader.find('.gem-c-step-nav__toggle-link-focus').each(function () {
-      expect($(this)).toHaveText('Show')
+    var $stepHeaders = $element[0].querySelectorAll('.js-toggle-panel')
+    var $stepNavToggleLinks = $element[0].querySelectorAll('.gem-c-step-nav__toggle-link-focus')
+    
+    for(var i = 0; i < $stepHeaders.length; i ++) {
+      expect($stepHeaders[i].querySelector('.gem-c-step-nav__toggle-link-focus')).not.toBe(null)
+    }
+
+    for(var i = 0; i < $stepNavToggleLinks.length; i ++) {
+      expect($stepNavToggleLinks[i]).toHaveText('Show')
       // It generates a chevron SVG icon for visual affordance
-      expect($(this).find('.gem-c-step-nav__chevron')).toExist()
-    })
+      expect($stepNavToggleLinks[i].querySelector('.gem-c-step-nav__chevron')).not.toBe(null)
+    }
   })
 
   describe('Clicking the "Show all steps" button', function () {

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -173,7 +173,7 @@ describe('A stepnav module', function () {
   it('inserts a button into each step to show/hide content', function () {
     var $titleButtons = $element[0].querySelectorAll('.js-step-title-button')
 
-    for(var i = 0; i < $titleButtons.length; i++) {
+    for (var i = 0; i < $titleButtons.length; i++) {
       expect($titleButtons[i]).toHaveClass('gem-c-step-nav__button--title')
       expect($titleButtons[i].getAttribute('aria-expanded')).toBe('false')
     }
@@ -190,15 +190,15 @@ describe('A stepnav module', function () {
   it('adds a show/hide element to each step', function () {
     var $stepHeaders = $element[0].querySelectorAll('.js-toggle-panel')
     var $stepNavToggleLinks = $element[0].querySelectorAll('.gem-c-step-nav__toggle-link-focus')
-    
-    for(var i = 0; i < $stepHeaders.length; i ++) {
+
+    for (var i = 0; i < $stepHeaders.length; i++) {
       expect($stepHeaders[i].querySelector('.gem-c-step-nav__toggle-link-focus')).not.toBe(null)
     }
 
-    for(var i = 0; i < $stepNavToggleLinks.length; i ++) {
-      expect($stepNavToggleLinks[i]).toHaveText('Show')
+    for (var j = 0; j < $stepNavToggleLinks.length; j++) {
+      expect($stepNavToggleLinks[j]).toHaveText('Show')
       // It generates a chevron SVG icon for visual affordance
-      expect($stepNavToggleLinks[i].querySelector('.gem-c-step-nav__chevron')).not.toBe(null)
+      expect($stepNavToggleLinks[j].querySelector('.gem-c-step-nav__chevron')).not.toBe(null)
     }
   })
 
@@ -218,7 +218,7 @@ describe('A stepnav module', function () {
     })
 
     it('changes the Show/Hide all button text to "Hide all steps"', function () {
-      expect($element.find('.js-step-controls-button')).toContainText('Hide all steps')
+      expect($element[0].querySelector('.js-step-controls-button').textContent).toBe('Hide all steps')
     })
 
     it('changes all the "show" elements to say "hide"', function () {
@@ -244,7 +244,7 @@ describe('A stepnav module', function () {
     })
 
     it('changes the Show/Hide all button text to "Show all steps"', function () {
-      expect($element.find('.js-step-controls-button')).toContainText('Show all steps')
+      expect($element[0].querySelector('.js-step-controls-button').textContent).toBe('Show all steps')
     })
 
     it('changes all the "hide" elements to say "show"', function () {

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -155,7 +155,7 @@ describe('A stepnav module', function () {
   it('has a show/hide all button', function () {
     var $showHideAllButton = $element[0].querySelector('.js-step-controls-button')
 
-    expect($showHideAllButton).toExist()
+    expect($showHideAllButton).not.toBe(null)
     expect($showHideAllButton).toHaveText('Show all steps')
     // It has an aria-expanded false attribute as all steps are hidden
     expect($showHideAllButton.getAttribute('aria-expanded')).toBe('false')

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -153,16 +153,16 @@ describe('A stepnav module', function () {
   })
 
   it('has a show/hide all button', function () {
-    var $showHideAllButton = $element.find('.js-step-controls-button')
+    var $showHideAllButton = $element[0].querySelector('.js-step-controls-button')
 
     expect($showHideAllButton).toExist()
     expect($showHideAllButton).toHaveText('Show all steps')
     // It has an aria-expanded false attribute as all steps are hidden
-    expect($showHideAllButton).toHaveAttr('aria-expanded', 'false')
+    expect($showHideAllButton.getAttribute('aria-expanded')).toBe('false')
     // It has an aria-controls attribute that includes all the step_content IDs
-    expect($showHideAllButton).toHaveAttr('aria-controls', 'step-panel-topic-step-one-1')
+    expect($showHideAllButton.getAttribute('aria-controls')).toBe('step-panel-topic-step-one-1')
     // It generates a chevron SVG icon for visual affordance
-    expect($showHideAllButton.find('.gem-c-step-nav__chevron')).toExist()
+    expect($showHideAllButton.querySelector('.gem-c-step-nav__chevron')).not.toBe(null)
   })
 
   it('has no steps which have an shown state', function () {
@@ -171,12 +171,14 @@ describe('A stepnav module', function () {
   })
 
   it('inserts a button into each step to show/hide content', function () {
-    var $titleButton = $element.find('.js-step-title-button')
+    var $titleButtons = $element[0].querySelectorAll('.js-step-title-button')
 
-    expect($titleButton).toHaveClass('gem-c-step-nav__button--title')
-    expect($titleButton).toHaveAttr('aria-expanded', 'false')
-    expect($titleButton[0]).toHaveAttr('aria-controls', 'step-panel-topic-step-one-1')
-    expect($titleButton[1]).toHaveAttr('aria-controls', 'step-panel-topic-step-two-1')
+    for(var i = 0; i < $titleButtons.length; i++) {
+      expect($titleButtons[i]).toHaveClass('gem-c-step-nav__button--title')
+      expect($titleButtons[i].getAttribute('aria-expanded')).toBe('false')
+    }
+    expect($titleButtons[0].getAttribute('aria-controls')).toBe('step-panel-topic-step-one-1')
+    expect($titleButtons[1].getAttribute('aria-controls')).toBe('step-panel-topic-step-two-1')
   })
 
   it('ensures all step content is hidden', function () {
@@ -268,9 +270,9 @@ describe('A stepnav module', function () {
 
     // When a step is open (testing: toggleState, setExpandedState)
     it('has a an aria-expanded attribute and the value is true', function () {
-      var $stepLink = $element.find('.gem-c-step-nav__header .gem-c-step-nav__button--title').first()
+      var $stepLink = $element[0].querySelector('.gem-c-step-nav__header .gem-c-step-nav__button--title')
       $stepLink.click()
-      expect($stepLink).toHaveAttr('aria-expanded', 'true')
+      expect($stepLink.getAttribute('aria-expanded')).toBe('true')
     })
 
     it('triggers a google analytics custom event when clicking on the title', function () {
@@ -327,11 +329,11 @@ describe('A stepnav module', function () {
 
     // When a step is hidden (testing: toggleState, setExpandedState)
     it('has a an aria-expanded attribute and the value is false', function () {
-      var $stepLink = $element.find('.gem-c-step-nav__header .gem-c-step-nav__button--title')
+      var $stepLink = $element[0].querySelector('.gem-c-step-nav__header .gem-c-step-nav__button--title')
       $stepLink.click()
-      expect($stepLink).toHaveAttr('aria-expanded', 'true')
+      expect($stepLink.getAttribute('aria-expanded')).toBe('true')
       $stepLink.click()
-      expect($stepLink).toHaveAttr('aria-expanded', 'false')
+      expect($stepLink.getAttribute('aria-expanded')).toBe('false')
     })
 
     it('triggers a google analytics custom event when clicking on the title', function () {

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -32,3 +32,7 @@ beforeEach(function () {
 afterEach(function () {
   resetCookies()
 })
+
+function isElementVisible(element) {
+  return !!( element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+}


### PR DESCRIPTION
## What
This PR removes the following `jasmine-jquery` helper functions and replaces them with a vanilla JS alternative:

- `toBeVisible()`
- `toContainElement()`
- `toContainText()`
- `toExist()`
- `toHaveAttr()`

## Why
The `jasmine-jquery` helper functions were causing [errors when running tests](https://github.com/alphagov/govuk_publishing_components/issues/2902) and so they have been replaced with a vanilla JS alternative. This also removes our tests' reliance on the `jasmine-jquery` library (which is no longer actively maintained).

## Visual Changes
N/A
