### PR TITLE
Add GA4 tracking to step by step links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix component auditing ([PR #3292](https://github.com/alphagov/govuk_publishing_components/pull/3292))
 * Fix smart answer PII issue ([PR #3291](https://github.com/alphagov/govuk_publishing_components/pull/3291))
 * Update accordion index parameter ([PR #3290](https://github.com/alphagov/govuk_publishing_components/pull/3290))
+* Add GA4 tracking to step by step links ([PR #3289](https://github.com/alphagov/govuk_publishing_components/pull/3289))
 
 ## 34.14.0
 

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav.html.erb
@@ -22,7 +22,7 @@
 %>
 <% if steps %>
   <div
-    data-module="gemstepnav<% if ga4_tracking %> ga4-event-tracker<% end %>"
+    data-module="gemstepnav<% if ga4_tracking %> ga4-event-tracker ga4-link-tracker<% end %>"
     <%= "data-ga4-expandable" if ga4_tracking %>
     class="gem-c-step-nav js-hidden <% if small %>govuk-!-display-none-print<% end %> <% unless small %>gem-c-step-nav--large<% end %>"
     <%= "data-remember" if remember_last_step %>
@@ -77,8 +77,10 @@
             <%
               in_substep = false
               options[:step_nav_content_id] = step_nav_content_id
+              options[:step_title] = step[:title]
               options[:step_index] = step_index
               options[:link_index] = 0
+              options[:ga4_tracking] = ga4_tracking
             %>
             <% step[:contents].each do |element| %>
               <%= step_nav_helper.render_step_nav_element(element, options) %>

--- a/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
+++ b/app/views/govuk_publishing_components/components/docs/step_by_step_nav.yml
@@ -79,6 +79,8 @@ examples:
       GA4 will then track these elements when they are expanded or collapsed.
       `data-ga4-event` contains a JSON with event data relevant to our tracking. `data-ga4-expandable` enables the value of `aria-expanded` to be captured.
       See the [ga4-event-tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) docs for more information.
+      Links are also tracked with the [ga4-link-tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md).
+      Therefore the `ga4-link-tracker` data module also exists on these step by step components. Any links will contain a data attribute of `ga4-link`, which contains the relevant tracking data as a JSON.
     data:
       ga4_tracking: true
       steps: [
@@ -92,6 +94,15 @@ examples:
             {
               type: 'paragraph',
               text: 'This is also a paragraph of text that intentionally contains lots of words in order to fill the width of the page successfully to check layout and so forth.'
+            },
+            {
+              type: 'list',
+              contents: [
+                {
+                  href: 'https://www.gov.uk/learn-to-drive-a-car',
+                  text: 'This is a link with GA4 tracking attributes on it.'
+                }
+              ]
             }
           ],
         },
@@ -103,6 +114,15 @@ examples:
               type: 'paragraph',
               text: 'Some more text.'
             },
+            {
+              type: 'list',
+              contents: [
+                {
+                  href: 'https://www.nationalarchives.gov.uk',
+                  text: 'This is another link with GA4 tracking attributes on it.'
+                }
+              ]
+            }
           ]
         },
       ]

--- a/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
+++ b/lib/govuk_publishing_components/presenters/step_by_step_nav_helper.rb
@@ -46,6 +46,7 @@ module GovukPublishingComponents
                 :li,
                 class: "gem-c-step-nav__list-item js-list-item #{link_active(contents[:active])}",
               ) do
+                @options[:ga4_index_total] = element[:contents].length if @options[:ga4_tracking]
                 create_list_item_content(contents)
               end,
             )
@@ -64,11 +65,26 @@ module GovukPublishingComponents
             concat create_context(link[:context])
           end
 
+          ga4_link_data ||= nil
+          if @options[:ga4_tracking]
+            ga4_link_data = {
+              "event_name": "navigation",
+              "type": "step by step",
+              "index": {
+                "index_section": (@options[:step_index] + 1).to_s,
+                "index_link": @link_index.to_s,
+              },
+              "index_total": @options[:ga4_index_total].to_s,
+              "section": @options[:step_title],
+            }.to_json
+          end
+
           link_to(
             href,
             rel: ("external" if href.start_with?("http")),
             data: {
               position: "#{@options[:step_index] + 1}.#{@link_index}",
+              ga4_link: ga4_link_data,
             },
             class: "gem-c-step-nav__link js-link",
           ) do

--- a/spec/components/step_by_step_nav_spec.rb
+++ b/spec/components/step_by_step_nav_spec.rb
@@ -258,6 +258,82 @@ describe "step nav", type: :view do
     render_component(steps: stepnav, ga4_tracking: true)
 
     assert_select ".gem-c-step-nav[data-ga4-expandable]"
-    assert_select ".gem-c-step-nav[data-module='gemstepnav ga4-event-tracker']"
+    assert_select ".gem-c-step-nav[data-module='gemstepnav ga4-event-tracker ga4-link-tracker']"
+  end
+
+  it "adds ga4 link attributes when there is one section per step" do
+    render_component(steps: [
+      {
+        title: "Step 1",
+        contents: [
+          {
+            type: "list",
+            contents: [
+              {
+                href: "/link1",
+                text: "Link 1",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        title: "Step 2",
+        contents: [
+          {
+            type: "list",
+            contents: [
+              {
+                href: "/link2",
+                text: "Link 2",
+              },
+            ],
+          },
+        ],
+      },
+    ], ga4_tracking: true)
+
+    expected = {
+      "event_name": "navigation",
+      "type": "step by step",
+      "index": { "index_section": "1", "index_link": "1" },
+      "index_total": "1",
+      "section": "Step 1",
+    }
+
+    assert_select "#{step1} .gem-c-step-nav__link[href='/link1'][data-ga4-link='#{expected.to_json}']"
+
+    expected = {
+      "event_name": "navigation",
+      "type": "step by step",
+      "index": { "index_section": "2", "index_link": "1" },
+      "index_total": "1",
+      "section": "Step 2",
+    }
+
+    assert_select ".gem-c-step-nav__step:nth-of-type(2) .gem-c-step-nav__link[href='/link2'][data-ga4-link='#{expected.to_json}']"
+  end
+
+  it "adds ga4 link attributes when there are variable sections per step" do
+    render_component(steps: stepnav, ga4_tracking: true)
+
+    expected = {
+      "event_name": "navigation",
+      "type": "step by step",
+      "index": { "index_section": "1", "index_link": "1" },
+      "index_total": "2",
+      "section": "Step 1",
+    }
+
+    assert_select "#{step1} .gem-c-step-nav__link[href='/link1'][data-ga4-link='#{expected.to_json}']"
+
+    expected = {
+      "event_name": "navigation",
+      "type": "step by step",
+      "index": { "index_section": "3", "index_link": "1" },
+      "index_total": "2",
+      "section": "Step 2",
+    }
+    assert_select "#{step2} .gem-c-step-nav__link[href='/link5'][data-ga4-link='#{expected.to_json}']"
   end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Adds link tracking to the step by step navigation links. Uses the `ga4-link-tracker`.

You can test it by running `collections` with a local version of publishing components and going to http://127.0.0.1:3070/learn-to-drive-a-car. You will then see the `ga4-link` attribute on the links within each step.

I've used the new `index` way of tracking, so let me know if I've implemented it incorrectly.

## Why
<!-- What are the reasons behind this change being made? -->
It's on our list of things to implement.

Trello card: https://trello.com/c/TI06lTIG/431-add-tracking-step-by-step-links

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.