### PR TITLE
Allow ga4-form-tracker text to be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow ga4-form-tracker text to be overridden ([PR #3409](https://github.com/alphagov/govuk_publishing_components/pull/3409))
+
 ## 35.4.0
 
 * Add auditing of application components to component auditing ([PR #3374](https://github.com/alphagov/govuk_publishing_components/pull/3374))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -43,7 +43,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       var formInputs = this.getFormInputs()
       var formData = this.getInputValues(formInputs)
-      data.text = this.combineGivenAnswers(formData) || 'No answer given'
+      data.text = data.text || (this.combineGivenAnswers(formData) || 'No answer given')
 
       var schemas = new window.GOVUK.analyticsGa4.Schemas()
       var schema = schemas.mergeProperties(data, 'event_data')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -100,6 +100,21 @@ describe('Google Analytics form tracking', function () {
       expect(window.dataLayer[0]).toEqual(expected)
     })
 
+    it('allows the text value to be overridden', function () {
+      var attributes = {
+        event_name: 'form_response',
+        type: 'smart answer',
+        section: 'What is the title of this question?',
+        action: 'Continue',
+        tool_name: 'What is the title of this smart answer?',
+        text: 'Hello World'
+      }
+      element.setAttribute('data-ga4-form', JSON.stringify(attributes))
+      window.GOVUK.triggerEvent(element, 'submit')
+      expected.event_data.text = 'Hello World'
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
     it('redacts data from text inputs', function () {
       element.innerHTML =
         '<label for="textid">Label</label>' +


### PR DESCRIPTION
Hi @andysellick, would you be able to approve this if all is OK? Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Allow the a `text` value to be set in a `data-ga4-form` JSON, which prevents the form input being used as the `text` value.

## Why
<!-- What are the reasons behind this change being made? -->
For local transactions (https://www.gov.uk/rubbish-collection-day) the PAs want to track the `text` value for a `form_submit` event as the text of the submit button(Find). Therefore this change makes it so that if the data-ga4-form JSON already contains text, it will be used.

https://trello.com/c/2qmN8Wjg/546-form-events-formsubmit-formerror-formcomplete-and-informationclick-on-localtransaction-format

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
