### PR TITLE
Ensure color contrast in code examples meets accessibility requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Always require AssetHelpers so gem can operate without Rails ([PR #3309](https://github.com/alphagov/govuk_publishing_components/pull/3309))
 * Update AssetHelper documentation ([PR #3298](https://github.com/alphagov/govuk_publishing_components/pull/3298))
+* Ensure color contrast in code examples meets accessibility requirements ([PR #3311](https://github.com/alphagov/govuk_publishing_components/pull/3311))
 
 ## 35.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -148,7 +148,7 @@
 
   code {
     padding: 0 5px;
-    color: govuk-colour("red");
+    color: #d13118;
     background-color: govuk-colour("light-grey");
   }
 }


### PR DESCRIPTION
## What
Update the text color for code examples in the component guide. The new color used is taken from the [Design System documentation](https://design-system.service.gov.uk/components/back-link/) and increases the color contrast from 4.34 to 4.51.

## Why
Improve legibility of the text and ensure that we meet [WCAG AA accessibility requirements](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html).

### Further info

https://gds-way.cloudapps.digital/manuals/accessibility.html#poor-colour-contrast

---

Fixes: https://github.com/alphagov/govuk_publishing_components/issues/3018