### PR TITLE
Remove inline styling from feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 
 ## Unreleased
 
+* Remove inline styling from feedback component ([PR #3159](https://github.com/alphagov/govuk_publishing_components/pull/3159))
 * Increase space beneath list items on the image_card component ([PR #3153](https://github.com/alphagov/govuk_publishing_components/pull/3153))
-
 
 ## 34.1.2
 

--- a/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_yes_no_banner.html.erb
@@ -4,7 +4,7 @@
       <div class="gem-c-feedback__prompt-question-answer">
         <h2 class="gem-c-feedback__prompt-question"><%= t("components.feedback.is_this_page_useful") %></h2>
         <ul class="gem-c-feedback__option-list">
-          <li class="gem-c-feedback__option-list-item govuk-visually-hidden" style="display: none" hidden>
+          <li class="gem-c-feedback__option-list-item govuk-visually-hidden" hidden>
             <% # Maybe button exists only to try and capture clicks by bots %>
             <%= link_to "/contact/govuk", {
               class: 'gem-c-feedback__prompt-link',
@@ -13,7 +13,6 @@
                 'track-action' => 'ffMaybeClick'
               },
               role: 'button',
-              style: 'display: none',
               hidden: 'hidden',
               'aria-hidden': 'true',
             } do %>


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

## What

This removes the usage of inline styles (`style="display:none;"`) on the feedback component.

## Why

To improve users security we intend to disallow the use of unsafe inline styles by the content security policy [1].

From my research these attributes were added as an idea that they may help reduce spam [2], however this did not resolve the spam problem and further attempts were made [3]. However this code was left in.

The process to update the CSP will take a while, we will first remove global offences like the below, then later remove unsafe-inline from the CSP with report-only on so we can discover if we have other offences and finally turn on the CSP. This should give us amble time to discover if this was impactful in the battle against spam bots - my expectation is that it's impact was negligible.

[1]: https://content-security-policy.com/unsafe-inline/
[2]: https://github.com/alphagov/govuk_publishing_components/pull/2568
[3]: https://github.com/alphagov/govuk_publishing_components/pull/2574

## Visual Changes

None
