### PR TITLE
Fix component auditing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix component auditing ([PR #3292](https://github.com/alphagov/govuk_publishing_components/pull/3292))
 * Fix smart answer PII issue ([PR #3291](https://github.com/alphagov/govuk_publishing_components/pull/3291))
 * Update accordion index parameter ([PR #3290](https://github.com/alphagov/govuk_publishing_components/pull/3290))
 

--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -27,10 +27,10 @@ module GovukPublishingComponents
         @find_all_javascripts = /\/\/ *= require govuk_publishing_components\/all_components/
         find_javascripts = /(?<=require govuk_publishing_components\/components\/)[a-zA-Z_-]+/
 
-        components_in_templates = find_components(templates, find_components, "templates", true) || []
-        components_in_stylesheets = find_components(stylesheets, find_stylesheets, "stylesheets", false) || []
-        components_in_print_stylesheets = find_components(stylesheets, find_print_stylesheets, "print_stylesheets", false) || []
-        components_in_javascripts = find_components(javascripts, find_javascripts, "javascripts", false) || []
+        components_in_templates = find_components(templates, find_components, "template", true) || []
+        components_in_stylesheets = find_components(stylesheets, find_stylesheets, "stylesheet", false) || []
+        components_in_print_stylesheets = find_components(stylesheets, find_print_stylesheets, "print_stylesheet", false) || []
+        components_in_javascripts = find_components(javascripts, find_javascripts, "javascript", false) || []
 
         ruby_paths = %w[/app/helpers/ /app/presenters/ /lib/]
         components_in_ruby = []
@@ -41,19 +41,19 @@ module GovukPublishingComponents
 
         components_found = [
           {
-            location: "templates",
+            location: "template",
             components: components_in_templates,
           },
           {
-            location: "stylesheets",
+            location: "stylesheet",
             components: components_in_stylesheets,
           },
           {
-            location: "print_stylesheets",
+            location: "print_stylesheet",
             components: components_in_print_stylesheets,
           },
           {
-            location: "javascripts",
+            location: "javascript",
             components: components_in_javascripts,
           },
           {
@@ -97,9 +97,9 @@ module GovukPublishingComponents
           components_found << find_match(find, src, type)
         end
 
-        get_helper_references(file, src) if %w[ruby templates].include?(type)
+        get_helper_references(file, src) if %w[ruby template].include?(type)
 
-        if type == "javascripts"
+        if type == "javascript"
           jquery_references = find_code_references(file, src, /\$\(/)
           @jquery_references << jquery_references if jquery_references
         else
@@ -130,9 +130,9 @@ module GovukPublishingComponents
     # looks for components in the given src of a file
     # returns an array of component names or an empty array
     def find_match(find, src, type)
-      return %w[all] if src.match(@find_all_stylesheets) && type == "stylesheets"
-      return %w[all] if src.match(@find_all_print_stylesheets) && type == "print_stylesheets"
-      return %w[all] if src.match(@find_all_javascripts) && type == "javascripts"
+      return %w[all] if src.match(@find_all_stylesheets) && type == "stylesheet"
+      return %w[all] if src.match(@find_all_print_stylesheets) && type == "print_stylesheet"
+      return %w[all] if src.match(@find_all_javascripts) && type == "javascript"
 
       matches = src.scan(find)
       return [] unless matches.any?

--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -21,15 +21,11 @@ module GovukPublishingComponents
         @find_all_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components/
         find_stylesheets = /(?<=@import ["']{1}govuk_publishing_components\/components\/)(?!print\/)+[a-zA-Z_-]+(?=['"])/
 
-        @find_all_print_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components_print/
-        find_print_stylesheets = /(?<=@import ["']{1}govuk_publishing_components\/components\/print\/)[a-zA-Z_-]+(?=['"])/
-
         @find_all_javascripts = /\/\/ *= require govuk_publishing_components\/all_components/
         find_javascripts = /(?<=require govuk_publishing_components\/components\/)[a-zA-Z_-]+/
 
         components_in_templates = find_components(templates, find_components, "template", true) || []
         components_in_stylesheets = find_components(stylesheets, find_stylesheets, "stylesheet", false) || []
-        components_in_print_stylesheets = find_components(stylesheets, find_print_stylesheets, "print_stylesheet", false) || []
         components_in_javascripts = find_components(javascripts, find_javascripts, "javascript", false) || []
 
         ruby_paths = %w[/app/helpers/ /app/presenters/ /lib/]
@@ -47,10 +43,6 @@ module GovukPublishingComponents
           {
             location: "stylesheet",
             components: components_in_stylesheets,
-          },
-          {
-            location: "print_stylesheet",
-            components: components_in_print_stylesheets,
           },
           {
             location: "javascript",
@@ -131,7 +123,6 @@ module GovukPublishingComponents
     # returns an array of component names or an empty array
     def find_match(find, src, type)
       return %w[all] if src.match(@find_all_stylesheets) && type == "stylesheet"
-      return %w[all] if src.match(@find_all_print_stylesheets) && type == "print_stylesheet"
       return %w[all] if src.match(@find_all_javascripts) && type == "javascript"
 
       matches = src.scan(find)

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -75,20 +75,20 @@ module GovukPublishingComponents
 
           summary = [
             {
-              name: "Components in templates",
-              value: templates[:components].flatten.uniq.sort.join(", "),
+              name: "In templates",
+              value: templates[:components],
             },
             {
-              name: "Components in stylesheets",
-              value: stylesheets[:components].join(", "),
+              name: "In stylesheets",
+              value: stylesheets[:components],
             },
             {
-              name: "Components in javascripts",
-              value: javascripts[:components].join(", "),
+              name: "In javascripts",
+              value: javascripts[:components],
             },
             {
-              name: "Components in ruby",
-              value: ruby[:components].join(", "),
+              name: "In ruby",
+              value: ruby[:components],
             },
           ]
 

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -57,12 +57,10 @@ module GovukPublishingComponents
           application_uses_static = @applications_using_static.include?(result[:name])
           templates = result[:components_found].find { |c| c[:location] == "template" }
           stylesheets = result[:components_found].find { |c| c[:location] == "stylesheet" }
-          print_stylesheets = result[:components_found].find { |c| c[:location] == "print_stylesheet" }
           javascripts = result[:components_found].find { |c| c[:location] == "javascript" }
           ruby = result[:components_found].find { |c| c[:location] == "ruby" }
 
           @all_stylesheets = true if stylesheets[:components].include?("all")
-          @all_print_stylesheets = true if print_stylesheets[:components].include?("all")
           @all_javascripts = true if javascripts[:components].include?("all")
 
           templates[:components] = include_any_components_within_components(templates[:components])
@@ -83,10 +81,6 @@ module GovukPublishingComponents
             {
               name: "Components in stylesheets",
               value: stylesheets[:components].join(", "),
-            },
-            {
-              name: "Components in print stylesheets",
-              value: print_stylesheets[:components].join(", "),
             },
             {
               name: "Components in javascripts",
@@ -209,7 +203,7 @@ module GovukPublishingComponents
           components: code.map { |c| c[:components] }.flatten.uniq.sort,
         },
       ]
-      assets = components.select { |c| c[:location] == "stylesheet" || c[:location] == "print_stylesheet" || c[:location] == "javascript" }
+      assets = components.select { |c| c[:location] == "stylesheet" || c[:location] == "javascript" }
 
       warnings << find_missing_items(code, assets)
       warnings << find_missing_items(assets, code)

--- a/app/views/govuk_publishing_components/audit/_applications.html.erb
+++ b/app/views/govuk_publishing_components/audit/_applications.html.erb
@@ -62,11 +62,11 @@
           <% application[:summary].each do |item| %>
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                <%= item[:name] %>
+                <%= item[:name] %> (<%= item[:value].length %>)
               </dt>
               <dd class="govuk-summary-list__value">
                 <% if item[:value].length > 0 %>
-                  <%= item[:value] %>
+                  <%= item[:value].join(", ") %>
                 <% else %>
                   None
                 <% end %>

--- a/spec/component_guide/audit_applications_spec.rb
+++ b/spec/component_guide/audit_applications_spec.rb
@@ -19,10 +19,6 @@ describe "Auditing the components in applications" do
           components: %w[all],
         },
         {
-          location: "print_stylesheet",
-          components: [],
-        },
-        {
           location: "javascript",
           components: %w[all],
         },

--- a/spec/component_guide/audit_applications_spec.rb
+++ b/spec/component_guide/audit_applications_spec.rb
@@ -11,19 +11,19 @@ describe "Auditing the components in applications" do
       application_found: true,
       components_found: [
         {
-          location: "templates",
+          location: "template",
           components: ["accordion", "back link", "contextual breadcrumbs", "contextual footer", "contextual sidebar", "details", "error summary", "feedback", "govspeak", "input", "layout footer", "layout for admin", "layout for public", "layout header", "notice", "skip link", "tabs", "title"],
         },
         {
-          location: "stylesheets",
+          location: "stylesheet",
           components: %w[all],
         },
         {
-          location: "print_stylesheets",
+          location: "print_stylesheet",
           components: [],
         },
         {
-          location: "javascripts",
+          location: "javascript",
           components: %w[all],
         },
         {

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -200,20 +200,20 @@ describe "Comparing data from an application with the components" do
         uses_static: false,
         summary: [
           {
-            name: "Components in templates",
-            value: "component four, component one, component that does not exist, component three",
+            name: "In templates",
+            value: ["component four", "component one", "component that does not exist", "component three"],
           },
           {
-            name: "Components in stylesheets",
-            value: "component one, component two, component three",
+            name: "In stylesheets",
+            value: ["component one", "component two", "component three"],
           },
           {
-            name: "Components in javascripts",
-            value: "",
+            name: "In javascripts",
+            value: [],
           },
           {
-            name: "Components in ruby",
-            value: "component three",
+            name: "In ruby",
+            value: ["component three"],
           },
         ],
         warnings: [
@@ -289,20 +289,20 @@ describe "Comparing data from an application with the components" do
         uses_static: false,
         summary: [
           {
-            name: "Components in templates",
-            value: "component one",
+            name: "In templates",
+            value: ["component one"],
           },
           {
-            name: "Components in stylesheets",
-            value: "",
+            name: "In stylesheets",
+            value: [],
           },
           {
-            name: "Components in javascripts",
-            value: "",
+            name: "In javascripts",
+            value: [],
           },
           {
-            name: "Components in ruby",
-            value: "",
+            name: "In ruby",
+            value: [],
           },
         ],
         warnings: [
@@ -403,20 +403,20 @@ describe "Comparing data from an application with the components" do
         uses_static: true,
         summary: [
           {
-            name: "Components in templates",
-            value: "component four, component one, component two",
+            name: "In templates",
+            value: ["component four", "component one", "component two"],
           },
           {
-            name: "Components in stylesheets",
-            value: "component one",
+            name: "In stylesheets",
+            value: ["component one"],
           },
           {
-            name: "Components in javascripts",
-            value: "",
+            name: "In javascripts",
+            value: [],
           },
           {
-            name: "Components in ruby",
-            value: "",
+            name: "In ruby",
+            value: [],
           },
         ],
         warnings: [
@@ -445,20 +445,20 @@ describe "Comparing data from an application with the components" do
         uses_static: false,
         summary: [
           {
-            name: "Components in templates",
-            value: "component one, component two",
+            name: "In templates",
+            value: ["component one", "component two"],
           },
           {
-            name: "Components in stylesheets",
-            value: "component one, component two",
+            name: "In stylesheets",
+            value: ["component one", "component two"],
           },
           {
-            name: "Components in javascripts",
-            value: "component one",
+            name: "In javascripts",
+            value: ["component one"],
           },
           {
-            name: "Components in ruby",
-            value: "",
+            name: "In ruby",
+            value: [],
           },
         ],
         warnings: [],
@@ -515,20 +515,20 @@ describe "Comparing data from an application with the components" do
         uses_static: false,
         summary: [
           {
-            name: "Components in templates",
-            value: "component one, component two",
+            name: "In templates",
+            value: ["component one", "component two"],
           },
           {
-            name: "Components in stylesheets",
-            value: "all",
+            name: "In stylesheets",
+            value: %w[all],
           },
           {
-            name: "Components in javascripts",
-            value: "all",
+            name: "In javascripts",
+            value: %w[all],
           },
           {
-            name: "Components in ruby",
-            value: "component that does not exist",
+            name: "In ruby",
+            value: ["component that does not exist"],
           },
         ],
         warnings: [
@@ -597,20 +597,20 @@ describe "Comparing data from an application with the components" do
         uses_static: false,
         summary: [
           {
-            name: "Components in templates",
-            value: "component four, component three, component two",
+            name: "In templates",
+            value: ["component four", "component three", "component two"],
           },
           {
-            name: "Components in stylesheets",
-            value: "component one, component three",
+            name: "In stylesheets",
+            value: ["component one", "component three"],
           },
           {
-            name: "Components in javascripts",
-            value: "all",
+            name: "In javascripts",
+            value: %w[all],
           },
           {
-            name: "Components in ruby",
-            value: "component that does not exist",
+            name: "In ruby",
+            value: ["component that does not exist"],
           },
         ],
         gem_style_references: [

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -11,21 +11,6 @@ describe "Comparing data from an application with the components" do
       "component three",
       "component four",
     ],
-    component_stylesheets: [
-      "component one",
-      "component two",
-      "component three",
-      "component four",
-    ],
-    component_print_stylesheets: [
-      "component two",
-    ],
-    component_javascripts: [
-      "component one",
-      "component four",
-    ],
-    component_tests: [],
-    component_javascript_tests: [],
     components_containing_components: [
       {
         component: "component three",
@@ -34,7 +19,92 @@ describe "Comparing data from an application with the components" do
         ],
       },
     ],
-    component_file_details: [],
+    component_file_details: [
+      {
+        name: "component one",
+        link: "",
+        template_exists: true,
+        template_lines: 1,
+        template_link: "",
+        stylesheet_exists: true,
+        stylesheet_lines: 1,
+        stylesheet_link: "",
+        print_stylesheet_exists: false,
+        javascript_exists: true,
+        javascript_lines: 1,
+        javascript_link: "",
+        test_exists: true,
+        test_lines: 1,
+        test_link: "",
+        javascript_test_exists: true,
+        javascript_test_lines: 1,
+        javascript_test_link: "",
+        helper_exists: true,
+      },
+      {
+        name: "component two",
+        link: "",
+        template_exists: true,
+        template_lines: 1,
+        template_link: "",
+        stylesheet_exists: true,
+        stylesheet_lines: 1,
+        stylesheet_link: "",
+        print_stylesheet_exists: true,
+        javascript_exists: false,
+        javascript_lines: 1,
+        javascript_link: "",
+        test_exists: true,
+        test_lines: 1,
+        test_link: "",
+        javascript_test_exists: true,
+        javascript_test_lines: 1,
+        javascript_test_link: "",
+        helper_exists: true,
+      },
+      {
+        name: "component three",
+        link: "",
+        template_exists: true,
+        template_lines: 1,
+        template_link: "",
+        stylesheet_exists: true,
+        stylesheet_lines: 1,
+        stylesheet_link: "",
+        print_stylesheet_exists: false,
+        javascript_exists: false,
+        javascript_lines: 1,
+        javascript_link: "",
+        test_exists: true,
+        test_lines: 1,
+        test_link: "",
+        javascript_test_exists: true,
+        javascript_test_lines: 1,
+        javascript_test_link: "",
+        helper_exists: true,
+      },
+      {
+        name: "component four",
+        link: "",
+        template_exists: true,
+        template_lines: 1,
+        template_link: "",
+        stylesheet_exists: true,
+        stylesheet_lines: 1,
+        stylesheet_link: "",
+        print_stylesheet_exists: false,
+        javascript_exists: true,
+        javascript_lines: 1,
+        javascript_link: "",
+        test_exists: true,
+        test_lines: 1,
+        test_link: "",
+        javascript_test_exists: true,
+        javascript_test_lines: 1,
+        javascript_test_link: "",
+        helper_exists: true,
+      },
+    ],
     component_numbers: {},
     component_listing: {},
   }
@@ -50,14 +120,14 @@ describe "Comparing data from an application with the components" do
         application_found: true,
         components_found: [
           {
-            location: "templates",
+            location: "template",
             components: [
               "component one",
               "component that does not exist",
             ],
           },
           {
-            location: "stylesheets",
+            location: "stylesheet",
             components: [
               "component one",
               "component two",
@@ -65,11 +135,11 @@ describe "Comparing data from an application with the components" do
             ],
           },
           {
-            location: "print_stylesheets",
+            location: "print_stylesheet",
             components: [],
           },
           {
-            location: "javascripts",
+            location: "javascript",
             components: [],
           },
           {
@@ -93,7 +163,7 @@ describe "Comparing data from an application with the components" do
         application_found: true,
         components_found: [
           {
-            location: "templates",
+            location: "template",
             components: [
               "component one",
               "component three",
@@ -101,7 +171,7 @@ describe "Comparing data from an application with the components" do
             ],
           },
           {
-            location: "stylesheets",
+            location: "stylesheet",
             components: [
               "component one",
               "component two",
@@ -109,11 +179,11 @@ describe "Comparing data from an application with the components" do
             ],
           },
           {
-            location: "print_stylesheets",
+            location: "print_stylesheet",
             components: [],
           },
           {
-            location: "javascripts",
+            location: "javascript",
             components: [],
           },
           {
@@ -161,26 +231,111 @@ describe "Comparing data from an application with the components" do
         warnings: [
           {
             component: "component that does not exist",
-            message: "Included in templates but component does not exist",
+            message: "Included in template but component does not exist",
           },
           {
             component: "component four",
-            message: "Included in code but not stylesheets",
+            message: "Included in code but not stylesheet",
           },
           {
             component: "component four",
-            message: "Included in code but not javascripts",
+            message: "Included in code but not javascript",
           },
           {
             component: "component one",
-            message: "Included in code but not javascripts",
+            message: "Included in code but not javascript",
           },
           {
             component: "component two",
-            message: "Included in stylesheets but not code",
+            message: "Included in stylesheet but not code",
           },
         ],
         warning_count: 5,
+        gem_style_references: [],
+        jquery_references: [],
+        component_locations: {},
+        helper_references: nil,
+      },
+    ]
+
+    expect(comparer.applications_data).to match(expected)
+  end
+
+  it "returns a comparison for an application using individual components where no assets have been included" do
+    application = [
+      {
+        name: "Dummy application",
+        application_found: true,
+        components_found: [
+          {
+            location: "template",
+            components: [
+              "component one",
+            ],
+          },
+          {
+            location: "stylesheet",
+            components: [],
+          },
+          {
+            location: "print_stylesheet",
+            components: [],
+          },
+          {
+            location: "javascript",
+            components: [],
+          },
+          {
+            location: "ruby",
+            components: [],
+          },
+        ],
+        gem_style_references: [],
+        jquery_references: [],
+        helper_references: nil,
+        component_locations: {},
+      },
+    ]
+    comparer = GovukPublishingComponents::AuditComparer.new(gem, application)
+
+    expected = [
+      {
+        name: "Dummy application",
+        application_found: true,
+        uses_static: false,
+        summary: [
+          {
+            name: "Components in templates",
+            value: "component one",
+          },
+          {
+            name: "Components in stylesheets",
+            value: "",
+          },
+          {
+            name: "Components in print stylesheets",
+            value: "",
+          },
+          {
+            name: "Components in javascripts",
+            value: "",
+          },
+          {
+            name: "Components in ruby",
+            value: "",
+          },
+        ],
+        warnings: [
+          {
+            component: "component one",
+            message: "Included in code but not stylesheet",
+          },
+          {
+            component: "component one",
+            message: "Included in code but not javascript",
+          },
+        ],
+        warning_count: 2,
         gem_style_references: [],
         jquery_references: [],
         component_locations: {},
@@ -199,7 +354,7 @@ describe "Comparing data from an application with the components" do
         application_found: true,
         components_found: [
           {
-            location: "templates",
+            location: "template",
             components: [
               "component one",
               "component two",
@@ -207,17 +362,17 @@ describe "Comparing data from an application with the components" do
             ],
           },
           {
-            location: "stylesheets",
+            location: "stylesheet",
             components: [
               "component one",
             ],
           },
           {
-            location: "print_stylesheets",
+            location: "print_stylesheet",
             components: [],
           },
           {
-            location: "javascripts",
+            location: "javascript",
             components: [],
           },
           {
@@ -234,27 +389,27 @@ describe "Comparing data from an application with the components" do
         application_found: true,
         components_found: [
           {
-            location: "templates",
+            location: "template",
             components: [
               "component one",
               "component two",
             ],
           },
           {
-            location: "stylesheets",
+            location: "stylesheet",
             components: [
               "component one",
               "component two",
             ],
           },
           {
-            location: "print_stylesheets",
+            location: "print_stylesheet",
             components: [
               "component two",
             ],
           },
           {
-            location: "javascripts",
+            location: "javascript",
             components: [
               "component one",
             ],
@@ -301,15 +456,15 @@ describe "Comparing data from an application with the components" do
         warnings: [
           {
             component: "component four",
-            message: "Included in code but not stylesheets",
+            message: "Included in code but not stylesheet",
           },
           {
             component: "component four",
-            message: "Included in code but not javascripts",
+            message: "Included in code but not javascript",
           },
           {
             component: "component one",
-            message: "Included in stylesheets but already included in static",
+            message: "Included in stylesheet but already included in static",
           },
         ],
         warning_count: 3,
@@ -363,22 +518,22 @@ describe "Comparing data from an application with the components" do
         application_found: true,
         components_found: [
           {
-            location: "templates",
+            location: "template",
             components: [
               "component one",
               "component two",
             ],
           },
           {
-            location: "stylesheets",
+            location: "stylesheet",
             components: %w[all],
           },
           {
-            location: "print_stylesheets",
+            location: "print_stylesheet",
             components: %w[all],
           },
           {
-            location: "javascripts",
+            location: "javascript",
             components: %w[all],
           },
           {
@@ -446,25 +601,25 @@ describe "Comparing data from an application with the components" do
         application_found: true,
         components_found: [
           {
-            location: "templates",
+            location: "template",
             components: [
               "component two",
               "component three",
             ],
           },
           {
-            location: "stylesheets",
+            location: "stylesheet",
             components: [
               "component one",
               "component three",
             ],
           },
           {
-            location: "print_stylesheets",
+            location: "print_stylesheet",
             components: %w[all],
           },
           {
-            location: "javascripts",
+            location: "javascript",
             components: %w[all],
           },
           {
@@ -525,15 +680,15 @@ describe "Comparing data from an application with the components" do
           },
           {
             component: "component four",
-            message: "Included in code but not stylesheets",
+            message: "Included in code but not stylesheet",
           },
           {
             component: "component two",
-            message: "Included in code but not stylesheets",
+            message: "Included in code but not stylesheet",
           },
           {
             component: "component one",
-            message: "Included in stylesheets but not code",
+            message: "Included in stylesheet but not code",
           },
           {
             component: "Possible component style override",
@@ -560,7 +715,7 @@ describe "Comparing data from an application with the components" do
         application_found: true,
         components_found: [
           {
-            location: "templates",
+            location: "template",
             components: [
               "component one",
               "component three",
@@ -568,7 +723,7 @@ describe "Comparing data from an application with the components" do
             ],
           },
           {
-            location: "stylesheets",
+            location: "stylesheet",
             components: [
               "component one",
               "component two",
@@ -576,11 +731,11 @@ describe "Comparing data from an application with the components" do
             ],
           },
           {
-            location: "print_stylesheets",
+            location: "print_stylesheet",
             components: [],
           },
           {
-            location: "javascripts",
+            location: "javascript",
             components: [],
           },
           {
@@ -621,21 +776,6 @@ describe "Comparing data from an application with the components" do
         "component three",
         "component four",
       ],
-      component_stylesheets: [
-        "component one",
-        "component two",
-        "component three",
-        "component four",
-      ],
-      component_print_stylesheets: [
-        "component two",
-      ],
-      component_javascripts: [
-        "component one",
-        "component four",
-      ],
-      component_tests: [],
-      component_javascript_tests: [],
       components_containing_components: [
         {
           component: "component three",
@@ -694,7 +834,92 @@ describe "Comparing data from an application with the components" do
           ],
         },
       ],
-      component_file_details: [],
+      component_file_details: [
+        {
+          name: "component one",
+          link: "",
+          template_exists: true,
+          template_lines: 1,
+          template_link: "",
+          stylesheet_exists: true,
+          stylesheet_lines: 1,
+          stylesheet_link: "",
+          print_stylesheet_exists: false,
+          javascript_exists: true,
+          javascript_lines: 1,
+          javascript_link: "",
+          test_exists: true,
+          test_lines: 1,
+          test_link: "",
+          javascript_test_exists: true,
+          javascript_test_lines: 1,
+          javascript_test_link: "",
+          helper_exists: true,
+        },
+        {
+          name: "component two",
+          link: "",
+          template_exists: true,
+          template_lines: 1,
+          template_link: "",
+          stylesheet_exists: true,
+          stylesheet_lines: 1,
+          stylesheet_link: "",
+          print_stylesheet_exists: true,
+          javascript_exists: false,
+          javascript_lines: 1,
+          javascript_link: "",
+          test_exists: true,
+          test_lines: 1,
+          test_link: "",
+          javascript_test_exists: true,
+          javascript_test_lines: 1,
+          javascript_test_link: "",
+          helper_exists: true,
+        },
+        {
+          name: "component three",
+          link: "",
+          template_exists: true,
+          template_lines: 1,
+          template_link: "",
+          stylesheet_exists: true,
+          stylesheet_lines: 1,
+          stylesheet_link: "",
+          print_stylesheet_exists: false,
+          javascript_exists: false,
+          javascript_lines: 1,
+          javascript_link: "",
+          test_exists: true,
+          test_lines: 1,
+          test_link: "",
+          javascript_test_exists: true,
+          javascript_test_lines: 1,
+          javascript_test_link: "",
+          helper_exists: true,
+        },
+        {
+          name: "component four",
+          link: "",
+          template_exists: true,
+          template_lines: 1,
+          template_link: "",
+          stylesheet_exists: true,
+          stylesheet_lines: 1,
+          stylesheet_link: "",
+          print_stylesheet_exists: false,
+          javascript_exists: true,
+          javascript_lines: 1,
+          javascript_link: "",
+          test_exists: true,
+          test_lines: 1,
+          test_link: "",
+          javascript_test_exists: true,
+          javascript_test_lines: 1,
+          javascript_test_link: "",
+          helper_exists: true,
+        },
+      ],
       component_numbers: {},
     }
 

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -135,10 +135,6 @@ describe "Comparing data from an application with the components" do
             ],
           },
           {
-            location: "print_stylesheet",
-            components: [],
-          },
-          {
             location: "javascript",
             components: [],
           },
@@ -179,10 +175,6 @@ describe "Comparing data from an application with the components" do
             ],
           },
           {
-            location: "print_stylesheet",
-            components: [],
-          },
-          {
             location: "javascript",
             components: [],
           },
@@ -214,10 +206,6 @@ describe "Comparing data from an application with the components" do
           {
             name: "Components in stylesheets",
             value: "component one, component two, component three",
-          },
-          {
-            name: "Components in print stylesheets",
-            value: "",
           },
           {
             name: "Components in javascripts",
@@ -278,10 +266,6 @@ describe "Comparing data from an application with the components" do
             components: [],
           },
           {
-            location: "print_stylesheet",
-            components: [],
-          },
-          {
             location: "javascript",
             components: [],
           },
@@ -310,10 +294,6 @@ describe "Comparing data from an application with the components" do
           },
           {
             name: "Components in stylesheets",
-            value: "",
-          },
-          {
-            name: "Components in print stylesheets",
             value: "",
           },
           {
@@ -368,10 +348,6 @@ describe "Comparing data from an application with the components" do
             ],
           },
           {
-            location: "print_stylesheet",
-            components: [],
-          },
-          {
             location: "javascript",
             components: [],
           },
@@ -399,12 +375,6 @@ describe "Comparing data from an application with the components" do
             location: "stylesheet",
             components: [
               "component one",
-              "component two",
-            ],
-          },
-          {
-            location: "print_stylesheet",
-            components: [
               "component two",
             ],
           },
@@ -439,10 +409,6 @@ describe "Comparing data from an application with the components" do
           {
             name: "Components in stylesheets",
             value: "component one",
-          },
-          {
-            name: "Components in print stylesheets",
-            value: "",
           },
           {
             name: "Components in javascripts",
@@ -487,10 +453,6 @@ describe "Comparing data from an application with the components" do
             value: "component one, component two",
           },
           {
-            name: "Components in print stylesheets",
-            value: "component two",
-          },
-          {
             name: "Components in javascripts",
             value: "component one",
           },
@@ -529,10 +491,6 @@ describe "Comparing data from an application with the components" do
             components: %w[all],
           },
           {
-            location: "print_stylesheet",
-            components: %w[all],
-          },
-          {
             location: "javascript",
             components: %w[all],
           },
@@ -562,10 +520,6 @@ describe "Comparing data from an application with the components" do
           },
           {
             name: "Components in stylesheets",
-            value: "all",
-          },
-          {
-            name: "Components in print stylesheets",
             value: "all",
           },
           {
@@ -615,10 +569,6 @@ describe "Comparing data from an application with the components" do
             ],
           },
           {
-            location: "print_stylesheet",
-            components: %w[all],
-          },
-          {
             location: "javascript",
             components: %w[all],
           },
@@ -653,10 +603,6 @@ describe "Comparing data from an application with the components" do
           {
             name: "Components in stylesheets",
             value: "component one, component three",
-          },
-          {
-            name: "Components in print stylesheets",
-            value: "all",
           },
           {
             name: "Components in javascripts",
@@ -729,10 +675,6 @@ describe "Comparing data from an application with the components" do
               "component two",
               "component three",
             ],
-          },
-          {
-            location: "print_stylesheet",
-            components: [],
           },
           {
             location: "javascript",


### PR DESCRIPTION
## What / why
Resolves a few issues with the component auditing. Specifically:

- fixes a silent problem introduced when the data structure changed in a recent update
- removes print stylesheet auditing, as we no longer have separate print styles for components
- adds a count to the component references found in applications

## Visual Changes
Mentions of print stylesheets have been removed from the auditing pages.

Counts have been added to the lists of components in applications:

![Screenshot 2023-03-09 at 10 46 37](https://user-images.githubusercontent.com/861310/224001825-ae6822a2-480b-498d-bb1d-fadad3e1f00b.png)
