### PR TITLE
Version 35.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.5.0
 
 * Allow ga4-form-tracker text to be overridden ([PR #3409](https://github.com/alphagov/govuk_publishing_components/pull/3409))
 * Change GA4 share values ([PR #3407](https://github.com/alphagov/govuk_publishing_components/pull/3407))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.4.0)
+    govuk_publishing_components (35.5.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.4.0".freeze
+  VERSION = "35.5.0".freeze
 end


### PR DESCRIPTION
## 35.5.0

* Allow ga4-form-tracker text to be overridden ([PR #3409](https://github.com/alphagov/govuk_publishing_components/pull/3409))
* Change GA4 share values ([PR #3407](https://github.com/alphagov/govuk_publishing_components/pull/3407))
* Add GA4 index_section_count to step by step links ([PR #3410](https://github.com/alphagov/govuk_publishing_components/pull/3410))
* Set GA4 link text to 'image' if there's only an image and no link text ([PR #3404](https://github.com/alphagov/govuk_publishing_components/pull/3404))