### PR TITLE
Version 34.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 34.7.0
 
 * Add GA4 modules error checking ([PR #3228](https://github.com/alphagov/govuk_publishing_components/pull/3228))
 * Add classes to align text in Govspeak tables ([PR #3217](https://github.com/alphagov/govuk_publishing_components/pull/3217))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (34.6.0)
+    govuk_publishing_components (34.7.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "34.6.0".freeze
+  VERSION = "34.7.0".freeze
 end


### PR DESCRIPTION
* Add GA4 modules error checking ([PR #3228](https://github.com/alphagov/govuk_publishing_components/pull/3228))
* Add classes to align text in Govspeak tables ([PR #3217](https://github.com/alphagov/govuk_publishing_components/pull/3217))
* Make links bold at all viewports on navbar menu ([PR #3219](https://github.com/alphagov/govuk_publishing_components/pull/3219))
* Add our 'assets' domain as a domain that should run our analytics ([PR #3224](https://github.com/alphagov/govuk_publishing_components/pull/3224))
* Add document list component option to remove first item top border ([PR #3221](https://github.com/alphagov/govuk_publishing_components/pull/3221))
* Allow a tracked ga4 link to be hardcoded via its ga4-link JSON ([PR #3227](https://github.com/alphagov/govuk_publishing_components/pull/3227))