### PR TITLE
Fix abbr element spacing in govuk-button--start 

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_button.scss
@@ -24,4 +24,11 @@
   .govuk-button--start {
     @extend .govuk-button--start;
   }
+
+  // Temporary fix for issue where there is no spacing between text
+  // and abbr elements in the govuk-button--start styled links
+
+  .govuk-button--start abbr {
+    padding: 0 .25em;
+  }
 }


### PR DESCRIPTION
## What

Add spacing to `abbr` so that in a link with `govuk-button--start` applied to it, there is spacing between the inline element and the text of the link.

## Why

If using an inline element (such as `<abbr>`, `<address>` or `<telephone>`) in a link with the `govuk-button--start` class applied to it, there will not be any spacing between the inline element and the text of the link. This issue came to our attention on this [page](https://www.gov.uk/government/organisations/department-for-work-pensions/about/accessible-documents-policy) of GOV.UK which was authored in Whitehall. 

I think this change in govspeak CSS should be temporary. Have raised an issue in [govuk-frontend](https://github.com/alphagov/govuk-frontend/issues/3406) but not sure what timeline of that fix will be.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

![Screenshot 2023-03-24 at 09 42 45](https://user-images.githubusercontent.com/3727504/227484344-b12efe31-b9ee-4f9c-bb16-982312208ec3.png)

### After

![Screenshot 2023-03-24 at 09 43 21](https://user-images.githubusercontent.com/3727504/227484318-b40f9982-b2ac-48b8-8ed7-2a13edb0a45e.png)
