### PR TITLE
Fix some issues with GA4 indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Remove hardcoded examples in the component guide ([3418](https://github.com/alphagov/govuk_publishing_components/pull/3418))
 * Remove list-style for govspeak ordered lists ([PR #3413](https://github.com/alphagov/govuk_publishing_components/pull/3413))
+* Fix some issues with GA4 indexes ([PR #3426](https://github.com/alphagov/govuk_publishing_components/pull/3426))
 
 ## 35.5.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -30,7 +30,32 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
       firstScript.parentNode.insertBefore(newScript, firstScript)
     },
 
+    ensureIndexesArePopulated: function (data) {
+      if (!data.event_data) {
+        return data
+      }
+
+      if (!data.event_data.index) {
+        return data
+      }
+
+      var indexKeys = ['index_link', 'index_section', 'index_section_count']
+
+      for (var i = 0; i < indexKeys.length; i++) {
+        var indexKey = indexKeys[i]
+
+        // If the index key isn't in the object, populate it. However if it's set to 0, leave it as 0. 0 is falsy so we have to add this extra check.
+        if (!data.event_data.index[indexKey] && data.event_data.index[indexKey] !== 0) {
+          data.event_data.index[indexKey] = undefined
+        }
+      }
+
+      return data
+    },
+
     sendData: function (data) {
+      data = this.ensureIndexesArePopulated(data)
+
       data.govuk_gem_version = this.getGemVersion()
       // set this in the console as a debugging aid
       if (window.GOVUK.analyticsGa4.showDebug) {

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -38,7 +38,9 @@
             "text": "GOV.UK",
             "section": "Logo",
             "index": {
+              "index_link": 1,
               "index_section": 0,
+              "index_section_count": 2,
             },
             "index_total": 1
           }.to_json %>"

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -124,7 +124,7 @@ describe "Super navigation header", type: :view do
 
     assert_select "header[data-module='gem-track-click ga4-event-tracker ga4-link-tracker']"
     assert_select "a[data-ga4-link]", count: 28
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","external":"false","text":"GOV.UK","section":"Logo","index":{"index_section":0},"index_total":1}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","external":"false","text":"GOV.UK","section":"Logo","index":{"index_link":1,"index_section":0,"index_section_count":2},"index_total":1}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":1,"index_link":1,"index_section_count":4},"index_total":16,"section":"Topics"}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":1,"index_link":16,"index_section_count":4},"index_total":16,"section":"Topics"}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":2,"index_link":1,"index_section_count":4},"index_total":6,"section":"Government activity"}\']'

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
@@ -95,7 +95,9 @@ describe('Google Analytics auto tracker', function () {
       expected.event_data.event_name = 'select_content'
       expected.event_data.type = 'tabs'
       expected.event_data.index = {
-        index_section: 7
+        index_section: 7,
+        index_link: undefined,
+        index_section_count: undefined
       }
       expected.govuk_gem_version = 'aVersion'
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -350,6 +350,107 @@ describe('GA4 core', function () {
       it('returns undefined if undefined is passed', function () {
         expect(GOVUK.analyticsGa4.core.trackFunctions.createIndexObject(undefined)).toEqual(undefined)
       })
+
+      describe('returns undefined for unset index keys', function () {
+        var ga4Data, expectedData
+        beforeEach(function () {
+          ga4Data = { event_data: { index: {} } }
+          expectedData = { event_data: { index: { index_link: undefined, index_section: undefined, index_section_count: undefined } } }
+        })
+
+        it('returns undefined for all keys if index exists, but no child keys', function () {
+          ga4Data = GOVUK.analyticsGa4.core.ensureIndexesArePopulated(ga4Data)
+          expect(ga4Data).toEqual(expectedData)
+        })
+
+        it('returns undefined for index_link if it doesnt exist', function () {
+          ga4Data.event_data.index.index_section = 123
+          ga4Data.event_data.index.index_section_count = 123
+          expectedData.event_data.index.index_section_count = 123
+          expectedData.event_data.index.index_section = 123
+
+          ga4Data = GOVUK.analyticsGa4.core.ensureIndexesArePopulated(ga4Data)
+
+          expect(ga4Data).toEqual(expectedData)
+        })
+
+        it('returns undefined for index_section if it doesnt exist', function () {
+          ga4Data.event_data.index.index_link = 123
+          ga4Data.event_data.index.index_section_count = 123
+          expectedData.event_data.index.index_link = 123
+          expectedData.event_data.index.index_section_count = 123
+
+          ga4Data = GOVUK.analyticsGa4.core.ensureIndexesArePopulated(ga4Data)
+
+          expect(ga4Data).toEqual(expectedData)
+        })
+
+        it('returns undefined for index_section_count if it doesnt exist', function () {
+          ga4Data.event_data.index.index_link = 123
+          ga4Data.event_data.index.index_section = 123
+          expectedData.event_data.index.index_link = 123
+          expectedData.event_data.index.index_section = 123
+
+          ga4Data = GOVUK.analyticsGa4.core.ensureIndexesArePopulated(ga4Data)
+
+          expect(ga4Data).toEqual(expectedData)
+        })
+
+        it('returns undefined for index_section_count and index_section if they dont exist', function () {
+          ga4Data.event_data.index.index_link = 123
+          expectedData.event_data.index.index_link = 123
+
+          ga4Data = GOVUK.analyticsGa4.core.ensureIndexesArePopulated(ga4Data)
+
+          expect(ga4Data).toEqual(expectedData)
+        })
+
+        it('returns undefined for index_section_count and index_link if they dont exist', function () {
+          ga4Data.event_data.index.index_section = 123
+          expectedData.event_data.index.index_section = 123
+
+          ga4Data = GOVUK.analyticsGa4.core.ensureIndexesArePopulated(ga4Data)
+
+          expect(ga4Data).toEqual(expectedData)
+        })
+
+        it('returns undefined for index_section and index_link if they dont exist', function () {
+          ga4Data.event_data.index.index_section_count = 123
+          expectedData.event_data.index.index_section_count = 123
+
+          ga4Data = GOVUK.analyticsGa4.core.ensureIndexesArePopulated(ga4Data)
+
+          expect(ga4Data).toEqual(expectedData)
+        })
+
+        it('does not set any indexes to undefined if they all exist', function () {
+          ga4Data.event_data.index.index_link = 123
+          ga4Data.event_data.index.index_section = 123
+          ga4Data.event_data.index.index_section_count = 123
+
+          expectedData.event_data.index.index_link = 123
+          expectedData.event_data.index.index_section = 123
+          expectedData.event_data.index.index_section_count = 123
+
+          ga4Data = GOVUK.analyticsGa4.core.ensureIndexesArePopulated(ga4Data)
+
+          expect(ga4Data).toEqual(expectedData)
+        })
+
+        it('ensures values set to 0 are not set to undefined (as 0 is falsy)', function () {
+          ga4Data.event_data.index.index_link = 0
+          ga4Data.event_data.index.index_section = 0
+          ga4Data.event_data.index.index_section_count = 0
+
+          expectedData.event_data.index.index_link = 0
+          expectedData.event_data.index.index_section = 0
+          expectedData.event_data.index.index_section_count = 0
+
+          ga4Data = GOVUK.analyticsGa4.core.ensureIndexesArePopulated(ga4Data)
+
+          expect(ga4Data).toEqual(expectedData)
+        })
+      })
     })
   })
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -541,7 +541,9 @@ describe('Google Analytics event tracking', function () {
         expected.event_data.text = button.textContent
         expected.event_data.section = button.textContent
         expected.event_data.index = {
-          index_section: i + 1
+          index_section: i + 1,
+          index_link: undefined,
+          index_section_count: undefined
         }
         expect(window.dataLayer[0]).toEqual(expected)
         button.setAttribute('aria-expanded', 'true')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -110,7 +110,9 @@ describe('GA4 click tracker', function () {
       expected.event_data.method = 'primary click'
       expected.event_data.external = 'false'
       expected.event_data.index = {
-        index_link: 1
+        index_link: 1,
+        index_section: undefined,
+        index_section_count: undefined
       }
     })
 
@@ -349,7 +351,7 @@ describe('GA4 click tracker', function () {
 
       initModule(element, true)
 
-      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 123 })
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 123, index_section: undefined, index_section_count: undefined })
     })
   })
 
@@ -362,7 +364,7 @@ describe('GA4 click tracker', function () {
 
       initModule(element, true)
 
-      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 123 })
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 123, index_section: undefined, index_section_count: undefined })
     })
   })
 
@@ -396,7 +398,7 @@ describe('GA4 click tracker', function () {
       initModule(element, false)
       link.click()
 
-      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 6, index_section: 4 })
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 6, index_section: 4, index_section_count: undefined })
     })
   })
 
@@ -412,7 +414,7 @@ describe('GA4 click tracker', function () {
       initModule(element, false)
       link.click()
 
-      expect(window.dataLayer[0].event_data.index).toEqual({ index_section: 1, index_section_count: 2 })
+      expect(window.dataLayer[0].event_data.index).toEqual({ index_section: 1, index_section_count: 2, index_link: undefined })
     })
   })
 


### PR DESCRIPTION
## What
- Sets any unused index keys in the `index` object to `undefined` if they aren't being used in the `index: {}` object.
- Updates the GOVUK Logo index values

## Why
<!-- What are the reasons behind this change being made? -->
- The PAs noticed that sometimes index values were being persisted between dataLayer pushes. This was because we aren't setting the indexes to `undefined` if they don't exist. Therefore, an `index_link`, `index_section` or `index_section_count` from a previous event could be included with the current event.
- Updates the GOVUK Logo index in accordance with this card: https://trello.com/c/SRFZ68d4/566-fix-index-on-govuk-link-click-nav-event-in-header-menu-bar

## Visual Changes
None.