### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@
 ## Unreleased
 
 * Rename type breadcrumbs to breadcrumb [(PR #3373)](https://github.com/alphagov/govuk_publishing_components/pull/3373)
+* Add missing background colour style for metadata block inverse option [(PR #3365)](https://github.com/alphagov/govuk_publishing_components/pull/3365)
 
 ## 35.3.3
 
 * Make Cookie Banner Implementation More Like Design System Implementation [(PR #3325)](https://github.com/alphagov/govuk_publishing_components/pull/3325)
 * Remove capitalisation on GA4 action property value [PR #3367](https://github.com/alphagov/govuk_publishing_components/pull/3367)
 * Add Welsh translation for `all_opens_in_new_tab` ([PR #3370](https://github.com/alphagov/govuk_publishing_components/pull/3370))
-* Add missing background colour style for metadata block inverse option [(PR #3365)](https://github.com/alphagov/govuk_publishing_components/pull/3365)
 
 ## 35.3.2
 


### PR DESCRIPTION
## What
Update CHANGELOG.md

## Why
Move "Add missing background colour style for metadata block inverse option ([PR #3365](https://github.com/alphagov/govuk_publishing_components/pull/3365))" to Unreleased

## Visual Changes
None