### PR TITLE
Bump to 35.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.3.1
 
 * Add brand colour for DSIT ([PR #3349](https://github.com/alphagov/govuk_publishing_components/pull/3349))
 * Update GA4 index parameter on related navigation ([PR #3346](https://github.com/alphagov/govuk_publishing_components/pull/3346))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.3.0)
+    govuk_publishing_components (35.3.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.3.0".freeze
+  VERSION = "35.3.1".freeze
 end


### PR DESCRIPTION
* Add brand colour for DSIT Add brand colour for DSIT (https://github.com/alphagov/govuk_publishing_components/pull/3349)
* Update GA4 index parameter on related navigation (https://github.com/alphagov/govuk_publishing_components/pull/3346)