### PR TITLE
Add ga4-link-tracker to image card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Catch errors when modules initialised ([PR #3190](https://github.com/alphagov/govuk_publishing_components/pull/3190))
 * Add translation strings for cookie banner confirmation message ([PR #3191](https://github.com/alphagov/govuk_publishing_components/pull/3191))
+* Add ga4-link-tracker to image card ([PR #3154](https://github.com/alphagov/govuk_publishing_components/pull/3154))
 
 ## 34.4.2
 

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -26,7 +26,7 @@
   extra_link_classes << brand_helper.color_class
 
   data_modules = %w[]
-  data_modules << "gem-track-click" if card_helper.is_tracking?
+  data_modules << "gem-track-click ga4-link-tracker" if card_helper.is_tracking?
   data_modules << "image-card" if card_helper.youtube_video_id
 %>
 <% if card_helper.href || card_helper.extra_details.any? %>

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -12,7 +12,7 @@ describe "ImageCard", type: :view do
   it "shows an image" do
     render_component(href: "#", image_src: "/moo.jpg", image_alt: "some meaningful alt text")
     assert_select ".gem-c-image-card .gem-c-image-card__image[src='/moo.jpg'][alt='some meaningful alt text']"
-    assert_select ".gem-c-image-card[data-module='gem-track-click']", false
+    assert_select ".gem-c-image-card[data-module='gem-track-click ga4-link-tracker']", false
   end
 
   it "shows heading text" do
@@ -110,13 +110,13 @@ describe "ImageCard", type: :view do
 
   it "applies tracking attributes" do
     render_component(href: "#", href_data_attributes: { track_category: "cat" }, heading_text: "test")
-    assert_select ".gem-c-image-card[data-module='gem-track-click']"
+    assert_select ".gem-c-image-card[data-module='gem-track-click ga4-link-tracker']"
     assert_select ".gem-c-image-card__title-link[data-track-category='cat']"
   end
 
   it "applies tracking attributes for extra details" do
     render_component(href: "#", extra_details: [{ href: "/", text: "1", data_attributes: { track_category: "cat" } }])
-    assert_select ".gem-c-image-card[data-module='gem-track-click']"
+    assert_select ".gem-c-image-card[data-module='gem-track-click ga4-link-tracker']"
     assert_select ".gem-c-image-card__list-item a[data-track-category='cat']"
   end
 


### PR DESCRIPTION
## What
This PR adds `ga4-link-tracker` to the `data-module` attribute on the `_image_card` component.

## Why
We are adding tracking to links on the homepage, which uses image cards.

[Trello card](https://trello.com/c/WAST3s6v/392-add-tracking-homepage)

## Visual Changes
N/A