### PR TITLE
Remove deprecated IE8 mixin

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -62,12 +62,6 @@ $large-input-size: 50px;
   // Double the border by adding its width again. Use `box-shadow` for this // instead of changing `border-width`
   // Also, `outline` cannot be utilised here as it is already used for the yellow focus state.
   box-shadow: inset 0 0 0 $govuk-border-width-form-element;
-
-  @include govuk-if-ie8 {
-    // IE8 doesn't support `box-shadow` so double the border with
-    // `border-width`.
-    border-width: $govuk-border-width-form-element * 2;
-  }
 }
 
 .gem-c-search__input[type="search"] { // overly specific to prevent some overrides from outside
@@ -136,12 +130,6 @@ $large-input-size: 50px;
     // Also, `outline` cannot be utilised
     // here as it is already used for the yellow focus state.
     box-shadow: inset 0 0 0 $govuk-border-width-form-element * 2 govuk-colour("black");
-
-    @include govuk-if-ie8 {
-      // IE8 doesn't support `box-shadow` so double the border with
-      // `border-width`.
-      border-width: $govuk-border-width-form-element * 2;
-    }
   }
 
   &::-moz-focus-inner {

--- a/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
@@ -44,17 +44,6 @@
         height: 140px;
         background: govuk-colour("white");
         outline: $govuk-border-width solid transparentize(govuk-colour("black"), .9);
-
-        @include govuk-if-ie8 {
-          // IE8 incorrectly asserts the "max-width: 100%" rule to be 0
-          // because of the collapsed width on its floating container
-          // Reset the max-width so that thumbnails render at the specified
-          // width above.
-          // http://www.456bereastreet.com/archive/201202/using_max-width_on_images_can_make_them_disappear_in_ie8/
-          max-width: none;
-          border: $govuk-border-width solid govuk-colour("mid-grey", $legacy: "grey-3");
-        }
-
         box-shadow: 0 2px 2px rgba(govuk-colour("black"), .4);
       }
 


### PR DESCRIPTION
## What

- the govuk-if-ie8 mixin is deprecated and being removed from govuk-frontend in v5
- we don't support Internet Explorer 8 anymore, so removing this seems like the cleanest course of action

## Why
Was causing this warning to appear at compile time:

```
WARNING: The govuk-if-ie8 mixin is deprecated and will be removed in v5.0. To silence this warning, update $govuk-suppressed-warnings with key: "ie8"
         on line 49:5 of node_modules/govuk-frontend/govuk/tools/../settings/_warnings.scss, in mixin `-warning`
         from line 37:12 of node_modules/govuk-frontend/govuk/tools/_ie8.scss, in mixin `govuk-if-ie8`
         from line 48:18 of app/assets/stylesheets/govuk_publishing_components/components/govspeak/_attachment.scss
         from line 4:9 of app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
         from line 42:9 of app/assets/stylesheets/govuk_publishing_components/_all_components.scss
         from line 1:9 of spec/dummy/app/assets/stylesheets/application.scss
```


## Visual Changes
None.
