### PR TITLE
Fix audit page styles

### DIFF
--- a/app/views/govuk_publishing_components/audit/show.html.erb
+++ b/app/views/govuk_publishing_components/audit/show.html.erb
@@ -1,6 +1,7 @@
-<% 
+<%
   add_gem_component_stylesheet("table")
   add_gem_component_stylesheet("select")
+  add_gem_component_stylesheet("summary-list")
 %>
 
 <% content_for :title, "Component audit" %>


### PR DESCRIPTION
## What / why
- the sections 'components containing other components' and 'helpers used by gem components' both use the summary list component, but because they need links inside that component (which aren't supported) we use hard coded component markup instead (yeah I know not ideal)
- these areas rely on the summary list component (and its CSS) being loaded already elsewhere in the page, but in the live component guide those parts of the page aren't loaded because we can't get data about applications, meaning that the summary lists in these sections appear unstyled
- as a fix manually include the summary list styles at the top of the audit page

## Visual Changes

Before | After
------ | ------
![Screenshot 2023-06-23 at 10 09 31](https://github.com/alphagov/govuk_publishing_components/assets/861310/f74459cd-ee69-489d-9cfd-93e00f1459c9) | ![Screenshot 2023-06-23 at 10 09 40](https://github.com/alphagov/govuk_publishing_components/assets/861310/8664b9f6-ad5e-42e9-83bb-74a1a596eac2)
