### PR TITLE
Conditionally set GA4 type in related navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Conditionally set GA4 type in related navigation ([PR #3390](https://github.com/alphagov/govuk_publishing_components/pull/3390))
+
 ## 35.3.4
 
 * Update organisation logo ([PR #3381](https://github.com/alphagov/govuk_publishing_components/pull/3381))

--- a/app/views/govuk_publishing_components/components/_related_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_related_navigation.html.erb
@@ -2,6 +2,7 @@
   related_nav_helper = GovukPublishingComponents::Presenters::RelatedNavigationHelper.new(local_assigns)
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   ga4_tracking ||= false
+  ga4_type = local_assigns[:context] == :footer ? "contextual footer" : "related content"
   data = {}
   data[:module] = "gem-track-click"
   data[:module] << " ga4-link-tracker" if ga4_tracking
@@ -42,7 +43,8 @@
         section_index: section_index,
         section_count: ga4_tracking_counts.index_section_count,
         random: random,
-        ga4_tracking: ga4_tracking %>
+        ga4_tracking: ga4_tracking,
+        ga4_type: ga4_type %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
+++ b/app/views/govuk_publishing_components/components/related_navigation/_section.html.erb
@@ -34,7 +34,7 @@
         link_class = "govuk-link #{related_nav_helper.section_css_class("govuk-link gem-c-related-navigation__section-link", section_title, link: link, link_is_inline: (index >= section_link_limit))}"
         ga4_attributes = {
           event_name: "navigation",
-          type: "related content",
+          type: ga4_type,
           index: {
             index_section: "#{section_index}",
             index_link: "#{index}",

--- a/spec/components/contextual_footer_spec.rb
+++ b/spec/components/contextual_footer_spec.rb
@@ -27,4 +27,28 @@ RSpec.describe "Contextual footer", type: :view do
       assert_no_selector ".gem-c-contextual-footer"
     end
   end
+
+  it "sets the GA4 type to \"contextual footer\"" do
+    content_item = {}
+    content_item["links"] = {
+      "topics" => [
+        {
+          "base_path" => "/skating",
+          "title" => "Skating",
+          "document_type" => "topic",
+        },
+        {
+          "base_path" => "/paragliding",
+          "title" => "Paragliding",
+          "document_type" => "topic",
+        },
+      ],
+    }
+
+    render_component(content_item: content_item, ga4_tracking: true)
+
+    assert_select ".gem-c-related-navigation[data-module='gem-track-click ga4-link-tracker']"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"contextual footer\",\"index\":{\"index_section\":\"1\",\"index_link\":\"1\",\"index_section_count\":\"1\"},\"index_total\":\"2\",\"section\":\"Explore the topic\"}']", text: "Skating"
+    assert_select ".gem-c-related-navigation__section-link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"contextual footer\",\"index\":{\"index_section\":\"1\",\"index_link\":\"2\",\"index_section_count\":\"1\"},\"index_total\":\"2\",\"section\":\"Explore the topic\"}']", text: "Paragliding"
+  end
 end


### PR DESCRIPTION
## What
This PR addresses a bug where the `index` parameters were not aggregating when a `contextual sidebar` and a `contextual footer` were rendered together on a page. Combining the index properties of 2 different components could be complex and so the simplest fix was to provide a differentiation between `contextual sidebar` and `contextual footer` components in the `type` parameter so that the `index` properties need not be aggregated.

## Why
Requested by PA's.

[Trello card](https://trello.com/c/dYtGpIpv/502-indexcount-is-different-for-related-content-and-contextual-footer)

## Visual Changes
N/A
