### PR TITLE
Always require AssetHelpers so gem can operate without Rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Always require AssetHelpers so gem can operate without Rails ([PR #3309](https://github.com/alphagov/govuk_publishing_components/pull/3309))
 * Update AssetHelper documentation ([PR #3298](https://github.com/alphagov/govuk_publishing_components/pull/3298))
 
 ## 35.0.0

--- a/lib/govuk_publishing_components.rb
+++ b/lib/govuk_publishing_components.rb
@@ -43,8 +43,6 @@ require "govuk_publishing_components/app_helpers/brand_helper"
 require "govuk_publishing_components/app_helpers/environment"
 require "govuk_publishing_components/app_helpers/asset_helper"
 
-require "govuk_publishing_components/railtie" if defined?(Rails::Railtie)
-
 # Add i18n paths and views for usage outside of a Rails app
 I18n.load_path.unshift(
   *Dir.glob(File.expand_path("config/locales/*.yml", GovukPublishingComponents::Config.gem_directory)),
@@ -54,6 +52,10 @@ ActiveSupport.on_load(:action_controller) do
   ActionController::Base.append_view_path(
     File.expand_path("app/views", GovukPublishingComponents::Config.gem_directory),
   )
+end
+
+ActiveSupport.on_load(:action_view) do
+  include GovukPublishingComponents::AppHelpers::AssetHelper
 end
 
 module GovukPublishingComponents

--- a/lib/govuk_publishing_components/railtie.rb
+++ b/lib/govuk_publishing_components/railtie.rb
@@ -1,7 +1,0 @@
-module GovukPublishingComponents
-  class Railtie < Rails::Railtie
-    initializer "govuk_publishing_components.view_helpers" do
-      ActiveSupport.on_load(:action_view) { include GovukPublishingComponents::AppHelpers::AssetHelper }
-    end
-  end
-end


### PR DESCRIPTION
## What

This fixes a problem I encountered when running Govspeak with the current version of the component gem:

```
Error:
GovspeakAttachmentTest#test_renders_an_attachment_component_for_a_found_attachment:
ActionView::Template::Error: undefined method `add_gem_component_stylesheet' for #<ActionView::Base:0x00000000002da0>
```

## Why

This error occurs because the views in this gem require the methods from GovukPublishingComponents::AppHelpers::AssetHelper and if they are only added if Rails exists then this gem will error. Govspeak is a user of this gem that does not have rails.

As this app is tested in a Rails environment it's very hard to write a test that exposes this issue and can cover a regression therefore I've not added one.

## Visual Changes

None