### PR TITLE
Change console.error to console.warn as it breaks Smokey tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change console.error to console.warn as it breaks Smokey tests ([PR #3210](https://github.com/alphagov/govuk_publishing_components/pull/3210))
+
 ## 34.5.0
 
 * Catch errors when modules initialised ([PR #3190](https://github.com/alphagov/govuk_publishing_components/pull/3190))

--- a/app/assets/javascripts/govuk_publishing_components/load-analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/load-analytics.js
@@ -127,7 +127,7 @@ window.GOVUK.loadAnalytics = {
     window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
 
     if (typeof window.GOVUK.analyticsGa4.core === 'undefined') {
-      console.error('load-analytics.js: window.GOVUK.analyticsGa4.core was not found - has ./analytics-ga4.js been imported?')
+      console.warn('load-analytics.js: window.GOVUK.analyticsGa4.core was not found - has ./analytics-ga4.js been imported?')
       return
     }
 
@@ -144,7 +144,7 @@ window.GOVUK.loadAnalytics = {
     }
 
     if (!this.environment) {
-      console.error('load-analytics.js: environment for GA4 not recognised - ' + this.environment + ' on ' + currentDomain)
+      console.warn('load-analytics.js: environment for GA4 not recognised - ' + this.environment + ' on ' + currentDomain)
       return
     }
 


### PR DESCRIPTION
## What
Change console.error to console.warn as it breaks Smokey tests.

## Why
<!-- What are the reasons behind this change being made? -->
Domains such as [assets.integration.publishing.service.gov.uk](http://assets.integration.publishing.service.gov.uk/) try to load our analytics but they aren't listed as a domain which loads our GA4. So the `console.error` would display. But smokey seems to treat a `console.error` as the JavaScript breaking.

## Visual Changes
None.