### PR TITLE
Bump version to 34.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 34.7.1
 
 * Use base path to form URLs for related World Location links ([PR #3102](https://github.com/alphagov/govuk_publishing_components/pull/3102))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (34.7.0)
+    govuk_publishing_components (34.7.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "34.7.0".freeze
+  VERSION = "34.7.1".freeze
 end


### PR DESCRIPTION
## What
Bumps the gem to version 34.7.1.

## Why
This includes a bug fix for world location related links.