### PR TITLE
Add data attributes to attachment links using JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add data attributes to attachment links using JS [(PR #3330)](https://github.com/alphagov/govuk_publishing_components/pull/3330)
+
 ## 35.2.0
 
 * Update to Lux 307 ([PR #3329](https://github.com/alphagov/govuk_publishing_components/pull/3329))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -273,6 +273,31 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
               index_link: parseInt(index[2])
             }
         }
+      },
+
+      addAttributesToElements: function (selector, dataAttributes) {
+        var targetElements = document.querySelectorAll(selector)
+
+        for (var i = 0; i < targetElements.length; i++) {
+          var element = targetElements[i]
+
+          for (var j = 0; j < dataAttributes.length; j++) {
+            var key = dataAttributes[j].key
+            var value = dataAttributes[j].value
+
+            // value must check for undefined only as it would return false on an empty string, the number 0, etc.
+            if (key && value !== undefined) {
+              var existingAttributeValue = element.getAttribute(key)
+
+              if (key === 'data-module' && existingAttributeValue) {
+                // Combines values to prevent replacing any existing data-module values.
+                element.setAttribute(key, existingAttributeValue + ' ' + value)
+              } else {
+                element.setAttribute(key, value)
+              }
+            }
+          }
+        }
       }
     },
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
@@ -8,6 +8,11 @@ var initFunction = function () {
     window.GOVUK.analyticsGa4.vars.internalDomains = []
     window.GOVUK.analyticsGa4.vars.internalDomains.push(window.GOVUK.analyticsGa4.core.trackFunctions.getHostname())
     window.GOVUK.analyticsGa4.core.trackFunctions.appendDomainsWithoutWWW(window.GOVUK.analyticsGa4.vars.internalDomains)
+    var attachmentLinkData = [
+      { key: 'data-module', value: 'ga4-link-tracker' },
+      { key: 'data-ga4-track-links-only', value: '' },
+      { key: 'data-ga4-link', value: JSON.stringify({ event_name: 'navigation', type: 'html attachment' }) }]
+    window.GOVUK.analyticsGa4.core.trackFunctions.addAttributesToElements('[data-ga4-attachment-link]', attachmentLinkData)
     window.GOVUK.analyticsGa4.core.load()
 
     var analyticsModules = window.GOVUK.analyticsGa4.analyticsModules

--- a/docs/analytics-ga4/analytics.md
+++ b/docs/analytics-ga4/analytics.md
@@ -50,6 +50,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
 
 When cookie consent is given, `init-ga4.js` looks through the `analyticsModules` object for anything with an `init` function, and executes them if found. This means that analytics code will not be executed unless consent is given, and gives a standard way to add more analytics code without additional initialisation.
 
+`init-ga4.js` also handles adding data attributes to certain HTML elements, such as attachment links defined in our `whitehall` repo. This approach is used when it is difficult to maintain data attributes directly on the tracked elements' HTML. In the case of the attachment links, it would require republishing thousands of documents each time the attachment link data attributes need changing. Therefore, it is more efficient to add the GA4 HTML attributes via JavaScript as it is easier to just redeploy `govuk_publishing_components` instead with changes. The code for adding these attributes sits in `init-ga4.js` as the attributes need to exist before `analyticsModules` are run. This is so that when trackers initialise, they can find the data attributes (i.e. `data-module='ga4-link-tracker'`), and will therefore know to add the right event listeners to the elements in question.
+
 ### Code structure for Modules
 
 Where analytics code is required as a [GOV.UK JavaScript Module](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/javascript-modules.md), the code structure for the [existing model for deferred loading](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/javascript-modules.md#modules-and-cookie-consent) should be used.

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
@@ -69,6 +69,50 @@ describe('Initialising GA4', function () {
       delete GOVUK.analyticsGa4.analyticsModules.TestError
       delete GOVUK.analyticsGa4.analyticsModules.TestNotError
     })
+
+    describe('adding attachment link data attributes to elements', function () {
+      var elements = []
+      beforeEach(function () {
+        GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+        for (var i = 0; i < 5; i++) {
+          elements[i] = document.createElement('div')
+          elements[i].setAttribute('data-ga4-attachment-link', '')
+          document.body.appendChild(elements[i])
+        }
+      })
+
+      afterEach(function () {
+        for (var i = 0; i < 5; i++) {
+          document.body.removeChild(elements[i])
+        }
+      })
+
+      it('adds correct data attributes to each element', function () {
+        GOVUK.analyticsGa4.init()
+
+        for (var i = 0; i < 5; i++) {
+          expect(elements[i].getAttribute('data-module')).toEqual('ga4-link-tracker')
+          expect(elements[i].getAttribute('data-ga4-track-links-only')).toEqual('')
+          expect(elements[i].getAttribute('data-ga4-link')).toEqual(JSON.stringify({ event_name: 'navigation', type: 'html attachment' }))
+        }
+      })
+
+      it('combines data modules if a module already exists', function () {
+        for (var i = 0; i < 5; i++) {
+          elements[i].setAttribute('data-module', 'govspeak')
+          elements[i].setAttribute('data-ga4-link', 'i will be overwritten')
+          elements[i].setAttribute('data-ga4-track-links-only', 'i will be overwritten too')
+        }
+
+        GOVUK.analyticsGa4.init()
+
+        for (i = 0; i < 5; i++) {
+          expect(elements[i].getAttribute('data-module')).toEqual('govspeak ga4-link-tracker')
+          expect(elements[i].getAttribute('data-ga4-track-links-only')).toEqual('')
+          expect(elements[i].getAttribute('data-ga4-link')).toEqual(JSON.stringify({ event_name: 'navigation', type: 'html attachment' }))
+        }
+      })
+    })
   })
 
   describe('Modules depending on cookie consent to run', function () {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Sets the GA4 data attributes for attachment links via JavaScript, instead of setting them directly on the attachment links' HTML.

## Why
<!-- What are the reasons behind this change being made? -->
Initially we were going to set our GA4 data attributes directly on each attachment links' HTML - as shown in https://github.com/alphagov/whitehall/pull/7481. However, as the HTML lives in `whitehall`, deploying the new HTML to our servers requires us to republish 45k+ documents which takes a bit of time.

This could become an issue if we constantly need to make changes to the data attributes, as we'd need to republish 45k documents every time. It also feels a bit like technical debt to implement something that would require 45k republishes to update.

Therefore, in `whitehall` we are going to set an attribute called `data-ga4-attachment-links` on the HTML of each attachment link once. Then, we can add the actual data attributes using JS by grabbing every instance of `data-ga4-attachment-link`. This will stop us having to republish 45k+ documents if the GA4 attributes ever need changing/updating. With this technique, we will only need to do the 45k+ republish once, just to add the tag `data-ga4-attachment-link` on everything.

I put the function call in `init-ga4.js` as it needs to run before the `ga4-link-tracker` module runs, otherwise the module wouldn't get initialised on the HTML if `data-module='ga4-link-tracker'` was added to each link after the tracker was initialised.

## Testing

The JS tests should demonstrate that it works, however if you want to see it for yourself:

1. Run `static` locally with a local version of `govuk_publishing_components`
2. Run `government-frontend`, pointing to your local `static`
3. Go to `init-ga4.js` in `govuk_publishing_components` and on `line 15` change the CSS selector we're using from `[data-ga4-attachment-link]` to `section.attachment.embedded`.
4. If you go to http://127.0.0.1:3090/government/publications/equality-act-guidance you will see that every attachment link has the GA4 link attributes - this is because they are section elements with the classes `attachment embedded`, so our GA4 code has added the attributes to every element matching `section.attachment.embedded`. Of course in our real solution we are going to be adding a GA4 specific selector `[data-ga4-attachment-link]` to the links we need via `whitehall`.

## Visual Changes
None.

### Before


### After
