### PR TITLE
[DO NOT MERGE] Create GA4 "change" event tracker for finder-frontend finders

### DIFF
--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
@@ -7,6 +7,7 @@
 //= require ./analytics-ga4/ga4-link-tracker
 //= require ./analytics-ga4/ga4-event-tracker
 //= require ./analytics-ga4/ga4-ecommerce-tracker
+//= require ./analytics-ga4/ga4-finder-tracker
 //= require ./analytics-ga4/ga4-form-tracker
 //= require ./analytics-ga4/ga4-auto-tracker
 //= require ./analytics-ga4/ga4-smart-answer-results-tracker

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
@@ -46,7 +46,7 @@
         // The "value" we need for a checkbox is the label text that the user sees beside the checkbox.
         elementValue = document.querySelector("label[for='" + checkboxId + "']").textContent
 
-        // If the checkbox unchecked is unchecked, the filter was removed.
+        // If the checkbox is unchecked, the filter was removed.
         wasFilterRemoved = !eventTarget.checked
       } else if (elementType === 'radio') {
         var radioId = eventTarget.id

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
@@ -9,6 +9,11 @@
 
     setFilterIndexes: function () {
       var filterContainer = document.querySelector('[data-ga4-filter-container]')
+
+      if (!filterContainer) {
+        return
+      }
+
       var filterSections = filterContainer.querySelectorAll('[data-ga4-section]')
 
       for (var i = 0; i < filterSections.length; i++) {

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
@@ -24,7 +24,7 @@
       if (elementType === 'checkbox') {
         var checkboxId = eventTarget.id
 
-        // The "value" for a checkbox is the label text that the user sees beside the checkbox.
+        // The "value" we need for a checkbox is the label text that the user sees beside the checkbox.
         elementValue = document.querySelector("label[for='" + checkboxId + "']").textContent
 
         if (eventTarget.checked === false) {
@@ -33,14 +33,13 @@
           wasFilterRemoved = true
         }
       } else if (elementType === 'select') {
-        // The value of a <select> is the ID of the <option>, so we need to grab the human friendly label.
-        console.log(eventTarget)
+        // The value of a <select> is the value attribute of the selected <option>, which is a hyphenated key. We need to grab the human readable label instead for tracking.
         elementValue = eventTarget.querySelector("option[value='" + eventTarget.value + "']").textContent
         var defaultValue = eventTarget.querySelector('option:first-of-type').textContent
         console.log('Default value:', defaultValue)
 
         if (elementValue === defaultValue) {
-          // <select> elements being reverted to their first option (i.e. their default value) counts as a "removed filter".
+          // <select> elements being reverted to their first option (i.e. their default value) count as a "removed filter". (This will be used on the filter <select>s but not the sort by <select>, as you can't "remove" the sort by filter.)
           console.log('Filter was removed because it matches a select default value')
           wasFilterRemoved = true
         }
@@ -48,7 +47,7 @@
         elementValue = eventTarget.value
         if (elementValue === '') {
           console.log('Filter was removed because the value is an empty string')
-          // Custom date filters being reset to an empty text box counts as a "removed filter".
+          // If our custom date filters are reset, they become an empty text box, so we count this as a "removed filter". This boolean won't be used for the keyword search box, as deleting the keyword isn't considered removing a filter.
           wasFilterRemoved = true
         }
       }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
@@ -68,6 +68,7 @@
 
           if (wasFilterRemoved) {
             schema.event_data.action = 'remove'
+            schema.event_data.text = elementType === 'text' ? undefined : elementValue
           } else {
             schema.event_data.action = elementType === 'text' ? 'search' : 'select'
             schema.event_data.index = this.getSectionIndex(section)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
@@ -1,0 +1,85 @@
+//= require govuk/vendor/polyfills/Element/prototype/closest.js
+;(function (global) {
+  'use strict'
+
+  var GOVUK = global.GOVUK || {}
+  GOVUK.analyticsGa4 = GOVUK.analyticsGa4 || {}
+
+  GOVUK.analyticsGa4.Ga4FinderTracker = {
+    trackChangeEvent: function (eventTarget, changeEventMetadata) {
+      changeEventMetadata = changeEventMetadata.split(' ')
+      var changeType = changeEventMetadata[0]
+
+      var elementType = changeEventMetadata[1]
+      var elementValue = ''
+
+      var wasFilterRemoved = false
+
+      var schema = new window.GOVUK.analyticsGa4.Schemas()
+      schema.event = 'event_data'
+      schema.event_data.type = 'finder'
+
+      if (elementType === 'checkbox') {
+        var checkboxId = eventTarget.id
+
+        // The "value" for a checkbox is the label text that the user sees beside the checkbox.
+        elementValue = document.querySelector("label[for='" + checkboxId + "']").textContent
+
+        if (eventTarget.checked === false) {
+          // Checkbox unchecked = filter was removed
+          console.log('Filter was removed because it was unchecked')
+          wasFilterRemoved = true
+        }
+      } else if (elementType === 'select') {
+        // The value of a <select> is the ID of the <option>, so we need to grab the human friendly label.
+        elementValue = eventTarget.querySelector("option[value='" + eventTarget.value + "']").textContent
+        var defaultValue = eventTarget.querySelector('option:first-of-type').textContent
+        console.log('Default value:', defaultValue)
+
+        if (elementValue === defaultValue) {
+          // <select> elements being reverted to their first option (i.e. their default value) counts as a "removed filter".
+          console.log('Filter was removed because it matches a select default value')
+          wasFilterRemoved = true
+        }
+      } else if (elementType === 'text') {
+        elementValue = eventTarget.value
+        if (elementValue === '') {
+          console.log('Filter was removed because the value is an empty string')
+          // Custom date filters being reset to an empty text box counts as a "removed filter".
+          wasFilterRemoved = true
+        }
+      }
+
+      console.log('Change type is', changeType)
+
+      switch (changeType) {
+        case 'update-filter':
+          console.log('Was the filter removed?', wasFilterRemoved)
+          if (wasFilterRemoved) {
+            console.log('TODO: Add GA4 schema for "filter removed" event with value', elementValue)
+          } else {
+            console.log('TODO: Add GA4 schema for "filter added event" with value', elementValue)
+          }
+          break
+
+        case 'update-keyword':
+          break
+
+        case 'clear-all-filters':
+          console.log('TODO: Add GA4 schema for "clear all filters" event with value "Clear all filters"')
+          break
+
+        case 'update-sort':
+          console.log('TODO: Add GA4 schema for "sort by updated" event with value "Clear all filters"')
+          break
+
+        default:
+          break
+      }
+
+      window.GOVUK.analyticsGa4.core.sendData(schema)
+    }
+  }
+
+  global.GOVUK = GOVUK
+})(window)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
@@ -57,6 +57,8 @@
         }
       }
 
+      schema.event_data.text = PIIRemover.stripPIIWithOverride(elementValue, true, true)
+
       switch (changeType) {
         case 'update-filter':
           schema.event_data.event_name = 'select_content'
@@ -80,7 +82,9 @@
           break
 
         case 'clear-all-filters':
-          console.log('TODO: Add GA4 schema for "clear all filters" event with value "Clear all filters"')
+          schema.event_data.event_name = 'select_content'
+          schema.event_data.action = 'remove'
+          schema.event_data.text = 'Clear all filters'
           break
 
         case 'update-sort':
@@ -91,7 +95,6 @@
           break
       }
 
-      schema.event_data.text = PIIRemover.stripPIIWithOverride(elementValue, true, true)
       window.GOVUK.analyticsGa4.core.sendData(schema)
     },
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
@@ -66,8 +66,8 @@
 
         case 'update-keyword':
           schema.event_data.event_name = 'search'
-          schema.event_data.url = window.location.href
           schema.event_data.text = PIIRemover.stripPIIWithOverride(elementValue, true, true)
+          schema.event_data.url = window.location.pathname
           schema.event_data.section = 'Search'
           schema.event_data.action = 'search'
           break

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
@@ -89,7 +89,9 @@
           break
 
         case 'update-sort':
-          console.log('TODO: Add GA4 schema for "sort by updated" event with value', elementValue)
+          schema.event_data.event_name = 'select_content'
+          schema.event_data.action = 'sort'
+          schema.event_data.section = 'Sort by'
           break
 
         default:

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
@@ -7,6 +7,8 @@
 
   GOVUK.analyticsGa4.Ga4FinderTracker = {
     trackChangeEvent: function (eventTarget, changeEventMetadata) {
+      var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
+
       changeEventMetadata = changeEventMetadata.split(' ')
       var changeType = changeEventMetadata[0]
 
@@ -15,7 +17,7 @@
 
       var wasFilterRemoved = false
 
-      var schema = new window.GOVUK.analyticsGa4.Schemas()
+      var schema = new GOVUK.analyticsGa4.Schemas().eventSchema()
       schema.event = 'event_data'
       schema.event_data.type = 'finder'
 
@@ -63,6 +65,11 @@
           break
 
         case 'update-keyword':
+          schema.event_data.event_name = 'search'
+          schema.event_data.url = window.location.href
+          schema.event_data.text = PIIRemover.stripPIIWithOverride(elementValue, true, true)
+          schema.event_data.section = 'Search'
+          schema.event_data.action = 'search'
           break
 
         case 'clear-all-filters':

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
@@ -34,6 +34,7 @@
         }
       } else if (elementType === 'select') {
         // The value of a <select> is the ID of the <option>, so we need to grab the human friendly label.
+        console.log(eventTarget)
         elementValue = eventTarget.querySelector("option[value='" + eventTarget.value + "']").textContent
         var defaultValue = eventTarget.querySelector('option:first-of-type').textContent
         console.log('Default value:', defaultValue)
@@ -77,7 +78,7 @@
           break
 
         case 'update-sort':
-          console.log('TODO: Add GA4 schema for "sort by updated" event with value "Clear all filters"')
+          console.log('TODO: Add GA4 schema for "sort by updated" event with value', elementValue)
           break
 
         default:

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.js
@@ -57,7 +57,7 @@
         }
       }
 
-      schema.event_data.text = PIIRemover.stripPIIWithOverride(elementValue, true, true)
+      schema.event_data.text = elementValue
 
       switch (changeType) {
         case 'update-filter':
@@ -79,6 +79,7 @@
           schema.event_data.url = window.location.pathname
           schema.event_data.section = 'Search'
           schema.event_data.action = 'search'
+          schema.event_data.text = PIIRemover.stripPIIWithOverride(schema.event_data.text, true, true)
           break
 
         case 'clear-all-filters':

--- a/docs/analytics-ga4/ga4-finder-tracker.md
+++ b/docs/analytics-ga4/ga4-finder-tracker.md
@@ -1,0 +1,122 @@
+# Google Analytics 4 event tracker
+
+This script is used to add GA4 tracking to the GOVUK finders in `finder-frontend` such as https://www.gov.uk/search/all. These finders use client side JavaScript to update their results in response to a change in the keyword or filters. Therefore, this tracker hooks in to the JavaScript `change` event that fires whenever a user updates their search. It then does some processing to push an appropriate GA4 event depending on what change was made to their search. This differs from the `ga4-form-tracker`, Firstly, because our finders are all contained in one large form. The `ga4-form-tracker` only allows for one GA4 event per `<form>` when we need multiple for each element that can change the search results. Secondly, the `ga4-form-tracker` relies on a JavaScript `submit` event. Our finder pages use a `change` event to update their results.
+
+## Basic use
+
+```html
+<form id="myForm">
+  <div data-ga4-form-container>
+    <div data-ga4-section="Topics">
+        <select data-ga4-change-category="update-filter select">
+            <option value="1">Default option</option>
+            <option value="2">Option 1</option>
+            <option value="3">Option 2</option>
+        </select>
+        <input type="search" data-ga4-change-category="update-keyword text" />
+    </div>
+  </div>
+</form>
+```
+
+```JavaScript
+var myForm = document.querySelector('myForm')
+
+window.GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes()
+
+myForm.addEventListener('change', function(event) {
+    var ga4ChangeCategory = event.target.closest('[data-ga4-change-category]').getAttribute('data-ga4-change-category')
+    window.GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent(event.target, ga4ChangeCategory)
+})
+```
+
+The tracker is not a regular module. Instead it is called manually where needed. This is to allow the tracker to be called at the appropriate time in our finders' code. In our case, we only call `Ga4FinderTracker.trackChangeEvent()` when our search successfully displays new results to the user. This stops erroring change events (i.e. the user inputting non-dates into the date filter) from being tracked as an "added filter" event. Therefore we only track updates to the finders if they result in a successful update to the search results.
+
+The flow of the tracker is:
+
+1. On your finder results page, tag your elements with the appropriate `data` attributes.
+
+    a. Tag the parent `<div>` or wrapper element for your filters with `data-ga4-filter-container`. This tells our code where to look for filter sections, so that we can set an `index_section` for each filter.
+
+    b. Tag each filters' wrapper element with a `data-ga4-section` attribute. This key can also be populated with a string value, which will be used to populate the `section` value of our GTM object. For example, on a "Topics" filter `<div>` you could add `data-ga4-section="Topics"` or just `data-ga4-section`.
+
+    c. Tag each element of the form that can trigger a `change` event with a `data-ga4-change-category`. This will contain some metadata about what the change is. The current categories are: `update-filter`, `update-sort`, `clear-all-filters` and `update-keyword`. As well as this, add the type of element that the filter is. This assists with our tracker extracting the value of the filter. For example, a `<select>` element that updates a filter would have `data-ga4-change-category="update-filter select"`. A search box would have `data-ga4-change-category="update-keyword text"`.
+
+2. When your finder page loads, call `Ga4FinderTracker.setFilterIndexes()`. This will grab the `data-ga4-filter-container` element. It will then look for every instance of `data-ga4-section` inside this element, then loop through them and assign an `index` to the section based on its position in the NodeList.
+
+3. In your finder's JavaScript code, find where it updates your search results, and call `Ga4FinderTracker.trackChangeEvent()`. Pass through the `event.target` of the element that triggered the change. Also grab and pass through the `data-ga4-change-category` that was set on the event target or its parent.
+
+4. The `ga4-finder-tracker` will then grab the "value" of the event target, using the metadata passed through to help categorise what type of element the change came from. The value in this case is the name of the filter that was set, the keyword that was input. For filters, it will also determine wether the change was the filter being "added" or "removed".
+For example if the event target is a checkbox, `<input type="checkbox" data-ga4-change-category="update-filter checkbox">`, and it is `checked`, then we know the filter was added. If it isn't `checked`, we know the filter was removed.
+
+5. Using the `data-ga4-change-category`, the value of the event target, and wether it is a removed filter or not, we then build the GTM object and push it to the `dataLayer`.
+
+## Element types tracked
+
+### Checkbox (`<input type="checkbox" />`)
+
+Checkboxes have `data-ga4-change-category="update-filter checkbox"` on them. If a change event is fired on the element, and the checkbox is `checked`, the `update-filter` event will build an "Add filter" GTM Object. If the checkbox is not `checked`, it will build a "Remove filter" GTM Object. The value we grab for a checkbox is the user friendly label associated with the `<input>`.
+
+### Select (`<select>`)
+
+The value we grab from a `<select>` is the user friendly text of the selected option.
+
+Filter selects have  `data-ga4-change-category="update-filter select"` on them.
+
+If the filter `<select>` element changes and is set to their _first option_, we treat this as a "Filter removed" event. This is because the first `<option>` in a `<select>` is their default state in our use case. Therefore if the select has changed, and we're on the first option, we can safely assume we've moved from a "Added filter" option, back to the default option, so it's treated as a "Removed filter."
+
+"Sort by" selects have  `data-ga4-change-category="update-sort select"` on them. They send a separate "Sort event", so checking wether the filter was added or removed is irrelevant in this case.
+
+### Radio buttons (`<input type="radio">`)
+
+Radio buttons have `data-ga4-change-category="update-filter radio"` on them. If the changed radio button is not the _first radio button_ (i.e. the default selection), then, the `update-filter` event will build an "Filter added" GTM Object. If the changed radio button is the _first radio button_, it will build a "Filter removed" GTM Object. This is because the first radio button in a list is typically the default "All XYZ" filter state. The value we grab for a radio button is the user friendly label associated with the `<input>`.
+
+### Date filters (`<input type="text">`)
+
+Our date filters have `data-ga4-change-category="update-filter text"` on them. The value we grab is the text that is input into its text field. If the text is an empty string, we treat this as a "Filter removed" event, as this means the date was removed. If text is available in the text box, we treat this as a "Filter added" event.
+
+### Search keyword changes (`<input type="text">`)
+
+Search boxes have `data-ga4-change-category="update-keyword text"` on them. The value we grab on change is the text that was input into the text box.  Regardless if text is available in the text box, we always treat it as a "search" event. This is because an empty search box is still as search event but it just searches for everything in our database.
+
+We apply the maximum level of PII removal on the user input.
+
+
+### Clear all filters button
+
+On mobile, there is a "Clear all filters" button. This triggers a `change` event on the whole `<form>` element when clicked. Therefore, we have added `data-ga4-change-category="clear-all-filters"` on the parent `<form>` in our finders. The value pushed to GTM is hard coded in `Ga4FinderTracker` as "Clear all filters", so an element type is not passed through to `data-ga4-change-category` as we don't need to do any value extraction.
+
+## Example GTM Objects
+
+```JSON
+{
+    "event": "event_data",
+    "event_data": {
+        "event_name": "select_content",
+        "type": "finder",
+        "text": "Environment",
+        "index": {
+            "index_section": 2,
+            "index_section_count": 5
+        },
+        "section": "Topic",
+        "action": "select"
+    },
+    "govuk_gem_version": "35.3.1",
+}
+```
+
+```JSON
+{
+    "event": "event_data",
+    "event_data": {
+        "event_name": "search",
+        "type": "finder",
+        "url": "/search/research-and-statistics",
+        "text": "hello world",
+        "section": "Search",
+        "action": "search"
+    },
+    "govuk_gem_version": "35.3.1",
+}
+```

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
@@ -6,6 +6,7 @@ describe('GA4 finder change tracker', function () {
   var inputParent
   var input
   var label
+  var label2
   var option1
   var option2
   var expected
@@ -105,6 +106,59 @@ describe('GA4 finder change tracker', function () {
 
     expected.event_data.action = 'remove'
     expected.event_data.index = undefined
+
+    expect(window.dataLayer[1]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for adding/removing a radio filter', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-filter radio')
+    inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
+    var index = { index_section: 1, index_section_count: 1 }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    option1 = document.createElement('input')
+    option1.setAttribute('type', 'radio')
+    option1.id = 'radio1'
+    option1.setAttribute('name', 'chocolates')
+    label = document.createElement('label')
+    label.setAttribute('for', 'radio1')
+    label.innerText = 'All types of chocolate (default)'
+
+    option2 = document.createElement('input')
+    option2.setAttribute('type', 'radio')
+    option2.setAttribute('name', 'chocolates')
+    option2.id = 'radio2'
+    label2 = document.createElement('label')
+    label2.setAttribute('for', 'radio2')
+    label2.innerText = 'Belgian chocolate'
+
+    inputParent.appendChild(option1)
+    inputParent.appendChild(label)
+    inputParent.appendChild(option2)
+    inputParent.appendChild(label2)
+    form.appendChild(inputParent)
+
+    option1.checked = false
+    option2.checked = true
+
+    window.GOVUK.triggerEvent(option2, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Your favourite chocolate'
+    expected.event_data.text = 'Belgian chocolate'
+    expected.event_data.action = 'select'
+    expected.event_data.index = index
+
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    option1.checked = true
+    option2.checked = false
+    window.GOVUK.triggerEvent(option1, 'change')
+
+    expected.event_data.action = 'remove'
+    expected.event_data.index = undefined
+    expected.event_data.text = 'All types of chocolate (default)'
 
     expect(window.dataLayer[1]).toEqual(expected)
   })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
@@ -138,4 +138,29 @@ describe('GA4 finder change tracker', function () {
 
     expect(window.dataLayer[0]).toEqual(expected)
   })
+
+  it('creates the correct GA4 object for adding a text filter', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-filter text')
+    inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
+    var index = { index_section: 2, index_section_count: 2 }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    input = document.createElement('input')
+    input.setAttribute('type', 'text')
+    input.value = "Here is an email that should not get redacted email@example.com"
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Your favourite chocolate'
+    expected.event_data.text = 'Here is an email that should not get redacted email@example.com'
+    expected.event_data.action = 'search'
+    expected.event_data.index = index
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
@@ -3,6 +3,9 @@
 describe('GA4 finder change tracker', function () {
   var GOVUK = window.GOVUK
   var form
+  var inputParent
+  var input
+  var label
   var expected
 
   function agreeToCookies () {
@@ -28,6 +31,11 @@ describe('GA4 finder change tracker', function () {
       }
     })
 
+    expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+    expected.govuk_gem_version = 'aVersion'
+    expected.event = 'event_data'
+    expected.event_data.type = 'finder'
+
     agreeToCookies()
   })
 
@@ -40,28 +48,54 @@ describe('GA4 finder change tracker', function () {
   })
 
   it('creates the correct GA4 object for a search box keyword update', function () {
-    var searchBoxParent = document.createElement('div')
-    searchBoxParent.setAttribute('data-ga4-change-category', 'update-keyword text')
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-keyword text')
 
-    var searchBox = document.createElement('input')
-    searchBox.setAttribute('type', 'search')
-    searchBox.value = 'Hello world my postcode is SW1A 0AA. My birthday is 1970-01-01. My email is email@example.com'
+    input = document.createElement('input')
+    input.setAttribute('type', 'search')
+    input.value = 'Hello world my postcode is SW1A 0AA. My birthday is 1970-01-01. My email is email@example.com'
 
-    searchBoxParent.appendChild(searchBox)
-    form.appendChild(searchBoxParent)
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
 
-    window.GOVUK.triggerEvent(searchBox, 'change')
+    window.GOVUK.triggerEvent(input, 'change')
 
-    expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
-    expected.govuk_gem_version = 'aVersion'
-    expected.event = 'event_data'
     expected.event_data.event_name = 'search'
-    expected.event_data.type = 'finder'
     expected.event_data.url = window.location.pathname
     expected.event_data.text = 'Hello world my postcode is [postcode]. My birthday is [date]. My email is [email]'
     expected.event_data.section = 'Search'
     expected.event_data.action = 'search'
-    console.log(window.dataLayer)
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for adding a checkbox filter', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-filter checkbox')
+    inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
+    var index = { index_section: 1, index_section_count: 1 }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    input = document.createElement('input')
+    input.setAttribute('type', 'checkbox')
+    input.id = 'checkbox'
+    input.checked = true
+    label = document.createElement('label')
+    label.setAttribute('for', 'checkbox')
+    label.innerText = 'All types of chocolate'
+
+    inputParent.appendChild(input)
+    inputParent.appendChild(label)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Your favourite chocolate'
+    expected.event_data.text = 'All types of chocolate'
+    expected.event_data.action = 'select'
+    expected.event_data.index = index
+
     expect(window.dataLayer[0]).toEqual(expected)
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
@@ -189,4 +189,16 @@ describe('GA4 finder change tracker', function () {
 
     expect(window.dataLayer[1]).toEqual(expected)
   })
+
+  it('creates the correct GA4 object for clearing all filters', function () {
+    form.setAttribute('data-ga4-change-category', 'clear-all-filters')
+
+    window.GOVUK.triggerEvent(form, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.action = 'remove'
+    expected.event_data.text = 'Clear all filters'
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
@@ -229,4 +229,24 @@ describe('GA4 finder change tracker', function () {
 
     expect(window.dataLayer[0]).toEqual(expected)
   })
+
+  it('sets the correct indexes', function () {
+    form.setAttribute('data-ga4-filter-container', '')
+
+    for (var i = 0; i < 5; i++) {
+      var div = document.createElement('div')
+      div.setAttribute('data-ga4-section', '')
+      form.appendChild(div)
+    }
+
+    // Grabs each data-ga4-section element within a data-ga4-filter-container, and sets the appropriate indexes.
+    window.GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes()
+
+    var divs = form.querySelectorAll('[data-ga4-section]')
+
+    for (i = 0; i < divs.length; i++) {
+      var expectedIndexObject = { index_section: i + 1, index_section_count: divs.length }
+      expect(divs[i].getAttribute('data-ga4-index')).toEqual(JSON.stringify(expectedIndexObject))
+    }
+  })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
@@ -139,7 +139,7 @@ describe('GA4 finder change tracker', function () {
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
-  it('creates the correct GA4 object for adding a text filter', function () {
+  it('creates the correct GA4 object for adding/removing a text filter', function () {
     inputParent = document.createElement('div')
     inputParent.setAttribute('data-ga4-change-category', 'update-filter text')
     inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
@@ -148,7 +148,7 @@ describe('GA4 finder change tracker', function () {
 
     input = document.createElement('input')
     input.setAttribute('type', 'text')
-    input.value = "Here is an email that should not get redacted email@example.com"
+    input.value = 'Here is an email that should not get redacted email@example.com'
 
     inputParent.appendChild(input)
     form.appendChild(inputParent)
@@ -162,5 +162,14 @@ describe('GA4 finder change tracker', function () {
     expected.event_data.index = index
 
     expect(window.dataLayer[0]).toEqual(expected)
+
+    input.value = ''
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.action = 'remove'
+    expected.event_data.index = undefined
+    expected.event_data.text = undefined
+
+    expect(window.dataLayer[1]).toEqual(expected)
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
@@ -6,6 +6,8 @@ describe('GA4 finder change tracker', function () {
   var inputParent
   var input
   var label
+  var option1
+  var option2
   var expected
 
   function agreeToCookies () {
@@ -93,6 +95,44 @@ describe('GA4 finder change tracker', function () {
     expected.event_data.event_name = 'select_content'
     expected.event_data.section = 'Your favourite chocolate'
     expected.event_data.text = 'All types of chocolate'
+    expected.event_data.action = 'select'
+    expected.event_data.index = index
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for adding a <select> filter', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-filter select')
+    inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
+    var index = { index_section: 5, index_section_count: 15 }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    input = document.createElement('select')
+    input.setAttribute('name', 'chocolates')
+    input.id = 'chocolates'
+
+    // This is the first/default option, so "adding a filter" means selecting any <option> other than this one.
+    option1 = document.createElement('option')
+    option1.value = 'all-types'
+    option1.innerText = 'All types of chocolate (default)'
+    input.appendChild(option1)
+
+    option2 = document.createElement('option')
+    option2.setAttribute('value', 'belgian-chocolate')
+    option2.innerText = 'Belgian chocolate'
+    input.appendChild(option2)
+
+    input.value = 'belgian-chocolate'
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Your favourite chocolate'
+    expected.event_data.text = 'Belgian chocolate'
     expected.event_data.action = 'select'
     expected.event_data.index = index
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
@@ -71,7 +71,7 @@ describe('GA4 finder change tracker', function () {
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
-  it('creates the correct GA4 object for adding a checkbox filter', function () {
+  it('creates the correct GA4 object for adding/removing a checkbox filter', function () {
     inputParent = document.createElement('div')
     inputParent.setAttribute('data-ga4-change-category', 'update-filter checkbox')
     inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
@@ -99,6 +99,14 @@ describe('GA4 finder change tracker', function () {
     expected.event_data.index = index
 
     expect(window.dataLayer[0]).toEqual(expected)
+
+    input.checked = false
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.action = 'remove'
+    expected.event_data.index = undefined
+
+    expect(window.dataLayer[1]).toEqual(expected)
   })
 
   it('creates the correct GA4 object for adding/removing a <select> filter', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
@@ -101,7 +101,7 @@ describe('GA4 finder change tracker', function () {
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
-  it('creates the correct GA4 object for adding a <select> filter', function () {
+  it('creates the correct GA4 object for adding/removing a <select> filter', function () {
     inputParent = document.createElement('div')
     inputParent.setAttribute('data-ga4-change-category', 'update-filter select')
     inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
@@ -137,6 +137,15 @@ describe('GA4 finder change tracker', function () {
     expected.event_data.index = index
 
     expect(window.dataLayer[0]).toEqual(expected)
+
+    input.value = 'all-types'
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.action = 'remove'
+    expected.event_data.index = undefined
+    expected.event_data.text = 'All types of chocolate (default)'
+
+    expect(window.dataLayer[1]).toEqual(expected)
   })
 
   it('creates the correct GA4 object for adding/removing a text filter', function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
@@ -201,4 +201,32 @@ describe('GA4 finder change tracker', function () {
 
     expect(window.dataLayer[0]).toEqual(expected)
   })
+
+  it('creates the correct GA4 object for changing the sort selection', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-sort select')
+    var index = { index_section: 1, index_section_count: 1 }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    input = document.createElement('select')
+    input.setAttribute('name', 'sort')
+    input.id = 'sort'
+
+    option1 = document.createElement('option')
+    option1.value = 'most-viewed'
+    option1.innerText = 'Most viewed'
+    input.appendChild(option1)
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Sort by'
+    expected.event_data.text = 'Most viewed'
+    expected.event_data.action = 'sort'
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
@@ -57,7 +57,7 @@ describe('GA4 finder change tracker', function () {
     expected.event = 'event_data'
     expected.event_data.event_name = 'search'
     expected.event_data.type = 'finder'
-    expected.event_data.url = window.location.href
+    expected.event_data.url = window.location.pathname
     expected.event_data.text = 'Hello world my postcode is [postcode]. My birthday is [date]. My email is [email]'
     expected.event_data.section = 'Search'
     expected.event_data.action = 'search'

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-finder-tracker.spec.js
@@ -1,0 +1,67 @@
+/* eslint-env jasmine */
+
+describe('GA4 finder change tracker', function () {
+  var GOVUK = window.GOVUK
+  var form
+  var expected
+
+  function agreeToCookies () {
+    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+  }
+
+  beforeAll(function () {
+    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+    window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
+    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
+  })
+
+  beforeEach(function () {
+    window.dataLayer = []
+    form = document.createElement('form')
+    document.body.appendChild(form)
+
+    form.addEventListener('change', function (e) {
+      var ga4ChangeCategory = e.target.closest('[data-ga4-change-category]')
+      if (ga4ChangeCategory) {
+        ga4ChangeCategory = ga4ChangeCategory.getAttribute('data-ga4-change-category')
+        window.GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent(e.target, ga4ChangeCategory)
+      }
+    })
+
+    agreeToCookies()
+  })
+
+  afterEach(function () {
+    document.body.removeChild(form)
+  })
+
+  afterAll(function () {
+    window.dataLayer = []
+  })
+
+  it('creates the correct GA4 object for a search box keyword update', function () {
+    var searchBoxParent = document.createElement('div')
+    searchBoxParent.setAttribute('data-ga4-change-category', 'update-keyword text')
+
+    var searchBox = document.createElement('input')
+    searchBox.setAttribute('type', 'search')
+    searchBox.value = 'Hello world my postcode is SW1A 0AA. My birthday is 1970-01-01. My email is email@example.com'
+
+    searchBoxParent.appendChild(searchBox)
+    form.appendChild(searchBoxParent)
+
+    window.GOVUK.triggerEvent(searchBox, 'change')
+
+    expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+    expected.govuk_gem_version = 'aVersion'
+    expected.event = 'event_data'
+    expected.event_data.event_name = 'search'
+    expected.event_data.type = 'finder'
+    expected.event_data.url = window.location.href
+    expected.event_data.text = 'Hello world my postcode is [postcode]. My birthday is [date]. My email is [email]'
+    expected.event_data.section = 'Search'
+    expected.event_data.action = 'search'
+    console.log(window.dataLayer)
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+})


### PR DESCRIPTION
Hi @andysellick / @JamesCGDS - would you be able to review this when you get a chance? I've tried to explain it as best as I could, but let me know if something doesn't make sense. Thanks. 

## What
- Adds a new JavaScript "change" event tracker for the finders in `finder-frontend`. Related to this PR: https://github.com/alphagov/finder-frontend/pull/3042

Related trello cards: https://trello.com/c/zCIwJ8pP/515-add-tracking-search-box-on-search-finder-pages https://trello.com/c/aEXGK5cE/527-add-tracking-select-filter-on-search-finders-selectcontent
https://trello.com/c/sH9vKqA4/528-add-tracking-remove-filter-on-search-finders-selectcontent
https://trello.com/c/ZQeyh2qb/530-add-tracking-sort-by-search-finders-selectcontent

So this adds tracking to the search box, adding and removing the filters, changing the sort order, and clicking "clear all filters" on mobile.

<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why
<!-- What are the reasons behind this change being made? -->
- This is needed because the finders are updated with client side JavaScript. They fire a `change` event whenever a keyword/filter/sort option is changed. Therefore we need to hook into this to track what was changed for GA4.
- As each finder is one big form, it fires one big change event if anything in the search changes. Therefore we need a way to know which element triggered the change, so that we can send the correct GA4 event. In `finder-frontend`, we grab the `event.target` as well as `data-` attributes on the input or input parent, which gives us a simple way to categorise the change and build our GA4 object. We then pass that information through to this `Ga4FinderTracker` which processes it into a GTM object.

## How to test this
1. Run `static` locally, pointing to your local `govuk_publishing_components` with this branch, `ga4-finder-tracker`.
2. In `finder-frontend`, checkout the branch `ga4-finder-tracker`  https://github.com/alphagov/finder-frontend/pull/3042
3. Run `finder-frontend` pointing to your local `static`
4. Go to http://127.0.0.1:3062/search/all and change something in the search (e.g. a keyword, add a filter, remove a filter, or click "Clear all filters" in mobile view. Check the `dataLayer` for an `event_data` event (it's usually index 7 in the dataLayer). Also check the finders without any filters e.g. http://127.0.0.1:3062/government/people and ones with radio buttons https://www.gov.uk/official-documents.

## Brief explanation of how it works

1. In finder-frontend, we define some data-attributes on the finder `<form>` elements. 
    a. Firstly, we put a `data-ga4-filter-container` on the element that wraps all the filters. This will be needed to set `index_section` on each filter.
    b. Next, we add a `data-ga4-section` on each filter with the `data-ga4-filter-container` element. This is needed to identify where we need to add `data-ga4-index` for our `index_section`s. This key is also used to identify the `section` value to add to the GTM object. E.g. for a Topics filter, the attribute would be `data-ga4-section="Topics"`
   c. Next, on each element that can cause a `change` event on the `<form>` we add an attribute called `data-ga4-change-category` which gives us 1. metadata on what that element changes about the search results and 2. the HTML type that the element is. For example, on a `<select>` element that changes the filters, we would add `data-ga4-change-category="update-filter select"`. On the search box we would add `data-ga4-change-category="update-keyword text".

2. On the loading of a `finder`, we call `window.GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes()` in `finder-frontend`. This will grab the `data-ga4-filter-container`, look for any `data-ga4-section` elements inside it, and set an `index_section` on each section it finds.
3. In `finder-frontend`, when the search results are changed, we pass through the `event.target` and `data-ga4-change-category` to `Ga4FinderTracker.trackFormChange()`.
4. `trackFormChange()` will grab the "value" of the Filter that caused the change. For example the name of the checkbox, or the new keyword that was just searched for.
5. If it was a filter that caused the `change` event, then `trackFormChange()` will try and determine wether the filter that changed was a `Add filter` or `Remove filter` event.
6. It will then use a `switch` statement to build the GTM object based on which `data-ga4-change-category` was passed. 

I've also written a markdown documentation file. Hope how I've built this makes sense.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
 
None.
