### PR TITLE
Additions to the GA4 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ yarn run jasmine:ci
 - [Testing a component](docs/testing-components.md)
 - [Component auditing](docs/auditing.md)
 - [Code documentation on rubydoc.info](http://www.rubydoc.info/gems/govuk_publishing_components)
+- [Our analytics approach](docs/analytics-ga4/analytics.md)
 
 More documentation can be found in the [docs directory](docs/).
 

--- a/docs/analytics-ga4/analytics.md
+++ b/docs/analytics-ga4/analytics.md
@@ -18,6 +18,8 @@ Events happen when a user interacts with certain things, for example clicking on
 
 Search data is gathered when users perform a search.
 
+For more information about different kinds of tracking, read our [overview of trackers](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-all-trackers.md).
+
 ## Cookie consent
 
 The analytics code is only loaded if users consent to cookies. This is managed by the `init-ga4.js` script.
@@ -66,16 +68,6 @@ When cookie consent is given, `init-ga4.js` looks through the `analyticsModules`
 
 Where analytics code is required as a [GOV.UK JavaScript Module](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/javascript-modules.md), the code structure for the [existing model for deferred loading](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/javascript-modules.md#modules-and-cookie-consent) should be used.
 
-## Link and event tracking
-
-There are several types of user initiated tracking. To distinguish them and simplify the code, we consider them as the following:
-
-- interactions with [links](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) where tracking is added using data attributes on specific links
-- interactions with [specialist links](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-specialist-link-tracker.md), e.g. external links, download links, mailto links, where tracking is determined automatically by the content of the link
-- interactions with [buttons or other interactive elements](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) e.g. details elements, where tracking is added using data attributes on specific elements
-
-Each type of tracking is handled by a separate script, but some code is shared between them as they do similar things.
-
 ## Data schemas
 
 All of the data sent to GTM is based on a common schema.
@@ -96,6 +88,8 @@ All of the data sent to GTM is based on a common schema.
 `event_data` is defined in the [ga4-schemas script](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js) and used in the [ga4-event-tracker script](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js).
 
 `search_results` is defined in the [ga4-ecommerce-tracker script](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.js).
+
+For more details of our data schema, see our [implementation record](https://docs.publishing.service.gov.uk/analytics/).
 
 ## How the dataLayer works
 

--- a/docs/analytics-ga4/ga4-all-trackers.md
+++ b/docs/analytics-ga4/ga4-all-trackers.md
@@ -1,0 +1,32 @@
+# Trackers
+
+For tracking different kinds of data on GOV.UK we have built several different trackers. Each type of tracking is handled by a separate script, but some code is shared between them as they often do similar things.
+
+Most of the trackers work by adding a `data-module` attribute to an element along with additional data attributes to provide specific tracking information. Some components have this already built into their code, which is usually activated using a `ga4_tracking: true` option.
+
+## Link tracking
+
+There are several types of link tracking. To distinguish them and simplify the code, we define them as follows.
+
+- the [link tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) handles link clicks with data attributes added to specific links, or to parent elements of groups of links
+- the [specialist link tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-specialist-link-tracker.md)automatically tracks clicks on 'special' links, such as external links, download links and mailto links
+
+## Event tracking
+
+The [event tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) handles tracking on buttons or other interactive elements, such as tabs and details elements.
+
+## Auto tracking
+
+The [auto tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-auto-tracker.md) is used to cause an event to occur as soon as a page has finished loading (but after a page view). This is used to track significant moments in journeys, such as the successful completion of a smart answer, or an error.
+
+## Ecommerce tracker
+
+The [ecommerce tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-ecommerce-tracker.md) is used to track things like search results within a finder.
+
+## Form tracker
+
+The [form tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-form-tracker.md) is designed to capture data about a form when it has been submitted.
+
+## Smart answer results tracker
+
+The [smart answer results tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-smart-answer-results-tracker.md) has been built specifically to track the Cost of Living smart answer.


### PR DESCRIPTION
## What
Trying to make the docs clearer and easier to navigate.

- adds a general overview of our different trackers
- documents our [debug option](https://github.com/alphagov/govuk_publishing_components/pull/3388) (which I forgot to write about at the time)
- adds a few more links to aid general navigation

## Why
Better docs, happier devs.

## Visual Changes
None. Well, some new words I guess.
