### PR TITLE
Add GA4 auto tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add GA4 auto tracker ([PR #3240](https://github.com/alphagov/govuk_publishing_components/pull/3240))
+
 ## 34.9.1
 
 * Update Component Guide skip_account to mention GOV.UK One Login ([PR #3247](https://github.com/alphagov/govuk_publishing_components/pull/3247))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
@@ -8,4 +8,5 @@
 //= require ./analytics-ga4/ga4-event-tracker
 //= require ./analytics-ga4/ga4-ecommerce-tracker
 //= require ./analytics-ga4/ga4-form-tracker
+//= require ./analytics-ga4/ga4-auto-tracker
 //= require ./analytics-ga4/init-ga4

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.js
@@ -1,0 +1,46 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  'use strict'
+
+  function Ga4AutoTracker (module) {
+    this.module = module
+    this.trackingTrigger = 'data-ga4-auto'
+  }
+
+  Ga4AutoTracker.prototype.init = function () {
+    var consentCookie = window.GOVUK.getConsentCookie()
+
+    if (consentCookie && consentCookie.settings) {
+      this.startModule()
+    } else {
+      this.startModule = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.startModule)
+    }
+  }
+
+  Ga4AutoTracker.prototype.startModule = function () {
+    this.sendEvent()
+  }
+
+  Ga4AutoTracker.prototype.sendEvent = function () {
+    if (window.dataLayer) {
+      try {
+        var data = this.module.getAttribute(this.trackingTrigger)
+        data = JSON.parse(data)
+      } catch (e) {
+        // if there's a problem with the config, don't start the tracker
+        console.error('GA4 configuration error: ' + e.message, window.location)
+        return
+      }
+
+      var schemas = new window.GOVUK.analyticsGa4.Schemas()
+      var schema = schemas.mergeProperties(data, 'event_data')
+
+      window.GOVUK.analyticsGa4.core.sendData(schema)
+    }
+  }
+
+  Modules.Ga4AutoTracker = Ga4AutoTracker
+})(window.GOVUK.Modules)

--- a/docs/analytics-ga4/ga4-auto-tracker.md
+++ b/docs/analytics-ga4/ga4-auto-tracker.md
@@ -1,0 +1,14 @@
+# Google Analytics 4 auto tracker
+
+This script is intended for adding GA4 tracking to any page where something must be recorded outside of a normal page view and without user interaction. The script is triggered when the page loads. It depends upon the main GA4 analytics code to function.
+
+## Basic use
+
+```html
+<div
+  data-module="ga4-auto-tracker"
+  data-ga4-auto='{ "event_name": "event name", "type": "a type", "section": "a section", "action": "an action", "tool_name": "a tool name" }'>
+</div>
+```
+
+This module was created to record events within smart answers such as a question input error and reaching a results page, but can be used elsewhere with different attributes.

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
@@ -1,0 +1,116 @@
+/* eslint-env jasmine */
+
+describe('Google Analytics auto tracker', function () {
+  var GOVUK = window.GOVUK
+  var element
+  var expected
+
+  function agreeToCookies () {
+    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+  }
+
+  function denyCookies () {
+    GOVUK.setCookie('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}')
+  }
+
+  beforeAll(function () {
+    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+    window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
+    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
+  })
+
+  beforeEach(function () {
+    window.dataLayer = []
+    element = document.createElement('form')
+    document.body.appendChild(element)
+    agreeToCookies()
+  })
+
+  afterEach(function () {
+    document.body.removeChild(element)
+  })
+
+  afterAll(function () {
+    window.dataLayer = []
+  })
+
+  describe('when the user has a cookie consent choice', function () {
+    it('starts the module if consent has already been given', function () {
+      agreeToCookies()
+      var tracker = new GOVUK.Modules.Ga4AutoTracker(element)
+      spyOn(tracker, 'startModule').and.callThrough()
+      tracker.init()
+
+      expect(tracker.startModule).toHaveBeenCalled()
+    })
+
+    it('starts the module on the same page as cookie consent is given', function () {
+      denyCookies()
+      var tracker = new GOVUK.Modules.Ga4AutoTracker(element)
+      spyOn(tracker, 'sendEvent')
+      tracker.init()
+      expect(tracker.sendEvent).not.toHaveBeenCalled()
+
+      // page has not been reloaded, user consents to cookies
+      window.GOVUK.triggerEvent(window, 'cookie-consent')
+      expect(tracker.sendEvent).toHaveBeenCalled()
+    })
+
+    it('does not do anything if consent is not given', function () {
+      denyCookies()
+      var tracker = new GOVUK.Modules.Ga4AutoTracker(element)
+      spyOn(tracker, 'sendEvent')
+      tracker.init()
+
+      expect(tracker.sendEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('configuring tracking without any data', function () {
+    beforeEach(function () {
+      element.setAttribute('data-ga4-auto', '')
+      new GOVUK.Modules.Ga4AutoTracker(element).init()
+    })
+
+    it('does not cause an error or fire an event', function () {
+      expect(window.dataLayer[0]).toEqual(undefined)
+    })
+  })
+
+  describe('configuring tracking with incorrect data', function () {
+    beforeEach(function () {
+      element.setAttribute('data-ga4-auto', 'invalid json')
+      new GOVUK.Modules.Ga4AutoTracker(element).init()
+    })
+
+    it('does not cause an error', function () {
+      expect(window.dataLayer[0]).toEqual(undefined)
+    })
+  })
+
+  describe('tracking on page load', function () {
+    beforeEach(function () {
+      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      expected.event = 'event_data'
+      expected.event_data.event_name = 'select_content'
+      expected.event_data.type = 'tabs'
+      expected.govuk_gem_version = 'aVersion'
+
+      var attributes = {
+        event_name: 'select_content',
+        type: 'tabs',
+        not_a_schema_attribute: 'something'
+      }
+      element.setAttribute('data-ga4-auto', JSON.stringify(attributes))
+      new GOVUK.Modules.Ga4AutoTracker(element).init()
+    })
+
+    it('pushes ga4 attributes to the dataLayer', function () {
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('does not include non-schema data attributes', function () {
+      expect(window.dataLayer[0].not_a_schema_attribute).toEqual(undefined)
+    })
+  })
+})


### PR DESCRIPTION
## What
Adds a GOVUK JavaScript module that when attached to a page with the right data attributes sends data to GA4 when the page loads. Initially for use on error pages in smart answers to send an event detailing the error.

## Why
Needed for the GA4 work with smart answers.

## Visual Changes
None.

Trello card: https://trello.com/c/xf2dDOBN/407-add-tracking-smart-answers-formerror