### PR TITLE
Add aria attributes to Details component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add component wrapper helper ([PR #3171](https://github.com/alphagov/govuk_publishing_components/pull/3171))
+* Add aria attributes to Details component ([PR #3225](https://github.com/alphagov/govuk_publishing_components/pull/3225))
 
 ## 34.7.1
 

--- a/app/views/govuk_publishing_components/components/_details.html.erb
+++ b/app/views/govuk_publishing_components/components/_details.html.erb
@@ -11,9 +11,11 @@
 
   data_attributes ||= {}
   data_attributes[:details_track_click] = ''
+
+  summary_aria_attributes ||= {}
 %>
 <%= tag.details class: css_classes, data: details_data_attributes, open: open do %>
-  <%= tag.summary class: "govuk-details__summary", data: data_attributes do %>
+  <%= tag.summary class: "govuk-details__summary", data: data_attributes, aria: summary_aria_attributes do %>
     <span class="govuk-details__summary-text">
       <%= title %>
     </span>

--- a/app/views/govuk_publishing_components/components/docs/details.yml
+++ b/app/views/govuk_publishing_components/components/docs/details.yml
@@ -36,6 +36,23 @@ examples:
           dimension20: "custom dimension"
       block: |
         We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
+  with_aria_attributes:
+    description: |
+      Aria attributes can be applied to the summary element of the component.
+    data:
+      title: Works with 2 agencies and public bodies
+      summary_aria_attributes:
+        label: Attorney General's office
+      block: |
+        <ul>
+          <li>Department 1</li>
+          <li>Department 2</li>
+        </ul>
+    embed: |
+      <div>
+        <p class="govuk-body">Attorney General's office</p>
+        <%= component %>
+      </div>
   with_GTM_tracking:
     description: Applies a tracking attribute specifically for use by Google Tag Manager in [Content Publisher](https://github.com/alphagov/content-publisher).
     data:

--- a/spec/components/details_spec.rb
+++ b/spec/components/details_spec.rb
@@ -47,6 +47,17 @@ describe "Details", type: :view do
     assert_select '.govuk-details .govuk-details__summary[data-track-label="track-label"]'
   end
 
+  it "applies aria labels to summary when provided" do
+    render_component(
+      title: "Some title",
+      summary_aria_attributes: {
+        label: "label",
+      },
+    )
+
+    assert_select '.govuk-details .govuk-details__summary[aria-label="label"]'
+  end
+
   it "defaults to the initial bottom margin if an incorrect value is passed" do
     render_component(
       title: "Some title",


### PR DESCRIPTION
## What

Add aria attributes to the Details component.

## Why

As part of the work to make the organisations page on GOV.UK more accessible. There is currently the following issue with the page:

> On the Departments, agencies and public bodies page, multiple buttons are present which began with the phrase "Works with" and contain the number of agencies or public bodies the organisation worked with. Many of these buttons have the same text occurring multiple times. For example, there are 23 occurrences of Works with 1 public body each of which relate to different department, agency or public body. Therefore, it's unclear in many instances which button related to which department, agency or public body which makes it difficult for screen reader users to differentiate between them.

@hannalaakso did some research and determined that the best way to fix the issue would be add an aria-label to the summary of the details.

[Relevant Trello Card](https://trello.com/c/NepoUk7x/1533-form-elements-on-departments-page-are-not-descriptive-of-their-function-or-purpose-9-m)