### PR TITLE
Apply GA4 tracking to site header search box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Apply GA4 tracking to site header search box ([PR #3269](https://github.com/alphagov/govuk_publishing_components/pull/3269))
+
 ## 34.11.0
+
 * Increase clickable area for links in navbar ([PR #3238](https://github.com/alphagov/govuk_publishing_components/pull/3238))
 * Cover all types of relative hrefs in hrefIsRelative function ([PR #3251](https://github.com/alphagov/govuk_publishing_components/pull/3251))
 * Force English text on our GA4 related navigation section tracking ([PR #3259](https://github.com/alphagov/govuk_publishing_components/pull/3259))
@@ -18,6 +23,7 @@
 * Add indexing of links using JS ([PR #3262](https://github.com/alphagov/govuk_publishing_components/pull/3262))
 
 ## 34.10.1
+
 * Remove the brand colour for Department for Energy Security and Net Zero ([PR #3255](https://github.com/alphagov/govuk_publishing_components/pull/3255))
 
 ## 34.10.0

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -7,6 +7,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   function Ga4FormTracker (module) {
     this.module = module
     this.trackingTrigger = 'data-ga4-form' // elements with this attribute get tracked
+    this.includeTextInputValues = this.module.hasAttribute('data-ga4-form-include-text')
   }
 
   Ga4FormTracker.prototype.init = function () {
@@ -82,8 +83,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         input.answer = labelText
       } else if (inputNodename === 'SELECT' && elem.options[elem.selectedIndex].value) {
         input.answer = elem.options[elem.selectedIndex].text
-      } else if (inputType === 'text' && elem.value) {
-        input.answer = '[REDACTED]'
+      } else if ((inputType === 'text' || inputType === 'search') && elem.value) {
+        if (this.includeTextInputValues) {
+          var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
+          input.answer = PIIRemover.stripPII(elem.value)
+        } else {
+          input.answer = '[REDACTED]'
+        }
       } else if (inputType === 'radio' && elem.checked) {
         input.answer = labelText
       } else {

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -262,6 +262,9 @@
               <form
                 class="gem-c-layout-super-navigation-header__search-form"
                 id="search"
+                data-module="ga4-form-tracker"
+                data-ga4-form='{ "event_name": "search", "type": "header menu bar", "section": "Search GOV.UK", "action": "Search", "url": "/search/all" }'
+                data-ga4-form-include-text
                 action="/search"
                 method="get"
                 role="search"

--- a/docs/analytics-ga4/ga4-form-tracker.md
+++ b/docs/analytics-ga4/ga4-form-tracker.md
@@ -19,7 +19,7 @@ The data attributes are used as follows:
 - `action` records the text of the form submission button e.g. `Continue`
 - `tool_name` records the overall name of the smart answer e.g. `How do I eat more healthily?`
 
-The script will automatically collect the answer submitted in the `text` field. For questions where multiple answers are possible, these will be comma separated. Where the answer is a text input, the value given is replaced with `[REDACTED]`, to avoid collecting personally identifiable information.
+The script will automatically collect the answer submitted in the `text` field. For questions where multiple answers are possible, these will be comma separated. Where the answer is a text input, the value given is replaced with `[REDACTED]`, to avoid collecting personally identifiable information. If text should not be redacted, add a `data-ga4-form-include-text` attribute to the form.
 
 In the example above, the following would be pushed to the dataLayer. Note that the schema automatically populates empty values, and that attributes not in the schema are ignored.
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -208,4 +208,40 @@ describe('Google Analytics form tracking', function () {
       expect(window.dataLayer[0]).toEqual(expected)
     })
   })
+
+  describe('when tracking a form with text redaction disabled', function () {
+    beforeEach(function () {
+      var attributes = {
+        event_name: 'form_response',
+        type: 'smart answer',
+        section: 'What is the title of this question?',
+        action: 'Continue',
+        tool_name: 'What is the title of this smart answer?'
+      }
+      element.setAttribute('data-ga4-form', JSON.stringify(attributes))
+      element.setAttribute('data-ga4-form-include-text', '')
+      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      expected.event = 'event_data'
+      expected.event_data.event_name = 'form_response'
+      expected.event_data.type = 'smart answer'
+      expected.event_data.section = 'What is the title of this question?'
+      expected.event_data.action = 'Continue'
+      expected.event_data.tool_name = 'What is the title of this smart answer?'
+      expected.govuk_gem_version = 'aVersion'
+      var tracker = new GOVUK.Modules.Ga4FormTracker(element)
+      tracker.init()
+    })
+
+    it('does not redact data from text inputs', function () {
+      element.innerHTML =
+        '<label for="textid">Label for text</label>' +
+        '<input type="text" id="textid" name="test-text" value="test-text-value"/>' +
+        '<label for="searchid">Label for search</label>' +
+        '<input type="search" id="searchid" name="test-search" value="test-search-value"/>'
+      expected.event_data.text = 'test-text-value,test-search-value'
+
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+  })
 })


### PR DESCRIPTION
## What
Adds tracking to the search box inside the site header.

![Screenshot 2023-02-22 at 10 33 31](https://user-images.githubusercontent.com/861310/220594977-232f2f3c-adb2-4353-987c-65b145981824.png)


Also modifies the GA4 form tracker to include an option to not redact text in text inputs (and search inputs) and applies this to the search box, so that we include user searches in tracking data.

## Why
Part of the GA4 implementation work.

## Visual Changes
None.

Trello card: https://trello.com/c/LNE9OTXb/427-add-tracking-search-box-on-the-header-menu-bar
