### PR TITLE
Bump to 35.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.3.1
 
 * Add brand colour for DSIT ([PR #3349](https://github.com/alphagov/govuk_publishing_components/pull/3349))
 * Update GA4 index parameter on related navigation ([PR #3346](https://github.com/alphagov/govuk_publishing_components/pull/3346))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.3.0)
+    govuk_publishing_components (35.3.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -332,10 +332,10 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
-    sentry-rails (5.8.0)
+    sentry-rails (5.9.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.8.0)
-    sentry-ruby (5.8.0)
+      sentry-ruby (~> 5.9.0)
+    sentry-ruby (5.9.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     smart_properties (1.17.0)
     sprockets (4.2.0)
@@ -398,4 +398,4 @@ RUBY VERSION
    ruby 3.0.5p211
 
 BUNDLED WITH
-   2.3.6
+   2.4.12

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.3.0".freeze
+  VERSION = "35.3.1".freeze
 end


### PR DESCRIPTION
* Add brand colour for DSIT Add brand colour for DSIT (https://github.com/alphagov/govuk_publishing_components/pull/3349)
* Update GA4 index parameter on related navigation (https://github.com/alphagov/govuk_publishing_components/pull/3346)