### PR TITLE
Ga4 part of heading tracking fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Make auditing aware of new asset loading model ([PR #3318](https://github.com/alphagov/govuk_publishing_components/pull/3318))
+* Ga4 part of heading tracking fix ([PR #3321](https://github.com/alphagov/govuk_publishing_components/pull/3321))
 
 ## 35.1.1
 

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -23,8 +23,18 @@
             data-track-dimension="<%= links[0][:text] %>"
             data-track-dimension-index="29"
             data-track-options='{"dimension96" : "<%= links[0][:tracking_id] %>" }'
-            <% if ga4_tracking %>
-              data-ga4-link='{"event_name":"navigation", "type":"related content", "index":{"index_link": "1"}, "index_total":"1"}'
+            <% if ga4_tracking 
+              ga4_attributes = {
+                event_name: "navigation",
+                type: "related content",
+                index:{
+                  "index_link": "1"
+                },
+                index_total: "1",
+                section: "Part of",
+              }.to_json
+            %>
+              data-ga4-link="<%= ga4_attributes %>"
             <% end %>
           >
             <%= links[0][:text] %>
@@ -43,8 +53,18 @@
                 data-track-dimension="<%= link[:text] %>"
                 data-track-dimension-index="29"
                 data-track-options='{"dimension96" : "<%= link[:tracking_id] %>" }'
-                <% if ga4_tracking %>
-                  data-ga4-link='{"event_name":"navigation", "type":"related content", "index":{"index_link": "<%= index + 1 %>"}, "index_total": "<%= links.length %>"}'
+                <% if ga4_tracking 
+                  ga4_attributes = {
+                    event_name: "navigation",
+                    type: "related content",
+                    index:{
+                      "index_link": (index + 1).to_s
+                    },
+                    index_total: (links.length).to_s,
+                    section: "Part of",
+                  }.to_json
+                %>
+                  data-ga4-link="<%= ga4_attributes %>"
                 <% end %>
               >
                 <%= link[:text] %>

--- a/spec/components/step_by_step_nav_related_spec.rb
+++ b/spec/components/step_by_step_nav_related_spec.rb
@@ -117,7 +117,15 @@ describe "Step by step navigation related", type: :view do
 
     this_link = ".gem-c-step-nav-related .gem-c-step-nav-related__heading .govuk-link"
 
-    assert_select "#{this_link}[data-ga4-link='{\"event_name\":\"navigation\", \"type\":\"related content\", \"index\":{\"index_link\": \"1\"}, \"index_total\":\"1\"}']"
+    expected = {
+      "event_name": "navigation",
+      "type": "related content",
+      "index": { "index_link": "1" },
+      "index_total": "1",
+      "section": "Part of",
+    }
+
+    assert_select "#{this_link}[data-ga4-link='#{expected.to_json}']"
   end
 
   it "does not add GA4 data attributes when ga4_tracking is false" do
@@ -125,7 +133,15 @@ describe "Step by step navigation related", type: :view do
 
     this_link = ".gem-c-step-nav-related .gem-c-step-nav-related__heading .govuk-link"
 
-    assert_select "#{this_link}[data-ga4-link='{\"event_name\":\"navigation\", \"type\":\"related content\", \"index\":{\"index_link\": \"1\"}, \"index_total\":\"1\"}']", false
+    expected = {
+      "event_name": "navigation",
+      "type": "related content",
+      "index": { "index_link": "1" },
+      "index_total": "1",
+      "section": "Part of",
+    }
+
+    assert_select "#{this_link}[data-ga4-link='#{expected.to_json}']", false
   end
 
   it "adds GA4 data attributes on multiple links when ga4_tracking is true" do
@@ -134,8 +150,24 @@ describe "Step by step navigation related", type: :view do
     link_one = ".gem-c-step-nav-related .gem-c-step-nav-related__links .govuk-link[href='/link1']"
     link_two = ".gem-c-step-nav-related .gem-c-step-nav-related__links .govuk-link[href='/link2']"
 
-    assert_select "#{link_one}[data-ga4-link='{\"event_name\":\"navigation\", \"type\":\"related content\", \"index\":{\"index_link\": \"1\"}, \"index_total\": \"2\"}']"
-    assert_select "#{link_two}[data-ga4-link='{\"event_name\":\"navigation\", \"type\":\"related content\", \"index\":{\"index_link\": \"2\"}, \"index_total\": \"2\"}']"
+    expected_one = {
+      "event_name": "navigation",
+      "type": "related content",
+      "index": { "index_link": "1" },
+      "index_total": "2",
+      "section": "Part of",
+    }
+
+    expected_two = {
+      "event_name": "navigation",
+      "type": "related content",
+      "index": { "index_link": "2" },
+      "index_total": "2",
+      "section": "Part of",
+    }
+
+    assert_select "#{link_one}[data-ga4-link='#{expected_one.to_json}']"
+    assert_select "#{link_two}[data-ga4-link='#{expected_two.to_json}']"
   end
 
   it "does not add GA4 data attributes on multiple links when ga4_tracking is false" do
@@ -144,7 +176,23 @@ describe "Step by step navigation related", type: :view do
     link_one = ".gem-c-step-nav-related .gem-c-step-nav-related__links .govuk-link[href='/link1']"
     link_two = ".gem-c-step-nav-related .gem-c-step-nav-related__links .govuk-link[href='/link2']"
 
-    assert_select "#{link_one}[data-ga4-link='{\"event_name\":\"navigation\", \"type\":\"related content\", \"index\":{\"index_link\": \"1\"}, \"index_total\": \"2\"}']", false
-    assert_select "#{link_two}[data-ga4-link='{\"event_name\":\"navigation\", \"type\":\"related content\", \"index\":{\"index_link\": \"2\"}, \"index_total\": \"2\"}']", false
+    expected_one = {
+      "event_name": "navigation",
+      "type": "related content",
+      "index": { "index_link": "1" },
+      "index_total": "2",
+      "section": "Part of",
+    }
+
+    expected_two = {
+      "event_name": "navigation",
+      "type": "related content",
+      "index": { "index_link": "2" },
+      "index_total": "2",
+      "section": "Part of",
+    }
+
+    assert_select "#{link_one}[data-ga4-link='#{expected_one.to_json}']", false
+    assert_select "#{link_two}[data-ga4-link='#{expected_two.to_json}']", false
   end
 end


### PR DESCRIPTION
## What
This PR adds "Part of" to the `section` parameter for links that appear under the "Part of" header in the contextual sidebar. Previously, `section` was `undefined`.

## Why
GA4 migration bug fix requested by PA's.

[Trello card](https://trello.com/c/I0gafCaw/429-add-tracking-for-part-of-step-by-steps-related-content)

## Visual Changes
N/A
