### PR TITLE
Remove superfluous CSP declarations

### DIFF
--- a/spec/dummy/config/initializers/content_security_policy.rb
+++ b/spec/dummy/config/initializers/content_security_policy.rb
@@ -11,19 +11,11 @@ require "govuk_app_config"
 #
 # [1]: https://github.com/alphagov/govuk_app_config/blob/31928b2079d82f6cbe7c296d4d6e54b4efc07b84/lib/govuk_app_config/govuk_content_security_policy.rb
 GovukContentSecurityPolicy.configure do |policy|
-  # Removes the ability to use script tags without a nonce, unsafe inline can't
-  # be used if you use a nonce in a CSP so this is removed to avoid confusion
-  script_policy_without_unsafe_inline = policy.script_src - ["'unsafe-inline'"]
-  policy.script_src(*script_policy_without_unsafe_inline)
   # Removes the ability to use style tags without a nonce and using inline styles
   # on elements, unsafe inline can't be used if you use a nonce in a CSP so
   # this is removed to avoid confusion
   style_policy_without_unsafe_inline = policy.style_src - ["'unsafe-inline'"]
   policy.style_src(*style_policy_without_unsafe_inline)
-  # This prevents the use of data encoded images, they need to reference files
-  # on an approved host
-  img_policy_without_data_scheme = policy.style_src - ["data:"]
-  policy.img_src(*img_policy_without_data_scheme)
 end
 
 # Sets a nonce per request that is set in the CSP directives for script_src and


### PR DESCRIPTION
These two rules are no longer needed as the rule changes were released in govuk_app_config v5, this app is using v7.

This also resolves an issue where img_src had the wrong rules because it modified policy.style_src rather than policy.img_src.

This should resolve the issue with: https://github.com/alphagov/govuk_publishing_components/pull/3332#pullrequestreview-1390248657
