### PR TITLE
Make auditing aware of new asset loading model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Make auditing aware of new asset loading model ([PR #3318](https://github.com/alphagov/govuk_publishing_components/pull/3318))
+
 ## 35.1.1
 
 * Remove links and sections count tracking for retired Cost of living hub page ([PR #3315](https://github.com/alphagov/govuk_publishing_components/pull/3315))

--- a/app/models/govuk_publishing_components/audit_applications.rb
+++ b/app/models/govuk_publishing_components/audit_applications.rb
@@ -18,7 +18,9 @@ module GovukPublishingComponents
 
         find_components = /(?<=govuk_publishing_components\/components\/)[a-zA-Z_-]+(?=['"])/
 
-        @find_all_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components/
+        @find_all_stylesheets = /@import ["']{1}govuk_publishing_components\/all_components/ # if using the all stylesheets option
+        @find_individual_asset_model = /render_component_stylesheets/ # if using per page component asset loading
+        @uses_individual_asset_model = false
         find_stylesheets = /(?<=@import ["']{1}govuk_publishing_components\/components\/)(?!print\/)+[a-zA-Z_-]+(?=['"])/
 
         @find_all_javascripts = /\/\/ *= require govuk_publishing_components\/all_components/
@@ -63,6 +65,7 @@ module GovukPublishingComponents
         jquery_references: @jquery_references.flatten.uniq.sort,
         component_locations: @component_locations,
         helper_references: @helper_references,
+        uses_individual_asset_model: @uses_individual_asset_model,
       }
     end
 
@@ -125,6 +128,7 @@ module GovukPublishingComponents
       return %w[all] if src.match(@find_all_stylesheets) && type == "stylesheet"
       return %w[all] if src.match(@find_all_javascripts) && type == "javascript"
 
+      @uses_individual_asset_model = true if src.match(@find_individual_asset_model) && type == "template"
       matches = src.scan(find)
       return [] unless matches.any?
 

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -61,9 +61,6 @@ module GovukPublishingComponents
           javascripts = result[:components_found].find { |c| c[:location] == "javascript" }
           ruby = result[:components_found].find { |c| c[:location] == "ruby" }
 
-          @all_stylesheets = true if stylesheets[:components].include?("all")
-          @all_javascripts = true if javascripts[:components].include?("all")
-
           templates[:components] = include_any_components_within_components(templates[:components])
 
           warnings = []

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -54,6 +54,7 @@ module GovukPublishingComponents
 
       results.each do |result|
         if result[:application_found]
+          @current_uses_individual_asset_model = result[:uses_individual_asset_model]
           application_uses_static = @applications_using_static.include?(result[:name])
           templates = result[:components_found].find { |c| c[:location] == "template" }
           stylesheets = result[:components_found].find { |c| c[:location] == "stylesheet" }
@@ -103,6 +104,7 @@ module GovukPublishingComponents
             jquery_references: result[:jquery_references],
             component_locations: result[:component_locations],
             helper_references: result[:helper_references],
+            uses_individual_asset_model: result[:uses_individual_asset_model],
           }
         else
           data << {
@@ -161,7 +163,8 @@ module GovukPublishingComponents
 
             check_static = @static_data && second_location != "code"
             asset_in_static = asset_already_in_static(second_location, component) if check_static
-            raise_warning = asset_in_gem && !asset_in_static
+            suppress_warning = @current_uses_individual_asset_model && second_location == "stylesheet"
+            raise_warning = asset_in_gem && !asset_in_static && !suppress_warning
 
             # this raises a warning if the asset exists and isn't included either in the application or static
             warnings << create_warning(component, "Included in #{first_location} but not #{second_location}") if raise_warning

--- a/app/views/govuk_publishing_components/audit/_applications.html.erb
+++ b/app/views/govuk_publishing_components/audit/_applications.html.erb
@@ -37,12 +37,24 @@
         <% github_link = 'https://github.com/alphagov/' + application[:name] + '/blob/main/' %>
 
         <% if @other_applications %>
-          <% if application[:uses_static] %>
-            <p class="govuk-body">This application uses <a href="https://github.com/alphagov/static" class="govuk-link">static</a>, which can contain assets for components used in more than one application. Warnings for missing component assets in this application that are already included in static have been suppressed.</p>
+          <% if application[:uses_individual_asset_model] %>
+            <div class="govuk-warning-text">
+              <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+              <strong class="govuk-warning-text__text">
+                <span class="govuk-warning-text__assistive">Warning</span>
+                  This application uses <a class="govuk-link" href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/set-up-individual-component-css-loading.md">per page asset loading</a> for components. Warnings about missing stylesheets have been suppressed.
+              </strong>
+            </div>            
           <% end %>
 
-          <% if application[:uses_individual_asset_model] %>
-            <p class="govuk-body">This application uses per page asset loading for components. Warnings about missing stylesheets have been suppressed.</p>
+          <% if application[:uses_static] %>
+            <div class="govuk-warning-text">
+              <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+              <strong class="govuk-warning-text__text">
+                <span class="govuk-warning-text__assistive">Warning</span>
+                  This application uses <a href="https://github.com/alphagov/static" class="govuk-link">static</a>, which can contain assets for components used in more than one application. Warnings for missing component assets in this application that are already included in static have been suppressed.
+              </strong>
+            </div>            
           <% end %>
 
           <% application[:warnings].each do |warning| %>
@@ -71,7 +83,7 @@
               <dd class="govuk-summary-list__value">
                 <% if item[:value].length > 0 %>
                   <%= item[:value].join(", ") %>
-                <% elsif application[:uses_individual_asset_model] %>
+                <% elsif application[:uses_individual_asset_model] && item[:name] == "In stylesheets" %>
                   Uses per page component asset loading
                 <% else %>
                   None
@@ -83,13 +95,13 @@
 
         <% if application[:gem_style_references].any? %>
           <%= render "govuk_publishing_components/components/heading", {
-            text: "Component references",
+            text: "Component references (#{application[:gem_style_references].length})",
             font_size: "m",
             margin_bottom: 4,
             heading_level: 3,
           } %>
 
-          <p class="govuk-body">This shows instances of `gem-c-` classes found in the application. If a reference is found in a stylesheet or in code a warning is created, as this could be a style override or hard coded component markup.</p>
+          <p class="govuk-body">This shows instances of `gem-c-` classes found in the application. This could be a style override or hard coded component markup, which is a violation of our principle of <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_principles.md#a-component-is-isolated-when" class="govuk-link">component isolation</a>.</p>
           <ul class="govuk-list govuk-list--bullet">
             <% application[:gem_style_references].each do |ref| %>
               <li>
@@ -101,7 +113,7 @@
 
         <% if application[:jquery_references].any? %>
           <%= render "govuk_publishing_components/components/heading", {
-            text: "jQuery references",
+            text: "jQuery references (#{application[:jquery_references].length})",
             font_size: "m",
             margin_bottom: 4,
             heading_level: 3,

--- a/app/views/govuk_publishing_components/audit/_applications.html.erb
+++ b/app/views/govuk_publishing_components/audit/_applications.html.erb
@@ -41,6 +41,10 @@
             <p class="govuk-body">This application uses <a href="https://github.com/alphagov/static" class="govuk-link">static</a>, which can contain assets for components used in more than one application. Warnings for missing component assets in this application that are already included in static have been suppressed.</p>
           <% end %>
 
+          <% if application[:uses_individual_asset_model] %>
+            <p class="govuk-body">This application uses per page asset loading for components. Warnings about missing stylesheets have been suppressed.</p>
+          <% end %>
+
           <% application[:warnings].each do |warning| %>
             <p class="govuk-body">
               <strong class="govuk-tag">Warn</strong>
@@ -67,6 +71,8 @@
               <dd class="govuk-summary-list__value">
                 <% if item[:value].length > 0 %>
                   <%= item[:value].join(", ") %>
+                <% elsif application[:uses_individual_asset_model] %>
+                  Uses per page component asset loading
                 <% else %>
                   None
                 <% end %>

--- a/spec/component_guide/audit_applications_spec.rb
+++ b/spec/component_guide/audit_applications_spec.rb
@@ -76,6 +76,7 @@ describe "Auditing the components in applications" do
         SharedHelper: ["lib/test_file_3.rb"],
         TableHelper: ["app/views/welcome/table.html.erb"],
       },
+      uses_individual_asset_model: true,
     }
 
     expect(application.data).to match(expected)

--- a/spec/component_guide/audit_comparer_spec.rb
+++ b/spec/component_guide/audit_comparer_spec.rb
@@ -243,6 +243,7 @@ describe "Comparing data from an application with the components" do
         jquery_references: [],
         component_locations: {},
         helper_references: nil,
+        uses_individual_asset_model: nil,
       },
     ]
 
@@ -320,6 +321,7 @@ describe "Comparing data from an application with the components" do
         jquery_references: [],
         component_locations: {},
         helper_references: nil,
+        uses_individual_asset_model: nil,
       },
     ]
 
@@ -438,6 +440,7 @@ describe "Comparing data from an application with the components" do
         jquery_references: [],
         component_locations: {},
         helper_references: nil,
+        uses_individual_asset_model: nil,
       },
       {
         name: "static",
@@ -467,6 +470,7 @@ describe "Comparing data from an application with the components" do
         jquery_references: [],
         component_locations: {},
         helper_references: nil,
+        uses_individual_asset_model: nil,
       },
     ]
 
@@ -542,6 +546,7 @@ describe "Comparing data from an application with the components" do
         jquery_references: [],
         component_locations: {},
         helper_references: nil,
+        uses_individual_asset_model: nil,
       },
     ]
 
@@ -648,6 +653,7 @@ describe "Comparing data from an application with the components" do
         warning_count: 6,
         helper_references: nil,
         component_locations: {},
+        uses_individual_asset_model: nil,
       },
     ]
 


### PR DESCRIPTION
## What
Update the auditing so that it suppresses warnings relating to missing stylesheets for applications that use the new per page component asset loading model. This model is currently only implemented in `frontend`, but will be rolled out to other applications soon.

Also do some minor cleaning up of the UI, including adding a notice for the above where relevant.

## Why
To remove misleading auditing warnings.

## Visual Changes
Example of what `frontend` looks like in the auditing now:

![Screenshot 2023-03-23 at 10 07 17](https://user-images.githubusercontent.com/861310/227173994-d5eb5805-0953-400f-b29e-2273e9095ba7.png)
