### PR TITLE
Update the Attachment component to accept a thumbnail parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add brand colour for DSIT ([PR #3349](https://github.com/alphagov/govuk_publishing_components/pull/3349))
 * Update GA4 index parameter on related navigation ([PR #3346](https://github.com/alphagov/govuk_publishing_components/pull/3346))
+* Update the Attachment component to accept a thumbnail parameter ([PR #3332](https://github.com/alphagov/govuk_publishing_components/pull/3332))
 
 ## 35.3.0
 

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -42,7 +42,9 @@
                 tabindex: "-1",
                 "aria-hidden": true,
                 data: data_attributes do %>
-      <% if attachment.document? %>
+      <% if attachment.thumbnail_url %>
+        <% image_tag(attachment.thumbnail_url, alt: "") %>
+      <% elsif attachment.document? %>
         <%= render "govuk_publishing_components/components/attachment/thumbnail_document" %>
       <% elsif attachment.spreadsheet? %>
         <%= render "govuk_publishing_components/components/attachment/thumbnail_spreadsheet" %>

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -168,3 +168,12 @@ examples:
         filename: department-for-transport-information-asset-register.csv
         content_type: text/csv
         file_size: 20000
+  with_custom_thumbnail:
+    data:
+      attachment:
+        title: "Department for Transport, temporary snow ploughs: guidance note"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/259634/temporary-snow-ploughs.pdf
+        filename: temporary-snow-ploughs.pdf
+        content_type: application/pdf
+        file_size: 20000
+        thumbnail_url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/791567/thumbnail_the_government_financial_reporting_review_web.pdf.png"

--- a/lib/govuk_publishing_components/presenters/attachment_helper.rb
+++ b/lib/govuk_publishing_components/presenters/attachment_helper.rb
@@ -12,6 +12,10 @@ module GovukPublishingComponents
         @attachment_data = attachment_data.with_indifferent_access
       end
 
+      def thumbnail_url
+        @attachment_data[:thumbnail_url]
+      end
+
       def title
         attachment_data.fetch(:title)
       end

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -129,6 +129,24 @@ describe "Attachment", type: :view do
     assert_select ".gem-c-attachment__metadata:nth-of-type(1)", text: "Ref: ISBN 978-1-5286-1173-2, 2259, Cd. 67"
   end
 
+  it "shows PDF thumbnails previews for PDF attachments" do
+    render_component(
+      attachment: {
+        title: "The government financial reporting review",
+        url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/791567/the_government_financial_reporting_review_web.pdf",
+        filename: "department-for-transport-information-asset-register.csv",
+        content_type: "application/pdf",
+        file_size: 20_000,
+        number_of_pages: 7,
+        isbn: "978-1-5286-1173-2",
+        unique_reference: "2259",
+        command_paper_number: "Cd. 67",
+        thumbnail_url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/791567/thumbnail_the_government_financial_reporting_review_web.pdf.png",
+      },
+    )
+    rendered.should include("https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/791567/thumbnail_the_government_financial_reporting_review_web.pdf.png")
+  end
+
   it "shows unnumbered details on the second metadata line if marked so" do
     render_component(
       attachment: {


### PR DESCRIPTION
[Trello card](https://trello.com/c/QX2nA0SV/1176-add-support-for-custom-thumbnails-to-the-attachment-govukpublishingcomponent)

## What
Update the Attachment component to accept new parameter for custom thumbnails.
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
We want to remove attachment rendering functionality out of Whitehall and instead use the functionality provided by the Govspeak gem (it uses govuk_publishing_components to render attachments so we need to update the Attachment component here to support PDF preview thumbnails).

## Visual Changes
The will be no visual change - thumbnails for PDF attachments should be rendered the same way as with previous implementation.

<img width="742" alt="Screenshot 2023-04-02 at 12 04 18" src="https://user-images.githubusercontent.com/4563521/229348980-161efa6a-bfee-4658-8d3a-88b67b8bf64d.png">
