### PR TITLE
Add document list component option to remove first item top border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add classes to align text in Govspeak tables ([PR #3217](https://github.com/alphagov/govuk_publishing_components/pull/3217))
 * Make links bold at all viewports on navbar menu ([PR #3219](https://github.com/alphagov/govuk_publishing_components/pull/3219))
 * Add our 'assets' domain as a domain that should run our analytics ([PR #3224](https://github.com/alphagov/govuk_publishing_components/pull/3224))
+* Add document list component option to remove first item top border ([PR #3221](https://github.com/alphagov/govuk_publishing_components/pull/3221))
 
 ## 34.6.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -29,6 +29,12 @@
   }
 }
 
+.gem-c-document-list--no-top-border-first-child {
+  .gem-c-document-list__item:first-child {
+    border-top: none;
+  }
+}
+
 .gem-c-document-list__item-title--context {
   margin-right: govuk-spacing(2);
 

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -6,6 +6,7 @@
   classes << " gem-c-document-list--bottom-margin" if local_assigns[:margin_bottom]
   classes << " gem-c-document-list--no-underline" if local_assigns[:remove_underline]
   classes << " gem-c-document-list--no-top-border" if local_assigns[:remove_top_border]
+  classes << " gem-c-document-list--no-top-border-first-child" if local_assigns[:remove_top_border_from_first_child]
 
   within_multitype_list ||= false
   within_multitype_list_class = " gem-c-document-list__multi-list" if within_multitype_list

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -195,9 +195,26 @@ examples:
           document_type: 'Statistical data set'
         subtext: 'First published during the 1996 Conservative Government'
   without_top_border_on_list_element:
-    description: Several interfaces across GOV.UK benefit from the semantics of the document list but have their own bespoke designs, sometimes meaning that the visual border element doesn't gel with said interface. Removing it using the below attribute allows for cleaner visual fidelity in this instances.
+    description: Several interfaces across GOV.UK benefit from the semantics of the document list but have their own bespoke designs, sometimes meaning that the visual border element doesn't gel with said interface. Removing it using the below attribute allows for cleaner visual fidelity in these instances.
     data:
       remove_top_border: true
+      items:
+      - link:
+          text: 'Department for Education – Statistics at DfE'
+          path: '/government/organisations/department-for-education/about/statistics'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Corporate information'
+      - link:
+          text: 'State-funded school inspections and outcomes: management information'
+          path: '/government/organisations/department-for-education/about/statistics'
+        metadata:
+          public_updated_at: 2017-07-19 15:01:48
+          document_type: 'Statistical data set'
+  without_top_border_on_first_list_element:
+    description: Several interfaces across GOV.UK benefit from the semantics of the document list but have their own bespoke designs, sometimes meaning that the visual border element doesn't gel with said interface. Removing it using the below attribute allows for cleaner visual fidelity in these instances.
+    data:
+      remove_top_border_from_first_child: true
       items:
       - link:
           text: 'Department for Education – Statistics at DfE'

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -277,6 +277,22 @@ describe "Document list", type: :view do
     assert_select ".gem-c-document-list.gem-c-document-list--no-top-border"
   end
 
+  it "removes the top border from the first list item" do
+    render_component(
+      remove_top_border_from_first_child: true,
+      items: [
+        {
+          link: {
+            text: "Link Title",
+            path: "/link/path",
+          },
+        },
+      ],
+    )
+
+    assert_select ".gem-c-document-list.gem-c-document-list--no-top-border-first-child"
+  end
+
   it "highlights items" do
     render_component(
       items: [


### PR DESCRIPTION
## What
https://trello.com/c/dhg330gw/1785-remove-grey-top-border-on-the-top-item-on-the-list-on-specialist-finders

Add an option `remove_top_border_from_first_child` to remove the top border from the first item of a document list.

**Review URL**

https://components-gem-pr-3221.herokuapp.com/component-guide/document_list/without_top_border_on_first_list_element/preview

## Why
On some finder pages e.g. [Air Accidents Investigation Branch reports](https://www.gov.uk/aaib-reports) a double border can be seen when no sort options are present.

The current `remove_top_border` option removes the top border from every item. The new option `remove_top_border_from_first_child` will remove the top border from the first item only.

## Visual Changes
### Before
<img src="https://user-images.githubusercontent.com/87758239/215523005-807c38ae-2e7f-4980-9017-2ac43c1e316b.png" width="660" style="max-width: 100%;">

### After
<img src="https://user-images.githubusercontent.com/87758239/215523092-8e13db94-d771-4b4f-a811-95bded0cc1c9.png" width="660" style="max-width: 100%;">

## Anything else

Will need to adjust padding in [finder-frontend](https://github.com/alphagov/finder-frontend)

### Before (Air Accidents Investigation Branch reports)
<img src="https://user-images.githubusercontent.com/87758239/215546610-f0f0b186-cfd8-4693-aec6-424c4caab343.png" width="660" style="max-width: 100%;">

### After (Air Accidents Investigation Branch reports)
<img src="https://user-images.githubusercontent.com/87758239/215546580-b578ec22-d438-45d5-85ed-f7be5aef4906.png" width="660" style="max-width: 100%;">