### PR TITLE
Update King's Awards for Enterprise domain

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics/linked-domains.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/linked-domains.js
@@ -90,7 +90,7 @@ window.GOVUK.analytics.linkedDomains = [
   'paydvlafine.service.gov.uk',
   'payments.service.gov.uk',
   'publish-payment-practices.service.gov.uk',
-  'queens-awards-enterprise.service.gov.uk',
+  'kings-awards-enterprise.service.gov.uk',
   'recruit.manage-apprenticeships.service.gov.uk',
   'register.fluorinated-gas.service.gov.uk',
   'register-trailer.service.gov.uk',


### PR DESCRIPTION
## What
Updated `queens-awards-enterprise.service.gov.uk` domain to reflect the recent change to `kings-awards-enterprise.service.gov.uk`.

## Why
The Queen's is Awards for Enterprise is being rebranded to The King's Awards for Enterprise.

## Visual Changes
None
