### PR TITLE
Make GA4 event tracker automatically get element text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Use setAttribute to add GA4 JSONs to step by step nav ([PR #3131](https://github.com/alphagov/govuk_publishing_components/pull/3131))
 * Add `id` attribute option to the label component ([PR #3093](https://github.com/alphagov/govuk_publishing_components/pull/3093))
+* Make GA4 event tracker automatically get element text ([PR #3137](https://github.com/alphagov/govuk_publishing_components/pull/3137))
 
 ## 34.0.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
@@ -42,6 +42,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         return
       }
 
+      var text = data.text || event.target.textContent
+      data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)
       schema.event = 'event_data'
       // get attributes from the data attribute to send to GA
       // only allow it if it already exists in the schema

--- a/docs/analytics-ga4/ga4-event-tracker.md
+++ b/docs/analytics-ga4/ga4-event-tracker.md
@@ -6,7 +6,7 @@ This script is intended for adding GA4 tracking to interactive elements such as 
 
 ```html
 <div data-module="ga4-event-tracker">
-  <button data-ga4-event='{ "event_name": "select_content", "type": "something", "index": "0", "index_total": "1", "text": "Click me"}'>
+  <button data-ga4-event='{ "event_name": "select_content", "type": "something", "index": "0", "index_total": "1" }'>
     Click me
   </button>
 </div>
@@ -37,6 +37,8 @@ In the example above, the following would be pushed to the dataLayer. Note that 
   }
 }
 ```
+
+The value for `text` will be determined based on the text of the element, or a value can be passed to override this in the `data-ga4-event` attribute.
 
 ## Advanced use
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -104,6 +104,7 @@ describe('Google Analytics event tracking', function () {
       expected.event = 'event_data'
       expected.event_data.event_name = 'select_content'
       expected.event_data.type = 'tabs'
+      expected.event_data.text = ''
       expected.govuk_gem_version = 'aVersion'
 
       var attributes = {
@@ -127,6 +128,43 @@ describe('Google Analytics event tracking', function () {
     })
   })
 
+  describe('doing tracking on the text of the element', function () {
+    var attributes
+
+    beforeEach(function () {
+      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      expected.event = 'event_data'
+      expected.event_data.event_name = 'select_content'
+      expected.govuk_gem_version = 'aVersion'
+
+      attributes = {
+        event_name: 'select_content'
+      }
+      element.textContent = 'text from the button'
+    })
+
+    it('records the text of the element by default', function () {
+      element.setAttribute('data-ga4-event', JSON.stringify(attributes))
+      document.body.appendChild(element)
+      new GOVUK.Modules.Ga4EventTracker(element).init()
+      expected.event_data.text = 'text from the button'
+
+      element.click()
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('uses the text from the attributes if provided', function () {
+      attributes.text = 'text from the attributes'
+      element.setAttribute('data-ga4-event', JSON.stringify(attributes))
+      document.body.appendChild(element)
+      new GOVUK.Modules.Ga4EventTracker(element).init()
+      expected.event_data.text = 'text from the attributes'
+
+      element.click()
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+  })
+
   describe('doing simple tracking on multiple elements', function () {
     var expected1
     var expected2
@@ -135,11 +173,13 @@ describe('Google Analytics event tracking', function () {
       expected1 = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected1.event = 'event_data'
       expected1.event_data.event_name = 'event1-name'
+      expected1.event_data.text = ''
       expected1.govuk_gem_version = 'aVersion'
 
       expected2 = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected2.event = 'event_data'
       expected2.event_data.event_name = 'event2-name'
+      expected2.event_data.text = ''
       expected2.govuk_gem_version = 'aVersion'
 
       var attributes1 = {


### PR DESCRIPTION
## What
- adjusts the event tracker to include the text of the tracked element in the analytics by default
- the tracked value for text can still be overridden by adding a value to the data attribute
- brings the event tracker functionality more in line with how the link tracker behaves

## Why
Some print page buttons haven't been explicitly given a text value, so they're not including the text of the button in tracking. Seems more efficient to reconfigure the event tracker to automatically get the text instead of updating all the instances of tracking on the print page button.

## Visual Changes
None.

Trello card: https://trello.com/c/QFQG5IKA/363-change-some-values-on-printpage-events
