### PR TITLE
Enable strip PII override in GA4 form tracker

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -86,7 +86,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       } else if ((inputType === 'text' || inputType === 'search') && elem.value) {
         if (this.includeTextInputValues) {
           var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
-          input.answer = PIIRemover.stripPII(elem.value)
+          input.answer = PIIRemover.stripPIIWithOverride(elem.value, true, true)
         } else {
           input.answer = '[REDACTED]'
         }


### PR DESCRIPTION
## What
- the form tracker (when configured to collect values from text inputs) strips PII from that value
- this only included the default things (see PII doc for list) and not dates or postcodes
- changing this to use PII strip override, which redacts everything possible

## Why
Part of the GA4 work, plus we don't want to collect any PII.

## Visual Changes
None.

Trello card: https://trello.com/c/LNE9OTXb/427-add-tracking-search-box-on-the-header-menu-bar