### PR TITLE
Fix component guide previews for application components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix some GA4 index bugs ([PR #3375](https://github.com/alphagov/govuk_publishing_components/pull/3375))
 * Rename type breadcrumbs to breadcrumb ([PR #3373](https://github.com/alphagov/govuk_publishing_components/pull/3373))
 * Update AssetHelper documentation ([PR #3378](https://github.com/alphagov/govuk_publishing_components/pull/3378))
+* Fix component guide previews for application components ([PR #3347](https://github.com/alphagov/govuk_publishing_components/pull/3347))
 
 ## 35.3.3
 

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -1,6 +1,42 @@
 // This file contains the styles for the Component Guide.
 
-@import "govuk_publishing_components/all_components";
+// feature flag for accessible link styles
+$govuk-new-link-styles: true;
+
+@import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/component_support";
+
+// Import the same stylesheets used in static
+// https://github.com/alphagov/static/blob/198a598682df40ce4a2c3c286c06244297c18cf0/app/assets/stylesheets/application.scss
+// Although the component guide does not use static, we still need to import the same stylesheets used in static
+// to avoid any rendering issues
+// By following the same approach as frontend rendering applications,
+// we ensure that stylesheets are loaded in the expected order and components render correctly
+@import "govuk_publishing_components/components/breadcrumbs";
+@import "govuk_publishing_components/components/button";
+@import "govuk_publishing_components/components/error-message";
+@import "govuk_publishing_components/components/heading";
+@import "govuk_publishing_components/components/hint";
+@import "govuk_publishing_components/components/input";
+@import "govuk_publishing_components/components/label";
+@import "govuk_publishing_components/components/search";
+@import "govuk_publishing_components/components/skip-link";
+@import "govuk_publishing_components/components/textarea";
+@import "govuk_publishing_components/components/title";
+
+@import "govuk_publishing_components/components/cookie-banner";
+@import "govuk_publishing_components/components/feedback";
+@import "govuk_publishing_components/components/layout-footer";
+@import "govuk_publishing_components/components/layout-for-public";
+@import "govuk_publishing_components/components/layout-header";
+@import "govuk_publishing_components/components/layout-super-navigation-header";
+
+// Imported to ensure inverse-header component examples render correctly
+// this helps avoid any issues with visual regressions tests
+@import "govuk_publishing_components/components/lead-paragraph";
+
+// Include required helpers
+@import "../../stylesheets/govuk_publishing_components/components/helpers/markdown-typography";
 
 $gem-guide-border-width: 1px;
 

--- a/app/views/govuk_publishing_components/component_guide/example.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/example.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "#{@component_example.name} example - #{@component_doc.name} component" %>
 <% content_for :application_stylesheet do %>
-  <% if @component_doc.source == "application" %>
+  <% if @component_doc.source == "application" && application_stylesheet_in_use? %>
     <%= render 'application_stylesheet' %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/component_guide/preview.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/preview.html.erb
@@ -1,5 +1,5 @@
 <% content_for :application_stylesheet do %>
-  <% if @component_doc.source == "application" %>
+  <% if @component_doc.source == "application" && application_stylesheet_in_use? %>
     <%= render 'application_stylesheet' %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/component_guide/show.html.erb
+++ b/app/views/govuk_publishing_components/component_guide/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "#{@component_doc.name} component" %>
 <% content_for :application_stylesheet do %>
-  <% if @component_doc.source == "application" %>
+  <% if @component_doc.source == "application" && application_stylesheet_in_use? %>
     <%= render 'application_stylesheet' %>
   <% end %>
 <% end %>

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -18,6 +18,7 @@
 
     <%= stylesheet_link_tag "component_guide/application", media: "all" %>
     <%= yield :application_stylesheet %>
+    <%= render_component_stylesheets %>
 
     <%= javascript_include_tag "govuk_publishing_components/vendor/modernizr" %>
     <%= yield :extra_headers %>

--- a/docs/install-and-use.md
+++ b/docs/install-and-use.md
@@ -40,7 +40,7 @@ Use a config block in an initialiser:
 # config/initializers/govuk_publishing_components.rb
 GovukPublishingComponents.configure do |c|
   c.component_guide_title = "My component guide"
-  c.application_stylesheet = "custom_stylesheet" # Defaults to "application"
+  c.application_stylesheet = "custom_stylesheet" # Defaults to "application", set to `nil` if the application stylesheet is not in use
   c.application_javascript = "custom_javascript" # Defaults to "application"
 end
 ```

--- a/lib/govuk_publishing_components/app_helpers/asset_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/asset_helper.rb
@@ -72,6 +72,10 @@ module GovukPublishingComponents
         COMPONENT_CSS_PATHS
       end
 
+      def application_stylesheet_in_use?
+        GovukPublishingComponents::Config.application_stylesheet.presence
+      end
+
     private
 
       def is_already_used?(component)

--- a/spec/component_guide/component_example_spec.rb
+++ b/spec/component_guide/component_example_spec.rb
@@ -31,13 +31,13 @@ describe "Component example" do
   it "includes the application stylesheet for an application component" do
     visit "/component-guide/test-component"
 
-    expect(page).to have_selector('link[href*="/assets/application.css"]', visible: false)
+    expect(page).to have_selector('link[href^="/assets/application-"][rel="stylesheet"]', visible: false)
   end
 
   it "doesn't include the application stylesheet for a gem component" do
     visit "/component-guide/button"
 
-    expect(page).not_to have_selector('link[href*="/assets/application.css"]', visible: false)
+    expect(page).not_to have_selector('link[href^="/assets/application-"][rel="stylesheet"]', visible: false)
   end
 
   it "lists examples in a human readable way" do

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -40,7 +40,5 @@ Rails.application.configure do
   # Raises error for missing translations
   config.i18n.raise_on_missing_translations = true
 
-  config.assets.digest = false
-
   config.assets.css_compressor = false
 end

--- a/spec/features/asset_helper_spec.rb
+++ b/spec/features/asset_helper_spec.rb
@@ -1,15 +1,18 @@
 describe "When the asset helper is configured", type: :view do
   scenario "go to page with multiple GOV.UK publishing components only" do
+    GovukPublishingComponents.configure do |config|
+      config.exclude_css_from_static = true
+    end
+
     visit "/asset_helper"
 
     within(:xpath, "//head", visible: false) do
       expect(page).to have_xpath("//link", visible: false, count: 3)
 
-      expect(page).to have_xpath("//link[1][@href=\'/assets/application.css\']", visible: false)
-      expect(page).to have_xpath("//link[2][@href=\'/assets/govuk_publishing_components/components/_notice.css\']", visible: false)
-      expect(page).to have_xpath("//link[3][@href=\'/assets/govuk_publishing_components/components/_details.css\']", visible: false)
-
-      expect(page).to have_no_xpath("//*[@href=\'/assets/govuk_publishing_components/components/_title.css\']", visible: false)
+      expect(page).to have_selector('link[href^="/assets/application-"][rel="stylesheet"]', visible: false)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_notice-"][rel="stylesheet"]', visible: false)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_details-"][rel="stylesheet"]', visible: false)
+      expect(page).not_to have_selector('link[href^="/assets/govuk_publishing_components/components/_title-"][rel="stylesheet"]', visible: false)
     end
   end
 
@@ -19,9 +22,9 @@ describe "When the asset helper is configured", type: :view do
     within(:xpath, "//head", visible: false) do
       expect(page).to have_xpath("//link", visible: false, count: 3)
 
-      expect(page).to have_xpath("//link[1][@href=\'/assets/application.css\']", visible: false)
-      expect(page).to have_xpath("//link[2][@href=\'/assets/govuk_publishing_components/components/_notice.css\']", visible: false)
-      expect(page).to have_xpath("//link[3][@href=\'/assets/components/_app-component.css\']", visible: false)
+      expect(page).to have_selector('link[href^="/assets/application-"][rel="stylesheet"]', visible: false)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_notice-"][rel="stylesheet"]', visible: false)
+      expect(page).to have_selector('link[href^="/assets/components/_app-component-"][rel="stylesheet"]', visible: false)
     end
   end
 
@@ -31,9 +34,9 @@ describe "When the asset helper is configured", type: :view do
     within(:xpath, "//head", visible: false) do
       expect(page).to have_xpath("//link", visible: false, count: 3)
 
-      expect(page).to have_xpath("//link[1][@href=\'/assets/application.css\']", visible: false)
-      expect(page).to have_xpath("//link[2][@href=\'/assets/govuk_publishing_components/components/_notice.css\']", visible: false)
-      expect(page).to have_xpath("//link[3][@href=\'/assets/views/_app-view.css\']", visible: false)
+      expect(page).to have_selector('link[href^="/assets/application-"][rel="stylesheet"]', visible: false)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_notice-"][rel="stylesheet"]', visible: false)
+      expect(page).to have_selector('link[href^="/assets/views/_app-view-"][rel="stylesheet"]', visible: false)
     end
   end
 end


### PR DESCRIPTION
## What

- Call `render_component_stylesheets` to load stylesheets individually
- Update application.css used in the component guide to request only the minimum number of stylesheets required to render components correctly
- Remove `config.assets.digest = false` setting in `test.rb`, this allows the default value of `true` to be used - https://guides.rubyonrails.org/configuring.html#config-assets-digest
- Check if the frontend rendering application is using an application.css stylesheet before including it in the component guide view templates

## Why

- Ensure component previews work in rendering applications that are loading stylesheets individually
- Removing `config.assets.digest = false` fixes a failing test when using the individual loading of stylesheets feature in the gem and matches the default behaviour for development and production environments
- Some applications no longer have an application.css file. For these applications, `application_stylesheet` should be set to `false` to avoid the error below:
```
Sprockets::Rails::Helper::AssetNotPrecompiledError at /taxon-list
Asset `application.css` was not declared to be precompiled in production.
Declare links to your assets in `app/assets/config/manifest.js`.
  //= link application.css
and restart your server
```

Trello: https://trello.com/c/hisIwM5O/1966-fix-component-previews-in-component-guide

## Steps to reproduce

### No application.css file

When viewing the component guide in a rendering application, the application.css is always requested for that application. However, some applications are not using an application.css file, which then causes a server error. We need to add a check to ensure that we only try to load this file when required.

To reproduce this issue:

- run the collections app locally
- visit `/component-guide`
- click on the link for any of the application components, you will then get an error similar to that below:

```
Sprockets::Rails::Helper::AssetNotPrecompiledError at /taxon-list
Asset `application.css` was not declared to be precompiled in production.
Declare links to your assets in `app/assets/config/manifest.js`.
  //= link application.css
and restart your server
```

**Note**: if you cannot reproduce the error, try running bundle exec rails assets:clobber assets:precompile to remove any existing assets and compile them again

### App levels components not rendered correctly

This issue is caused because the component stylesheet is not loaded for app level components in the component guide, we just need to add support for this.

To reproduce this issue:

- run the finder-frontend app locally
- visit `/component-guide`
- click on any of the application components, date-filter, expander or option-select.

## Percy - Visual changes

Percy is reporting the 2 visual changes below, these only impact the component guide, not the live rendering applications.

### Character count component

This is because the `textarea` element now has `margin-bottom: 5px` instead of `0px`, this is correct and is what is used in both the Design System and GOV.UK

- [Design System Character Count example](https://design-system.service.gov.uk/components/character-count/)
- [GOV.UK Contact page with `texarea` example](https://www.gov.uk/contact/govuk)

### Label component

The visual difference is because the change in how stylesheets are loaded in the component guide, the required stylesheet from the radio component are not included, this is mentioned in the component guide:

> Note that this example will not render correctly - do not be alarmed. It only works properly when inside the radio component.

https://components.publishing.service.gov.uk/component-guide/label/inside_a_radio_component