### PR TITLE
Remove GTAG code

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -11,34 +11,23 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
       var newScript = document.createElement('script')
       newScript.async = true
 
-      if (window.GOVUK.analyticsGa4.vars.gtag_id) {
-        // initialise gtag
-        window.dataLayer = window.dataLayer || []
-        var gtag = function () { window.dataLayer.push(arguments) }
-        gtag('js', new Date())
-        gtag('config', window.GOVUK.analyticsGa4.vars.gtag_id)
+      // initialise GTM
+      window.dataLayer = window.dataLayer || []
+      window.dataLayer.push({ 'gtm.blocklist': ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] })
+      window.dataLayer.push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
 
-        newScript.src = '//www.googletagmanager.com/gtag/js?id=' + window.GOVUK.analyticsGa4.vars.gtag_id
-        firstScript.parentNode.insertBefore(newScript, firstScript)
-      } else {
-        // initialise GTM
-        window.dataLayer = window.dataLayer || []
-        window.dataLayer.push({ 'gtm.blocklist': ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] })
-        window.dataLayer.push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
-
-        var auth = window.GOVUK.analyticsGa4.vars.auth || ''
-        var preview = window.GOVUK.analyticsGa4.vars.preview || ''
-        if (auth) {
-          auth = '&gtm_auth=' + auth
-        }
-        if (preview) {
-          preview = '&gtm_preview=' + preview + '&gtm_cookies_win=x'
-        }
-
-        this.googleSrc = 'https://www.googletagmanager.com/gtm.js?id=' + window.GOVUK.analyticsGa4.vars.id + auth + preview
-        newScript.src = this.googleSrc
-        firstScript.parentNode.insertBefore(newScript, firstScript)
+      var auth = window.GOVUK.analyticsGa4.vars.auth || ''
+      var preview = window.GOVUK.analyticsGa4.vars.preview || ''
+      if (auth) {
+        auth = '&gtm_auth=' + auth
       }
+      if (preview) {
+        preview = '&gtm_preview=' + preview + '&gtm_cookies_win=x'
+      }
+
+      this.googleSrc = 'https://www.googletagmanager.com/gtm.js?id=' + window.GOVUK.analyticsGa4.vars.id + auth + preview
+      newScript.src = this.googleSrc
+      firstScript.parentNode.insertBefore(newScript, firstScript)
     },
 
     sendData: function (data) {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -56,15 +56,6 @@ describe('GA4 core', function () {
     })
   })
 
-  it('loads the GTAG snippet', function () {
-    window.GOVUK.analyticsGa4.vars.gtag_id = 'fake'
-    GOVUK.analyticsGa4.core.load()
-
-    expect(window.dataLayer.length).toEqual(2)
-    expect(window.dataLayer[0]).toContain('js')
-    expect(window.dataLayer[1]).toContain('config')
-  })
-
   it('pushes data to the dataLayer', function () {
     var data = {
       hello: 'I must be going'


### PR DESCRIPTION
## What
Remove unused GTAG code from the GA4 analytics code.

## Why
No longer in use.

## Visual Changes
None.

Trello card: https://trello.com/c/gnixI84y/295-remove-gtag
