### PR TITLE
Bump version to 35.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.3.5
 
 * Add GA4 debugging assistance ([PR #3388](https://github.com/alphagov/govuk_publishing_components/pull/3388))
 * Remove custom brand colours for Department for Business And Trade ([PR #3391](https://github.com/alphagov/govuk_publishing_components/pull/3391))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.3.4)
+    govuk_publishing_components (35.3.5)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -124,7 +124,7 @@ GEM
       rest-client (~> 2.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    govuk_app_config (7.2.0)
+    govuk_app_config (7.2.1)
       logstasher (~> 2.1)
       plek (>= 4, < 6)
       prometheus_exporter (~> 2.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.3.4".freeze
+  VERSION = "35.3.5".freeze
 end


### PR DESCRIPTION
Releases version 35.3.5 of the gem.

This will include:
* Add GA4 debugging assistance ([PR #3388](https://github.com/alphagov/govuk_publishing_components/pull/3388))
* Remove custom brand colours for Department for Business And Trade ([PR #3391](https://github.com/alphagov/govuk_publishing_components/pull/3391))
* Conditionally set GA4 type in related navigation ([PR #3390](https://github.com/alphagov/govuk_publishing_components/pull/3390))
* Change type 'html attachment' to just 'attachment' ([PR #3382](https://github.com/alphagov/govuk_publishing_components/pull/3382))
* Update popular on gov.uk links in search bar ([PR #3385](https://github.com/alphagov/govuk_publishing_components/pull/3385))
