### PR TITLE
Add ga4-link attribute for other 'see all updates' link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add option for blue bar background to public_layout ([PR #3380](https://github.com/alphagov/govuk_publishing_components/pull/3380))
+* Add ga4-link attribute for other 'see all updates' link ([PR #3451](https://github.com/alphagov/govuk_publishing_components/pull/3451/))
 
 ## 35.7.0
 

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -20,6 +20,11 @@
   classes << shared_helper.get_margin_bottom if local_assigns[:margin_bottom]
 
   ga4_tracking ||= false
+  ga4_object = {
+    event_name: "navigation",
+    type: "content",
+    section: "Top"
+  }.to_json
 %>
 <%= content_tag :div, class: classes, data: { module: "gem-toggle metadata" } do %>
   <dl class="gem-c-metadata__list" data-module="gem-track-click">
@@ -48,19 +53,15 @@
       <dd class="gem-c-metadata__definition">
         <%= last_updated %>
         <% if local_assigns.include?(:see_updates_link) %>
-          &#8212; <a href="#full-publication-update-history" class="gem-c-metadata__definition-link govuk-!-display-none-print js-see-all-updates-link"
-                             data-track-category="content-history"
-                             data-track-action="see-all-updates-link-clicked"
-                             data-track-label="history"
-                             <% if ga4_tracking %>
-                              data-module="ga4-link-tracker"
-                              data-ga4-link="<%= {
-                                event_name: "navigation",
-                                type: "content",
-                                section: "Top"
-                              }.to_json %>"
-                             <% end%>
-                             >
+          &#8212; <a href="#full-publication-update-history"
+                    class="gem-c-metadata__definition-link govuk-!-display-none-print js-see-all-updates-link"
+                    data-track-category="content-history"
+                    data-track-action="see-all-updates-link-clicked"
+                    data-track-label="history"
+                    <% if ga4_tracking %>
+                      data-module="ga4-link-tracker"
+                      data-ga4-link="<%= ga4_object %>"
+                    <% end%>>
             <%= t("components.metadata.see_all_updates") %>
           </a>
         <% end %>
@@ -74,7 +75,12 @@
         %>
         <% if definition.any? %>
           <dt class="gem-c-metadata__term"><%= title %>:</dt>
-          <dd class="gem-c-metadata__definition">
+          <dd class="gem-c-metadata__definition"
+              <% if ga4_tracking %>
+                data-module="ga4-link-tracker"
+                data-ga4-track-links-only
+                data-ga4-link="<%= ga4_object %>"
+              <% end%>>
             <%= render 'govuk_publishing_components/components/metadata/sentence', items: definition, toggle_id: "#{index}-#{SecureRandom.hex(4)}" %>
           </dd>
         <% end %>

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -207,7 +207,7 @@ describe "Metadata", type: :view do
   end
 
   it "adds GA4 tracking to the 'see all updates' link when GA4 tracking is true" do
-    render_component(last_updated: "Hello World", see_updates_link: true, ga4_tracking: true)
+    render_component(last_updated: "Hello World", see_updates_link: true, ga4_tracking: true, other: { "Updated" => "13 April 2023, <a href=\"/hmrc-internal-manuals/self-assessment-claims-manual/updates\">see all updates</a>" })
 
     expected_ga4_json = {
       "event_name": "navigation",
@@ -218,6 +218,12 @@ describe "Metadata", type: :view do
     assert_select ".js-see-all-updates-link" do |see_all_updates_link|
       expect(see_all_updates_link.attr("data-module").to_s).to eq "ga4-link-tracker"
       expect(see_all_updates_link.attr("data-ga4-link").to_s).to eq expected_ga4_json
+    end
+
+    assert_select ".gem-c-metadata__definition:nth-of-type(2)" do |alternate_see_all_updates_container|
+      expect(alternate_see_all_updates_container.attr("data-module").to_s).to eq "ga4-link-tracker"
+      expect(alternate_see_all_updates_container.attr("data-ga4-track-links-only").to_s).to eq ""
+      expect(alternate_see_all_updates_container.attr("data-ga4-link").to_s).to eq expected_ga4_json
     end
   end
 


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- There are 'see all updates' links that are rendered via the metadata component. For example on [this page](https://www.gov.uk/hmrc-internal-manuals/self-assessment-claims-manual/sacm1005) 
- The link can be rendered in two ways.
- This PR formats the existing GA4 link tracking, as it looked like the formatting was wrong.
- This PR also adds GA4 tracking to the second way  the link can be rendered (i.e. adds `data-ga4-link` onto `<dd class="gem-c-metadata__definition">`.
- This PR also adds tests for the new tracking.
## Why
<!-- What are the reasons behind this change being made? -->
It's part of the content navigation GA4 work - https://trello.com/c/C9M2EJQu/553-content-navigation-chapter-headings-next-previous-view-a-printable-version-navigation-and-show-hide-updates-interaction

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
