### PR TITLE
Add GA4 debugging assistance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add GA4 debugging assistance ([PR #3388](https://github.com/alphagov/govuk_publishing_components/pull/3388))
 * Conditionally set GA4 type in related navigation ([PR #3390](https://github.com/alphagov/govuk_publishing_components/pull/3390))
 * Change type 'html attachment' to just 'attachment' ([PR #3382](https://github.com/alphagov/govuk_publishing_components/pull/3382))
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -32,6 +32,10 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
 
     sendData: function (data) {
       data.govuk_gem_version = this.getGemVersion()
+      // set this in the console as a debugging aid
+      if (window.GOVUK.analyticsGa4.showDebug) {
+        console.info(JSON.stringify(data, null, ' '))
+      }
       window.dataLayer.push(data)
     },
 


### PR DESCRIPTION
## What
- outputs details of analytics data pushed to the datalayer, to aid with debugging analytics events on any system particularly between pages
- to use, set the variable in the console: window.GOVUK.analyticsGa4.showDebug = true, then set the console to preserve log, then do a thing to trigger an event

## Why
I've been finding that the browser tools for debugging analytics events aren't 100% reliable, and this will help in some situation.

## Visual Changes
None.

Outputs into the console something like the below. I've tried to format it so it's readable - if you just output the object and go to another page, it doesn't persist the content of the object, so it's not accessible.

![Screenshot 2023-05-10 at 14 55 20](https://github.com/alphagov/govuk_publishing_components/assets/861310/24d17b47-55ae-450b-9fe4-b77622355944)
