### PR TITLE
Set ga 4 related links locale as :en

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Set up individual component CSS loading, **Note:** this change is experimental, it will be used in the `frontend` application first, please do not implement this feature in other applications ([PR #3342](https://github.com/alphagov/govuk_publishing_components/pull/3342))
+* Set ga 4 related links locale as :en ([PR #3273](https://github.com/alphagov/govuk_publishing_components/pull/3273))
 
 ## 34.12.0
 

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -69,7 +69,7 @@ module GovukPublishingComponents
         # Force English so we can still understand what is being tracked if translated.
         underscores_to_spaces = true
         underscores_to_spaces = false if section == "related_content"
-        I18n.with_locale("en") do
+        I18n.with_locale(:en) do
           construct_section_text(section, underscores_to_spaces)
         end
       end


### PR DESCRIPTION
Instead of "en" otehrwise this test in Frontend:

https://github.com/alphagov/frontend/actions/runs/4235734374/jobs/7359722094#step:7:19

was broken. I fixed the test as part of https://github.com/alphagov/frontend/pull/3551/commits/94f20061d045bd0c1ab0e03b138827f255066027 but that depends on this PR.