### PR TITLE
Update GA4 index parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Drop support for Ruby 2.7 ([PR #3310](https://github.com/alphagov/govuk_publishing_components/pull/3310))
+* Update GA4 index parameter ([PR #3297](https://github.com/alphagov/govuk_publishing_components/pull/3297))
 * Make auditing aware of new asset loading model ([PR #3318](https://github.com/alphagov/govuk_publishing_components/pull/3318))
 * Ga4 part of heading tracking fix ([PR #3321](https://github.com/alphagov/govuk_publishing_components/pull/3321))
 * Ga4 fix index ([PR #3313](https://github.com/alphagov/govuk_publishing_components/pull/3313))

--- a/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
@@ -196,8 +196,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           event_name: 'select_content',
           type: 'step by step',
           text: titleText.trim(),
-          index: i + 1,
-          index_total: this.$module.totalSteps
+          index: {
+            index_section: i + 1,
+            index_section_count: this.$module.totalSteps
+          },
+          index_total: thisel.querySelectorAll('a').length
         }
 
         var button = thisel.querySelector('.js-step-title-button')

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -43,7 +43,9 @@
             "external": "false",
             "text": "GOV.UK",
             "section": "Logo",
-            "index": 0,
+            "index": {
+              "index_section": 0,
+            },
             "index_total": navigation_links_length
           }.to_json %>"
         >
@@ -128,7 +130,9 @@
                   event_name: "select_content",
                   type: "header menu bar",
                   text: link[:label],
-                  index: 1,
+                  index: {
+                    index_section: 1,
+                  },
                   index_total: 2,
                   section: link[:label]
                 }
@@ -159,7 +163,9 @@
                 "event_name": "select_content",
                 "type": "header menu bar",
                 "text": "Search",
-                "index": 2,
+                "index": {
+                  "index_section": 2,
+                },
                 "index_total": 2,
                 "section": "Search"
               }.to_json %>"
@@ -238,7 +244,11 @@
                             ga4_link: {
                               "event_name": "navigation",
                               "type": "header menu bar",
-                              "index": "1.#{column_index + 1}.#{index + 1}",
+                              "index": {
+                                "index_section": column_index + 1,
+                                "index_link": index + 1,
+                                "index_section_count": 4,
+                              },
                               "index_total": navigation_links_length,
                               "section": column[:label],
                             }
@@ -308,7 +318,11 @@
                         ga4_link: {
                           "event_name": "navigation",
                           "type": "header menu bar",
-                          "index": "2.2.#{index + 1}",
+                          "index": {
+                            "index_section": 4,
+                            "index_link": index + 1,
+                            "index_section_count": 4,
+                          },
                           "index_total": navigation_links_length,
                           "section": popular_links_heading,
                         }

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -124,12 +124,12 @@ describe "Super navigation header", type: :view do
 
     assert_select "header[data-module='gem-track-click ga4-event-tracker ga4-link-tracker']"
     assert_select "a[data-ga4-link]", count: 28
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","external":"false","text":"GOV.UK","section":"Logo","index":0,"index_total":28}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"1.1.1","index_total":28,"section":"Topics"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"1.1.16","index_total":28,"section":"Topics"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"1.2.1","index_total":28,"section":"Government activity"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"1.2.6","index_total":28,"section":"Government activity"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"2.2.1","index_total":28,"section":"Popular on GOV.UK"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"2.2.5","index_total":28,"section":"Popular on GOV.UK"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","external":"false","text":"GOV.UK","section":"Logo","index":{"index_section":0},"index_total":28}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":1,"index_link":1,"index_section_count":4},"index_total":28,"section":"Topics"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":1,"index_link":16,"index_section_count":4},"index_total":28,"section":"Topics"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":2,"index_link":1,"index_section_count":4},"index_total":28,"section":"Government activity"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":2,"index_link":6,"index_section_count":4},"index_total":28,"section":"Government activity"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":4,"index_link":1,"index_section_count":4},"index_total":28,"section":"Popular on GOV.UK"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":4,"index_link":5,"index_section_count":4},"index_total":28,"section":"Popular on GOV.UK"}\']'
   end
 end

--- a/spec/javascripts/components/step-by-step-nav-spec.js
+++ b/spec/javascripts/components/step-by-step-nav-spec.js
@@ -943,7 +943,7 @@ describe('A stepnav module', function () {
       var stepNav = element.childNodes[0]
       var stepButton = stepNav.querySelector('#topic-step-one .js-step-title button')
 
-      expect(stepButton.getAttribute('data-ga4-event')).toEqual('{"event_name":"select_content","type":"step by step","text":"This title\'s got quotation marks \\" in it.","index":1,"index_total":3}')
+      expect(stepButton.getAttribute('data-ga4-event')).toEqual('{"event_name":"select_content","type":"step by step","text":"This title\'s got quotation marks \\" in it.","index":{"index_section":1,"index_section_count":3},"index_total":1}')
     })
   })
 })


### PR DESCRIPTION
## What
Update parts of the GA4 code to reflect recent changes in the `index` parameter, specifically the new additional parameter, `index_section_count`, which is the number of sections in the thing being tracked.

Applied to:

- site header
- step by step

## Why
Part of the GA4 migration work.

## Visual Changes
None.

Trello card: https://trello.com/c/16ngDhBP/493-change-the-index-parameter-part-2-indexsectioncount