### PR TITLE
Version 35.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.6.0
 
 * Remove GA4 index parsing code ([PR #3434](https://github.com/alphagov/govuk_publishing_components/pull/3434))
 * Fix GA4 tracking on step nav related ([PR #3431](https://github.com/alphagov/govuk_publishing_components/pull/3431))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.5.0)
+    govuk_publishing_components (35.6.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.5.0".freeze
+  VERSION = "35.6.0".freeze
 end


### PR DESCRIPTION
## 35.6.0

* Remove GA4 index parsing code ([PR #3434](https://github.com/alphagov/govuk_publishing_components/pull/3434))
* Fix GA4 tracking on step nav related ([PR #3431](https://github.com/alphagov/govuk_publishing_components/pull/3431))
* Remove hardcoded examples in the component guide ([PR #3418](https://github.com/alphagov/govuk_publishing_components/pull/3418))
* Remove list-style for govspeak ordered lists ([PR #3413](https://github.com/alphagov/govuk_publishing_components/pull/3413))
* Fix some issues with GA4 indexes ([PR #3426](https://github.com/alphagov/govuk_publishing_components/pull/3426))
* Fix PII on referrer parameter ([PR #3430](https://github.com/alphagov/govuk_publishing_components/pull/3430))
* Add GA4 tracking for content navigation ([PR #3420](https://github.com/alphagov/govuk_publishing_components/pull/3420))
* Update setIndexes function ([PR #3435](https://github.com/alphagov/govuk_publishing_components/pull/3435))
