### PR TITLE
Remove 'Cost of living support' from navbar and footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Ensure color contrast in code examples meets accessibility requirements ([PR #3311](https://github.com/alphagov/govuk_publishing_components/pull/3311))
 * Update error summary to use component wrapper helper ([PR #3308](https://github.com/alphagov/govuk_publishing_components/pull/3308))
 * Add GA4 tracking to footer links ([PR #3306](https://github.com/alphagov/govuk_publishing_components/pull/3306))
+* Remove 'Cost of living support' from navbar and footer ([PR #3312](https://github.com/alphagov/govuk_publishing_components/pull/3312))
 
 ## 35.0.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -705,7 +705,7 @@ $after-button-padding-left: govuk-spacing(4);
   }
 
   @include govuk-media-query($from: "desktop") {
-    @include columns($items: 17, $columns: 2, $selector: "li", $flow: column);
+    @include columns($items: 16, $columns: 2, $selector: "li", $flow: column);
   }
 }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,8 +102,6 @@ en:
           href: "/browse/childcare-parenting"
         - text: Citizenship and living in the UK
           href: "/browse/citizenship"
-        - text: Cost of living support
-          href: "/cost-of-living"
         - text: Crime, justice and the law
           href: "/browse/justice"
         - text: Disabled people
@@ -185,8 +183,6 @@ en:
           href: "/browse/childcare-parenting"
         - label: Citizenship and living in the UK
           href: "/browse/citizenship"
-        - label: Cost of living support
-          href: "/cost-of-living"
         - label: Crime, justice and the law
           href: "/browse/justice"
         - label: Disabled people

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -123,13 +123,13 @@ describe "Super navigation header", type: :view do
     render_component({ ga4_tracking: true })
 
     assert_select "header[data-module='gem-track-click ga4-event-tracker ga4-link-tracker']"
-    assert_select "a[data-ga4-link]", count: 29
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","external":"false","text":"GOV.UK","section":"Logo","index":0,"index_total":29}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"1.1.1","index_total":29,"section":"Topics"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"1.1.17","index_total":29,"section":"Topics"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"1.2.1","index_total":29,"section":"Government activity"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"1.2.6","index_total":29,"section":"Government activity"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"2.2.1","index_total":29,"section":"Popular on GOV.UK"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"2.2.5","index_total":29,"section":"Popular on GOV.UK"}\']'
+    assert_select "a[data-ga4-link]", count: 28
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","external":"false","text":"GOV.UK","section":"Logo","index":0,"index_total":28}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"1.1.1","index_total":28,"section":"Topics"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"1.1.16","index_total":28,"section":"Topics"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"1.2.1","index_total":28,"section":"Government activity"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"1.2.6","index_total":28,"section":"Government activity"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"2.2.1","index_total":28,"section":"Popular on GOV.UK"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":"2.2.5","index_total":28,"section":"Popular on GOV.UK"}\']'
   end
 end


### PR DESCRIPTION
## What
Remove 'Cost of living support' from navbar and footer added in https://github.com/alphagov/govuk_publishing_components/pull/2939

## Why
The custom navigation page was replaced by a guide.
https://trello.com/c/j34Whcl4/1709-shut-down-cost-of-living-navigation-page-l

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before


### After
