### PR TITLE
Version 35.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.8.0
 
 * Upgrade LUX to version 309 ([PR #3458](https://github.com/alphagov/govuk_publishing_components/pull/3458))
 * Refactor document list component ([PR #3454](https://github.com/alphagov/govuk_publishing_components/pull/3454))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.7.0)
+    govuk_publishing_components (35.8.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.7.0".freeze
+  VERSION = "35.8.0".freeze
 end


### PR DESCRIPTION
## 35.8.0

* Upgrade LUX to version 309 ([PR #3458](https://github.com/alphagov/govuk_publishing_components/pull/3458))
* Refactor document list component ([PR #3454](https://github.com/alphagov/govuk_publishing_components/pull/3454))
* Add option for blue bar background to public_layout ([PR #3380](https://github.com/alphagov/govuk_publishing_components/pull/3380))
* Add ga4-link attribute for other 'see all updates' link ([PR #3451](https://github.com/alphagov/govuk_publishing_components/pull/3451/))
* Change GA4 type ([PR #3456](https://github.com/alphagov/govuk_publishing_components/pull/3456))
* Use safe navigation operator in asset_helper.rb ([PR #3455](https://github.com/alphagov/govuk_publishing_components/pull/3455))
