### PR TITLE
Release 34.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 34.8.0
 
 * Add GA4 Form tracker ([PR #3215](https://github.com/alphagov/govuk_publishing_components/pull/3215))
 * Add component wrapper helper ([PR #3171](https://github.com/alphagov/govuk_publishing_components/pull/3171))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (34.7.1)
+    govuk_publishing_components (34.8.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "34.7.1".freeze
+  VERSION = "34.8.0".freeze
 end


### PR DESCRIPTION
## 34.8.0

* Add GA4 Form tracker ([PR #3215](https://github.com/alphagov/govuk_publishing_components/pull/3215))
* Add component wrapper helper ([PR #3171](https://github.com/alphagov/govuk_publishing_components/pull/3171))
* Add aria attributes to Details component ([PR #3225](https://github.com/alphagov/govuk_publishing_components/pull/3225))