### PR TITLE
Version 34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 34.0.0
 
 * **BREAKING** Remove print stylesheets from components ([PR #3110](https://github.com/alphagov/govuk_publishing_components/pull/3110))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (33.1.0)
+    govuk_publishing_components (34.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "33.1.0".freeze
+  VERSION = "34.0.0".freeze
 end


### PR DESCRIPTION
## 34.0.0

* **BREAKING** Remove print stylesheets from components ([PR #3110](https://github.com/alphagov/govuk_publishing_components/pull/3110))

## How to fix applications for this release

This release removes print stylesheets from components (13 in total), in favour of print media queries for the same styles in the screen stylesheet. Applications that upgrade to this version will break if they include any of the removed print stylesheets.

To fix, do the following:

- remove any references to components from the applications print stylesheet e.g. `@import "govuk_publishing_components/components/print/accordion";`
- update the application stylesheet line in the application layout template to ensure it is set to media `all` e.g. `<link rel="stylesheet" href="application.css" media="all">`
