### PR TITLE
Ga4 fix index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Make auditing aware of new asset loading model ([PR #3318](https://github.com/alphagov/govuk_publishing_components/pull/3318))
 * Ga4 part of heading tracking fix ([PR #3321](https://github.com/alphagov/govuk_publishing_components/pull/3321))
+* Ga4 fix index ([PR #3313](https://github.com/alphagov/govuk_publishing_components/pull/3313))
 
 ## 35.1.1
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -230,13 +230,19 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
           // Only index links that are not search results
           if (!link.getAttribute('data-ga4-ecommerce-path')) {
             totalLinks++
-            link.setAttribute('data-ga4-index', totalLinks)
+            link.setAttribute('data-ga4-index', '{"index_link": "' + totalLinks + '"}')
           }
         }
 
-        var ga4LinkData = JSON.parse(module.getAttribute('data-ga4-link'))
-        ga4LinkData.index_total = totalLinks
-        module.setAttribute('data-ga4-link', JSON.stringify(ga4LinkData))
+        try {
+          var ga4LinkData = JSON.parse(module.getAttribute('data-ga4-link'))
+          ga4LinkData.index_total = totalLinks
+          module.setAttribute('data-ga4-link', JSON.stringify(ga4LinkData))
+        } catch (e) {
+          // if there's a problem with the config, don't start the tracker
+          console.error('Unable to JSON.parse or JSON.stringify index: ' + e.message, window.location)
+          return
+        }
       },
 
       // index is given as a string of the form 1.2.3 or 1.2

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -241,7 +241,6 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
         } catch (e) {
           // if there's a problem with the config, don't start the tracker
           console.error('Unable to JSON.parse or JSON.stringify index: ' + e.message, window.location)
-          return
         }
       },
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -109,16 +109,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Ga4LinkTracker.prototype.setIndex = function (indexData, target) {
     var index
-    
-    if(target.getAttribute('data-ga4-index')) {
+
+    if (target.getAttribute('data-ga4-index')) {
       try {
         index = JSON.parse(target.getAttribute('data-ga4-index'))
       } catch (e) {
         console.error('Unable to parse index as JSON: ' + e.message, window.location)
         return
       }
-    }
-    else {
+    } else {
       index = indexData || undefined
     }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -87,8 +87,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       data.link_path_parts = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkPathParts(data.url)
       data.method = window.GOVUK.analyticsGa4.core.trackFunctions.getClickType(event)
       data.external = window.GOVUK.analyticsGa4.core.trackFunctions.isExternalLink(data.url) ? 'true' : 'false'
-      data.index = event.target.getAttribute('data-ga4-index') ? parseInt(event.target.getAttribute('data-ga4-index')) : data.index || undefined
-      data.index = window.GOVUK.analyticsGa4.core.trackFunctions.createIndexObject(data.index)
+      data.index = this.setIndex(data.index, event.target)
 
       if (data.type === 'smart answer' && data.action === 'change response') {
         data.section = PIIRemover.stripPIIWithOverride(data.section, true, true)
@@ -106,6 +105,24 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     } else {
       return target.closest('a')
     }
+  }
+
+  Ga4LinkTracker.prototype.setIndex = function (indexData, target) {
+    var index
+    
+    if(target.getAttribute('data-ga4-index')) {
+      try {
+        index = JSON.parse(target.getAttribute('data-ga4-index'))
+      } catch (e) {
+        console.error('Unable to parse index as JSON: ' + e.message, window.location)
+        return
+      }
+    }
+    else {
+      index = indexData || undefined
+    }
+
+    return window.GOVUK.analyticsGa4.core.trackFunctions.createIndexObject(index)
   }
 
   Modules.Ga4LinkTracker = Ga4LinkTracker

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -304,12 +304,12 @@ describe('GA4 core', function () {
         expect(data.index_total).toEqual(5)
       })
 
-      it('sets the index of each link', function () {
+      it('sets the index object of each link', function () {
         var links = module.querySelectorAll('a')
 
         for (var i = 0; i < links.length; i++) {
-          var linkIndex = parseInt(links[i].getAttribute('data-ga4-index'))
-          expect(linkIndex).toEqual(i + 1)
+          var linkIndex = links[i].getAttribute('data-ga4-index')
+          expect(linkIndex).toEqual('{"index_link": "' + (i + 1) + '"}')
         }
       })
     })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -335,4 +335,17 @@ describe('GA4 click tracker', function () {
       expect(GOVUK.analyticsGa4.core.trackFunctions.setIndexes).not.toHaveBeenCalled()
     })
   })
+
+  describe('when data-ga4-index exists on a link', function () {
+    it('will be used to set the index property', function () {
+      element = document.createElement('a')
+      element.setAttribute('data-ga4-link', '{"someData": "blah"}')
+      element.setAttribute('data-ga4-index', '{"index_link": "123"}')
+      element.setAttribute('href', '/')
+
+      initModule(element, true)
+
+      expect(window.dataLayer[0].event_data.index).toEqual({"index_link": "123"})
+    })
+  })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -345,7 +345,7 @@ describe('GA4 click tracker', function () {
 
       initModule(element, true)
 
-      expect(window.dataLayer[0].event_data.index).toEqual({"index_link": "123"})
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: '123' })
     })
   })
 })


### PR DESCRIPTION
## What
[PR #3277](https://github.com/alphagov/govuk_publishing_components/pull/3277) changed the structure of GA4 `index` attributes on HTML elements. This PR updates our JS to use the new `index` approach.

This PR also includes a minor refactor of how `data.index` is set.

## Why
Part of the GA4 migration.

[Trello card](https://trello.com/c/evfeFHKx/496-ga4-informationclick-index-bug)

## Visual Changes
N/A