### PR TITLE
Add organisation brand colour for Department for Business & Trade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ## 35.3.1
 
+* Add organisation brand colour for Department for Business & Trade ([#3361](https://github.com/alphagov/govuk_publishing_components/pull/3361))
 * Add brand colour for DSIT ([PR #3349](https://github.com/alphagov/govuk_publishing_components/pull/3349))
 * Update GA4 index parameter on related navigation ([PR #3346](https://github.com/alphagov/govuk_publishing_components/pull/3346))
 * Update the Attachment component to accept a thumbnail parameter ([PR #3332](https://github.com/alphagov/govuk_publishing_components/pull/3332))

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -96,3 +96,27 @@
     border-color: #045f71;
   }
 }
+
+// This change should be removed after relevant govuk-frontend release
+
+.brand--department-for-business-and-trade {
+  .brand__color {
+    color: #cf102d;
+
+    &:link,
+    &:visited,
+    &:active {
+      color: #cf102d;
+    }
+
+    &:hover,
+    &:focus {
+      color: $govuk-focus-text-colour;
+    }
+  }
+
+  &.brand__border-color,
+  .brand__border-color {
+    border-color: #cf102d;
+  }
+}


### PR DESCRIPTION
[Trello card](https://trello.com/c/rtK4IWUx/1206-update-department-of-business-trade-branding-labels-in-publishing-components)
This change should be removed after relevant govuk-frontend release.

## What
We are updating the labelling of Department of International Trade to Department for Business & Trade.

## Why
This is part of the Supporting Government changes work (departments updates).
