### PR TITLE
Update hint component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix GA4 index parameters on step nav show/hide all control ([PR #3397](https://github.com/alphagov/govuk_publishing_components/pull/3397))
 * Update to LUX 308 ([PR #3394](https://github.com/alphagov/govuk_publishing_components/pull/3394))
 * Ensure PIIRemover is running on GA4 link clicks ([PR #3402](https://github.com/alphagov/govuk_publishing_components/pull/3402))
+* Update hint component ([PR #3405](https://github.com/alphagov/govuk_publishing_components/pull/3405))
 
 ## 35.3.5
 

--- a/app/views/govuk_publishing_components/components/_hint.html.erb
+++ b/app/views/govuk_publishing_components/components/_hint.html.erb
@@ -2,11 +2,15 @@
   add_gem_component_stylesheet("hint")
 
   id ||= "hint-#{SecureRandom.hex(4)}"
+  is_radio_label_hint ||= false
   right_to_left ||= false
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   css_classes = %w( gem-c-hint govuk-hint )
-  css_classes << shared_helper.get_margin_bottom
+  css_classes << "govuk-radios__hint" if is_radio_label_hint
+
+  custom_margin_bottom_class = shared_helper.get_margin_bottom if [*0..9].include?(local_assigns[:margin_bottom])
+  css_classes << custom_margin_bottom_class if local_assigns[:margin_bottom]
 %>
 
 <%= tag.div id: id, class: css_classes, dir: right_to_left ? "rtl" : nil do %>

--- a/app/views/govuk_publishing_components/components/_label.html.erb
+++ b/app/views/govuk_publishing_components/components/_label.html.erb
@@ -15,9 +15,6 @@
   css_classes << "govuk-label--s" if bold
   css_classes << "govuk-radios__label" if is_radio_label
   css_classes << "govuk-label--#{heading_size}" if heading_size
-
-  hint_text_css_classes = %w[govuk-hint]
-  hint_text_css_classes << "govuk-radios__hint" if is_radio_label
 %>
 
 <% if is_page_heading %>
@@ -29,7 +26,10 @@
 <% end %>
 
 <% if hint_text.present? %>
-  <%= tag.div id: hint_id, class: hint_text_css_classes, dir: right_to_left ? "rtl" : nil do %>
-    <%= hint_text %>
-  <% end %>
+  <%= render "govuk_publishing_components/components/hint", {
+    id: hint_id,
+    text: hint_text,
+    right_to_left: right_to_left ? "rtl" : nil,
+    is_radio_label_hint: is_radio_label
+  } %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/hint.yml
+++ b/app/views/govuk_publishing_components/components/docs/hint.yml
@@ -15,7 +15,7 @@ examples:
     data:
       text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
   with_margin_bottom:
-    description: The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to a margin bottom of `3` (`15px`).
+    description: The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale).
     data:
       text: "You qualify if you were born in the UK before June 1960."
       margin_bottom: 9

--- a/spec/components/hint_spec.rb
+++ b/spec/components/hint_spec.rb
@@ -8,7 +8,7 @@ describe "Hint", type: :view do
   it "renders hint" do
     render_component(text: "For example, ‘QQ 12 34 56 C’.")
 
-    assert_select '.govuk-hint.govuk-\!-margin-bottom-3', text: "For example, ‘QQ 12 34 56 C’."
+    assert_select ".govuk-hint", text: "For example, ‘QQ 12 34 56 C’."
   end
 
   it "applies a specified bottom margin" do
@@ -23,10 +23,10 @@ describe "Hint", type: :view do
     assert_select '.govuk-hint.govuk-\!-margin-bottom-0'
   end
 
-  it "defaults to the initial bottom margin if an incorrect value is passed" do
+  it "does not default to the initial bottom margin if an incorrect value is passed" do
     render_component(text: "For example, ‘QQ 12 34 56 C’.", margin_bottom: 12)
 
-    assert_select '.govuk-hint.govuk-\!-margin-bottom-3'
+    assert_select '.govuk-hint.govuk-\!-margin-bottom-3', false
   end
 
   it "renders the component with the correct `dir` attribute" do


### PR DESCRIPTION
## What

- Replace hardcoded hint component by using the render method, instead of hardcoding it in the label component view template
- Add a new `is_radio_label_hint` input, setting this to `true` will add the `govuk-radios__hint` class to apply the correct styling when the label is used on a radio input
- margin-bottom will now only be applied if it is passed as an input, it will not default to margin-bottom-3, instead it will default to the margin used in the design system

## Why

- To ensure that any future changes to the hint component are reflected when used in the `label` component view template
- Allow the `hint` component stylesheet to be included when used within the `label` component view template, this happens automatically when using the render method

Trello: https://trello.com/c/Hhs2H5S7/1993-fully-implement-individual-loading-of-assets-in-the-component-guide

## Visual Changes

Percy is showing several visual changes, these are all related to how `margin-bottom` is now applied. Previously, the shared_helper would default to `margin-bottom-3` (15px), regardless of context.

The styling now matches the margin-bottom set in the Design System, for this reason I believe the visual changes should be approved. You can still pass in a margin-bottom value if you want to override margin-bottom from the design system.

I have included a before and after image for the [input component when used with a hint](https://components.publishing.service.gov.uk/component-guide/input/with_hint/preview).

### Input with hint - Before

CSS applied
```CSS
.govuk-\!-margin-bottom-3 {
    margin-bottom: 15px !important;
}
```

<img width="1383" alt="Screenshot 2023-05-17 at 10 26 19" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/44490123-0ad2-4b6a-adae-975d33fd69b4">

### Input with hint - After

CSS applied

```CSS
.govuk-label:not(.govuk-label--m):not(.govuk-label--l):not(.govuk-label--xl) + .govuk-hint {
    margin-bottom: 10px;
}
```

<img width="1492" alt="Screenshot 2023-05-17 at 11 45 04" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/3d37f564-d4ad-43e8-ae8b-22170cd2a7ea">