### PR TITLE
Force English text on our GA4 related navigation section tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 * Increase clickable area for links in navbar ([PR #3238](https://github.com/alphagov/govuk_publishing_components/pull/3238))
 * Cover all types of relative hrefs in hrefIsRelative function ([PR #3251](https://github.com/alphagov/govuk_publishing_components/pull/3251))
+* Force English text on our GA4 related navigation section tracking ([PR #3259](https://github.com/alphagov/govuk_publishing_components/pull/3259))
 
 ## 34.10.1
 * Remove the brand colour for Department for Energy Security and Net Zero ([PR #3255](https://github.com/alphagov/govuk_publishing_components/pull/3255))

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -4,14 +4,18 @@
      data-module="gem-toggle">
 
   <% if section_title === "related_items" %>
-   <% heading_text = related_nav_helper.component_title %>
+   <%
+      heading_text = related_nav_helper.construct_section_text("related_content", true)
+      ga4_heading_text = related_nav_helper.construct_ga4_section_text("related_content")
+   %>
   <% else %>
     <%=
       heading_class = related_nav_helper.section_css_class("gem-c-related-navigation__sub-heading", section_title)
       heading_data = { 'track-count' => related_nav_helper.section_data_track_count(:related_item_section) }
       heading_id = "related-nav-#{section_title}-#{random}"
       heading_level = related_nav_helper.section_heading_level
-      heading_text = related_nav_helper.construct_section_heading(section_title)
+      heading_text = related_nav_helper.construct_section_text(section_title, true)
+      ga4_heading_text = related_nav_helper.construct_ga4_section_text(section_title)
 
       content_tag(heading_level, id: heading_id, class: heading_class, data: heading_data) do
         heading_text
@@ -31,7 +35,7 @@
           event_name: "navigation",
           type: "related content",
           index: "#{section_index}.#{index}",
-          section: heading_text,
+          section: ga4_heading_text,
         } if ga4_tracking
         link_element = link_to(
           link[:text],
@@ -41,7 +45,7 @@
           lang: shared_helper.t_locale_check(link[:locale]),
           data: {
             track_category: 'relatedLinkClicked',
-            track_action: "#{section_index}.#{index} #{related_nav_helper.construct_section_heading(section_title) || t('components.related_navigation.related_content')}",
+            track_action: "#{section_index}.#{index} #{related_nav_helper.construct_section_text(section_title, true) || t('components.related_navigation.related_content')}",
             track_label: link[:path],
             track_options: {
               dimension28: links.length.to_s,

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -53,20 +53,25 @@ module GovukPublishingComponents
         end
       end
 
-      def construct_section_heading(section_title)
-        unless section_title == "related_items"
+      def construct_section_text(section, underscores_to_spaces)
+        unless section == "related_items"
+          defaults = [I18n.t("components.related_navigation.#{section}")]
+          defaults << section.tr("_", " ") if underscores_to_spaces
+
           I18n.t(
-            "components.related_#{@context}_navigation." + section_title,
-            default: [
-              I18n.t("components.related_navigation.#{section_title}"),
-              section_title.tr("_", " "),
-            ],
+            "components.related_#{@context}_navigation.#{section}",
+            default: defaults,
           )
         end
       end
 
-      def component_title
-        I18n.t("components.related_#{@context}_navigation.related_content", default: I18n.t("components.related_navigation.related_content"))
+      def construct_ga4_section_text(section)
+        # Force English so we can still understand what is being tracked if translated.
+        underscores_to_spaces = true
+        underscores_to_spaces = false if section == "related_content"
+        I18n.with_locale("en") do
+          construct_section_text(section, underscores_to_spaces)
+        end
       end
 
       def section_css_class(css_class, section_title, link: {}, link_is_inline: false)


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Ensures that the `section` value on our Related Navigation tracking is always English so that we can understand the text in the analytics dashboard.

## Why
<!-- What are the reasons behind this change being made? -->
- The headings on our Related Navigation `section` elements get translated, however for the purpose of analysis we always want it to be English, so that everything is tracked under the same label even if they are translated. This keeps the analytics under one label instead of different labels for each language.

## Visual Changes

None.
