### PR TITLE
[Fixes] World Locations Links From Base Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Update to LUX 308 ([PR #3394](https://github.com/alphagov/govuk_publishing_components/pull/3394))
 * Ensure PIIRemover is running on GA4 link clicks ([PR #3402](https://github.com/alphagov/govuk_publishing_components/pull/3402))
 * Update hint component ([PR #3405](https://github.com/alphagov/govuk_publishing_components/pull/3405))
+* [Fixes] World Locations Links From Base Path ([PR #3396](https://github.com/alphagov/govuk_publishing_components/pull/3396))
 
 ## 35.3.5
 

--- a/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
+++ b/lib/govuk_publishing_components/presenters/related_navigation_helper.rb
@@ -12,9 +12,6 @@ module GovukPublishingComponents
         world_locations
         statistical_data_sets
       ].freeze
-      WORLD_LOCATION_SPECIAL_CASES = {
-        "UK Mission to the European Union" => "uk-mission-to-the-eu",
-      }.freeze
 
       attr_reader :related_navigation, :index_section_count
 
@@ -127,11 +124,14 @@ module GovukPublishingComponents
       end
 
       def related_world_locations
-        content_item_links_for("world_locations")
-          .map do |link|
-            slug = WORLD_LOCATION_SPECIAL_CASES[link[:text]] || link[:text].parameterize
-            link.merge(path: "/world/#{slug}/news")
-          end
+        content_item_links_for("world_locations").each do |link|
+          build_world_locations_path_for link
+        end
+      end
+
+      def build_world_locations_path_for(link)
+        slug = link[:text].parameterize
+        link[:path] ||= "/world/#{slug}/news"
       end
 
       def related_statistical_data_sets

--- a/spec/components/related_navigation_spec.rb
+++ b/spec/components/related_navigation_spec.rb
@@ -69,22 +69,22 @@ describe "Related navigation", type: :view do
     assert_select ".gem-c-related-navigation__section-link[href=\"/air-quality-statistics\"]", text: "Air quality statistics"
   end
 
-  it "renders world locations section when passed world location items" do
+  it "renders world locations section when passed world location items with base path" do
     content_item = {}
-    content_item["links"] = construct_links("world_locations", "/world/usa/news", "USA")
+    content_item["links"] = construct_links("world_locations", "/uk-mission-to-the-eu", "UK Mission to the European Union")
+    render_component(content_item: content_item)
+
+    assert_select ".gem-c-related-navigation__sub-heading", text: "World locations"
+    assert_select ".gem-c-related-navigation__section-link[href=\"/uk-mission-to-the-eu\"]", text: "UK Mission to the European Union"
+  end
+
+  it "renders world locations section when passed world location items without base path" do
+    content_item = {}
+    content_item["links"] = construct_links("world_locations", nil, "USA")
     render_component(content_item: content_item)
 
     assert_select ".gem-c-related-navigation__sub-heading", text: "World locations"
     assert_select ".gem-c-related-navigation__section-link[href=\"/world/usa/news\"]", text: "USA"
-  end
-
-  it "renders world locations section when passed special case world location items" do
-    content_item = {}
-    content_item["links"] = construct_links("world_locations", nil, "UK Mission to the European Union")
-    render_component(content_item: content_item)
-
-    assert_select ".gem-c-related-navigation__sub-heading", text: "World locations"
-    assert_select ".gem-c-related-navigation__section-link[href=\"/world/uk-mission-to-the-eu/news\"]", text: "UK Mission to the European Union"
   end
 
   it "renders collection section when passed collection items" do


### PR DESCRIPTION
## What
Navigation helper: Within related navigation links, world Locations paths are now generated based on the base path if it is provided in the content item. Not a breaking change since if there is no base path provided, it will fall to previous behaviour of generating the slug based on page title. The special cases list has been removed since it is out of date.

## Why
Making it more flexible to deal with cases in related navigation links where there are pages where the name does not match the slug. e.g. "UK and NATO" / "uk-joint-delegation-to-nato".
The special cases list was out of date, with the new update now we should just default to using the base path if it is already being provided. This should fix some broken links

## Visual Changes
No visual changes.
No breaking changes. 
