### PR TITLE
Update accordion index parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix smart answer PII issue ([PR #3291](https://github.com/alphagov/govuk_publishing_components/pull/3291))
+* Update accordion index parameter ([PR #3290](https://github.com/alphagov/govuk_publishing_components/pull/3290))
 
 ## 34.14.0
 

--- a/app/assets/javascripts/govuk_publishing_components/components/accordion.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/accordion.js
@@ -62,7 +62,7 @@ window.GOVUK.Modules.GovukAccordion = window.GOVUKFrontend.Accordion;
     var isGa4Enabled = dataModule ? dataModule.indexOf('ga4-event-tracker') !== -1 : false
     if (isGa4Enabled) {
       var indexTotal = this.$module.querySelectorAll('.govuk-accordion__section').length
-      var showAllAttributesGa4 = { event_name: 'select_content', type: 'accordion', index: 0, index_total: indexTotal }
+      var showAllAttributesGa4 = { event_name: 'select_content', type: 'accordion', index: { index_section: 0, index_section_count: indexTotal } }
       showAll = this.$module.querySelector(this.showAllControls)
       showAll.setAttribute('data-ga4-event', JSON.stringify(showAllAttributesGa4))
     }

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -67,8 +67,10 @@
             event_name: "select_content",
             type: "accordion",
             text: item[:heading][:text],
-            index: index,
-            index_total: items.length
+            index: {
+              index_section: index,
+              index_section_count: items.length,
+            },
           }.to_json
         end
 

--- a/spec/components/accordion_spec.rb
+++ b/spec/components/accordion_spec.rb
@@ -203,6 +203,10 @@ describe "Accordion", type: :view do
           heading: { text: "Heading 1" },
           content: { html: "<p>Content 1.</p>" },
         },
+        {
+          heading: { text: "Heading 2" },
+          content: { html: "<p>Content 2.</p>" },
+        },
       ],
     }
 
@@ -210,7 +214,8 @@ describe "Accordion", type: :view do
 
     assert_select ".govuk-accordion[data-ga4-expandable]"
     assert_select '.govuk-accordion[data-module="govuk-accordion gem-accordion ga4-event-tracker"]'
-    assert_select '.govuk-accordion__section-heading[data-ga4-event=\'{"event_name":"select_content","type":"accordion","text":"Heading 1","index":1,"index_total":1}\']'
+    assert_select '.govuk-accordion__section-heading[data-ga4-event=\'{"event_name":"select_content","type":"accordion","text":"Heading 1","index":{"index_section":1,"index_section_count":2}}\']'
+    assert_select '.govuk-accordion__section-heading[data-ga4-event=\'{"event_name":"select_content","type":"accordion","text":"Heading 2","index":{"index_section":2,"index_section_count":2}}\']'
   end
 
   it '`data-module="govuk-accordion"` attribute is present when no custom data attributes given' do

--- a/spec/javascripts/components/accordion-spec.js
+++ b/spec/javascripts/components/accordion-spec.js
@@ -107,8 +107,10 @@ describe('Accordion component', function () {
     var ga4Object = {
       event_name: 'select_content',
       type: 'accordion',
-      index: 0,
-      index_total: 3
+      index: {
+        index_section: 0,
+        index_section_count: 3
+      }
     }
     accordion.setAttribute('data-show-all-attributes', JSON.stringify(wrappingObject))
     accordion.setAttribute('data-module', accordion.getAttribute('data-module') + ' ga4-event-tracker')


### PR DESCRIPTION
## What
- in line with changes to the index parameter, explicitly define index as index_section, remove index_total and use that value for index_section_count

## Why
Part of the GA4 migration work.

## Visual Changes
None.

Trello card: https://trello.com/c/8tNN5gGX/426-change-the-index-parameter