### PR TITLE
Remove capitalisation on GA4 action property value

### DIFF
--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -270,7 +270,7 @@
                 class="gem-c-layout-super-navigation-header__search-form"
                 id="search"
                 data-module="ga4-form-tracker"
-                data-ga4-form='{ "event_name": "search", "type": "header menu bar", "section": "Search GOV.UK", "action": "Search", "url": "/search/all" }'
+                data-ga4-form='{ "event_name": "search", "type": "header menu bar", "section": "Search GOV.UK", "action": "search", "url": "/search/all" }'
                 data-ga4-form-include-text
                 action="/search"
                 method="get"


### PR DESCRIPTION
## What
This PR fixes a small bug where the `action` value was capitalised on search box tracking in the header.

## Why
Requested by the PA's.

## Visual Changes
N/A

[Trello card](https://trello.com/c/ODSHAwII/534-remove-capitalisation-on-action-search-on-home-page-and-header-menu-bar)
