### PR TITLE
Add helpers by component to auditing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add helpers by component to auditing ([PR #3263](https://github.com/alphagov/govuk_publishing_components/pull/3263))
 * Apply GA4 tracking to site header search box ([PR #3269](https://github.com/alphagov/govuk_publishing_components/pull/3269))
 * Add GA4 tracking to related navigation component 'show more' link ([PR #3268](https://github.com/alphagov/govuk_publishing_components/pull/3268))
 

--- a/app/views/govuk_publishing_components/audit/_components.html.erb
+++ b/app/views/govuk_publishing_components/audit/_components.html.erb
@@ -63,9 +63,54 @@
     items: component_items
   %>
 
+  <% helpers_by_component = capture do %>
+    <dl class="govuk-summary-list">
+      <% @components[:helper_usage].each do |helper| %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/<%= helper[:link] %>" class="govuk-link"><%= helper[:name] %></a> 
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <details class="govuk-details" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  Used by <%= helper[:used_by].length %> components
+                </span>
+              </summary>
+              <div class="govuk-details__text">
+                <ul class="govuk-list govuk-list--bullet">
+                  <% helper[:used_by].each do |component| %>
+                    <% github_link = 'https://github.com/alphagov/govuk_publishing_components/tree/main/app/views/govuk_publishing_components/components/' %>                    
+                    <li>
+                      <a href="<%= github_link %><%= component[:link] %>" class="govuk-link"><%= component[:name] %></a>
+                    </li>
+                  <% end %>            
+                </ul>
+              </div>
+            </details>            
+          </dd>
+        </div>
+      <% end %>
+    </dl>
+  <% end %>
+
+  <%
+    component_items << {
+      heading: {
+        text: "Helpers by component",
+      },
+      summary: {
+        text: "Shows which components use common helpers",
+      },
+      content: {
+        html: helpers_by_component
+      },
+    }
+  %>
+
   <%= render 'items_in_applications',
     heading: 'Helpers by application',
-    summary: 'Shows any applications that use helper classes from the components gem',
+    summary: 'Shows any applications that use helpers from the components gem',
     content: @components[:helpers_used_by_applications],
     items: component_items
   %>

--- a/spec/component_guide/audit_components_spec.rb
+++ b/spec/component_guide/audit_components_spec.rb
@@ -37,7 +37,7 @@ describe "Auditing the components in the gem" do
           name: "test component",
           link: "/component-guide/test_component",
           template_exists: true,
-          template_lines: 3,
+          template_lines: 7,
           template_link: "https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_test_component.html.erb",
           stylesheet_exists: true,
           stylesheet_lines: 4,
@@ -79,6 +79,42 @@ describe "Auditing the components in the gem" do
         javascript_test: 1,
         helper: 1,
       },
+      helper_usage: [
+        {
+          link: "lib/govuk_publishing_components/app_helpers/brand_helper.rb",
+          match: /(GovukPublishingComponents::AppHelpers::BrandHelper.new)/,
+          name: "Brand helper",
+          used_by: [],
+        },
+        {
+          link: "lib/govuk_publishing_components/presenters/component_wrapper_helper.rb",
+          match: /(GovukPublishingComponents::Presenters::ComponentWrapperHelper.new)/,
+          name: "Component wrapper helper",
+          used_by: [
+            {
+              name: "test component",
+              link: "_test_component.html.erb",
+            },
+          ],
+        },
+        {
+          link: "lib/govuk_publishing_components/presenters/heading_helper.rb",
+          match: /(GovukPublishingComponents::Presenters::HeadingHelper.new)/,
+          name: "Heading helper",
+          used_by: [],
+        },
+        {
+          link: "lib/govuk_publishing_components/presenters/shared_helper.rb",
+          match: /(GovukPublishingComponents::Presenters::SharedHelper.new)/,
+          name: "Shared helper",
+          used_by: [
+            {
+              name: "test component",
+              link: "_test_component.html.erb",
+            },
+          ],
+        },
+      ],
     }
 
     expect(gem.data).to match(expected)

--- a/spec/dummy_gem/app/views/govuk_publishing_components/components/_test_component.html.erb
+++ b/spec/dummy_gem/app/views/govuk_publishing_components/components/_test_component.html.erb
@@ -1,3 +1,7 @@
+<%
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+%>
 <div class="some-test-component">
   <h1 class="something-inside-test-component">Test component heading</h1>
 </div>


### PR DESCRIPTION
## What
Expands the component auditing to audit which components use some of our shared helper code, specifically the brand helper, component wrapper helper, heading helper and shared helper. 

You can find this by running the component guide locally and following the 'audit' link from the main page.

## Why
The component wrapper helper is probably going to take on some of the work of the shared helper, so we'll eventually be migrating code from one to the other, so it's helpful to know which components use it.

Also generally useful to know which components rely on different bits of code.

## Visual Changes
New section added to the auditing page:

![Screenshot 2023-02-21 at 11 46 21](https://user-images.githubusercontent.com/861310/220336965-e84f7068-9997-4182-965c-e7dd3af2449f.png)
