### PR TITLE
Change type 'html attachment' to just 'attachment'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Conditionally set GA4 type in related navigation ([PR #3390](https://github.com/alphagov/govuk_publishing_components/pull/3390))
+* Change type 'html attachment' to just 'attachment' ([PR #3382](https://github.com/alphagov/govuk_publishing_components/pull/3382))
 
 ## 35.3.4
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
@@ -11,7 +11,7 @@ var initFunction = function () {
     var attachmentLinkData = [
       { key: 'data-module', value: 'ga4-link-tracker' },
       { key: 'data-ga4-track-links-only', value: '' },
-      { key: 'data-ga4-link', value: JSON.stringify({ event_name: 'navigation', type: 'html attachment' }) }]
+      { key: 'data-ga4-link', value: JSON.stringify({ event_name: 'navigation', type: 'attachment' }) }]
     window.GOVUK.analyticsGa4.core.trackFunctions.addAttributesToElements('[data-ga4-attachment-link]', attachmentLinkData)
     window.GOVUK.analyticsGa4.core.load()
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.spec.js
@@ -93,7 +93,7 @@ describe('Initialising GA4', function () {
         for (var i = 0; i < 5; i++) {
           expect(elements[i].getAttribute('data-module')).toEqual('ga4-link-tracker')
           expect(elements[i].getAttribute('data-ga4-track-links-only')).toEqual('')
-          expect(elements[i].getAttribute('data-ga4-link')).toEqual(JSON.stringify({ event_name: 'navigation', type: 'html attachment' }))
+          expect(elements[i].getAttribute('data-ga4-link')).toEqual(JSON.stringify({ event_name: 'navigation', type: 'attachment' }))
         }
       })
 
@@ -109,7 +109,7 @@ describe('Initialising GA4', function () {
         for (i = 0; i < 5; i++) {
           expect(elements[i].getAttribute('data-module')).toEqual('govspeak ga4-link-tracker')
           expect(elements[i].getAttribute('data-ga4-track-links-only')).toEqual('')
-          expect(elements[i].getAttribute('data-ga4-link')).toEqual(JSON.stringify({ event_name: 'navigation', type: 'html attachment' }))
+          expect(elements[i].getAttribute('data-ga4-link')).toEqual(JSON.stringify({ event_name: 'navigation', type: 'attachment' }))
         }
       })
     })


### PR DESCRIPTION
https://trello.com/c/IsRPgFh9/559-change-html-attachment-type-to-attachment-on-attachment-navigation-clicks

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Change type 'html attachment' to just 'attachment'

## Why
<!-- What are the reasons behind this change being made? -->
This change is being made because we're going to add data-ga4-attachment-link to every attachment link, so soon it won't just be html attachments being tracked with this type.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
