### PR TITLE
Add ga4 tracking to single page notifications button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fix GA4 accordion tracking bugs ([PR #3461](https://github.com/alphagov/govuk_publishing_components/pull/3461))
+* Add ga4 tracking to single page notifications button ([PR #3443](https://github.com/alphagov/govuk_publishing_components/pull/3443))
 
 ## 35.8.0
 

--- a/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
@@ -1,25 +1,37 @@
 <%
   add_gem_component_stylesheet("single-page-notification-button")
 
-  component_helper = GovukPublishingComponents::Presenters::SinglePageNotificationButtonHelper.new(local_assigns)
+  spnb_helper = GovukPublishingComponents::Presenters::SinglePageNotificationButtonHelper.new(local_assigns)
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
 
   wrapper_classes = %w(govuk-!-display-none-print)
   wrapper_classes << shared_helper.get_margin_bottom
+
+  ga4_data_attributes = ga4_data_attributes ||= nil
+  ga4_link_data_attributes = ga4_data_attributes[:ga4_link] if ga4_data_attributes
+  ga4_link_data_attributes[:url] = spnb_helper.form_action if ga4_link_data_attributes
+
+  component_helper.add_class(wrapper_classes.join(" "))
+  component_helper.add_data_attribute({ module: "gem-track-click" })
+  component_helper.add_data_attribute({ module: ga4_data_attributes[:module] }) if ga4_data_attributes
 %>
 <% button_text = capture do %>
-  <svg class="gem-c-single-page-notification-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 459.334 459.334"><path fill="currentColor" d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"/></svg><span class="gem-c-single-page-notication-button__text"><%= component_helper.button_text %></span>
+  <svg class="gem-c-single-page-notification-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 459.334 459.334"><path fill="currentColor" d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"/></svg><span class="gem-c-single-page-notication-button__text"><%= spnb_helper.button_text %></span>
 <% end %>
-<%= tag.div class: wrapper_classes, data: { module: "gem-track-click"} do %>
-  <%= tag.form class: component_helper.classes, action: component_helper.form_action, method: "POST", data: component_helper.data do %>
-    <input type="hidden" name="base_path" value="<%= component_helper.base_path %>">
-    <% if component_helper.skip_account %>
-      <input type="hidden" name="<%= component_helper.skip_account_param %>" value="true">
-      <input type="hidden" name="link" value="<%= component_helper.base_path %>">
+<%= tag.div(**component_helper.all_attributes) do %>
+  <%= tag.form class: spnb_helper.classes, action: spnb_helper.form_action, method: "POST", data: spnb_helper.data do %>
+    <input type="hidden" name="base_path" value="<%= spnb_helper.base_path %>">
+    <% if spnb_helper.skip_account %>
+      <input type="hidden" name="<%= spnb_helper.skip_account_param %>" value="true">
+      <input type="hidden" name="link" value="<%= spnb_helper.base_path %>">
     <% end %>
     <%= content_tag(:button, button_text, {
       class: "govuk-body-s gem-c-single-page-notification-button__submit",
       type: "submit",
+      data: {
+        ga4_link: ga4_link_data_attributes
+      }
     }) %>
   <% end %>
-<% end if component_helper.base_path %>
+<% end if spnb_helper.base_path %>

--- a/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
+++ b/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
@@ -25,6 +25,19 @@ examples:
       base_path: '/current-page-path'
       data_attributes:
         test_attribute: "testing"
+  with_ga4_tracking:
+    description: To add GA4 tracking, pass a `ga4_data_attributes` object with the necessary properties to the component. For example:-
+    data:
+      base_path: '/current-page-path'
+      ga4_data_attributes:
+        module: "ga4-link-tracker"
+        ga4_link:
+          event_name: "navigation"
+          type: "subscribe"
+          index:
+            index_link: 1
+          index_total: 1
+          section: "Top"
   with_margin_bottom:
     description: |
       The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a margin bottom of 15px.

--- a/spec/components/single_page_notification_button_spec.rb
+++ b/spec/components/single_page_notification_button_spec.rb
@@ -137,4 +137,38 @@ describe "Single page notification button", type: :view do
 
     assert_select ".gem-c-single-page-notification-button[data-track-action='Subscribe-button']"
   end
+
+  it "renders the GA4 data attributes and module that it is passed" do
+    local_assigns = {
+      base_path: "/the-current-page",
+      ga4_data_attributes: {
+        module: "ga4-link-tracker",
+        ga4_link: {
+          event_name: "navigation",
+          type: "subscribe",
+          index: {
+            index_link: 1,
+          },
+          index_total: 2,
+          section: "Top",
+        },
+      },
+    }
+    render_component(local_assigns)
+
+    assert_select "[data-module='gem-track-click ga4-link-tracker']"
+    assert_select ".gem-c-single-page-notification-button__submit" do |button|
+      expect(button.attr("data-ga4-link").to_s).to eq '{"event_name":"navigation","type":"subscribe","index":{"index_link":1},"index_total":2,"section":"Top","url":"/email/subscriptions/single-page/new"}'
+    end
+  end
+
+  it "does not render any GA4 data attributes or modules that it isn't passed" do
+    render_component({ base_path: "/the-current-page" })
+
+    assert_select "[data-module='gem-track-click']"
+    assert_select "[data-module='gem-track-click ga4-link-tracker']", false
+    assert_select ".gem-c-single-page-notification-button__submit" do |button|
+      expect(button.attr("data-ga4-link")).to eq nil
+    end
+  end
 end


### PR DESCRIPTION
## What
This PR adds GA4 tracking to the `single_page_notification_button` component (see example screenshot below).

![image](https://github.com/alphagov/govuk_publishing_components/assets/110391449/97097979-7905-42f8-b689-2dc62a9d47cb)

The `single_page_notification_button` component can appear twice on a page - once at the top and once in the contextual footer ([example](https://www.gov.uk/guidance/travel-to-england-from-another-country-during-coronavirus-covid-19)). Whilst the component consists of a form and a submit button, it has been treated as a link in GA4 tracking terms as certain parameters such as `link_path_parts` and `link_domain` rely on functions that are only present in the `linkTracker` module (and therefore is unsuitable for the `eventTracker`).

## Why
Part of the GA4 migration.

[Trello card](https://trello.com/c/iP21pmuk/565-subscribe-get-emails-about-this-page-stop-getting-emails-about-this-page-button)

## Visual Changes
N/A
