### PR TITLE
Version 34.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 34.14.0
 
 * Change how GA4 index parameter works ([PR #3277](https://github.com/alphagov/govuk_publishing_components/pull/3277))
 * Add GA4 tracking to the super breadcrumb ([PR #3272](https://github.com/alphagov/govuk_publishing_components/pull/3272))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (34.13.0)
+    govuk_publishing_components (34.14.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "34.13.0".freeze
+  VERSION = "34.14.0".freeze
 end


### PR DESCRIPTION
## 34.14.0

* Change how GA4 index parameter works ([PR #3277](https://github.com/alphagov/govuk_publishing_components/pull/3277))
* Add GA4 tracking to the super breadcrumb ([PR #3272](https://github.com/alphagov/govuk_publishing_components/pull/3272))
* Add ga4 tracking to 'part of' heading ([PR #3284](https://github.com/alphagov/govuk_publishing_components/pull/3284))
