### PR TITLE
Version 34.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 34.2.0
 
 * Update the list of popular links in the super navigation header ([PR #3167](https://github.com/alphagov/govuk_publishing_components/pull/3167))
 * Replace input search icon data:image with file asset ([PR #3163](https://github.com/alphagov/govuk_publishing_components/pull/3163))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (34.1.3)
+    govuk_publishing_components (34.2.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "34.1.3".freeze
+  VERSION = "34.2.0".freeze
 end


### PR DESCRIPTION
## 34.2.0
* Update the list of popular links in the super navigation header ([PR #3167](https://github.com/alphagov/govuk_publishing_components/pull/3167))
* Replace input search icon data:image with file asset ([PR #3163](https://github.com/alphagov/govuk_publishing_components/pull/3163))
