### PR TITLE
Replace data:image based test for a CSP friendly one

### DIFF
--- a/spec/component_guide/component_example_accessibility_testing_spec.rb
+++ b/spec/component_guide/component_example_accessibility_testing_spec.rb
@@ -39,9 +39,9 @@ describe "Component example with automated testing", js: true do
     expect(page).to have_selector(selector_with_error)
 
     within ".component-guide-preview--warning" do
-      expect(page).to have_selector("h3", text: "Elements must have sufficient color contrast")
+      expect(page).to have_selector("h3", text: "aria-roledescription must be on elements with a semantic role (aria-roledescription)")
       expect(page).to have_selector('h3 a[href*="https://dequeuniversity.com"]', text: "(see guidance)")
-      expect(page).to have_text("Element's background color could not be determined due to a background image")
+      expect(page).to have_text("Check that the aria-roledescription is announced by supported screen readers")
     end
   end
 end

--- a/spec/dummy/app/views/components/_test-component-with-a11y-incomplete-warning.html.erb
+++ b/spec/dummy/app/views/components/_test-component-with-a11y-incomplete-warning.html.erb
@@ -1,3 +1,3 @@
 <div class="test-component-with-a11y-incomplete-warning">
-  <p style="background-image: url('data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='); color: white;">Paragraph with background</p>
+  <h2 aria-roledescription="test" role="heading" aria-level="1">A heading with a role description</h2>
 </div>

--- a/spec/dummy/app/views/components/docs/test-component-with-a11y-incomplete-warning.yml
+++ b/spec/dummy/app/views/components/docs/test-component-with-a11y-incomplete-warning.yml
@@ -1,5 +1,5 @@
 name: Test component with an incomplete accessibility warning
-description: Component link has a background image (a black pixel) meaning aXe can’t determine the colour contrast
+description: Component uses a roledescription for a header and aXe doesn't know if it will be announced to screen readers.
 examples:
   default:
     data: {}


### PR DESCRIPTION
## What

This updates the test component with an accessibility incomplete warning to no longer use inline styles and a data:image.

## Why

We are intending to remove both the ability to set inline styles and the ability to use data images in the GOV.UK Content Security Policy [1]. This is because both of them offer potential security risks.

However a problem was that this test component relied on both of these. After much digging I found a different issue that could trigger an incomplete accessibility warning and I've converted the test to use that.

[1]: https://github.com/alphagov/govuk_app_config/blob/9b01e06d889be266501714e0dc0fc70a86e7e240/lib/govuk_app_config/govuk_content_security_policy.rb#L32-L65

## Visual Changes

None