### PR TITLE
Add GA4 modules error checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add GA4 modules error checking ([PR #3228](https://github.com/alphagov/govuk_publishing_components/pull/3228))
 * Add classes to align text in Govspeak tables ([PR #3217](https://github.com/alphagov/govuk_publishing_components/pull/3217))
 * Make links bold at all viewports on navbar menu ([PR #3219](https://github.com/alphagov/govuk_publishing_components/pull/3219))
 * Add our 'assets' domain as a domain that should run our analytics ([PR #3224](https://github.com/alphagov/govuk_publishing_components/pull/3224))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
@@ -2,8 +2,6 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
 
 var initFunction = function () {
-  // to be added: digital identity consent mechanism
-
   var consentCookie = window.GOVUK.getConsentCookie()
 
   if (consentCookie && consentCookie.usage) {
@@ -16,10 +14,14 @@ var initFunction = function () {
     for (var property in analyticsModules) {
       var module = analyticsModules[property]
       if (typeof module.init === 'function') {
-        module.init()
+        try {
+          module.init()
+        } catch (e) {
+          // if there's a problem with the module, catch the error to allow other modules to start
+          console.warn('Error starting analytics module ' + property + ': ' + e.message, window.location)
+        }
       }
     }
-    // to be added: cross domain tracking code
   } else {
     window.addEventListener('cookie-consent', window.GOVUK.analyticsGa4.init)
   }


### PR DESCRIPTION
## What
Wraps the initialisation of each GA4 analytics module in a try/catch block, which means that any errors in the initialisation of a module will not prevent any following modules from initialising.

## Why
Follows on from this [similar change](https://github.com/alphagov/govuk_publishing_components/pull/3190) to the main modules systems, which prevents an individual module failing from stopping all following modules from initialising.

## Visual Changes
None.
