### PR TITLE
Update single page notification button to support skipping GOV.UK account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow single page notification button to skip the govuk-account ([PR #3229](https://github.com/alphagov/govuk_publishing_components/pull/3229))
+
 ## 34.8.1
 
 * Reverts release 34.7.1 concerning related World Location links ([PR #3243](https://github.com/alphagov/govuk_publishing_components/pull/3243))

--- a/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
@@ -9,8 +9,12 @@
   <svg class="gem-c-single-page-notification-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 459.334 459.334"><path fill="currentColor" d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"/></svg><span class="gem-c-single-page-notication-button__text"><%= component_helper.button_text %></span>
 <% end %>
 <%= tag.div class: wrapper_classes, data: { module: "gem-track-click"} do %>
-  <%= tag.form class: component_helper.classes, action: "/email/subscriptions/single-page/new", method: "POST", data: component_helper.data do %>
+  <%= tag.form class: component_helper.classes, action: component_helper.form_action, method: "POST", data: component_helper.data do %>
     <input type="hidden" name="base_path" value="<%= component_helper.base_path %>">
+    <% if component_helper.skip_account %>
+      <input type="hidden" name="<%= component_helper.skip_account_param %>" value="true">
+      <input type="hidden" name="link" value="<%= component_helper.base_path %>">
+    <% end %>
     <%= content_tag(:button, button_text, {
       class: "govuk-body-s gem-c-single-page-notification-button__submit",
       type: "submit",

--- a/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
+++ b/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
@@ -63,4 +63,3 @@ examples:
       base_path: '/current-page-path'
       js_enhancement: true
       skip_account: true
-  

--- a/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
+++ b/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
@@ -57,3 +57,10 @@ examples:
       button_text:
         subscribe: 'Subscribe to this page of things'
         unsubscribe: 'Unsubscribe to this page of things'
+  with_skip_account:
+    description: If the skip_account flag is present, the button action will be set to the non GOV.UK account signup endpoint of /email-signup.
+    data:
+      base_path: '/current-page-path'
+      js_enhancement: true
+      skip_account: true
+  

--- a/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb
@@ -1,7 +1,7 @@
 module GovukPublishingComponents
   module Presenters
     class SinglePageNotificationButtonHelper
-      attr_reader :already_subscribed, :data_attributes, :base_path, :js_enhancement, :button_type, :button_location, :classes
+      attr_reader :already_subscribed, :data_attributes, :base_path, :js_enhancement, :button_type, :button_location, :classes, :skip_account
 
       def initialize(local_assigns)
         @local_assigns = local_assigns
@@ -15,6 +15,7 @@ module GovukPublishingComponents
         @classes << "js-personalisation-enhancement" if js_enhancement
         @button_text_subscribe = custom_button_text_is_valid? ? custom_subscribe_text : default_subscribe_text
         @button_text_unsubscribe = custom_button_text_is_valid? ? custom_unsubscribe_text : default_unsubscribe_text
+        @skip_account = @local_assigns[:skip_account] || nil
       end
 
       def data
@@ -57,6 +58,22 @@ module GovukPublishingComponents
 
       def default_unsubscribe_text
         I18n.t("components.single_page_notification_button.unsubscribe_text")
+      end
+
+      def form_action
+        @skip_account ? email_alert_frontend_endpoint_no_account : email_alert_frontend_endpoint_enforce_account
+      end
+
+      def email_alert_frontend_endpoint_enforce_account
+        "/email/subscriptions/single-page/new"
+      end
+
+      def email_alert_frontend_endpoint_no_account
+        "/email-signup"
+      end
+
+      def skip_account_param
+        "single_page_subscription"
       end
     end
   end

--- a/spec/components/single_page_notification_button_spec.rb
+++ b/spec/components/single_page_notification_button_spec.rb
@@ -50,6 +50,27 @@ describe "Single page notification button", type: :view do
     assert_select ".gem-c-single-page-notification-button", text: "Stop getting emails about this page"
   end
 
+  it "by defaults sets a form action of '/email/subscriptions/single-page/new'" do
+    local_assigns = {
+      base_path: "/the-current-page",
+    }
+    render_component(local_assigns)
+    assert_select "form[action='/email/subscriptions/single-page/new']"
+    assert_select "input[name='base_path']", value: "/the-current-page"
+  end
+
+  it "sets a form action of '/email-signup' and adds a hidden link param if skip_account is provided" do
+    local_assigns = {
+      base_path: "/the-current-page",
+      skip_account: "true",
+    }
+    render_component(local_assigns)
+    assert_select "form[action='/email-signup']"
+    assert_select "input[name='base_path']", value: "/the-current-page"
+    assert_select "input[name='single_page_subscription']", value: "true"
+    assert_select "input[name='link']", value: "/the-current-page"
+  end
+
   it "has data attributes if data_attributes is specified" do
     render_component({ base_path: "/the-current-page", data_attributes: { custom_attribute: "kaboom!" } })
     assert_select ".gem-c-single-page-notification-button[data-custom-attribute='kaboom!']"


### PR DESCRIPTION
## What

Support non account sign up flow from the single page notification button component

If the `skip_account` attribute is set:
 - The form action of the component will be set to `/email-signup`. This is a route served by email-alert-frontend which does not enforce the GOV.UK account.  It's used by the [subscription links component ](https://components.publishing.service.gov.uk/component-guide/subscription_links) on [topic pages](https://www.gov.uk/topic/benefits-credits/child-benefit) and other doc types. The default form action will remain `/email/subscriptions/single-page/new`, which is the endpoint served my email-alert-frontend that enforces the GOV.UK account )
 - Two params will be added to the request
     -  `single_page_subscription` that will be used by email alert frontend to set the correct list attributes for email alert api. See related work here: https://github.com/alphagov/email-alert-frontend/pull/1489
    - `link` which is required by email alert frontend to fetch the correct content item. See https://github.com/alphagov/email-alert-frontend/blob/main/app/controllers/content_item_signups_controller.rb#L47-L57

## Why
So that users can sign up to single page email notifications without being force to login or sign up to a GOV.UK account.

## Visual Changes
None

https://trello.com/c/TelEwi1O/1498-extend-the-single-page-notification-button-in-govuk-publishing-components-so-that-it-accepts-a-new-singlepage-attribute-s
https://trello.com/c/DCLGQJU4/1457-extend-email-alert-frontend-to-support-an-account-less-sign-up-journey-from-the-single-page-notification-button-l
