### PR TITLE
Add documentation for testing a branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ yarn run jasmine:ci
 
 - [Install and use this gem](docs/install-and-use.md)
 - [Use a component in your application](docs/use-components.md)
+- [Test a branch of the gem](docs/test-a-branch-of-the-gem.md)
 
 ### Managing the gem
 

--- a/docs/test-a-branch-of-the-gem.md
+++ b/docs/test-a-branch-of-the-gem.md
@@ -1,0 +1,51 @@
+# Test a branch of the components gem
+
+This document explains how to test a github branch of `govuk_publishing_components` in an application, either locally or for testing a change in the gem on integration.
+
+## Prepare a branch of govuk_publishing_components
+
+Create a branch of `govuk_publishing_components` with the changes that you want to test.
+
+In a separate commit, modify the `.gitignore` file, replacing the `node_modules` line with the following.
+
+```
+node_modules/@babel
+node_modules/@nodelib
+node_modules/@oclif
+node_modules/acorn
+node_modules/ajv
+node_modules/caniuse-lite
+node_modules/devtools-protocol
+node_modules/es-abstract
+node_modules/eslint
+node_modules/eslint-plugin-import
+node_modules/eslint-plugin-react
+node_modules/lodash
+node_modules/micromark
+node_modules/percy-client
+node_modules/postcss
+node_modules/puppeteer
+node_modules/stylelint
+node_modules/table
+```
+
+Commit and push the `.gitignore` and `node_modules` directory. This will add to the branch everything needed to make the components gem work - basically all the things that are normally installed as part of installing a gem.
+
+**DO NOT** merge this change to `main` - once you have finished testing your branch, delete this commit.
+
+## Prepare the application to use the gem branch
+
+The application to use the branch of the components gem may vary depending on what you are testing, however the process remains the same.
+
+Create a branch of the application and modify the Gemfile to point to the branch of `govuk_publishing_components`.
+
+```
+gem "govuk_publishing_components", git: 'https://github.com/alphagov/govuk_publishing_components.git', branch: 'branch-name'
+```
+
+Test your changes locally.
+
+- if you are using the startup scripts to run your application, stop the script, run `bundle update govuk_publishing_components` and restart
+- if you are using govuk-docker, stop the application, run `govuk-docker-run bundle update govuk_publishing_components` and restart
+
+You can also push this branch to github and the heroku preview generated from the pull request will use the branch of `govuk_publishing_components`. Once you have pushed to github you can also deploy this branch to integration for further testing. Note that you do not need to do anything with the branch of `govuk_publishing_components` - only the application needs to be deployed to integration.


### PR DESCRIPTION
## What / why
Adding documentation for testing a branch of the gem.

- was originally in dev docs, but multiple people expressed an inability to find it
- removing from dev docs (originally at https://docs.publishing.service.gov.uk/manual/test-a-branch-of-the-components-gem.html)
- adding it here to the gem will automatically include it in dev docs anyway
- copied with no changes

## Visual Changes
None.
