### PR TITLE
GOV.UK account name change

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,9 +153,9 @@ en:
         navigation:
           menu_bar:
             account:
-              link_text: Your account
+              link_text: Your GOV.UK One Login
             manage:
-              link_text: Manage your account
+              link_text: Settings
     layout_header:
       hide_button: Hide search
       menu: Menu

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -218,7 +218,7 @@ describe "Layout for public", type: :view do
   it "indicates the active account navigation item if the location parameter is passed" do
     render_component({ show_account_layout: true, account_nav_location: "manage" })
 
-    assert_select ".gem-c-layout-for-public-account-nav li.gem-c-layout-for-public-account-menu__item.gem-c-layout-for-public-account-menu__item--current a[aria-current=page]", text: "Manage your account"
+    assert_select ".gem-c-layout-for-public-account-nav li.gem-c-layout-for-public-account-menu__item.gem-c-layout-for-public-account-menu__item--current a[aria-current=page]", text: "Settings"
   end
 
   it "can accept custom cookie banner content" do


### PR DESCRIPTION
**Go Live at 10:00 on 9th Feb 2023**

The account has recently undergone some structural changes and is currently being rebranded to GOV.UK One Login. This updates the account navigation link text to reflect that change
