### PR TITLE
Remove GA4 index parsing code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Remove GA4 index parsing code ([PR #3434](https://github.com/alphagov/govuk_publishing_components/pull/3434))
 * Fix GA4 tracking on step nav related ([PR #3431](https://github.com/alphagov/govuk_publishing_components/pull/3431))
 * Remove hardcoded examples in the component guide ([PR #3418](https://github.com/alphagov/govuk_publishing_components/pull/3418))
 * Remove list-style for govspeak ordered lists ([PR #3413](https://github.com/alphagov/govuk_publishing_components/pull/3413))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.js
@@ -35,9 +35,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         return
       }
 
-      if (data.index) {
-        data.index = window.GOVUK.analyticsGa4.core.trackFunctions.createIndexObject(data.index)
-      }
       var schemas = new window.GOVUK.analyticsGa4.Schemas()
       var schema = schemas.mergeProperties(data, 'event_data')
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -274,37 +274,6 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
         }
       },
 
-      // index is given as a string of the form 1.2.3 or 1.2
-      // split this into named sub-parameters
-      createIndexObject: function (index) {
-        if (typeof index === 'undefined') {
-          return undefined
-        }
-        if (typeof index === 'object') {
-          return index
-        }
-
-        index = index.toString().split('.')
-        // this will soon include 'index_section_count'
-        // number of sections overall in the thing being tracked (but not yet in use)
-        switch (index.length) {
-          case 1:
-            return {
-              index_section: parseInt(index[0])
-            }
-          case 2:
-            return {
-              index_section: parseInt(index[0]),
-              index_link: parseInt(index[1])
-            }
-          case 3:
-            return {
-              index_section: parseInt(index[1]),
-              index_link: parseInt(index[2])
-            }
-        }
-      },
-
       addAttributesToElements: function (selector, dataAttributes) {
         var targetElements = document.querySelectorAll(selector)
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
@@ -42,7 +42,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       var text = data.text || event.target.textContent
       data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)
-      data.index = window.GOVUK.analyticsGa4.core.trackFunctions.createIndexObject(data.index)
 
       var schemas = new window.GOVUK.analyticsGa4.Schemas()
       var schema = schemas.mergeProperties(data, 'event_data')

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -111,9 +111,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
   }
 
-  Ga4LinkTracker.prototype.setIndex = function (indexData, target) {
-    var index = window.GOVUK.analyticsGa4.core.trackFunctions.createIndexObject(indexData)
-
+  Ga4LinkTracker.prototype.setIndex = function (index, target) {
     if (target.getAttribute('data-ga4-index')) {
       try {
         var indexLink = JSON.parse(target.getAttribute('data-ga4-index'))

--- a/docs/analytics-ga4/ga4-link-tracker.md
+++ b/docs/analytics-ga4/ga4-link-tracker.md
@@ -8,12 +8,12 @@ This script is intended for adding GA4 tracking to links. It depends upon the ma
 <a
   href="/link"
   data-module="ga4-link-tracker"
-  data-ga4-link='{ "event_name": "navigation", "type": "home page", "index": 0, "index_total": 1, "section": "name of section" }'>
+  data-ga4-link='{ "event_name": "navigation", "type": "home page", "index": { "index_link": 1, "index_section": 1, "index_section_count": 3 }, "index_total": 1, "section": "name of section" }'>
     Link
 </a>
 ```
 
-Note that the specific detail of the `data-ga4-link` attribute will depend on the context of the link.
+Note that the specific detail of the `data-ga4-link` attribute will depend on the context of the link. This is particularly true for the index parameters.
 
 ## Basic use (multiple links)
 
@@ -23,12 +23,12 @@ Specific tracking can be applied to multiple elements within a container, by app
 <div data-module="ga4-link-tracker">
   <a
     href="/a-page"
-    data-ga4-link='{ "event_name": "navigation", "type": "browse", "index": "0", "index_total": "2", "section": "name of section" }'>
+    data-ga4-link='{ "event_name": "navigation", "type": "browse", "index": { "index_link": 1, "index_section": 1, "index_section_count": 2 }, "index_total": "2", "section": "name of section" }'>
     Link 1
   </a>
   <a
     href="/another-page"
-    data-ga4-link='{ "event_name": "navigation", "type": "browse", "index": "1", "index_total": "2", "section": "name of section" }'>
+    data-ga4-link='{ "event_name": "navigation", "type": "browse", "index": { "index_link": 2, "index_section": 1, "index_section_count": 2 }, "index_total": "2", "section": "name of section" }'>
     Link 2
   </a>
 </div>
@@ -44,7 +44,7 @@ The text of the link can be overridden by another value if passed in the data at
 <a
   href="/link"
   data-module="ga4-link-tracker"
-  data-ga4-link='{ "event_name": "navigation", "type": "home page", "index": 0, "index_total": 1, "section": "name of section", "text": "This text will be recorded in the GA event" }'>
+  data-ga4-link='{ "event_name": "navigation", "type": "home page", "index": { "index_link": 1, "index_section": 1, "index_section_count": 3 }, "index_total": 1, "section": "name of section", "text": "This text will be recorded in the GA event" }'>
     This text will not be recorded
 </a>
 ```

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.spec.js
@@ -105,7 +105,11 @@ describe('Google Analytics auto tracker', function () {
         event_name: 'select_content',
         type: 'tabs',
         not_a_schema_attribute: 'something',
-        index: '7'
+        index: {
+          index_section: 7,
+          index_link: undefined,
+          index_section_count: undefined
+        }
       }
       element.setAttribute('data-ga4-auto', JSON.stringify(attributes))
       new GOVUK.Modules.Ga4AutoTracker(element).init()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -366,42 +366,6 @@ describe('GA4 core', function () {
     })
 
     describe('when handling the index parameter', function () {
-      it('converts a three digit index into sub-parameters as expected', function () {
-        var expected = {
-          index_section: 2,
-          index_link: 3
-        }
-        expect(GOVUK.analyticsGa4.core.trackFunctions.createIndexObject('1.2.3')).toEqual(expected)
-      })
-
-      it('converts a two digit index into sub-parameters as expected', function () {
-        var expected = {
-          index_section: 1,
-          index_link: 2
-        }
-        expect(GOVUK.analyticsGa4.core.trackFunctions.createIndexObject('1.2')).toEqual(expected)
-      })
-
-      it('converts a one digit index into sub-parameters as expected', function () {
-        var expected = {
-          index_section: 1
-        }
-        expect(GOVUK.analyticsGa4.core.trackFunctions.createIndexObject('1')).toEqual(expected)
-      })
-
-      it('copes when passed an actual number', function () {
-        expect(GOVUK.analyticsGa4.core.trackFunctions.createIndexObject(1)).toEqual({ index_section: 1 })
-      })
-
-      it('returns the object if an object is passed', function () {
-        var expected = { index: 1 }
-        expect(GOVUK.analyticsGa4.core.trackFunctions.createIndexObject(expected)).toEqual(expected)
-      })
-
-      it('returns undefined if undefined is passed', function () {
-        expect(GOVUK.analyticsGa4.core.trackFunctions.createIndexObject(undefined)).toEqual(undefined)
-      })
-
       describe('returns undefined for unset index keys', function () {
         var ga4Data, expectedData
         beforeEach(function () {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jasmine */
 
-describe('Google Analytics event tracking', function () {
+describe('Google Analytics event tracker', function () {
   var GOVUK = window.GOVUK
   var element
   var expected
@@ -532,7 +532,9 @@ describe('Google Analytics event tracking', function () {
           type: 'header menu bar',
           text: button.textContent,
           section: button.textContent,
-          index: i + 1,
+          index: {
+            index_section: i + 1
+          },
           index_total: buttons.length
         }))
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jasmine */
 
-describe('GA4 click tracker', function () {
+describe('GA4 link tracker', function () {
   var GOVUK = window.GOVUK
   var element
   var expected
@@ -382,23 +382,6 @@ describe('GA4 click tracker', function () {
       link.click()
 
       expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 3, index_section: 1, index_section_count: 2 })
-    })
-    it('combines both (when index is a string) into a single index object', function () {
-      element = document.createElement('div')
-      element.setAttribute('data-ga4-track-links-only', '')
-
-      // index can appear as a decimal however we only need to test one digit in this case because a decimal indicates
-      // that the link index is already available and therefore wouldn't require combining with data-ga4-index
-      element.setAttribute('data-ga4-link', '{"index": "4"}')
-      element.innerHTML = '<a class="link" href="#link1">Link 1</a>'
-
-      var link = element.querySelector('.link')
-      link.setAttribute('data-ga4-index', '{"index_link": ' + 6 + '}')
-
-      initModule(element, false)
-      link.click()
-
-      expect(window.dataLayer[0].event_data.index).toEqual({ index_link: 6, index_section: 4, index_section_count: undefined })
     })
   })
 


### PR DESCRIPTION
## What
This code was used to convert string values for the GA4 index parameter into sub attributes such as index_section, index_link. It was originally written to be future proof i.e. if passed an object that already contained these sub attributes, it just returned it. At this point nothing is using it, so it's redundant.

## Why
This code is no longer needed as all instances of code that uses an index parameter now has it as sub attributes already.

## Visual Changes
None.

Trello card: https://trello.com/c/TDGHW9cX/438-remove-index-processing-code
