### PR TITLE
Add GA4 Form tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add GA4 Form tracker ([PR #3215](https://github.com/alphagov/govuk_publishing_components/pull/3215))
 * Add component wrapper helper ([PR #3171](https://github.com/alphagov/govuk_publishing_components/pull/3171))
 * Add aria attributes to Details component ([PR #3225](https://github.com/alphagov/govuk_publishing_components/pull/3225))
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
@@ -7,4 +7,5 @@
 //= require ./analytics-ga4/ga4-link-tracker
 //= require ./analytics-ga4/ga4-event-tracker
 //= require ./analytics-ga4/ga4-ecommerce-tracker
+//= require ./analytics-ga4/ga4-form-tracker
 //= require ./analytics-ga4/init-ga4

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
@@ -31,8 +31,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   Ga4EventTracker.prototype.trackClick = function (event) {
     var target = window.GOVUK.analyticsGa4.core.trackFunctions.findTrackingAttributes(event.target, this.trackingTrigger)
     if (target) {
-      var schema = new window.GOVUK.analyticsGa4.Schemas().eventSchema()
-
       try {
         var data = target.getAttribute(this.trackingTrigger)
         data = JSON.parse(data)
@@ -44,14 +42,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       var text = data.text || event.target.textContent
       data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)
-      schema.event = 'event_data'
-      // get attributes from the data attribute to send to GA
-      // only allow it if it already exists in the schema
-      for (var property in data) {
-        if (property in schema.event_data) {
-          schema.event_data[property] = data[property]
-        }
-      }
+
+      var schemas = new window.GOVUK.analyticsGa4.Schemas()
+      var schema = schemas.mergeProperties(data, 'event_data')
 
       /* Ensure it only tracks aria-expanded in an element with data-ga4-expandable on it. */
       if (target.closest('[data-ga4-expandable]')) {

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -30,7 +30,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   Ga4FormTracker.prototype.trackFormSubmit = function (event) {
     var target = window.GOVUK.analyticsGa4.core.trackFunctions.findTrackingAttributes(event.target, this.trackingTrigger)
     if (target) {
-      var schema = new window.GOVUK.analyticsGa4.Schemas().eventSchema()
       try {
         var data = target.getAttribute(this.trackingTrigger)
         data = JSON.parse(data)
@@ -43,14 +42,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var formInputs = this.getFormInputs()
       var formData = this.getInputValues(formInputs)
       data.text = this.combineGivenAnswers(formData) || 'No answer given'
-      schema.event = 'event_data'
-      // get attributes from the data attribute to send to GA
-      // only allow it if it already exists in the schema
-      for (var property in data) {
-        if (property in schema.event_data) {
-          schema.event_data[property] = data[property]
-        }
-      }
+
+      var schemas = new window.GOVUK.analyticsGa4.Schemas()
+      var schema = schemas.mergeProperties(data, 'event_data')
       window.GOVUK.analyticsGa4.core.sendData(schema)
     }
   }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -1,0 +1,119 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  'use strict'
+
+  function Ga4FormTracker (module) {
+    this.module = module
+    this.trackingTrigger = 'data-ga4-form' // elements with this attribute get tracked
+  }
+
+  Ga4FormTracker.prototype.init = function () {
+    var consentCookie = window.GOVUK.getConsentCookie()
+
+    if (consentCookie && consentCookie.settings) {
+      this.startModule()
+    } else {
+      this.startModule = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.startModule)
+    }
+  }
+
+  // triggered by cookie-consent event, which happens when users consent to cookies
+  Ga4FormTracker.prototype.startModule = function () {
+    if (window.dataLayer) {
+      this.module.addEventListener('submit', this.trackFormSubmit.bind(this))
+    }
+  }
+
+  Ga4FormTracker.prototype.trackFormSubmit = function (event) {
+    var target = window.GOVUK.analyticsGa4.core.trackFunctions.findTrackingAttributes(event.target, this.trackingTrigger)
+    if (target) {
+      var schema = new window.GOVUK.analyticsGa4.Schemas().eventSchema()
+      try {
+        var data = target.getAttribute(this.trackingTrigger)
+        data = JSON.parse(data)
+      } catch (e) {
+        // if there's a problem with the config, don't start the tracker
+        console.warn('GA4 configuration error: ' + e.message, window.location)
+        return
+      }
+
+      var formInputs = this.getFormInputs()
+      var formData = this.getInputValues(formInputs)
+      data.text = this.combineGivenAnswers(formData) || 'No answer given'
+      schema.event = 'event_data'
+      // get attributes from the data attribute to send to GA
+      // only allow it if it already exists in the schema
+      for (var property in data) {
+        if (property in schema.event_data) {
+          schema.event_data[property] = data[property]
+        }
+      }
+      window.GOVUK.analyticsGa4.core.sendData(schema)
+    }
+  }
+
+  Ga4FormTracker.prototype.getFormInputs = function () {
+    var inputs = []
+    var labels = this.module.querySelectorAll('label')
+
+    for (var i = 0; i < labels.length; i++) {
+      var label = labels[i]
+      var labelFor = label.getAttribute('for')
+      var input = false
+      if (labelFor) {
+        input = this.module.querySelector('[id=' + labelFor + ']')
+      } else {
+        input = label.querySelector('input')
+      }
+      inputs.push({
+        input: input,
+        label: label
+      })
+    }
+    return inputs
+  }
+
+  Ga4FormTracker.prototype.getInputValues = function (inputs) {
+    for (var i = inputs.length - 1; i >= 0; i--) {
+      var input = inputs[i]
+      var elem = input.input
+      var labelText = input.label.innerText || input.label.textContent
+      var inputType = elem.getAttribute('type')
+      var inputNodename = elem.nodeName
+
+      if (inputType === 'checkbox' && elem.checked) {
+        input.answer = labelText
+      } else if (inputNodename === 'SELECT' && elem.options[elem.selectedIndex].value) {
+        input.answer = elem.options[elem.selectedIndex].text
+      } else if (inputType === 'text' && elem.value) {
+        input.answer = '[REDACTED]'
+      } else if (inputType === 'radio' && elem.checked) {
+        input.answer = labelText
+      } else {
+        // remove the input from those gathered as it has no value
+        inputs.splice(i, 1)
+      }
+    }
+    return inputs
+  }
+
+  Ga4FormTracker.prototype.combineGivenAnswers = function (data) {
+    var answers = ''
+    for (var i = 0; i < data.length; i++) {
+      var answer = data[i].answer
+      if (answer) {
+        answers += answer + ','
+      }
+    }
+    // remove the trailing comma
+    if (answers.length) {
+      answers = answers.slice(0, -1)
+      return answers
+    }
+  }
+
+  Modules.Ga4FormTracker = Ga4FormTracker
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -58,8 +58,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   Ga4LinkTracker.prototype.trackClick = function (event) {
     var target = window.GOVUK.analyticsGa4.core.trackFunctions.findTrackingAttributes(event.target, this.trackingTrigger)
     if (target) {
-      var schema = new window.GOVUK.analyticsGa4.Schemas().eventSchema()
-
       try {
         var data = target.getAttribute(this.trackingTrigger)
         data = JSON.parse(data)
@@ -69,7 +67,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         return
       }
 
-      schema.event = 'event_data'
       var text = data.text || event.target.textContent
       data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)
       var url = data.url || this.findLink(event.target).getAttribute('href')
@@ -79,14 +76,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       data.method = window.GOVUK.analyticsGa4.core.trackFunctions.getClickType(event)
       data.external = window.GOVUK.analyticsGa4.core.trackFunctions.isExternalLink(data.url) ? 'true' : 'false'
 
-      // get attributes from the data attribute to send to GA
-      // only allow it if it already exists in the schema
-      for (var property in data) {
-        if (property in schema.event_data) {
-          schema.event_data[property] = data[property]
-        }
-      }
-
+      var schemas = new window.GOVUK.analyticsGa4.Schemas()
+      var schema = schemas.mergeProperties(data, 'event_data')
       window.GOVUK.analyticsGa4.core.sendData(schema)
     }
   }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
@@ -29,6 +29,19 @@
     }
   }
 
+  // get attributes from the data attribute to send to GA
+  // only allow it if it already exists in the schema
+  Schemas.prototype.mergeProperties = function (data, eventAttribute) {
+    var schema = this.eventSchema()
+    schema.event = eventAttribute
+    for (var property in data) {
+      if (property in schema.event_data) {
+        schema.event_data[property] = data[property]
+      }
+    }
+    return schema
+  }
+
   GOVUK.analyticsGa4 = GOVUK.analyticsGa4 || {}
   GOVUK.analyticsGa4.Schemas = Schemas
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
@@ -23,7 +23,8 @@
         external: this.undefined,
         method: this.undefined,
         link_domain: this.undefined,
-        link_path_parts: this.undefined
+        link_path_parts: this.undefined,
+        tool_name: this.undefined
       }
     }
   }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
@@ -49,43 +49,34 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       if (!href) {
         return
       }
-      var clickData = {}
+      var data = {}
       if (window.GOVUK.analyticsGa4.core.trackFunctions.isMailToLink(href)) {
-        clickData.event_name = 'navigation'
-        clickData.type = 'email'
-        clickData.external = 'true'
+        data.event_name = 'navigation'
+        data.type = 'email'
+        data.external = 'true'
       } else if (this.isDownloadLink(href)) {
-        clickData.event_name = 'file_download'
-        clickData.type = this.isPreviewLink(href) ? 'preview' : 'generic download'
-        clickData.external = window.GOVUK.analyticsGa4.core.trackFunctions.isExternalLink(href) ? 'true' : 'false'
+        data.event_name = 'file_download'
+        data.type = this.isPreviewLink(href) ? 'preview' : 'generic download'
+        data.external = window.GOVUK.analyticsGa4.core.trackFunctions.isExternalLink(href) ? 'true' : 'false'
       } else if (window.GOVUK.analyticsGa4.core.trackFunctions.isExternalLink(href)) {
-        clickData.event_name = 'navigation'
-        clickData.type = 'generic link'
-        clickData.external = 'true'
+        data.event_name = 'navigation'
+        data.type = 'generic link'
+        data.external = 'true'
       }
 
-      if (Object.keys(clickData).length > 0) {
-        clickData.url = href
-        if (clickData.url) {
-          clickData.url = window.GOVUK.analyticsGa4.core.trackFunctions.removeCrossDomainParams(clickData.url)
-          clickData.link_domain = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkDomain(clickData.url)
-          clickData.link_path_parts = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkPathParts(clickData.url)
+      if (Object.keys(data).length > 0) {
+        data.url = href
+        if (data.url) {
+          data.url = window.GOVUK.analyticsGa4.core.trackFunctions.removeCrossDomainParams(data.url)
+          data.link_domain = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkDomain(data.url)
+          data.link_path_parts = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkPathParts(data.url)
         }
 
-        clickData.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(element.textContent)
-        clickData.method = window.GOVUK.analyticsGa4.core.trackFunctions.getClickType(event)
+        data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(element.textContent)
+        data.method = window.GOVUK.analyticsGa4.core.trackFunctions.getClickType(event)
 
-        var schema = new window.GOVUK.analyticsGa4.Schemas().eventSchema()
-        schema.event = 'event_data'
-
-        // get attributes from the clickData object to send to GA
-        // only allow it if it already exists in the schema
-        for (var property in clickData) {
-          if (property in schema.event_data) {
-            schema.event_data[property] = clickData[property]
-          }
-        }
-
+        var schemas = new window.GOVUK.analyticsGa4.Schemas()
+        var schema = schemas.mergeProperties(data, 'event_data')
         window.GOVUK.analyticsGa4.core.sendData(schema)
       }
     },

--- a/docs/analytics-ga4/ga4-form-tracker.md
+++ b/docs/analytics-ga4/ga4-form-tracker.md
@@ -1,0 +1,38 @@
+# Google Analytics 4 form tracker
+
+This script is intended for adding GA4 tracking to forms, specifically for smart answers and simple smart answers. The script is triggered on the 'submit' event of the form. It depends upon the main GA4 analytics code to function.
+
+## Basic use
+
+```html
+<form
+  data-module="ga4-form-tracker"
+  data-ga4-form='{ "event_name": "form_response", "type": "something", "section": "form title", "action": "Continue", "tool_name": "title" }'>
+  <!-- form contents -->
+</form>
+```
+
+The data attributes are used as follows:
+
+- `type` records the type of form e.g. `smart answer` or `simple smart answer`
+- `section` records the current question e.g. `What are your favourite puddings?`
+- `action` records the text of the form submission button e.g. `Continue`
+- `tool_name` records the overall name of the smart answer e.g. `How do I eat more healthily?`
+
+The script will automatically collect the answer submitted in the `text` field. For questions where multiple answers are possible, these will be comma separated. Where the answer is a text input, the value given is replaced with `[REDACTED]`, to avoid collecting personally identifiable information.
+
+In the example above, the following would be pushed to the dataLayer. Note that the schema automatically populates empty values, and that attributes not in the schema are ignored.
+
+```
+{
+  'event': 'event_data',
+  'event_data': {
+    'event_name': 'form_response',
+    'type': 'smart answer',
+    'tool_name': 'How do I eat more healthily?',
+    'section': 'What are your favourite puddings?',
+    'text': 'yoghurt,pie,trifle',
+    'action': 'Continue'
+  }
+}
+```

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -1,0 +1,211 @@
+/* eslint-env jasmine */
+
+describe('Google Analytics form tracking', function () {
+  var GOVUK = window.GOVUK
+  var element
+  var expected
+
+  function agreeToCookies () {
+    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+  }
+
+  function denyCookies () {
+    GOVUK.setCookie('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}')
+  }
+
+  beforeAll(function () {
+    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+    window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
+    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
+  })
+
+  beforeEach(function () {
+    window.dataLayer = []
+    element = document.createElement('form')
+    document.body.appendChild(element)
+    agreeToCookies()
+  })
+
+  afterEach(function () {
+    document.body.removeChild(element)
+  })
+
+  afterAll(function () {
+    window.dataLayer = []
+  })
+
+  describe('when the user has a cookie consent choice', function () {
+    it('starts the module if consent has already been given', function () {
+      agreeToCookies()
+      var tracker = new GOVUK.Modules.Ga4FormTracker(element)
+      spyOn(tracker, 'trackFormSubmit')
+      tracker.init()
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(tracker.trackFormSubmit).toHaveBeenCalled()
+    })
+
+    it('starts the module on the same page as cookie consent is given', function () {
+      denyCookies()
+      var tracker = new GOVUK.Modules.Ga4FormTracker(element)
+      spyOn(tracker, 'trackFormSubmit')
+      tracker.init()
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(tracker.trackFormSubmit).not.toHaveBeenCalled()
+
+      // page has not been reloaded, user consents to cookies
+      window.GOVUK.triggerEvent(window, 'cookie-consent')
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(tracker.trackFormSubmit).toHaveBeenCalled()
+    })
+
+    it('does not do anything if consent is not given', function () {
+      denyCookies()
+      var tracker = new GOVUK.Modules.Ga4FormTracker(element)
+      spyOn(tracker, 'trackFormSubmit')
+      tracker.init()
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(tracker.trackFormSubmit).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when tracking a form', function () {
+    beforeEach(function () {
+      var attributes = {
+        event_name: 'form_response',
+        type: 'smart answer',
+        section: 'What is the title of this question?',
+        action: 'Continue',
+        tool_name: 'What is the title of this smart answer?'
+      }
+      element.setAttribute('data-ga4-form', JSON.stringify(attributes))
+      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      expected.event = 'event_data'
+      expected.event_data.event_name = 'form_response'
+      expected.event_data.type = 'smart answer'
+      expected.event_data.section = 'What is the title of this question?'
+      expected.event_data.action = 'Continue'
+      expected.event_data.tool_name = 'What is the title of this smart answer?'
+      expected.govuk_gem_version = 'aVersion'
+      var tracker = new GOVUK.Modules.Ga4FormTracker(element)
+      tracker.init()
+    })
+
+    it('collects basic data', function () {
+      window.GOVUK.triggerEvent(element, 'submit')
+      expected.event_data.text = 'No answer given'
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('redacts data from text inputs', function () {
+      element.innerHTML =
+        '<label for="textid">Label</label>' +
+        '<input type="text" id="textid" name="test-text" value="test-text-value"/>'
+      expected.event_data.text = '[REDACTED]'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('redacts data from multiple text inputs', function () {
+      element.innerHTML =
+        '<label for="textid1">Label</label>' +
+        '<input type="text" id="textid1" name="test-text1" value="text 1"/>' +
+        '<label for="textid2">Label</label>' +
+        '<input type="text" id="textid2" name="test-text2"/>' +
+        '<label for="textid3">Label</label>' +
+        '<input type="text" id="textid3" name="test-text3" value="text 3"/>'
+      expected.event_data.text = '[REDACTED],[REDACTED]'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('collects data from checkboxes', function () {
+      element.innerHTML =
+        '<label><input type="checkbox" id="c1" name="checkbox[]" value="checkbox1"/>checkbox1</label>' +
+        '<label><input type="checkbox" id="c2" name="checkbox[]" value="checkbox2"/>checkbox2</label>' +
+        '<label><input type="checkbox" id="c3" name="checkbox[]" value="checkbox3"/>checkbox3</label>'
+      document.getElementById('c1').checked = true
+      document.getElementById('c3').checked = true
+      expected.event_data.text = 'checkbox1,checkbox3'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('collects data from radio buttons', function () {
+      element.innerHTML =
+        '<label><input type="radio" id="r1" name="radio[]" value="radio1"/>radio1</label>' +
+        '<label><input type="radio" id="r2" name="radio[]" value="radio2"/>radio2</label>' +
+        '<label><input type="radio" id="r3" name="radio[]" value="radio3"/>radio3</label>'
+      document.getElementById('r1').checked = true
+      document.getElementById('r2').checked = true
+      expected.event_data.text = 'radio2'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('collects data from select elements', function () {
+      element.innerHTML =
+        '<label for="s1">Label</label>' +
+        '<select name="select" id="s1">' +
+          '<option value="option1">Option 1</option>' +
+          '<option value="option2">Option 2</option>' +
+          '<option value="option3">Option 3</option>' +
+        '</select>'
+      var select = document.getElementById('s1')
+      select.selectedIndex = 2
+      window.GOVUK.triggerEvent(select, 'change')
+      expected.event_data.text = 'Option 3'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('collects data from a select and a text input', function () {
+      element.innerHTML =
+        '<label for="s1">Label</label>' +
+        '<select name="select" id="s1">' +
+          '<option value="option1">Option 1</option>' +
+          '<option value="option2">Option 2</option>' +
+          '<option value="option3">Option 3</option>' +
+        '</select>' +
+        '<label for="text">Label</label>' +
+        '<input type="text" id="text" name="test-text" value="Some text"/>'
+      var select = document.getElementById('s1')
+      select.selectedIndex = 2
+      window.GOVUK.triggerEvent(select, 'change')
+      expected.event_data.text = 'Option 3,[REDACTED]'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('copes when the form is not well formed', function () {
+      element.innerHTML =
+        '<input type="text" id="textid" name="test-text" value="test-text-value"/>' +
+        '<select name="select" id="s1">' +
+          '<option value="option1">Option 1</option>' +
+          '<option value="option2">Option 2</option>' +
+          '<option value="option3">Option 3</option>' +
+        '</select>' +
+        '<input type="radio" id="r1" name="radio[]" value="radio1"/>radio1' +
+        '<input type="radio" id="r2" name="radio[]" value="radio2"/>radio2' +
+        '<input type="checkbox" id="c1" name="checkbox[]" value="checkbox1"/>checkbox1' +
+        '<input type="checkbox" id="c2" name="checkbox[]" value="checkbox2"/>checkbox2'
+
+      var select = document.getElementById('s1')
+      select.selectedIndex = 2
+      window.GOVUK.triggerEvent(select, 'change')
+      window.GOVUK.triggerEvent(element, 'submit')
+      expected.event_data.text = 'No answer given'
+
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+  })
+})


### PR DESCRIPTION
## What
Adds a script to track form submissions in GA4. Should be clearly documented in the `md` file, brief summary:

- requires `data-ga4-form` attribute on the form, containing some information
- fires on form submission
- identifies answer(s) chosen by searching through label elements to find inputs (label first, because we need the label text and a label is linked to an input using the `for` attribute, but not vice versa)
- redacts any answers given in a text input, to prevent the collection of PII

Originally tried to use `formData` for this, which isn't fully supported by IE11. Fallback was that IE11 users wouldn't have their answers recorded. However the syntax for accessing formData was causing IE11 to throw an error, so have switched to a more traditional approach.

## Why
Needed for smart answers and simple smart answers.

## Visual Changes
None.

Trello card: https://trello.com/c/cuivnCEV/406-add-tracking-smart-answers-formresponse