### PR TITLE
Fix smart answer PII issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix smart answer PII issue ([PR #3291](https://github.com/alphagov/govuk_publishing_components/pull/3291))
+
 ## 34.14.0
 
 * Change how GA4 index parameter works ([PR #3277](https://github.com/alphagov/govuk_publishing_components/pull/3277))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -61,6 +61,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Ga4LinkTracker.prototype.trackClick = function (event) {
     var element = event.target
+    var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
 
     // don't track this link if it's already being tracked by the ecommerce tracker
     if (element.closest('[data-ga4-ecommerce-path]')) {
@@ -81,13 +82,17 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var text = data.text || event.target.textContent
       data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)
       var url = data.url || this.findLink(event.target).getAttribute('href')
-      data.url = window.GOVUK.analyticsGa4.core.trackFunctions.removeCrossDomainParams(url)
+      data.url = window.GOVUK.analyticsGa4.core.trackFunctions.removeCrossDomainParams(PIIRemover.stripPII(url))
       data.link_domain = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkDomain(data.url)
       data.link_path_parts = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkPathParts(data.url)
       data.method = window.GOVUK.analyticsGa4.core.trackFunctions.getClickType(event)
       data.external = window.GOVUK.analyticsGa4.core.trackFunctions.isExternalLink(data.url) ? 'true' : 'false'
       data.index = event.target.getAttribute('data-ga4-index') ? parseInt(event.target.getAttribute('data-ga4-index')) : data.index || undefined
       data.index = window.GOVUK.analyticsGa4.core.trackFunctions.createIndexObject(data.index)
+
+      if (data.type === 'smart answer' && data.action === 'change response') {
+        data.section = PIIRemover.stripPIIWithOverride(data.section, true, true)
+      }
 
       var schemas = new window.GOVUK.analyticsGa4.Schemas()
       var schema = schemas.mergeProperties(data, 'event_data')

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
@@ -4,7 +4,8 @@
   var GOVUK = global.GOVUK || {}
   var EMAIL_PATTERN = /[^\s=/?&#]+(?:@|%40)[^\s=/?&]+/g
   var POSTCODE_PATTERN = /\b[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9](?!refund)[ABD-HJLNPQ-Z]{2,3}\b/gi
-  var DATE_PATTERN = /\d{4}(-?)\d{2}(-?)\d{2}/g
+  var DATE_PATTERN_NUMERIC = /\d{4}(-?)\d{2}(-?)\d{2}/g
+  var DATE_PATTERN_STRING = /\d{1,2}\s(January|February|March|April|May|June|July|August|September|October|November|December)\s\d{4}/g
   var ESCAPE_REGEX_PATTERN = /[|\\{}()[\]^$+*?.]/g
 
   // specific URL parameters to be redacted from accounts URLs
@@ -85,7 +86,8 @@
     stripped = this.stripQueryStringParameters(stripped)
 
     if (this.stripDatePII === true) {
-      stripped = stripped.replace(DATE_PATTERN, '[date]')
+      stripped = stripped.replace(DATE_PATTERN_NUMERIC, '[date]')
+      stripped = stripped.replace(DATE_PATTERN_STRING, '[date]')
     }
     if (this.stripPostcodePII === true) {
       stripped = stripped.replace(POSTCODE_PATTERN, '[postcode]')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
@@ -14,21 +14,23 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
 
   describe('by default', function () {
     it('strips email addresses, but not postcodes and dates from strings', function () {
-      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date')
-      expect(string).toEqual('this is [email] address, this is a sw1a 1aa postcode, this is a 2019-01-21 date')
+      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date, and this is another 1 January 1990 date')
+      expect(string).toEqual('this is [email] address, this is a sw1a 1aa postcode, this is a 2019-01-21 date, and this is another 1 January 1990 date')
     })
 
     it('strips email addresses but not dates and postcodes from objects', function () {
       var obj = {
         email: 'this is an@email.com address',
         postcode: 'this is a sw1a 1aa postcode',
-        date: 'this is a 2019-01-21 date'
+        date: 'this is a 2019-01-21 date',
+        date2: 'this is another 1 January 1990 date'
       }
 
       var strippedObj = {
         email: 'this is [email] address',
         postcode: 'this is a sw1a 1aa postcode',
-        date: 'this is a 2019-01-21 date'
+        date: 'this is a 2019-01-21 date',
+        date2: 'this is another 1 January 1990 date'
       }
 
       obj = pii.stripPII(obj)
@@ -39,13 +41,15 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
       var arr = [
         'this is an@email.com address',
         'this is a sw1a 1aa postcode',
-        'this is a 2019-01-21 date'
+        'this is a 2019-01-21 date',
+        'this is another 1 January 1990 date'
       ]
 
       var strippedArr = [
         'this is [email] address',
         'this is a sw1a 1aa postcode',
-        'this is a 2019-01-21 date'
+        'this is a 2019-01-21 date',
+        'this is another 1 January 1990 date'
       ]
 
       arr = pii.stripPII(arr)
@@ -74,8 +78,8 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
     })
 
     it('strips email addresses, postcodes and dates from strings', function () {
-      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date')
-      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a [date] date')
+      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date, and this is another 1 January 1990 date')
+      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a [date] date, and this is another [date] date')
     })
 
     it('strips all PII from objects', function () {
@@ -83,6 +87,7 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
         email: 'this is an@email.com address',
         postcode: 'this is a sw1a 1aa postcode',
         date: 'this is a 2019-01-21 date',
+        date2: 'this is another 1 January 1990 date',
         uuid: 'd6c2de5d-ef90-45d1-82d4-5f2438369eea'
       }
 
@@ -90,6 +95,7 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
         email: 'this is [email] address',
         postcode: 'this is a [postcode] postcode',
         date: 'this is a [date] date',
+        date2: 'this is another [date] date',
         uuid: 'd6c2de5d-ef90-45d1-82d4-5f2438369eea'
       }
 
@@ -101,13 +107,15 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
       var arr = [
         'this is an@email.com address',
         'this is a sw1a 1aa postcode',
-        'this is a 2019-01-21 date'
+        'this is a 2019-01-21 date',
+        'and this is another 1 January 1990 date'
       ]
 
       var strippedArr = [
         'this is [email] address',
         'this is a [postcode] postcode',
-        'this is a [date] date'
+        'this is a [date] date',
+        'and this is another [date] date'
       ]
 
       arr = pii.stripPII(arr)
@@ -123,8 +131,8 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
 
     it('observes the meta tag and strips out postcodes', function () {
       expect(pii.stripPostcodePII).toEqual(true)
-      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a long GL194LYX postcode, this is a 2019-01-21 date, this is a d6c2de5d-ef90-45d1-82d4-5f2438369eea content ID, this is a p800refund')
-      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a long [postcode] postcode, this is a 2019-01-21 date, this is a d6c2de5d-ef90-45d1-82d4-5f2438369eea content ID, this is a p800refund')
+      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a long GL194LYX postcode, this is a 2019-01-21 date, this is another 1 January 1990 date, this is a d6c2de5d-ef90-45d1-82d4-5f2438369eea content ID, this is a p800refund')
+      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a long [postcode] postcode, this is a 2019-01-21 date, this is another 1 January 1990 date, this is a d6c2de5d-ef90-45d1-82d4-5f2438369eea content ID, this is a p800refund')
     })
 
     it('doesn\'t strip out UUIDs in URLs', function () {
@@ -172,8 +180,8 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
 
     it('observes the meta tag and strips out dates', function () {
       expect(pii.stripDatePII).toEqual(true)
-      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date')
-      expect(string).toEqual('this is [email] address, this is a sw1a 1aa postcode, this is a [date] date')
+      var string = pii.stripPII('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date, and this is another 1 January 1990 date')
+      expect(string).toEqual('this is [email] address, this is a sw1a 1aa postcode, this is a [date] date, and this is another [date] date')
     })
   })
 
@@ -185,23 +193,23 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
     })
 
     it('observes the override and strips out emails', function () {
-      var string = pii.stripPIIWithOverride('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date', false, false)
-      expect(string).toEqual('this is [email] address, this is a sw1a 1aa postcode, this is a 2019-01-21 date')
+      var string = pii.stripPIIWithOverride('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date and this is another 1 January 1990 date', false, false)
+      expect(string).toEqual('this is [email] address, this is a sw1a 1aa postcode, this is a 2019-01-21 date and this is another 1 January 1990 date')
     })
 
     it('observes the override and strips out emails and dates', function () {
-      var string = pii.stripPIIWithOverride('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date', true, false)
-      expect(string).toEqual('this is [email] address, this is a sw1a 1aa postcode, this is a [date] date')
+      var string = pii.stripPIIWithOverride('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date and this is another 1 January 1990 date', true, false)
+      expect(string).toEqual('this is [email] address, this is a sw1a 1aa postcode, this is a [date] date and this is another [date] date')
     })
 
     it('observes the override and strips out emails and postcodes', function () {
-      var string = pii.stripPIIWithOverride('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date', false, true)
-      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a 2019-01-21 date')
+      var string = pii.stripPIIWithOverride('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date and this is another 1 January 1990 date', false, true)
+      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a 2019-01-21 date and this is another 1 January 1990 date')
     })
 
     it('observes the override and strips out emails, postcodes and dates', function () {
-      var string = pii.stripPIIWithOverride('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date', true, true)
-      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a [date] date')
+      var string = pii.stripPIIWithOverride('this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date and this is another 1 January 1990 date', true, true)
+      expect(string).toEqual('this is [email] address, this is a [postcode] postcode, this is a [date] date and this is another [date] date')
     })
   })
 


### PR DESCRIPTION
Dates were being recorded on change response events - this PR redacts them

## What
When changing a form response on smart answers, dates that are in string format are being recorded and this is a PII issue. Therefore, this PR redacts the dates and replaces them with `[date]` (e.g. `1 January 1990` is replaced with `[date]`).

## Why
Addresses a PII issue.

## Visual Changes
N/A

Trello card: https://trello.com/c/dWFDOLAV/433-smart-answer-bugs-formchangeresponse
