### PR TITLE
Update error summary to use component wrapper helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Always require AssetHelpers so gem can operate without Rails ([PR #3309](https://github.com/alphagov/govuk_publishing_components/pull/3309))
 * Update AssetHelper documentation ([PR #3298](https://github.com/alphagov/govuk_publishing_components/pull/3298))
 * Ensure color contrast in code examples meets accessibility requirements ([PR #3311](https://github.com/alphagov/govuk_publishing_components/pull/3311))
+* Update error summary to use component wrapper helper ([PR #3308](https://github.com/alphagov/govuk_publishing_components/pull/3308))
 
 ## 35.0.0
 

--- a/app/views/govuk_publishing_components/components/_error_summary.html.erb
+++ b/app/views/govuk_publishing_components/components/_error_summary.html.erb
@@ -9,12 +9,14 @@
   if items.empty? && !title
     raise ArgumentError, "The error_summary component needs at least one item or a title in order to render."
   end
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.set_id(id)
+  component_helper.add_class("gem-c-error-summary govuk-error-summary")
+  component_helper.add_data_attribute({ module: "govuk-error-summary" })
 %>
-<%= tag.div(
-  class: "gem-c-error-summary govuk-error-summary",
-  data: { module: "govuk-error-summary" }.merge(data_attributes),
-  id: id,
-) do %>
+
+<%= tag.div(**component_helper.all_attributes) do %>
   <%= tag.div(
     role: "alert",
   ) do %>

--- a/app/views/govuk_publishing_components/components/docs/error_summary.yml
+++ b/app/views/govuk_publishing_components/components/docs/error_summary.yml
@@ -7,6 +7,7 @@ shared_accessibility_criteria:
   - link
 accessibility_excluded_rules:
   - skip-link # This component is creating references to to sections on the page that do not exist in examples
+uses_component_wrapper_helper: true
 examples:
   default:
     data:
@@ -26,18 +27,6 @@ examples:
       - text: Descriptive link to the question with an error 2
         href: '#example-error-2'
       - text: Description of error without link
-  with_data_attributes:
-    description: |
-      The example shown applies a tracking attribute specifically for use by Google Tag Manager in [Content Publisher](https://github.com/alphagov/content-publisher).
-      
-      Other data attributes can also be applied as required. Note that the component does not include built in tracking. If this is required consider using the [track click script](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics/track-click.md).
-    data:
-      title: Message to alert the user to a problem goes here
-      description: Optional description of the errors and how to correct them
-      data_attributes:
-        tracking: GTM-123AB
-      items:
-      - text: Descriptive link to the question with an error 1
   with_custom_target_on_links:
     data:
       title: Message to alert the user to a problem goes here


### PR DESCRIPTION
## What
Update error summary to use [component wrapper helper](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component-wrapper-helper.md)

## Why

Resolves an issue whereby the data attribute for `module: "govuk-error-summary"` is overwritten when the same option is passed to the component. For example:

```
<%= render "govuk_publishing_components/components/error_summary", {
  data_attributes: {
    module: "auto-track-event"
  },
} %>
```
## Visual Changes
None

## Anything else
See https://github.com/alphagov/frontend/pull/3562