### PR TITLE
Fix bug where analytics tries to init in tests which don't import it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix bug where analytics tries to init in tests which don't import it ([PR #3185](https://github.com/alphagov/govuk_publishing_components/pull/3185))
+
 ## 34.4.0
 
 * Add GA4 tracking to related navigation ([PR #3179](https://github.com/alphagov/govuk_publishing_components/pull/3179))

--- a/app/assets/javascripts/govuk_publishing_components/dependencies.js
+++ b/app/assets/javascripts/govuk_publishing_components/dependencies.js
@@ -8,11 +8,13 @@ document.addEventListener('DOMContentLoaded', function () {
   window.GOVUK.modules.start()
 
   // if statements ensure these functions don't execute during testing
-  if (typeof window.GOVUK.analyticsGa4.vars === 'undefined') {
-    window.GOVUK.loadAnalytics.loadGa4()
-  }
-
-  if (typeof window.GOVUK.analyticsInit === 'undefined') {
-    window.GOVUK.loadAnalytics.loadUa()
+  if (typeof window.GOVUK.loadAnalytics !== 'undefined') {
+    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+    if (typeof window.GOVUK.analyticsGa4.vars === 'undefined') {
+      window.GOVUK.loadAnalytics.loadGa4()
+    }
+    if (typeof window.GOVUK.analyticsVars === 'undefined') {
+      window.GOVUK.loadAnalytics.loadUa()
+    }
   }
 })


### PR DESCRIPTION
Hi @andysellick,

Would you be able to approve this if all is OK? 

Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

We want the analytics to load in if it hasn't been already, which is why we check for `undefined` values, and load in analytics if the values are undefined.

However, our tests do not import `load-analytics.js` by default, so having a nested check like `window.GOVUK.analyticsGa4.vars` resulted in an error in our tests, as `window.GOVUK.analyticsGa4` didn't exist, so we couldn't run a check on `window.GOVUK.analyticsGa4.vars` without the JS crashing.

Therefore I have added extra if statements which ensure this code only runs when we can guarantee that `load-analytics.js` has been imported.

I've checked this against the Jasmine tests in `frontend`, `finder-frontend`, and `government-frontend` and they're now passing.

## Why
<!-- What are the reasons behind this change being made? -->
Without this, tests across our applications to fail, because the `DOMContentLoaded` code was running on tests which did not have `load-analytics.js` loaded into the DOM (which is imported only when `_layout_for_public` is rendered. So `window.GOVUK.analyticsGa4` did not exist and then the `window.GOVUK.analyticsGa4.vars` check would crash.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.