### PR TITLE
Remove the content security policy unsafe eval customisation

### DIFF
--- a/app/controllers/govuk_publishing_components/application_controller.rb
+++ b/app/controllers/govuk_publishing_components/application_controller.rb
@@ -5,19 +5,6 @@ module GovukPublishingComponents
     before_action :set_x_frame_options_header
     before_action :set_disable_slimmer_header
 
-    if defined? content_security_policy
-      content_security_policy do |p|
-        # don't do anything if the app doesn't have a content security policy
-        next unless p.directives.any?
-
-        # Unfortunately the axe core script uses a dependency that uses eval
-        # see: https://github.com/dequelabs/axe-core/issues/1175
-        # Thus all components shown by govuk_publishing_components need this
-        # enabled
-        p.script_src(*p.script_src, :unsafe_eval)
-      end
-    end
-
   private
 
     def set_x_frame_options_header


### PR DESCRIPTION
Fixes #2834 

## What

This removes the CSP customisation that allowed unsafe_eval for viewing the components gem.

## Why

This use of unsafe_eval was required when we were using axe-core < 3.31 [1]. We are now using version 4.6.1 so can remove this code.

[1]: https://github.com/dequelabs/axe-core/pull/1707

## Visual Changes

None