### PR TITLE
Add GA4 scroll tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add GA4 scroll tracker ([PR #3464](https://github.com/alphagov/govuk_publishing_components/pull/3464))
 * Ensure search forms have their text sent to GA4 in lowercase ([PR #3504](https://github.com/alphagov/govuk_publishing_components/pull/3504))
 * Add GA4 HTML attachment tracking to attachment component ([PR #3500](https://github.com/alphagov/govuk_publishing_components/pull/3500))
 * Add functionality for preventing the redaction of publicly available information ([PR #3509](https://github.com/alphagov/govuk_publishing_components/pull/3509))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4.js
@@ -10,4 +10,5 @@
 //= require ./analytics-ga4/ga4-form-tracker
 //= require ./analytics-ga4/ga4-auto-tracker
 //= require ./analytics-ga4/ga4-smart-answer-results-tracker
+//= require ./analytics-ga4/ga4-scroll-tracker
 //= require ./analytics-ga4/init-ga4

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
@@ -24,7 +24,8 @@
         method: this.undefined,
         link_domain: this.undefined,
         link_path_parts: this.undefined,
-        tool_name: this.undefined
+        tool_name: this.undefined,
+        percent_scrolled: this.undefined
       }
     }
   }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
@@ -11,7 +11,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       percentages: [20, 40, 60, 80, 100],
       scrollTimeoutDelay: 20,
       resizeTimeoutDelay: 100,
-      pageHeightTimeoutDelay: 500
+      pageHeightTimeoutDelay: 500,
+      markerAttribute: 'data-ga4-scroll-marker'
     }
   }
 
@@ -35,6 +36,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     window.GOVUK.analyticsGa4.vars.scrollTrackerStarted = true
 
     if (this.trackType === 'headings') {
+      this.track = new Ga4ScrollTracker.Heading(this.config)
+    } else if (this.trackType === 'markers') {
+      this.config.trackMarkers = true
       this.track = new Ga4ScrollTracker.Heading(this.config)
     } else {
       this.track = new Ga4ScrollTracker.Percentage(this.config)
@@ -138,6 +142,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     for (var i = 0; i < totalHeadings; i++) {
       var heading = headingsFound[i]
+      var type = this.config.trackMarkers ? 'marker' : 'heading'
       // only track headings that are visible i.e. not inside display: none
       if (this.visible(heading)) {
         var pos = heading.getBoundingClientRect()
@@ -147,7 +152,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           top: pos.top + document.documentElement.scrollTop,
           bottom: pos.bottom + document.documentElement.scrollTop,
           eventData: {
-            type: 'heading',
+            type: type,
             text: heading.textContent.replace(/\s+/g, ' ').trim(),
             index: {
               index_section: i + 1,
@@ -164,6 +169,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   Ga4ScrollTracker.Heading.prototype.findAllowedHeadings = function () {
     var headingsFound = []
     var headings = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+    if (this.config.trackMarkers) {
+      headings = ['[' + this.config.markerAttribute + ']']
+    }
 
     // this is a loop that only happens once as we currently only have one
     // allowed element for headings to be in - 'main'

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
@@ -32,18 +32,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
 
     this.trackType = this.$module.getAttribute('data-ga4-track-type')
-    var trackHeadings = this.$module.getAttribute('data-ga4-track-headings')
-    if (trackHeadings) {
-      try {
-        this.config.trackHeadings = JSON.parse(trackHeadings)
-      } catch (e) {
-        // if there's a problem with the config, don't start the tracker
-        console.error('GA4 scroll tracker configuration error: ' + e.message, window.location)
-        window.GOVUK.analyticsGa4.vars.scrollTrackerStarted = false
-        return
-      }
-    }
-
     window.GOVUK.analyticsGa4.vars.scrollTrackerStarted = true
 
     if (this.trackType === 'headings') {
@@ -165,7 +153,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   Ga4ScrollTracker.Heading.prototype.findAllowedHeadings = function () {
     var headingsFound = []
     var headings = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
-    var trackHeadings = this.config.trackHeadings
 
     // this is a loop that only happens once as we currently only have one
     // allowed element for headings to be in - 'main'
@@ -174,13 +161,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       for (var e = 0; e < insideElements.length; e++) {
         var found = insideElements[e].querySelectorAll(headings)
         for (var f = 0; f < found.length; f++) {
-          if (trackHeadings) {
-            if (trackHeadings.includes(found[f].textContent.trim())) {
-              headingsFound.push(found[f])
-            }
-          } else {
-            headingsFound.push(found[f])
-          }
+          headingsFound.push(found[f])
         }
       }
     }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
@@ -109,8 +109,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
 
         data.type = node.eventData.type
-        data.text = node.eventData.text // will be undefined if tracking percent
-        data.percent_scrolled = node.eventData.percent_scrolled // will be undefined if tracking headings
+        // following will be undefined if tracking percentages
+        data.text = node.eventData.text
+        data.index = window.GOVUK.analyticsGa4.core.ensureIndexesArePopulated(node.eventData.index || {})
+        // following will be undefined if tracking headings
+        data.percent_scrolled = node.eventData.percent_scrolled
 
         var schemas = new window.GOVUK.analyticsGa4.Schemas()
         var schema = schemas.mergeProperties(data, 'event_data')
@@ -131,8 +134,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   Ga4ScrollTracker.Heading.prototype.getTrackingNodes = function () {
     var headingsDetails = []
     var headingsFound = this.findAllowedHeadings()
+    var totalHeadings = headingsFound.length
 
-    for (var i = 0; i < headingsFound.length; i++) {
+    for (var i = 0; i < totalHeadings; i++) {
       var heading = headingsFound[i]
       // only track headings that are visible i.e. not inside display: none
       if (this.visible(heading)) {
@@ -142,7 +146,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           alreadySeen: heading.getAttribute('data-ga4-scrolltracker-already-seen'),
           top: pos.top + document.documentElement.scrollTop,
           bottom: pos.bottom + document.documentElement.scrollTop,
-          eventData: { type: 'heading', text: heading.textContent.replace(/\s+/g, ' ').trim() }
+          eventData: {
+            type: 'heading',
+            text: heading.textContent.replace(/\s+/g, ' ').trim(),
+            index: {
+              index_section: i + 1,
+              index_section_count: totalHeadings
+            }
+          }
         })
       }
     }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
@@ -1,0 +1,225 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function Ga4ScrollTracker ($module) {
+    this.$module = $module
+    this.pageHeight = document.querySelector('body').clientHeight
+    this.trackedNodes = []
+    this.config = {
+      allowHeadingsInside: ['main'],
+      percentages: [20, 40, 60, 80, 100],
+      scrollTimeoutDelay: 20,
+      resizeTimeoutDelay: 100,
+      pageHeightTimeoutDelay: 500
+    }
+  }
+
+  Ga4ScrollTracker.prototype.init = function () {
+    var consentCookie = window.GOVUK.getConsentCookie()
+
+    if (consentCookie && consentCookie.settings) {
+      this.startModule()
+    } else {
+      this.startModule = this.startModule.bind(this)
+      window.addEventListener('cookie-consent', this.startModule)
+    }
+  }
+
+  Ga4ScrollTracker.prototype.startModule = function () {
+    if (window.GOVUK.analyticsGa4.vars.scrollTrackerStarted) {
+      return
+    }
+
+    this.trackType = this.$module.getAttribute('data-ga4-track-type')
+    var trackHeadings = this.$module.getAttribute('data-ga4-track-headings')
+    if (trackHeadings) {
+      try {
+        this.config.trackHeadings = JSON.parse(trackHeadings)
+      } catch (e) {
+        // if there's a problem with the config, don't start the tracker
+        console.error('GA4 scroll tracker configuration error: ' + e.message, window.location)
+        window.GOVUK.analyticsGa4.vars.scrollTrackerStarted = false
+        return
+      }
+    }
+
+    window.GOVUK.analyticsGa4.vars.scrollTrackerStarted = true
+
+    if (this.trackType === 'headings') {
+      this.track = new Ga4ScrollTracker.Heading(this.config)
+    } else {
+      this.track = new Ga4ScrollTracker.Percentage(this.config)
+    }
+
+    this.getWindowDetails()
+    // if the URL has a hash we want to prevent tracking on initial page load
+    // until the browser jumps down the page, at which point a scroll event
+    // will happen and tracking will continue normally
+    var windowHash = window.location.hash
+    var dontTrackOnLoad = windowHash && document.getElementById(windowHash.substring(1))
+    if (!dontTrackOnLoad) {
+      this.trackVisibleNodes()
+    }
+
+    if (this.trackedNodes.length) {
+      // store event listener functions as variables so they can be removed if needed
+      this.scrollEvent = this.onScroll.bind(this)
+      window.addEventListener('scroll', this.scrollEvent)
+      this.resizeEvent = this.onResize.bind(this)
+      window.addEventListener('resize', this.resizeEvent)
+
+      // check if the page height changes e.g. accordion opened
+      this.interval = window.setInterval(function () {
+        var pageHeight = document.querySelector('body').clientHeight
+        if (pageHeight !== this.pageHeight) {
+          this.pageHeight = pageHeight
+          this.getWindowDetails()
+          this.trackVisibleNodes()
+        }
+      }.bind(this), this.config.pageHeightTimeoutDelay)
+    }
+  }
+
+  Ga4ScrollTracker.prototype.onScroll = function () {
+    clearTimeout(this.scrollTimeout)
+    this.scrollTimeout = setTimeout(function () {
+      this.trackVisibleNodes()
+    }.bind(this), this.config.scrollTimeoutDelay)
+  }
+
+  Ga4ScrollTracker.prototype.onResize = function () {
+    clearTimeout(this.resizeTimeout)
+    this.resizeTimeout = setTimeout(function () {
+      this.getWindowDetails()
+      this.trackVisibleNodes()
+    }.bind(this), this.config.resizeTimeoutDelay)
+  }
+
+  Ga4ScrollTracker.prototype.getWindowDetails = function () {
+    this.pageHeight = document.querySelector('body').clientHeight
+    this.windowHeight = window.innerHeight
+    this.trackedNodes = this.track.getTrackingNodes(this.trackedNodes)
+  }
+
+  Ga4ScrollTracker.prototype.trackVisibleNodes = function () {
+    var data = {
+      event_name: 'scroll',
+      action: 'scroll',
+      type: this.config.type
+    }
+    for (var i = 0; i < this.trackedNodes.length; i++) {
+      var node = this.trackedNodes[i]
+      if (this.isVisible(node.top, node.bottom) && !node.alreadySeen) {
+        node.alreadySeen = true
+        // we store whether a heading has been tracked or not on the heading
+        // because if headings appear/disappear (e.g. inside an accordion)
+        // the order changes, so we can't refer to the previous trackedNodes
+        // as we do with percentages
+        if (node.node) {
+          node.node.setAttribute('data-ga4-scrolltracker-already-seen', true)
+        }
+
+        data.type = node.eventData.type
+        data.text = node.eventData.text // will be undefined if tracking percent
+        data.percent_scrolled = node.eventData.percent_scrolled // will be undefined if tracking headings
+
+        var schemas = new window.GOVUK.analyticsGa4.Schemas()
+        var schema = schemas.mergeProperties(data, 'event_data')
+        window.GOVUK.analyticsGa4.core.sendData(schema)
+      }
+    }
+  }
+
+  Ga4ScrollTracker.prototype.isVisible = function (top, bottom) {
+    var scroll = window.scrollY || document.documentElement.scrollTop // IE fallback
+    return scroll <= top && (scroll + this.windowHeight) >= bottom
+  }
+
+  Ga4ScrollTracker.Heading = function (config) {
+    this.config = config
+  }
+
+  Ga4ScrollTracker.Heading.prototype.getTrackingNodes = function () {
+    var headingsDetails = []
+    var headingsFound = this.findAllowedHeadings()
+
+    for (var i = 0; i < headingsFound.length; i++) {
+      var heading = headingsFound[i]
+      // only track headings that are visible i.e. not inside display: none
+      if (this.visible(heading)) {
+        var pos = heading.getBoundingClientRect()
+        headingsDetails.push({
+          node: heading,
+          alreadySeen: heading.getAttribute('data-ga4-scrolltracker-already-seen'),
+          top: pos.top + document.documentElement.scrollTop,
+          bottom: pos.bottom + document.documentElement.scrollTop,
+          eventData: { type: 'heading', text: heading.textContent.replace(/\s+/g, ' ').trim() }
+        })
+      }
+    }
+    return headingsDetails
+  }
+
+  // check heading is inside allowed elements, generally ignores everything outside of page content
+  Ga4ScrollTracker.Heading.prototype.findAllowedHeadings = function () {
+    var headingsFound = []
+    var headings = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+    var trackHeadings = this.config.trackHeadings
+
+    // this is a loop that only happens once as we currently only have one
+    // allowed element for headings to be in - 'main'
+    for (var h = 0; h < this.config.allowHeadingsInside.length; h++) {
+      var insideElements = document.querySelectorAll(this.config.allowHeadingsInside[h])
+      for (var e = 0; e < insideElements.length; e++) {
+        var found = insideElements[e].querySelectorAll(headings)
+        for (var f = 0; f < found.length; f++) {
+          if (trackHeadings) {
+            if (trackHeadings.includes(found[f].textContent.trim())) {
+              headingsFound.push(found[f])
+            }
+          } else {
+            headingsFound.push(found[f])
+          }
+        }
+      }
+    }
+    return headingsFound
+  }
+
+  // this is bit more verbose than checking offsetParent !== null but more reliable for IE10+
+  Ga4ScrollTracker.Heading.prototype.visible = function (el) {
+    return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length)
+  }
+
+  Ga4ScrollTracker.Percentage = function (config) {
+    this.config = config
+  }
+
+  Ga4ScrollTracker.Percentage.prototype.getTrackingNodes = function (trackedNodes) {
+    var body = document.body
+    var html = document.documentElement
+    var pageHeight = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight)
+
+    var percentDetails = []
+
+    for (var i = 0; i < this.config.percentages.length; i++) {
+      var percent = this.config.percentages[i]
+      // subtract 1 pixel to solve a bug where 100% can't be reached in some cases
+      var pos = ((pageHeight / 100) * percent) - 1
+      var alreadySeen = false
+      if (trackedNodes.length) {
+        alreadySeen = trackedNodes[i].alreadySeen
+      }
+      percentDetails.push({
+        alreadySeen: alreadySeen,
+        top: pos,
+        bottom: pos,
+        eventData: { type: 'percent', percent_scrolled: String(percent) }
+      })
+    }
+    return percentDetails
+  }
+
+  Modules.Ga4ScrollTracker = Ga4ScrollTracker
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
@@ -108,8 +108,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         // because if headings appear/disappear (e.g. inside an accordion)
         // the order changes, so we can't refer to the previous trackedNodes
         // as we do with percentages
-        if (node.node) {
-          node.node.setAttribute('data-ga4-scrolltracker-already-seen', true)
+        if (node.element) {
+          node.element.setAttribute('data-ga4-scrolltracker-already-seen', true)
         }
 
         data.type = node.eventData.type
@@ -147,7 +147,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       if (this.visible(heading)) {
         var pos = heading.getBoundingClientRect()
         headingsDetails.push({
-          node: heading,
+          element: heading,
           alreadySeen: heading.getAttribute('data-ga4-scrolltracker-already-seen'),
           top: pos.top + document.documentElement.scrollTop,
           bottom: pos.bottom + document.documentElement.scrollTop,

--- a/docs/analytics-ga4/ga4-scroll-tracker.md
+++ b/docs/analytics-ga4/ga4-scroll-tracker.md
@@ -1,0 +1,132 @@
+# Google Analytics 4 scroll tracker
+
+The scroll tracker can be added to pages that require scroll tracking.
+
+## Overview
+
+The scroll tracker is a GOVUK.Module and can be initialised by adding the relevant code to a template. Since scroll tracking is only required once on a page, it should be initialised using a meta tag in the HEAD element as shown.
+
+```html
+<% content_for :extra_head_content do %>
+  <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
+<% end %>
+```
+
+Note that since the scroll tracker is initialised by the `data-module` attribute, the meta `name` can be anything, we use `govuk:scroll-tracker` only for reference.
+
+### Track percentages
+
+By default, the scroll tracker tracks by percentage scrolled. Specifically, it will make a push to the dataLayer when the user scrolls to 20%, 40%, 60%, 80% and 100% of the page height.
+
+When tracking percentages, the following data will be pushed to the dataLayer.
+
+```
+{
+  event: "event_data",
+  event_data: {
+    action: "scroll",
+    event_name: "scroll",
+    percent_scrolled: 20,
+    type: "percent"
+  }
+}
+```
+
+### Track headings
+
+The scroll tracker can be configured to track headings using the `data-ga4-track-type` option.
+
+```html
+<% content_for :extra_head_content do %>
+  <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker" data-ga4-track-type="headings"/>
+<% end %>
+```
+
+When tracking headings, the following data will be pushed to the dataLayer.
+
+```
+{
+  event: "event_data",
+  event_data: {
+    action: "scroll",
+    event_name: "scroll",
+    index: {
+      index_section: 2, // index of heading in headings tracked
+      index_section_count: 5 // total number of headings being tracked
+    },
+    text: "Text of heading",
+    type: "heading"
+  }
+}
+```
+
+### Track markers
+
+Sometimes only certain elements on a page should be tracked. This can be done by adding a marker to the required elements and configuring as shown.
+
+```html
+<% content_for :extra_head_content do %>
+  <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker" data-ga4-track-type="markers"/>
+<% end %>
+
+<div data-ga4-scroll-marker>
+  Some content
+</div>
+
+<div data-ga4-scroll-marker>
+  Some other content
+</div>
+```
+
+Any element that a marker is attached to should be short in both height and text content to be tracked well, because:
+
+- the `text` attribute collects the full text of the element with the marker
+- scroll tracking only happens when the marked element is fully visible to the user
+
+When tracking markers, the following data will be pushed to the dataLayer.
+
+```
+{
+  event: "event_data",
+  event_data: {
+    action: "scroll",
+    event_name: "scroll",
+    index: {
+      index_section: 1, // index of marker in markers tracked
+      index_section_count: 2 // total number of markers being tracked
+    },
+    text: "Some content",
+    type: "marker"
+  }
+}
+```
+
+## Adding tracking to specific pages
+
+A single template may render multiple pages and different configurations may be required. If this is the case, configuration can be handled by the template.
+
+```html
+<% content_for :extra_head_content do %>
+  <% if ["/foreign-travel-advice/benin", "/foreign-travel-advice/france"].include?(content_item.base_path) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker" data-ga4-track-type="headings" data-track-headings="['Summary']"/>
+  <% else %>
+    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
+  <% end %>
+<% end %>
+```
+
+## Behaviour
+
+The scroll tracker finds the position of things (percentages and headings, including the text of headings) on page load to minimise calculations when the user scrolls. This finding of positions is repeated if any of the following occur:
+
+- the user resizes the page
+- the height of the page changes (for example if the cookie banner is dismissed, or an accordion item is expanded). This also detects user font size or zoom level changes
+
+Operation:
+
+- Tracking events are only fired once i.e. if a user scrolls up and down a page, duplicate events are not tracked.
+- Tracking events are fired on page load for things that are immediately visible.
+- If the user has followed a jump link, e.g. `https://www.gov.uk/foreign-travel-advice/spain/coronavirus#finance` the tracker detects this and doesn't fire tracking events until after the browser jumps to the relevant section. It also checks that the hash matches a valid element on the page, and continues as normal if it doesn't.
+- Headings are tracked only when the whole of the heading is visible in the viewport.
+- Headings are only tracked if they are inside the 'main' element, in order to avoid tracking headings in e.g. the cookie banner, the footer (this has been written to be extendable in future if other elements/classes are required)
+- Hidden headings are not tracked, unless they become visible (e.g. if inside an accordion that is opened).

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
@@ -65,48 +65,6 @@ describe('GA4 scroll tracker', function () {
     expect(scrollTracker2.getWindowDetails).not.toHaveBeenCalled()
   })
 
-  describe('with invalid configuration', function () {
-    beforeEach(function () {
-      var el = document.createElement('div')
-      var data = 'invalid'
-      el.setAttribute('data-ga4-track-headings', data)
-      scrollTracker = new GOVUK.Modules.Ga4ScrollTracker(el)
-    })
-
-    it('does not start scroll tracking', function () {
-      scrollTracker.init()
-
-      expect(window.GOVUK.analyticsGa4.vars.scrollTrackerStarted).toEqual(false)
-    })
-  })
-
-  describe('tracking specific headings', function () {
-    var el
-
-    beforeEach(function () {
-      var headings = '<main><h1>First heading</h1><h2>Second heading</h2><h2>Third heading</h2></main>'
-      el = document.createElement('div')
-      el.innerHTML = headings
-      document.body.appendChild(el)
-      var data = '["First heading", "Third heading"]'
-      el.setAttribute('data-ga4-track-headings', data)
-      el.setAttribute('data-ga4-track-type', 'headings')
-      scrollTracker = new GOVUK.Modules.Ga4ScrollTracker(el)
-    })
-
-    afterEach(function () {
-      document.body.removeChild(el)
-    })
-
-    it('only tracks those headings', function () {
-      scrollTracker.init()
-
-      expect(scrollTracker.trackedNodes.length).toEqual(2)
-      expect(scrollTracker.trackedNodes[0].eventData.text).toEqual('First heading')
-      expect(scrollTracker.trackedNodes[1].eventData.text).toEqual('Third heading')
-    })
-  })
-
   describe('when tracking headings', function () {
     var el
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
@@ -14,7 +14,11 @@ describe('GA4 scroll tracker', function () {
         action: 'scroll',
         event_name: 'scroll',
         external: undefined,
-        index: undefined,
+        index: {
+          index_link: undefined,
+          index_section: undefined,
+          index_section_count: undefined
+        },
         index_total: undefined,
         link_domain: undefined,
         link_path_parts: undefined,
@@ -88,6 +92,7 @@ describe('GA4 scroll tracker', function () {
       scrollTracker = new GOVUK.Modules.Ga4ScrollTracker(el)
       scrollTracker.init()
       expected.event_data.type = 'heading'
+      expected.event_data.index.index_section_count = 3
     })
 
     afterEach(function () {
@@ -96,6 +101,7 @@ describe('GA4 scroll tracker', function () {
 
     it('should send a tracking event on initialisation for headings that are already visible', function () {
       expected.event_data.text = 'Heading 1'
+      expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
     })
 
@@ -108,6 +114,7 @@ describe('GA4 scroll tracker', function () {
     it('should track headings on scroll and ignore already tracked headings', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
+      expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
 
       el.querySelector('h3').style.marginTop = '0px'
@@ -117,12 +124,14 @@ describe('GA4 scroll tracker', function () {
 
       expect(window.dataLayer.length).toEqual(2)
       expected.event_data.text = 'Heading 3'
+      expected.event_data.index.index_section = 3
       expect(window.dataLayer[1]).toEqual(expected)
     })
 
     it('should track newly visible headings on scroll and ignore already tracked headings', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
+      expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
 
       el.querySelector('h2').style.display = 'block'
@@ -131,6 +140,7 @@ describe('GA4 scroll tracker', function () {
       jasmine.clock().tick(200)
 
       expected.event_data.text = 'Heading 2'
+      expected.event_data.index.index_section = 2
       expect(window.dataLayer[1]).toEqual(expected)
       expect(window.dataLayer.length).toEqual(2)
     })
@@ -138,6 +148,7 @@ describe('GA4 scroll tracker', function () {
     it('should track when the body height changes', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
+      expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
 
       var pageHeight = document.querySelector('body').clientHeight
@@ -147,6 +158,7 @@ describe('GA4 scroll tracker', function () {
 
       expect(window.dataLayer.length).toEqual(2)
       expected.event_data.text = 'Heading 3'
+      expected.event_data.index.index_section = 3
       expect(window.dataLayer[1]).toEqual(expected)
 
       document.querySelector('body').removeAttribute('style')
@@ -155,6 +167,7 @@ describe('GA4 scroll tracker', function () {
     it('should not track headings wrapped in ignored elements', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
+      expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
 
       el.querySelector('h4').style.display = 'block'
@@ -276,6 +289,8 @@ describe('GA4 scroll tracker', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
       expected.event_data.type = 'heading'
+      expected.event_data.index.index_section = 1
+      expected.event_data.index.index_section_count = 2
       expect(window.dataLayer[0]).toEqual(expected)
     })
   })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
@@ -1,0 +1,324 @@
+/* eslint-env jasmine, jquery */
+var GOVUK = window.GOVUK || {}
+
+describe('GA4 scroll tracker', function () {
+  var scrollTracker, scrollTracker2, expected
+
+  beforeEach(function () {
+    window.dataLayer = []
+    window.GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+    jasmine.clock().install()
+    expected = {
+      event: 'event_data',
+      event_data: {
+        action: 'scroll',
+        event_name: 'scroll',
+        external: undefined,
+        index: undefined,
+        index_total: undefined,
+        link_domain: undefined,
+        link_path_parts: undefined,
+        method: undefined,
+        percent_scrolled: undefined,
+        section: undefined,
+        text: undefined,
+        tool_name: undefined,
+        type: undefined,
+        url: undefined
+      },
+      govuk_gem_version: 'gem-version'
+    }
+    spyOn(GOVUK.analyticsGa4.core, 'getGemVersion').and.returnValue('gem-version')
+  })
+
+  afterEach(function () {
+    window.dataLayer = []
+    stopComponent(scrollTracker)
+    if (scrollTracker2) {
+      stopComponent(scrollTracker2)
+    }
+    jasmine.clock().uninstall()
+
+    window.GOVUK.deleteCookie('cookies_policy')
+    window.GOVUK.analyticsGa4.vars.scrollTrackerStarted = false
+  })
+
+  // remove all the event listeners, otherwise conflicts occur
+  function stopComponent (tracker) {
+    window.removeEventListener('scroll', tracker.scrollEvent)
+    window.removeEventListener('resize', tracker.resizeEvent)
+    clearInterval(tracker.interval)
+  }
+
+  it('should only initialise once on a page', function () {
+    var el = document.createElement('div')
+    scrollTracker = new GOVUK.Modules.Ga4ScrollTracker(el)
+    spyOn(scrollTracker, 'getWindowDetails')
+    scrollTracker.init()
+
+    var el2 = document.createElement('div')
+    scrollTracker2 = new GOVUK.Modules.Ga4ScrollTracker(el2)
+    spyOn(scrollTracker2, 'getWindowDetails')
+    scrollTracker2.init()
+
+    expect(scrollTracker.getWindowDetails).toHaveBeenCalled()
+    expect(scrollTracker2.getWindowDetails).not.toHaveBeenCalled()
+  })
+
+  describe('with invalid configuration', function () {
+    beforeEach(function () {
+      var el = document.createElement('div')
+      var data = 'invalid'
+      el.setAttribute('data-ga4-track-headings', data)
+      scrollTracker = new GOVUK.Modules.Ga4ScrollTracker(el)
+    })
+
+    it('does not start scroll tracking', function () {
+      scrollTracker.init()
+
+      expect(window.GOVUK.analyticsGa4.vars.scrollTrackerStarted).toEqual(false)
+    })
+  })
+
+  describe('tracking specific headings', function () {
+    var el
+
+    beforeEach(function () {
+      var headings = '<main><h1>First heading</h1><h2>Second heading</h2><h2>Third heading</h2></main>'
+      el = document.createElement('div')
+      el.innerHTML = headings
+      document.body.appendChild(el)
+      var data = '["First heading", "Third heading"]'
+      el.setAttribute('data-ga4-track-headings', data)
+      el.setAttribute('data-ga4-track-type', 'headings')
+      scrollTracker = new GOVUK.Modules.Ga4ScrollTracker(el)
+    })
+
+    afterEach(function () {
+      document.body.removeChild(el)
+    })
+
+    it('only tracks those headings', function () {
+      scrollTracker.init()
+
+      expect(scrollTracker.trackedNodes.length).toEqual(2)
+      expect(scrollTracker.trackedNodes[0].eventData.text).toEqual('First heading')
+      expect(scrollTracker.trackedNodes[1].eventData.text).toEqual('Third heading')
+    })
+  })
+
+  describe('when tracking headings', function () {
+    var el
+
+    beforeEach(function () {
+      var extremeHeight = window.innerHeight + 1000
+      var FIXTURE =
+        '<main style="position: absolute; top: 0px;">' +
+          '<h1>Heading 1</h1>' +
+          '<div style="height:' + extremeHeight + 'px">' +
+            '<h2 style="display: none;">Heading 2</h2>' +
+            '<h3 style="margin-top: ' + extremeHeight + 'px;">Heading 3</h3>' +
+          '</div>' +
+        '</main>' +
+        '<div>' +
+          '<h4 style="display: none;">Never track</h4>' +
+        '</div>'
+      el = document.createElement('div')
+      el.setAttribute('data-ga4-track-type', 'headings')
+      el.innerHTML = FIXTURE
+      document.body.appendChild(el)
+      scrollTracker = new GOVUK.Modules.Ga4ScrollTracker(el)
+      scrollTracker.init()
+      expected.event_data.type = 'heading'
+    })
+
+    afterEach(function () {
+      document.body.removeChild(el)
+    })
+
+    it('should send a tracking event on initialisation for headings that are already visible', function () {
+      expected.event_data.text = 'Heading 1'
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('should not track a heading more than once', function () {
+      GOVUK.triggerEvent(document.body, 'scroll')
+      jasmine.clock().tick(200)
+      expect(window.dataLayer.length).toEqual(1)
+    })
+
+    it('should track headings on scroll and ignore already tracked headings', function () {
+      expect(window.dataLayer.length).toEqual(1)
+      expected.event_data.text = 'Heading 1'
+      expect(window.dataLayer[0]).toEqual(expected)
+
+      el.querySelector('h3').style.marginTop = '0px'
+      GOVUK.triggerEvent(document.body, 'resize')
+      GOVUK.triggerEvent(document.body, 'scroll')
+      jasmine.clock().tick(200)
+
+      expect(window.dataLayer.length).toEqual(2)
+      expected.event_data.text = 'Heading 3'
+      expect(window.dataLayer[1]).toEqual(expected)
+    })
+
+    it('should track newly visible headings on scroll and ignore already tracked headings', function () {
+      expect(window.dataLayer.length).toEqual(1)
+      expected.event_data.text = 'Heading 1'
+      expect(window.dataLayer[0]).toEqual(expected)
+
+      el.querySelector('h2').style.display = 'block'
+      // call resize to trigger the tracker to re-assess the headings
+      GOVUK.triggerEvent(document.body, 'resize')
+      jasmine.clock().tick(200)
+
+      expected.event_data.text = 'Heading 2'
+      expect(window.dataLayer[1]).toEqual(expected)
+      expect(window.dataLayer.length).toEqual(2)
+    })
+
+    it('should track when the body height changes', function () {
+      expect(window.dataLayer.length).toEqual(1)
+      expected.event_data.text = 'Heading 1'
+      expect(window.dataLayer[0]).toEqual(expected)
+
+      var pageHeight = document.querySelector('body').clientHeight
+      el.querySelector('h3').style.marginTop = '0px'
+      document.querySelector('body').style.height = (pageHeight + 1) + 'px'
+      jasmine.clock().tick(600)
+
+      expect(window.dataLayer.length).toEqual(2)
+      expected.event_data.text = 'Heading 3'
+      expect(window.dataLayer[1]).toEqual(expected)
+
+      document.querySelector('body').removeAttribute('style')
+    })
+
+    it('should not track headings wrapped in ignored elements', function () {
+      expect(window.dataLayer.length).toEqual(1)
+      expected.event_data.text = 'Heading 1'
+      expect(window.dataLayer[0]).toEqual(expected)
+
+      el.querySelector('h4').style.display = 'block'
+      GOVUK.triggerEvent(document.body, 'resize')
+      jasmine.clock().tick(200)
+
+      expect(window.dataLayer.length).toEqual(1)
+    })
+  })
+
+  describe('when tracking by percentage scrolled', function () {
+    var el
+
+    beforeEach(function () {
+      // set the page height so that no track events get fired initially
+      var height = window.innerHeight * 6
+      setPageHeight(height)
+      el = document.createElement('div')
+      document.body.appendChild(el)
+      scrollTracker = new GOVUK.Modules.Ga4ScrollTracker(el)
+      scrollTracker.init()
+      expected.event_data.type = 'percent'
+    })
+
+    afterEach(function () {
+      document.body.removeChild(el)
+      resetPageHeight()
+    })
+
+    it('should send a tracking event on page load for positions that are already visible', function () {
+      setPageHeight(10)
+
+      expect(window.dataLayer.length).toEqual(5)
+
+      expected.event_data.percent_scrolled = '20'
+      expect(window.dataLayer[0]).toEqual(expected)
+      expected.event_data.percent_scrolled = '40'
+      expect(window.dataLayer[1]).toEqual(expected)
+      expected.event_data.percent_scrolled = '60'
+      expect(window.dataLayer[2]).toEqual(expected)
+      expected.event_data.percent_scrolled = '80'
+      expect(window.dataLayer[3]).toEqual(expected)
+      expected.event_data.percent_scrolled = '100'
+      expect(window.dataLayer[4]).toEqual(expected)
+    })
+
+    it('should track new positions on scroll and ignore already tracked positions', function () {
+      var height = window.innerHeight
+      setPageHeight(height * 4)
+
+      expect(window.dataLayer.length).toEqual(1)
+      expected.event_data.percent_scrolled = '20'
+      expect(window.dataLayer[0]).toEqual(expected)
+
+      setPageHeight(10)
+
+      expect(window.dataLayer.length).toEqual(5)
+      expected.event_data.percent_scrolled = '40'
+      expect(window.dataLayer[1]).toEqual(expected)
+      expected.event_data.percent_scrolled = '60'
+      expect(window.dataLayer[2]).toEqual(expected)
+      expected.event_data.percent_scrolled = '80'
+      expect(window.dataLayer[3]).toEqual(expected)
+      expected.event_data.percent_scrolled = '100'
+      expect(window.dataLayer[4]).toEqual(expected)
+    })
+
+    function setPageHeight (height) {
+      var html = document.documentElement
+      html.style.overflow = 'auto'
+      var body = document.querySelector('body')
+      body.style.height = height + 'px'
+      body.style.overflow = 'hidden'
+      jasmine.clock().tick(600)
+    }
+
+    function resetPageHeight () {
+      var html = document.documentElement
+      html.removeAttribute('style')
+      var body = document.querySelector('body')
+      body.removeAttribute('style')
+    }
+  })
+
+  describe('when the URL includes a hash', function () {
+    var el
+
+    beforeEach(function () {
+      var h2pos = window.innerHeight + 1000
+      var FIXTURE =
+        '<main style="position: absolute; top: 0px;">' +
+          '<h1>Heading 1</h1>' +
+          '<h2 style="margin-top: ' + h2pos + 'px;" id="testId">Heading 2</h3>' +
+        '</main>'
+      el = document.createElement('div')
+      el.setAttribute('data-ga4-track-type', 'headings')
+      el.innerHTML = FIXTURE
+      document.body.appendChild(el)
+    })
+
+    afterEach(function () {
+      document.body.removeChild(el)
+      window.location.hash = ''
+    })
+
+    it('does not track headings on initial page load', function () {
+      window.location.hash = 'testId'
+      scrollTracker = new GOVUK.Modules.Ga4ScrollTracker(el)
+      scrollTracker.init()
+
+      expect(window.dataLayer.length).toEqual(0)
+    })
+
+    it('does track headings on initial page load if there is a hash but it does not match an ID on the page', function () {
+      window.location.hash = 'notAThing'
+      scrollTracker = new GOVUK.Modules.Ga4ScrollTracker(el)
+      scrollTracker.init()
+
+      expect(window.dataLayer.length).toEqual(1)
+      expected.event_data.text = 'Heading 1'
+      expected.event_data.type = 'heading'
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+  })
+})


### PR DESCRIPTION
## What
Adds a scroll tracker for GA4.

This code is based on the existing UA scroll tracker, which was rewritten relatively recently to be more efficient, with a few alterations, specifically:

- data is now collected and pushed to the dataLayer
- 'markers' can be used to track, in addition to the existing percentage and heading tracking options

See the included documentation for full details.

## Why
Part of the GA4 migration.

## Visual Changes
None.

Trello card: https://trello.com/c/BEPuXcrG/607-scroll-tracking-heading-type-home-page
