### PR TITLE
Remove service manual frontend from auditing

### DIFF
--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -17,7 +17,6 @@ module GovukPublishingComponents
         licence-finder
         release
         search-admin
-        service-manual-frontend
         signon
         smart-answers
         static


### PR DESCRIPTION
## What / why
- service manual frontend has been retired and merged with (government-frontend? I think) so we no longer need to include it in the component auditing

## Visual Changes
None.
