### PR TITLE
Ensure GA4 link text is 'image' when the event target is an image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix GA4 accordion tracking bugs ([PR #3461](https://github.com/alphagov/govuk_publishing_components/pull/3461))
 * Add ga4 tracking to single page notifications button ([PR #3443](https://github.com/alphagov/govuk_publishing_components/pull/3443))
 * Update notice component example ([PR #3465](https://github.com/alphagov/govuk_publishing_components/pull/3465))
+* Ensure GA4 link text is 'image' when the event target is an image ([PR #3462](https://github.com/alphagov/govuk_publishing_components/pull/3462))
 
 ## 35.8.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -82,7 +82,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var text = data.text || event.target.textContent
       data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)
       data.text = this.PIIRemover.stripPIIWithOverride(data.text, true, true)
-      if (!data.text && (element.querySelector('img') || element.querySelector('svg'))) {
+      if (!data.text && (element.querySelector('img') || element.querySelector('svg') || element.tagName === 'IMG' || element.closest('svg'))) {
         data.text = 'image'
       }
       var url = data.url || this.findLink(event.target).getAttribute('href')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -452,5 +452,23 @@ describe('GA4 link tracker', function () {
         expect(window.dataLayer[0].event_data.text).toEqual('image')
       }
     })
+
+    it('sets the text property to image when the nested elements are clicked', function () {
+      element = document.createElement('div')
+      element.setAttribute('data-ga4-track-links-only', '')
+      element.setAttribute('data-ga4-link', '{"someData": "blah"}')
+      element.innerHTML = '<a href="#link1"><img class="link" src=""/></a>' +
+      '<a href="#link1"><svg class="link"></svg></a>' +
+      '<a href="#link1"><svg><path class="link"></path></svg></a>'
+
+      var links = element.querySelectorAll('.link')
+
+      for (var i = 0; i < links.length; i++) {
+        window.dataLayer = []
+        initModule(element, false)
+        window.GOVUK.triggerEvent(links[i], 'click')
+        expect(window.dataLayer[0].event_data.text).toEqual('image')
+      }
+    })
   })
 })


### PR DESCRIPTION
Would you be able to approve this if all is OK? Thanks :+1:

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- When the user clicks a link that is an image, we want our GA4 `text` value to be `'image'`.
- To do this, we were running a `querySelector` on the link, to see if it contained an `<img>` or `<svg>`.
- This only works if the `event.target` comes back as the link, as that allows us to do the `querySelector` which checks for the nested image elements.
- The issue we had was that sometimes the `event.target` comes back as the image itself, not the parent link. Therefore running `.querySelector` would not do anything as you were already on the furthest nested element.
- Therefore, we need to also do a `.closest()` so that if the event target is the image itself, we still can set the link text to `'image'`.

## Why
<!-- What are the reasons behind this change being made? -->
- The PAs want to track clicks on attachment link thumbnails with the text `'image'`. We previously wrote code to do this, but the issue with the attachment link thumbnails are that they are `<svg>` elements with a `<path>` as their children. When clicking on the thumbnail, the `event.target` would be the `<path>` element, not the parent `<a>` tag, so our previous code would never fire to set the link text as `'image'`.
- https://trello.com/c/EDhj7vSG/614-clicking-svg-links-should-pass-the-link-text-image-to-the-datalayer

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
