### PR TITLE
Add option for blue bar background to public_layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add option for blue bar background to public_layout ([PR #3380](https://github.com/alphagov/govuk_publishing_components/pull/3380))
+
 ## 35.7.0
 
 * Component auditing improvements ([PR #3423](https://github.com/alphagov/govuk_publishing_components/pull/3423))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-for-public.scss
@@ -9,6 +9,10 @@
   height: govuk-spacing(2);
 }
 
+.gem-c-layout-for-public__blue-bar-wrapper--browse {
+  background-color: #263135;
+}
+
 .js-enabled .gem-c-layout-for-public__global-banner-wrapper {
   margin-top: - govuk-spacing(2);
   min-height: govuk-spacing(2);

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -3,9 +3,11 @@
 
   emergency_banner ||= nil
   full_width ||= false
+  blue_bar ||= local_assigns.include?(:blue_bar) ? local_assigns[:blue_bar] : !full_width
   global_bar ||= nil
   html_lang ||= "en"
   layout_helper = GovukPublishingComponents::Presenters::PublicLayoutHelper.new(local_assigns)
+  blue_bar_background_colour = layout_helper.blue_bar_background_colours.include?(blue_bar_background_colour) ? blue_bar_background_colour : nil
   logo_link ||= "/"
   navigation_items ||= []
   omit_feedback_form ||= false
@@ -44,6 +46,9 @@
   blue_bar_dedupe = !full_width && global_bar.present?
   body_css_classes = %w(gem-c-layout-for-public govuk-template__body)
   body_css_classes << "draft" if draft_watermark
+
+  blue_bar_wrapper_classes = %w()
+  blue_bar_wrapper_classes << "gem-c-layout-for-public__blue-bar-wrapper--#{blue_bar_background_colour}" if blue_bar_background_colour
 -%>
 <!DOCTYPE html>
   <!--[if lt IE 9]><html class="lte-ie8 govuk-template" lang="<%= html_lang %>"><![endif]-->
@@ -117,8 +122,10 @@
 
     <%= raw(emergency_banner) %>
 
-    <% unless full_width %>
-      <div class="gem-c-layout-for-public__blue-bar govuk-width-container"></div>
+    <% if (blue_bar && !global_bar.present?) || (blue_bar_dedupe) %>
+      <%= content_tag(:div, class: blue_bar_wrapper_classes) do %>
+        <div class="gem-c-layout-for-public__blue-bar govuk-width-container"></div>
+      <% end %>
     <% end %>
 
     <% if global_bar.present? %>

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -27,6 +27,12 @@ examples:
     description: This allows the header to be omitted which is currently used when rendering CSV previews from Whitehall
     data:
       omit_header: true
+  blue_bar_background:
+    description: For use when a page has a heading component with a background colour.
+    data:
+      full_width: true
+      blue_bar: true
+      blue_bar_background_colour: "no"
   omit_feedback:
     description: This allows the feedback form to be omitted
     data:

--- a/lib/govuk_publishing_components/presenters/public_layout_helper.rb
+++ b/lib/govuk_publishing_components/presenters/public_layout_helper.rb
@@ -1,6 +1,7 @@
 module GovukPublishingComponents
   module Presenters
     class PublicLayoutHelper
+      BLUE_BAR_BACKGROUND_COLOURS = %w[browse].freeze
       FOOTER_NAVIGATION_COLUMNS = [2, 1].freeze
       FOOTER_TRACK_ACTIONS = %w[topicsLink governmentactivityLink].freeze
       FOOTER_META = {
@@ -67,6 +68,10 @@ module GovukPublishingComponents
 
       def footer_track_actions
         FOOTER_TRACK_ACTIONS
+      end
+
+      def blue_bar_background_colours
+        BLUE_BAR_BACKGROUND_COLOURS
       end
 
       def generate_data_attribute(link, track_action)

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -129,6 +129,30 @@ describe "Layout for public", type: :view do
     assert_select ".gem-c-layout-for-public__blue-bar", false
   end
 
+  it "renders the blue bar if `blue_bar` is `true`" do
+    render_component(blue_bar: true)
+
+    assert_select ".gem-c-layout-for-public__blue-bar"
+  end
+
+  it "renders the blue bar if `full_width` is true and `blue_bar` is true" do
+    render_component(full_width: true, blue_bar: true)
+
+    assert_select ".gem-c-layout-for-public__blue-bar"
+  end
+
+  it "renders the blue bar with a background if valid background specified" do
+    render_component(blue_bar: true, full_width: true, blue_bar_background_colour: "browse")
+
+    assert_select ".gem-c-layout-for-public__blue-bar-wrapper--browse .gem-c-layout-for-public__blue-bar"
+  end
+
+  it "does not render the blue bar with a background if an invalid background specified" do
+    render_component(blue_bar: true, full_width: true, blue_bar_background_colour: "invalid")
+
+    assert page.has_no_selector? ".gem-c-layout-for-public__blue-bar-wrapper--invalid"
+  end
+
   it "has the default logo link when no logo_link is specified" do
     render_component({})
 


### PR DESCRIPTION
## What

Add a new option `blue_bar_background` for public_layout. Add new option `blue_bar` for public_layout. Rework logic for blue bar appearance in the public_layout. Add tests for the blue bar background and the blue bar logic.

## Why

There are [instances of pages on collections](https://www.gov.uk/browse) that have a coloured background in the heading section. This meant that the blue bar (which is rendered in the public_layout) had to be rendered by collections otherwise it would result in a gap between the blue bar and coloured section. This solution seemed fine until we had a recent deployment of the global bar. As the global bar includes a blue bar, it meant that the Browse pages had two blue bars. They therefore needed to be removed while the global bar was present and then added back again when the global bar was removed. 

To avoid this needing to happen the next time the bar is deployed, changes have been made to the `public_layout` component. It means that if a page has a coloured background heading it can be specified using the attributes and then it will be applied to the blue bar. This means the blue bar can always be rendered in public_layout and so applications don't need to render the blue bar if they have a heading section with a background colour.

[Relevant Trello Card](https://trello.com/c/pT7Sh8Yn/1793-update-layoutforpublic-template-so-that-global-bar-is-independent-of-requiring-changes-in-the-browse-template-l)