### PR TITLE
Ensure PIIRemover is running on GA4 link clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add auditing of application components to component auditing ([PR #3374](https://github.com/alphagov/govuk_publishing_components/pull/3374))
 * Fix GA4 index parameters on step nav show/hide all control ([PR #3397](https://github.com/alphagov/govuk_publishing_components/pull/3397))
 * Update to LUX 308 ([PR #3394](https://github.com/alphagov/govuk_publishing_components/pull/3394))
+* Ensure PIIRemover is running on GA4 link clicks ([PR #3402](https://github.com/alphagov/govuk_publishing_components/pull/3402))
 
 ## 35.3.5
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -10,6 +10,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.trackingTrigger = 'data-ga4-link' // elements with this attribute get tracked
     this.trackLinksOnly = this.module.hasAttribute('data-ga4-track-links-only')
     this.limitToElementClass = this.module.getAttribute('data-ga4-limit-to-element-class')
+    this.PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
   }
 
   Ga4LinkTracker.prototype.init = function () {
@@ -61,7 +62,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Ga4LinkTracker.prototype.trackClick = function (event) {
     var element = event.target
-    var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
 
     // don't track this link if it's already being tracked by the ecommerce tracker
     if (element.closest('[data-ga4-ecommerce-path]')) {
@@ -81,9 +81,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       var text = data.text || event.target.textContent
       data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)
-      data.text = PIIRemover.stripPIIWithOverride(data.text, true, true)
+      data.text = this.PIIRemover.stripPIIWithOverride(data.text, true, true)
       var url = data.url || this.findLink(event.target).getAttribute('href')
-      data.url = window.GOVUK.analyticsGa4.core.trackFunctions.removeCrossDomainParams(PIIRemover.stripPIIWithOverride(url, true, true))
+      data.url = window.GOVUK.analyticsGa4.core.trackFunctions.removeCrossDomainParams(this.PIIRemover.stripPIIWithOverride(url, true, true))
       data.link_domain = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkDomain(data.url)
       data.link_path_parts = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkPathParts(data.url)
       data.method = window.GOVUK.analyticsGa4.core.trackFunctions.getClickType(event)
@@ -91,7 +91,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       data.index = this.setIndex(data.index, event.target)
 
       if (data.type === 'smart answer' && data.action === 'change response') {
-        data.section = PIIRemover.stripPIIWithOverride(data.section, true, true)
+        data.section = this.PIIRemover.stripPIIWithOverride(data.section, true, true)
       }
 
       var schemas = new window.GOVUK.analyticsGa4.Schemas()

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -81,8 +81,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       var text = data.text || event.target.textContent
       data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)
+      data.text = PIIRemover.stripPIIWithOverride(data.text, true, true)
       var url = data.url || this.findLink(event.target).getAttribute('href')
-      data.url = window.GOVUK.analyticsGa4.core.trackFunctions.removeCrossDomainParams(PIIRemover.stripPII(url))
+      data.url = window.GOVUK.analyticsGa4.core.trackFunctions.removeCrossDomainParams(PIIRemover.stripPIIWithOverride(url, true, true))
       data.link_domain = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkDomain(data.url)
       data.link_path_parts = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkPathParts(data.url)
       data.method = window.GOVUK.analyticsGa4.core.trackFunctions.getClickType(event)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
@@ -15,6 +15,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
         window.GOVUK.analyticsGa4.core.trackFunctions.appendDomainsWithoutWWW(this.dedicatedDownloadDomains)
         this.handleClick = this.handleClick.bind(this)
         this.handleMousedown = this.handleMousedown.bind(this)
+        this.PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
 
         document.querySelector('body').addEventListener('click', this.handleClick)
         document.querySelector('body').addEventListener('contextmenu', this.handleClick)
@@ -50,10 +51,12 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
         return
       }
       var data = {}
+      var mailToLink = false
       if (window.GOVUK.analyticsGa4.core.trackFunctions.isMailToLink(href)) {
         data.event_name = 'navigation'
         data.type = 'email'
         data.external = 'true'
+        mailToLink = true
       } else if (this.isDownloadLink(href)) {
         data.event_name = 'file_download'
         data.type = this.isPreviewLink(href) ? 'preview' : 'generic download'
@@ -65,7 +68,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       }
 
       if (Object.keys(data).length > 0) {
-        data.url = href
+        data.url = mailToLink ? href : this.PIIRemover.stripPIIWithOverride(href, true, true)
         if (data.url) {
           data.url = window.GOVUK.analyticsGa4.core.trackFunctions.removeCrossDomainParams(data.url)
           data.link_domain = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkDomain(data.url)
@@ -73,6 +76,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
         }
 
         data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(element.textContent)
+        data.text = mailToLink ? data.text : this.PIIRemover.stripPIIWithOverride(data.text, true, true)
         data.method = window.GOVUK.analyticsGa4.core.trackFunctions.getClickType(event)
 
         var schemas = new window.GOVUK.analyticsGa4.Schemas()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -427,4 +427,22 @@ describe('GA4 click tracker', function () {
       expect(window.dataLayer[0].event_data.index).toEqual(undefined)
     })
   })
+
+  describe('PII removal', function () {
+    it('redacts dates, postcodes and emails', function () {
+      element = document.createElement('div')
+      element.setAttribute('data-ga4-track-links-only', '')
+      element.setAttribute('data-ga4-link', '{"someData": "blah"}')
+      element.innerHTML = '<a class="link" href="#/2022-02-02/SW10AA/email@example.com">2022-02-02 SW1 0AA email@example.com</a>'
+
+      var link = element.querySelector('.link')
+
+      initModule(element, false)
+      link.click()
+
+      expect(window.dataLayer[0].event_data.url).toEqual('#/[date]/[postcode]/[email]')
+      expect(window.dataLayer[0].event_data.link_path_parts[1]).toEqual('#/[date]/[postcode]/[email]')
+      expect(window.dataLayer[0].event_data.text).toEqual('[date] [postcode] [email]')
+    })
+  })
 })


### PR DESCRIPTION
## What
Add the PII Remover to the link trackers text/urls

https://trello.com/c/YZrXpxh0/570-fix-inconsistency-with-pii-remover

## Why
<!-- What are the reasons behind this change being made? -->
The implementation guide has this `//PII Cleansed` on all the URLs for link clicks, and a few of the `text` values. I'm not sure how often PII is going to show up on our `GA4LinkTracker` (since we usually determine where this is used) but I'm adding it just so it's in sync with the implementation guide.

`mailto:` links aren't PII cleansed since the PAs said it's useful for the email to come through on those links.

## Visual Changes
None.