### PR TITLE
Rename type breadcrumbs to breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Rename type breadcrumbs to breadcrumb [(PR #3373)](https://github.com/alphagov/govuk_publishing_components/pull/3373)
+
 ## 35.3.3
 
 * Make Cookie Banner Implementation More Like Design System Implementation [(PR #3325)](https://github.com/alphagov/govuk_publishing_components/pull/3325)

--- a/lib/govuk_publishing_components/presenters/breadcrumbs_helper.rb
+++ b/lib/govuk_publishing_components/presenters/breadcrumbs_helper.rb
@@ -60,7 +60,7 @@ module GovukPublishingComponents
           },
           ga4_link: {
             event_name: "navigation",
-            type: "breadcrumbs",
+            type: "breadcrumb",
             index: {
               index_link: index.to_s,
             },

--- a/spec/components/breadcrumbs_spec.rb
+++ b/spec/components/breadcrumbs_spec.rb
@@ -72,7 +72,7 @@ describe "Breadcrumbs", type: :view do
 
     expected_tracking_options = {
       event_name: "navigation",
-      type: "breadcrumbs",
+      type: "breadcrumb",
       index: {
         index_link: "1",
       },


### PR DESCRIPTION
## What
This PR makes a very small change to the GA4 event `type` parameter when tracking breadcrumbs and changes it to `breadcrumb` rather than `breadcrumbs`.

## Why
Requested by PA's

[Trello card](https://trello.com/c/Fwv2tyhJ/514-rename-breadcrumb)

## Visual Changes
N/A