### PR TITLE
Add our 'assets' domain as a domain that should run our analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Make links bold at all viewports on navbar menu ([PR #3219](https://github.com/alphagov/govuk_publishing_components/pull/3219))
+* Add our 'assets' domain as a domain that should run our analytics ([PR #3224](https://github.com/alphagov/govuk_publishing_components/pull/3224))
 
 
 ## 34.6.0

--- a/app/assets/javascripts/govuk_publishing_components/load-analytics.js
+++ b/app/assets/javascripts/govuk_publishing_components/load-analytics.js
@@ -5,15 +5,18 @@
 window.GOVUK.loadAnalytics = {
   productionDomains: [
     'www.gov.uk',
-    'www-origin.publishing.service.gov.uk'
+    'www-origin.publishing.service.gov.uk',
+    'assets.publishing.service.gov.uk'
   ],
   stagingDomains: [
     'www.staging.publishing.service.gov.uk',
-    'www-origin.staging.publishing.service.gov.uk'
+    'www-origin.staging.publishing.service.gov.uk',
+    'assets.staging.publishing.service.gov.uk'
   ],
   integrationDomains: [
     'www.integration.publishing.service.gov.uk',
-    'www-origin.integration.publishing.service.gov.uk'
+    'www-origin.integration.publishing.service.gov.uk',
+    'assets.integration.publishing.service.gov.uk'
   ],
   developmentDomains: [
     'localhost', '127.0.0.1', '0.0.0.0'

--- a/spec/javascripts/govuk_publishing_components/load-analytics.spec.js
+++ b/spec/javascripts/govuk_publishing_components/load-analytics.spec.js
@@ -31,7 +31,8 @@ describe('Analytics loading', function () {
     it('loads GA4 on production domains', function () {
       var domains = [
         'www.gov.uk',
-        'www-origin.publishing.service.gov.uk'
+        'www-origin.publishing.service.gov.uk',
+        'assets.publishing.service.gov.uk'
       ]
 
       for (var i = 0; i < domains.length; i++) {
@@ -45,8 +46,8 @@ describe('Analytics loading', function () {
     it('loads GA4 on staging domains', function () {
       var domains = [
         'www.staging.publishing.service.gov.uk',
-        'www.staging.publishing.service.gov.uk',
-        'www-origin.staging.publishing.service.gov.uk'
+        'www-origin.staging.publishing.service.gov.uk',
+        'assets.staging.publishing.service.gov.uk'
       ]
       for (var i = 0; i < domains.length; i++) {
         window.GOVUK.analyticsGa4.vars = null
@@ -59,8 +60,8 @@ describe('Analytics loading', function () {
     it('loads GA4 on integration domains', function () {
       var domains = [
         'www.integration.publishing.service.gov.uk',
-        'www.integration.publishing.service.gov.uk',
-        'www-origin.integration.publishing.service.gov.uk'
+        'www-origin.integration.publishing.service.gov.uk',
+        'assets.integration.publishing.service.gov.uk'
       ]
 
       for (var i = 0; i < domains.length; i++) {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
We missed the assets domain off of our list of GOVUK domains, so both UA and GA4 are not running on these types of links:

https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1006267/Annex_B_-_Example_CSV_file_-_Appeals_in_vocational_and_technical_qualifications_-_guide_to_the_data_submission_process.csv/preview

## Why
<!-- What are the reasons behind this change being made? -->
Our tracking should be running on this domain

## Visual Changes
None.