### PR TITLE
Change brand colour for No. 10 to be govuk-black

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Update component auditing following print style changes ([PR #3128](https://github.com/alphagov/govuk_publishing_components/pull/3128))
 * Remove the redundant region role from the cookie banner ([PR #3075](https://github.com/alphagov/govuk_publishing_components/pull/3075))
+* Change brand colour for No. 10 to be govuk-black ([PR #3143](https://github.com/alphagov/govuk_publishing_components/pull/3143))
 
 ## 34.1.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -57,12 +57,12 @@
 
 .brand--prime-ministers-office-10-downing-street {
   .brand__color {
-    color: govuk-colour("bright-purple");
+    color: govuk-colour("black");
 
     &:link,
     &:visited,
     &:active {
-      color: govuk-colour("bright-purple");
+      color: govuk-colour("black");
     }
 
     &:hover,


### PR DESCRIPTION
## What

Change brand colour for No. 10 to be govuk-black instead of bright-purple.

## Why

As part of the new redesign of No. 10's page, the link colour is to be changed to black. The links are styled using brand__color, so there this needs to be updated to the new colour.

## Visual Changes

### Before

![Screenshot 2022-12-15 at 10 52 21](https://user-images.githubusercontent.com/3727504/207842306-caadae77-5c36-491b-a3cb-f46adfe73a85.png)

### After

![Screenshot 2022-12-15 at 10 52 12](https://user-images.githubusercontent.com/3727504/207842291-1b0c32e1-7b35-4bc9-9602-709d21e9f58f.png)

