### PR TITLE
Fix PII on referrer parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Change GA4 share values ([PR #3407](https://github.com/alphagov/govuk_publishing_components/pull/3407))
 * Add GA4 index_section_count to step by step links ([PR #3410](https://github.com/alphagov/govuk_publishing_components/pull/3410))
 * Set GA4 link text to 'image' if there's only an image and no link text ([PR #3404](https://github.com/alphagov/govuk_publishing_components/pull/3404))
+* Fix PII on referrer parameter ([PR #3430](https://github.com/alphagov/govuk_publishing_components/pull/3430))
 
 ## 35.4.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -17,7 +17,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             location: this.getLocation(),
             /* If the init() function receives a referrer parameter, this indicates that it has been called as a part of an AJAX request and
             this.getReferrer() will not return the correct value. Therefore we need to rely on the referrer parameter. */
-            referrer: referrer || this.getReferrer(),
+            referrer: referrer ? this.PIIRemover.stripPIIWithOverride(referrer, true, true) : this.getReferrer(),
             title: this.getTitle(),
             status_code: this.getStatusCode(),
 


### PR DESCRIPTION
## What
When conducting a search on a finder application (e.g. https://www.gov.uk/search/all?), the `referrer` parameter on the `pageView` object does not redact PII. (Instructions to recreate the issue have been left on this [trello card](https://trello.com/c/hs46dfAY/591-pii-coming-through-in-referrer-property-on-pageview-object))

## Why
PII issue fix.

[Trello card](https://trello.com/c/hs46dfAY/591-pii-coming-through-in-referrer-property-on-pageview-object)

## Visual Changes
N/A
