### PR TITLE
Ga4 accordion link tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add data attributes to attachment links using JS [(PR #3330)](https://github.com/alphagov/govuk_publishing_components/pull/3330)
+* Ga4 accordion link tracking ([PR #3328](https://github.com/alphagov/govuk_publishing_components/pull/3328))
 
 ## 35.2.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -230,7 +230,7 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
           // Only index links that are not search results
           if (!link.getAttribute('data-ga4-ecommerce-path')) {
             totalLinks++
-            link.setAttribute('data-ga4-index', '{"index_link": "' + totalLinks + '"}')
+            link.setAttribute('data-ga4-index', '{"index_link": ' + totalLinks + '}')
           }
         }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -108,28 +108,22 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   Ga4LinkTracker.prototype.setIndex = function (indexData, target) {
-    var index
+    var index = window.GOVUK.analyticsGa4.core.trackFunctions.createIndexObject(indexData)
 
     if (target.getAttribute('data-ga4-index')) {
       try {
-        index = JSON.parse(target.getAttribute('data-ga4-index'))
+        var indexLink = JSON.parse(target.getAttribute('data-ga4-index'))
 
         // Check whether the index object already exists on a parent element, as is the case with tracking accordion links.
-        // If true, combine data-ga4-index with the index object
-        if (typeof indexData === 'object') {
-          for (var i = 0; i < Object.keys(indexData).length; i++) {
-            index[Object.keys(indexData)[i]] = indexData[Object.keys(indexData)[i]]
-          }
-        }
+        // If true, combine data-ga4-index with the index object. Otherwise, just return indexLink
+        index = index ? window.GOVUK.extendObject(index, indexLink) : indexLink
       } catch (e) {
         console.error('Unable to parse index as JSON: ' + e.message, window.location)
         return
       }
-    } else {
-      index = indexData || undefined
     }
 
-    return window.GOVUK.analyticsGa4.core.trackFunctions.createIndexObject(index)
+    return index
   }
 
   Modules.Ga4LinkTracker = Ga4LinkTracker

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -113,6 +113,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (target.getAttribute('data-ga4-index')) {
       try {
         index = JSON.parse(target.getAttribute('data-ga4-index'))
+
+        // Check whether the index object already exists on a parent element, as is the case with tracking accordion links.
+        // If true, combine data-ga4-index with the index object
+        if (typeof indexData === 'object') {
+          for (var i = 0; i < Object.keys(indexData).length; i++) {
+            index[Object.keys(indexData)[i]] = indexData[Object.keys(indexData)[i]]
+          }
+        }
       } catch (e) {
         console.error('Unable to parse index as JSON: ' + e.message, window.location)
         return

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -63,8 +63,8 @@
             type: "accordion",
             section: item[:heading][:text],
             index: {
-              index_section: index.to_s,
-              index_section_count: (items.length).to_s,
+              index_section: index,
+              index_section_count: (items.length),
             }
           }.to_json
         end

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -37,6 +37,7 @@
         index = i + 1
 
         item[:data_attributes] ||= nil
+        ga4_link_data_attributes ||= nil
 
         if ga4_tracking
           item[:data_attributes] ||= {}
@@ -48,6 +49,24 @@
               index_section: index,
               index_section_count: items.length,
             },
+          }.to_json
+
+          # Data attributes for accordion links. These have been created 
+          # separately from the item[:data_attributes] object in order to 
+          # keep them from colliding with GA4 event tracking and UA tracking 
+          # attributes
+          ga4_link_data_attributes = {}
+          ga4_link_data_attributes[:module] = "ga4-link-tracker"
+          ga4_link_data_attributes[:ga4_tracks_links_only] = ""
+          ga4_link_data_attributes[:ga4_set_indexes] = ""
+          ga4_link_data_attributes[:ga4_link] = {
+            event_name: "navigation",
+            type: "accordion",
+            section: item[:heading][:text],
+            index: {
+              index_section: index.to_s,
+              index_section_count: (items.length).to_s,
+            }
           }.to_json
         end
 
@@ -74,7 +93,13 @@
           %>
           <%= tag.div(item[:summary][:text], id: "#{id}-summary-#{index}", class: summary_classes) if item[:summary].present? %>
         <% end %>
-        <%= tag.div(item[:content][:html], id: "#{id}-content-#{index}", class: "govuk-accordion__section-content", 'aria-labelledby': "#{id}-heading-#{index}") %>
+        <%= tag.div(
+          item[:content][:html], 
+          id: "#{id}-content-#{index}", 
+          class: "govuk-accordion__section-content", 
+          'aria-labelledby': "#{id}-heading-#{index}",
+          data: ga4_link_data_attributes
+        ) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -51,10 +51,9 @@
             },
           }.to_json
 
-          # Data attributes for accordion links. These have been created 
-          # separately from the item[:data_attributes] object in order to 
-          # keep them from colliding with GA4 event tracking and UA tracking 
-          # attributes
+          # These attributes have been created separately from the item[:data_attributes] 
+          # object in order to keep them from colliding with GA4 event tracking and UA 
+          # tracking attributes
           ga4_link_data_attributes = {}
           ga4_link_data_attributes[:module] = "ga4-link-tracker"
           ga4_link_data_attributes[:ga4_tracks_links_only] = ""

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -309,7 +309,7 @@ describe('GA4 core', function () {
 
         for (var i = 0; i < links.length; i++) {
           var linkIndex = links[i].getAttribute('data-ga4-index')
-          expect(linkIndex).toEqual('{"index_link": "' + (i + 1) + '"}')
+          expect(linkIndex).toEqual('{"index_link": ' + (i + 1) + '}')
         }
       })
     })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -348,4 +348,66 @@ describe('GA4 click tracker', function () {
       expect(window.dataLayer[0].event_data.index).toEqual({ index_link: '123' })
     })
   })
+
+  describe('when data-ga4-index exists on the target element', function () {
+    it('sets the index object to contain index_link only', function () {
+      element = document.createElement('a')
+      element.setAttribute('data-ga4-link', '{"someData": "blah"}')
+      element.setAttribute('data-ga4-index', '{"index_link": "123"}')
+      element.setAttribute('href', '#link1')
+
+      initModule(element, true)
+
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: '123' })
+    })
+  })
+
+  describe('when data-ga4-index exists on the target element and index exists on the parent', function () {
+    it('combines both objects into a single index object', function () {
+      element = document.createElement('div')
+      element.setAttribute('data-ga4-track-links-only', '')
+      element.setAttribute('data-ga4-link', '{"index":{"index_section": "1", "index_section_count": "2"}}')
+      element.innerHTML = '<a class="link" href="#link1">Link 1</a>'
+
+      var link = element.querySelector('.link')
+      link.setAttribute('data-ga4-index', '{"index_link": "' + 3 + '"}')
+
+      initModule(element, false)
+      link.click()
+
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: '3', index_section: '1', index_section_count: '2' })
+    })
+  })
+
+  describe('when data-ga4-index does not exist on the target element but index exists on the parent', function () {
+    it('does not modify the index object', function () {
+      element = document.createElement('div')
+      element.setAttribute('data-ga4-track-links-only', '')
+      element.setAttribute('data-ga4-link', '{"index":{"index_section": "1", "index_section_count": "2"}}')
+      element.innerHTML = '<a class="link" href="#link1">Link 1</a>'
+
+      var link = element.querySelector('.link')
+
+      initModule(element, false)
+      link.click()
+
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_section: '1', index_section_count: '2' })
+    })
+  })
+
+  describe('if neither data-ga4-index or index exist', function () {
+    it('sets the index property to undefined', function () {
+      element = document.createElement('div')
+      element.setAttribute('data-ga4-track-links-only', '')
+      element.setAttribute('data-ga4-link', '{"someData": "blah"}')
+      element.innerHTML = '<a class="link" href="#link1">Link 1</a>'
+
+      var link = element.querySelector('.link')
+
+      initModule(element, false)
+      link.click()
+
+      expect(window.dataLayer[0].event_data.index).toEqual(undefined)
+    })
+  })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -340,12 +340,12 @@ describe('GA4 click tracker', function () {
     it('will be used to set the index property', function () {
       element = document.createElement('a')
       element.setAttribute('data-ga4-link', '{"someData": "blah"}')
-      element.setAttribute('data-ga4-index', '{"index_link": "123"}')
+      element.setAttribute('data-ga4-index', '{"index_link": 123}')
       element.setAttribute('href', '/')
 
       initModule(element, true)
 
-      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: '123' })
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 123 })
     })
   })
 
@@ -353,29 +353,46 @@ describe('GA4 click tracker', function () {
     it('sets the index object to contain index_link only', function () {
       element = document.createElement('a')
       element.setAttribute('data-ga4-link', '{"someData": "blah"}')
-      element.setAttribute('data-ga4-index', '{"index_link": "123"}')
+      element.setAttribute('data-ga4-index', '{"index_link": 123}')
       element.setAttribute('href', '#link1')
 
       initModule(element, true)
 
-      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: '123' })
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 123 })
     })
   })
 
   describe('when data-ga4-index exists on the target element and index exists on the parent', function () {
-    it('combines both objects into a single index object', function () {
+    it('combines both (when index is an object) into a single index object', function () {
       element = document.createElement('div')
       element.setAttribute('data-ga4-track-links-only', '')
-      element.setAttribute('data-ga4-link', '{"index":{"index_section": "1", "index_section_count": "2"}}')
+      element.setAttribute('data-ga4-link', '{"index":{"index_section": 1, "index_section_count": 2}}')
       element.innerHTML = '<a class="link" href="#link1">Link 1</a>'
 
       var link = element.querySelector('.link')
-      link.setAttribute('data-ga4-index', '{"index_link": "' + 3 + '"}')
+      link.setAttribute('data-ga4-index', '{"index_link": ' + 3 + '}')
 
       initModule(element, false)
       link.click()
 
-      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: '3', index_section: '1', index_section_count: '2' })
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 3, index_section: 1, index_section_count: 2 })
+    })
+    it('combines both (when index is a string) into a single index object', function () {
+      element = document.createElement('div')
+      element.setAttribute('data-ga4-track-links-only', '')
+
+      // index can appear as a decimal however we only need to test one digit in this case because a decimal indicates
+      // that the link index is already available and therefore wouldn't require combining with data-ga4-index
+      element.setAttribute('data-ga4-link', '{"index": "4"}')
+      element.innerHTML = '<a class="link" href="#link1">Link 1</a>'
+
+      var link = element.querySelector('.link')
+      link.setAttribute('data-ga4-index', '{"index_link": ' + 6 + '}')
+
+      initModule(element, false)
+      link.click()
+
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 6, index_section: 4 })
     })
   })
 
@@ -383,7 +400,7 @@ describe('GA4 click tracker', function () {
     it('does not modify the index object', function () {
       element = document.createElement('div')
       element.setAttribute('data-ga4-track-links-only', '')
-      element.setAttribute('data-ga4-link', '{"index":{"index_section": "1", "index_section_count": "2"}}')
+      element.setAttribute('data-ga4-link', '{"index":{"index_section": 1, "index_section_count": 2}}')
       element.innerHTML = '<a class="link" href="#link1">Link 1</a>'
 
       var link = element.querySelector('.link')
@@ -391,7 +408,7 @@ describe('GA4 click tracker', function () {
       initModule(element, false)
       link.click()
 
-      expect(window.dataLayer[0].event_data.index).toEqual({ index_section: '1', index_section_count: '2' })
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_section: 1, index_section_count: 2 })
     })
   })
 


### PR DESCRIPTION
## What
This PR adds GA4 tracking to accordion links. 

This PR also includes a change to the `setIndex` function and it will now combine `data-ga4-index` (our method of adding `index_link` to links that are generated by content publishers ([further details here)](https://github.com/alphagov/govuk_publishing_components/pull/3262)) with the `index` property if it exists on a parent element.

## Why
Part of the GA4 migration.

The change to `setIndex` has been made because in some scenarios, such as accordion links, we need to set `data-ga4-link` on a parent element due to the links being generated by a content publisher. Within `data-ga4-link`, an `index` property may already exist and contain values such as `index_section` and `index_section_count`. In order to prevent this data from being overwritten with the value in `data-ga4-index` (the previous implementation set `index` to the value of `data-ga4-index` if it existed), `setIndex` combines them together.

[Trello card](https://trello.com/c/F8LlOd07/490-add-tracking-accordion-links)

## Visual Changes
N/A
