### PR TITLE
Update notice component example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fix GA4 accordion tracking bugs ([PR #3461](https://github.com/alphagov/govuk_publishing_components/pull/3461))
 * Add ga4 tracking to single page notifications button ([PR #3443](https://github.com/alphagov/govuk_publishing_components/pull/3443))
+* Update notice component example ([PR #3465](https://github.com/alphagov/govuk_publishing_components/pull/3465))
 
 ## 35.8.0
 

--- a/app/views/govuk_publishing_components/components/docs/notice.yml
+++ b/app/views/govuk_publishing_components/components/docs/notice.yml
@@ -35,7 +35,7 @@ examples:
       title: 'Advisory Committee on Novel Foods and Processes has a <a href="http://www.food.gov.uk/acnfp">separate website</a>'
   without_title:
     data:
-      description_govspeak: '<p>Scheduled to publish at 8am on 25 April 2019<br/><a href="change-date">Change date</a><br/><a href="stop-scheduled-publishing">Stop scheduled publishing</a></p>'
+      description_govspeak: '<p>Scheduled to publish at 8am on 25 April 2019</p><ul><li><a href="change-date">Change date</a></li><li><a href="stop-scheduled-publishing">Stop scheduled publishing</a></li></ul>'
   with_aria_live:
     description: Passing the aria live flag to the notice component will read the notice out to users if the notice changes, e.g on form submission the notice may go from hidden to visible.
     data:


### PR DESCRIPTION
## What

Update HTML in Notice example to remove line break elements and replace with unordered list (to represent the two links).

## Why

WCAG 2.2 2.5.8 fail (Target Size (Minimum) (Level AA)). See https://w3c.github.io/wcag/understanding/target-size-minimum.html.

## Visual Changes

### Before

![components-gem-pr-3464 herokuapp com_component-guide_notice_without_title](https://github.com/alphagov/govuk_publishing_components/assets/87758239/510760a3-4771-4811-92fa-e757eee8302a)

### After

![components-gem-pr-3465 herokuapp com_component-guide_notice_without_title](https://github.com/alphagov/govuk_publishing_components/assets/87758239/5cefae0f-fc72-4733-9a08-29bbf75abc8f)

## Anything else

See https://github.com/alphagov/govuk_publishing_components/issues/3439