### PR TITLE
Version 34.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 34.1.1
 
 * Update component auditing following print style changes ([PR #3128](https://github.com/alphagov/govuk_publishing_components/pull/3128))
 * Remove the redundant region role from the cookie banner ([PR #3075](https://github.com/alphagov/govuk_publishing_components/pull/3075))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (34.1.0)
+    govuk_publishing_components (34.1.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "34.1.0".freeze
+  VERSION = "34.1.1".freeze
 end


### PR DESCRIPTION
## 34.1.1

* Update component auditing following print style changes ([PR #3128](https://github.com/alphagov/govuk_publishing_components/pull/3128))
* Remove the redundant region role from the cookie banner ([PR #3075](https://github.com/alphagov/govuk_publishing_components/pull/3075))
* Change brand colour for No. 10 to be govuk-black ([PR #3143](https://github.com/alphagov/govuk_publishing_components/pull/3143))