### PR TITLE
Add GA4 tracking to the super breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Change how GA4 index parameter works ([PR #3277](https://github.com/alphagov/govuk_publishing_components/pull/3277))
+* Add GA4 tracking to the super breadcrumb ([PR #3272](https://github.com/alphagov/govuk_publishing_components/pull/3272))
 
 ## 34.13.0
 

--- a/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_breadcrumbs.html.erb
@@ -1,7 +1,10 @@
-<% prioritise_taxon_breadcrumbs ||= false %>
-<% breadcrumb_selector = GovukPublishingComponents::Presenters::BreadcrumbSelector.new(content_item, request, prioritise_taxon_breadcrumbs) %>
-<% inverse ||= false %>
-<% collapse_on_mobile ||= true unless local_assigns[:collapse_on_mobile].eql?(false) %>
+<% 
+  ga4_tracking ||= false
+  prioritise_taxon_breadcrumbs ||= false
+  breadcrumb_selector = GovukPublishingComponents::Presenters::BreadcrumbSelector.new(content_item, request, prioritise_taxon_breadcrumbs, ga4_tracking)
+  inverse ||= false
+  collapse_on_mobile ||= true unless local_assigns[:collapse_on_mobile].eql?(false) 
+%>
 
 <div class="gem-c-contextual-breadcrumbs">
   <% if breadcrumb_selector.step_by_step %>

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_header.html.erb
@@ -3,11 +3,16 @@
 
   title ||= false
   path ||= false
+  ga4_tracking ||= false
   breadcrumbs = [
     { title: "Home", url: "/" },
     { title: title, url: path }
   ]
   breadcrumb_presenter = GovukPublishingComponents::Presenters::Breadcrumbs.new(breadcrumbs)
+
+  data = {}
+  data[:module] = "gem-track-click"
+  data[:module] << " ga4-link-tracker" if ga4_tracking
 
   tracking_id ||= false
   tracking_category ||= "stepNavHeaderClicked"
@@ -30,7 +35,7 @@
     <%= raw JSON.pretty_generate(breadcrumb_presenter.structured_data) %>
   </script>
 
-  <%= tag.div class: classes, data: { module: "gem-track-click" } do %>
+  <%= tag.div(class: classes, data: data) do %>
     <strong class="gem-c-step-nav-header__part-of">Part of</strong>
     <% if path %>
       <a href="<%= path %>"
@@ -38,6 +43,9 @@
         data-track-category="<%= tracking_category %>"
         data-track-action="<%= tracking_action %>"
         data-track-label="<%= tracking_label %>"
+        <% if ga4_tracking %>
+          data-ga4-link='{"event_name":"navigation", "type":"super breadcrumb", "index":{"index_link": "1"}, "index_total":"1"}'
+        <% end %>
         <% if tracking_dimension_enabled %>
           data-track-dimension="<%= tracking_dimension %>"
           data-track-dimension-index="<%= tracking_dimension_index %>"

--- a/app/views/govuk_publishing_components/components/docs/contextual_breadcrumbs.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_breadcrumbs.yml
@@ -32,3 +32,16 @@ examples:
       inverse: true
     context:
       dark_background: true
+  with_ga4_tracking:
+    description: |
+      Adds GA4 tracking to the step by step nav header component when it is rendered as a breadcrumb. See the 
+      [ga4-link-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
+      Note: tracking on regular breadcrumbs is enabled by default and does not require activating.
+    data:
+      ga4_tracking: true
+      content_item:
+        title: "A content item"
+        links:
+          part_of_step_navs:
+            - title: "Learn to drive a car: step by step"
+              base_path: "/micropigs-vs-micropugs"

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav_header.yml
@@ -51,3 +51,9 @@ examples:
       tracking_action: "customTrackingAction"
       tracking_label: "customTrackingLabel"
       tracking_dimension_enabled: false
+  with_ga4_tracking:
+    description: The ga4_tracking boolean allows you to add Google Analytics 4 (GA4) tracking to your component. Setting this to true will add the `ga4-link-tracker` module to your component. The JavaScript will then add a `data-ga4-link` attribute which contains a JSON object with data relevant to our tracking. See the [ga4-link-tracker docs](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
+    data:
+      ga4_tracking: true
+      title: 'Learn to drive a motorbike: step by step'
+      path: /learn-to-drive-a-motorbike

--- a/docs/analytics-ga4/ga4-link-tracker.md
+++ b/docs/analytics-ga4/ga4-link-tracker.md
@@ -87,3 +87,14 @@ To apply tracking to links within a specific element within part of a page, use 
   </div>
 </div>
 ```
+
+## Using the link tracker on components
+
+Where possible, link tracking is optional for components in order to provide flexibility where different types of tracking might overlap. To track links within a component (e.g. contextual breadcrumbs), use the `ga4_tracking` option as shown:
+
+```erb
+<%= render 'govuk_publishing_components/components/contextual_breadcrumbs', {
+  ga4_tracking: true,
+  items: []
+} %>
+```

--- a/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
+++ b/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb
@@ -3,10 +3,11 @@ module GovukPublishingComponents
     class BreadcrumbSelector
       attr_reader :content_item, :request, :prioritise_taxon_breadcrumbs
 
-      def initialize(content_item, request, prioritise_taxon_breadcrumbs)
+      def initialize(content_item, request, prioritise_taxon_breadcrumbs, ga4_tracking)
         @content_item = content_item
         @request = request
         @prioritise_taxon_breadcrumbs = prioritise_taxon_breadcrumbs
+        @ga4_tracking = ga4_tracking
       end
 
       def breadcrumbs
@@ -37,7 +38,7 @@ module GovukPublishingComponents
         elsif navigation.content_tagged_to_current_step_by_step?
           {
             step_by_step: true,
-            breadcrumbs: navigation.step_nav_helper.header,
+            breadcrumbs: navigation.step_nav_helper.header(@ga4_tracking),
           }
         elsif navigation.content_is_tagged_to_a_live_taxon? && prioritise_taxon_breadcrumbs
           {

--- a/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
+++ b/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation.rb
@@ -82,12 +82,13 @@ module GovukPublishingComponents
         end
       end
 
-      def header
+      def header(ga4_tracking)
         if show_header?
           {
             title: current_step_nav.title,
             path: current_step_nav.base_path,
             tracking_id: current_step_nav.content_id,
+            ga4_tracking: ga4_tracking,
           }
         else
           {}

--- a/spec/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/page_with_step_by_step_navigation_spec.rb
@@ -144,11 +144,12 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
 
       it "handled gracefully" do
         step_nav_links = described_class.new(content_store_response, "/giant-pool/planning")
+        ga4_tracking = true
 
         expect(step_nav_links.step_navs.count).to eq(0)
 
         expect(step_nav_links.show_header?).to be false
-        expect(step_nav_links.header).to eq({})
+        expect(step_nav_links.header(ga4_tracking)).to eq({})
 
         expect(step_nav_links.show_related_links?).to be false
         expect(step_nav_links.related_links).to eq([])
@@ -171,14 +172,16 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
 
       it "parses the content item" do
         step_nav_links = described_class.new(content_store_response, "/vomit-comet-session")
+        ga4_tracking = true
 
         expect(step_nav_links.step_navs.count).to eq(1)
 
         expect(step_nav_links.show_header?).to be true
-        expect(step_nav_links.header).to eq(
+        expect(step_nav_links.header(ga4_tracking)).to eq(
           path: "/learn-to-spacewalk",
           title: "Learn to spacewalk: small step by giant leap",
           tracking_id: "cccc-dddd",
+          ga4_tracking: ga4_tracking,
         )
 
         expect(step_nav_links.show_related_links?).to be true
@@ -503,6 +506,7 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
 
         it "parses the content item" do
           step_nav_links = described_class.new(content_store_response, "/vomit-comet-session")
+          ga4_tracking = true
 
           expect(step_nav_links.step_navs.count).to eq(0)
           expect(step_nav_links.secondary_step_by_steps.count).to eq(1)
@@ -510,10 +514,11 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
           expect(step_nav_links.show_secondary_step_by_step?).to be true
           expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be true
           expect(step_nav_links.show_header?).to be true
-          expect(step_nav_links.header).to eq(
+          expect(step_nav_links.header(ga4_tracking)).to eq(
             path: "/lose-your-lunch",
             title: "Lose your lunch: lurch by lurch",
             tracking_id: "aaaa-bbbb",
+            ga4_tracking: ga4_tracking,
           )
 
           expect(step_nav_links.show_related_links?).to be true
@@ -606,6 +611,7 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
 
         it "parses the content item" do
           step_nav_links = described_class.new(content_store_response, "/vomit-comet-session")
+          ga4_tracking = true
 
           expect(step_nav_links.step_navs.count).to eq(1)
           expect(step_nav_links.secondary_step_by_steps.count).to eq(1)
@@ -613,10 +619,11 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
           expect(step_nav_links.show_secondary_step_by_step?).to be false
           expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
           expect(step_nav_links.show_header?).to be true
-          expect(step_nav_links.header).to eq(
+          expect(step_nav_links.header(ga4_tracking)).to eq(
             path: "/PRIMARY-lose-your-lunch",
             title: "PRIMARY Lose your lunch: lurch by lurch",
             tracking_id: "PRIMARY-aaaa-bbbb",
+            ga4_tracking: ga4_tracking,
           )
 
           expect(step_nav_links.show_related_links?).to be true
@@ -654,6 +661,7 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
 
         it "parses the content item" do
           step_nav_links = described_class.new(content_store_response, "/vomit-comet-session")
+          ga4_tracking = true
 
           expect(step_nav_links.step_navs.count).to eq(1)
           expect(step_nav_links.secondary_step_by_steps.count).to eq(2)
@@ -661,10 +669,11 @@ RSpec.describe GovukPublishingComponents::Presenters::PageWithStepByStepNavigati
           expect(step_nav_links.show_secondary_step_by_step?).to be false
           expect(step_nav_links.show_related_links_for_secondary_step_by_steps?).to be false
           expect(step_nav_links.show_header?).to be true
-          expect(step_nav_links.header).to eq(
+          expect(step_nav_links.header(ga4_tracking)).to eq(
             path: "/PRIMARY-lose-your-lunch",
             title: "PRIMARY Lose your lunch: lurch by lurch",
             tracking_id: "PRIMARY-aaaa-bbbb",
+            ga4_tracking: ga4_tracking,
           )
 
           expect(step_nav_links.show_related_links?).to be true


### PR DESCRIPTION
## What
Adds tracking to the super breadcrumb.

In order to provide the capability of toggling GA4 tracking on and off, a `ga4_tracking` boolean is passed to the `step_by_step_nav_header` component (the component responsible for rendering the super breadcrumb) where it is used to determine whether GA4 data attributes should be included in the HTML. In order for this to work, a `ga4_tracking` parameter has been added to the `page_with_step_by_step_navigation` and `breadcrumb_selector` presenters (without these changes, the template would return an error stating that the incorrect number of parameters had been passed).

## Why
Part of the GA4 migration.

## Visual Changes
N/A

Trello card: https://trello.com/c/AM5JCKEd/430-add-tracking-to-super-breadcrumbs
