### PR TITLE
Add GA4 tracking to our breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Cover all types of relative hrefs in hrefIsRelative function ([PR #3251](https://github.com/alphagov/govuk_publishing_components/pull/3251))
 * Force English text on our GA4 related navigation section tracking ([PR #3259](https://github.com/alphagov/govuk_publishing_components/pull/3259))
 * Add ga4 tracking smart answer results ([PR #3235](https://github.com/alphagov/govuk_publishing_components/pull/3235))
+* Add GA4 tracking to our breadcrumbs ([PR #3257](https://github.com/alphagov/govuk_publishing_components/pull/3257))
 
 ## 34.10.1
 * Remove the brand colour for Department for Energy Security and Net Zero ([PR #3255](https://github.com/alphagov/govuk_publishing_components/pull/3255))

--- a/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_breadcrumbs.html.erb
@@ -13,7 +13,7 @@
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class(classes.join(" "))
-  component_helper.add_data_attribute({ module: "gem-track-click" })
+  component_helper.add_data_attribute({ module: "gem-track-click ga4-link-tracker" })
 %>
 
 <script type="application/ld+json">

--- a/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/breadcrumbs.yml
@@ -2,7 +2,7 @@ name: "Breadcrumbs"
 description: "Navigational breadcrumbs, showing page hierarchy"
 body: |
   Accepts an array of breadcrumb objects. Each crumb must have a title and a URL.
-  Links have tracking data but links to the homepage (any link with a url of `/`) will be tracked separately as `homeLinkClicked`.
+  Links are tracked, but in Universal Analytics, links to the homepage (any link with a url of `/`) will be tracked separately as `homeLinkClicked`.
 
   We recommend that if using the breadcrumbs for navigation purposes, you set `collapse_on_mobile` to `true` to make things more readable for mobile users. However, you can specify `collapse_on_mobile:``false` or remove the flag completely to stop this behaviour.
 shared_accessibility_criteria:

--- a/lib/govuk_publishing_components/presenters/breadcrumbs.rb
+++ b/lib/govuk_publishing_components/presenters/breadcrumbs.rb
@@ -58,6 +58,12 @@ module GovukPublishingComponents
             dimension28: breadcrumbs_length.to_s,
             dimension29: crumb[:title],
           },
+          ga4_link: {
+            event_name: "navigation",
+            type: "breadcrumbs",
+            index: index.to_s,
+            index_total: breadcrumbs_length.to_s,
+          },
         }
 
         is_homepage = crumb[:url] == "/"

--- a/spec/components/breadcrumbs_spec.rb
+++ b/spec/components/breadcrumbs_spec.rb
@@ -52,7 +52,7 @@ describe "Breadcrumbs", type: :view do
     expect(structured_data["itemListElement"].first["item"]["name"]).to eq("Section 1")
   end
 
-  it "renders all data attributes for tracking" do
+  it "renders all data attributes for universal analytics tracking" do
     render_component(breadcrumbs: [{ title: "Section", url: "/section" }])
 
     expected_tracking_options = {
@@ -60,11 +60,25 @@ describe "Breadcrumbs", type: :view do
       dimension29: "Section",
     }
 
-    assert_select '.gem-c-breadcrumbs[data-module="gem-track-click"]', 1
+    assert_select '.gem-c-breadcrumbs[data-module="gem-track-click ga4-link-tracker"]', 1
     assert_select '.govuk-breadcrumbs__list-item:first-child a[data-track-action="1"]', 1
     assert_select '.govuk-breadcrumbs__list-item:first-child a[data-track-label="/section"]', 1
     assert_select '.govuk-breadcrumbs__list-item:first-child a[data-track-category="breadcrumbClicked"]', 1
     assert_select ".govuk-breadcrumbs__list-item:first-child a[data-track-options='#{expected_tracking_options.to_json}']", 1
+  end
+
+  it "renders all data attributes for google analytics 4 tracking" do
+    render_component(breadcrumbs: [{ title: "Section", url: "/section" }])
+
+    expected_tracking_options = {
+      event_name: "navigation",
+      type: "breadcrumbs",
+      index: "1",
+      index_total: "1",
+    }
+
+    assert_select '.gem-c-breadcrumbs[data-module="gem-track-click ga4-link-tracker"]', 1
+    assert_select ".govuk-breadcrumbs__list-item:first-child a[data-ga4-link='#{expected_tracking_options.to_json}']", 1
   end
 
   it "a link to the homepage has separate tracking data" do
@@ -75,7 +89,7 @@ describe "Breadcrumbs", type: :view do
       dimension29: "Section",
     }
 
-    assert_select '.gem-c-breadcrumbs[data-module="gem-track-click"]', 1
+    assert_select '.gem-c-breadcrumbs[data-module="gem-track-click ga4-link-tracker"]', 1
 
     assert_select '.govuk-breadcrumbs__list-item:nth-child(1) a[data-track-action="1"]', 1
     assert_select '.govuk-breadcrumbs__list-item:nth-child(1) a[data-track-label="/section"]', 1


### PR DESCRIPTION
Hi @JamesCGDS, would you be able to review this? Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds the `ga4-link-tracker` to our Breadcrumbs component.

## Why
<!-- What are the reasons behind this change being made? -->
- It's one of the interactions on our to do list.
- I didn't create a boolean called `ga4_tracking: true` that toggles wether tracking is enabled. My thinking is that if we used a `ga4_tracking` boolean, we would have to add `ga4_tracking: true` to each frontend app, which might become a challenge to deploy and maintain, as some apps have multiple breadcrumb renders (e.g. `collections` has 6.) As well as this, the UA tracking doesn't have a toggler (it is always enabled by default on all breadcrumbs), so just adding the ga4 stuff directly into the component without a toggler replicates the existing functionality we have for tracking.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
