### PR TITLE
Remove hardcoded examples in the component guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove hardcoded examples in the component guide ([3418](https://github.com/alphagov/govuk_publishing_components/pull/3418))
+
 ## 35.5.0
 
 * Allow ga4-form-tracker text to be overridden ([PR #3409](https://github.com/alphagov/govuk_publishing_components/pull/3409))

--- a/app/assets/stylesheets/component_guide/application.scss
+++ b/app/assets/stylesheets/component_guide/application.scss
@@ -31,10 +31,6 @@ $govuk-new-link-styles: true;
 @import "govuk_publishing_components/components/layout-header";
 @import "govuk_publishing_components/components/layout-super-navigation-header";
 
-// Imported to ensure inverse-header component examples render correctly
-// this helps avoid any issues with visual regressions tests
-@import "govuk_publishing_components/components/lead-paragraph";
-
 // Include required helpers
 @import "../../stylesheets/govuk_publishing_components/components/helpers/markdown-typography";
 

--- a/app/views/govuk_publishing_components/components/docs/contextual_guidance.yml
+++ b/app/views/govuk_publishing_components/components/docs/contextual_guidance.yml
@@ -23,7 +23,14 @@ examples:
       content: |
         <p>The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.</p>
       block: |
-        <div class="govuk-form-group">
-          <label class="gem-c-label govuk-label" for="news-title">News title</label>
-          <input id="news-title" type="text" class="gem-c-input govuk-input" aria-describedby="news-title-guidance">
-        </div>
+        <!-- example content -->
+          <%= render "govuk_publishing_components/components/input", { 
+              label: {
+                text: "News title"
+              },
+              name: "news-title",
+              id: "news-title",
+              describedby: "news-title-guidance"
+            } 
+          %>
+          <!-- end of example content -->

--- a/app/views/govuk_publishing_components/components/docs/fieldset.yml
+++ b/app/views/govuk_publishing_components/components/docs/fieldset.yml
@@ -11,23 +11,41 @@ examples:
     data:
       legend_text: 'Do you have a passport?'
       block: |
-        <!-- Use the radio component, this is hardcoded only for this example -->
-          <input type="radio" id="default-yes" name="default">
-          <label for="default-yes">Yes</label>
-
-          <input type="radio" id="default-no" name="default">
-          <label for="default-no">No</label>
+        <!-- example content -->
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "default",
+            items: [
+              {
+                value: "default-yes",
+                text: "Yes"
+              },
+              {
+                value: "default-no",
+                text: "No"
+              }
+            ]
+          } %>
+          <!-- end of example content -->
   with_id_attribute:
     data:
       legend_text: 'Do you have a passport?'
       id: passports
       block: |
-        <!-- Use the radio component, this is hardcoded only for this example -->
-          <input type="radio" id="passport-yes" name="default">
-          <label for="passport-yes">Yes</label>
-
-          <input type="radio" id="passport-no" name="default">
-          <label for="passport-no">No</label>
+        <!-- example content -->
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "passport",
+            items: [
+              {
+                value: "passport-yes",
+                text: "Yes"
+              },
+              {
+                value: "passport-no",
+                text: "No"
+              }
+            ]
+          } %>
+          <!-- end of example content -->
   with_heading:
     description: Make the legend different sizes. Valid options are `s`, `m`, `l` and `xl`.
     data:
@@ -35,33 +53,60 @@ examples:
       heading_level: 2
       heading_size: 'm'
       block: |
-        <!-- Use the radio component, this is hardcoded only for this example -->
-          <input type="radio" id="level-yes" name="default">
-          <label for="level-yes">Yes</label>
-
-          <input type="radio" id="level-no" name="default">
-          <label for="level-no">No</label>
+        <!-- example content -->
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "level",
+            items: [
+              {
+                value: "level-yes",
+                text: "Yes"
+              },
+              {
+                value: "level-no",
+                text: "No"
+              }
+            ]
+          } %>
+          <!-- end of example content -->
   with_custom_legend_size:
     description: Make the legend different sizes. Valid options are `s`, `m`, `l` and `xl`.
     data:
       legend_text: 'Do you have a driving license?'
       heading_size: 'l'
       block: |
-        <!-- Use the radio component, this is hardcoded only for this example -->
-          <input type="radio" id="size-yes" name="default">
-          <label for="size-yes">Yes</label>
-
-          <input type="radio" id="size-no" name="default">
-          <label for="size-no">No</label>
+        <!-- example content -->
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "size",
+            items: [
+              {
+                value: "size-yes",
+                text: "Yes"
+              },
+              {
+                value: "size-no",
+                text: "No"
+              }
+            ]
+          } %>
+          <!-- end of example content -->
   with_error_message:
     description: The component also accepts an `error_id`, or generates one automatically.
     data:
       legend_text: 'Do you have a passport?'
       error_message: 'Please choose an option'
       block: |
-        <!-- Use the radio component, this is hardcoded only for this example -->
-          <input type="radio" id="default2-yes" name="default2">
-          <label for="default2-yes">Yes</label>
-
-          <input type="radio" id="default2-no" name="default2">
-          <label for="default2-no">No</label>
+        <!-- example content -->
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "default2",
+            items: [
+              {
+                value: "default2-yes",
+                text: "Yes"
+              },
+              {
+                value: "default2-no",
+                text: "No"
+              }
+            ]
+          } %>
+          <!-- end of example content -->

--- a/app/views/govuk_publishing_components/components/docs/inverse_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/inverse_header.yml
@@ -16,49 +16,59 @@ examples:
   default:
     data:
       block: |
-        <div class="gem-c-title gem-c-title--inverse">
-          <h1 class="gem-c-title__text govuk-heading-l">
-            Education, Training and Skills
-          </h1>
-        </div>
+        <!-- example content -->
+          <%= render "govuk_publishing_components/components/title", {
+            title: "Education, Training and Skills",
+            inverse: true
+          } %>
+          <!-- end of example content -->
   for_full_page_width:
     description: "Used when the header covers the full width of the page, but it's content is in the grid layout. The left-right padding is removed to make the contents line up with the other items on the page."
     data:
-      full_width: true
-      block: |
-        <div class="gem-c-title gem-c-title--inverse">
-          <h1 class="gem-c-title__text govuk-heading-l">
-            Education, Training and Skills
-          </h1>
-        </div>
+        full_width: true
+        block: |
+          <!-- example content -->
+            <%= render "govuk_publishing_components/components/title", {
+              title: "Education, Training and Skills",
+              inverse: true
+            } %>
+            <!-- end of example content -->
   html_publication_header:
     description: "The inverse header component is used on HTML publications. [See example on GOV.UK here](https://www.gov.uk/government/publications/ln5-0at-jackson-homes-scopwick-ltd-environmental-permit-application-advertisement/ln5-0at-jackson-homes-scopwick-ltd-environmental-permit-application)"
     data:
       block: |
-        <div class="gem-c-title gem-c-title--inverse gem-c-title--bottom-margin">
-          <p class="gem-c-title__context govuk-caption-m">Notice</p>
-          <h1 class="gem-c-title__text govuk-heading-l">
-            LN5 0AT, Jackson Homes (Scopwick) Ltd: environmental permit application
-          </h1>
-        </div>
-        <p class="publication-header__last-changed">Published 22 April 2016</p>
+        <!-- example content -->
+          <%= render "govuk_publishing_components/components/title", {
+            title: "LN5 0AT, Jackson Homes (Scopwick) Ltd: environmental permit application",
+            inverse: true,
+            context: "Notice",
+          } %>
+          <p class="publication-header__last-changed">Published 22 April 2016</p>
+          <!-- end of example content -->
   with_breadcrumbs_and_paragraph:
     data:
       padding_top: false
       block: |
-        <div class="gem-c-breadcrumbs govuk-breadcrumbs govuk-breadcrumbs--collapse-on-mobile gem-c-breadcrumbs--inverse">
-          <ol class="govuk-breadcrumbs__list">
-            <li class="govuk-breadcrumbs__list-item">
-              <a href="/section" class="govuk-breadcrumbs__link">Section</a>
-            </li>
-            <li class="govuk-breadcrumbs__list-item">
-              <a href="/section/sub-section" class="govuk-breadcrumbs__link">Education of disadvantaged children</a>
-            </li>
-          </ol>
-        </div>
-        <p class="gem-c-lead-paragraph gem-c-lead-paragraph--inverse">
-          Schools and academies, further and higher education, apprenticeships and other skills training, student funding, early years.
-        </p>
+        <!-- example content -->
+          <%= render "govuk_publishing_components/components/breadcrumbs", {
+            collapse_on_mobile: true,
+            breadcrumbs: [
+              {
+                title: "Section",
+                url: "/section"
+              },
+              {
+                title: "Education of disadvantaged children",
+                url: "/section/sub-section"
+              }
+            ],
+            inverse: true
+          } %>
+          <%= render "govuk_publishing_components/components/lead_paragraph", {
+            text: "Schools and academies, further and higher education, apprenticeships and other skills training, student funding, early years.",
+            inverse: true
+          } %>
+          <!-- end of example content -->
   with_link:
     data:
       block: |

--- a/app/views/govuk_publishing_components/components/docs/modal_dialogue.yml
+++ b/app/views/govuk_publishing_components/components/docs/modal_dialogue.yml
@@ -27,7 +27,13 @@ display_preview: false
 examples:
   default:
     embed: |
-      <button class="govuk-button" data-toggle="modal" data-target="modal-default">Open modal</button>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Open modal",
+        data_attributes: {
+          toggle: "modal",
+          target: "modal-default"
+        }
+      } %>
       <%= component %>
     data:
       id: modal-default
@@ -38,7 +44,13 @@ examples:
     description: |
       A wide version of the modal dialogue will provide the same width with the main container
     embed: |
-      <button class="govuk-button" data-toggle="modal" data-target="modal-wide">Open wide modal</button>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Open wide modal",
+        data_attributes: {
+          toggle: "modal",
+          target: "modal-wide"
+        }
+      } %>
       <%= component %>
     data:
       id: modal-wide
@@ -50,7 +62,13 @@ examples:
     description: |
       Modal dialogue with form elements inside to show how it prevents tabbing to outside the dialogue when open while preserving the tabindex on focusable elements
     embed: |
-      <button class="govuk-button" data-toggle="modal" data-target="modal-with-form">Open modal with form</button>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Open modal with form",
+        data_attributes: {
+          toggle: "modal",
+          target: "modal-with-form"
+        }
+      } %>
       <%= component %>
     data:
       id: modal-with-form
@@ -65,7 +83,13 @@ examples:
     description: |
       Modal dialogue with a large block content to show how the modal scrolls withing the page and how it prevents scrolling the page while the dialogue is open
     embed: |
-      <button class="govuk-button" data-toggle="modal" data-target="modal-with-large-content">Open modal with large content</button>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Open modal with large content",
+        data_attributes: {
+          toggle: "modal",
+          target: "modal-with-large-content"
+          }
+        } %>
       <%= component %>
     data:
       id: modal-with-large-content
@@ -78,7 +102,13 @@ examples:
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
   with_data_attributes:
     embed: |
-      <button class="govuk-button" data-toggle="modal" data-target="modal-with-data-attributes">Open modal with data attributes</button>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Open modal with data attributes",
+        data_attributes: {
+          toggle: "modal",
+          target: "modal-with-data-attributes"
+        }
+      } %>
       <%= component %>
     data:
       id: modal-with-data-attributes

--- a/app/views/govuk_publishing_components/components/docs/textarea.yml
+++ b/app/views/govuk_publishing_components/components/docs/textarea.yml
@@ -94,9 +94,15 @@ examples:
   with_aria_attributes:
     description: Use `describedby` when the textarea is described by an element outside the component; for example, when used in conjunction with a [contextual guidance](/component-guide/contextual_guidance).
     embed: |
-      <%= component %>
-      <p class="govuk-body" id="contextual-guidance">The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.</p>
+      <%= render "govuk_publishing_components/components/contextual_guidance", {
+          html_for: "contextual-guidance-id",
+          guidance_id: "contextual-guidance",
+          content: sanitize("<p>The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.</p>")
+        } do %>
+        <%= component %>
+      <% end %>
     data:
+      id: "contextual-guidance-id"
       label:
         text: "Title"
         bold: true


### PR DESCRIPTION
## What

- Fix and improve rendering for several components in the component guide
- Remove several hardcoded examples in the component guide
- Remove import of `lead-paragraph` stylesheet in application.scss
- Fix the `textarea` - [With aria attributes](https://components.publishing.service.gov.uk/component-guide/textarea/with_aria_attributes) component example. The `contextual-guidance` component now renders when focusing the textarea in the component guide example.

## Why

When calling the render method, we ensure that any required stylesheets are automatically requested. By using this approach in `inverse-header.yml`, we ensure the required stylesheets are requested. Using this approach, we no longer need to import the `lead-paragraph` stylesheet into application.scss for the component guide to render this component as expected.

The added benefit of this approach is that it allows anyone to copy and paste the code examples, and avoid hardcoding components in their own applications.

Trello: https://trello.com/c/Hhs2H5S7/1993-fully-implement-individual-loading-of-assets-in-the-component-guide

## Visual Changes

Percy is showing visual changes in the 4 components listed below, please see the related comments explaining the reasons for this:

### Form fieldset

The radio components are now styled correctly, the original example does not have any styling applied

### Modal dialogue

The preview example is now correct. The `button` component was hardcoded into the modal dialogue component documentation. Now that the `button` component is rendered from the publishing components gem, margin-bottom is set to 0 as expected

### Form textarea

The `contextual-guidance` component now renders when focusing the textarea in the component guide example

### Inverse header

The examples currently use the `title` component, but also hardcode `govuk-heading-l` on the heading, this is not currently possible in the title component and does not match how it is used on the live example linked to from the component guide, for example https://www.gov.uk/government/publications/ln5-0at-jackson-homes-scopwick-ltd-environmental-permit-application-advertisement/ln5-0at-jackson-homes-scopwick-ltd-environmental-permit-application 

Given the reasons listed above, I believe the new examples are an improvement in the component guide.