### PR TITLE
Release version 35.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.7.0
 
 * Component auditing improvements ([PR #3423](https://github.com/alphagov/govuk_publishing_components/pull/3423))
 * Fully implement loading of individual stylesheets in component guide ([PR #3379](https://github.com/alphagov/govuk_publishing_components/pull/3379))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.6.0)
+    govuk_publishing_components (35.7.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -188,7 +188,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
     minitest (5.18.0)
-    net-imap (0.3.4)
+    net-imap (0.3.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -399,4 +399,4 @@ RUBY VERSION
    ruby 3.0.5p211
 
 BUNDLED WITH
-   2.3.6
+   2.3.14

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.6.0".freeze
+  VERSION = "35.7.0".freeze
 end


### PR DESCRIPTION
* Component auditing improvements ([PR #3423](https://github.com/alphagov/govuk_publishing_components/pull/3423))
* Fully implement loading of individual stylesheets in component guide ([PR #3379](https://github.com/alphagov/govuk_publishing_components/pull/3379))
* Add support for HTML and external attachment types ([PR #3442](https://github.com/alphagov/govuk_publishing_components/pull/3442))
* Add 'View online' preview link to Attachment ([PR #3449](https://github.com/alphagov/govuk_publishing_components/pull/3449))