### PR TITLE
Version 35.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.4.0
 
 * Add auditing of application components to component auditing ([PR #3374](https://github.com/alphagov/govuk_publishing_components/pull/3374))
 * Fix GA4 index parameters on step nav show/hide all control ([PR #3397](https://github.com/alphagov/govuk_publishing_components/pull/3397))
@@ -15,6 +15,7 @@
 * Ensure PIIRemover is running on GA4 link clicks ([PR #3402](https://github.com/alphagov/govuk_publishing_components/pull/3402))
 * Update hint component ([PR #3405](https://github.com/alphagov/govuk_publishing_components/pull/3405))
 * [Fixes] World Locations Links From Base Path ([PR #3396](https://github.com/alphagov/govuk_publishing_components/pull/3396))
+* Remove the blue background from search button ([PR #3393](https://github.com/alphagov/govuk_publishing_components/pull/3393))
 
 ## 35.3.5
 
@@ -23,7 +24,6 @@
 * Conditionally set GA4 type in related navigation ([PR #3390](https://github.com/alphagov/govuk_publishing_components/pull/3390))
 * Change type 'html attachment' to just 'attachment' ([PR #3382](https://github.com/alphagov/govuk_publishing_components/pull/3382))
 * Update popular on gov.uk links in search bar ([PR #3385](https://github.com/alphagov/govuk_publishing_components/pull/3385))
-* Remove the blue background from search button ([PR #3393](https://github.com/alphagov/govuk_publishing_components/pull/3393))
 
 ## 35.3.4
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.3.5)
+    govuk_publishing_components (35.4.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.3.5".freeze
+  VERSION = "35.4.0".freeze
 end


### PR DESCRIPTION
## 35.4.0

* Add auditing of application components to component auditing ([PR #3374](https://github.com/alphagov/govuk_publishing_components/pull/3374))
* Fix GA4 index parameters on step nav show/hide all control ([PR #3397](https://github.com/alphagov/govuk_publishing_components/pull/3397))
* Update to LUX 308 ([PR #3394](https://github.com/alphagov/govuk_publishing_components/pull/3394))
* Ensure PIIRemover is running on GA4 link clicks ([PR #3402](https://github.com/alphagov/govuk_publishing_components/pull/3402))
* Update hint component ([PR #3405](https://github.com/alphagov/govuk_publishing_components/pull/3405))
* [Fixes] World Locations Links From Base Path ([PR #3396](https://github.com/alphagov/govuk_publishing_components/pull/3396))
* Remove the blue background from search button ([PR #3393](https://github.com/alphagov/govuk_publishing_components/pull/3393))