### PR TITLE
Test against Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.7, '3.0', 3.1]
+        ruby: [2.7, '3.0', 3.1, 3.2]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.13.10)
+    nokogiri (1.14.0)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     null_logger (0.0.1)


### PR DESCRIPTION
Ruby 3.2 was released on December 25th 2022