### PR TITLE
Add margin_bottom param to Attachment component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add margin_bottom param to Attachment component ([PR #3475](https://github.com/alphagov/govuk_publishing_components/pull/3475))
+
 ## 35.9.0
 
 * Update single page notification button ([PR #3471](https://github.com/alphagov/govuk_publishing_components/pull/3471))

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -9,6 +9,9 @@
   data_attributes ||= {}
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
+  container_class_names = %w[gem-c-attachment govuk-!-display-none-print]
+  container_class_names << shared_helper.get_margin_bottom if local_assigns.key?(:margin_bottom)
+
   case attachment.type
   when "file"
     if attachment.content_type_name
@@ -48,7 +51,7 @@
   end
   
 %>
-<%= tag.section class: "gem-c-attachment govuk-!-display-none-print" do %>
+<%= tag.section class: class_names(container_class_names) do %>
   <%= tag.div class: "gem-c-attachment__thumbnail" do %>
     <%= link_to attachment.url,
                 class: "govuk-link",

--- a/app/views/govuk_publishing_components/components/docs/attachment.yml
+++ b/app/views/govuk_publishing_components/components/docs/attachment.yml
@@ -86,6 +86,16 @@ examples:
         file_size: 20000
       data_attributes:
         gtm: "attachment-preview"
+  with_margin_bottom:
+    description: The component accepts a number for margin bottom from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to no margin bottom.
+    data:
+      attachment:
+        title: "Department for Transport information asset register"
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/747661/department-for-transport-information-asset-register.csv
+        filename: department-for-transport-information-asset-register.csv
+        content_type: application/pdf
+        file_size: 20000
+      margin_bottom: 9
   command_paper_numbered:
     description: |
       Command paper, numbered

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -255,4 +255,17 @@ describe "Attachment", type: :view do
       expect(thumbnail.first.attr("src")).to eq(src) if type == "custom"
     end
   end
+
+  it "accepts margin_bottom" do
+    render_component(attachment: { title: "Attachment", url: "https://gov.uk/attachment" }, margin_bottom: 6)
+    assert_select '.gem-c-attachment[class~="govuk-!-margin-bottom-6"]'
+
+    render_component(attachment: { title: "Attachment", url: "https://gov.uk/attachment" }, margin_bottom: 3)
+    assert_select '.gem-c-attachment[class~="govuk-!-margin-bottom-3"]'
+  end
+
+  it "defaults to no margin_bottom" do
+    render_component(attachment: { title: "Attachment", url: "https://gov.uk/attachment" })
+    assert_select '.gem-c-attachment:not([class*="govuk-!-margin-bottom-"])'
+  end
 end


### PR DESCRIPTION
## What

The Attachment component defaults to having no margin-bottom.

However sometimes we need it to have a margin-bottom value, for example when rendering a list of attachments on a document. Otherwise the components look too 'squashed up'.

This has previously been worked around by [wrapping the component in a container element][1] with margin bottom. But this feels a bit hacky and becomes trickier when we don't have so much control over the way the markup around the component (for example, when it's been embedded within a Govspeak document).

[1]: https://github.com/alphagov/government-frontend/blob/0bec9a842902db2a7353d28400fa7bf5d7008c8b/app/views/content_items/_attachments.html.erb#L18-L23

## Why

To make the attachment usable within Whitehall and Govspeak, without needing extra wrapper `<div>`s to apply a margin. This will enable us to [remove custom attachment rendering from Whitehall](https://trello.com/c/Z5IwGrAw/1177-remove-custom-attachment-rendering-from-whitehall).

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

N/A

### After

<img width="960" alt="Attachment with margin bottom" src="https://github.com/alphagov/govuk_publishing_components/assets/7735945/a93c86ad-2f28-49e3-b0d7-28e61a159384">
