### PR TITLE
Change GA4 type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add option for blue bar background to public_layout ([PR #3380](https://github.com/alphagov/govuk_publishing_components/pull/3380))
 * Add ga4-link attribute for other 'see all updates' link ([PR #3451](https://github.com/alphagov/govuk_publishing_components/pull/3451/))
+* Change GA4 type ([PR #3456](https://github.com/alphagov/govuk_publishing_components/pull/3456))
 
 ## 35.7.0
 

--- a/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
+++ b/app/views/govuk_publishing_components/components/_step_by_step_nav_related.html.erb
@@ -26,7 +26,7 @@
             <% if ga4_tracking 
               ga4_attributes = {
                 event_name: "navigation",
-                type: "related content",
+                type: "part of",
                 index:{
                   "index_link": "1"
                 },
@@ -56,7 +56,7 @@
                 <% if ga4_tracking 
                   ga4_attributes = {
                     event_name: "navigation",
-                    type: "related content",
+                    type: "part of",
                     index:{
                       "index_link": (index + 1).to_s
                     },

--- a/spec/components/step_by_step_nav_related_spec.rb
+++ b/spec/components/step_by_step_nav_related_spec.rb
@@ -119,7 +119,7 @@ describe "Step by step navigation related", type: :view do
 
     expected = {
       "event_name": "navigation",
-      "type": "related content",
+      "type": "part of",
       "index": { "index_link": "1" },
       "index_total": "1",
       "section": "Some text",
@@ -152,7 +152,7 @@ describe "Step by step navigation related", type: :view do
 
     expected_one = {
       "event_name": "navigation",
-      "type": "related content",
+      "type": "part of",
       "index": { "index_link": "1" },
       "index_total": "2",
       "section": "Some more text",
@@ -160,7 +160,7 @@ describe "Step by step navigation related", type: :view do
 
     expected_two = {
       "event_name": "navigation",
-      "type": "related content",
+      "type": "part of",
       "index": { "index_link": "2" },
       "index_total": "2",
       "section": "Some more text",


### PR DESCRIPTION
## What
This PR makes a change to the `type` parameter of elements that appear at the top and bottom of a `Part of` sidebar. Previously, the `type` was set to `related content` but this has now changed to `part of`.

Example (top):
![image](https://github.com/alphagov/govuk_publishing_components/assets/110391449/3813fe70-ae58-46f9-9452-02e85221c2f9)

Example (bottom):
![image](https://github.com/alphagov/govuk_publishing_components/assets/110391449/a513c471-a75d-40ab-b2ff-f837bdd141ec)

## Why
GA4 bug fix.

[Trello card](https://trello.com/c/oXi9yaRO/598-part-of-also-part-of-showing-event-type-related-content-rather-than-part-of)

## Visual Changes
N/A
