### PR TITLE
Remove the blue background from search button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Conditionally set GA4 type in related navigation ([PR #3390](https://github.com/alphagov/govuk_publishing_components/pull/3390))
 * Change type 'html attachment' to just 'attachment' ([PR #3382](https://github.com/alphagov/govuk_publishing_components/pull/3382))
 * Update popular on gov.uk links in search bar ([PR #3385](https://github.com/alphagov/govuk_publishing_components/pull/3385))
+* Remove the blue background from search button ([PR #3393](https://github.com/alphagov/govuk_publishing_components/pull/3393))
 
 ## 35.3.4
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -532,10 +532,6 @@ $after-button-padding-left: govuk-spacing(4);
   margin: 0;
   padding: govuk-spacing(1) govuk-spacing(4);
 
-  @include govuk-media-query($from: "desktop") {
-    border-right: 0;
-  }
-
   @include govuk-media-query($from: 360px) {
     &:before {
       @include chevron(govuk-colour("white"));
@@ -575,7 +571,6 @@ $after-button-padding-left: govuk-spacing(4);
     right: 0;
 
     @include focus-not-focus-visible {
-      background: $govuk-brand-colour;
       border-bottom: 1px solid govuk-colour("dark-blue");
       border-left: none;
       position: relative;


### PR DESCRIPTION
## What

Remove blue background from search button in layout_super_navigation_header.

## Why

As a result of Design sessions with the GOV.UK design team, it was noticed that the background of the search button is black on mobile, and blue on desktop – which adds an unnecessary inconsistency. The proposed solution was Remove the blue background from desktop, and add a divider between the Menu and the Search elements.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

![Screenshot 2023-05-11 at 12 47 40](https://github.com/alphagov/govuk_publishing_components/assets/3727504/bd2886e3-7f54-4178-bbf9-11a50c4b5f19)

### After

![Screenshot 2023-05-11 at 12 47 31](https://github.com/alphagov/govuk_publishing_components/assets/3727504/37aac539-d3af-4e8f-90f1-9d2eeda1944e)

[Relevant Trello Card](https://trello.com/c/q8HGC7LF/1765-remove-blue-background-from-search-icon-in-menu-header-s)
