### PR TITLE
Fix GA4 accordion tracking bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix GA4 accordion tracking bugs ([PR #3461](https://github.com/alphagov/govuk_publishing_components/pull/3461))
+
 ## 35.8.0
 
 * Upgrade LUX to version 309 ([PR #3458](https://github.com/alphagov/govuk_publishing_components/pull/3458))

--- a/app/views/govuk_publishing_components/components/_accordion.html.erb
+++ b/app/views/govuk_publishing_components/components/_accordion.html.erb
@@ -40,11 +40,12 @@
         ga4_link_data_attributes ||= nil
 
         if ga4_tracking
+          heading_text = Nokogiri::HTML(item[:heading][:text]).text
           item[:data_attributes] ||= {}
           item[:data_attributes][:ga4_event] = {
             event_name: "select_content",
             type: "accordion",
-            text: item[:heading][:text],
+            text: heading_text,
             index: {
               index_section: index,
               index_section_count: items.length,
@@ -56,12 +57,12 @@
           # tracking attributes
           ga4_link_data_attributes = {}
           ga4_link_data_attributes[:module] = "ga4-link-tracker"
-          ga4_link_data_attributes[:ga4_tracks_links_only] = ""
+          ga4_link_data_attributes[:ga4_track_links_only] = ""
           ga4_link_data_attributes[:ga4_set_indexes] = ""
           ga4_link_data_attributes[:ga4_link] = {
             event_name: "navigation",
             type: "accordion",
-            section: item[:heading][:text],
+            section: heading_text,
             index: {
               index_section: index,
               index_section_count: (items.length),


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
On https://www.gov.uk/guidance/find-a-skills-bootcamp/updates if you expand an accordion or click on a child link, the dataLayer is passing through the link's `section`, or the accordion heading `text` value with HTML inside of it. If you click the whitespace next to a child link a JS error will appear as well. This PR fixes that.

It also corrects a `ga4-track-links-only` typo which resulted in JS errors, since the link tracker was trying to grab a `href` on non-link elements.

## Why
<!-- What are the reasons behind this change being made? -->
- Fixes a JS error (it didn't seem to affect other tracking on the page, it just output an error in the console.)
- https://trello.com/c/ABnBc5Wy/590-html-markup-appearing-in-section-parameter

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->
None.
