### PR TITLE
GOV.UK account name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Update "Account" copy to "GOV.UK One Login" ([PR #3246](https://github.com/alphagov/govuk_publishing_components/pull/3246))
+
 ## 34.9.0
 
 * Allow single page notification button to skip the govuk-account ([PR #3229](https://github.com/alphagov/govuk_publishing_components/pull/3229))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,9 +153,9 @@ en:
         navigation:
           menu_bar:
             account:
-              link_text: Your account
+              link_text: Your GOV.UK One Login
             manage:
-              link_text: Manage your account
+              link_text: Settings
     layout_header:
       hide_button: Hide search
       menu: Menu

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -218,7 +218,7 @@ describe "Layout for public", type: :view do
   it "indicates the active account navigation item if the location parameter is passed" do
     render_component({ show_account_layout: true, account_nav_location: "manage" })
 
-    assert_select ".gem-c-layout-for-public-account-nav li.gem-c-layout-for-public-account-menu__item.gem-c-layout-for-public-account-menu__item--current a[aria-current=page]", text: "Manage your account"
+    assert_select ".gem-c-layout-for-public-account-nav li.gem-c-layout-for-public-account-menu__item.gem-c-layout-for-public-account-menu__item--current a[aria-current=page]", text: "Settings"
   end
 
   it "can accept custom cookie banner content" do


### PR DESCRIPTION
## What
Link name changes for GOV.UK One Login

## Why
GOV.UK One Login official name change on 9th February 2023.

## Visual Changes

### Before


### After

https://trello.com/c/EbkPjP8y/1817-thursday-9th-feb-email-alerts-pr-approvals-for-digital-identity-accounts-team