### PR TITLE
Remove links and sections count tracking for Cost of living page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove links and sections count tracking for retired Cost of living hub page ([PR #3315](https://github.com/alphagov/govuk_publishing_components/pull/3315))
+
 ## 35.1.0
 
 * Always require AssetHelpers so gem can operate without Rails ([PR #3309](https://github.com/alphagov/govuk_publishing_components/pull/3309))

--- a/app/assets/javascripts/govuk_publishing_components/analytics/page-content.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics/page-content.js
@@ -17,8 +17,6 @@
         // if there are no accordion sections on the browse level 2 page
         // then it is a default page with one or two lists
         return document.querySelectorAll('[data-track-count="accordionSection"]').length || document.querySelectorAll('main .govuk-list').length
-      case isCostOfLivingHub():
-        return document.querySelectorAll('[data-track-count="accordionSection"]').length
       case isNewBrowsePage():
         return document.querySelectorAll('[data-track-count="cardList"]').length
       case isMainstreamBrowsePage():
@@ -53,7 +51,6 @@
       case isDocumentCollectionPage():
         return document.querySelectorAll('.document-collection .group-document-list li a').length
       case isNewBrowsePageLevelTwo():
-      case isCostOfLivingHub():
         return document.querySelectorAll('[data-track-count="contentLink"]').length
       case isNewBrowsePage():
         return document.querySelectorAll('[data-track-count="cardLink"]').length
@@ -109,11 +106,6 @@
   function isNewBrowsePageLevelTwo () {
     return getMetaAttribute(metaApplicationSelector) === 'collections' &&
       getMetaAttribute(metaNavigationTypeSelector) === 'browse level 2'
-  }
-
-  function isCostOfLivingHub () {
-    return getMetaAttribute(metaApplicationSelector) === 'collections' &&
-      getMetaAttribute(metaNavigationTypeSelector) === 'cost of living hub'
   }
 
   function isNewBrowsePage () {

--- a/spec/javascripts/govuk_publishing_components/analytics/page-content.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics/page-content.spec.js
@@ -446,29 +446,6 @@ describe('Page content', function () {
     })
   })
 
-  describe('in cost of living hub', function () {
-    beforeEach(function () {
-      createMetaTags('rendering-application', 'collections')
-      createMetaTags('navigation-page-type', 'cost of living hub')
-    })
-
-    it('gets the number of accordion sections', function () {
-      for (var i = 1; i <= 4; i++) {
-        createDummyElement('div', false, false, 'data-track-count', 'accordionSection')
-      }
-      var result = window.GOVUK.PageContent.getNumberOfSections()
-      expect(result).toEqual(4)
-    })
-
-    it('gets the number of links', function () {
-      for (var i = 1; i <= 4; i++) {
-        createDummyElement('a', false, false, 'data-track-count', 'contentLink')
-      }
-      var result = window.GOVUK.PageContent.getNumberOfLinks()
-      expect(result).toEqual(4)
-    })
-  })
-
   describe('by default', function () {
     it('gets the number of sidebar sections', function () {
       for (var p = 1; p <= 4; p++) {


### PR DESCRIPTION
## What
Remove links and sections count tracking for Cost of living page.
Reverts https://github.com/alphagov/govuk_publishing_components/pull/2921

## Why
Cost of living page used to be a custom navigation page hardcoded in collections.  It's been decommissioned and replaced with a guide, which doesn't need custom tracking.

https://trello.com/c/j34Whcl4/1709-shut-down-cost-of-living-navigation-page-l


## Visual Changes
n/a
