### PR TITLE
Update popular on govuk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add GA4 debugging assistance ([PR #3388](https://github.com/alphagov/govuk_publishing_components/pull/3388))
 * Conditionally set GA4 type in related navigation ([PR #3390](https://github.com/alphagov/govuk_publishing_components/pull/3390))
 * Change type 'html attachment' to just 'attachment' ([PR #3382](https://github.com/alphagov/govuk_publishing_components/pull/3382))
+* Update popular on gov.uk links in search bar ([PR #3385](https://github.com/alphagov/govuk_publishing_components/pull/3385))
 
 ## 35.3.4
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -236,10 +236,10 @@ en:
         href: "/guidance/getting-the-energy-bills-support-scheme-discount"
       - label: Find a job
         href: "/find-a-job"
-      - label: Coronavirus (COVID-19)
-        href: "/coronavirus"
       - label: 'Universal Credit account: sign in'
         href: "/sign-in-universal-credit"
+      - label: Check your National Insurance record
+        href: "/check-national-insurance-record"
       popular_links_heading: Popular on GOV.UK
       search_text: Search GOV.UK
     metadata:


### PR DESCRIPTION
## What
Update popular on GOV.UK links in top search bar to match those in the [homepage body](https://github.com/alphagov/frontend/blob/main/config/locales/en.yml#L382-L392) 

## Why
Popular links should be consistent across the site. It's a pain that they are set in different places.

## Visual Changes

### Before
<img width="1041" alt="Screenshot 2023-05-10 at 13 07 14" src="https://github.com/alphagov/govuk_publishing_components/assets/17908089/da31a182-fc1d-4e4b-bec3-379e8e87dc00">

### After

