### PR TITLE
Increase space beneath list items on the image_card component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Increase space beneath list items on the image_card component ([PR #3153](https://github.com/alphagov/govuk_publishing_components/pull/3153))
+
+
 ## 34.1.2
 
 * Bump govuk-frontend from 4.4.0 to 4.4.1 ([PR #3147](https://github.com/alphagov/govuk_publishing_components/pull/3147))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -131,7 +131,7 @@
   list-style: none;
 
   .gem-c-image-card__list-item {
-    margin-bottom: govuk-spacing(1);
+    margin-bottom: govuk-spacing(2);
   }
 
   .gem-c-image-card__list-item--text {


### PR DESCRIPTION
## What
Increase the space beneath list items on the image_card component.

## Why
To improve readability of multiple links.

## Visual Changes
### Before

![image](https://user-images.githubusercontent.com/2166204/208932013-b9508fd5-ea01-4c38-9dc5-1358c4c29ff5.png)

### After

![image](https://user-images.githubusercontent.com/2166204/208931840-88fdd7b7-2a93-4db0-8919-7c72a378aed2.png)


