### PR TITLE
Fix smart answer results tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add ga4 tracking smart answer results ([PR #3235](https://github.com/alphagov/govuk_publishing_components/pull/3235))
 * Add GA4 tracking to our breadcrumbs ([PR #3257](https://github.com/alphagov/govuk_publishing_components/pull/3257))
 * Make Navbar Menu Relatively Positioned Instead of Absolutely Positioned ([PR #3201](https://github.com/alphagov/govuk_publishing_components/pull/3201))
+* Fix smart answer results tracking ([PR #3261](https://github.com/alphagov/govuk_publishing_components/pull/3261))
 
 ## 34.10.1
 * Remove the brand colour for Department for Energy Security and Net Zero ([PR #3255](https://github.com/alphagov/govuk_publishing_components/pull/3255))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -237,7 +237,7 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
       },
 
       getResultCount: function (element, id) {
-        var resultCount = element.querySelector('#' + id).textContent
+        var resultCount = element.querySelector('#' + id)
 
         if (!resultCount) {
           return null
@@ -245,7 +245,7 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
 
         // In order to extract the number of results from resultCount (which is a string at this point (e.g. '12,345 results')), we remove the comma and
         // split string at the space character so it can be parsed as an integer
-        resultCount = resultCount.replace(',', '')
+        resultCount = resultCount.textContent.replace(',', '')
         resultCount = resultCount.split(' ')[0]
 
         return parseInt(resultCount)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-smart-answer-results-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-smart-answer-results-tracker.js
@@ -22,7 +22,9 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
 
   // triggered by cookie-consent event, which happens when users consent to cookies
   Ga4SmartAnswerResultsTracker.prototype.startModule = function () {
-    if (window.dataLayer) {
+    // only run this code if the dataLayer exists and an element with a data-ga4-ecommerce-path
+    // attribute exists as this indicates that ecommerce tracking is required
+    if (window.dataLayer && this.module.querySelector('[data-ga4-ecommerce-path]')) {
       this.trackResults()
       this.module.addEventListener('click', this.handleClick.bind(this))
     }


### PR DESCRIPTION
## What
This PR contains two small changes to the smart answers results tracking:

- Moves a call to `textContent()` a little later in the code as this was causing errors when calling it on a node that didn't exist
- Checks that elements with a `data-ga4-ecommerce-path` data attribute exist before tracking results and attaching event listeners

## Why
Prevents this code from erroring and running where it isn't needed

## Visual Changes
N/A
