### PR TITLE
Add classes to align text in Govspeak tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@
 
 ## Unreleased
 
+* Add classes to align text in Govspeak tables ([PR #3217](https://github.com/alphagov/govuk_publishing_components/pull/3217))
 * Make links bold at all viewports on navbar menu ([PR #3219](https://github.com/alphagov/govuk_publishing_components/pull/3219))
 * Add our 'assets' domain as a domain that should run our analytics ([PR #3224](https://github.com/alphagov/govuk_publishing_components/pull/3224))
-
 
 ## 34.6.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_tables.scss
@@ -41,5 +41,17 @@
     td small {
       font-size: 1em;
     }
+
+    .cell-text-left {
+      text-align: left;
+    }
+
+    .cell-text-center {
+      text-align: center;
+    }
+
+    .cell-text-right {
+      text-align: right;
+    }
   }
 }

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -180,11 +180,32 @@ examples:
             </tr>
           </tbody>
         </table>
+  tables_with_alignments:
+    data:
+      block: |
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Default aligned</th>
+              <th class="cell-text-left" scope="col">Left aligned</th>
+              <th class="cell-text-center" scope="col">Center aligned</th>
+              <th class="cell-text-right" scope="col">Right aligned</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>First body part</td>
+              <td class="cell-text-left">Second cell</td>
+              <td class="cell-text-center">Third cell</td>
+              <td class="cell-text-right">fourth cell</td>
+            </tr>
+          </tbody>
+        </table>
   charts:
     description: |
       The Government Statistical Service (GSS) guidance recommends [a limit of four categories as best practice for basic data visualisations](https://gss.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/#section-5).
 
-      Note that charts which have up to 7 categories, [chart with colours](http://govuk-publishing-components.dev.gov.uk/component-guide/govspeak/chart_with_colours/preview), for example, will display subsequent bars in `#3d3d3d`, `#a285d1` and the 7th bar in the default colour of `#0b0c0c` and will still meet the colour contrast requirements for adjacent colours. 
+      Note that charts which have up to 7 categories, [chart with colours](http://govuk-publishing-components.dev.gov.uk/component-guide/govspeak/chart_with_colours/preview), for example, will display subsequent bars in `#3d3d3d`, `#a285d1` and the 7th bar in the default colour of `#0b0c0c` and will still meet the colour contrast requirements for adjacent colours.
       Charts that have 8 or more categories will display additional bars in the default colour and will not meet colour contrast requirements for adjacent colours.
     data:
       block: |


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

This change is made to support the proposed change in: https://github.com/alphagov/govspeak/pull/268, which is made to allow for GOV.UK to use a Content Security Policy that can help prevent Cross-site scripting (XSS) attacks. This change will need to be merged and released first.

This adds three classes that can be used within `.gem-c-govspeak table` to set the text alignment of cells. These are required because the Govspeak output for text aligned cells is going to change from an inline style (`<td style="text-align: right;">item</td>`) to a class (`<td class="cell-text-right">item</td>`)

Class naming wise, I didn't use a BEM approach as there did not to be precedent for it in the classes within govspeak. I then took some inspiration from tailwind conventions to apply text-<direction> to a prefix of `cell-`.

