### PR TITLE
Add GA4 tracking to contextual sidebar Ukraine CTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add GA4 auto tracker ([PR #3240](https://github.com/alphagov/govuk_publishing_components/pull/3240))
+* Add GA4 tracking to contextual sidebar Ukraine CTA ([PR #3236](https://github.com/alphagov/govuk_publishing_components/pull/3236))
 
 ## 34.9.1
 

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -29,6 +29,6 @@
   <% end %>
 
   <% if navigation.show_ukraine_cta? %>
-    <%= render 'govuk_publishing_components/components/contextual_sidebar/ukraine_cta', content_item: content_item %>
+    <%= render 'govuk_publishing_components/components/contextual_sidebar/ukraine_cta', content_item: content_item, ga4_tracking: ga4_tracking %>
   <% end %>
 </div>

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_ukraine_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_ukraine_cta.html.erb
@@ -1,14 +1,23 @@
-<% shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns) %>
-<%
+<% 
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   title = t("components.related_navigation.ukraine.title")
   lang = shared_helper.t_locale("components.related_navigation.ukraine.title")
+  data_module = "gem-track-click"
+  data_module << " ga4-link-tracker" if ga4_tracking
 %>
-
-<%= tag.div class: "gem-c-contextual-sidebar__cta gem-c-contextual-sidebar__cta--ukraine", data: { module: "gem-track-click" } do %>
+<%= tag.div class: "gem-c-contextual-sidebar__cta gem-c-contextual-sidebar__cta--ukraine", data: { module: data_module } do %>
   <%= tag.h2 title, class: "gem-c-contextual-sidebar__heading govuk-heading-s" %>
   <%= tag.ul class: "gem-c-contextual-sidebar__list" do %>
-    <% t("components.related_navigation.ukraine.links").each do |link| %>
+    <% t("components.related_navigation.ukraine.links").each_with_index do |link, index| %>
       <%= tag.li class: "gem-c-contextual-sidebar__text govuk-body" do %>
+        <%
+          ga4_attributes = {
+            event_name: "navigation",
+            type: "related content",
+            index: "1.#{index + 1}",
+            section: title,
+          } if ga4_tracking
+        %>
         <%= link_to link[:label],
           link[:href],
           class: "govuk-link",
@@ -18,9 +27,10 @@
             "track-label": link[:href],
             "track-dimension": link[:label],
             "track-dimension-index": "29",
+            ga4_link: ga4_attributes,
           },
           lang: lang %>
       <% end %>
     <% end %>
-  <% end %>    
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -104,7 +104,7 @@ examples:
               base_path: "/government/topical-events/russian-invasion-of-ukraine-uk-government-response"
               locale: "en"
   with_ga4_tracking_on_related_navigation:
-    description: Adds Google Analytics 4 tracking to components within the sidebar. Currently only the Related Navigation and Step by Step navigation components accept this option.
+    description: Adds Google Analytics 4 tracking to components within the sidebar. Currently only the Related Navigation component, Step by Step navigation component and Ukraine CTA accept this option.
     data:
       ga4_tracking: true
       content_item:
@@ -124,8 +124,13 @@ examples:
           - title: The future of jobs and skills
             base_path: /government/collections/the-future-of-jobs-and-skills
             document_type: document_collection
+          topical_events:
+            - content_id: "bfa79635-ffda-4b5d-8266-a9cd3a03649c"
+              title: "Russian invasion of Ukraine: UK government response"
+              base_path: "/government/topical-events/russian-invasion-of-ukraine-uk-government-response"
+              locale: "en"
   with_ga4_tracking_on_step_by_step:
-    description: Adds Google Analytics 4 tracking to components within the sidebar. Currently only the Related Navigation and Step by Step navigation components accept this option.
+    description: Adds Google Analytics 4 tracking to components within the sidebar. Currently only the Related Navigation component, Step by Step navigation component and Ukraine CTA accept this option.
     data:
       ga4_tracking: true
       content_item:

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -132,32 +132,23 @@ examples:
         title: "A content item"
         links:
           part_of_step_navs:
-            - title: "Learn to drive a car: step by step"
-              base_path: "/micropigs-vs-micropugs"
+            - title: "What to do when someone dies: step by step"
+              base_path: "/when-someone-dies"
               details:
                 step_by_step_nav:
-                  title: 'Stay in the UK after it leaves the EU (''settled status''): step by step'
+                  title: 'What to do when someone dies: step by step'
                   steps:
-                  - title: Check you're allowed to drive
+                  - title: Register the death
                     contents:
-                    - type: paragraph
-                      text: Most people can start learning to drive when they’re 17.
                     - type: list
                       contents:
-                      - text: Check what age you can drive
-                        href: "/vehicles-can-drive"
+                      - text: Register the death
+                        href: "/after-a-death"
                     optional: false
-                  - title: Testing the and
-                    logic: and
+                  - title: Arrange the funeral
                     contents:
-                    - type: paragraph
-                      text: hello hello what's UP
-                  - title: Driving lessons and practice
-                    contents:
-                    - type: paragraph
-                      text: You need a provisional driving licence to take lessons or practice.
                     - type: list
                       contents:
-                      - text: The Highway Code
-                        href: "/guidance/the-highway-code"
+                      - text: Arrange the funeral
+                        href: "/after-a-death/arrange-the-funeral"
                     optional: false

--- a/spec/components/contextual_sidebar_spec.rb
+++ b/spec/components/contextual_sidebar_spec.rb
@@ -21,4 +21,27 @@ describe "Contextual sidebar", type: :view do
     end
     assert_select ".gem-c-contextual-sidebar"
   end
+
+  it "applies GA4 tracking to the Ukraine sidebar" do
+    should_show_ukraine = {
+      links: {
+        topical_events: [
+          {
+            content_id: "bfa79635-ffda-4b5d-8266-a9cd3a03649c",
+            title: "Russian invasion of Ukraine: UK government response",
+            base_path: "/government/topical-events/russian-invasion-of-ukraine-uk-government-response",
+            locale: "en",
+          },
+        ],
+      },
+    }.deep_stringify_keys!
+    content_item = GovukSchemas::Example.find("document_collection", example_name: "document_collection")
+    content_item = content_item.deep_merge!(should_show_ukraine)
+
+    render_component(
+      ga4_tracking: true,
+      content_item: content_item,
+    )
+    assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine[data-module='gem-track-click ga4-link-tracker']"
+  end
 end


### PR DESCRIPTION
## What
Adds tracking to the Ukraine CTA on pages such as: https://www.gov.uk/foreign-travel-advice/ukraine

![Screenshot 2023-02-06 at 13 24 52](https://user-images.githubusercontent.com/861310/216982912-828635e3-43a4-4c9e-8d26-78311f2f128b.png)

This tracking is based on the tracking already implemented for the Related Navigation component, but uses 'Invasion of Ukraine' as the value for `section`. The link index is based on the link position but is always prefixed with `1` because there is only one list of links in this section.

## Why
Part of the GA4 migration.

## Visual Changes
None.

Trello card: https://trello.com/c/ml0rt88c/420-add-tracking-to-ukraine-call-out-box
