### PR TITLE
Release version 34.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 34.12.0
 
+* Update link on Invasion of Ukraine sidebar ([PR #3274](https://github.com/alphagov/govuk_publishing_components/pull/3264))
 * Add helpers by component to auditing ([PR #3263](https://github.com/alphagov/govuk_publishing_components/pull/3263))
 * Apply GA4 tracking to site header search box ([PR #3269](https://github.com/alphagov/govuk_publishing_components/pull/3269))
 * Add GA4 tracking to related navigation component 'show more' link ([PR #3268](https://github.com/alphagov/govuk_publishing_components/pull/3268))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (34.11.0)
+    govuk_publishing_components (34.12.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "34.11.0".freeze
+  VERSION = "34.12.0".freeze
 end


### PR DESCRIPTION
## 34.12.0

* Update link on Invasion of Ukraine sidebar ([PR #3274](https://github.com/alphagov/govuk_publishing_components/pull/3264))
* Add helpers by component to auditing ([PR #3263](https://github.com/alphagov/govuk_publishing_components/pull/3263))
* Apply GA4 tracking to site header search box ([PR #3269](https://github.com/alphagov/govuk_publishing_components/pull/3269))
* Add GA4 tracking to related navigation component 'show more' link ([PR #3268](https://github.com/alphagov/govuk_publishing_components/pull/3268))