### PR TITLE
Cover all types of relative hrefs in hrefIsRelative function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Unreleased
 * Increase clickable area for links in navbar ([PR #3238](https://github.com/alphagov/govuk_publishing_components/pull/3238))
-
+* Cover all types of relative hrefs in hrefIsRelative function ([PR #3251](https://github.com/alphagov/govuk_publishing_components/pull/3251))
 
 ## 34.10.1
 * Remove the brand colour for Department for Energy Security and Net Zero ([PR #3255](https://github.com/alphagov/govuk_publishing_components/pull/3255))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -40,6 +40,12 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
     },
 
     trackFunctions: {
+
+      getDomainRegex: function () {
+        // This regex matches a protocol and domain name at the start of a string such as https://www.gov.uk, http://gov.uk, //gov.uk
+        return /^(http:||https:)?(\/\/)([^\/]*)/ // eslint-disable-line no-useless-escape
+      },
+
       findTrackingAttributes: function (clicked, trackingTrigger) {
         if (clicked.hasAttribute('[' + trackingTrigger + ']')) {
           return clicked
@@ -82,12 +88,10 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
       },
 
       hrefIsRelative: function (href) {
-        // Checks that a link is relative, but is not a protocol relative url
-        return href[0] === '/' && href[1] !== '/'
-      },
+        // Checks that a href is relative by the lack of http:, https:// or // at the start of the href.
+        var domain = this.getDomainRegex().exec(href)
 
-      hrefIsAnchor: function (href) {
-        return href[0] === '#'
+        return !domain
       },
 
       isMailToLink: function (href) {
@@ -115,7 +119,7 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
 
       isInternalLink: function (href) {
         var internalDomains = window.GOVUK.analyticsGa4.vars.internalDomains
-        if (this.hrefIsRelative(href) || this.hrefIsAnchor(href)) {
+        if (this.hrefIsRelative(href)) {
           return true
         }
         var result = false
@@ -187,12 +191,10 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
           return undefined
         }
 
-        if (this.hrefIsRelative(href) || this.hrefIsAnchor(href)) {
+        if (this.hrefIsRelative(href)) {
           return this.getProtocol() + '//' + this.getHostname()
         } else {
-          // This regex matches a protocol and domain name at the start of a string such as https://www.gov.uk, http://gov.uk, //gov.uk
-          var domainRegex = /^(http:||https:)?(\/\/)([^\/]*)/ // eslint-disable-line no-useless-escape
-          var domain = domainRegex.exec(href)
+          var domain = this.getDomainRegex().exec(href)
           if (domain) {
             return domain[0]
           }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -149,24 +149,51 @@ describe('GA4 core', function () {
       })
     })
 
-    it('correctly identifies a relative URL', function () {
-      var href = '/relativeURL'
-      expect(GOVUK.analyticsGa4.core.trackFunctions.hrefIsRelative(href)).toEqual(true)
+    it('correctly identifies relative URLs', function () {
+      var relativeURLs = [
+        'g',
+        './g',
+        'g/',
+        '/g',
+        '?y',
+        'g?y',
+        'g?y/./x',
+        '#s',
+        'g#s',
+        'g#s/./x',
+        'g?y#s',
+        ';x',
+        'g;x',
+        'g;x?y#s',
+        '.',
+        './',
+        '..',
+        '../',
+        '../g',
+        '../..',
+        '../../',
+        '../../g',
+        '']
+
+      for (var i = 0; i < relativeURLs.length; i++) {
+        var href = relativeURLs[i]
+        expect(GOVUK.analyticsGa4.core.trackFunctions.hrefIsRelative(href)).toEqual(true)
+      }
+
+      // When no href is passed
+      expect(GOVUK.analyticsGa4.core.trackFunctions.hrefIsRelative()).toEqual(true)
     })
 
-    it('correctly identifies a non-relative URL', function () {
-      var href = '//notarelativeURL'
-      expect(GOVUK.analyticsGa4.core.trackFunctions.hrefIsRelative(href)).toEqual(false)
-    })
-
-    it('correctly identifies an anchor link', function () {
-      var href = '#link'
-      expect(GOVUK.analyticsGa4.core.trackFunctions.hrefIsAnchor(href)).toEqual(true)
-    })
-
-    it('correctly identifies a non anchor link', function () {
-      var href = '/link'
-      expect(GOVUK.analyticsGa4.core.trackFunctions.hrefIsAnchor(href)).toEqual(false)
+    it('correctly identifies non-relative URLs', function () {
+      var nonRelativeURLs = ['//notarelativeURL',
+        'https://www.gov.uk',
+        'http://gov.uk',
+        'https://www.gov.uk/#anchor',
+        'http://www.gov.uk/path']
+      for (var i = 0; i < nonRelativeURLs.length; i++) {
+        var href = nonRelativeURLs[i]
+        expect(GOVUK.analyticsGa4.core.trackFunctions.hrefIsRelative(href)).toEqual(false)
+      }
     })
 
     it('correctly identifies a mailto link', function () {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Previously we were checking if a URL was relative by the presence of a slash at the start of the href. We would also check if a URL was an anchor link by the presence of a `#` at the start of the href.
- This method was not accounting for all cases of relative hrefs. For example, a href starting with `?` is a valid relative href.
- Therefore, we now check if the href is relative or an anchor link by the lack of a domain name at the start of the href. In other words, if the href doesn't contain http://domain.example, https://domain.example, or //domain.example, then we assume the href is a relative href or anchor link.

## Why
<!-- What are the reasons behind this change being made? -->
This should cover all the types of relative hrefs and anchor links. Our tests pass against all these examples of relative URLs from RFC 1808 https://www.rfc-editor.org/rfc/rfc1808#section-5 apart from two on their list, but this is because: 
- `//g`, is a protocol relative URL, not a traditional relative URL. 
- Any href with colons at the start like `g:h` are detected as relative hrefs in this code, but browsers treat these as an external link going to a new domain. However, the RFC doesn't recommend people structure their links like this anyway: https://www.rfc-editor.org/rfc/rfc1808#section-5.3

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.