### PR TITLE
Version 34.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 34.1.2
+
+* Bump govuk-frontend from 4.4.0 to 4.4.1 ([PR #3147](https://github.com/alphagov/govuk_publishing_components/pull/3147))
+
 ## 34.1.1
 
 * Update component auditing following print style changes ([PR #3128](https://github.com/alphagov/govuk_publishing_components/pull/3128))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (34.1.1)
+    govuk_publishing_components (34.1.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "34.1.1".freeze
+  VERSION = "34.1.2".freeze
 end


### PR DESCRIPTION
## 34.1.2

* Bump govuk-frontend from 4.4.0 to 4.4.1 ([PR #3147](https://github.com/alphagov/govuk_publishing_components/pull/3147))