### PR TITLE
Increase clickable area for links in navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+* Increase clickable area for links in navbar ([PR #3238](https://github.com/alphagov/govuk_publishing_components/pull/3238))
+
+
 ## 34.10.1
 * Remove the brand colour for Department for Energy Security and Net Zero ([PR #3255](https://github.com/alphagov/govuk_publishing_components/pull/3255))
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -692,31 +692,24 @@ $after-button-padding-left: govuk-spacing(4);
 // Dropdown menu items.
 .gem-c-layout-super-navigation-header__dropdown-list-item {
   box-sizing: border-box;
-  padding: 0 0 govuk-spacing(5) 0;
+  padding: 0 0 govuk-spacing(3) 0;
   position: relative;
+  margin: 0 0 govuk-spacing(2) 0;
   @include govuk-media-query($from: "desktop") {
-    padding: 0 0 govuk-spacing(4) 0;
+    padding: 0 0 govuk-spacing(3) 0;
+    margin: 0 govuk-spacing(3) govuk-spacing(1) govuk-spacing(3);
   }
 }
 
 // Navigation menu items.
 .gem-c-layout-super-navigation-header__navigation-second-items {
-
   list-style: none;
   margin: 0;
   padding: govuk-spacing(3) govuk-spacing(5) govuk-spacing(5) 0;
 
-  & > li {
-    margin: 0;
-  }
-
   @include govuk-media-query($from: "desktop") {
     margin: 0 (0 - govuk-spacing(3)) govuk-spacing(9);
     padding: govuk-spacing(2) 0 0 0;
-
-    & > li {
-      margin: 0 govuk-spacing(3);
-    }
   }
 }
 
@@ -743,11 +736,15 @@ $after-button-padding-left: govuk-spacing(4);
   font-size: govuk-px-to-rem(16px);
   font-weight: bold;
 
+  &:after {
+    @include make-selectable-area-bigger;
+  }
+
   @include govuk-media-query($from: "desktop") {
     padding: 0;
 
     &:after {
-      content: none;
+      @include make-selectable-area-bigger;
     }
   }
 }
@@ -810,12 +807,6 @@ $after-button-padding-left: govuk-spacing(4);
 
   &:after {
     @include make-selectable-area-bigger;
-  }
-
-  @include govuk-media-query($from: "desktop") {
-    &:after {
-      content: none;
-    }
   }
 }
 


### PR DESCRIPTION
## What

Although some of the links on navbar use larger clickable areas on mobile viewports, this does not take into account users using touchscreens at larger viewports. This PR increases the touch areas for topic links in mobile viewport, topic links in desktop viewport and popular links in all viewports. It uses the already existing mixin in the layout-super-navigation-header.

## Why

For users who have trouble controlling their mouse, having the touch target limited to the link itself (for example the links in the Topics section of the menu) means it can be tricky to select with an unsteady hand. Could also make it difficult to click links if user a using a large touchscreen.

[Relevant Trello Card](https://trello.com/c/AMSVEJpN/1572-touch-targets-for-selecting-links-in-menu-could-be-bigger-s)