### PR TITLE
Version 34.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 34.5.1
 
 * Change console.error to console.warn as it breaks Smokey tests ([PR #3210](https://github.com/alphagov/govuk_publishing_components/pull/3210))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (34.5.0)
+    govuk_publishing_components (34.5.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "34.5.0".freeze
+  VERSION = "34.5.1".freeze
 end


### PR DESCRIPTION
## 34.5.1

* Change console.error to console.warn as it breaks Smokey tests ([PR #3210](https://github.com/alphagov/govuk_publishing_components/pull/3210))