### PR TITLE
Version 35.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.2.0
 
 * Update to Lux 307 ([PR #3329](https://github.com/alphagov/govuk_publishing_components/pull/3329))
 * Drop support for Ruby 2.7 ([PR #3310](https://github.com/alphagov/govuk_publishing_components/pull/3310))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.1.1)
+    govuk_publishing_components (35.2.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.1.1".freeze
+  VERSION = "35.2.0".freeze
 end


### PR DESCRIPTION
## 35.2.0

* Update to Lux 307 ([PR #3329](https://github.com/alphagov/govuk_publishing_components/pull/3329))
* Drop support for Ruby 2.7 ([PR #3310](https://github.com/alphagov/govuk_publishing_components/pull/3310))
* Update GA4 index parameter ([PR #3297](https://github.com/alphagov/govuk_publishing_components/pull/3297))
* Make the component wrapper helper more robust ([PR #3324](https://github.com/alphagov/govuk_publishing_components/pull/3324))
* Make auditing aware of new asset loading model ([PR #3318](https://github.com/alphagov/govuk_publishing_components/pull/3318))
* Ga4 part of heading tracking fix ([PR #3321](https://github.com/alphagov/govuk_publishing_components/pull/3321))
* Ga4 fix index ([PR #3313](https://github.com/alphagov/govuk_publishing_components/pull/3313))
* Fix search icon cut-off in navbar  ([PR #3322](https://github.com/alphagov/govuk_publishing_components/pull/3322))
* Update AssetHelper documentation  ([PR #3323](https://github.com/alphagov/govuk_publishing_components/pull/3323))
