### PR TITLE
Version 35.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.9.0
 
 * Update single page notification button ([PR #3471](https://github.com/alphagov/govuk_publishing_components/pull/3471))
 * Fix GA4 accordion tracking bugs ([PR #3461](https://github.com/alphagov/govuk_publishing_components/pull/3461))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.8.0)
+    govuk_publishing_components (35.9.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -351,7 +351,7 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.2)
     tilt (2.0.10)
-    timeout (0.3.2)
+    timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uglifier (4.2.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.8.0".freeze
+  VERSION = "35.9.0".freeze
 end


### PR DESCRIPTION
## Version 35.9.0

* Update single page notification button ([PR #3471](https://github.com/alphagov/govuk_publishing_components/pull/3471))
* Fix GA4 accordion tracking bugs ([PR #3461](https://github.com/alphagov/govuk_publishing_components/pull/3461))
* Add ga4 tracking to single page notifications button ([PR #3443](https://github.com/alphagov/govuk_publishing_components/pull/3443))
* Update notice component example ([PR #3465](https://github.com/alphagov/govuk_publishing_components/pull/3465))
* Ensure GA4 link text is 'image' when the event target is an image ([PR #3462](https://github.com/alphagov/govuk_publishing_components/pull/3462))