### PR TITLE
Add GA4 tracking option to tabs component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add GA4 tracking option to tabs component ([PR #3296](https://github.com/alphagov/govuk_publishing_components/pull/3296))
 * Fix component auditing ([PR #3292](https://github.com/alphagov/govuk_publishing_components/pull/3292))
 * Fix smart answer PII issue ([PR #3291](https://github.com/alphagov/govuk_publishing_components/pull/3291))
 * Update accordion index parameter ([PR #3290](https://github.com/alphagov/govuk_publishing_components/pull/3290))

--- a/app/views/govuk_publishing_components/components/_tabs.html.erb
+++ b/app/views/govuk_publishing_components/components/_tabs.html.erb
@@ -6,15 +6,33 @@
   panel_css_classes = %w(govuk-tabs__panel)
   panel_css_classes << "gem-c-tabs__panel--no-border" if panel_border == false
   panel_css_classes = panel_css_classes.join(" ")
+
+  ga4_tracking ||= false
+  data_module = "govuk-tabs"
+  data_module << " ga4-event-tracker" if ga4_tracking
 %>
 <% if tabs.count > 1 %>
-  <div class="govuk-tabs gem-c-tabs" data-module="govuk-tabs">
+  <div class="govuk-tabs gem-c-tabs" data-module="<%= data_module %>">
     <h2 class="govuk-tabs__title">
       <%= t("components.tabs.contents") %>
     </h2>
     <ul class="govuk-tabs__list">
-      <% tabs.each do |tab| %>
+      <% tabs.each_with_index do |tab, index| %>
       <li class="govuk-tabs__list-item">
+        <%
+          tab[:tab_data_attributes] ||= {}
+          if ga4_tracking
+            tab[:tab_data_attributes][:ga4_event] = {
+              event_name: "select_content",
+              type: "tabs",
+              text: tab[:label],
+              index: {
+                index_section: index + 1,
+                index_section_count: tabs.length,
+              },
+            }
+          end
+        %>
         <%= link_to(tab[:label],
                     "##{tab[:id]}",
                     class: "govuk-tabs__tab",

--- a/app/views/govuk_publishing_components/components/docs/tabs.yml
+++ b/app/views/govuk_publishing_components/components/docs/tabs.yml
@@ -84,3 +84,18 @@ examples:
             tracking: GTM-123AB
           content: |
             <p class="govuk-body-m">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam congue elementum commodo. Vestibulum elit turpis, efficitur quis posuere vitae, commodo vitae augue. Donec ut pharetra ligula. Phasellus ac mauris eu felis bibendum dapibus rutrum sed quam. Pellentesque posuere ante id consequat pretium.</p>
+  with_ga4_tracking:
+    description: Enables GA4 tracking. This will add the required data module and data attributes to the tabs. See the [ga4-event-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) for more information.
+    data:
+      ga4_tracking: true
+      tabs:
+        - id: "tab-with-ga4-tracking-1"
+          label: "First section"
+          title: "First section"
+          content: |
+            <p class="govuk-body-m">Fusce at dictum tellus, ac accumsan est. Nulla vitae turpis in nulla gravida tincidunt. Duis lectus felis, tempus id bibendum sit amet, posuere ut elit. Donec enim odio, eleifend in urna a, sagittis egestas est. Proin id ex ultricies, porta eros id, vehicula quam. Morbi non sagittis velit.</p>
+        - id: "tab-with-ga4-tracking-2"
+          label: "Second section"
+          title: "Second section"
+          content: |
+            <p class="govuk-body-m">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam congue elementum commodo. Vestibulum elit turpis, efficitur quis posuere vitae, commodo vitae augue. Donec ut pharetra ligula. Phasellus ac mauris eu felis bibendum dapibus rutrum sed quam. Pellentesque posuere ante id consequat pretium.</p>

--- a/spec/components/tabs_spec.rb
+++ b/spec/components/tabs_spec.rb
@@ -24,10 +24,38 @@ describe "Tabs", type: :view do
         },
       ],
     )
-    assert_select ".govuk-tabs"
+    assert_select ".govuk-tabs[data-module='govuk-tabs']"
     assert_select ".govuk-tabs__tab", 2
     assert_select ".govuk-tabs__panel", 2
     assert_select "#tab1"
     assert_select "#tab1"
+  end
+
+  it "renders with GA4 tracking" do
+    render_component(
+      ga4_tracking: true,
+      tabs: [
+        {
+          id: "tab1",
+          label: "First section",
+          content: "<p>Fusce at dictum tellus, ac accumsan est. Nulla vitae turpis in nulla gravida tincidunt.</p>",
+        },
+        {
+          id: "tab2",
+          label: "Second section",
+          content: "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>",
+        },
+        {
+          id: "tab3",
+          label: "Third section",
+          content: "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>",
+        },
+      ],
+    )
+
+    assert_select ".govuk-tabs[data-module='govuk-tabs ga4-event-tracker']"
+    assert_select ".govuk-tabs__tab[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"tabs\",\"text\":\"First section\",\"index\":{\"index_section\":1,\"index_section_count\":3}}']"
+    assert_select ".govuk-tabs__tab[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"tabs\",\"text\":\"Second section\",\"index\":{\"index_section\":2,\"index_section_count\":3}}']"
+    assert_select ".govuk-tabs__tab[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"tabs\",\"text\":\"Third section\",\"index\":{\"index_section\":3,\"index_section_count\":3}}']"
   end
 end


### PR DESCRIPTION
## What
- previously relied on manually passing data attributes per tab from the application to the component
- but no actual need for this, attributes can be determined inside the component, and simply activated by setting ga4_tracking to true
- does not represent a breaking change as options can be switched over later once this is deployed

Example of current tracking on tabs for comparison: https://www.gov.uk/bank-holidays

## Why
Should make enabling tracking on tabs simpler.

## Visual Changes
None.

Trello card: https://trello.com/c/OSeC4N43/261-epic-technical-debt
