### PR TITLE
Remove list-style for govspeak ordered lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove hardcoded examples in the component guide ([3418](https://github.com/alphagov/govuk_publishing_components/pull/3418))
+* Remove list-style for govspeak ordered lists ([PR #3413](https://github.com/alphagov/govuk_publishing_components/pull/3413))
 
 ## 35.5.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -102,7 +102,6 @@
 
   ul {
     list-style: disc;
-    list-style-position: outside;
   }
 
   li {

--- a/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/helpers/_markdown-typography.scss
@@ -87,7 +87,9 @@
 
   ol,
   ul {
-    list-style: decimal;
+    // we intentionally don't set list-style for ol elements, so that they can
+    // utilise the type attribute for the formatting. Browsers default to a
+    // style of decimal.
     list-style-position: outside;
     margin-left: $gutter-two-thirds;
     padding: 0;

--- a/app/views/govuk_publishing_components/components/docs/govspeak.yml
+++ b/app/views/govuk_publishing_components/components/docs/govspeak.yml
@@ -80,6 +80,49 @@ examples:
           </li>
           <li>three</li>
         </ul>
+  ordered_lists_types:
+    description: |
+      Govspeak/markdown does not generate HTML with type and start attributes,
+      however we still provide support for them as some advanced users write
+      HTML directly to achieve the list formatting.
+    data:
+      block: |
+        <h2>Lowercase alphabetical list</h2>
+        <ol type="a">
+          <li>one</li>
+          <li>two</li>
+        </ol>
+
+        <h2>Uppercase alphabetical list</h2>
+        <ol type="A">
+          <li>one</li>
+          <li>two</li>
+        </ol>
+
+        <h2>Lowercase Roman numeral list</h2>
+        <ol type="i">
+          <li>one</li>
+          <li>two</li>
+        </ol>
+
+        <h2>Uppercase Roman numberal list</h2>
+        <ol type="I">
+          <li>one</li>
+          <li>two</li>
+        </ol>
+
+        <h2>Numerical list starting at 3</h2>
+        <ol start="3">
+          <li>three</li>
+          <li>four</li>
+        </ol>
+
+        <h2>Lowercase alphabetical list, starting at 3</h2>
+        <ol type="a" start="3">
+          <li>three</li>
+          <li>four</li>
+        </ol>
+
   legislative_lists:
     data:
       block: |


### PR DESCRIPTION
This removes setting list-style on ordered lists to instead allow the
use of the type attribute on an ordered list to specify the list-style.

I couldn't determine why this style was needed. Current browsers style
this as list-style decimal by default and I can't find any code this
undoes. It could be that previously this was to undo an earlier
override, but it would be very unconventional for current GOV.UK to
style an `ol` without a class so this seems unlikely.

The motivation for making this change is to support some niche behaviour
used by publishers that will become disabled. Currently some advanced
published have managed to published ordered lists that are alphabetical
or roman numeral prefixed by use of an `ol` element with a style
attribute. This will not be available with the role out of the GOV.UK
Content Security Policy which forbids unsafe inline styles [1].

[1]: https://github.com/alphagov/govuk_app_config/pull/291

## Visual Changes

### Before
<img width="985" alt="Screenshot 2023-05-23 at 17 50 59" src="https://github.com/alphagov/govuk_publishing_components/assets/282717/6ac8d722-a95f-4fce-a335-c8feed3c3ee8">

### After
<img width="991" alt="Screenshot 2023-05-23 at 17 50 38" src="https://github.com/alphagov/govuk_publishing_components/assets/282717/3c336ffb-9e36-4e59-81c0-0fa4d1d127a5">

