### PR TITLE
Add GA4 tracking to related navigation component 'show more' link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Apply GA4 tracking to site header search box ([PR #3269](https://github.com/alphagov/govuk_publishing_components/pull/3269))
+* Add GA4 tracking to related navigation component 'show more' link ([PR #3268](https://github.com/alphagov/govuk_publishing_components/pull/3268))
 
 ## 34.11.0
 

--- a/app/views/govuk_publishing_components/components/docs/related_navigation.yml
+++ b/app/views/govuk_publishing_components/components/docs/related_navigation.yml
@@ -333,3 +333,23 @@ examples:
             - title: UK-China High-Level People to People Dialogue 2017
               base_path: /government/topical-events/uk-china-high-level-people-to-people-dialogue-2017
               document_type: topical_event
+          world_locations:
+            - title: Algeria
+              base_path: /world/algeria/news
+            - title: Austria
+              base_path: /world/austria/news
+            - title: Belarus
+              base_path: /world/belarus/news
+            - title: Belgium
+              base_path: /world/belgium/news
+            - title: Bolivia
+              base_path: /world/bolivia/news
+            - title: Brazil
+              base_path: /world/brazil/news
+            - title: Canada
+              base_path: /world/canada/news
+            - title: Chile
+              base_path: /world/chile/news
+            - title: China
+              base_path: /world/China/news
+ 

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -63,17 +63,23 @@
     <% end %>
 
     <% if links.length > section_link_limit %>
-      <li class="gem-c-related-navigation__link toggle-wrap">
-        <a href="#"
-          class="gem-c-related-navigation__toggle"
-          data-controls="toggle_<%= section_title %>"
-          data-expanded="false"
-          data-toggled-text="<%= t("common.toggle_less") %>">
+      <%
+        classes = "gem-c-related-navigation__link toggle-wrap"      
+        data_attributes_li = { module: "ga4-event-tracker" } if ga4_tracking
+        data_attributes_link = {
+          controls: "toggle_#{section_title}",
+          expanded: "false",
+          toggled_text: t("common.toggle_less")
+        }
+        data_attributes_link[:ga4_event] = { "event_name": "select_content", "type": "related content" } if ga4_tracking
+      %>
+      <%= tag.li(class: classes, data: data_attributes_li) do %>
+        <%= link_to("#", class: "gem-c-related-navigation__toggle", data: data_attributes_link) do %>
           <%= t("common.toggle_more",
             show: t('common.show'),
-            number: related_nav_helper.remaining_link_count(links)) %>
-        </a>
-      </li>
+            number: related_nav_helper.remaining_link_count(links)) %>        
+        <% end %>
+      <% end %>
 
       <li class="gem-c-related-navigation__link gem-c-related-navigation__link--truncated-links">
         <span id="toggle_<%= section_title %>" class="gem-c-related-navigation__toggle-more js-hidden">

--- a/spec/components/related_navigation_spec.rb
+++ b/spec/components/related_navigation_spec.rb
@@ -167,6 +167,7 @@ describe "Related navigation", type: :view do
 
     assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales/news\"]", text: "Wales"
     assert_select ".gem-c-related-navigation__link.toggle-wrap", text: "Show 2 more"
+    assert_select ".gem-c-related-navigation__link.toggle-wrap[data-module='ga4-event-tracker']", false
     assert_select "#toggle_world_locations .gem-c-related-navigation__section-link[href=\"/world/mauritius/news\"]", text: "Mauritius"
     assert_select "#toggle_world_locations .gem-c-related-navigation__section-link[href=\"/world/brazil/news\"]", text: "Brazil"
   end
@@ -232,19 +233,11 @@ describe "Related navigation", type: :view do
           "document_type" => "topic",
         },
       ],
+      "world_locations" => [],
     }
-    content_item["details"] = {
-      "external_related_links" => [
-        {
-          "url" => "http://something",
-          "title" => "Travel insurance",
-        },
-        {
-          "url" => "http://somethingelse",
-          "title" => "Extreme sports insurance",
-        },
-      ],
-    }
+    %w[USA Wales Fiji Iceland Sweden Mauritius Brazil].each do |country|
+      content_item["links"]["world_locations"] << { "title" => country }
+    end
 
     render_component(content_item: content_item, ga4_tracking: true)
 
@@ -255,8 +248,9 @@ describe "Related navigation", type: :view do
     assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":\"2.1\",\"section\":\"Explore the topic\"}']", text: "Skating"
     assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":\"2.2\",\"section\":\"Explore the topic\"}']", text: "Paragliding"
 
-    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":\"3.1\",\"section\":\"Elsewhere on the web\"}']", text: "Travel insurance"
-    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":\"3.2\",\"section\":\"Elsewhere on the web\"}']", text: "Extreme sports insurance"
+    assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales/news\"]", text: "Wales"
+    assert_select ".gem-c-related-navigation__link.toggle-wrap[data-module='ga4-event-tracker']"
+    assert_select ".gem-c-related-navigation__toggle[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"related content\"}']", text: "Show 2 more"
   end
 
   it "uses lang when locale is set" do


### PR DESCRIPTION
## What
- on related navigation, [where world locations exceed 5 items](https://components.publishing.service.gov.uk/component-guide/related_navigation/with_extensive_world_locations), a toggle link to display the rest is shown
- add GA4 tracking to this link, where GA4 tracking has been enabled

Example URL: https://www.gov.uk/guidance/appoint-someone-to-deal-with-customs-on-your-behalf

![Screenshot 2023-02-22 at 09 04 50](https://user-images.githubusercontent.com/861310/220572984-9c4ec087-678e-404d-8e0b-25e75c06b4e3.png)

## Why
Part of the GA4 work.

## Visual Changes
None.

Trello card: https://trello.com/c/OhcANGS4/422-add-tracking-show-more-interaction-click-on-related-content
