### PR TITLE
Refactor document list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Refactor document list component ([PR #3454](https://github.com/alphagov/govuk_publishing_components/pull/3454))
 * Add option for blue bar background to public_layout ([PR #3380](https://github.com/alphagov/govuk_publishing_components/pull/3380))
 * Add ga4-link attribute for other 'see all updates' link ([PR #3451](https://github.com/alphagov/govuk_publishing_components/pull/3451/))
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_document-list.scss
@@ -8,10 +8,14 @@
 }
 
 .gem-c-document-list__item {
-  margin-bottom: govuk-spacing(5);
+  margin-top: govuk-spacing(5);
   padding-top: govuk-spacing(2);
   border-top: 1px solid $govuk-border-colour;
   list-style: none;
+
+  &:first-child {
+    margin-top: 0;
+  }
 }
 
 .gem-c-document-list__item-title {
@@ -84,14 +88,6 @@
     padding-right: 0;
     padding-left: govuk-spacing(4);
   }
-}
-
-.gem-c-document-list--bottom-margin {
-  margin-bottom: govuk-spacing(4);
-}
-
-.gem-c-document-list--top-margin {
-  margin-top: govuk-spacing(4);
 }
 
 .gem-c-document-list__multi-list {

--- a/app/views/govuk_publishing_components/components/_document_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_document_list.html.erb
@@ -1,14 +1,15 @@
 <%
   add_gem_component_stylesheet("document-list")
 
+  local_assigns[:margin_bottom] ||= 5
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   items ||= []
 
-  classes = "gem-c-document-list"
-  classes << " gem-c-document-list--top-margin" if local_assigns[:margin_top]
-  classes << " gem-c-document-list--bottom-margin" if local_assigns[:margin_bottom]
-  classes << " gem-c-document-list--no-underline" if local_assigns[:remove_underline]
-  classes << " gem-c-document-list--no-top-border" if local_assigns[:remove_top_border]
-  classes << " gem-c-document-list--no-top-border-first-child" if local_assigns[:remove_top_border_from_first_child]
+  classes = %w[gem-c-document-list]
+  classes << "gem-c-document-list--no-underline" if local_assigns[:remove_underline]
+  classes << "gem-c-document-list--no-top-border" if local_assigns[:remove_top_border]
+  classes << "gem-c-document-list--no-top-border-first-child" if local_assigns[:remove_top_border_from_first_child]
+  classes << shared_helper.get_margin_bottom
 
   within_multitype_list ||= false
   within_multitype_list_class = " gem-c-document-list__multi-list" if within_multitype_list
@@ -19,7 +20,7 @@
 %>
 <% if items.any? %>
   <% unless within_multitype_list %>
-    <ul class="<%= classes %>">
+    <ul class="<%= classes.join(" ") %>">
   <% end %>
     <% items.each do |item| %>
       <% highlight_class = " gem-c-document-list__item--highlight" if item[:highlight] %>

--- a/app/views/govuk_publishing_components/components/docs/document_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/document_list.yml
@@ -37,6 +37,23 @@ examples:
         metadata:
           public_updated_at: 2016-09-05 16:48:27
           document_type: 'Statutory guidance'
+  with_margin:
+    description: The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having a margin bottom of 5 (25px).
+    data:
+      margin_bottom: 9
+      items:
+      - link:
+          text: 'Alternative provision'
+          path: '/government/publications/alternative-provision'
+        metadata:
+          public_updated_at: 2016-06-27 10:29:44
+          document_type: 'Statutory guidance'
+      - link:
+          text: 'Behaviour and discipline in schools: guide for governing bodies'
+          path: '/government/publications/behaviour-and-discipline-in-schools-guidance-for-governing-bodies'
+        metadata:
+          public_updated_at: 2015-09-24 16:42:48
+          document_type: 'Statutory guidance'
   without_links:
     data:
       items:

--- a/spec/components/document_list_spec.rb
+++ b/spec/components/document_list_spec.rb
@@ -13,10 +13,8 @@ describe "Document list", type: :view do
     assert_empty render_component(items: [])
   end
 
-  it "adds spacing around the document list when margin flags are set" do
+  it "applies default margin to the component" do
     render_component(
-      margin_bottom: true,
-      margin_top: true,
       items: [
         {
           link: {
@@ -31,7 +29,27 @@ describe "Document list", type: :view do
       ],
     )
 
-    assert_select ".gem-c-document-list.gem-c-document-list--top-margin.gem-c-document-list--bottom-margin"
+    assert_select '.gem-c-document-list.govuk-\!-margin-bottom-5'
+  end
+
+  it "applies margin to the component" do
+    render_component(
+      margin_bottom: 6,
+      items: [
+        {
+          link: {
+            text: "School behaviour and attendance: parental responsibility measures",
+            path: "/government/publications/parental-responsibility-measures-for-behaviour-and-attendance",
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+            document_type: "Statutory guidance",
+          },
+        },
+      ],
+    )
+
+    assert_select '.gem-c-document-list.govuk-\!-margin-bottom-6'
   end
 
   it "renders a document list correctly" do


### PR DESCRIPTION
**NOTE** this PR is linked to [changes in collections](https://github.com/alphagov/collections/pull/3301), which relies on this change.

## What
- remove top and bottom margin options (undocumented and soon to be not used)
- add shared helper for margin bottom, and document
- change CSS to prevent last list item from setting the bottom margin of the component

## Why
The document list component had no bottom margin on the parent item by default. However, every list item in it had a bottom margin of 25px, which meant that the 25px of bottom margin extended out of the parent list, effectively setting the bottom margin of the component.

(for reference, this is a weird CSS thing where if a child has bottom margin it will escape from the parent unless the parent has padding (or any number of other things, turns out margin is complex) and the parent in this case didn't have padding)

This seemed like a brittle situation, so this changes the list items to have the same margin top instead, and setting the first-child to margin top zero. At the same time we add the shared_helper margin bottom options, setting by default a bottom margin of 25px, so there should be no visual change.

Turns out the document list component also had options to set the margin top and bottom but this was not documented. Also the margin bottom setting was less than the escaped margin from the last list item, so it wouldn't have had any effect anyway. I've checked our applications and the only place where this component is used with those options is `collections`, so a separate PR will be raised to deal with this.

**Further note**: there's another undocumented feature of this component, which is to have it not be wrapped in a `<ul>` by passing `within_multitype_list` as an option. Does anyone know if this is being used anywhere? I couldn't see any.

## Visual Changes
None.

The visual changes in Percy are because I added a new documentation entry for the new margin bottom option.
