### PR TITLE
Disable axe-core rules for issues highlighted in component guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add GA4 tracking to related navigation ([PR #3179](https://github.com/alphagov/govuk_publishing_components/pull/3179))
 * Add Youtube Embed Support to the ImageCard Component ([PR #3156](https://github.com/alphagov/govuk_publishing_components/pull/3156))
 * Remove dependency on .js.erb and puppet for loading our analytics ([PR #3145](https://github.com/alphagov/govuk_publishing_components/pull/3145))
+* Disable axe-core rules for issues highlighted in component guide ([PR #3180](https://github.com/alphagov/govuk_publishing_components/pull/3180))
 
 ## 34.3.0
 

--- a/app/views/govuk_publishing_components/components/docs/emergency_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/emergency_banner.yml
@@ -7,7 +7,9 @@ body: |
 
 shared_accessibility_criteria:
   - link
-
+accessibility_excluded_rules:
+  - duplicate-id-aria # IDs will be duplicated in component examples list
+  - landmark-unique # aria-label attributes will be duplicated in component examples list
 examples:
   default:
     description: |

--- a/app/views/govuk_publishing_components/components/docs/intervention.yml
+++ b/app/views/govuk_publishing_components/components/docs/intervention.yml
@@ -14,9 +14,10 @@ accessibility_criteria: |
   - have a border colour contrast ratio of more than 4.5:1 with its background to be visually distinct
   - prevent screen readers from announcing the dismiss link icon
 
-
 shared_accessibility_criteria:
   - link
+accessibility_excluded_rules:
+  - landmark-unique # aria-label attributes will be duplicated in component examples list
 examples:
   default:
     data:

--- a/app/views/govuk_publishing_components/components/docs/layout_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_header.yml
@@ -7,6 +7,7 @@ govuk_frontend_components:
   - header
 accessibility_excluded_rules:
   - landmark-banner-is-top-level # The header element can not be top level in the examples
+  - duplicate-id # IDs will be duplicated in component examples list
   - duplicate-id-aria # IDs will be duplicated in component examples list
   - form-field-multiple-labels # Form labels will be ambiguous in component examples list
   - landmark-no-duplicate-banner # banners will be duplicated in component examples list

--- a/app/views/govuk_publishing_components/components/docs/previous_and_next_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/previous_and_next_navigation.yml
@@ -21,6 +21,8 @@ accessibility_criteria: |
 
 shared_accessibility_criteria:
   - link
+accessibility_excluded_rules:
+  - landmark-unique # aria-label attributes will be duplicated in component examples list
 examples:
   default:
     data:

--- a/app/views/govuk_publishing_components/components/docs/translation_nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/translation_nav.yml
@@ -14,6 +14,8 @@ accessibility_criteria: |
     [Watch a screen reader pronounce text differently based on lang attribute](https://bit.ly/screenreaderpronunciation)
 shared_accessibility_criteria:
   - link
+accessibility_excluded_rules:
+  - landmark-unique # aria-label attributes will be duplicated in component examples list
 examples:
   default:
     data:


### PR DESCRIPTION
## What

Disable axe-core rules for issues highlighted in component guide:

- `duplicate-id-aria`
- `duplicate-id`
- `landmark-unique`

## Why

The issues are highlighted because there are multiple instances of components, per page, in the component guide.

It's unlikely these issues would ever be seen because typically only one of these components would be deployed on any page e.g. **emergency banner**, **layout header**.