### PR TITLE
Remove unnecessary select height adjustment

### DIFF
--- a/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
@@ -4,11 +4,3 @@
 .gem-c-select__select--full-width {
   width: 100%;
 }
-
-// Solution to text inside selects becoming unreadable if font size in
-// the browser is increased. This is currently a problem in govuk-frontend
-.gem-c-select {
-  .govuk-select {
-    height: 2.14em;
-  }
-}


### PR DESCRIPTION
## What

Remove a height adjustment for selects that was needed because of an old issue in GOV.UK Frontend which has since been fixed.

## Why

This was [introduced in August 2019][1] to mitigate an [issue in GOV.UK Frontend where the height of a select component was set in pixels, which meant it did not scale if users changed the text size in their browser][2].

That issue [was fixed in GOV.UK Frontend][3] and [released as part of v3.3.0][4] in October 2019. Since then the height of a select component has been set in rem (as long as compatibility mode is not enabled) which means this adjustment can be removed.

[1]: https://github.com/alphagov/govuk_publishing_components/pull/1018
[2]: https://github.com/alphagov/govuk-frontend/issues/1519
[3]: https://github.com/alphagov/govuk-frontend/pull/1574
[4]: https://github.com/alphagov/govuk-frontend/releases/tag/v3.3.0#:~:text=Pull%20request%20%231574%3A%20Make%20form%20elements%20scale%20correctly%20when%20text%20resized%20by%20user.

## Visual Changes

None