### PR TITLE
Add support for HTML and external attachment types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fully implement loading of individual stylesheets in component guide ([PR #3379](https://github.com/alphagov/govuk_publishing_components/pull/3379))
+* Add support for HTML and external attachment types ([PR #3442](https://github.com/alphagov/govuk_publishing_components/pull/3442))
 
 ## 35.6.0
 

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -9,30 +9,44 @@
   data_attributes ||= {}
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
-  if attachment.content_type_name
-    content = if attachment.content_type_abbr
-                raw tag.abbr(attachment.content_type.abbr,
-                             title: attachment.content_type_name,
-                             class: "gem-c-attachment__abbr")
-              else
-                attachment.content_type_name
-              end
-    attributes << tag.span(content, class: "gem-c-attachment__attribute")
-  end
+  case attachment.type
+  when "file"
+    if attachment.content_type_name
+      content = if attachment.content_type_abbr
+                  raw tag.abbr(attachment.content_type.abbr,
+                              title: attachment.content_type_name,
+                              class: "gem-c-attachment__abbr")
+                else
+                  attachment.content_type_name
+                end
+      attributes << tag.span(content, class: "gem-c-attachment__attribute")
+    end
 
-  if attachment.file_size
+    if attachment.file_size
+      attributes << tag.span(
+        number_to_human_size(attachment.file_size),
+        class: "gem-c-attachment__attribute",
+      )
+    end
+
+    if attachment.number_of_pages
+      attributes << tag.span(
+        t("components.attachment.page", count: attachment.number_of_pages),
+        class: "gem-c-attachment__attribute",
+      )
+    end
+  when "html"
     attributes << tag.span(
-      number_to_human_size(attachment.file_size),
+      "HTML",
+      class: "gem-c-attachment__attribute",
+    )
+  when "external"
+    attributes << tag.span(
+      attachment.url,
       class: "gem-c-attachment__attribute",
     )
   end
-
-  if attachment.number_of_pages
-    attributes << tag.span(
-      t("components.attachment.page", count: attachment.number_of_pages),
-      class: "gem-c-attachment__attribute",
-    )
-  end
+  
 %>
 <%= tag.section class: "gem-c-attachment govuk-!-display-none-print" do %>
   <%= tag.div class: "gem-c-attachment__thumbnail" do %>
@@ -42,8 +56,10 @@
                 tabindex: "-1",
                 "aria-hidden": true,
                 data: data_attributes do %>
-      <% if attachment.thumbnail_url %>
-        <% image_tag(attachment.thumbnail_url, alt: "") %>
+      <% if attachment.thumbnail_url.present? %>
+        <% image_tag(attachment.thumbnail_url, alt: "", class: "gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom") %>
+      <% elsif attachment.html? %>
+        <%= render "govuk_publishing_components/components/attachment/thumbnail_html" %>
       <% elsif attachment.document? %>
         <%= render "govuk_publishing_components/components/attachment/thumbnail_document" %>
       <% elsif attachment.spreadsheet? %>

--- a/app/views/govuk_publishing_components/components/attachment/_thumbnail_document.html.erb
+++ b/app/views/govuk_publishing_components/components/attachment/_thumbnail_document.html.erb
@@ -1,3 +1,3 @@
-<svg class="gem-c-attachment__thumbnail-image" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+<svg class="gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--document" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
   <path d="M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z" stroke-width="0"/>
 </svg>

--- a/app/views/govuk_publishing_components/components/attachment/_thumbnail_generic.html.erb
+++ b/app/views/govuk_publishing_components/components/attachment/_thumbnail_generic.html.erb
@@ -1,4 +1,4 @@
-<svg class="gem-c-attachment__thumbnail-image" version="1.1" viewBox="0 0 84 120" width="84" height="120" aria-hidden="true">
+<svg class="gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--generic" version="1.1" viewBox="0 0 84 120" width="84" height="120" aria-hidden="true">
   <path d="M74.85 5v106H5" fill="none" stroke-miterlimit="10" stroke-width="2"/>
   <path d="M79.85 10v106H10" fill="none" stroke-miterlimit="10" stroke-width="2"/>
 </svg>

--- a/app/views/govuk_publishing_components/components/attachment/_thumbnail_html.html.erb
+++ b/app/views/govuk_publishing_components/components/attachment/_thumbnail_html.html.erb
@@ -1,0 +1,3 @@
+<svg class="gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--html" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+  <path d="M30,95h57v9H30V95z M30,77v9h39v-9H30z M30,122h48v-9H30V122z M12,68h9v-9h-9V68z M12,104h9v-9h-9V104z M12,86h9v-9h-9V86z M12,122h9v-9h-9V122z M87,12v27H12V12H87z M33,17h-4v8h-6v-8h-4v18h4v-7l6,0v7l4,0V17z M49,17H35l0,3h5v15h4V20l5,0V17z M68,17h-4 l-5,6l-5-6h-4v18h4l0-12l5,6l5-6l0,12h4V17z M81,32h-6V17h-4v18h10V32z M30,68h57v-9H30V68z" stroke-width="0"/>
+</svg>

--- a/app/views/govuk_publishing_components/components/attachment/_thumbnail_spreadsheet.html.erb
+++ b/app/views/govuk_publishing_components/components/attachment/_thumbnail_spreadsheet.html.erb
@@ -1,4 +1,4 @@
-<svg class="gem-c-attachment__thumbnail-image" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+<svg class="gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--spreadsheet" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
   <path d="M12 12h75v27H12zm0 47h18.75v63H12zm55 2v59H51V61h16m2-2H49v63h20V59z" stroke-width="0"/>
   <path d="M49 61.05V120H32.8V61.05H49m2-2H30.75v63H51V59zm34 2V120H69.05V61.05H85m2-2H67v63h20V59z" stroke-width="0"/>
   <path d="M30 68.5h56.5M30 77.34h56.5M30 112.7h56.5M30 95.02h56.5M30 86.18h56.5M30 103.86h56.5" fill="none" stroke-miterlimit="10" stroke-width="2"/>

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -177,3 +177,15 @@ examples:
         content_type: application/pdf
         file_size: 20000
         thumbnail_url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/791567/thumbnail_the_government_financial_reporting_review_web.pdf.png"
+  html_attachment:
+    data:
+      attachment:
+        title: "Smart meters: unlocking the future"
+        url: https://www.gov.uk/government/publications/smart-meters-unlocking-the-future/smart-meters-unlocking-the-future
+        type: html
+  external_attachment:
+    data:
+      attachment:
+        title: "Architects Registration Board annual report 2021"
+        url: https://arb.org.uk/wp-content/uploads/ARB-Annual-Report-and-Financial-Statement-2021-published.pdf
+        type: external

--- a/lib/govuk_publishing_components/presenters/attachment_helper.rb
+++ b/lib/govuk_publishing_components/presenters/attachment_helper.rb
@@ -94,11 +94,11 @@ module GovukPublishingComponents
           { content_type: "application/rtf", abbr: "RTF", name: "Rich Text Format" }.freeze,
           { content_type: "application/vnd.ms-excel", name: "MS Excel Spreadsheet", spreadsheet: true }.freeze,
           { content_type: "application/vnd.ms-excel.sheet.macroenabled.12", abbr: "XLSM", name: "MS Excel Macro-Enabled Workbook" }.freeze,
-          { content_type: "application/vnd.ms-powerpoint", name: "MS Powerpoint Presentation" }.freeze, # ppt
+          { content_type: "application/vnd.ms-powerpoint", name: "MS PowerPoint Presentation" }.freeze, # ppt
           { content_type: "application/vnd.oasis.opendocument.presentation", abbr: "ODP", name: "OpenDocument Presentation", opendocument: true }.freeze,
           { content_type: "application/vnd.oasis.opendocument.spreadsheet", abbr: "ODS", name: "OpenDocument Spreadsheet", opendocument: true, spreadsheet: true }.freeze,
           { content_type: "application/vnd.oasis.opendocument.text", abbr: "ODT", name: "OpenDocument Text document", opendocument: true, document: true }.freeze,
-          { content_type: "application/vnd.openxmlformats-officedocument.presentationml.presentation", name: "MS Powerpoint Presentation" }.freeze, # pptx
+          { content_type: "application/vnd.openxmlformats-officedocument.presentationml.presentation", name: "MS PowerPoint Presentation" }.freeze, # pptx
           { content_type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", name: "MS Excel Spreadsheet", spreadsheet: true }.freeze, # xlsx
           { content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", name: "MS Word Document", document: true }.freeze, # docx
           { content_type: "application/xml", abbr: "XML", name: "XML Document" }.freeze,

--- a/lib/govuk_publishing_components/presenters/attachment_helper.rb
+++ b/lib/govuk_publishing_components/presenters/attachment_helper.rb
@@ -7,7 +7,7 @@ module GovukPublishingComponents
 
       # Expects a hash of attachment data
       # * title and url are required
-      # * content_type, filename, file_size, number of pages, alternative_format_contact_email can be provided
+      # * type, content_type, filename, file_size, number of pages, alternative_format_contact_email can be provided
       def initialize(attachment_data)
         @attachment_data = attachment_data.with_indifferent_access
       end
@@ -22,6 +22,14 @@ module GovukPublishingComponents
 
       def url
         attachment_data.fetch(:url)
+      end
+
+      def type
+        attachment_data.fetch(:type, "file")
+      end
+
+      def html?
+        type == "html"
       end
 
       def content_type

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -15,6 +15,7 @@ describe "Attachment", type: :view do
     render_component(attachment: { title: "Attachment", url: "https://gov.uk/attachment" })
     assert_select ".gem-c-attachment"
     assert_select "a[href='https://gov.uk/attachment']", text: "Attachment"
+    assert_thumbnail "generic"
   end
 
   it "can have a target specified" do
@@ -38,6 +39,7 @@ describe "Attachment", type: :view do
     assert_select "abbr.gem-c-attachment__abbr[title='Portable Document Format']", text: "PDF"
     expect(rendered).to match(/2 KB/)
     expect(rendered).to match(/2 pages/)
+    assert_thumbnail "document"
   end
 
   it "can show file type that doesn't have an abbreviation" do
@@ -72,6 +74,7 @@ describe "Attachment", type: :view do
       },
     )
     assert_select "a[href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation']"
+    assert_thumbnail "spreadsheet"
   end
 
   it "shows section to request a different format if a contact email is provided that is not in the pilot" do
@@ -129,7 +132,8 @@ describe "Attachment", type: :view do
     assert_select ".gem-c-attachment__metadata:nth-of-type(1)", text: "Ref: ISBN 978-1-5286-1173-2, 2259, Cd. 67"
   end
 
-  it "shows PDF thumbnails previews for PDF attachments" do
+  it "shows a custom thumbnail image when one is provided" do
+    thumbnail_url = "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/791567/thumbnail_the_government_financial_reporting_review_web.pdf.png"
     render_component(
       attachment: {
         title: "The government financial reporting review",
@@ -141,10 +145,10 @@ describe "Attachment", type: :view do
         isbn: "978-1-5286-1173-2",
         unique_reference: "2259",
         command_paper_number: "Cd. 67",
-        thumbnail_url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/791567/thumbnail_the_government_financial_reporting_review_web.pdf.png",
+        thumbnail_url: thumbnail_url,
       },
     )
-    rendered.should include("https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/791567/thumbnail_the_government_financial_reporting_review_web.pdf.png")
+    assert_thumbnail "custom", src: thumbnail_url
   end
 
   it "shows unnumbered details on the second metadata line if marked so" do
@@ -205,5 +209,23 @@ describe "Attachment", type: :view do
   it "defaults to h2 if heading_level is not specified" do
     render_component(attachment: { title: "Attachment", url: "https://gov.uk/attachment" })
     assert_select "h2.gem-c-attachment__title .gem-c-attachment__link", text: "Attachment"
+  end
+
+  it "renders HTML attachments" do
+    render_component(attachment: { title: "Attachment", url: "https://gov.uk/attachment", type: "html" })
+    assert_select ".gem-c-attachment__metadata", text: "HTML"
+    assert_thumbnail "html"
+  end
+
+  it "renders External attachments" do
+    render_component(attachment: { title: "Attachment", url: "https://gov.uk/attachment", type: "external" })
+    assert_select ".gem-c-attachment__metadata", text: "https://gov.uk/attachment"
+    assert_thumbnail "generic"
+  end
+
+  def assert_thumbnail(type, src: nil)
+    assert_select ".gem-c-attachment__thumbnail-image.gem-c-attachment__thumbnail-image--#{type}" do |thumbnail|
+      expect(thumbnail.first.attr("src")).to eq(src) if type == "custom"
+    end
   end
 end


### PR DESCRIPTION
## What

This commit adds support for HTML and external attachments to the Attachment component.

So far, the Attachment component has only been able to represent file attachments – i.e. attachments which have a 'content type' and a thumbnail that changes depending on the type of file it is.

This change acts as an enabler for us to switch off custom rendering of embedded attachments in the Whitehall Publisher app. It also ports across the HTML attachment thumbnail SVG which is currently [held in Whitehall][1].

I've also taken the opportunity to tighten up the tests to specify which thumbnail should appear for the various different types of attachments. This just supplements existing tests rather than explicitly testing them independently.

I've also fixed a minor styling bug which was present, where custom thumbnail images didn't receive a grey border because the `<img>` element was missing the required CSS class name.

## Why

So that we can stop Whitehall from rendering attachments using its own in-app partials. Instead, it'll be able to use the Govspeak gem to render attachments, which in turn uses this Attachment component. It'll bring Whitehall more in line with other publishing apps such as Content Publisher.

## Visual Changes

The styling of HTML and external attachments replicates what is currently rendered by Whitehall.

For example, see this publication which includes File, HTML and External attachment types (all currently rendered by Whitehall): [Traineeship employer incentive registration form](https://www.gov.uk/government/publications/traineeship-employer-incentive-registration-form)

| Description | Before | After |
| --- | --- | --- |
| Custom thumbnail | <img width="960" alt="custom_thumbnail_before" src="https://github.com/alphagov/govuk_publishing_components/assets/7735945/9fa534e6-c444-4b86-8c11-986c029fcaf5"> | <img width="960" alt="custom_thumbnail_after" src="https://github.com/alphagov/govuk_publishing_components/assets/7735945/2ca379ab-46c0-4804-9b7e-e98166d7c258"> |
| HTML attachment | N/A | <img width="960" alt="html_attachment" src="https://github.com/alphagov/govuk_publishing_components/assets/7735945/e16d20db-ba79-4ab0-b140-dd4b7ffd6767"> |
| External attachment | N/A | <img width="960" alt="external_attachment" src="https://github.com/alphagov/govuk_publishing_components/assets/7735945/49070152-3235-447a-8463-5b71b429f97a"> |

Trello: https://trello.com/c/Z5IwGrAw/1177-remove-custom-attachment-rendering-from-whitehall