### PR TITLE
Improve accessibility of button focus states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Restyle subscription link ([PR #3177](https://github.com/alphagov/govuk_publishing_components/pull/3177))
 * Change "+" to "Show" in related navigation and metadata block components ([PR #3038](https://github.com/alphagov/govuk_publishing_components/pull/3038))
 * Extend the `input` and `textarea` components to use the `dir` attribute ([PR #3081](https://github.com/alphagov/govuk_publishing_components/pull/3081))
+* Improve accessibility of button focus states ([PR #3146](https://github.com/alphagov/govuk_publishing_components/pull/3146))
 
 ## 34.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -95,32 +95,24 @@
   margin-bottom: 0;
   width: 100%;
 
-  &:hover {
-    // backup style for browsers that don't support rgba
-    background: govuk-colour("mid-grey");
-    background: rgba(govuk-colour("black"), .2);
-    color: govuk-colour("black");
-  }
-
-  &:active:focus:not(:hover) {
-    background: govuk-colour("yellow");
-  }
   @include govuk-media-query($from: tablet) {
     @include govuk-font(16);
   }
-}
-
-.gem-c-feedback__email-link,
-.gem-c-feedback__prompt-link {
-  position: relative;
-
-  &:focus:not(:active):not(:hover) {
-    border-color: govuk-colour("black");
-  }
 
   &:focus,
+  &:focus:not(:active):not(:hover) {
+    background: govuk-colour("yellow");
+    border-color: govuk-colour("black");
+    box-shadow: 0 5px  0 govuk-colour("black");
+  }
+
   &:active {
-    color: $govuk-focus-text-colour;
+    color: govuk-colour("black");
+  }
+
+  &:hover {
+    background: govuk-colour("mid-grey");
+    color: govuk-colour("black");
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_feedback.scss
@@ -223,12 +223,16 @@
 }
 
 .gem-c-feedback__email-link {
-  display: block;
+  display: inline-block;
   margin-top: govuk-spacing(4);
 
   @include govuk-media-query($from: desktop) {
-    display: inline-block;
     margin-top: govuk-spacing(2);
+  }
+
+  &:focus,
+  &:active {
+    color: $govuk-focus-text-colour;
   }
 }
 


### PR DESCRIPTION
## What
The focus state of the Yes/No buttons in the feedback component are not different enough compared to the non-focus state to be fully accessible. [Trello](https://trello.com/c/ZHN94FVx/1496-feedback-component-button-focus-states-not-fully-accessible-s)

## Why
It will be difficult for people with visual impairments to distinguish the two states.

This might fail [WCAG 2.4.11 Focus Appearance](https://www.w3.org/TR/WCAG22/#focus-appearance) (which might become a new success criterion in WCAG 2.2). The yellow/grey doesn’t pass (1.2:1) and the reduction of 1px to the bottom doesn’t help enough.

It also nearly fails [WCAG 1.4.11 Non-text Contrast](https://www.w3.org/TR/WCAG21/#non-text-contrast) but technically passes because the bottom border changes its width a tiny bit.

[GOV.UK](http://gov.uk/) focus states will probably be used as an example by the W3C to highlight how to do 2.4.11 Focus Appearance well, so it would also help getting this fixed for that purpose.

## Visual Changes

### Before
<img width="687" alt="image" src="https://user-images.githubusercontent.com/2166204/211616830-9536849e-ef6d-45bf-8cff-d932d9b185c8.png">

### After
<img width="686" alt="image" src="https://user-images.githubusercontent.com/2166204/211616993-8048bfcf-1b5e-4da9-8b0c-878b0faffe37.png">