### PR TITLE
Restyle subscription link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Support Rails Content Security Policy nonce on inline JavaScript ([PR #3173](https://github.com/alphagov/govuk_publishing_components/pull/3173))
+* Restyle subscription link ([PR #3177](https://github.com/alphagov/govuk_publishing_components/pull/3177))
 
 ## 34.2.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_subscription-links.scss
@@ -123,7 +123,6 @@
   .gem-c-subscription-links__item--link {
     padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
     border: 1px solid transparent;
-    border-bottom: 1px solid govuk-colour("dark-grey", $legacy: "grey-1");
 
     &:focus {
       border-bottom-color: transparent;

--- a/app/views/govuk_publishing_components/components/_subscription_links.html.erb
+++ b/app/views/govuk_publishing_components/components/_subscription_links.html.erb
@@ -36,7 +36,7 @@
             </svg><%= sl_helper.email_signup_link_text %>
           <% end %>
           <%= link_to email_link_text, sl_helper.email_signup_link, {
-            class: "govuk-link govuk-link--no-underline gem-c-subscription-links__item #{brand_helper.color_class} gem-c-subscription-links__item--link",
+            class: "govuk-link gem-c-subscription-links__item #{brand_helper.color_class} gem-c-subscription-links__item--link",
             data: sl_helper.email_signup_link_data_attributes,
             lang: email_signup_link_text_locale
           } %>


### PR DESCRIPTION
## What

Removes the border-bottom from 'Get Emails' subscription link from the subscription links component in the 'with copyable feed' variant. Restores the default link underline style.

## Why

This was a request from a designer and is part of the No. 10 organisation page redesign.

## Visual Changes

### Before

![Screenshot 2023-01-09 at 09 50 37](https://user-images.githubusercontent.com/3727504/211280958-fc423ad0-bd4c-4f23-83cd-a425bbdb722e.png)

### After

![Screenshot 2023-01-09 at 09 50 06](https://user-images.githubusercontent.com/3727504/211280950-ccb8e444-beb4-4475-a461-f227f1cbdb71.png)



