### PR TITLE
Support Rails Content Security Policy nonce on inline JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Support Rails Content Security Policy nonce on inline JavaScript ([PR #3173](https://github.com/alphagov/govuk_publishing_components/pull/3173))
+
 ## 34.2.0
 
 * Update the list of popular links in the super navigation header ([PR #3167](https://github.com/alphagov/govuk_publishing_components/pull/3167))

--- a/app/views/govuk_publishing_components/components/_google_tag_manager_script.html.erb
+++ b/app/views/govuk_publishing_components/components/_google_tag_manager_script.html.erb
@@ -7,7 +7,7 @@
     gtm_attributes << "gtm_preview=" + gtm_preview if gtm_preview
   gtm_attributes = gtm_attributes.join('&')
 %>
-<script>
+<%= javascript_tag nonce: true do -%>
 var doNotTrack = ( navigator.doNotTrack === '1' || navigator.doNotTrack === 'yes' || navigator.msDoNotTrack === '1' || window.doNotTrack === '1' )
 if (!doNotTrack) {
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -16,4 +16,4 @@ if (!doNotTrack) {
   'https://www.googletagmanager.com/gtm.js?id='+i+dl+'&<%= raw gtm_attributes %>';f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','<%= gtm_id %>');
 }
-</script>
+<% end -%>

--- a/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb
@@ -14,9 +14,9 @@
     <%= yield :head %>
   </head>
   <body class="gem-c-layout-for-admin govuk-template__body">
-    <script>
+    <%= javascript_tag nonce: true do -%>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+    <% end -%>
     <%= yield %>
     <%= javascript_include_tag "application" %>
   </body>

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -81,9 +81,9 @@
     <%= yield :head %>
   </head>
   <%= tag.body class: body_css_classes do %>
-    <script>
+    <%= javascript_tag nonce: true do -%>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+    <% end -%>
     <%= render "govuk_publishing_components/components/skip_link", {
       href: "#content"
     } %>

--- a/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
+++ b/app/views/govuk_publishing_components/components/feedback/_problem_form.html.erb
@@ -68,7 +68,7 @@
   # This seems to be a more reliable way to make sure the script is executed.
 %>
 
-<script>
+<%= javascript_tag nonce: true do -%>
   document.addEventListener("DOMContentLoaded", function () {
     var input = document.querySelector("#giraffe"),
       form = document.querySelector("#something-is-wrong")
@@ -80,4 +80,4 @@
       e.preventDefault();
     }
   });
-</script>
+<% end -%>

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -23,9 +23,9 @@
     <%= yield :extra_headers %>
   </head>
   <body class="gem-c-layout-for-admin govuk-template__body <%= 'hide-header-and-footer' if @preview %>">
-    <script>
+    <%= javascript_tag nonce: true do -%>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+    <% end -%>
     <% if @preview %>
       <main id="wrapper" class="govuk-width-container">
         <%= yield %>


### PR DESCRIPTION

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

This changes the approach to adding inline script to components. If an app has a [Rails nonce configured][3] this will add the nonce attribute to the script tags. If an app does not have a nonce generator configured then the script tag will not be given a nonce attribute. In order to implement this fully to GOV.UK there will also be changes needed in Slimmer to inject nonces into layouts, which will come later.

This has been put together so that govuk_publishing_components can have the aspirational CSP for GOV.UK implemented before other apps, so that any indiscretions don't get introduced into components.

Before:

```
<script>
  document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
</script>
```

After (with nonce generator configured):

```
<script nonce="ntkA9+c5yZHnUMvxbOPsTw==">
//<![CDATA[
      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');

//]]>
</script>
```
Note a consequence of using the Rails helper for script tags is that they are wrapped in CDATA escaping, while a bit legacy looking (it's from the XHTML days) this has no functional impact.

## Why
<!-- What are the reasons behind this change being made? -->

The motivation for this change is to work towards removing the unsafe-inline attribute from the [GOV.UK Content Security Policy][1]. In order to use inline script when unsafe-inline is removed we need script tags to be annotated with a [nonce][2] attribute that matches one sent in the HTTP header. This helps prevent XSS scripting as injecting script cannot guess what the nonce would be.

## Visual Changes

None

[1]: https://github.com/alphagov/govuk_app_config/blob/31928b2079d82f6cbe7c296d4d6e54b4efc07b84/lib/govuk_app_config/govuk_content_security_policy.rb#L55-L59
[2]: https://content-security-policy.com/nonce/
[3]: https://edgeguides.rubyonrails.org/security.html#adding-a-nonce