### PR TITLE
Version 35.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.3.0
 
 * Add data attributes to attachment links using JS [(PR #3330)](https://github.com/alphagov/govuk_publishing_components/pull/3330)
 * Ga4 accordion link tracking ([PR #3328](https://github.com/alphagov/govuk_publishing_components/pull/3328))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.2.0)
+    govuk_publishing_components (35.3.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.2.0".freeze
+  VERSION = "35.3.0".freeze
 end


### PR DESCRIPTION
## 35.3.0

* Add data attributes to attachment links using JS [(PR #3330)](https://github.com/alphagov/govuk_publishing_components/pull/3330)
* Ga4 accordion link tracking ([PR #3328](https://github.com/alphagov/govuk_publishing_components/pull/3328))
* Fix GA4 Step Nav link tracking bug ([PR #3334](https://github.com/alphagov/govuk_publishing_components/pull/3334))
