### PR TITLE
Fix flaky contextual navigation tests

### DIFF
--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -521,7 +521,7 @@ describe "Contextual navigation" do
     expect(page).not_to have_selector(".gem-c-breadcrumbs")
   end
 
-  def content_store_has_random_item(schema: "placeholder", links: {})
+  def content_store_has_random_item(schema: "guide", links: {})
     content_item = random_item(
       schema,
       "base_path" => "/page-with-contextual-navigation",


### PR DESCRIPTION
This resolves a number of tests that fail intermittently (see below). These tests would fail based on random schema generation, the failure would occur when the random document type selected for the placeholder schema was html_publication, which has an additional request to the content store [1].

This can be resolved by switching the schema that is used by default to not have randomly selected document types. This allows avoiding non-deterministic behaviour.

Intermittent tests:
```
rspec ./spec/features/contextual_navigation_spec.rb:25 # Contextual navigation There's a mainstream browse page tagged
rspec ./spec/features/contextual_navigation_spec.rb:38 # Contextual navigation The page has curated related items
rspec ./spec/features/contextual_navigation_spec.rb:87 # Contextual navigation A browse page has a topic
```

Example of failing test:
```
     Failure/Error: @parent_item ||= Services.content_store.content_item(content_item_navigation.parent_api_path)

     WebMock::NetConnectNotAllowedError:
       Real HTTP connections are disabled. Unregistered request: GET http://content-store.dev.gov.uk/content/browse/benefits with headers {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Host'=>'content-store.dev.gov.uk', 'User-Agent'=>'gds-api-adapters/85.0.0 ()'}

       You can stub this request with the following snippet:

       stub_request(:get, "http://content-store.dev.gov.uk/content/browse/benefits").
         with(
           headers: {
       	  'Accept'=>'application/json',
       	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
       	  'Host'=>'content-store.dev.gov.uk',
       	  'User-Agent'=>'gds-api-adapters/85.0.0 ()'
           }).
         to_return(status: 200, body: "", headers: {})

       registered request stubs:

       stub_request(:get, "http://content-store.dev.gov.uk/content/page-with-contextual-navigation")

       ============================================================
     # ./lib/govuk_publishing_components/presenters/breadcrumb_selector.rb:86:in `parent_item'
     # ./lib/govuk_publishing_components/presenters/breadcrumb_selector.rb:82:in `parent_item_navigation'
     # ./lib/govuk_publishing_components/presenters/breadcrumb_selector.rb:92:in `parent_item_options'
     # ./lib/govuk_publishing_components/presenters/breadcrumb_selector.rb:110:in `parent_is_step_by_step?'
     # ./lib/govuk_publishing_components/presenters/breadcrumb_selector.rb:26:in `best_match_option'
     # ./lib/govuk_publishing_components/presenters/breadcrumb_selector.rb:17:in `step_by_step'
     # ./app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb:7:in `___sers_kevin_dew_govuk_govuk_publishing_components_app_views_govuk_publishing_components_components__contextual_breadcrumbs_html_erb__2626890578174845449_62900'
     # ./spec/dummy/app/views/welcome/contextual_navigation.html.erb:2:in `_app_views_welcome_contextual_navigation_html_erb___4124861535232250557_62880'
     # ./spec/features/contextual_navigation_spec.rb:359:in `and_i_visit_that_page'
     # ./spec/features/contextual_navigation_spec.rb:40:in `block (2 levels) in <top (required)>'
```

[1]: https://github.com/alphagov/govuk_publishing_components/blob/5e682ed57f88cbedef61cafc0e62e4707170d38c/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb#L22-L29

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before


### After
