### PR TITLE
Add Welsh translation for `all_opens_in_new_tab`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Make Cookie Banner Implementation More Like Design System Implementation [(PR #3325)](https://github.com/alphagov/govuk_publishing_components/pull/3325)
 * Remove capitalisation on GA4 action property value [PR #3367](https://github.com/alphagov/govuk_publishing_components/pull/3367)
+* Add Welsh translation for `all_opens_in_new_tab` ([PR #3370](https://github.com/alphagov/govuk_publishing_components/pull/3370))
 
 ## 35.3.2
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -176,7 +176,7 @@ cy:
       label: Chwilio ar GOV.UK
       search_button: Chwilio
     share_links:
-      all_opens_in_new_tab:
+      all_opens_in_new_tab: Bydd rhannu yn agor y dudalen hon mewn tab newydd
       opens_in_new_tab:
     show_password:
       announce_hide: Mae eich cyfrinair wedi'i guddio


### PR DESCRIPTION
## What
Adds the Welsh translation for "Sharing will open the page in a new tab".

## Why
A department (DVLA) have noticed the text is in the wrong language on their Welsh organisation page and on their Welsh news stories.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5318644