### PR TITLE
Version 35.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.0.0
 
+* Fix redaction bug in GA4 form tracker ([PR #3300](https://github.com/alphagov/govuk_publishing_components/pull/3300))
 * Add GA4 tracking option to tabs component ([PR #3296](https://github.com/alphagov/govuk_publishing_components/pull/3296))
 * Fix component auditing ([PR #3292](https://github.com/alphagov/govuk_publishing_components/pull/3292))
 * Fix smart answer PII issue ([PR #3291](https://github.com/alphagov/govuk_publishing_components/pull/3291))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (34.14.0)
+    govuk_publishing_components (35.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -263,7 +263,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
-    raindrops (0.20.0)
+    raindrops (0.20.1)
     rake (13.0.6)
     regexp_parser (2.6.2)
     request_store (1.5.1)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "34.14.0".freeze
+  VERSION = "35.0.0".freeze
 end


### PR DESCRIPTION
## 35.0.0

* Fix redaction bug in GA4 form tracker ([PR #3300](https://github.com/alphagov/govuk_publishing_components/pull/3300))
* Add GA4 tracking option to tabs component ([PR #3296](https://github.com/alphagov/govuk_publishing_components/pull/3296))
* Fix component auditing ([PR #3292](https://github.com/alphagov/govuk_publishing_components/pull/3292))
* Fix smart answer PII issue ([PR #3291](https://github.com/alphagov/govuk_publishing_components/pull/3291))
* Update accordion index parameter ([PR #3290](https://github.com/alphagov/govuk_publishing_components/pull/3290))
* Add GA4 tracking to step by step links ([PR #3289](https://github.com/alphagov/govuk_publishing_components/pull/3289))
* **BREAKING** Expand use of component wrapper helper ([PR #3254](https://github.com/alphagov/govuk_publishing_components/pull/3254))
