### PR TITLE
Make Cookie Banner Implementation More Like Design System Implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Make Cookie Banner Implementation More Like Design System Implementation [(PR #3325)](https://github.com/alphagov/govuk_publishing_components/pull/3325)
+
 ## 35.3.2
 
 * Fix GA4 index_total parameter in various places ([PR #3358](https://github.com/alphagov/govuk_publishing_components/pull/3358))

--- a/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
@@ -76,7 +76,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   CookieBanner.prototype.setCookieConsent = function () {
     if (this.$acceptCookiesButton.getAttribute('data-cookie-types') === 'all') {
-      this.$module.querySelector('.gem-c-cookie-banner__confirmation-message__accepted').hidden = false
+      this.$module.querySelector('.gem-c-cookie-banner__confirmation-message--accepted').hidden = false
     }
     window.GOVUK.approveAllCookieTypes()
     this.$module.showConfirmationMessage()
@@ -92,7 +92,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   CookieBanner.prototype.rejectCookieConsent = function () {
-    this.$module.querySelector('.gem-c-cookie-banner__confirmation-message__rejected').hidden = false
+    this.$module.querySelector('.gem-c-cookie-banner__confirmation-message--rejected').hidden = false
     this.$module.showConfirmationMessage()
     this.$module.cookieBannerConfirmationMessage.focus()
     window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
@@ -100,11 +100,17 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   CookieBanner.prototype.showConfirmationMessage = function () {
-    this.$cookieBannerMainContent = document.querySelector('.js-banner-wrapper')
+    this.$cookieBannerHeader = document.querySelector('.govuk-cookie-banner__heading')
+    this.$cookieBannerHeader.hidden = true
 
+    this.$cookieBannerMainContent = document.querySelector('.gem-c-cookie-banner__content')
     this.$cookieBannerMainContent.hidden = true
-    this.$module.cookieBannerConfirmationMessage.style.display = 'block'
-    this.$module.cookieBannerConfirmationMessage.hidden = false
+
+    this.$cookieBannerConfirmationButtons = document.querySelector('.js-confirmation-buttons')
+    this.$cookieBannerConfirmationButtons.hidden = true
+
+    this.$cookieBannerHideButton = document.querySelector('.js-hide-button')
+    this.$cookieBannerHideButton.hidden = false
   }
 
   CookieBanner.prototype.isInCookiesPage = function () {

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
@@ -1,15 +1,18 @@
 @import "govuk_publishing_components/individual_component_support";
 @import "govuk/components/cookie-banner/cookie-banner";
-$govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
+
+.gem-c-cookie-banner .govuk-button-group[hidden] {
+  display: none;
+}
+
+.govuk-cookie-banner .govuk-cookie-banner__heading[hidden] {
+  display: none;
+}
 
 .js-enabled {
   .gem-c-cookie-banner {
     display: none; // shown with JS, always on for non-JS
   }
-}
-
-.gem-c-cookie-banner {
-  background-color: $govuk-cookie-banner-background;
 }
 
 // can't be used without js so implement there
@@ -18,64 +21,10 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
 }
 
 .gem-c-cookie-banner__confirmation {
-  display: none;
-  position: relative;
-  padding: govuk-spacing(1);
-
   // This element is focused using JavaScript so that it's being read out by screen readers
   // for this reason we don't want to show the default outline or emphasise it visually using `govuk-focused-text`
   &:focus {
     outline: none;
-  }
-}
-
-.gem-c-cookie-banner__confirmation-message,
-.gem-c-cookie-banner__hide-button {
-  display: block;
-
-  @include govuk-media-query($from: desktop) {
-    display: inline-block;
-  }
-}
-
-.gem-c-cookie-banner__confirmation-message {
-  margin-right: govuk-spacing(4);
-
-  @include govuk-media-query($from: desktop) {
-    max-width: 90%;
-    margin-bottom: 0;
-  }
-}
-
-// Override style from design system so we can have consistent
-// padding on the the banner and the confirmation
-
-.govuk-cookie-banner {
-  padding-top: 0;
-}
-
-// Override the styles from govuk_template
-// stylelint-disable selector-max-id
-.gem-c-cookie-banner#global-cookie-message {
-  background-color: $govuk-cookie-banner-background;
-  padding: govuk-spacing(3) 0 0 0;
-  box-sizing: border-box;
-
-  .gem-c-cookie-banner__message,
-  .gem-c-cookie-banner__buttons,
-  .gem-c-cookie-banner__confirmation,
-  .gem-c-cookie-banner__confirmation-message {
-    @include govuk-font($size: 19);
-  }
-
-  p {
-    @include govuk-font($size: 19);
-    margin: 0 0 govuk-spacing(2) 0;
-  }
-
-  .gem-c-cookie-banner__message,
-  .gem-c-cookie-banner__confirmation {
-    margin-bottom: - govuk-spacing(2);
   }
 }
 

--- a/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
@@ -28,71 +28,63 @@
                                   },
                                 )))
   services_cookies ||= nil
-  css_classes = %w(gem-c-cookie-banner govuk-clearfix)
+  css_classes = %w(gem-c-cookie-banner govuk-clearfix govuk-cookie-banner js-banner-wrapper)
   css_classes << "gem-c-cookie-banner--services" if services_cookies
 %>
+
 <div id="<%= id %>" class="<%= css_classes.join(' ') %>" data-module="cookie-banner" data-nosnippet role="region" aria-label="<%= title %>">
-  <div class="govuk-cookie-banner js-banner-wrapper">
-    <div class="gem-c-cookie-banner__message govuk-cookie-banner__message govuk-width-container">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h2 class="govuk-cookie-banner__heading govuk-heading-m"><%= title %></h2>
-          <div class="govuk-cookie-banner__content">
-            <%= text %>
-          </div>
+  <div class="govuk-cookie-banner__message govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m"><%= title %></h2>
+        <div tabindex="-1" class="govuk-cookie-banner__content gem-c-cookie-banner__confirmation">
+          <span class="gem-c-cookie-banner__content"><%= text %></span>
+          <p class="gem-c-cookie-banner__confirmation-message--accepted govuk-body" hidden><%= t("components.cookie_banner.confirmation_message.accepted") %>. <span class="gem-c-cookie-banner__confirmation-message"><%= confirmation_message %></span></p>
+          <p class="gem-c-cookie-banner__confirmation-message--rejected govuk-body" hidden><%= t("components.cookie_banner.confirmation_message.rejected") %>. <span class="gem-c-cookie-banner__confirmation-message"><%= confirmation_message %></span></p>
         </div>
       </div>
-      <% if services_cookies %>
-          <div class="govuk-button-group">
-            <%= render "govuk_publishing_components/components/button", {
-              name: "cookies",
-              text: services_cookies.dig(:yes, :text) || "Yes",
-              data_attributes: { module: "gem-track-click", "accept-cookies": "true", }.merge(services_cookies.dig(:yes, :data_attributes) || {})
-            } %>
-            <%= render "govuk_publishing_components/components/button", {
-              name: "cookies",
-              text: services_cookies.dig(:no, :text) || "No",
-              data_attributes: { module: "gem-track-click", "reject-cookies": "true", }.merge(services_cookies.dig(:no, :data_attributes) || {})
-            } %>
-            <% if services_cookies[:cookie_preferences] %>
-              <%= link_to services_cookies.dig(:cookie_preferences, :text), services_cookies.dig(:cookie_preferences, :href), class: "govuk-link" %>
-            <% end %>
-          </div>
-        <% else %>
-          <div class="govuk-button-group">
-            <%= render "govuk_publishing_components/components/button", {
-                name: "cookies",
-                text: t("components.cookie_banner.buttons.accept_cookies"),
-                data_attributes: {
-                  module: "gem-track-click",
-                  "accept-cookies": "true",
-                  "track-category": "cookieBanner",
-                  "track-action": "Cookie banner accepted",
-                  "cookie-types": "all",
-                }
-            } %>
-            <%= render "govuk_publishing_components/components/button", {
-                name: "cookies",
-                text: t("components.cookie_banner.buttons.reject_cookies"),
-                data_attributes: {
-                  module: "gem-track-click",
-                  "reject-cookies": "true",
-                  "track-category": "cookieBanner",
-                  "track-action": "Cookie banner rejected",
-                }
-            } %>
-            <a class="govuk-link" href="<%= cookie_preferences_href %>"><%= t("components.cookie_banner.buttons.view_cookies") %></a>
-          </div>
-        <% end %>
     </div>
-  </div>
-  <div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1" hidden>
-    <p class="gem-c-cookie-banner__confirmation-message" role="alert">
-      <span class="gem-c-cookie-banner__confirmation-message__accepted" hidden><%= t("components.cookie_banner.confirmation_message.accepted") %>. </span>
-      <span class="gem-c-cookie-banner__confirmation-message__rejected" hidden><%= t("components.cookie_banner.confirmation_message.rejected") %>. </span>
-      <%= confirmation_message %>
-    </p>
-    <div class="govuk-button-group">
+    <div class="js-confirmation-buttons govuk-button-group">
+      <% if services_cookies %>
+        <%= render "govuk_publishing_components/components/button", {
+          name: "cookies",
+          text: services_cookies.dig(:yes, :text) || "Yes",
+          data_attributes: { module: "gem-track-click", "accept-cookies": "true", }.merge(services_cookies.dig(:yes, :data_attributes) || {})
+        } %>
+        <%= render "govuk_publishing_components/components/button", {
+          name: "cookies",
+          text: services_cookies.dig(:no, :text) || "No",
+          data_attributes: { module: "gem-track-click", "reject-cookies": "true", }.merge(services_cookies.dig(:no, :data_attributes) || {})
+        } %>
+        <% if services_cookies[:cookie_preferences] %>
+          <%= link_to services_cookies.dig(:cookie_preferences, :text), services_cookies.dig(:cookie_preferences, :href), class: "govuk-link" %>
+        <% end %>
+      <% else %>
+        <%= render "govuk_publishing_components/components/button", {
+            name: "cookies",
+            text: t("components.cookie_banner.buttons.accept_cookies"),
+            data_attributes: {
+              module: "gem-track-click",
+              "accept-cookies": "true",
+              "track-category": "cookieBanner",
+              "track-action": "Cookie banner accepted",
+              "cookie-types": "all",
+            }
+        } %>
+        <%= render "govuk_publishing_components/components/button", {
+            name: "cookies",
+            text: t("components.cookie_banner.buttons.reject_cookies"),
+            data_attributes: {
+              module: "gem-track-click",
+              "reject-cookies": "true",
+              "track-category": "cookieBanner",
+              "track-action": "Cookie banner rejected",
+            }
+        } %>
+        <a class="govuk-link" href="<%= cookie_preferences_href %>"><%= t("components.cookie_banner.buttons.view_cookies") %></a>
+      <% end %>
+    </div>
+    <div hidden class="js-hide-button govuk-button-group">
       <button class="gem-c-cookie-banner__hide-button govuk-button" data-hide-cookie-banner="true" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner"><%= t("components.cookie_banner.hide") %></button>
     </div>
   </div>

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -46,7 +46,7 @@ describe "Cookie banner", type: :view do
   it "renders a hide link within the confirmation banner" do
     render_component({})
 
-    assert_select ".gem-c-cookie-banner__confirmation .gem-c-cookie-banner__hide-button", text: "Hide this message"
+    assert_select ".govuk-button-group .gem-c-cookie-banner__hide-button", text: "Hide this message"
     assert_select '.gem-c-cookie-banner__hide-button[data-module=gem-track-click][data-track-category=cookieBanner][data-track-action="Hide cookie banner"]'
   end
 
@@ -56,8 +56,8 @@ describe "Cookie banner", type: :view do
       text: sanitize("This is some custom text with a link to the <a href='/cookies' class='govuk-link'>cookies page</a>"),
       confirmation_message: "You’ve accepted all cookies.",
     )
-    assert_select ".gem-c-cookie-banner__message .govuk-heading-m", text: "Can we store analytics cookies on your device?"
-    assert_select ".govuk-cookie-banner__content", text: "This is some custom text with a link to the cookies page"
+    assert_select ".govuk-cookie-banner__heading.govuk-heading-m", text: "Can we store analytics cookies on your device?"
+    assert_select ".gem-c-cookie-banner__content", text: "This is some custom text with a link to the cookies page"
     assert_select ".govuk-link[href='/cookies']", text: "cookies page"
     assert_select ".gem-c-cookie-banner__confirmation-message", text: /You’ve accepted all cookies./
   end

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -249,7 +249,7 @@ describe "Layout for public", type: :view do
       },
     })
 
-    assert_select ".gem-c-cookie-banner__message .govuk-cookie-banner__heading", text: "Can we use cookies to collect information about how you use GOV.UK?"
+    assert_select ".govuk-cookie-banner__heading.govuk-heading-m", text: "Can we use cookies to collect information about how you use GOV.UK?"
   end
 
   it "displays as draft watermark" do

--- a/spec/javascripts/components/cookie-banner-spec.js
+++ b/spec/javascripts/components/cookie-banner-spec.js
@@ -14,37 +14,32 @@ describe('Cookie banner', function () {
     container = document.createElement('div')
 
     container.innerHTML =
-    '<div id="global-cookie-message" class="gem-c-cookie-banner govuk-clearfix" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet="" style="display: block;">' +
-      '<div class="govuk-cookie-banner js-banner-wrapper" role="region" aria-label="Cookies on GOV.UK">' +
-        '<div class="gem-c-cookie-banner__message govuk-cookie-banner__message govuk-width-container govuk-body">' +
-          '<div class="govuk-grid-row">' +
-            '<div class="govuk-grid-column-two-thirds">' +
-              '<h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on GOV.UK</h2>' +
-              '<div class="govuk-cookie-banner__content">' +
-                '<p class="govuk-body">We use some essential cookies to make this website work</p>' +
-                '<p class="govuk-body">We\'d like to set additional cookies to understand how you use GOV.UK, remember your settings and improve government services.</p>' +
-                '<p class="govuk-body">We also use cookies set by other sites to help us deliver content from their services.</p>' +
+      '<div id="global-cookie-message" class="gem-c-cookie-banner govuk-clearfix govuk-cookie-banner js-banner-wrapper" data-module="cookie-banner" data-nosnippet="" role="region" aria-label="Cookies on GOV.UK">' +
+          '<div class="govuk-cookie-banner__message govuk-width-container">' +
+              '<div class="govuk-grid-row">' +
+                  '<div class="govuk-grid-column-two-thirds">' +
+                      '<h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on GOV.UK</h2>' +
+                      '<div tabindex="-1" class="govuk-cookie-banner__content gem-c-cookie-banner__confirmation">' +
+                          '<span class="gem-c-cookie-banner__content">' +
+                              '<p class="govuk-body">We use some essential cookies to make this website work.</p>' +
+                              '<p class="govuk-body">We’d like to set additional cookies to understand how you use GOV.UK, remember your settings and improve government services.</p>' +
+                              '<p class="govuk-body">We also use cookies set by other sites to help us deliver content from their services.</p>' +
+                          '</span>' +
+                          '<p class="gem-c-cookie-banner__confirmation-message--accepted govuk-body" hidden="">You have accepted additional cookies. <span class="gem-c-cookie-banner__confirmation-message">You can <a class="govuk-link" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation" href="/help/cookies">change your cookie settings</a> at any time.</span></p>' +
+                          '<p class="gem-c-cookie-banner__confirmation-message--rejected govuk-body" hidden="">You have rejected additional cookies. <span class="gem-c-cookie-banner__confirmation-message">You can <a class="govuk-link" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation" href="/help/cookies">change your cookie settings</a> at any time.</span></p>' +
+                      '</div>' +
+                  '</div>' +
               '</div>' +
-            '</div>' +
+              '<div class="js-confirmation-buttons govuk-button-group">' +
+                  '<button class="gem-c-button govuk-button" type="submit" data-module="gem-track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted" data-cookie-types="all" style="display: block;">Accept additional cookies</button>' +
+                  '<button class="gem-c-button govuk-button" type="submit" data-module="gem-track-click" data-reject-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner rejected" style="display: block;">Reject additional cookies</button>' +
+                  '<a class="govuk-link" href="/help/cookies">View cookies</a>' +
+              '</div>' +
+              '<div hidden="" class="js-hide-button govuk-button-group">' +
+                  '<button class="gem-c-cookie-banner__hide-button govuk-button" data-hide-cookie-banner="true" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide this message</button>' +
+              '</div>' +
           '</div>' +
-          '<div class="govuk-button-group">' +
-            '<button class="gem-c-button govuk-button" type="submit" data-module="gem-track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted" data-cookie-types="all" style="display: block;">Accept additional cookies</button>' +
-            '<button class="gem-c-button govuk-button" type="submit" data-module="gem-track-click" data-reject-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner rejected" style="display: block;">Reject additional cookies</button>' +
-            '<a class="govuk-link" href="/help/cookies">View cookies</a>' +
-          '</div>' +
-        '</div>' +
-      '</div>' +
-      '<div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1" hidden="">' +
-        '<p class="gem-c-cookie-banner__confirmation-message" role="alert">' +
-          '<span class="gem-c-cookie-banner__confirmation-message__accepted" hidden>You have accepted additional cookies. </span>' +
-          '<span class="gem-c-cookie-banner__confirmation-message__rejected" hidden="">You have rejected additional cookies. </span>' +
-          'You can <a class="govuk-link" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation" href="/help/cookies">change your cookie settings</a> at any time.' +
-        '</p>' +
-        '<div class="govuk-button-group">' +
-          '<button class="gem-c-cookie-banner__hide-button govuk-button" data-hide-cookie-banner="true" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide this message</button>' +
-        '</div>' +
-      '</div>' +
-    '</div>'
+      '</div>'
 
     document.body.appendChild(container)
     // set and store consent for all as a basis of comparison
@@ -65,11 +60,13 @@ describe('Cookie banner', function () {
     new GOVUK.Modules.CookieBanner(element).init()
 
     var cookieBannerMain = document.querySelector('.js-banner-wrapper')
-    var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
+    var cookieBannerConfirmationAccept = document.querySelector('.gem-c-cookie-banner__confirmation-message--accepted')
+    var cookieBannerConfirmationReject = document.querySelector('.gem-c-cookie-banner__confirmation-message--rejected')
 
     expect(element).toBeVisible()
     expect(cookieBannerMain).toBeVisible()
-    expect(cookieBannerConfirmation).toBeHidden()
+    expect(cookieBannerConfirmationAccept).toBeHidden()
+    expect(cookieBannerConfirmationReject).toBeHidden()
   })
 
   it('should show the cookie banner when preferences have not been actively set', function () {
@@ -79,11 +76,13 @@ describe('Cookie banner', function () {
     new GOVUK.Modules.CookieBanner(element).init()
 
     var cookieBannerMain = document.querySelector('.js-banner-wrapper')
-    var cookieBannerConfirmation = document.querySelector('.gem-c-cookie-banner__confirmation')
+    var cookieBannerConfirmationAccept = document.querySelector('.gem-c-cookie-banner__confirmation-message--accepted')
+    var cookieBannerConfirmationReject = document.querySelector('.gem-c-cookie-banner__confirmation-message--rejected')
 
     expect(element).toBeVisible()
     expect(cookieBannerMain).toBeVisible()
-    expect(cookieBannerConfirmation).toBeHidden()
+    expect(cookieBannerConfirmationAccept).toBeHidden()
+    expect(cookieBannerConfirmationReject).toBeHidden()
   })
 
   it('should hide the cookie banner when preferences have been actively set', function () {
@@ -165,18 +164,14 @@ describe('Cookie banner', function () {
     new GOVUK.Modules.CookieBanner(element).init()
 
     var acceptCookiesButton = document.querySelector('[data-accept-cookies]')
-    var mainCookieBanner = document.querySelector('.gem-c-cookie-banner__message')
-    var confirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
-    var confirmationMessageText = document.querySelector('.gem-c-cookie-banner__confirmation-message')
+    var confirmationMessageAccepted = document.querySelector('.gem-c-cookie-banner__confirmation-message--accepted')
 
-    expect(mainCookieBanner).toBeVisible()
-    expect(confirmationMessage).toBeHidden()
+    expect(confirmationMessageAccepted).toBeHidden()
 
     acceptCookiesButton.click()
 
-    expect(mainCookieBanner).toBeHidden()
-    expect(confirmationMessage).toBeVisible()
-    expect(confirmationMessageText.innerText).toContain('You have accepted additional cookies. You can change your cookie settings at any time.')
+    expect(confirmationMessageAccepted).toBeVisible()
+    expect(confirmationMessageAccepted.innerText).toContain('You have accepted additional cookies. You can change your cookie settings at any time.')
   })
 
   it('shows a confirmation message when cookies have been rejected', function () {
@@ -184,18 +179,28 @@ describe('Cookie banner', function () {
     new GOVUK.Modules.CookieBanner(element).init()
 
     var rejectCookiesButton = document.querySelector('[data-reject-cookies]')
-    var mainCookieBanner = document.querySelector('.gem-c-cookie-banner__message')
-    var confirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
-    var confirmationMessageText = document.querySelector('.gem-c-cookie-banner__confirmation-message')
+    var confirmationMessageRejected = document.querySelector('.gem-c-cookie-banner__confirmation-message--rejected')
 
-    expect(mainCookieBanner).toBeVisible()
-    expect(confirmationMessage).toBeHidden()
+    expect(confirmationMessageRejected).toBeHidden()
 
     rejectCookiesButton.click()
 
-    expect(mainCookieBanner).toBeHidden()
-    expect(confirmationMessage).toBeVisible()
-    expect(confirmationMessageText.innerText).toContain('You have rejected additional cookies. You can change your cookie settings at any time.')
+    expect(confirmationMessageRejected).toBeVisible()
+    expect(confirmationMessageRejected.innerText).toContain('You have rejected additional cookies. You can change your cookie settings at any time.')
+  })
+
+  it('set focus to the confirmation message after clicking button', function () {
+    var element = document.querySelector('[data-module="cookie-banner"]')
+    new GOVUK.Modules.CookieBanner(element).init()
+
+    var rejectCookiesButton = document.querySelector('[data-reject-cookies]')
+    var confirmationMessage = document.querySelector('.gem-c-cookie-banner__confirmation')
+
+    rejectCookiesButton.click()
+
+    var focusedElement = document.activeElement
+
+    expect(focusedElement.className).toBe(confirmationMessage.className)
   })
 
   it('set cookies_preferences_set cookie, and re-set cookies_policy expiration date when rejecting cookies', function () {


### PR DESCRIPTION
## What

Align the Cookie Banner in the govuk_publishing_components to the Cookie Banner in the Design System. This involved:

- Replacing the partial with the same HTML as the Design System Cookie Banner
- Reworking how the JS hides/shows confirmation messages
- Removing unnecessary classes now the HTML is the same as the Design System Cookie Banner
- Updating the tests to make sure they still work, including adding new test for the focus after the user has made a choice

## Why

The Cookie Banner in govuk_publishing_components has different HTML to the Cookie Banner in the Design System. This is despite the fact that the they both resemble each other and have no differences in functionality. Ideally they should be using the same mark-up and classes as the Design System implementation is backed up by user-research and accessibility testing. It will also make it easier to keep up with future updates to the Cookie Banner.

## Visual Changes

We are removing the bespoke padding between the paragraphs and using the classes in the Design System implementation instead. It also means replacing the full-width wrapper with a 2/3rds width wrapper. This results in visual changes and these changes have been run past a designer who has approved them.

### Before

![Screenshot 2023-04-17 at 16 56 04](https://user-images.githubusercontent.com/3727504/232543738-b2982c96-3399-47a3-87d4-e6f0aed6ca98.png)

![Screenshot 2023-04-18 at 17 07 22](https://user-images.githubusercontent.com/3727504/232837407-ea41e14f-1538-4584-b953-3f9c55133084.png)


### After

![image](https://user-images.githubusercontent.com/3727504/232543796-c5a7f943-d9ac-4630-8d66-08e052f747b1.png)

![Screenshot 2023-04-18 at 17 07 29](https://user-images.githubusercontent.com/3727504/232837428-e440ab3d-0ca7-44c1-98cb-3afbb19efd6d.png)


[Relevant Trello Card](https://trello.com/c/j82uodb1/1728-align-cookie-banner-with-govuk-design-system-cookie-banner-m)
