### PR TITLE
Tweak text in component guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update Component Guide skip_account to mention GOV.UK One Login ([PR #3247](https://github.com/alphagov/govuk_publishing_components/pull/3247))
 * Update "Account" copy to "GOV.UK One Login" ([PR #3246](https://github.com/alphagov/govuk_publishing_components/pull/3246))
 
 ## 34.9.0

--- a/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
+++ b/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
@@ -58,7 +58,7 @@ examples:
         subscribe: 'Subscribe to this page of things'
         unsubscribe: 'Unsubscribe to this page of things'
   with_skip_account:
-    description: If the skip_account flag is present, the button action will be set to the non GOV.UK account signup endpoint of /email-signup.
+    description: If the skip_account flag is present, the button action will be set to the non GOV.UK One Login signup endpoint of /email-signup.
     data:
       base_path: '/current-page-path'
       js_enhancement: true


### PR DESCRIPTION
## What
Small copy update in component publishing guide

## Why
GOV.UK Account now GOV.UK One Login, maintain consistent use.

