### PR TITLE
Use string splitter on taxonomyAll and taxonomyAllIds pageview values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add GA4 auto tracker ([PR #3240](https://github.com/alphagov/govuk_publishing_components/pull/3240))
 * Add GA4 tracking to contextual sidebar Ukraine CTA ([PR #3236](https://github.com/alphagov/govuk_publishing_components/pull/3236))
+* Use string splitter on taxonomyAll and taxonomyAllIds pageview values ([PR #3249](https://github.com/alphagov/govuk_publishing_components/pull/3249))
 
 ## 34.9.1
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -63,13 +63,17 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
           return
         }
 
+        return this.splitStringIntoParts(path)
+      },
+
+      splitStringIntoParts: function (string) {
         /*
         This will create an object with 5 keys that are indexes ("1", "2", etc.)
-        The values will be each part of the link path split every 100 characters, or undefined.
+        The values will be each part of the string split every 100 characters, or undefined.
         For example: {"1": "/hello/world/etc...", "2": "/more/path/text...", "3": undefined, "4": undefined, "5": undefined}
         Undefined values are needed to override the persistent object in GTM so that any values from old pushes are overwritten.
         */
-        var parts = path.match(/.{1,100}/g)
+        var parts = string.match(/.{1,100}/g)
         var obj = {}
         for (var i = 0; i < 5; i++) {
           obj[(i + 1).toString()] = parts[i]

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -31,8 +31,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             taxonomy_level1: this.getMetaContent('themes'),
             taxonomy_main: this.getMetaContent('taxon-slug'),
             taxonomy_main_id: this.getMetaContent('taxon-id'),
-            taxonomy_all: this.getMetaContent('taxon-slugs'),
-            taxonomy_all_ids: this.getMetaContent('taxon-ids'),
+            taxonomy_all: this.splitLongMetaContent('taxon-slugs'),
+            taxonomy_all_ids: this.splitLongMetaContent('taxon-ids'),
 
             language: this.getLanguage(),
             history: this.getHistory(),
@@ -104,6 +104,13 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     getWithDrawn: function () {
       var withdrawn = this.getMetaContent('withdrawn')
       return (withdrawn === 'withdrawn') ? 'true' : 'false'
+    },
+
+    splitLongMetaContent: function (metatag) {
+      var tag = this.getMetaContent(metatag)
+      if (tag) {
+        return window.GOVUK.analyticsGa4.core.trackFunctions.splitStringIntoParts(tag)
+      }
     },
 
     // return only the date from given timestamps of the form

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -163,7 +163,58 @@ describe('Google Tag Manager page view tracking', function () {
     for (var i = 0; i < tags.length; i++) {
       var tag = tags[i]
       createMetaTags(tag.tagName, tag.value)
-      expected.page_view[tag.gtmName] = tag.value
+      if (tag.gtmName === 'taxonomy_all_ids' || tag.gtmName === 'taxonomy_all') {
+        expected.page_view[tag.gtmName] = {
+          1: tag.value,
+          2: undefined,
+          3: undefined,
+          4: undefined,
+          5: undefined
+        }
+      } else {
+        expected.page_view[tag.gtmName] = tag.value
+      }
+    }
+
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('splits taxonomy_all and taxonomy_all_ids into five parts', function () {
+    var tags = [
+      {
+        gtmName: 'taxonomy_all',
+        tagName: 'taxon-slugs',
+        value: 'finance-support,premises-rates,company-closure-administration-liquidation-and-insolvency,contract-working-hours,dismissals-redundancies,food-and-farming-industry,producing-distributing-food-food-labelling,recruiting-hiring,recruiting-hiring,redundancies-dismissals,sale-goods-services-data,scientific-research-and-development,self-employed'
+      },
+      {
+        gtmName: 'taxonomy_all_ids',
+        tagName: 'taxon-ids',
+        value: 'ccfc50f5-e193-4dac-9d78-50b3a8bb24c5,68cc0b3c-7f80-4869-9dc7-b2ceef5f4f08,864fe969-7d5a-4251-b8b5-a50d57be943f,23a712ff-23b3-4f5a-83f1-44ac679fe615,a1c6c263-e4ef-4b96-b82f-e070ff157367,e2559668-cf36-47fc-8a77-2e760e12a812,f1126ffb-e352-4129-bb33-8e4dfdbee9ac,c195d3e6-5924-4def-b1c2-24a685a0b210,55e8ea89-9ba8-4439-a703-7d26723a4ec0,a4d954b4-3a64-488c-a0fc-fa91ecb8cf2b,c39ac533-be2c-4460-93ba-e656793568ef,429bf677-b514-4c10-8a89-c0eee4acc7ec,24e91c04-21cb-479a-8f23-df0eaab31788thistextisincluded!!ButThisSentenceIsNotAsItIsOver500Characters.'
+      }
+    ]
+
+    for (var i = 0; i < tags.length; i++) {
+      var tag = tags[i]
+      createMetaTags(tag.tagName, tag.value)
+    }
+
+    // taxonomy_all
+    expected.page_view[tags[0].gtmName] = {
+      1: 'finance-support,premises-rates,company-closure-administration-liquidation-and-insolvency,contract-wo',
+      2: 'rking-hours,dismissals-redundancies,food-and-farming-industry,producing-distributing-food-food-label',
+      3: 'ling,recruiting-hiring,recruiting-hiring,redundancies-dismissals,sale-goods-services-data,scientific',
+      4: '-research-and-development,self-employed',
+      5: undefined
+    }
+
+    // taxonomy_all_ids
+    expected.page_view[tags[1].gtmName] = {
+      1: 'ccfc50f5-e193-4dac-9d78-50b3a8bb24c5,68cc0b3c-7f80-4869-9dc7-b2ceef5f4f08,864fe969-7d5a-4251-b8b5-a5',
+      2: '0d57be943f,23a712ff-23b3-4f5a-83f1-44ac679fe615,a1c6c263-e4ef-4b96-b82f-e070ff157367,e2559668-cf36-4',
+      3: '7fc-8a77-2e760e12a812,f1126ffb-e352-4129-bb33-8e4dfdbee9ac,c195d3e6-5924-4def-b1c2-24a685a0b210,55e8',
+      4: 'ea89-9ba8-4439-a703-7d26723a4ec0,a4d954b4-3a64-488c-a0fc-fa91ecb8cf2b,c39ac533-be2c-4460-93ba-e65679',
+      5: '3568ef,429bf677-b514-4c10-8a89-c0eee4acc7ec,24e91c04-21cb-479a-8f23-df0eaab31788thistextisincluded!!'
     }
 
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()


### PR DESCRIPTION
Hi @andysellick / @JamesCGDS - could one of you review this please? Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Converts two PageView values from strings into objects. These objects contain their string split up into 5 parts, with each part being 100 character segments of the original string.

## Why
<!-- What are the reasons behind this change being made? -->
GA4 only allows strings to be a maximum of 100 characters. There are two pageview values that sometimes contain strings that are over 100 characters. For example, on https://gov.uk/business-support-helpline you have:

```JSON

{
"taxonomy_all": "finance-support,premises-rates,company-closure-administration-liquidation-and-insolvency,contract-working-hours,dismissals-redundancies,food-and-farming-industry,producing-distributing-food-food-labelling,recruiting-hiring,recruiting-hiring,redundancies-dismissals,sale-goods-services-data,scientific-research-and-development,self-employed",
"taxonomy_all_ids": "ccfc50f5-e193-4dac-9d78-50b3a8bb24c5,68cc0b3c-7f80-4869-9dc7-b2ceef5f4f08,864fe969-7d5a-4251-b8b5-a50d57be943f,23a712ff-23b3-4f5a-83f1-44ac679fe615,a1c6c263-e4ef-4b96-b82f-e070ff157367,e2559668-cf36-47fc-8a77-2e760e12a812,f1126ffb-e352-4129-bb33-8e4dfdbee9ac,c195d3e6-5924-4def-b1c2-24a685a0b210,55e8ea89-9ba8-4439-a703-7d26723a4ec0,a4d954b4-3a64-488c-a0fc-fa91ecb8cf2b,c39ac533-be2c-4460-93ba-e656793568ef,429bf677-b514-4c10-8a89-c0eee4acc7ec,24e91c04-21cb-479a-8f23-df0eaab31788"
}
```

Which get cut off in the GA4 dashboard to look like:

```JSON

{
"taxonomy_all": "finance-support,premises-rates,company-closure-administration-liquidation-and-insolvency,contract-wo",
"taxonomy_all_ids": "ccfc50f5-e193-4dac-9d78-50b3a8bb24c5,68cc0b3c-7f80-4869-9dc7-b2ceef5f4f08,864fe969-7d5a-4251-b8b5-a5"
}
```

Therefore this uses the existing functionality we wrote to split up long URLs. We use it to turn these long strings into an object of strings, so that the original long string can be reconstructed in the GA4 dashboard.

For example:

```JSON
{
   "taxonomy_all":{
      "1":"finance-support,premises-rates,company-closure-administration-liquidation-and-insolvency,contract-wo",
      "2":"rking-hours,dismissals-redundancies,food-and-farming-industry,producing-distributing-food-food-label",
      "3":"ling,recruiting-hiring,recruiting-hiring,redundancies-dismissals,sale-goods-services-data,scientific",
      "4":"-research-and-development,self-employed",
      "5":"undefined"
   }
}

```

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
