### PR TITLE
Fix GA4 tracking on step nav related

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 ## Unreleased
 
-* Remove hardcoded examples in the component guide ([3418](https://github.com/alphagov/govuk_publishing_components/pull/3418))
+* Fix GA4 tracking on step nav related ([PR #3431](https://github.com/alphagov/govuk_publishing_components/pull/3431))
+* Remove hardcoded examples in the component guide ([PR #3418](https://github.com/alphagov/govuk_publishing_components/pull/3418))
 * Remove list-style for govspeak ordered lists ([PR #3413](https://github.com/alphagov/govuk_publishing_components/pull/3413))
 * Fix some issues with GA4 indexes ([PR #3426](https://github.com/alphagov/govuk_publishing_components/pull/3426))
 * Fix PII on referrer parameter ([PR #3430](https://github.com/alphagov/govuk_publishing_components/pull/3430))

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -61,7 +61,7 @@
                       "index_link": (index + 1).to_s
                     },
                     index_total: (links.length).to_s,
-                    section: "Part of",
+                    section: pretitle,
                   }.to_json
                 %>
                   data-ga4-link="<%= ga4_attributes %>"

--- a/spec/components/step_by_step_nav_related_spec.rb
+++ b/spec/components/step_by_step_nav_related_spec.rb
@@ -145,7 +145,7 @@ describe "Step by step navigation related", type: :view do
   end
 
   it "adds GA4 data attributes on multiple links when ga4_tracking is true" do
-    render_component(links: two_links, ga4_tracking: true)
+    render_component(pretitle: "Some more text", links: two_links, ga4_tracking: true)
 
     link_one = ".gem-c-step-nav-related .gem-c-step-nav-related__links .govuk-link[href='/link1']"
     link_two = ".gem-c-step-nav-related .gem-c-step-nav-related__links .govuk-link[href='/link2']"
@@ -155,7 +155,7 @@ describe "Step by step navigation related", type: :view do
       "type": "related content",
       "index": { "index_link": "1" },
       "index_total": "2",
-      "section": "Part of",
+      "section": "Some more text",
     }
 
     expected_two = {
@@ -163,7 +163,7 @@ describe "Step by step navigation related", type: :view do
       "type": "related content",
       "index": { "index_link": "2" },
       "index_total": "2",
-      "section": "Part of",
+      "section": "Some more text",
     }
 
     assert_select "#{link_one}[data-ga4-link='#{expected_one.to_json}']"


### PR DESCRIPTION
## What / why
Fixes incorrect GA4 data for the `pretitle` (in this case 'Also part of') on the step by step nav related component on pages like: https://www.gov.uk/guidance/appoint-someone-to-deal-with-customs-on-your-behalf

![Screenshot 2023-06-06 at 13 38 27](https://github.com/alphagov/govuk_publishing_components/assets/861310/9912e072-d5db-4a6e-a88c-e55cb643a547)

- had been partly done, but component outputs two slightly different chunks of markup depending on the number of links passed to it, and only one chunk had been modified to include the right pretitle value in the GA4 data
- also updating test as pretitle had been omitted

## Visual Changes
None

Trello card: https://trello.com/c/DNTld882/531-amend-section-parameter-to-say-also-part-of-step-by-steps-related-content
