### PR TITLE
Add ga4 tracking to 'part of' heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Change how GA4 index parameter works ([PR #3277](https://github.com/alphagov/govuk_publishing_components/pull/3277))
 * Add GA4 tracking to the super breadcrumb ([PR #3272](https://github.com/alphagov/govuk_publishing_components/pull/3272))
+* Add ga4 tracking to 'part of' heading ([PR #3284](https://github.com/alphagov/govuk_publishing_components/pull/3284))
 
 ## 34.13.0
 

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -10,7 +10,7 @@
 <div class="gem-c-contextual-sidebar">
   <% if navigation.content_tagged_to_a_reasonable_number_of_step_by_steps? %>
     <%# Rendering step by step related items because there are a few but not too many of them %>
-    <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links %>
+    <%= render 'govuk_publishing_components/components/step_by_step_nav_related', links: navigation.step_nav_helper.related_links, ga4_tracking: ga4_tracking %>
   <% end %>
 
   <% if navigation.content_tagged_to_current_step_by_step? %>
@@ -26,7 +26,8 @@
     <%= render 'govuk_publishing_components/components/step_by_step_nav_related', {
       pretitle: t("components.contextual_sidebar.pretitle"),
       links: navigation.step_nav_helper.also_part_of_step_nav,
-      always_display_as_list: true
+      always_display_as_list: true,
+      ga4_tracking: ga4_tracking
     } %>
   <% end %>
 

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -1,14 +1,17 @@
 <%
   add_gem_component_stylesheet("step-by-step-nav-related")
-
+  ga4_tracking ||= false
   links ||= []
   pretitle ||= t("components.step_by_step_nav_related.part_of")
   always_display_as_list ||= false
+  classes = %w(gem-c-step-nav-related)
+  classes << "gem-c-step-nav-related--singular" if links.length == 1
+  data = {}
+  data[:module] = "gem-track-click"
+  data[:module] << " ga4-link-tracker" if ga4_tracking
 %>
 <% if links.any? %>
-  <div
-    class="gem-c-step-nav-related <%= "gem-c-step-nav-related--singular" if links.length == 1 %>"
-    data-module="gem-track-click">
+  <%= tag.div(class: classes, data: data) do %>
     <h2 class="gem-c-step-nav-related__heading">
       <span class="gem-c-step-nav-related__pretitle"><%= pretitle %></span>
       <% if links.length == 1 && !always_display_as_list %>
@@ -19,14 +22,18 @@
             data-track-label="<%= links[0][:href] %>"
             data-track-dimension="<%= links[0][:text] %>"
             data-track-dimension-index="29"
-            data-track-options='{"dimension96" : "<%= links[0][:tracking_id] %>" }'>
+            data-track-options='{"dimension96" : "<%= links[0][:tracking_id] %>" }'
+            <% if ga4_tracking %>
+              data-ga4-link='{"event_name":"navigation", "type":"related content", "index":{"index_link": "1"}, "index_total":"1"}'
+            <% end %>
+          >
             <%= links[0][:text] %>
           </a>
         </h2>
       <% else %>
         </h2>
         <ul class="gem-c-step-nav-related__links">
-          <% links.each do |link| %>
+          <% links.each_with_index do |link, index| %>
             <li class="gem-c-step-nav-related__link-item">
               <a href="<%= link[:href] %>"
                 class="govuk-link"
@@ -35,12 +42,16 @@
                 data-track-label="<%= link[:href] %>"
                 data-track-dimension="<%= link[:text] %>"
                 data-track-dimension-index="29"
-                data-track-options='{"dimension96" : "<%= link[:tracking_id] %>" }'>
+                data-track-options='{"dimension96" : "<%= link[:tracking_id] %>" }'
+                <% if ga4_tracking %>
+                  data-ga4-link='{"event_name":"navigation", "type":"related content", "index":{"index_link": "<%= index + 1 %>"}, "index_total": "<%= links.length %>"}'
+                <% end %>
+              >
                 <%= link[:text] %>
               </a>
             </li>
           <% end %>
         </ul>
       <% end %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_sidebar.yml
@@ -157,3 +157,14 @@ examples:
                       - text: Arrange the funeral
                         href: "/after-a-death/arrange-the-funeral"
                     optional: false
+  with_ga4_tracking_on_part_of_step_by_step_heading(s):
+    description: Adds Google Analytics 4 tracking to the "Part of" step by step heading(s) in the sidebar. Currently only the Related Navigation component, Step by Step navigation component and Ukraine CTA accept this option.
+    data:
+      ga4_tracking: true
+      content_item:
+        links:
+          part_of_step_navs:
+            - title: "Choosing a micropig or micropug: step by step"
+              base_path: "/micropigs-vs-micropugs"
+            - title: "Walk your micropig: step by step"
+              base_path: "/porgs-step-by-step"

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav_related.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav_related.yml
@@ -76,3 +76,13 @@ examples:
           text: 'Learn to drive a motorbike: step by step'
         }
       ]
+  with_ga4_tracking:
+    description: The ga4_tracking boolean allows you to add Google Analytics 4 (GA4) tracking to your component. Setting this to true will add the `ga4-link-tracker` module to your component. The JavaScript will then add a `data-ga4-link` attribute which contains a JSON object with data relevant to our tracking. See the [ga4-link-tracker docs](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
+    data:
+      ga4_tracking: true
+      links: [
+        {
+          href: '#',
+          text: 'With ga4 tracking'
+        }
+      ]

--- a/spec/components/step_by_step_nav_related_spec.rb
+++ b/spec/components/step_by_step_nav_related_spec.rb
@@ -111,4 +111,40 @@ describe "Step by step navigation related", type: :view do
     assert_select ".gem-c-step-nav-related .gem-c-step-nav-related__heading .gem-c-step-nav-related__pretitle", text: "Part of"
     assert_select ".gem-c-step-nav-related .gem-c-step-nav-related__links .govuk-link[href='/link1']", text: "Link 1"
   end
+
+  it "adds GA4 data attributes when ga4_tracking is true" do
+    render_component(links: one_link, ga4_tracking: true)
+
+    this_link = ".gem-c-step-nav-related .gem-c-step-nav-related__heading .govuk-link"
+
+    assert_select "#{this_link}[data-ga4-link='{\"event_name\":\"navigation\", \"type\":\"related content\", \"index\":{\"index_link\": \"1\"}, \"index_total\":\"1\"}']"
+  end
+
+  it "does not add GA4 data attributes when ga4_tracking is false" do
+    render_component(links: one_link, ga4_tracking: false)
+
+    this_link = ".gem-c-step-nav-related .gem-c-step-nav-related__heading .govuk-link"
+
+    assert_select "#{this_link}[data-ga4-link='{\"event_name\":\"navigation\", \"type\":\"related content\", \"index\":{\"index_link\": \"1\"}, \"index_total\":\"1\"}']", false
+  end
+
+  it "adds GA4 data attributes on multiple links when ga4_tracking is true" do
+    render_component(links: two_links, ga4_tracking: true)
+
+    link_one = ".gem-c-step-nav-related .gem-c-step-nav-related__links .govuk-link[href='/link1']"
+    link_two = ".gem-c-step-nav-related .gem-c-step-nav-related__links .govuk-link[href='/link2']"
+
+    assert_select "#{link_one}[data-ga4-link='{\"event_name\":\"navigation\", \"type\":\"related content\", \"index\":{\"index_link\": \"1\"}, \"index_total\": \"2\"}']"
+    assert_select "#{link_two}[data-ga4-link='{\"event_name\":\"navigation\", \"type\":\"related content\", \"index\":{\"index_link\": \"2\"}, \"index_total\": \"2\"}']"
+  end
+
+  it "does not add GA4 data attributes on multiple links when ga4_tracking is false" do
+    render_component(links: two_links, ga4_tracking: false)
+
+    link_one = ".gem-c-step-nav-related .gem-c-step-nav-related__links .govuk-link[href='/link1']"
+    link_two = ".gem-c-step-nav-related .gem-c-step-nav-related__links .govuk-link[href='/link2']"
+
+    assert_select "#{link_one}[data-ga4-link='{\"event_name\":\"navigation\", \"type\":\"related content\", \"index\":{\"index_link\": \"1\"}, \"index_total\": \"2\"}']", false
+    assert_select "#{link_two}[data-ga4-link='{\"event_name\":\"navigation\", \"type\":\"related content\", \"index\":{\"index_link\": \"2\"}, \"index_total\": \"2\"}']", false
+  end
 end


### PR DESCRIPTION
## What
Adds tracking to links in the step by step "Part of" heading in the related navigation sidebar.

This component is rendered by calling the `contextual_sidebar` component, which already has had the `ga4_tracking` boolean added wherever it is called as part of previous GA4 PR's. In other words, the only PR required to activate this tracking is this one and won't require PR's for enabling tracking to be raised in other applications.

## Why
Part of the GA4 migration.

## Visual Changes
N/A

Trello card: https://trello.com/c/I0gafCaw/429-add-tracking-for-part-of-step-by-steps-related-content
