### PR TITLE
Version 34.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 34.3.0
 
 * Support Rails Content Security Policy nonce on inline JavaScript ([PR #3173](https://github.com/alphagov/govuk_publishing_components/pull/3173))
 * Restyle subscription link ([PR #3177](https://github.com/alphagov/govuk_publishing_components/pull/3177))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (34.2.0)
+    govuk_publishing_components (34.3.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -107,6 +107,7 @@ GEM
       rexml
     crass (1.0.6)
     csv (3.2.5)
+    date (3.3.3)
     diff-lcs (1.5.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -175,8 +176,11 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -186,11 +190,12 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     minitest (5.17.0)
-    net-imap (0.3.1)
+    net-imap (0.3.4)
+      date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.1.3)
+    net-protocol (0.2.1)
       timeout
     net-smtp (0.3.3)
       net-protocol
@@ -345,7 +350,7 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)
     tilt (2.0.10)
-    timeout (0.3.0)
+    timeout (0.3.1)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     uglifier (4.2.0)
@@ -397,4 +402,4 @@ RUBY VERSION
    ruby 2.7.6
 
 BUNDLED WITH
-   2.3.25
+   2.3.6

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "34.2.0".freeze
+  VERSION = "34.3.0".freeze
 end


### PR DESCRIPTION
* Support Rails Content Security Policy nonce on inline JavaScript ([PR #3173](https://github.com/alphagov/govuk_publishing_components/pull/3173))
* Restyle subscription link ([PR #3177](https://github.com/alphagov/govuk_publishing_components/pull/3177))
* Change "+" to "Show" in related navigation and metadata block components ([PR #3038](https://github.com/alphagov/govuk_publishing_components/pull/3038))
* Extend the `input` and `textarea` components to use the `dir` attribute ([PR #3081](https://github.com/alphagov/govuk_publishing_components/pull/3081))
* Improve accessibility of button focus states ([PR #3146](https://github.com/alphagov/govuk_publishing_components/pull/3146))