### PR TITLE
Release 35.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.1.1
 
 * Remove links and sections count tracking for retired Cost of living hub page ([PR #3315](https://github.com/alphagov/govuk_publishing_components/pull/3315))
 * Update the list of popular links in the super navigation header ([PR #3316](https://github.com/alphagov/govuk_publishing_components/pull/3316))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.1.0)
+    govuk_publishing_components (35.1.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.1.0".freeze
+  VERSION = "35.1.1".freeze
 end


### PR DESCRIPTION
* Remove links and sections count tracking for retired Cost of living hub page ([PR #3315](https://github.com/alphagov/govuk_publishing_components/pull/3315))
* Update the list of popular links in the super navigation header ([PR #3316](https://github.com/alphagov/govuk_publishing_components/pull/3316))