### PR TITLE
Add error checking for populateLinkDomain

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -188,8 +188,10 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
         } else {
           // This regex matches a protocol and domain name at the start of a string such as https://www.gov.uk, http://gov.uk, //gov.uk
           var domainRegex = /^(http:||https:)?(\/\/)([^\/]*)/ // eslint-disable-line no-useless-escape
-          var domain = domainRegex.exec(href)[0]
-          return domain
+          var domain = domainRegex.exec(href)
+          if (domain) {
+            return domain[0]
+          }
         }
       },
 


### PR DESCRIPTION
## What / why
Adds an error check to the populateLinkDomain function in ga4-core.

- code assumed that regex to get domain would succeed, but future work for the intervention banner where a link has a href of ?hide-intervention=true caused this code to error
- now checks to see if the regex was successful before returning anything

## Visual Changes
None.
