### PR TITLE
Update component generator and guidance

### DIFF
--- a/docs/generate-a-new-component.md
+++ b/docs/generate-a-new-component.md
@@ -10,6 +10,8 @@ The gem includes a component generator to stub the minimal files required for a 
 rails generate govuk_publishing_components:component [component_name]
 ```
 
+`component_name` should use underscores and not hyphens. Read our [component conventions](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_conventions.md#structure) for further details.
+
 This will create a template, scss file and yml documentation file for a new component. It will not create a test file as this cannot be reliably done automatically across applications, but a test file will be necessary.
 
 ## Option 2: create a component in the gem

--- a/lib/generators/govuk_publishing_components/component_generator.rb
+++ b/lib/generators/govuk_publishing_components/component_generator.rb
@@ -18,8 +18,8 @@ module GovukPublishingComponents
       create_directory_if_not_exists(docs_dir)
       create_directory_if_not_exists(scss_dir)
 
-      template "_component.html.erb", "#{template_dir}_#{@public_name}.html.erb"
-      template "component.yml.erb", "#{docs_dir}#{@public_name}.yml"
+      template "_component.html.erb", "#{template_dir}_#{@public_name.gsub('-', '_')}.html.erb"
+      template "component.yml.erb", "#{docs_dir}#{@public_name.gsub('-', '_')}.yml"
       template "_component.scss", "#{scss_dir}_#{@public_name}.scss"
     end
 


### PR DESCRIPTION
## What
- update the application component generator code to explicitly replace hyphens with underscores in component names to follow our component naming conventions
- also [update the documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/generate-a-new-component.md) for this to clarify what should be done

## Why
We noticed recently that components in applications don't always follow our component conventions, which makes it harder to audit components. See issue: https://github.com/alphagov/govuk_publishing_components/issues/3369

## Visual Changes
None.
