### PR TITLE
Remove jasmine jquery from tests 2

### DIFF
--- a/spec/javascripts/components/checkboxes-spec.js
+++ b/spec/javascripts/components/checkboxes-spec.js
@@ -60,7 +60,7 @@ describe('Checkboxes component', function () {
   var $nonExclusiveOptions
 
   beforeEach(function () {
-    window.setFixtures(FIXTURE)
+    window.specHelpers.setFixtures(FIXTURE)
     loadCheckboxesComponent()
 
     $parentCheckboxWrapper = $('.govuk-checkboxes--nested:eq(0)').closest('.govuk-checkboxes__item')

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -63,9 +63,9 @@ describe('Cookie banner', function () {
     var cookieBannerMain = document.querySelector('.js-banner-wrapper')
     var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
 
-    expect(window.isElementVisible(element)).toBeTruthy()
-    expect(window.isElementVisible(cookieBannerMain)).toBeTruthy()
-    expect(window.isElementHidden(cookieBannerConfirmation)).toEqual(true)
+    expect(window.specHelpers.isElementVisible(element)).toBeTruthy()
+    expect(window.specHelpers.isElementVisible(cookieBannerMain)).toBeTruthy()
+    expect(window.specHelpers.isElementHidden(cookieBannerConfirmation)).toEqual(true)
   })
 
   it('should show the cookie banner when preferences have not been actively set', function () {
@@ -77,9 +77,9 @@ describe('Cookie banner', function () {
     var cookieBannerMain = document.querySelector('.js-banner-wrapper')
     var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
 
-    expect(window.isElementVisible(element)).toBeTruthy()
-    expect(window.isElementVisible(cookieBannerMain)).toBeTruthy()
-    expect(window.isElementHidden(cookieBannerConfirmation)).toEqual(true)
+    expect(window.specHelpers.isElementVisible(element)).toBeTruthy()
+    expect(window.specHelpers.isElementVisible(cookieBannerMain)).toBeTruthy()
+    expect(window.specHelpers.isElementHidden(cookieBannerConfirmation)).toEqual(true)
   })
 
   it('should hide the cookie banner when preferences have been actively set', function () {
@@ -88,7 +88,7 @@ describe('Cookie banner', function () {
     var element = document.querySelector('[data-module="cookie-banner"]')
     new GOVUK.Modules.CookieBanner(element).init()
 
-    expect(window.isElementHidden(element)).toEqual(true)
+    expect(window.specHelpers.isElementHidden(element)).toEqual(true)
   })
 
   it('sets a default consent cookie', function () {
@@ -164,13 +164,13 @@ describe('Cookie banner', function () {
     var mainCookieBanner = document.querySelector('.js-banner-wrapper')
     var confirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
 
-    expect(window.isElementVisible(mainCookieBanner)).toBeTruthy()
-    expect(window.isElementHidden(confirmationMessage)).toEqual(true)
+    expect(window.specHelpers.isElementVisible(mainCookieBanner)).toBeTruthy()
+    expect(window.specHelpers.isElementHidden(confirmationMessage)).toEqual(true)
 
     acceptCookiesButton.click()
 
-    expect(window.isElementHidden(mainCookieBanner)).toEqual(true)
-    expect(window.isElementVisible(confirmationMessage)).toBeTruthy()
+    expect(window.specHelpers.isElementHidden(mainCookieBanner)).toEqual(true)
+    expect(window.specHelpers.isElementVisible(confirmationMessage)).toBeTruthy()
   })
 
   it('set cookies_preferences_set cookie, and re-set cookies_policy expiration date when rejecting cookies', function () {
@@ -195,7 +195,7 @@ describe('Cookie banner', function () {
     var link = document.querySelector('button[data-hide-cookie-banner="true"]')
     link.dispatchEvent(new window.Event('click'))
 
-    expect(window.isElementHidden(element)).toEqual(true)
+    expect(window.specHelpers.isElementHidden(element)).toEqual(true)
     expect(GOVUK.getCookie('cookies_preferences_set')).toBeTruthy()
   })
 
@@ -214,7 +214,7 @@ describe('Cookie banner', function () {
     it('should hide the cookie banner', function () {
       var element = document.querySelector('[data-module="cookie-banner"]')
       new GOVUK.Modules.CookieBanner(element).init()
-      expect(window.isElementHidden(element)).toEqual(true)
+      expect(window.specHelpers.isElementHidden(element)).toEqual(true)
     })
   })
 })

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -161,7 +161,7 @@ describe('Cookie banner', function () {
     new GOVUK.Modules.CookieBanner(element).init()
 
     var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
-    var mainCookieBanner = document.querySelector('.js-banner-wrapper')
+    var mainCookieBanner = document.querySelector('.gem-c-cookie-banner__message')
     var confirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
 
     expect(window.specHelpers.isElementVisible(mainCookieBanner)).toBeTruthy()

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -65,7 +65,7 @@ describe('Cookie banner', function () {
 
     expect(window.isElementVisible(element)).toBeTruthy()
     expect(window.isElementVisible(cookieBannerMain)).toBeTruthy()
-    expect(cookieBannerConfirmation).toBeHidden()
+    expect(window.isElementHidden(cookieBannerConfirmation)).toEqual(true)
   })
 
   it('should show the cookie banner when preferences have not been actively set', function () {
@@ -79,7 +79,7 @@ describe('Cookie banner', function () {
 
     expect(window.isElementVisible(element)).toBeTruthy()
     expect(window.isElementVisible(cookieBannerMain)).toBeTruthy()
-    expect(cookieBannerConfirmation).toBeHidden()
+    expect(window.isElementHidden(cookieBannerConfirmation)).toEqual(true)
   })
 
   it('should hide the cookie banner when preferences have been actively set', function () {
@@ -88,7 +88,7 @@ describe('Cookie banner', function () {
     var element = document.querySelector('[data-module="cookie-banner"]')
     new GOVUK.Modules.CookieBanner(element).init()
 
-    expect(element).toBeHidden()
+    expect(window.isElementHidden(element)).toEqual(true)
   })
 
   it('sets a default consent cookie', function () {
@@ -161,15 +161,15 @@ describe('Cookie banner', function () {
     new GOVUK.Modules.CookieBanner(element).init()
 
     var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
-    var mainCookieBanner = document.querySelector('.gem-c-cookie-banner__message')
+    var mainCookieBanner = document.querySelector('.js-banner-wrapper')
     var confirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
 
     expect(window.isElementVisible(mainCookieBanner)).toBeTruthy()
-    expect(confirmationMessage).toBeHidden()
+    expect(window.isElementHidden(confirmationMessage)).toEqual(true)
 
     acceptCookiesButton.click()
 
-    expect(mainCookieBanner).toBeHidden()
+    expect(window.isElementHidden(mainCookieBanner)).toEqual(true)
     expect(window.isElementVisible(confirmationMessage)).toBeTruthy()
   })
 
@@ -195,7 +195,7 @@ describe('Cookie banner', function () {
     var link = document.querySelector('button[data-hide-cookie-banner="true"]')
     link.dispatchEvent(new window.Event('click'))
 
-    expect(element).toBeHidden()
+    expect(window.isElementHidden(element)).toEqual(true)
     expect(GOVUK.getCookie('cookies_preferences_set')).toBeTruthy()
   })
 
@@ -214,7 +214,7 @@ describe('Cookie banner', function () {
     it('should hide the cookie banner', function () {
       var element = document.querySelector('[data-module="cookie-banner"]')
       new GOVUK.Modules.CookieBanner(element).init()
-      expect(element).toBeHidden()
+      expect(window.isElementHidden(element)).toEqual(true)
     })
   })
 })

--- a/spec/javascripts/components/copy-to-clipboard-spec.js
+++ b/spec/javascripts/components/copy-to-clipboard-spec.js
@@ -17,7 +17,7 @@ describe('Copy to clipboard component', function () {
         '<input value="https://www.gov.uk" class="gem-c-input govuk-input" type="text" readonly="readonly">' +
         '<button class="gem-c-button govuk-button" type="submit">Copy link</button>' +
       '</div>'
-    window.setFixtures(FIXTURE)
+    window.specHelpers.setFixtures(FIXTURE)
   })
 
   it('calls the Web API when clicked', function () {

--- a/spec/javascripts/components/details-spec.js
+++ b/spec/javascripts/components/details-spec.js
@@ -20,7 +20,7 @@ describe('Details component', function () {
         '</summary>' +
       '</details>'
 
-    window.setFixtures(FIXTURE)
+    window.specHelpers.setFixtures(FIXTURE)
   })
 
   afterEach(function () {

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -540,7 +540,7 @@ describe('Feedback component', function () {
         loadFeedbackComponent()
         fillAndSubmitSomethingIsWrongForm()
 
-        expect($('.gem-c-feedback form [type=submit]')).toBeDisabled()
+        expect(window.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(true)
 
         jasmine.Ajax.requests.mostRecent().respondWith({
           status: 422,
@@ -548,7 +548,7 @@ describe('Feedback component', function () {
           responseText: '{"errors": {"description": ["can\'t be blank"]}}'
         })
 
-        expect($('.gem-c-feedback form [type=submit]')).not.toBeDisabled()
+        expect(window.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(false)
       })
 
       it('retains the feedback the user originally entered', function () {
@@ -611,7 +611,7 @@ describe('Feedback component', function () {
         loadFeedbackComponent()
         fillAndSubmitPageIsNotUsefulForm()
 
-        expect($('.gem-c-feedback form [type=submit]')).toBeDisabled()
+        expect(window.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(true)
 
         jasmine.Ajax.requests.mostRecent().respondWith({
           status: 422,
@@ -619,7 +619,7 @@ describe('Feedback component', function () {
           responseText: '{"errors": {"description": ["can\'t be blank"]}}'
         })
 
-        expect($('.gem-c-feedback form [type=submit]')).not.toBeDisabled()
+        expect(window.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(false)
       })
 
       it('retains the feedback the user originally entered', function () {
@@ -728,7 +728,7 @@ describe('Feedback component', function () {
       })
 
       it('re-enables the submit button', function () {
-        expect($('.gem-c-feedback form [type=submit]')).not.toBeDisabled()
+        expect(window.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(false)
       })
     })
 

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -172,7 +172,7 @@ describe('Feedback component', function () {
       var $success = $('.js-prompt-success')
 
       expect(($success).prop('hidden')).toBe(false)
-      expect($success).toHaveText('Thank you for your feedback')
+      expect($success.text()).toEqual('Thank you for your feedback')
     })
 
     it('hides the question links', function () {
@@ -390,7 +390,7 @@ describe('Feedback component', function () {
         var $success = $('.js-prompt-success')
 
         expect(($success).prop('hidden')).toBe(false)
-        expect($success).toHaveText('Thank you for your feedback')
+        expect($success.text()).toEqual('Thank you for your feedback')
       })
 
       it('focusses the success message', function () {
@@ -484,7 +484,7 @@ describe('Feedback component', function () {
         var $prompt = $('.js-prompt-success')
 
         expect(($prompt).prop('hidden')).toBe(false)
-        expect($prompt).toHaveText('Thank you for your feedback')
+        expect($prompt.text()).toEqual('Thank you for your feedback')
       })
 
       it('focusses the success message', function () {

--- a/spec/javascripts/components/feedback-spec.js
+++ b/spec/javascripts/components/feedback-spec.js
@@ -104,7 +104,7 @@ describe('Feedback component', function () {
   '</div>'
 
   beforeEach(function () {
-    window.setFixtures(FIXTURE)
+    window.specHelpers.setFixtures(FIXTURE)
     spyOn(GOVUK.analytics, 'trackEvent')
   })
 
@@ -540,7 +540,7 @@ describe('Feedback component', function () {
         loadFeedbackComponent()
         fillAndSubmitSomethingIsWrongForm()
 
-        expect(window.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(true)
+        expect(window.specHelpers.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(true)
 
         jasmine.Ajax.requests.mostRecent().respondWith({
           status: 422,
@@ -548,7 +548,7 @@ describe('Feedback component', function () {
           responseText: '{"errors": {"description": ["can\'t be blank"]}}'
         })
 
-        expect(window.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(false)
+        expect(window.specHelpers.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(false)
       })
 
       it('retains the feedback the user originally entered', function () {
@@ -611,7 +611,7 @@ describe('Feedback component', function () {
         loadFeedbackComponent()
         fillAndSubmitPageIsNotUsefulForm()
 
-        expect(window.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(true)
+        expect(window.specHelpers.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(true)
 
         jasmine.Ajax.requests.mostRecent().respondWith({
           status: 422,
@@ -619,7 +619,7 @@ describe('Feedback component', function () {
           responseText: '{"errors": {"description": ["can\'t be blank"]}}'
         })
 
-        expect(window.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(false)
+        expect(window.specHelpers.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(false)
       })
 
       it('retains the feedback the user originally entered', function () {
@@ -728,7 +728,7 @@ describe('Feedback component', function () {
       })
 
       it('re-enables the submit button', function () {
-        expect(window.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(false)
+        expect(window.specHelpers.isElementDisabled('.gem-c-feedback form [type=submit]')).toEqual(false)
       })
     })
 

--- a/spec/javascripts/components/initial-focus-spec.js
+++ b/spec/javascripts/components/initial-focus-spec.js
@@ -18,7 +18,7 @@ describe('Initial focus script', function () {
         '<div class="gem-c-success-summary__body">A further description</div>' +
       '</div>'
 
-    window.setFixtures(FIXTURE)
+    window.specHelpers.setFixtures(FIXTURE)
   })
 
   it('focus', function () {

--- a/spec/javascripts/components/layout-super-navigation-header-spec.js
+++ b/spec/javascripts/components/layout-super-navigation-header-spec.js
@@ -684,7 +684,7 @@ describe('The super header navigation', function () {
     it('has the initialised class once the JavaScript has run', function () {
       var $module = document.querySelector('[data-module="super-navigation-mega-menu"]')
 
-      expect($module).toHaveClass('js-module-initialised')
+      expect(window.isClassOnElement($module, 'js-module-initialised')).toEqual(true)
     })
   })
 

--- a/spec/javascripts/components/layout-super-navigation-header-spec.js
+++ b/spec/javascripts/components/layout-super-navigation-header-spec.js
@@ -684,7 +684,7 @@ describe('The super header navigation', function () {
     it('has the initialised class once the JavaScript has run', function () {
       var $module = document.querySelector('[data-module="super-navigation-mega-menu"]')
 
-      expect(window.isClassOnElement($module, 'js-module-initialised')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($module, 'js-module-initialised')).toEqual(true)
     })
   })
 

--- a/spec/javascripts/components/metadata-spec.js
+++ b/spec/javascripts/components/metadata-spec.js
@@ -19,7 +19,7 @@ describe('The metadata component', function () {
           '<a data-controls="target" data-expanded aria-expanded="false"></a>' +
           '<div id="target" class="js-hidden">Target</div>' +
         '</div>'
-      window.setFixtures(FIXTURE)
+      window.specHelpers.setFixtures(FIXTURE)
       element = document.querySelector('[data-module="metadata"]')
       target = document.querySelector('#toggle-me')
 
@@ -32,7 +32,7 @@ describe('The metadata component', function () {
 
     it('does not click target if target does not exist', function () {
       var FIXTURE = '<div data-module="metadata"><a href="#toggle-me" class="js-see-all-updates-link"></a></div>'
-      window.setFixtures(FIXTURE)
+      window.specHelpers.setFixtures(FIXTURE)
       element = document.querySelector('[data-module="metadata"]')
 
       init(element)
@@ -45,7 +45,7 @@ describe('The metadata component', function () {
 
     it('does not click target if target is already expanded', function () {
       var FIXTURE = '<div data-module="metadata"><a href="#toggle-me" class="js-see-all-updates-link"></a></div><div id="toggle-me" data-module="gem-toggle"><a aria-expanded="true"></a></div>'
-      window.setFixtures(FIXTURE)
+      window.specHelpers.setFixtures(FIXTURE)
       element = document.querySelector('[data-module="metadata"]')
       target = document.querySelector('#toggle-me')
 

--- a/spec/javascripts/components/modal-dialogue-spec.js
+++ b/spec/javascripts/components/modal-dialogue-spec.js
@@ -82,7 +82,7 @@ describe('Modal dialogue component', function () {
       modal.resize('wide')
 
       var dialogBox = modal.querySelector('.gem-c-modal-dialogue__box')
-      expect(dialogBox).toHaveClass('gem-c-modal-dialogue__box--wide')
+      expect(window.isClassOnElement(dialogBox, 'gem-c-modal-dialogue__box--wide')).toEqual(true)
     })
 
     it('should resize the modal to narrow width', function () {
@@ -91,7 +91,7 @@ describe('Modal dialogue component', function () {
       modal.resize('narrow')
 
       var dialogBox = modal.querySelector('.gem-c-modal-dialogue__box')
-      expect(dialogBox).not.toHaveClass('gem-c-modal-dialogue__box--wide')
+      expect(window.isClassOnElement(dialogBox, 'gem-c-modal-dialogue__box--wide')).toEqual(false)
     })
   })
 

--- a/spec/javascripts/components/modal-dialogue-spec.js
+++ b/spec/javascripts/components/modal-dialogue-spec.js
@@ -50,7 +50,7 @@ describe('Modal dialogue component', function () {
 
     it('should show the modal dialogue', function () {
       var modal = document.querySelector('.gem-c-modal-dialogue')
-      expect(window.isElementVisible(modal)).toBeTruthy()
+      expect(window.specHelpers.isElementVisible(modal)).toBeTruthy()
     })
   })
 
@@ -60,7 +60,7 @@ describe('Modal dialogue component', function () {
       modal.open()
 
       keyPress(modal, 27)
-      expect(window.isElementHidden(modal)).toEqual(true)
+      expect(window.specHelpers.isElementHidden(modal)).toEqual(true)
     })
   })
 
@@ -72,7 +72,7 @@ describe('Modal dialogue component', function () {
 
       var modal = document.querySelector('.gem-c-modal-dialogue')
       document.querySelector('.gem-c-modal-dialogue__close-button').click()
-      expect(window.isElementHidden(modal)).toEqual(true)
+      expect(window.specHelpers.isElementHidden(modal)).toEqual(true)
     })
   })
 
@@ -82,7 +82,7 @@ describe('Modal dialogue component', function () {
       modal.resize('wide')
 
       var dialogBox = modal.querySelector('.gem-c-modal-dialogue__box')
-      expect(window.isClassOnElement(dialogBox, 'gem-c-modal-dialogue__box--wide')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement(dialogBox, 'gem-c-modal-dialogue__box--wide')).toEqual(true)
     })
 
     it('should resize the modal to narrow width', function () {
@@ -91,7 +91,7 @@ describe('Modal dialogue component', function () {
       modal.resize('narrow')
 
       var dialogBox = modal.querySelector('.gem-c-modal-dialogue__box')
-      expect(window.isClassOnElement(dialogBox, 'gem-c-modal-dialogue__box--wide')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement(dialogBox, 'gem-c-modal-dialogue__box--wide')).toEqual(false)
     })
   })
 
@@ -108,7 +108,7 @@ describe('Modal dialogue component', function () {
 
     it('should show the modal dialogue', function () {
       var modal = document.querySelector('.gem-c-modal-dialogue')
-      expect(window.isElementVisible(modal)).toBeTruthy()
+      expect(window.specHelpers.isElementVisible(modal)).toBeTruthy()
     })
 
     it('should focus the modal dialogue', function () {
@@ -122,7 +122,7 @@ describe('Modal dialogue component', function () {
       var modal = document.querySelector('.gem-c-modal-dialogue')
       modal.open()
       modal.close()
-      expect(window.isElementHidden(modal)).toEqual(true)
+      expect(window.specHelpers.isElementHidden(modal)).toEqual(true)
     })
   })
 })

--- a/spec/javascripts/components/modal-dialogue-spec.js
+++ b/spec/javascripts/components/modal-dialogue-spec.js
@@ -60,7 +60,7 @@ describe('Modal dialogue component', function () {
       modal.open()
 
       keyPress(modal, 27)
-      expect(modal).toBeHidden()
+      expect(window.isElementHidden(modal)).toEqual(true)
     })
   })
 
@@ -72,7 +72,7 @@ describe('Modal dialogue component', function () {
 
       var modal = document.querySelector('.gem-c-modal-dialogue')
       document.querySelector('.gem-c-modal-dialogue__close-button').click()
-      expect(modal).toBeHidden()
+      expect(window.isElementHidden(modal)).toEqual(true)
     })
   })
 
@@ -122,7 +122,7 @@ describe('Modal dialogue component', function () {
       var modal = document.querySelector('.gem-c-modal-dialogue')
       modal.open()
       modal.close()
-      expect(modal).toBeHidden()
+      expect(window.isElementHidden(modal)).toEqual(true)
     })
   })
 })

--- a/spec/javascripts/components/single-page-notification-button-spec.js
+++ b/spec/javascripts/components/single-page-notification-button-spec.js
@@ -49,7 +49,7 @@ describe('Single page notification component', function () {
     })
 
     var button = document.querySelector('form.gem-c-single-page-notification-button')
-    expect(button).toHaveClass('gem-c-single-page-notification-button--visible')
+    expect(window.isClassOnElement(button, 'gem-c-single-page-notification-button--visible')).toEqual(true)
   })
 
   it('renders "Subscribe-button" tracking attribute value if "active" in the API response is false', function () {

--- a/spec/javascripts/components/single-page-notification-button-spec.js
+++ b/spec/javascripts/components/single-page-notification-button-spec.js
@@ -115,7 +115,7 @@ describe('Single page notification component', function () {
     })
 
     var button = document.querySelector('form.gem-c-single-page-notification-button')
-    expect(button).toHaveText('Start getting emails about this stuff')
+    expect(button.textContent).toEqual('Start getting emails about this stuff')
   })
 
   it('renders custom unsubscribe button text when API response is received if "data-button-text-subscribe" and "data-button-text-unsubscribe" are set', function () {
@@ -135,7 +135,7 @@ describe('Single page notification component', function () {
     })
 
     var button = document.querySelector('form.gem-c-single-page-notification-button')
-    expect(button).toHaveText('Stop getting emails about this stuff')
+    expect(button.textContent).toEqual('Stop getting emails about this stuff')
   })
 
   it('should remain unchanged if the response is not JSON', function () {
@@ -149,7 +149,7 @@ describe('Single page notification component', function () {
     })
 
     var button = document.querySelector('form.gem-c-single-page-notification-button.gem-c-single-page-notification-button--visible button')
-    expect(button).toHaveText('Get emails about this page')
+    expect(button.textContent).toEqual('Get emails about this page')
     expect(GOVUK.Modules.SinglePageNotificationButton.prototype.responseIsJSON(responseText)).toBe(false)
   })
 
@@ -164,7 +164,7 @@ describe('Single page notification component', function () {
     })
 
     var button = document.querySelector('form.gem-c-single-page-notification-button.gem-c-single-page-notification-button--visible button')
-    expect(button).toHaveText('Get emails about this page')
+    expect(button.textContent).toEqual('Get emails about this page')
     expect(GOVUK.Modules.SinglePageNotificationButton.prototype.responseIsJSON(responseText)).toBe(false)
   })
 
@@ -178,7 +178,7 @@ describe('Single page notification component', function () {
     })
 
     var button = document.querySelector('form.gem-c-single-page-notification-button.gem-c-single-page-notification-button--visible button')
-    expect(button).toHaveText('Get emails about this page')
+    expect(button.textContent).toEqual('Get emails about this page')
   })
 
   it('should remain unchanged if xhr times out', function () {
@@ -187,7 +187,7 @@ describe('Single page notification component', function () {
     jasmine.Ajax.requests.mostRecent().responseTimeout()
 
     var button = document.querySelector('form.gem-c-single-page-notification-button.gem-c-single-page-notification-button--visible button')
-    expect(button).toHaveText('Get emails about this page')
+    expect(button.textContent).toEqual('Get emails about this page')
     jasmine.clock().uninstall()
   })
 

--- a/spec/javascripts/components/single-page-notification-button-spec.js
+++ b/spec/javascripts/components/single-page-notification-button-spec.js
@@ -10,7 +10,7 @@ describe('Single page notification component', function () {
         '<input type="hidden" name="base_path" value="/current-page-path">' +
         '<button class="gem-c-single-page-notification-button__submit" type="submit"><span class="gem-c-single-page-notication-button__text">Get emails about this page</span></button>' +
     '</form>'
-    window.setFixtures(FIXTURE)
+    window.specHelpers.setFixtures(FIXTURE)
     jasmine.Ajax.install()
   })
 
@@ -31,7 +31,7 @@ describe('Single page notification component', function () {
         '<input type="hidden" name="base_path" value="/current-page-path">' +
         '<button class="gem-c-single-page-notification-button__submit" type="submit">Get emails about this page</button>' +
       '</form>'
-    window.setFixtures(FIXTURE)
+    window.specHelpers.setFixtures(FIXTURE)
 
     initButton()
     var request = jasmine.Ajax.requests.mostRecent()
@@ -49,7 +49,7 @@ describe('Single page notification component', function () {
     })
 
     var button = document.querySelector('form.gem-c-single-page-notification-button')
-    expect(window.isClassOnElement(button, 'gem-c-single-page-notification-button--visible')).toEqual(true)
+    expect(window.specHelpers.isClassOnElement(button, 'gem-c-single-page-notification-button--visible')).toEqual(true)
   })
 
   it('renders "Subscribe-button" tracking attribute value if "active" in the API response is false', function () {
@@ -84,7 +84,7 @@ describe('Single page notification component', function () {
         '<input type="hidden" name="base_path" value="/current-page-path">' +
         '<button class="gem-c-single-page-notification-button__submit" type="submit"><span class="gem-c-single-page-notication-button__text">Get emails about this page</span></button>' +
     '</form>'
-    window.setFixtures(FIXTURE)
+    window.specHelpers.setFixtures(FIXTURE)
 
     initButton()
 
@@ -104,7 +104,7 @@ describe('Single page notification component', function () {
       '<input type="hidden" name="base_path" value="/current-page-path">' +
       '<button class="gem-c-single-page-notification-button__submit" type="submit"><span class="gem-c-single-page-notication-button__text">Get emails about this page</span></button>' +
     '</form>'
-    window.setFixtures(FIXTURE)
+    window.specHelpers.setFixtures(FIXTURE)
 
     initButton()
 
@@ -124,7 +124,7 @@ describe('Single page notification component', function () {
       '<input type="hidden" name="base_path" value="/current-page-path">' +
       '<button class="gem-c-single-page-notification-button__submit" type="submit"><span class="gem-c-single-page-notication-button__text">Get emails about this page</span></button>' +
     '</form>'
-    window.setFixtures(FIXTURE)
+    window.specHelpers.setFixtures(FIXTURE)
 
     initButton()
 

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -156,7 +156,7 @@ describe('A stepnav module', function () {
     var $showHideAllButton = $element[0].querySelector('.js-step-controls-button')
 
     expect($showHideAllButton).not.toBe(null)
-    expect($showHideAllButton).toHaveText('Show all steps')
+    expect($showHideAllButton.textContent).toEqual('Show all steps')
     // It has an aria-expanded false attribute as all steps are hidden
     expect($showHideAllButton.getAttribute('aria-expanded')).toBe('false')
     // It has an aria-controls attribute that includes all the step_content IDs
@@ -196,7 +196,8 @@ describe('A stepnav module', function () {
     }
 
     for (var j = 0; j < $stepNavToggleLinks.length; j++) {
-      expect($stepNavToggleLinks[j]).toHaveText('Show')
+      expect($stepNavToggleLinks[j].textContent).toEqual('Show')
+
       // It generates a chevron SVG icon for visual affordance
       expect($stepNavToggleLinks[j].querySelector('.gem-c-step-nav__chevron')).not.toBe(null)
     }
@@ -223,7 +224,7 @@ describe('A stepnav module', function () {
 
     it('changes all the "show" elements to say "hide"', function () {
       $element.find('.js-toggle-link-text').each(function () {
-        expect($(this)).toHaveText('Hide')
+        expect($(this).text()).toEqual('Hide')
       })
     })
 
@@ -249,7 +250,7 @@ describe('A stepnav module', function () {
 
     it('changes all the "hide" elements to say "show"', function () {
       $element.find('.js-toggle-link-text').each(function () {
-        expect($(this)).toHaveText('Show')
+        expect($(this).text()).toEqual('Show')
       })
     })
 
@@ -463,12 +464,12 @@ describe('A stepnav module', function () {
 
     it('sets the show/hide link text to "hide"', function () {
       var $step1 = $element.find('#topic-step-one')
-      expect($step1.find('.js-toggle-link-text')).toHaveText('Hide')
+      expect($step1.find('.js-toggle-link-text').text()).toEqual('Hide')
     })
 
     it('sets the show all/hide all button text correctly', function () {
       var $showHideAllButton = $element.find('.js-step-controls-button')
-      expect($showHideAllButton).toHaveText('Show all steps')
+      expect($showHideAllButton.text()).toEqual('Show all steps')
     })
   })
 
@@ -487,7 +488,7 @@ describe('A stepnav module', function () {
 
     it('sets the show all/hide all button text correctly', function () {
       var $showHideAllButton = $element.find('.js-step-controls-button')
-      expect($showHideAllButton).toHaveText('Hide all steps')
+      expect($showHideAllButton.text()).toEqual('Hide all steps')
     })
   })
 

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -145,11 +145,11 @@ describe('A stepnav module', function () {
   }
 
   it('has a class of gem-c-step-nav--active to indicate the js has loaded', function () {
-    expect($element).toHaveClass('gem-c-step-nav--active')
+    expect(window.isClassOnElement($element[0], 'gem-c-step-nav--active')).toEqual(true)
   })
 
   it('is not hidden', function () {
-    expect($element).not.toHaveClass('js-hidden')
+    expect(window.isClassOnElement($element[0], 'js-hidden')).toEqual(false)
   })
 
   it('has a show/hide all button', function () {
@@ -174,7 +174,7 @@ describe('A stepnav module', function () {
     var $titleButtons = $element[0].querySelectorAll('.js-step-title-button')
 
     for (var i = 0; i < $titleButtons.length; i++) {
-      expect($titleButtons[i]).toHaveClass('gem-c-step-nav__button--title')
+      expect(window.isClassOnElement($titleButtons[i], 'gem-c-step-nav__button--title')).toEqual(true)
       expect($titleButtons[i].getAttribute('aria-expanded')).toBe('false')
     }
     expect($titleButtons[0].getAttribute('aria-controls')).toBe('step-panel-topic-step-one-1')
@@ -183,7 +183,7 @@ describe('A stepnav module', function () {
 
   it('ensures all step content is hidden', function () {
     $element.find('.gem-c-step-nav__step').each(function (index, $step) {
-      expect($step).not.toHaveClass('step-is-shown')
+      expect(window.isClassOnElement($step, 'step-is-shown')).toEqual(false)
     })
   })
 
@@ -270,7 +270,7 @@ describe('A stepnav module', function () {
       var $stepLink = $element.find('.gem-c-step-nav__header .gem-c-step-nav__button--title').first()
       var $step = $element.find('.gem-c-step-nav__step').first()
       $stepLink.click()
-      expect($step).toHaveClass('step-is-shown')
+      expect(window.isClassOnElement($step[0], 'step-is-shown')).toEqual(true)
     })
 
     // When a step is open (testing: toggleState, setExpandedState)
@@ -327,9 +327,9 @@ describe('A stepnav module', function () {
       var $stepLink = $element.find('.gem-c-step-nav__header .gem-c-step-nav__button--title')
       var $step = $element.find('.gem-c-step-nav__step')
       $stepLink.click()
-      expect($step).toHaveClass('step-is-shown')
+      expect(window.isClassOnElement($step[0], 'step-is-shown')).toEqual(true)
       $stepLink.click()
-      expect($step).not.toHaveClass('step-is-shown')
+      expect(window.isClassOnElement($step[0], 'step-is-shown')).toEqual(false)
     })
 
     // When a step is hidden (testing: toggleState, setExpandedState)
@@ -446,17 +446,19 @@ describe('A stepnav module', function () {
 
     it('opens the steps it has remembered', function () {
       var $step1 = $element.find('#topic-step-one')
-      expect($step1).toHaveClass('step-is-shown')
-      expect($step1.find('.js-panel')).not.toHaveClass('js-hidden')
+      expect(window.isClassOnElement($step1[0], 'step-is-shown')).toEqual(true)
+      var $jsPanel = $step1.find('.js-panel')
+      expect(window.isClassOnElement($jsPanel[0], 'js-hidden')).toEqual(false)
 
       var $step3 = $element.find('#topic-step-three')
-      expect($step3).toHaveClass('step-is-shown')
-      expect($step3.find('.js-panel')).not.toHaveClass('js-hidden')
+      expect(window.isClassOnElement($step3[0], 'step-is-shown')).toEqual(true)
+      $jsPanel = $step3.find('.js-panel')
+      expect(window.isClassOnElement($jsPanel[0], 'js-hidden')).toEqual(false)
     })
 
     it('leaves the other steps hidden', function () {
       var $step2 = $element.find('#topic-step-two')
-      expect($step2).not.toHaveClass('step-is-shown')
+      expect(window.isClassOnElement($step2[0], 'step-is-shown')).toEqual(false)
     })
 
     it('sets the show/hide link text to "hide"', function () {
@@ -506,9 +508,9 @@ describe('A stepnav module', function () {
       var $step2 = $element.find('#topic-step-two')
       var $step3 = $element.find('#topic-step-three')
 
-      expect($step1).not.toHaveClass('step-is-shown')
-      expect($step2).not.toHaveClass('step-is-shown')
-      expect($step3).not.toHaveClass('step-is-shown')
+      expect(window.isClassOnElement($step1[0], 'step-is-shown')).toEqual(false)
+      expect(window.isClassOnElement($step2[0], 'step-is-shown')).toEqual(false)
+      expect(window.isClassOnElement($step3[0], 'step-is-shown')).toEqual(false)
 
       $step1.click()
       expect(window.sessionStorage.getItem('unique-id')).toBe('["topic-step-one","topic-step-two","topic-step-three"]') // i.e. unchanged
@@ -524,15 +526,15 @@ describe('A stepnav module', function () {
 
     it('shows the step it\'s supposed to', function () {
       var $openStep = $element.find('#topic-step-two')
-      expect($openStep).toHaveClass('step-is-shown')
+      expect(window.isClassOnElement($openStep[0], 'step-is-shown')).toEqual(true)
     })
 
     it('leaves the other steps closed', function () {
       var $closedStep1 = $element.find('#topic-step-one')
       var $closedStep3 = $element.find('#topic-step-three')
 
-      expect($closedStep1).not.toHaveClass('step-is-shown')
-      expect($closedStep3).not.toHaveClass('step-is-shown')
+      expect(window.isClassOnElement($closedStep1[0], 'step-is-shown')).toEqual(false)
+      expect(window.isClassOnElement($closedStep3[0], 'step-is-shown')).toEqual(false)
     })
   })
 
@@ -711,8 +713,8 @@ describe('A stepnav module', function () {
     it('highlights the first active link and its parent step if no sessionStorage value is set', function () {
       expect(window.sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe(null)
       var $active = $element.find('.js-link[data-position="2.1"]')
-      expect($active.closest('.js-list-item')).toHaveClass('gem-c-step-nav__list-item--active')
-      expect($active.closest('.js-step')).toHaveClass('gem-c-step-nav__step--active')
+      expect(window.isClassOnElement($active.closest('.js-list-item')[0], 'gem-c-step-nav__list-item--active')).toEqual(true)
+      expect(window.isClassOnElement($active.closest('.js-step')[0], 'gem-c-step-nav__step--active')).toEqual(true)
       expect($element.find('.gem-c-step-nav__list-item--active').length).toBe(1)
       expect($element.find('.gem-c-step-nav__list-item--active').length).toBe(1)
       expect($element.find('.step-is-shown').length).toBe(1)
@@ -729,16 +731,18 @@ describe('A stepnav module', function () {
       var $firstLink = $element.find('.js-link[data-position="3.4"]')[0]
       $firstLink.click()
       expect(window.sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe('3.4')
-      expect($firstLink.closest('.js-list-item')).toHaveClass('gem-c-step-nav__list-item--active')
-      expect($firstLink.closest('.js-step')).toHaveClass('gem-c-step-nav__step--active')
+      expect(window.isClassOnElement($firstLink.closest('.js-list-item'), 'gem-c-step-nav__list-item--active')).toEqual(true)
+      expect(window.isClassOnElement($firstLink.closest('.js-step'), 'gem-c-step-nav__step--active')).toEqual(true)
+
       expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1)
       expect($element.find(('.gem-c-step-nav__step--active')).length).toBe(1)
 
       var $secondLink = $element.find('.js-link[data-position="3.5"]')[0]
       $secondLink.click()
       expect(window.sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe('3.5')
-      expect($secondLink.closest('.js-list-item')).toHaveClass('gem-c-step-nav__list-item--active')
-      expect($secondLink.closest('.js-step')).toHaveClass('gem-c-step-nav__step--active')
+      expect(window.isClassOnElement($secondLink.closest('.js-list-item'), 'gem-c-step-nav__list-item--active')).toEqual(true)
+      expect(window.isClassOnElement($secondLink.closest('.js-step'), 'gem-c-step-nav__step--active')).toEqual(true)
+
       expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1)
       expect($element.find(('.gem-c-step-nav__step--active')).length).toBe(1)
     })
@@ -800,7 +804,8 @@ describe('A stepnav module', function () {
 
     it('highlights the first active link if no sessionStorage value is set', function () {
       expect(window.sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe(null)
-      expect($element.find('.js-link[data-position="2.1"]').closest('.js-list-item')).toHaveClass('gem-c-step-nav__list-item--active')
+      var $jsLink = $element.find('.js-link[data-position="2.1"]').closest('.js-list-item')[0]
+      expect(window.isClassOnElement($jsLink, 'gem-c-step-nav__list-item--active')).toEqual(true)
       expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1)
     })
   })

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -145,11 +145,11 @@ describe('A stepnav module', function () {
   }
 
   it('has a class of gem-c-step-nav--active to indicate the js has loaded', function () {
-    expect(window.isClassOnElement($element[0], 'gem-c-step-nav--active')).toEqual(true)
+    expect(window.specHelpers.isClassOnElement($element[0], 'gem-c-step-nav--active')).toEqual(true)
   })
 
   it('is not hidden', function () {
-    expect(window.isClassOnElement($element[0], 'js-hidden')).toEqual(false)
+    expect(window.specHelpers.isClassOnElement($element[0], 'js-hidden')).toEqual(false)
   })
 
   it('has a show/hide all button', function () {
@@ -174,7 +174,7 @@ describe('A stepnav module', function () {
     var $titleButtons = $element[0].querySelectorAll('.js-step-title-button')
 
     for (var i = 0; i < $titleButtons.length; i++) {
-      expect(window.isClassOnElement($titleButtons[i], 'gem-c-step-nav__button--title')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($titleButtons[i], 'gem-c-step-nav__button--title')).toEqual(true)
       expect($titleButtons[i].getAttribute('aria-expanded')).toBe('false')
     }
     expect($titleButtons[0].getAttribute('aria-controls')).toBe('step-panel-topic-step-one-1')
@@ -183,7 +183,7 @@ describe('A stepnav module', function () {
 
   it('ensures all step content is hidden', function () {
     $element.find('.gem-c-step-nav__step').each(function (index, $step) {
-      expect(window.isClassOnElement($step, 'step-is-shown')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement($step, 'step-is-shown')).toEqual(false)
     })
   })
 
@@ -271,7 +271,7 @@ describe('A stepnav module', function () {
       var $stepLink = $element.find('.gem-c-step-nav__header .gem-c-step-nav__button--title').first()
       var $step = $element.find('.gem-c-step-nav__step').first()
       $stepLink.click()
-      expect(window.isClassOnElement($step[0], 'step-is-shown')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($step[0], 'step-is-shown')).toEqual(true)
     })
 
     // When a step is open (testing: toggleState, setExpandedState)
@@ -328,9 +328,9 @@ describe('A stepnav module', function () {
       var $stepLink = $element.find('.gem-c-step-nav__header .gem-c-step-nav__button--title')
       var $step = $element.find('.gem-c-step-nav__step')
       $stepLink.click()
-      expect(window.isClassOnElement($step[0], 'step-is-shown')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($step[0], 'step-is-shown')).toEqual(true)
       $stepLink.click()
-      expect(window.isClassOnElement($step[0], 'step-is-shown')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement($step[0], 'step-is-shown')).toEqual(false)
     })
 
     // When a step is hidden (testing: toggleState, setExpandedState)
@@ -447,19 +447,19 @@ describe('A stepnav module', function () {
 
     it('opens the steps it has remembered', function () {
       var $step1 = $element.find('#topic-step-one')
-      expect(window.isClassOnElement($step1[0], 'step-is-shown')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($step1[0], 'step-is-shown')).toEqual(true)
       var $jsPanel = $step1.find('.js-panel')
-      expect(window.isClassOnElement($jsPanel[0], 'js-hidden')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement($jsPanel[0], 'js-hidden')).toEqual(false)
 
       var $step3 = $element.find('#topic-step-three')
-      expect(window.isClassOnElement($step3[0], 'step-is-shown')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($step3[0], 'step-is-shown')).toEqual(true)
       $jsPanel = $step3.find('.js-panel')
-      expect(window.isClassOnElement($jsPanel[0], 'js-hidden')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement($jsPanel[0], 'js-hidden')).toEqual(false)
     })
 
     it('leaves the other steps hidden', function () {
       var $step2 = $element.find('#topic-step-two')
-      expect(window.isClassOnElement($step2[0], 'step-is-shown')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement($step2[0], 'step-is-shown')).toEqual(false)
     })
 
     it('sets the show/hide link text to "hide"', function () {
@@ -509,9 +509,9 @@ describe('A stepnav module', function () {
       var $step2 = $element.find('#topic-step-two')
       var $step3 = $element.find('#topic-step-three')
 
-      expect(window.isClassOnElement($step1[0], 'step-is-shown')).toEqual(false)
-      expect(window.isClassOnElement($step2[0], 'step-is-shown')).toEqual(false)
-      expect(window.isClassOnElement($step3[0], 'step-is-shown')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement($step1[0], 'step-is-shown')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement($step2[0], 'step-is-shown')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement($step3[0], 'step-is-shown')).toEqual(false)
 
       $step1.click()
       expect(window.sessionStorage.getItem('unique-id')).toBe('["topic-step-one","topic-step-two","topic-step-three"]') // i.e. unchanged
@@ -527,15 +527,15 @@ describe('A stepnav module', function () {
 
     it('shows the step it\'s supposed to', function () {
       var $openStep = $element.find('#topic-step-two')
-      expect(window.isClassOnElement($openStep[0], 'step-is-shown')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($openStep[0], 'step-is-shown')).toEqual(true)
     })
 
     it('leaves the other steps closed', function () {
       var $closedStep1 = $element.find('#topic-step-one')
       var $closedStep3 = $element.find('#topic-step-three')
 
-      expect(window.isClassOnElement($closedStep1[0], 'step-is-shown')).toEqual(false)
-      expect(window.isClassOnElement($closedStep3[0], 'step-is-shown')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement($closedStep1[0], 'step-is-shown')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement($closedStep3[0], 'step-is-shown')).toEqual(false)
     })
   })
 
@@ -714,8 +714,8 @@ describe('A stepnav module', function () {
     it('highlights the first active link and its parent step if no sessionStorage value is set', function () {
       expect(window.sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe(null)
       var $active = $element.find('.js-link[data-position="2.1"]')
-      expect(window.isClassOnElement($active.closest('.js-list-item')[0], 'gem-c-step-nav__list-item--active')).toEqual(true)
-      expect(window.isClassOnElement($active.closest('.js-step')[0], 'gem-c-step-nav__step--active')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($active.closest('.js-list-item')[0], 'gem-c-step-nav__list-item--active')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($active.closest('.js-step')[0], 'gem-c-step-nav__step--active')).toEqual(true)
       expect($element.find('.gem-c-step-nav__list-item--active').length).toBe(1)
       expect($element.find('.gem-c-step-nav__list-item--active').length).toBe(1)
       expect($element.find('.step-is-shown').length).toBe(1)
@@ -732,8 +732,8 @@ describe('A stepnav module', function () {
       var $firstLink = $element.find('.js-link[data-position="3.4"]')[0]
       $firstLink.click()
       expect(window.sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe('3.4')
-      expect(window.isClassOnElement($firstLink.closest('.js-list-item'), 'gem-c-step-nav__list-item--active')).toEqual(true)
-      expect(window.isClassOnElement($firstLink.closest('.js-step'), 'gem-c-step-nav__step--active')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($firstLink.closest('.js-list-item'), 'gem-c-step-nav__list-item--active')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($firstLink.closest('.js-step'), 'gem-c-step-nav__step--active')).toEqual(true)
 
       expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1)
       expect($element.find(('.gem-c-step-nav__step--active')).length).toBe(1)
@@ -741,8 +741,8 @@ describe('A stepnav module', function () {
       var $secondLink = $element.find('.js-link[data-position="3.5"]')[0]
       $secondLink.click()
       expect(window.sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe('3.5')
-      expect(window.isClassOnElement($secondLink.closest('.js-list-item'), 'gem-c-step-nav__list-item--active')).toEqual(true)
-      expect(window.isClassOnElement($secondLink.closest('.js-step'), 'gem-c-step-nav__step--active')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($secondLink.closest('.js-list-item'), 'gem-c-step-nav__list-item--active')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($secondLink.closest('.js-step'), 'gem-c-step-nav__step--active')).toEqual(true)
 
       expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1)
       expect($element.find(('.gem-c-step-nav__step--active')).length).toBe(1)
@@ -806,7 +806,7 @@ describe('A stepnav module', function () {
     it('highlights the first active link if no sessionStorage value is set', function () {
       expect(window.sessionStorage.getItem('govuk-step-nav-active-link_unique-id')).toBe(null)
       var $jsLink = $element.find('.js-link[data-position="2.1"]').closest('.js-list-item')[0]
-      expect(window.isClassOnElement($jsLink, 'gem-c-step-nav__list-item--active')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($jsLink, 'gem-c-step-nav__list-item--active')).toEqual(true)
       expect($element.find(('.gem-c-step-nav__list-item--active')).length).toBe(1)
     })
   })

--- a/spec/javascripts/components/table-spec.js
+++ b/spec/javascripts/components/table-spec.js
@@ -39,7 +39,7 @@ describe('Table component', function () {
         '<p class="js-gem-c-table__message govuk-!-display-none">That search returns no results.</p>' +
       '</div>'
 
-    window.setFixtures(FIXTURE)
+    window.specHelpers.setFixtures(FIXTURE)
 
     element = document.querySelector('[data-module="table"]')
     filter = document.querySelector('.js-gem-c-table__filter')

--- a/spec/javascripts/components/toggle-input-class-on-focus-spec.js
+++ b/spec/javascripts/components/toggle-input-class-on-focus-spec.js
@@ -23,7 +23,6 @@ describe('A toggle class module', function () {
 
     it('applies the focus style on focus and removes it on blur', function () {
       var searchInput = document.querySelector('.js-class-toggle')
-      expect(window.specHelpers.isClassOnElement(searchInput, 'js-class-toggle')).toEqual(true)
       expect(window.specHelpers.isClassOnElement(searchInput, 'focus')).toEqual(false)
 
       searchInput.dispatchEvent(new window.Event('focus'))

--- a/spec/javascripts/components/toggle-input-class-on-focus-spec.js
+++ b/spec/javascripts/components/toggle-input-class-on-focus-spec.js
@@ -23,14 +23,14 @@ describe('A toggle class module', function () {
 
     it('applies the focus style on focus and removes it on blur', function () {
       var searchInput = document.querySelector('.js-class-toggle')
-      expect(window.isClassOnElement(searchInput, 'js-class-toggle')).toEqual(true)
-      expect(window.isClassOnElement(searchInput, 'focus')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement(searchInput, 'js-class-toggle')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement(searchInput, 'focus')).toEqual(false)
 
       searchInput.dispatchEvent(new window.Event('focus'))
-      expect(window.isClassOnElement(searchInput, 'focus')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement(searchInput, 'focus')).toEqual(true)
 
       searchInput.dispatchEvent(new window.Event('blur'))
-      expect(window.isClassOnElement(searchInput, 'focus')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement(searchInput, 'focus')).toEqual(false)
     })
   })
 

--- a/spec/javascripts/components/toggle-input-class-on-focus-spec.js
+++ b/spec/javascripts/components/toggle-input-class-on-focus-spec.js
@@ -23,11 +23,14 @@ describe('A toggle class module', function () {
 
     it('applies the focus style on focus and removes it on blur', function () {
       var searchInput = document.querySelector('.js-class-toggle')
-      expect(searchInput).not.toHaveClass('focus')
+      expect(window.isClassOnElement(searchInput, 'js-class-toggle')).toEqual(true)
+      expect(window.isClassOnElement(searchInput, 'focus')).toEqual(false)
+
       searchInput.dispatchEvent(new window.Event('focus'))
-      expect(searchInput).toHaveClass('focus')
+      expect(window.isClassOnElement(searchInput, 'focus')).toEqual(true)
+
       searchInput.dispatchEvent(new window.Event('blur'))
-      expect(searchInput).not.toHaveClass('focus')
+      expect(window.isClassOnElement(searchInput, 'focus')).toEqual(false)
     })
   })
 

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
@@ -146,19 +146,19 @@ describe('Magna charta', function () {
     })
 
     it('the new chart copies over any other classes', function () {
-      expect(window.isClassOnElement(graph[0], 'no-key')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement(graph[0], 'no-key')).toEqual(true)
     })
 
     it('running toggle switches between chart and table', function () {
       toggle[0].click()
-      expect(window.isClassOnElement(table[0], 'mc-hidden')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement(table[0], 'mc-hidden')).toEqual(false)
 
-      expect(window.isClassOnElement(graphContainer[0], 'mc-hidden')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement(graphContainer[0], 'mc-hidden')).toEqual(true)
 
       // toggle it back
       toggle[0].click()
-      expect(window.isClassOnElement(table[0], 'mc-hidden')).toEqual(true)
-      expect(window.isClassOnElement(graphContainer[0], 'mc-hidden')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement(table[0], 'mc-hidden')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement(graphContainer[0], 'mc-hidden')).toEqual(false)
     })
 
     it('new chart div contains all table bits as divs', function () {
@@ -199,14 +199,14 @@ describe('Magna charta', function () {
 
     it('new chart is inserted into DOM after table', function () {
       var chartContainer = table.next()
-      expect(window.isClassOnElement(chartContainer[0], 'mc-chart-container')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement(chartContainer[0], 'mc-chart-container')).toEqual(true)
 
-      expect(window.isClassOnElement(chartContainer.children(':first')[0], 'mc-chart')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement(chartContainer.children(':first')[0], 'mc-chart')).toEqual(true)
     })
 
     it('bars are given classes to track what number they are', function () {
       graph.find('.mc-bar-cell').each(function (i, item) {
-        expect(window.isClassOnElement($(item)[0], 'mc-bar-1')).toEqual(true)
+        expect(window.specHelpers.isClassOnElement($(item)[0], 'mc-bar-1')).toEqual(true)
       })
     })
   })
@@ -226,7 +226,7 @@ describe('Magna charta', function () {
     })
 
     it('the graph of a multiple table is given a class', function () {
-      expect(window.isClassOnElement(graph[0], 'mc-multiple')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement(graph[0], 'mc-multiple')).toEqual(true)
       expect(magna.options.multiple).toBe(true)
     })
   })
@@ -246,7 +246,7 @@ describe('Magna charta', function () {
     })
 
     it('the graph of a multiple table is given a class', function () {
-      expect(window.isClassOnElement(graph[0], 'mc-multiple')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement(graph[0], 'mc-multiple')).toEqual(true)
       expect(magna.options.multiple).toBe(true)
     })
   })
@@ -279,7 +279,7 @@ describe('Magna charta', function () {
       var head = graph.find('.mc-thead')
       expect(head.find('.mc-stacked-header').length).toBe(1)
       var $tableHeading = head.find('.mc-th').eq(1)
-      expect(window.isClassOnElement($tableHeading[0], 'mc-key-1')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement($tableHeading[0], 'mc-key-1')).toEqual(true)
 
       expect(head.find('.mc-key-header').length).toBe(2)
     })
@@ -299,7 +299,7 @@ describe('Magna charta', function () {
       rows.each(function (_, row) {
         var cells = $(row).find('.mc-bar-cell')
         cells.each(function (i, cell) {
-          expect(window.isClassOnElement($(cell)[0], 'mc-bar-' + (i + 1))).toEqual(true)
+          expect(window.specHelpers.isClassOnElement($(cell)[0], 'mc-bar-' + (i + 1))).toEqual(true)
         })
       })
     })
@@ -330,14 +330,14 @@ describe('Magna charta', function () {
     })
 
     it('doesnt show the chart initially', function () {
-      expect(window.isClassOnElement(table[0], 'mc-hidden')).toEqual(false)
-      expect(window.isClassOnElement(graphContainer[0], 'mc-hidden')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement(table[0], 'mc-hidden')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement(graphContainer[0], 'mc-hidden')).toEqual(true)
     })
 
     it('graph is shown when toggle is called', function () {
       element.find('.mc-toggle-button')[0].click()
-      expect(window.isClassOnElement(table[0], 'mc-hidden')).toEqual(true)
-      expect(window.isClassOnElement(graphContainer[0], 'mc-hidden')).toEqual(false)
+      expect(window.specHelpers.isClassOnElement(table[0], 'mc-hidden')).toEqual(true)
+      expect(window.specHelpers.isClassOnElement(graphContainer[0], 'mc-hidden')).toEqual(false)
     })
   })
 

--- a/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
+++ b/spec/javascripts/govuk_publishing_components/lib/govspeak/magna-charta-spec.js
@@ -146,18 +146,19 @@ describe('Magna charta', function () {
     })
 
     it('the new chart copies over any other classes', function () {
-      expect(graph).toHaveClass('no-key')
+      expect(window.isClassOnElement(graph[0], 'no-key')).toEqual(true)
     })
 
     it('running toggle switches between chart and table', function () {
       toggle[0].click()
-      expect(table).not.toHaveClass('mc-hidden')
-      expect(graphContainer).toHaveClass('mc-hidden')
+      expect(window.isClassOnElement(table[0], 'mc-hidden')).toEqual(false)
+
+      expect(window.isClassOnElement(graphContainer[0], 'mc-hidden')).toEqual(true)
 
       // toggle it back
       toggle[0].click()
-      expect(table).toHaveClass('mc-hidden')
-      expect(graphContainer).not.toHaveClass('mc-hidden')
+      expect(window.isClassOnElement(table[0], 'mc-hidden')).toEqual(true)
+      expect(window.isClassOnElement(graphContainer[0], 'mc-hidden')).toEqual(false)
     })
 
     it('new chart div contains all table bits as divs', function () {
@@ -198,13 +199,14 @@ describe('Magna charta', function () {
 
     it('new chart is inserted into DOM after table', function () {
       var chartContainer = table.next()
-      expect(chartContainer).toHaveClass('mc-chart-container')
-      expect(chartContainer.children(':first')).toHaveClass('mc-chart')
+      expect(window.isClassOnElement(chartContainer[0], 'mc-chart-container')).toEqual(true)
+
+      expect(window.isClassOnElement(chartContainer.children(':first')[0], 'mc-chart')).toEqual(true)
     })
 
     it('bars are given classes to track what number they are', function () {
       graph.find('.mc-bar-cell').each(function (i, item) {
-        expect($(item)).toHaveClass('mc-bar-1')
+        expect(window.isClassOnElement($(item)[0], 'mc-bar-1')).toEqual(true)
       })
     })
   })
@@ -224,7 +226,7 @@ describe('Magna charta', function () {
     })
 
     it('the graph of a multiple table is given a class', function () {
-      expect(graph).toHaveClass('mc-multiple')
+      expect(window.isClassOnElement(graph[0], 'mc-multiple')).toEqual(true)
       expect(magna.options.multiple).toBe(true)
     })
   })
@@ -244,7 +246,7 @@ describe('Magna charta', function () {
     })
 
     it('the graph of a multiple table is given a class', function () {
-      expect(graph).toHaveClass('mc-multiple')
+      expect(window.isClassOnElement(graph[0], 'mc-multiple')).toEqual(true)
       expect(magna.options.multiple).toBe(true)
     })
   })
@@ -276,7 +278,9 @@ describe('Magna charta', function () {
     it('header cells get the right values', function () {
       var head = graph.find('.mc-thead')
       expect(head.find('.mc-stacked-header').length).toBe(1)
-      expect(head.find('.mc-th').eq(1)).toHaveClass('mc-key-1')
+      var $tableHeading = head.find('.mc-th').eq(1)
+      expect(window.isClassOnElement($tableHeading[0], 'mc-key-1')).toEqual(true)
+
       expect(head.find('.mc-key-header').length).toBe(2)
     })
 
@@ -295,7 +299,7 @@ describe('Magna charta', function () {
       rows.each(function (_, row) {
         var cells = $(row).find('.mc-bar-cell')
         cells.each(function (i, cell) {
-          expect($(cell)).toHaveClass('mc-bar-' + (i + 1))
+          expect(window.isClassOnElement($(cell)[0], 'mc-bar-' + (i + 1))).toEqual(true)
         })
       })
     })
@@ -326,14 +330,14 @@ describe('Magna charta', function () {
     })
 
     it('doesnt show the chart initially', function () {
-      expect(table).not.toHaveClass('mc-hidden')
-      expect(graphContainer).toHaveClass('mc-hidden')
+      expect(window.isClassOnElement(table[0], 'mc-hidden')).toEqual(false)
+      expect(window.isClassOnElement(graphContainer[0], 'mc-hidden')).toEqual(true)
     })
 
     it('graph is shown when toggle is called', function () {
       element.find('.mc-toggle-button')[0].click()
-      expect(table).toHaveClass('mc-hidden')
-      expect(graphContainer).not.toHaveClass('mc-hidden')
+      expect(window.isClassOnElement(table[0], 'mc-hidden')).toEqual(true)
+      expect(window.isClassOnElement(graphContainer[0], 'mc-hidden')).toEqual(false)
     })
   })
 

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -44,3 +44,7 @@ function isElementDisabled(selector) {
 var isElementHidden = function(element) {
   return element.style.display === "none" || element.style.visibility === "none" || element.hasAttribute('hidden') || element.getAttribute("type") === "hidden"
 }
+
+var isClassOnElement = function (element, className) {
+    return element.classList.contains(className)
+}

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -33,22 +33,24 @@ afterEach(function () {
   resetCookies()
 })
 
-function isElementVisible(element) {
-  return !!( element.offsetWidth || element.offsetHeight || element.getClientRects().length)
-}
+var specHelpers = {
+  isElementVisible: function(element) {
+    return !!( element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+  },
 
-function isElementDisabled(selector) {
-  return document.querySelector(selector+':disabled') !== null
-}
+  isElementDisabled: function(selector) {
+    return document.querySelector(selector+':disabled') !== null
+  },
 
-function isElementHidden(element) {
-  return !this.isElementVisible(element)
-}
+  isElementHidden: function(element) {
+    return !this.isElementVisible(element)
+  },
 
-function isClassOnElement(element, className) {
-    return element.classList.contains(className)
-}
+  isClassOnElement: function(element, className) {
+      return element.classList.contains(className)
+  },
 
-function setFixtures(html) {
-  return jasmine.getFixtures().proxyCallTo_('set', arguments)
+  setFixtures: function(html) {
+    return jasmine.getFixtures().proxyCallTo_('set', arguments)
+  }
 }

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -40,3 +40,7 @@ function isElementVisible(element) {
 function isElementDisabled(selector) {
   return document.querySelector(selector+':disabled') !== null
 }
+
+var isElementHidden = function(element) {
+  return element.style.display === "none" || element.style.visibility === "none" || element.hasAttribute('hidden') || element.getAttribute("type") === "hidden"
+}

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -48,3 +48,7 @@ var isElementHidden = function(element) {
 var isClassOnElement = function (element, className) {
     return element.classList.contains(className)
 }
+
+var setFixtures = function(html) {
+  return jasmine.getFixtures().proxyCallTo_('set', arguments)
+}

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -36,3 +36,7 @@ afterEach(function () {
 function isElementVisible(element) {
   return !!( element.offsetWidth || element.offsetHeight || element.getClientRects().length)
 }
+
+function isElementDisabled(selector) {
+  return document.querySelector(selector+':disabled') !== null
+}

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -41,14 +41,14 @@ function isElementDisabled(selector) {
   return document.querySelector(selector+':disabled') !== null
 }
 
-var isElementHidden = function(element) {
-  return element.style.display === "none" || element.style.visibility === "none" || element.hasAttribute('hidden') || element.getAttribute("type") === "hidden"
+function isElementHidden(element) {
+  return !this.isElementVisible(element)
 }
 
-var isClassOnElement = function (element, className) {
+function isClassOnElement(element, className) {
     return element.classList.contains(className)
 }
 
-var setFixtures = function(html) {
+function setFixtures(html) {
   return jasmine.getFixtures().proxyCallTo_('set', arguments)
 }

--- a/spec/javascripts/helpers/jasmine-jquery-2.0.5.js
+++ b/spec/javascripts/helpers/jasmine-jquery-2.0.5.js
@@ -738,10 +738,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     jasmine.getFixtures().proxyCallTo_('appendLoad', arguments)
   }
 
-  window.setFixtures = function (html) {
-    return jasmine.getFixtures().proxyCallTo_('set', arguments)
-  }
-
   window.appendSetFixtures = function () {
     jasmine.getFixtures().proxyCallTo_('appendSet', arguments)
   }

--- a/spec/javascripts/helpers/jasmine-jquery-2.0.5.js
+++ b/spec/javascripts/helpers/jasmine-jquery-2.0.5.js
@@ -390,14 +390,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         }
       },
 
-      toBeHidden: function () {
-        return {
-          compare: function (actual) {
-            return { pass: $(actual).is(':hidden') }
-          }
-        }
-      },
-
       toBeSelected: function () {
         return {
           compare: function (actual) {

--- a/spec/javascripts/helpers/jasmine-jquery-2.0.5.js
+++ b/spec/javascripts/helpers/jasmine-jquery-2.0.5.js
@@ -473,21 +473,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         }
       },
 
-      toHaveText: function () {
-        return {
-          compare: function (actual, text) {
-            var actualText = $(actual).text()
-            var trimmedText = $.trim(actualText)
-
-            if (text && $.isFunction(text.test)) {
-              return { pass: text.test(actualText) || text.test(trimmedText) }
-            } else {
-              return { pass: (actualText == text || trimmedText == text) }
-            }
-          }
-        }
-      },
-
       toContainText: function () {
         return {
           compare: function (actual, text) {

--- a/spec/javascripts/helpers/jasmine-jquery-2.0.5.js
+++ b/spec/javascripts/helpers/jasmine-jquery-2.0.5.js
@@ -551,14 +551,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         }
       },
 
-      toBeDisabled: function () {
-        return {
-          compare: function (actual, selector) {
-            return { pass: $(actual).is(':disabled') }
-          }
-        }
-      },
-
       toBeFocused: function (selector) {
         return {
           compare: function (actual, selector) {

--- a/spec/javascripts/helpers/jasmine-jquery-2.0.5.js
+++ b/spec/javascripts/helpers/jasmine-jquery-2.0.5.js
@@ -360,14 +360,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
   beforeEach(function () {
     jasmine.addMatchers({
-      toHaveClass: function () {
-        return {
-          compare: function (actual, className) {
-            return { pass: $(actual).hasClass(className) }
-          }
-        }
-      },
-
       toHaveCss: function () {
         return {
           compare: function (actual, css) {


### PR DESCRIPTION
Hi @JamesCGDS / @andysellick would you be able to approve this? Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
This PR removes the following `jasmine-jquery` helper functions and replaces them with a vanilla JS alternative:

- toBeDisabled()
- toBeHidden()
- toHaveClass()
- toHaveText()
- setFixtures() - this has just been copied over from `jasmine-jquery` instead of rewritten


This is being merged into `remove_jasmine_jquery_from_tests` first so there's no `CHANGELOG.md` commit.

## Why
<!-- What are the reasons behind this change being made? -->
The `jasmine-jquery` helper functions were causing https://github.com/alphagov/govuk_publishing_components/issues/2902 and so they have been replaced with a vanilla JS alternative. This also removes our tests' reliance on the `jasmine-jquery` library (which is no longer actively maintained).

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before


### After
