### PR TITLE
Update popular links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove links and sections count tracking for retired Cost of living hub page ([PR #3315](https://github.com/alphagov/govuk_publishing_components/pull/3315))
+* Update the list of popular links in the super navigation header ([PR #3316](https://github.com/alphagov/govuk_publishing_components/pull/3316))
 
 ## 35.1.0
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,8 +230,8 @@ en:
       navigation_search_heading: Search and popular pages
       navigation_search_subheading: Search
       popular_links:
-      - label: Check benefits and financial support you can get
-        href: "/check-benefits-financial-support"
+      - label: Get support with the cost of living
+        href: "/cost-of-living"
       - label: Find out about the Energy Bills Support Scheme
         href: "/guidance/getting-the-energy-bills-support-scheme-discount"
       - label: Find a job


### PR DESCRIPTION
## What

This removes /check-benefits-financial-support from the popular links and adds /cost-of-living so that it matches the list of popular links on the homepage. See https://github.com/alphagov/frontend/pull/3568

It's being actioned based on this Zendesk ticket https://govuk.zendesk.com/agent/tickets/5268340

## Visual Changes

### Before

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/42515961/226949988-89913d5a-0870-4cbd-a7ef-3d8360eeb82d.png">


### After

<img width="999" alt="image" src="https://user-images.githubusercontent.com/42515961/226949872-87a0e8be-bb35-4656-bffd-bf7bf02e776b.png">
