### PR TITLE
Revert world locations base_path change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Reverts release 34.7.1 concerning related World Location links ([PR #3243](https://github.com/alphagov/govuk_publishing_components/pull/3243))
+
 ## 34.8.0
 
 * Add GA4 Form tracker ([PR #3215](https://github.com/alphagov/govuk_publishing_components/pull/3215))

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -12,6 +12,9 @@ module GovukPublishingComponents
         world_locations
         statistical_data_sets
       ].freeze
+      WORLD_LOCATION_SPECIAL_CASES = {
+        "UK Mission to the European Union" => "uk-mission-to-the-eu",
+      }.freeze
 
       def initialize(options = {})
         @content_item = options.fetch(:content_item) { raise ArgumentError, "missing argument: content_item" }
@@ -112,6 +115,10 @@ module GovukPublishingComponents
 
       def related_world_locations
         content_item_links_for("world_locations")
+          .map do |link|
+            slug = WORLD_LOCATION_SPECIAL_CASES[link[:text]] || link[:text].parameterize
+            link.merge(path: "/world/#{slug}/news")
+          end
       end
 
       def related_statistical_data_sets

--- a/spec/components/contextual_footer_spec.rb
+++ b/spec/components/contextual_footer_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "Contextual footer", type: :view do
       # If this item is a part of a step nav or secondary step nav this component might not render
       payload["links"].delete("part_of_step_navs")
       payload["links"].delete("secondary_to_step_navs")
-      payload["links"].delete("world_locations")
       payload
     end
 

--- a/spec/components/related_navigation_spec.rb
+++ b/spec/components/related_navigation_spec.rb
@@ -71,11 +71,20 @@ describe "Related navigation", type: :view do
 
   it "renders world locations section when passed world location items" do
     content_item = {}
-    content_item["links"] = construct_links("world_locations", "/world/usa", "USA")
+    content_item["links"] = construct_links("world_locations", "/world/usa/news", "USA")
     render_component(content_item: content_item)
 
     assert_select ".gem-c-related-navigation__sub-heading", text: "World locations"
-    assert_select ".gem-c-related-navigation__section-link[href=\"/world/usa\"]", text: "USA"
+    assert_select ".gem-c-related-navigation__section-link[href=\"/world/usa/news\"]", text: "USA"
+  end
+
+  it "renders world locations section when passed special case world location items" do
+    content_item = {}
+    content_item["links"] = construct_links("world_locations", nil, "UK Mission to the European Union")
+    render_component(content_item: content_item)
+
+    assert_select ".gem-c-related-navigation__sub-heading", text: "World locations"
+    assert_select ".gem-c-related-navigation__section-link[href=\"/world/uk-mission-to-the-eu/news\"]", text: "UK Mission to the European Union"
   end
 
   it "renders collection section when passed collection items" do
@@ -152,24 +161,24 @@ describe "Related navigation", type: :view do
   it "adds a show more toggle link to long sections" do
     content_item = { "links" => { "world_locations" => [] } }
     %w[USA Wales Fiji Iceland Sweden Mauritius Brazil].each do |country|
-      content_item["links"]["world_locations"] << { "title" => country, "base_path" => "/world/#{country.downcase}" }
+      content_item["links"]["world_locations"] << { "title" => country }
     end
     render_component(content_item: content_item)
 
-    assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales\"]", text: "Wales"
+    assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales/news\"]", text: "Wales"
     assert_select ".gem-c-related-navigation__link.toggle-wrap", text: "Show 2 more"
-    assert_select "#toggle_world_locations .gem-c-related-navigation__section-link[href=\"/world/mauritius\"]", text: "Mauritius"
-    assert_select "#toggle_world_locations .gem-c-related-navigation__section-link[href=\"/world/brazil\"]", text: "Brazil"
+    assert_select "#toggle_world_locations .gem-c-related-navigation__section-link[href=\"/world/mauritius/news\"]", text: "Mauritius"
+    assert_select "#toggle_world_locations .gem-c-related-navigation__section-link[href=\"/world/brazil/news\"]", text: "Brazil"
   end
 
   it "does not use a Show More for only one link above the max per section" do
     content_item = { "links" => { "world_locations" => [] } }
     %w[USA Wales Fiji Iceland Sweden Mauritius].each do |country|
-      content_item["links"]["world_locations"] << { "title" => country, "base_path" => "/world/#{country.downcase}" }
+      content_item["links"]["world_locations"] << { "title" => country }
     end
     render_component(content_item: content_item)
 
-    assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales\"]", text: "Wales"
+    assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales/news\"]", text: "Wales"
     assert_select ".gem-c-related-navigation__link.toggle-wrap", false, "Progressive disclosure should not display for only 1 link"
   end
 

--- a/spec/lib/govuk_publishing_components/presenters/related_navigation_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/related_navigation_helper_spec.rb
@@ -110,7 +110,6 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
               "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
               "title" => "World, ~ (@Location)",
               "locale" => "en",
-              "base_path" => "/world/somewhere",
             },
           ],
         },
@@ -127,7 +126,7 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
         "related_contacts" => [],
         "related_external_links" => [],
         "topical_events" => [{ locale: "en", path: "/related-topical-event", text: "related topical event" }],
-        "world_locations" => [{ locale: "en", path: "/world/somewhere", text: "World, ~ (@Location)" }],
+        "world_locations" => [{ locale: "en", path: "/world/world-location/news", text: "World, ~ (@Location)" }],
         "statistical_data_sets" => [],
       }
 


### PR DESCRIPTION
## What

From raised Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5207548

The [PR implementing the change](https://github.com/alphagov/govuk_publishing_components/pull/3102/commits/727cf81008226df642c832b0a11da14394538723) in how we fetch base_paths for world_locations caused the world location related links to redirect back to the same page. 

This occurred as the logic was changed to fetch the `base_path` from the links hash but the `base_path` isn't part of the included attributes for world locations and so the path (href) was blank [1] which causes the behaviour of redirecting back to the original page.

`base_paths` generated by parameterising the title is still flawed as it generates some broken links, however most links should now work after this revert. We should implement the original change when the base_path is included in the links. 

Example page of missing base_paths: /api/content/government/news/switzerland-hands-over-ukraine-recovery-conference-hosting-to-uk.

[1]: https://github.com/alphagov/govuk_publishing_components/blob/727cf81008226df642c832b0a11da14394538723/lib/govuk_publishing_components/presenters/related_navigation_helper.rb#L197.


## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

<img width="985" alt="Screenshot 2023-02-08 at 12 32 09" src="https://user-images.githubusercontent.com/24479188/217530879-54f38db1-9c9b-405b-b508-7ccee036ef43.png">

### After

<img width="751" alt="Screenshot 2023-02-08 at 12 31 26" src="https://user-images.githubusercontent.com/24479188/217530927-80f3d6cc-1f61-46d6-bf39-8909cac51574.png">

