### PR TITLE
Version 34.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 34.13.0
 
 * Set up individual component CSS loading, **Note:** this change is experimental, it will be used in the `frontend` application first, please do not implement this feature in other applications ([PR #3342](https://github.com/alphagov/govuk_publishing_components/pull/3342))
 * Set ga 4 related links locale as :en ([PR #3273](https://github.com/alphagov/govuk_publishing_components/pull/3273))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (34.12.0)
+    govuk_publishing_components (34.13.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "34.12.0".freeze
+  VERSION = "34.13.0".freeze
 end


### PR DESCRIPTION
## 34.13.0

* Set up individual component CSS loading, **Note:** this change is experimental, it will be used in the `frontend` application first, please do not implement this feature in other applications ([PR #3342](https://github.com/alphagov/govuk_publishing_components/pull/3342))
* Set ga 4 related links locale as :en ([PR #3273](https://github.com/alphagov/govuk_publishing_components/pull/3273))