### PR TITLE
Fully implement loading of individual stylesheets in component guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fully implement loading of individual stylesheets in component guide ([PR #3379](https://github.com/alphagov/govuk_publishing_components/pull/3379))
+
 ## 35.6.0
 
 * Remove GA4 index parsing code ([PR #3434](https://github.com/alphagov/govuk_publishing_components/pull/3434))

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -6,31 +6,6 @@ $govuk-new-link-styles: true;
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/component_support";
 
-// Import the same stylesheets used in static
-// https://github.com/alphagov/static/blob/198a598682df40ce4a2c3c286c06244297c18cf0/app/assets/stylesheets/application.scss
-// Although the component guide does not use static, we still need to import the same stylesheets used in static
-// to avoid any rendering issues
-// By following the same approach as frontend rendering applications,
-// we ensure that stylesheets are loaded in the expected order and components render correctly
-@import "govuk_publishing_components/components/breadcrumbs";
-@import "govuk_publishing_components/components/button";
-@import "govuk_publishing_components/components/error-message";
-@import "govuk_publishing_components/components/heading";
-@import "govuk_publishing_components/components/hint";
-@import "govuk_publishing_components/components/input";
-@import "govuk_publishing_components/components/label";
-@import "govuk_publishing_components/components/search";
-@import "govuk_publishing_components/components/skip-link";
-@import "govuk_publishing_components/components/textarea";
-@import "govuk_publishing_components/components/title";
-
-@import "govuk_publishing_components/components/cookie-banner";
-@import "govuk_publishing_components/components/feedback";
-@import "govuk_publishing_components/components/layout-footer";
-@import "govuk_publishing_components/components/layout-for-public";
-@import "govuk_publishing_components/components/layout-header";
-@import "govuk_publishing_components/components/layout-super-navigation-header";
-
 // Include required helpers
 @import "../../stylesheets/govuk_publishing_components/components/helpers/markdown-typography";
 

--- a/app/views/govuk_publishing_components/components/_character_count.html.erb
+++ b/app/views/govuk_publishing_components/components/_character_count.html.erb
@@ -1,6 +1,4 @@
 <%
-  add_gem_component_stylesheet("character-count")
-
   id ||= "character-count-#{SecureRandom.hex(4)}"
   maxlength ||= nil
   maxwords ||= nil
@@ -24,3 +22,7 @@
     </div>
   <% end %>
 <% end %>
+<%
+  add_gem_component_stylesheet("error-message")
+  add_gem_component_stylesheet("character-count")
+%>

--- a/app/views/govuk_publishing_components/components/_feedback.html.erb
+++ b/app/views/govuk_publishing_components/components/_feedback.html.erb
@@ -1,4 +1,5 @@
 <%
+  add_gem_component_stylesheet("button")
   add_gem_component_stylesheet("feedback")
 
   def utf_encode(element)

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -1,4 +1,5 @@
 <%
+  add_gem_component_stylesheet("layout-header")
   add_gem_component_stylesheet("layout-super-navigation-header")
 
   logo_link ||= "https://www.gov.uk/"

--- a/app/views/govuk_publishing_components/components/_radio.html.erb
+++ b/app/views/govuk_publishing_components/components/_radio.html.erb
@@ -1,4 +1,5 @@
 <%
+  add_gem_component_stylesheet("label")
   add_gem_component_stylesheet("radio")
 
   local_assigns[:margin_bottom] ||= 6

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -49,6 +49,7 @@
 
 <div class="<%= classes.join(" ") %>" data-module="gem-toggle-input-class-on-focus">
   <% if wrap_label_in_a_heading %>
+    <% add_gem_component_stylesheet("label") %>
     <%= content_tag(shared_helper.get_heading_level, class: "govuk-!-margin-0") do %>
       <%= tag_label %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_select.html.erb
@@ -17,6 +17,7 @@
 <% if select_helper.options.any? && id && label %>
   <%= content_tag :div, class: select_helper.css_classes do %>
     <% if is_page_heading %>
+      <% add_gem_component_stylesheet("title") %>
       <%= tag.h1 label_tag(id, label, class: select_helper.label_classes), class: "gem-c-title__text" %>
     <% else %>
       <%= label_tag(id, label, class: select_helper.label_classes) %>

--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -1,3 +1,25 @@
+<% content_for :body do %>
+  <% if @preview %>
+    <main id="wrapper" class="govuk-width-container">
+      <%= yield %>
+    </main>
+  <% else %>
+    <%= render "govuk_publishing_components/components/layout_header", {
+      environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
+      product_name: GovukPublishingComponents::Config.component_guide_title,
+      href: component_guide_path
+    } %>
+    <div class="govuk-width-container app-width-container--wide">
+      <% if @guide_breadcrumbs %>
+        <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @guide_breadcrumbs  %>
+      <% end %>
+      <main id="wrapper" class="govuk-main-wrapper">
+        <%= yield %>
+      </main>
+    </div>
+    <%= render "govuk_publishing_components/components/layout_footer" %>
+  <% end %>
+<% end %>
 <!DOCTYPE html>
 <html lang="en" class="<%= "govuk-template" unless @preview %>">
   <head>
@@ -27,26 +49,7 @@
     <%= javascript_tag nonce: true do -%>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     <% end -%>
-    <% if @preview %>
-      <main id="wrapper" class="govuk-width-container">
-        <%= yield %>
-      </main>
-    <% else %>
-      <%= render "govuk_publishing_components/components/layout_header", {
-        environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
-        product_name: GovukPublishingComponents::Config.component_guide_title,
-        href: component_guide_path
-      } %>
-      <div class="govuk-width-container app-width-container--wide">
-        <% if @guide_breadcrumbs %>
-          <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @guide_breadcrumbs  %>
-        <% end %>
-        <main id="wrapper" class="govuk-main-wrapper">
-          <%= yield %>
-        </main>
-      </div>
-      <%= render "govuk_publishing_components/components/layout_footer" %>
-    <% end %>
+    <%= yield :body %>
 
     <%= javascript_include_tag "component_guide/application" %>
     <%= javascript_include_tag "#{GovukPublishingComponents::Config.application_javascript}" %>

--- a/lib/govuk_publishing_components/app_helpers/asset_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/asset_helper.rb
@@ -79,11 +79,15 @@ module GovukPublishingComponents
     private
 
       def is_already_used?(component)
-        if GovukPublishingComponents::Config.exclude_css_from_static
+        if GovukPublishingComponents::Config.exclude_css_from_static && !viewing_component_guide?
           all_component_stylesheets_being_used.include?(component) || STATIC_STYLESHEET_LIST.include?(component)
         else
           all_component_stylesheets_being_used.include?(component)
         end
+      end
+
+      def viewing_component_guide?
+        request.path.include?("/component-guide")
       end
     end
   end

--- a/spec/features/asset_helper_spec.rb
+++ b/spec/features/asset_helper_spec.rb
@@ -39,4 +39,21 @@ describe "When the asset helper is configured", type: :view do
       expect(page).to have_selector('link[href^="/assets/views/_app-view-"][rel="stylesheet"]', visible: false)
     end
   end
+
+  scenario "request all stylesheets when exclude_css_from_static is set to false" do
+    GovukPublishingComponents.configure do |config|
+      config.exclude_css_from_static = false
+    end
+
+    visit "/asset_helper"
+
+    within(:xpath, "//head", visible: false) do
+      expect(page).to have_xpath("//link", visible: false, count: 4)
+
+      expect(page).to have_selector('link[href^="/assets/application-"][rel="stylesheet"]', visible: false)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_notice-"][rel="stylesheet"]', visible: false)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_details-"][rel="stylesheet"]', visible: false)
+      expect(page).to have_selector('link[href^="/assets/govuk_publishing_components/components/_title-"][rel="stylesheet"]', visible: false)
+    end
+  end
 end

--- a/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
   describe "Asset helper" do
     include GovukPublishingComponents::AppHelpers::AssetHelper
 
+    def request
+      double(ActionDispatch::Request, { path: "/" })
+    end
+
     it "detect the total number of stylesheet paths" do
       expect(get_component_css_paths.count).to eql(73)
     end
@@ -19,6 +23,10 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
     end
 
     it "initialize asset helper then add multiple stylesheets but exclude 'button' stylesheet since it's already in static" do
+      GovukPublishingComponents.configure do |config|
+        config.exclude_css_from_static = true
+      end
+
       add_gem_component_stylesheet("accordion")
       add_gem_component_stylesheet("back-link")
       add_gem_component_stylesheet("button")


### PR DESCRIPTION
## What

Fully implement loading of individual stylesheets in component guide.

- Remove import of stylesheets used in static from application.scss
- Update asset_helper.rb to ensure all component stylesheets are requested when viewing the component guide
- Ensure stylesheets are requested in the expected order, for example, the `button` stylesheet should always be requested before the `feedback` stylesheet in the [feedback component](https://github.com/alphagov/govuk_publishing_components/pull/3379/files#diff-467712c9048ef82f631d6018dc019d21a911b8c5dedbfe37a512b84cea69045eR2)

## Why

The components in the gem should render correctly when using the individual loading of stylesheets feature in any application.

Without this change, applications would need to import all the stylesheets we import in static - https://github.com/alphagov/static/blob/main/app/assets/stylesheets/application.scss#L11-L30 into their application.css file, in order for components to render correctly.

Trello: https://trello.com/c/Hhs2H5S7/1993-fully-implement-individual-loading-of-assets-in-the-component-guide

## Visual changes

Percy is showing 1 visual change for the "Form checkboxes - Checkbox items with conditional reveal checked" component. This appears to be expected given the [note included in the documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/docs/checkboxes.yml#L303):

> Note: ... No styling will be applied to the inserted content by the component.