### PR TITLE
Add GA4 tracking to related navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add GA4 tracking to related navigation ([PR #3179](https://github.com/alphagov/govuk_publishing_components/pull/3179))
+
 ## 34.3.0
 
 * Support Rails Content Security Policy nonce on inline JavaScript ([PR #3173](https://github.com/alphagov/govuk_publishing_components/pull/3173))

--- a/app/views/govuk_publishing_components/components/_contextual_footer.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_footer.html.erb
@@ -1,10 +1,12 @@
 <% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request) %>
+<% ga4_tracking ||= false %>
 
 <% unless navigation.content_tagged_to_current_step_by_step? %>
   <div class="gem-c-contextual-footer">
     <%# Rendering related navigation because no step by step list %>
     <%= render 'govuk_publishing_components/components/related_navigation',
                content_item: content_item,
+               ga4_tracking: ga4_tracking,
                context: :footer %>
   </div>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -1,5 +1,9 @@
-<% navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request) %>
-<% shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns) %>
+<%
+  ga4_tracking ||= false
+  request.query_parameters[:ga4_tracking] = ga4_tracking
+  navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request)
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+%>
 
 <div class="gem-c-contextual-sidebar">
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
@@ -12,7 +16,7 @@
     <%= render 'govuk_publishing_components/components/step_by_step_nav', navigation.step_nav_helper.sidebar %>
   <% else %>
     <%# Rendering related navigation sidebar because no step by step list %>
-    <%= render 'govuk_publishing_components/components/related_navigation', content_item: content_item, context: :sidebar %>
+    <%= render 'govuk_publishing_components/components/related_navigation', content_item: content_item, context: :sidebar, ga4_tracking: ga4_tracking %>
   <% end %>
 
   <% if navigation.content_tagged_to_other_step_by_steps? %>

--- a/app/views/govuk_publishing_components/components/_related_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_related_navigation.html.erb
@@ -1,10 +1,15 @@
-<% related_nav_helper = GovukPublishingComponents::Presenters::RelatedNavigationHelper.new(local_assigns) %>
-<% shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns) %>
+<%
+  related_nav_helper = GovukPublishingComponents::Presenters::RelatedNavigationHelper.new(local_assigns)
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  ga4_tracking ||= false
+  data = {}
+  data[:module] = "gem-track-click"
+  data[:module] << " ga4-link-tracker" if ga4_tracking
+%>
 
 <% if related_nav_helper.related_navigation? %>
   <% random = SecureRandom.hex(4) %>
-  <div class="gem-c-related-navigation">
-
+  <%= tag.div(class: "gem-c-related-navigation", data: data) do %>
     <% if local_assigns[:context] != :footer %>
       <h2 id="related-nav-related_items-<%= random %>"
           class="gem-c-related-navigation__main-heading"
@@ -33,7 +38,8 @@
         section_title: section_title,
         links: links,
         section_index: section_index,
-        random: random %>
+        random: random,
+        ga4_tracking: ga4_tracking %>
     <% end %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/contextual_footer.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_footer.yml
@@ -69,3 +69,46 @@ examples:
           ordered_related_items:
             - title: "Find an apprenticeship"
               base_path: "/apply-apprenticeship"
+  with_ga4_tracking:
+    description: Adds Google Analytics 4 tracking to the Related Navigation component, if it is visible.
+    data:
+      ga4_tracking: true
+      content_item:
+        title: "A content item"
+        links:
+          topics:
+          - title: Apprenticeships, 14 to 19 education and training for work
+            base_path: /browse/education/find-course
+            document_type: topic
+          - title: Finding a job
+            base_path: /browse/working/finding-job
+            document_type: topic
+          - title: Apprenticeships
+            base_path: /topic/further-education-skills/apprenticeships
+            document_type: topic
+          topical_events:
+          - title: UK-China High-Level People to People Dialogue 2017
+            base_path: /government/topical-events/uk-china-high-level-people-to-people-dialogue-2017
+            document_type: topical_event
+          related:
+          - title: Pest Control
+            base_path: /pest-control
+            document_type: contact
+          related_statistical_data_sets:
+          - title: International road fuel prices
+            base_path: /government/statistical-data-sets/comparisons-of-industrial-and-domestic-energy-prices-monthly-figures
+            document_type: statistical_data_set
+          - title: Weekly road fuel prices
+            base_path: /government/statistical-data-sets/oil-and-petroleum-products-weekly-statistics
+            document_type: statistical_data_set
+          world_locations:
+          - title: South Sudan
+            base_path: /world/south-sudan/news
+          - title: USA
+            base_path: /world/usa/news
+        details:
+          external_related_links:
+          - url: "http://media.slc.co.uk/sfe/1718/ft/sfe_terms_and_conditions_guide_1718_d.pdf"
+            title: "Student loans: terms and conditions 2017 to 2018 (PDF, 136KB)"
+          - title: The Student Room repaying your student loan
+            url: https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -103,3 +103,61 @@ examples:
               title: "Russian invasion of Ukraine: UK government response"
               base_path: "/government/topical-events/russian-invasion-of-ukraine-uk-government-response"
               locale: "en"
+  with_ga4_tracking_on_related_navigation:
+    description: Adds Google Analytics 4 tracking to components within the sidebar. Currently only the Related Navigation and Step by Step navigation components accept this option.
+    data:
+      ga4_tracking: true
+      content_item:
+        title: "UK forces arrive to reinforce NATO’s eastern flank"
+        content_id: "a342fd46-d801-4c1e-9d8f-f41fba6da563"
+        locale: "en"
+        links:
+          ordered_related_items:
+          - title: Find an apprenticeship
+            base_path: /apply-apprenticeship
+          - title: Careers helpline for teenagers
+            base_path: /careers-helpline-for-teenagers
+          document_collections:
+          - title: Recruit an apprentice (formerly apprenticeship vacancies)
+            base_path: /government/collections/apprenticeship-vacancies
+            document_type: document_collection
+          - title: The future of jobs and skills
+            base_path: /government/collections/the-future-of-jobs-and-skills
+            document_type: document_collection
+  with_ga4_tracking_on_step_by_step:
+    description: Adds Google Analytics 4 tracking to components within the sidebar. Currently only the Related Navigation and Step by Step navigation components accept this option.
+    data:
+      ga4_tracking: true
+      content_item:
+        title: "A content item"
+        links:
+          part_of_step_navs:
+            - title: "Learn to drive a car: step by step"
+              base_path: "/micropigs-vs-micropugs"
+              details:
+                step_by_step_nav:
+                  title: 'Stay in the UK after it leaves the EU (''settled status''): step by step'
+                  steps:
+                  - title: Check you're allowed to drive
+                    contents:
+                    - type: paragraph
+                      text: Most people can start learning to drive when they’re 17.
+                    - type: list
+                      contents:
+                      - text: Check what age you can drive
+                        href: "/vehicles-can-drive"
+                    optional: false
+                  - title: Testing the and
+                    logic: and
+                    contents:
+                    - type: paragraph
+                      text: hello hello what's UP
+                  - title: Driving lessons and practice
+                    contents:
+                    - type: paragraph
+                      text: You need a provisional driving licence to take lessons or practice.
+                    - type: list
+                      contents:
+                      - text: The Highway Code
+                        href: "/guidance/the-highway-code"
+                    optional: false

--- a/app/views/govuk_publishing_components/components/docs/related_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/related_navigation.yml
@@ -306,3 +306,30 @@ examples:
               title: "Student loans: terms and conditions 2017 to 2018 (PDF, 136KB)"
             - title: The Student Room repaying your student loan
               url: https://www.thestudentroom.co.uk/content.php?r=5967-Repaying-your-student-loan
+  with_ga4_tracking:
+    description: Adds Google Analytics 4 tracking to the component, using the [GA4 link tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md).
+    data:
+      ga4_tracking: true
+      content_item:
+        links:
+          ordered_related_items:
+            - title: Find an apprenticeship
+              base_path: /apply-apprenticeship
+            - title: Training and study at work
+              base_path: /training-study-work-your-rights
+            - title: Careers helpline for teenagers
+              base_path: /careers-helpline-for-teenagers
+          topics:
+            - title: Apprenticeships, 14 to 19 education and training for work
+              base_path: /browse/education/find-course
+              document_type: topic
+            - title: Finding a job
+              base_path: /browse/working/finding-job
+              document_type: topic
+            - title: Apprenticeships
+              base_path: /topic/further-education-skills/apprenticeships
+              document_type: topic
+          topical_events:
+            - title: UK-China High-Level People to People Dialogue 2017
+              base_path: /government/topical-events/uk-china-high-level-people-to-people-dialogue-2017
+              document_type: topical_event

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -3,20 +3,23 @@
      aria-labelledby="related-nav-<%= section_title %>-<%= random %>"
      data-module="gem-toggle">
 
-  <% unless section_title === "related_items" %>
+  <% if section_title === "related_items" %>
+   <% heading_text = related_nav_helper.component_title %>
+  <% else %>
     <%=
       heading_class = related_nav_helper.section_css_class("gem-c-related-navigation__sub-heading", section_title)
       heading_data = { 'track-count' => related_nav_helper.section_data_track_count(:related_item_section) }
       heading_id = "related-nav-#{section_title}-#{random}"
       heading_level = related_nav_helper.section_heading_level
+      heading_text = related_nav_helper.construct_section_heading(section_title)
 
       content_tag(heading_level, id: heading_id, class: heading_class, data: heading_data) do
-        related_nav_helper.construct_section_heading(section_title)
+        heading_text
       end
     %>
   <% end %>
 
-  <ul class="gem-c-related-navigation__link-list" data-module="gem-track-click">
+  <ul class="gem-c-related-navigation__link-list">
     <% constructed_link_array = [] %>
 
     <% section_link_limit = related_nav_helper.calculate_section_link_limit(links) %>
@@ -24,6 +27,12 @@
     <% links.each.with_index(1) do |link, index| %>
       <%
         link_class = "govuk-link #{related_nav_helper.section_css_class("govuk-link gem-c-related-navigation__section-link", section_title, link: link, link_is_inline: (index >= section_link_limit))}"
+        ga4_attributes = {
+          event_name: "navigation",
+          type: "related content",
+          index: "#{section_index}.#{index}",
+          section: heading_text,
+        } if ga4_tracking
         link_element = link_to(
           link[:text],
           link[:path],
@@ -37,7 +46,8 @@
             track_options: {
               dimension28: links.length.to_s,
               dimension29: link[:text]
-            }
+            },
+            ga4_link: ga4_attributes,
           }
         )
       %>

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -77,7 +77,7 @@ module GovukPublishingComponents
         if show_sidebar?
           @sidebar ||= current_step_nav.content.tap do |sb|
             configure_for_sidebar(sb)
-            sb.merge!(small: true, heading_level: 3, tracking_id: current_step_nav.content_id)
+            sb.merge!(small: true, heading_level: 3, tracking_id: current_step_nav.content_id, ga4_tracking: @query_parameters[:ga4_tracking])
           end
         end
       end

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -65,6 +65,10 @@ module GovukPublishingComponents
         end
       end
 
+      def component_title
+        I18n.t("components.related_#{@context}_navigation.related_content", default: I18n.t("components.related_navigation.related_content"))
+      end
+
       def section_css_class(css_class, section_title, link: {}, link_is_inline: false)
         css_classes = [css_class]
         css_classes << "#{css_class}--#{@context}" unless @context.nil?

--- a/spec/components/related_navigation_spec.rb
+++ b/spec/components/related_navigation_spec.rb
@@ -201,10 +201,62 @@ describe "Related navigation", type: :view do
     )
     render_component(content_item: content_item)
 
-    assert_select ".gem-c-related-navigation__nav-section ul[data-module='gem-track-click']"
+    assert_select ".gem-c-related-navigation[data-module='gem-track-click']"
     assert_select ".gem-c-related-navigation__section-link[data-track-category='relatedLinkClicked']"
     assert_select ".gem-c-related-navigation__section-link[data-track-action='1.1 Explore the topic']"
     assert_select ".gem-c-related-navigation__section-link[data-track-label='/apprenticeships']"
+  end
+
+  it "tracks links with GA4" do
+    content_item = {}
+    content_item["links"] = {
+      "ordered_related_items" => [
+        {
+          "base_path" => "/fishing",
+          "title" => "Fishing",
+        },
+        {
+          "base_path" => "/surfing",
+          "title" => "Surfing",
+        },
+      ],
+      "topics" => [
+        {
+          "base_path" => "/skating",
+          "title" => "Skating",
+          "document_type" => "topic",
+        },
+        {
+          "base_path" => "/paragliding",
+          "title" => "Paragliding",
+          "document_type" => "topic",
+        },
+      ],
+    }
+    content_item["details"] = {
+      "external_related_links" => [
+        {
+          "url" => "http://something",
+          "title" => "Travel insurance",
+        },
+        {
+          "url" => "http://somethingelse",
+          "title" => "Extreme sports insurance",
+        },
+      ],
+    }
+
+    render_component(content_item: content_item, ga4_tracking: true)
+
+    assert_select ".gem-c-related-navigation[data-module='gem-track-click ga4-link-tracker']"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":\"1.1\",\"section\":\"Related content\"}']", text: "Fishing"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":\"1.2\",\"section\":\"Related content\"}']", text: "Surfing"
+
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":\"2.1\",\"section\":\"Explore the topic\"}']", text: "Skating"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":\"2.2\",\"section\":\"Explore the topic\"}']", text: "Paragliding"
+
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":\"3.1\",\"section\":\"Elsewhere on the web\"}']", text: "Travel insurance"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":\"3.2\",\"section\":\"Elsewhere on the web\"}']", text: "Extreme sports insurance"
   end
 
   it "uses lang when locale is set" do


### PR DESCRIPTION
## What
Adds Google Analytics 4 tracking to the sidebar and footer sections using the existing [ga4-link-tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md).

### Changes to the Related Navigation component

The [Related Navigation component](https://components.publishing.service.gov.uk/component-guide/related_navigation) shows a series of links. It is usually seen in the sidebar of a page but not exclusively. It includes some logic for which sections are displayed in different contexts, which is used when it is wrapped by other components.

- adds a `ga4_tracking` option that then adds relevant attributes to links as well as adding `ga4-link-tracker` into the `data-module` attribute
- changes how JS modules for tracking are enabled. UA tracking is enabled by default, so this change moves the `gem-track-click` `data-module` attribute from individual sections within the component to the top level, so that module is only initialised once (and combines it with the `ga4-link-tracker` `data-module` if GA4 tracking is enabled)
- changes how the title for each section is determined, as this is needed for the GA4 tracking. Content in each section has the title determined based on the content, except for the first section where the title defaulted to 'Related content'. Changes were needed since the attributes on all links when tracked needed to include the section title
- changes the aria-label configuration to fix an accessibility warning in the component guide (which I think was in error but this way seems better) by explicitly setting what was formerly the heading `id` to the `aria-label` instead, fixes the accessibility warning

### Changes to the Contextual Sidebar component

The [Contextual Sidebar component](https://components.publishing.service.gov.uk/component-guide/contextual_sidebar) is a wrapper for other components, including the Related Navigation component and the Step by Step Navigation component. It usually appears in the sidebar of a page.

- adds the `ga4_tracking` option to Contextual Sidebar, which is then passed to the Related Navigation component if set
- also passes any `ga4_tracking` option to the Step by Step Navigation component. This is slightly complicated by the fact that the step nav in this context only accepts one parameter, so we have to add the `ga4_tracking` flag to the `request.query_parameters` object, so it gets passed through various helpers and finally to the component itself correctly.

### Changes to the Contextual Footer component

The [Contextual Footer component](https://components.publishing.service.gov.uk/component-guide/contextual_footer) is a wrapper for the Related Navigation component. It appears in the footer of some pages. It contains logic that determines if a step by step navigation is already shown on the page - if this is false, the Related Navigation component is displayed.

- adds the `ga4_tracking` option, which is then passed to the Related Navigation component if set

## Why
We want to add tracking to links in the sidebar.

## Visual Changes
None.

Trello card: https://trello.com/c/IMjw2dHg/382-add-tracking-related-links-contextual-sidebar-and-contextual-footer
