### PR TITLE
Load modules after analytics has loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Load modules after analytics has loaded ([PR #3187](https://github.com/alphagov/govuk_publishing_components/pull/3187))
+
 ## 34.4.1
 
 * Fix bug where analytics tries to init in tests which don't import it ([PR #3185](https://github.com/alphagov/govuk_publishing_components/pull/3185))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/auto-scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/auto-scroll-tracker.js
@@ -1,5 +1,6 @@
 window.GOVUK = window.GOVUK || {}
-window.GOVUK.Modules = window.GOVUK.Modules || {};
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+window.GOVUK.analyticsVars = window.GOVUK.analyticsVars || {};
 
 (function (Modules) {
   function AutoScrollTracker ($module) {

--- a/app/assets/javascripts/govuk_publishing_components/dependencies.js
+++ b/app/assets/javascripts/govuk_publishing_components/dependencies.js
@@ -5,16 +5,18 @@
 // = require ./modules.js
 
 document.addEventListener('DOMContentLoaded', function () {
-  window.GOVUK.modules.start()
+  window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+  window.GOVUK.analyticsVars = window.GOVUK.analyticsVars || {}
 
   // if statements ensure these functions don't execute during testing
   if (typeof window.GOVUK.loadAnalytics !== 'undefined') {
-    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
     if (typeof window.GOVUK.analyticsGa4.vars === 'undefined') {
       window.GOVUK.loadAnalytics.loadGa4()
     }
-    if (typeof window.GOVUK.analyticsVars === 'undefined') {
+    if (typeof window.GOVUK.analyticsVars.gaProperty === 'undefined') {
       window.GOVUK.loadAnalytics.loadUa()
     }
   }
+
+  window.GOVUK.modules.start()
 })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Moves our modules to start after analytics has loaded, copying the order it ran in `static`.
- Ensures `window.GOVUK.analyticsVars` and `window.GOVUK.analyticsGa4` exist before other code runs.
- Some of the modules required Universal Analytics to exist, so we should load our analytics first to reduce the risk of crashing JavaScript. I have also ensured auto-scroll-tracker isn't relying on a different module initialising window.GOVUK.analyticsVars.

## Why
<!-- What are the reasons behind this change being made? -->
`AutoScrollTracker` crashed because it tried to access `window.GOVUK.analyticsVars` before it existed, which broke the accordions in `collections`.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
