### PR TITLE
Update GA4 index parameter on related navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@
 
 ## Unreleased
 
-* Add brand colour for DSIT [(PR #3349)](https://github.com/alphagov/govuk_publishing_components/pull/3349)
+* Add brand colour for DSIT ([PR #3349](https://github.com/alphagov/govuk_publishing_components/pull/3349))
+* Update GA4 index parameter on related navigation ([PR #3346](https://github.com/alphagov/govuk_publishing_components/pull/3346))
 
 ## 35.3.0
 
-* Add data attributes to attachment links using JS [(PR #3330)](https://github.com/alphagov/govuk_publishing_components/pull/3330)
+* Add data attributes to attachment links using JS ([PR #3330](https://github.com/alphagov/govuk_publishing_components/pull/3330))
 * Ga4 accordion link tracking ([PR #3328](https://github.com/alphagov/govuk_publishing_components/pull/3328))
 * Fix GA4 Step Nav link tracking bug ([PR #3334](https://github.com/alphagov/govuk_publishing_components/pull/3334))
 
@@ -26,8 +27,8 @@
 * Make auditing aware of new asset loading model ([PR #3318](https://github.com/alphagov/govuk_publishing_components/pull/3318))
 * Ga4 part of heading tracking fix ([PR #3321](https://github.com/alphagov/govuk_publishing_components/pull/3321))
 * Ga4 fix index ([PR #3313](https://github.com/alphagov/govuk_publishing_components/pull/3313))
-* Fix search icon cut-off in navbar  ([PR #3322](https://github.com/alphagov/govuk_publishing_components/pull/3322))
-* Update AssetHelper documentation  ([PR #3323](https://github.com/alphagov/govuk_publishing_components/pull/3323))
+* Fix search icon cut-off in navbar ([PR #3322](https://github.com/alphagov/govuk_publishing_components/pull/3322))
+* Update AssetHelper documentation ([PR #3323](https://github.com/alphagov/govuk_publishing_components/pull/3323))
 
 ## 35.1.1
 

--- a/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
+++ b/app/views/govuk_publishing_components/components/_contextual_sidebar.html.erb
@@ -5,6 +5,9 @@
   request.query_parameters[:ga4_tracking] = ga4_tracking
   navigation = GovukPublishingComponents::Presenters::ContextualNavigation.new(content_item, request)
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  show_ukraine_cta = navigation.show_ukraine_cta?
+  ga4_tracking_counts = OpenStruct.new(index_section_count: 0)
+  ga4_tracking_counts.index_section_count = 1 if show_ukraine_cta
 %>
 
 <div class="gem-c-contextual-sidebar">
@@ -18,7 +21,7 @@
     <%= render 'govuk_publishing_components/components/step_by_step_nav', navigation.step_nav_helper.sidebar %>
   <% else %>
     <%# Rendering related navigation sidebar because no step by step list %>
-    <%= render 'govuk_publishing_components/components/related_navigation', content_item: content_item, context: :sidebar, ga4_tracking: ga4_tracking %>
+    <%= render 'govuk_publishing_components/components/related_navigation', content_item: content_item, context: :sidebar, ga4_tracking: ga4_tracking, ga4_tracking_counts: ga4_tracking_counts %>
   <% end %>
 
   <% if navigation.content_tagged_to_other_step_by_steps? %>
@@ -31,7 +34,7 @@
     } %>
   <% end %>
 
-  <% if navigation.show_ukraine_cta? %>
-    <%= render 'govuk_publishing_components/components/contextual_sidebar/ukraine_cta', content_item: content_item, ga4_tracking: ga4_tracking %>
+  <% if show_ukraine_cta %>
+    <%= render 'govuk_publishing_components/components/contextual_sidebar/ukraine_cta', content_item: content_item, ga4_tracking: ga4_tracking, ga4_tracking_counts: ga4_tracking_counts %>
   <% end %>
 </div>

--- a/app/views/govuk_publishing_components/components/_related_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_related_navigation.html.erb
@@ -30,7 +30,6 @@
     <% end %>
 
     <% section_index = 0 %>
-
     <% related_nav_helper.related_navigation.each do |section_title, links| %>
       <% next unless links.any? %>
 
@@ -42,6 +41,7 @@
         section_title: section_title,
         links: links,
         section_index: section_index,
+        section_count: related_nav_helper.index_section_count,
         random: random,
         ga4_tracking: ga4_tracking %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/_related_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_related_navigation.html.erb
@@ -5,12 +5,11 @@
   data = {}
   data[:module] = "gem-track-click"
   data[:module] << " ga4-link-tracker" if ga4_tracking
-%>
+  ga4_tracking_counts ||= OpenStruct.new(index_section_count: 0)
+  ga4_tracking_counts.index_section_count += related_nav_helper.index_section_count
 
-<%
   add_gem_component_stylesheet("related-navigation")
 %>
-
 <% if related_nav_helper.related_navigation? %>
   <% random = SecureRandom.hex(4) %>
   <%= tag.div(class: "gem-c-related-navigation", data: data) do %>
@@ -41,7 +40,7 @@
         section_title: section_title,
         links: links,
         section_index: section_index,
-        section_count: related_nav_helper.index_section_count,
+        section_count: ga4_tracking_counts.index_section_count,
         random: random,
         ga4_tracking: ga4_tracking %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/contextual_sidebar/_ukraine_cta.html.erb
+++ b/app/views/govuk_publishing_components/components/contextual_sidebar/_ukraine_cta.html.erb
@@ -8,13 +8,19 @@
 <%= tag.div class: "gem-c-contextual-sidebar__cta gem-c-contextual-sidebar__cta--ukraine", data: { module: data_module } do %>
   <%= tag.h2 title, class: "gem-c-contextual-sidebar__heading govuk-heading-s" %>
   <%= tag.ul class: "gem-c-contextual-sidebar__list" do %>
+    <% index_total = t("components.related_navigation.ukraine.links").length %>
     <% t("components.related_navigation.ukraine.links").each_with_index do |link, index| %>
       <%= tag.li class: "gem-c-contextual-sidebar__text govuk-body" do %>
         <%
           ga4_attributes = {
             event_name: "navigation",
             type: "related content",
-            index: "1.#{index + 1}",
+            index: {
+              index_section: "#{ga4_tracking_counts.index_section_count}",
+              index_link: "#{index + 1}",
+              index_section_count: "#{ga4_tracking_counts.index_section_count}",
+            },
+            index_total: "#{index_total}",
             section: title,
           } if ga4_tracking
         %>

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -24,17 +24,23 @@
   <% end %>
 
   <ul class="gem-c-related-navigation__link-list">
-    <% constructed_link_array = [] %>
-
-    <% section_link_limit = related_nav_helper.calculate_section_link_limit(links) %>
-
+    <% 
+      constructed_link_array = []
+      section_link_limit = related_nav_helper.calculate_section_link_limit(links)
+      index_total = links.length
+    %>
     <% links.each.with_index(1) do |link, index| %>
       <%
         link_class = "govuk-link #{related_nav_helper.section_css_class("govuk-link gem-c-related-navigation__section-link", section_title, link: link, link_is_inline: (index >= section_link_limit))}"
         ga4_attributes = {
           event_name: "navigation",
           type: "related content",
-          index: "#{section_index}.#{index}",
+          index: {
+            index_section: "#{section_index}",
+            index_link: "#{index}",
+            index_section_count: "#{section_count}",
+          },
+          index_total: "#{index_total}",
           section: ga4_heading_text,
         } if ga4_tracking
         link_element = link_to(

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -16,12 +16,16 @@ module GovukPublishingComponents
         "UK Mission to the European Union" => "uk-mission-to-the-eu",
       }.freeze
 
+      attr_reader :related_navigation, :index_section_count
+
       def initialize(options = {})
         @content_item = options.fetch(:content_item) { raise ArgumentError, "missing argument: content_item" }
         @context = options.fetch(:context, nil)
+        @related_navigation = related_navigation_contents
+        @index_section_count = section_count
       end
 
-      def related_navigation
+      def related_navigation_contents
         case @context.try(:to_sym)
         when :sidebar
           {
@@ -51,6 +55,10 @@ module GovukPublishingComponents
             "related_contacts" => related_contacts,
           }
         end
+      end
+
+      def section_count
+        @related_navigation.select { |_, links| links.any? }.length
       end
 
       def construct_section_text(section, underscores_to_spaces)

--- a/spec/components/contextual_sidebar_spec.rb
+++ b/spec/components/contextual_sidebar_spec.rb
@@ -42,6 +42,9 @@ describe "Contextual sidebar", type: :view do
       ga4_tracking: true,
       content_item: content_item,
     )
+    index_total = 4 # have to hard code this here but if ukraine links change this number may change, and test will fail
     assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine[data-module='gem-track-click ga4-link-tracker']"
+    assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine .govuk-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":{\"index_section\":\"1\",\"index_link\":\"1\",\"index_section_count\":\"1\"},\"index_total\":\"#{index_total}\",\"section\":\"Invasion of Ukraine\"}']"
+    assert_select ".gem-c-contextual-sidebar .gem-c-contextual-sidebar__cta--ukraine .govuk-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":{\"index_section\":\"1\",\"index_link\":\"2\",\"index_section_count\":\"1\"},\"index_total\":\"#{index_total}\",\"section\":\"Invasion of Ukraine\"}']"
   end
 end

--- a/spec/components/related_navigation_spec.rb
+++ b/spec/components/related_navigation_spec.rb
@@ -232,6 +232,11 @@ describe "Related navigation", type: :view do
           "title" => "Paragliding",
           "document_type" => "topic",
         },
+        {
+          "base_path" => "/knitting",
+          "title" => "Knitting",
+          "document_type" => "topic",
+        },
       ],
       "world_locations" => [],
     }
@@ -242,11 +247,11 @@ describe "Related navigation", type: :view do
     render_component(content_item: content_item, ga4_tracking: true)
 
     assert_select ".gem-c-related-navigation[data-module='gem-track-click ga4-link-tracker']"
-    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":\"1.1\",\"section\":\"Related content\"}']", text: "Fishing"
-    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":\"1.2\",\"section\":\"Related content\"}']", text: "Surfing"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":{\"index_section\":\"1\",\"index_link\":\"1\",\"index_section_count\":\"3\"},\"index_total\":\"2\",\"section\":\"Related content\"}']", text: "Fishing"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":{\"index_section\":\"1\",\"index_link\":\"2\",\"index_section_count\":\"3\"},\"index_total\":\"2\",\"section\":\"Related content\"}']", text: "Surfing"
 
-    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":\"2.1\",\"section\":\"Explore the topic\"}']", text: "Skating"
-    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":\"2.2\",\"section\":\"Explore the topic\"}']", text: "Paragliding"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":{\"index_section\":\"2\",\"index_link\":\"1\",\"index_section_count\":\"3\"},\"index_total\":\"3\",\"section\":\"Explore the topic\"}']", text: "Skating"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"related content\",\"index\":{\"index_section\":\"2\",\"index_link\":\"2\",\"index_section_count\":\"3\"},\"index_total\":\"3\",\"section\":\"Explore the topic\"}']", text: "Paragliding"
 
     assert_select ".gem-c-related-navigation__section-link[href=\"/world/wales/news\"]", text: "Wales"
     assert_select ".gem-c-related-navigation__link.toggle-wrap[data-module='ga4-event-tracker']"


### PR DESCRIPTION
## What
Update the GA4 `index` parameter on the related navigation and contextual sidebar components. Specifically:

- break the `index` parameter into `index_section` and `index_link` sub parameters
- add a new `index_section_count` sub parameter
- add the `index_total` parameter

## Why
Part of the GA4 migration. We've changed how the index parameters should work, this is to reflect that.

## Visual Changes
None.

Trello card: https://trello.com/c/16ngDhBP/493-change-the-index-parameter-part-2-indexsectioncount