### PR TITLE
Rename taxon parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Use setAttribute to add GA4 JSONs to step by step nav ([PR #3131](https://github.com/alphagov/govuk_publishing_components/pull/3131))
 * Add `id` attribute option to the label component ([PR #3093](https://github.com/alphagov/govuk_publishing_components/pull/3093))
 * Make GA4 event tracker automatically get element text ([PR #3137](https://github.com/alphagov/govuk_publishing_components/pull/3137))
+* Rename taxon parameters ([PR #3139](https://github.com/alphagov/govuk_publishing_components/pull/3139))
 
 ## 34.0.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -28,11 +28,11 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             content_id: this.getMetaContent('content-id'),
 
             browse_topic: this.getMetaContent('section'),
-            taxon_slug: this.getMetaContent('taxon-slug'),
-            taxon_id: this.getMetaContent('taxon-id'),
             taxonomy_level1: this.getMetaContent('themes'),
-            taxon_slugs: this.getMetaContent('taxon-slugs'),
-            taxon_ids: this.getMetaContent('taxon-ids'),
+            taxonomy_main: this.getMetaContent('taxon-slug'),
+            taxonomy_main_id: this.getMetaContent('taxon-id'),
+            taxonomy_all: this.getMetaContent('taxon-slugs'),
+            taxonomy_all_ids: this.getMetaContent('taxon-ids'),
 
             language: this.getLanguage(),
             history: this.getHistory(),

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -28,11 +28,11 @@ describe('Google Tag Manager page view tracking', function () {
         content_id: undefined,
 
         browse_topic: undefined,
-        taxon_slug: undefined,
-        taxon_id: undefined,
+        taxonomy_main: undefined,
+        taxonomy_main_id: undefined,
         taxonomy_level1: undefined,
-        taxon_slugs: undefined,
-        taxon_ids: undefined,
+        taxonomy_all: undefined,
+        taxonomy_all_ids: undefined,
 
         language: undefined,
         history: 'false',
@@ -134,12 +134,12 @@ describe('Google Tag Manager page view tracking', function () {
         value: 'this section'
       },
       {
-        gtmName: 'taxon_slug',
+        gtmName: 'taxonomy_main',
         tagName: 'taxon-slug',
         value: 'this taxon slug'
       },
       {
-        gtmName: 'taxon_id',
+        gtmName: 'taxonomy_main_id',
         tagName: 'taxon-id',
         value: 'this taxon id'
       },
@@ -149,12 +149,12 @@ describe('Google Tag Manager page view tracking', function () {
         value: 'this theme'
       },
       {
-        gtmName: 'taxon_slugs',
+        gtmName: 'taxonomy_all',
         tagName: 'taxon-slugs',
         value: 'this taxon slugs'
       },
       {
-        gtmName: 'taxon_ids',
+        gtmName: 'taxonomy_all_ids',
         tagName: 'taxon-ids',
         value: 'this taxon ids'
       }


### PR DESCRIPTION
## What
This PR renames the following parameters in the `page_view` object:

- `taxon_slug` to `taxonomy_main`
- `taxon_id` to `taxonomy_main_id`
- `taxon_slugs` to `taxonomy_all`
- `taxon_ids` to `taxonomy_all_ids`

The order of the parameters has also been modified slightly at the request of the PA's.

## Why

This change has been requested by PA's.

Related trello ticket: https://trello.com/c/vaOo3M8D/341-rename-themes-to-taxonomylevel1


## Visual Changes
N/A
