### PR TITLE
Make the component wrapper more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update to Lux 307 ([PR #3329](https://github.com/alphagov/govuk_publishing_components/pull/3329))
 * Drop support for Ruby 2.7 ([PR #3310](https://github.com/alphagov/govuk_publishing_components/pull/3310))
 * Update GA4 index parameter ([PR #3297](https://github.com/alphagov/govuk_publishing_components/pull/3297))
+* Make the component wrapper helper more robust ([PR #3324](https://github.com/alphagov/govuk_publishing_components/pull/3324))
 * Make auditing aware of new asset loading model ([PR #3318](https://github.com/alphagov/govuk_publishing_components/pull/3318))
 * Ga4 part of heading tracking fix ([PR #3321](https://github.com/alphagov/govuk_publishing_components/pull/3321))
 * Ga4 fix index ([PR #3313](https://github.com/alphagov/govuk_publishing_components/pull/3313))

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -5,6 +5,7 @@ module GovukPublishingComponents
         @options = options
 
         check_id_is_valid(@options[:id]) if @options.include?(:id)
+        check_data_attributes_are_valid(@options[:data_attributes]) if @options.include?(:data_attributes)
         check_classes_are_valid(@options[:classes]) if @options.include?(:classes)
         check_aria_is_valid(@options[:aria]) if @options.include?(:aria)
         check_role_is_valid(@options[:role]) if @options.include?(:role)
@@ -33,6 +34,7 @@ module GovukPublishingComponents
       end
 
       def add_data_attribute(attributes)
+        check_data_attributes_are_valid(attributes)
         extend_object(:data_attributes, attributes)
       end
 
@@ -52,6 +54,15 @@ module GovukPublishingComponents
         return if id.blank?
 
         raise(ArgumentError, "Id (#{id}) cannot start with a number or contain whitespace and can only contain letters, digits, `_` and `-`") unless /^[a-zA-Z][\w:-]*$/.match?(id)
+      end
+
+      def check_data_attributes_are_valid(attributes)
+        return if attributes.blank?
+
+        attributes_keys = attributes.map { |key, _| key.to_s }
+        invalid_attributes = attributes_keys.map { |a| a if /^(xml)/.match?(a) || /[A-Z :]+/.match?(a) }.compact
+
+        raise(ArgumentError, "Data attributes (#{invalid_attributes.join(', ')}) cannot contain capitals, spaces or colons, or start with 'xml'") if invalid_attributes.any?
       end
 
       def check_classes_are_valid(classes)

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -51,15 +51,15 @@ module GovukPublishingComponents
       def check_id_is_valid(id)
         return if id.blank?
 
-        raise(ArgumentError, "Id cannot start with a number or contain whitespace and can only contain letters, digits, `_` and `-`") unless /^[a-zA-Z][\w:-]*$/.match?(id)
+        raise(ArgumentError, "Id (#{id}) cannot start with a number or contain whitespace and can only contain letters, digits, `_` and `-`") unless /^[a-zA-Z][\w:-]*$/.match?(id)
       end
 
       def check_classes_are_valid(classes)
         return if classes.blank?
 
-        classes = classes.split(" ")
-        unless classes.all? { |c| c.start_with?("js-", "gem-c-", "govuk-", "brand--") }
-          raise(ArgumentError, "Passed classes must be prefixed with `js-`")
+        class_array = classes.split(" ")
+        unless class_array.all? { |c| c.start_with?("js-", "gem-c-", "govuk-", "brand--") }
+          raise(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")
         end
       end
 
@@ -68,8 +68,12 @@ module GovukPublishingComponents
 
         arias = %w[activedescendant atomic autocomplete busy checked colcount colindex colspan controls current describedby description details disabled dropeffect errormessage expanded flowto grabbed haspopup hidden invalid keyshortcuts label labelledby level live modal multiline multiselectable orientation owns placeholder posinset pressed readonly relevant required roledescription rowcount rowindex rowspan selected setsize sort valuemax valuemin valuenow valuetext]
 
-        unless attributes.all? { |key, _value| arias.include? key.to_s }
-          raise(ArgumentError, "Aria attribute is not recognised")
+        # array keys are immutable so we have to do this to make a copy, in order to
+        # subtract valid aria attributes from invalid in the error message below
+        attributes_keys = attributes.map { |key, _| key.to_s }
+
+        unless attributes_keys.all? { |key| arias.include? key }
+          raise(ArgumentError, "Aria attribute (#{(attributes_keys - arias).join(', ')}) not recognised")
         end
       end
 
@@ -79,7 +83,7 @@ module GovukPublishingComponents
         roles = %w[alert alertdialog application article associationlist associationlistitemkey associationlistitemvalue banner blockquote caption cell code columnheader combobox complementary contentinfo definition deletion dialog directory document emphasis feed figure form group heading img insertion list listitem log main marquee math menu menubar meter navigation none note paragraph presentation region row rowgroup rowheader scrollbar search searchbox separator separator slider spinbutton status strong subscript superscript switch tab table tablist tabpanel term time timer toolbar tooltip tree treegrid treeitem]
         role = role.split(" ") # can have more than one role
         unless role.all? { |r| roles.include? r }
-          raise(ArgumentError, "Role attribute is not recognised")
+          raise(ArgumentError, "Role attribute (#{(role - roles).join(', ')}) is not recognised")
         end
       end
 

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -13,11 +13,11 @@ module GovukPublishingComponents
       def all_attributes
         attributes = {}
 
-        attributes[:id] = @options[:id] if @options[:id]
-        attributes[:data] = @options[:data_attributes] if @options[:data_attributes]
-        attributes[:aria] = @options[:aria] if @options[:aria]
-        attributes[:class] = @options[:classes] if @options[:classes]
-        attributes[:role] = @options[:role] if @options[:role]
+        attributes[:id] = @options[:id] unless @options[:id].blank?
+        attributes[:data] = @options[:data_attributes] unless @options[:data_attributes].blank?
+        attributes[:aria] = @options[:aria] unless @options[:aria].blank?
+        attributes[:class] = @options[:classes] unless @options[:classes].blank?
+        attributes[:role] = @options[:role] unless @options[:role].blank?
 
         attributes
       end
@@ -49,10 +49,14 @@ module GovukPublishingComponents
     private
 
       def check_id_is_valid(id)
+        return if id.blank?
+
         raise(ArgumentError, "Id cannot start with a number or contain whitespace and can only contain letters, digits, `_` and `-`") unless /^[a-zA-Z][\w:-]*$/.match?(id)
       end
 
       def check_classes_are_valid(classes)
+        return if classes.blank?
+
         classes = classes.split(" ")
         unless classes.all? { |c| c.start_with?("js-", "gem-c-", "govuk-", "brand--") }
           raise(ArgumentError, "Passed classes must be prefixed with `js-`")
@@ -60,6 +64,8 @@ module GovukPublishingComponents
       end
 
       def check_aria_is_valid(attributes)
+        return if attributes.blank?
+
         arias = %w[activedescendant atomic autocomplete busy checked colcount colindex colspan controls current describedby description details disabled dropeffect errormessage expanded flowto grabbed haspopup hidden invalid keyshortcuts label labelledby level live modal multiline multiselectable orientation owns placeholder posinset pressed readonly relevant required roledescription rowcount rowindex rowspan selected setsize sort valuemax valuemin valuenow valuetext]
 
         unless attributes.all? { |key, _value| arias.include? key.to_s }
@@ -68,6 +74,8 @@ module GovukPublishingComponents
       end
 
       def check_role_is_valid(role)
+        return if role.blank?
+
         roles = %w[alert alertdialog application article associationlist associationlistitemkey associationlistitemvalue banner blockquote caption cell code columnheader combobox complementary contentinfo definition deletion dialog directory document emphasis feed figure form group heading img insertion list listitem log main marquee math menu menubar meter navigation none note paragraph presentation region row rowgroup rowheader scrollbar search searchbox separator separator slider spinbutton status strong subscript superscript switch tab table tablist tabpanel term time timer toolbar tooltip tree treegrid treeitem]
         role = role.split(" ") # can have more than one role
         unless role.all? { |r| roles.include? r }

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -34,9 +34,10 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
     end
 
     it "rejects invalid class names" do
+      classes = "js-okay not-cool-man"
       expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "js-okay not-cool-man")
-      }.to raise_error(ArgumentError, "Passed classes must be prefixed with `js-`")
+        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: classes)
+      }.to raise_error(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")
     end
 
     it "can set an id, overriding a passed value" do
@@ -46,36 +47,22 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
     end
 
     it "does not accept invalid ids" do
-      error = "Id cannot start with a number or contain whitespace and can only contain letters, digits, `_` and `-`"
-      expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: "2idstartingwithanumber")
-      }.to raise_error(ArgumentError, error)
-
-      expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: "id containing spaces")
-      }.to raise_error(ArgumentError, error)
-
-      expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: "idwitha.character")
-      }.to raise_error(ArgumentError, error)
+      ["2idstartingwithanumber", "id containing spaces", "idwitha.character"].each do |id|
+        error = "Id (#{id}) cannot start with a number or contain whitespace and can only contain letters, digits, `_` and `-`"
+        expect {
+          GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: id)
+        }.to raise_error(ArgumentError, error)
+      end
     end
 
     it "does not accept invalid ids when passed" do
-      error = "Id cannot start with a number or contain whitespace and can only contain letters, digits, `_` and `-`"
-      expect {
-        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: "original")
-        helper.set_id("2idstartingwithanumber")
-      }.to raise_error(ArgumentError, error)
-
-      expect {
-        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: "original")
-        helper.set_id("id containing spaces")
-      }.to raise_error(ArgumentError, error)
-
-      expect {
-        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: "original")
-        helper.set_id("idwitha.character")
-      }.to raise_error(ArgumentError, error)
+      ["2idstartingwithanumber", "id containing spaces", "idwitha.character"].each do |id|
+        error = "Id (#{id}) cannot start with a number or contain whitespace and can only contain letters, digits, `_` and `-`"
+        expect {
+          helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(id: "original")
+          helper.set_id(id)
+        }.to raise_error(ArgumentError, error)
+      end
     end
 
     it "can add a class to already passed classes" do
@@ -85,10 +72,11 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
     end
 
     it "will error if trying to add an invalid class to already passed classes" do
+      classes = "gem-c-extra something-invalid"
       expect {
         helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "js-original")
-        helper.add_class("gem-c-extra something-invalid")
-      }.to raise_error(ArgumentError, "Passed classes must be prefixed with `js-`")
+        helper.add_class(classes)
+      }.to raise_error(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")
     end
 
     it "does not error if passed blank values" do
@@ -124,38 +112,39 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
     end
 
     it "does not accept invalid aria attributes" do
-      error = "Aria attribute is not recognised"
+      invalid_aria = { potato: "salad", label: "something", spoon: "invalid" }
+      error = "Aria attribute (potato, spoon) not recognised"
       expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(aria: { potato: "salad" })
+        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(aria: invalid_aria)
       }.to raise_error(ArgumentError, error)
 
       expect {
         helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(aria: { label: "something" })
-        helper.add_aria_attribute({ potato: "salad" })
+        helper.add_aria_attribute(invalid_aria)
       }.to raise_error(ArgumentError, error)
     end
 
     it "does not accept an invalid role" do
-      error = "Role attribute is not recognised"
+      error = "Role attribute (custarddoughnuts, moose) is not recognised"
       expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "custarddoughnuts")
+        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "custarddoughnuts moose")
       }.to raise_error(ArgumentError, error)
 
       expect {
-        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "navigation custarddoughnuts")
+        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "navigation custarddoughnuts moose")
       }.to raise_error(ArgumentError, error)
     end
 
     it "does not accept an invalid role when passed" do
-      error = "Role attribute is not recognised"
+      error = "Role attribute (custarddoughnuts, moose) is not recognised"
       expect {
         helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "navigation")
-        helper.add_role("custarddoughnuts")
+        helper.add_role("custarddoughnuts moose")
       }.to raise_error(ArgumentError, error)
 
       expect {
         helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "navigation")
-        helper.add_role("alert custarddoughnuts")
+        helper.add_role("alert custarddoughnuts moose")
       }.to raise_error(ArgumentError, error)
     end
   end

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -99,6 +99,19 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
       expect(component_helper.all_attributes).to eql({})
     end
 
+    it "does not accept invalid data attributes" do
+      invalid_data = { module: "ok", xml_something: "notok", "XML_something": "notok", "has space": "notok", "has:colon": "notok", normal: "ok" }
+      error = "Data attributes (xml_something, XML_something, has space, has:colon) cannot contain capitals, spaces or colons, or start with 'xml'"
+      expect {
+        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(data_attributes: invalid_data)
+      }.to raise_error(ArgumentError, error)
+
+      expect {
+        helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(data_attributes: { module: "something" })
+        helper.add_data_attribute(invalid_data)
+      }.to raise_error(ArgumentError, error)
+    end
+
     it "can add data attributes to already passed data attributes" do
       helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(data_attributes: { module: "original-module", other: "other" })
       helper.add_data_attribute({ module: "extra-module", another: "another" })

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -91,6 +91,26 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
       }.to raise_error(ArgumentError, "Passed classes must be prefixed with `js-`")
     end
 
+    it "does not error if passed blank values" do
+      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(
+        id: nil,
+        classes: nil,
+        data_attributes: nil,
+        aria: nil,
+        role: nil,
+      )
+      expect(component_helper.all_attributes).to eql({})
+
+      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(
+        id: "",
+        classes: "",
+        data_attributes: "",
+        aria: "",
+        role: "",
+      )
+      expect(component_helper.all_attributes).to eql({})
+    end
+
     it "can add data attributes to already passed data attributes" do
       helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(data_attributes: { module: "original-module", other: "other" })
       helper.add_data_attribute({ module: "extra-module", another: "another" })


### PR DESCRIPTION
## What
Improve the component wrapper helper in the following ways.

- let it recognise if blank or nil values are passed for certain things. Previously it was possible to pass `nil` as an ID attribute, at which point the wrapper would error because `nil` is not a valid HTML ID, rather than simply ignoring it
- improve the error messages to include the thing that is causing the error, in order to make troubleshooting issues easier

## Why
`Frontend` had a bit of code where `nil` was being [passed to a component as an ID](https://github.com/alphagov/frontend/commit/44a16abd2888cb0dddbb4a2d01f5a75477bbb089), which was causing the build to fail. This change should prevent similar errors in the future.

## Visual Changes
None.
