### PR TITLE
Improve single page notification button helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Update single page notification button ([PR #3471](https://github.com/alphagov/govuk_publishing_components/pull/3471))
 * Fix GA4 accordion tracking bugs ([PR #3461](https://github.com/alphagov/govuk_publishing_components/pull/3461))
 * Add ga4 tracking to single page notifications button ([PR #3443](https://github.com/alphagov/govuk_publishing_components/pull/3443))
 * Update notice component example ([PR #3465](https://github.com/alphagov/govuk_publishing_components/pull/3465))

--- a/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
+++ b/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb
@@ -22,7 +22,7 @@
 <%= tag.div(**component_helper.all_attributes) do %>
   <%= tag.form class: spnb_helper.classes, action: spnb_helper.form_action, method: "POST", data: spnb_helper.data do %>
     <input type="hidden" name="base_path" value="<%= spnb_helper.base_path %>">
-    <% if spnb_helper.skip_account %>
+    <% if spnb_helper.skip_the_gov_uk_account? %>
       <input type="hidden" name="<%= spnb_helper.skip_account_param %>" value="true">
       <input type="hidden" name="link" value="<%= spnb_helper.base_path %>">
     <% end %>

--- a/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb
+++ b/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb
@@ -61,7 +61,11 @@ module GovukPublishingComponents
       end
 
       def form_action
-        @skip_account ? email_alert_frontend_endpoint_no_account : email_alert_frontend_endpoint_enforce_account
+        if skip_the_gov_uk_account?
+          email_alert_frontend_endpoint_no_account
+        else
+          email_alert_frontend_endpoint_enforce_account
+        end
       end
 
       def email_alert_frontend_endpoint_enforce_account
@@ -74,6 +78,10 @@ module GovukPublishingComponents
 
       def skip_account_param
         "single_page_subscription"
+      end
+
+      def skip_the_gov_uk_account?
+        @skip_account == "true"
       end
     end
   end

--- a/spec/components/single_page_notification_button_spec.rb
+++ b/spec/components/single_page_notification_button_spec.rb
@@ -59,7 +59,19 @@ describe "Single page notification button", type: :view do
     assert_select "input[name='base_path']", value: "/the-current-page"
   end
 
-  it "sets a form action of '/email-signup' and adds a hidden link param if skip_account is provided" do
+  it "set the default form action of '/email/subscriptions/single-page/new' if skip_account is present but not 'true' " do
+    local_assigns = {
+      base_path: "/the-current-page",
+      skip_account: "anything-goes",
+    }
+    render_component(local_assigns)
+    assert_select "form[action='/email/subscriptions/single-page/new']"
+    assert_select "input[name='base_path']", value: "/the-current-page"
+    assert_select "input[name='single_page_subscription']", false
+    assert_select "input[name='link']", false
+  end
+
+  it "sets a form action of '/email-signup' and adds a hidden link param if skip_account is 'true'" do
     local_assigns = {
       base_path: "/the-current-page",
       skip_account: "true",


### PR DESCRIPTION
## What

Prior to this PR, if `skip_account` is present, the form action for the single page notification button is the non-govuk-acount signup endpoint, and the params necessary for that route are added to the request.

If `skip_account` is `nil`, the default form action is set that enforces the govuk_account 

New changes:
Instead of [checking if `skip_account` is present](https://github.com/alphagov/govuk_publishing_components/blob/7aecb57136a75439e5d8262cf7b5950ef2e1d3bd/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb#L64), [check if `skip_account == "true"`](https://github.com/alphagov/govuk_publishing_components/blob/b36cc86680060aabc503a2be97239f56773a104d/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb#L83-L85)

## Why

When this component is called by the frontend, we can pass anything into the the skip_account field, so we need to make the code here stricter. For example passing `"false"` to skip_account in Frontend, we would expect the component to implement the default non-govuk-account sign up path for the button. But in fact that would not have been the case, because `"false".present?` returns true.

## Visual Changes
None

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

