### PR TITLE
Remove custom brand colours for Department for Business And Trade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add GA4 debugging assistance ([PR #3388](https://github.com/alphagov/govuk_publishing_components/pull/3388))
+* Remove custom brand colours for Department for Business And Trade ([PR #3391](https://github.com/alphagov/govuk_publishing_components/pull/3391))
 * Conditionally set GA4 type in related navigation ([PR #3390](https://github.com/alphagov/govuk_publishing_components/pull/3390))
 * Change type 'html attachment' to just 'attachment' ([PR #3382](https://github.com/alphagov/govuk_publishing_components/pull/3382))
 * Update popular on gov.uk links in search bar ([PR #3385](https://github.com/alphagov/govuk_publishing_components/pull/3385))

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss
@@ -96,27 +96,3 @@
     border-color: #045f71;
   }
 }
-
-// This change should be removed after relevant govuk-frontend release
-
-.brand--department-for-business-and-trade {
-  .brand__color {
-    color: #cf102d;
-
-    &:link,
-    &:visited,
-    &:active {
-      color: #cf102d;
-    }
-
-    &:hover,
-    &:focus {
-      color: $govuk-focus-text-colour;
-    }
-  }
-
-  &.brand__border-color,
-  .brand__border-color {
-    border-color: #cf102d;
-  }
-}


### PR DESCRIPTION
[Trello card](https://trello.com/c/rtK4IWUx/1206-update-department-of-business-trade-branding-labels-in-publishing-components)

## What
This is reverting changes done in https://github.com/alphagov/govuk_publishing_components/pull/3361

## Why
Changes can be removed as relevant govuk-frontend update is released.
