### PR TITLE
Use safe navigation operator in asset_helper.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add option for blue bar background to public_layout ([PR #3380](https://github.com/alphagov/govuk_publishing_components/pull/3380))
 * Add ga4-link attribute for other 'see all updates' link ([PR #3451](https://github.com/alphagov/govuk_publishing_components/pull/3451/))
 * Change GA4 type ([PR #3456](https://github.com/alphagov/govuk_publishing_components/pull/3456))
+* Use safe navigation operator in asset_helper.rb ([PR #3455](https://github.com/alphagov/govuk_publishing_components/pull/3455))
 
 ## 35.7.0
 

--- a/lib/govuk_publishing_components/app_helpers/asset_helper.rb
+++ b/lib/govuk_publishing_components/app_helpers/asset_helper.rb
@@ -87,7 +87,7 @@ module GovukPublishingComponents
       end
 
       def viewing_component_guide?
-        request.path.include?("/component-guide")
+        request&.path&.include?("/component-guide")
       end
     end
   end

--- a/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/app_helpers/asset_helper_spec.rb
@@ -4,6 +4,16 @@ RSpec.describe GovukPublishingComponents::AppHelpers::AssetHelper do
   describe "Asset helper" do
     include GovukPublishingComponents::AppHelpers::AssetHelper
 
+    it "exclude stylesheets already in static when exclude_css_from_static is true and the request object is not available" do
+      GovukPublishingComponents.configure do |config|
+        config.exclude_css_from_static = true
+      end
+
+      add_gem_component_stylesheet("button")
+      expect(all_component_stylesheets_being_used).to eql([])
+    end
+
+    # Create a mock request
     def request
       double(ActionDispatch::Request, { path: "/" })
     end


### PR DESCRIPTION
## What
Update the `viewing_component_guide?` method to use the safe navigation operator in asset_helper.rb

## Why
This will fix the issue below when using the AssetHelper in the smart answers rendering application.

```
undefined method `path' for nil:NilClass
```

## Further info
The issue in smart answers is that the AssetHelper tries to check if we are viewing the component guide, it does this by checking if the request path contains "component-guide", however the "request" object is not available when trying to render govspeak outside of the component-guide.

This only appears to happen in smart answers, using govspeak in another rendering application does not cause any issues.

Using this approach, calling `!viewing_component_guide?` will return `false` if the request object is not available, even if the component guide is being viewed. The impact here would be low, and limited to stylesheets from static not being loaded in the component guide. For this to happen, the request object would need to be nil in the component guide.

It is worth nothing that when testing release 35.7.0 of the gem in smart answers, we had access to the request object when viewing the component guide, so we are still able to perform this check.