### PR TITLE
Improved consistency across GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,12 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: ${{ inputs.ref || github.ref }}
-
     # Clone the publishing-api repo, a dependency of the govuk_schemas gem, for content schemas
-    # Make it available at ../govuk-content-schemas, which is where govuk_schemas expects it to be
-    - run: git clone -b main --single-branch https://github.com/alphagov/publishing-api ../publishing-api
-
+    - uses: actions/checkout@v3
+      with:
+        repository: alphagov/publishing-api
+        ref: main
+        path: tmp/publishing-api
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
@@ -40,6 +41,8 @@ jobs:
         cache: yarn
     - run: yarn install
     - run: bundle exec rake
+      env:
+        GOVUK_CONTENT_SCHEMAS_PATH: tmp/publishing-api/content_schemas
 
   # This job is needed to work around the fact that matrix jobs spawn multiple status checks – i.e. one job per variant.
   # The branch protection rules depend on this as a composite job to ensure that all preceding test_matrix checks passed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         node-version: lts/* # use the latest LTS release
         cache: yarn
-    - run: yarn install
+    - run: yarn install --frozen-lockfile
     - run: bundle exec rake
       env:
         GOVUK_CONTENT_SCHEMAS_PATH: tmp/publishing-api/content_schemas

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,15 @@
 name: Continuous integration
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'The branch, tag or SHA to checkout'
+        default: main
+        type: string
 
 jobs:
   # This matrix job runs the test suite against multiple Ruby versions
@@ -12,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref || github.ref }}
 
     # Clone the publishing-api repo, a dependency of the govuk_schemas gem, for content schemas
     # Make it available at ../govuk-content-schemas, which is where govuk_schemas expects it to be

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     # Clone the publishing-api repo, a dependency of the govuk_schemas gem, for content schemas
     # Make it available at ../govuk-content-schemas, which is where govuk_schemas expects it to be
-    - run: git clone -b deployed-to-production --single-branch https://github.com/alphagov/publishing-api ../publishing-api
+    - run: git clone -b main --single-branch https://github.com/alphagov/publishing-api ../publishing-api
 
     - uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -49,6 +49,6 @@ jobs:
           node-version: lts/* # use the latest LTS release
           cache: yarn
       - run: yarn install --frozen-lockfile
-      - run: npx percy exec -- bundle exec rspec --tag visual_regression
+      - run: yarn run percy exec -- bundle exec rspec --tag visual_regression
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -23,6 +23,12 @@ on:
       - "README.md"
       - "LICENCE.md"
       - "SUPPORT.md"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'The branch, tag or SHA to checkout'
+        default: main
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name || github.run_id }}
@@ -33,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true # Also runs `bundle install`


### PR DESCRIPTION
## What

This makes a number of consistency updates to the GitHub actions for this gem. Most notably it changes how workflows run as per: https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#when-the-ci-workflow-should-run to only run on pull request and a push to main. Should you wish to run it before opening a PR you can run the workflow directly from the actions UI.

Aside from this there a few other rather bengin consistency tweaks - see commits for details


## Why

To make this project more consistent with GOV.UK approach and save on using surplus GitHub Actions

## Visual Changes

None
