### PR TITLE
Version 34.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 34.1.3
 
 * Remove inline styling from feedback component ([PR #3159](https://github.com/alphagov/govuk_publishing_components/pull/3159))
 * Increase space beneath list items on the image_card component ([PR #3153](https://github.com/alphagov/govuk_publishing_components/pull/3153))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (34.1.2)
+    govuk_publishing_components (34.1.3)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "34.1.2".freeze
+  VERSION = "34.1.3".freeze
 end


### PR DESCRIPTION
## Version 34.1.3

* Remove inline styling from feedback component ([PR #3159](https://github.com/alphagov/govuk_publishing_components/pull/3159))
* Increase space beneath list items on the image_card component ([PR #3153](https://github.com/alphagov/govuk_publishing_components/pull/3153))