### PR TITLE
Set GA4 link text to 'image' if there is only an image and no link text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Allow ga4-form-tracker text to be overridden ([PR #3409](https://github.com/alphagov/govuk_publishing_components/pull/3409))
 * Change GA4 share values ([PR #3407](https://github.com/alphagov/govuk_publishing_components/pull/3407))
 * Add GA4 index_section_count to step by step links ([PR #3410](https://github.com/alphagov/govuk_publishing_components/pull/3410))
+* Set GA4 link text to 'image' if there's only an image and no link text ([PR #3404](https://github.com/alphagov/govuk_publishing_components/pull/3404))
 
 ## 35.4.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -82,7 +82,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var text = data.text || event.target.textContent
       data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)
       data.text = this.PIIRemover.stripPIIWithOverride(data.text, true, true)
-      if (!data.text && element.querySelector('img')) {
+      if (!data.text && (element.querySelector('img') || element.querySelector('svg'))) {
         data.text = 'image'
       }
       var url = data.url || this.findLink(event.target).getAttribute('href')

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -82,6 +82,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var text = data.text || event.target.textContent
       data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)
       data.text = this.PIIRemover.stripPIIWithOverride(data.text, true, true)
+      if (!data.text && element.querySelector('img')) {
+        data.text = 'image'
+      }
       var url = data.url || this.findLink(event.target).getAttribute('href')
       data.url = window.GOVUK.analyticsGa4.core.trackFunctions.removeCrossDomainParams(this.PIIRemover.stripPIIWithOverride(url, true, true))
       data.link_domain = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkDomain(data.url)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
@@ -77,7 +77,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
 
         data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(element.textContent)
         data.text = mailToLink ? data.text : this.PIIRemover.stripPIIWithOverride(data.text, true, true)
-        if (!data.text && element.querySelector('img')) {
+        if (!data.text && (element.querySelector('img') || element.querySelector('svg'))) {
           data.text = 'image'
         }
         data.method = window.GOVUK.analyticsGa4.core.trackFunctions.getClickType(event)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
@@ -77,6 +77,9 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
 
         data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(element.textContent)
         data.text = mailToLink ? data.text : this.PIIRemover.stripPIIWithOverride(data.text, true, true)
+        if (!data.text && element.querySelector('img')) {
+          data.text = 'image'
+        }
         data.method = window.GOVUK.analyticsGa4.core.trackFunctions.getClickType(event)
 
         var schemas = new window.GOVUK.analyticsGa4.Schemas()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -449,4 +449,20 @@ describe('GA4 click tracker', function () {
       expect(window.dataLayer[0].event_data.text).toEqual('[date] [postcode] [email]')
     })
   })
+
+  describe('if the link is an on an image with no inner text', function () {
+    it('sets the text property to image', function () {
+      element = document.createElement('div')
+      element.setAttribute('data-ga4-track-links-only', '')
+      element.setAttribute('data-ga4-link', '{"someData": "blah"}')
+      element.innerHTML = '<a class="link" href="#link1"><img src=""></></a>'
+
+      var link = element.querySelector('.link')
+
+      initModule(element, false)
+      link.click()
+
+      expect(window.dataLayer[0].event_data.text).toEqual('image')
+    })
+  })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -455,14 +455,17 @@ describe('GA4 click tracker', function () {
       element = document.createElement('div')
       element.setAttribute('data-ga4-track-links-only', '')
       element.setAttribute('data-ga4-link', '{"someData": "blah"}')
-      element.innerHTML = '<a class="link" href="#link1"><img src=""></></a>'
+      element.innerHTML = '<a class="link" href="#link1"><img src=""/></a>' +
+      '<a class="link" href="#link1"><svg></svg></a>'
 
-      var link = element.querySelector('.link')
+      var links = element.querySelectorAll('.link')
 
-      initModule(element, false)
-      link.click()
-
-      expect(window.dataLayer[0].event_data.text).toEqual('image')
+      for (var i = 0; i < links.length; i++) {
+        window.dataLayer = []
+        initModule(element, false)
+        links[i].click()
+        expect(window.dataLayer[0].event_data.text).toEqual('image')
+      }
     })
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
@@ -761,7 +761,8 @@ describe('A specialist link tracker', function () {
     beforeEach(function () {
       window.dataLayer = []
       links = document.createElement('div')
-      links.innerHTML = '<a class="link" href="https://example.com"><img src=""></></a>'
+      links.innerHTML = '<a class="link" href="https://example.com"><img src=""/></a>' +
+      '<a class="link" href="https://example.com"><svg></svg></a>'
 
       body.appendChild(links)
       body.addEventListener('click', preventDefault)
@@ -777,9 +778,13 @@ describe('A specialist link tracker', function () {
     })
 
     it('sets the text property to image', function () {
-      var link = document.querySelector('.link')
-      GOVUK.triggerEvent(link, 'click')
-      expect(window.dataLayer[0].event_data.text).toEqual('image')
+      var links = document.querySelectorAll('.link')
+
+      for (var i = 0; i < links.length; i++) {
+        window.dataLayer = []
+        GOVUK.triggerEvent(links[i], 'click')
+        expect(window.dataLayer[0].event_data.text).toEqual('image')
+      }
     })
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.spec.js
@@ -160,7 +160,7 @@ describe('A specialist link tracker', function () {
 
       expected.event_data.link_domain = 'http://www.nationalarchives.gov.uk'
       expected.event_data.url = parentLink.getAttribute('href')
-      expected.event_data.text = parentLink.innerText.trim()
+      expected.event_data.text = 'image'
 
       expect(window.dataLayer[0]).toEqual(expected)
     })
@@ -386,7 +386,7 @@ describe('A specialist link tracker', function () {
         GOVUK.triggerEvent(link, 'click')
         expected.event_data.link_domain = link.closest('a').getAttribute('link_domain')
         expected.event_data.url = link.closest('a').getAttribute('href')
-        expected.event_data.text = link.closest('a').innerText.trim()
+        expected.event_data.text = 'image'
         expected.event_data.type = 'generic download'
         expected.event_data.external = link.closest('a').getAttribute('external')
         var linkPath = link.closest('a').getAttribute('path')
@@ -754,6 +754,32 @@ describe('A specialist link tracker', function () {
       GOVUK.triggerEvent(linkToTest, 'click')
       expect(window.dataLayer[0].event_data.link_path_parts[1]).toEqual('mailto:email@example.com')
       expect(window.dataLayer[0].event_data.url).toEqual('mailto:email@example.com')
+    })
+  })
+
+  describe('if the link contains an image and no inner text', function () {
+    beforeEach(function () {
+      window.dataLayer = []
+      links = document.createElement('div')
+      links.innerHTML = '<a class="link" href="https://example.com"><img src=""></></a>'
+
+      body.appendChild(links)
+      body.addEventListener('click', preventDefault)
+
+      linkTracker = GOVUK.analyticsGa4.analyticsModules.Ga4SpecialistLinkTracker
+      linkTracker.init()
+    })
+
+    afterEach(function () {
+      body.removeEventListener('click', preventDefault)
+      links.remove()
+      linkTracker.stopTracking()
+    })
+
+    it('sets the text property to image', function () {
+      var link = document.querySelector('.link')
+      GOVUK.triggerEvent(link, 'click')
+      expect(window.dataLayer[0].event_data.text).toEqual('image')
     })
   })
 })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Set GA4 link text to `'image'` if there is no link text, and they are clicking on an image link

https://trello.com/c/Psw0vf3r/550-blank-text-being-sent-when-user-opens-a-file-or-html-attachment-by-clicking-on-the-image

## Why
<!-- What are the reasons behind this change being made? -->
Without this, the `text` value sent to the dataLayer is an empty string.

## Visual Changes
None
