### PR TITLE
Add link option to tabs component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add GA4 HTML attachment tracking to attachment component ([PR #3500](https://github.com/alphagov/govuk_publishing_components/pull/3500))
 * Add functionality for preventing the redaction of publicly available information ([PR #3509](https://github.com/alphagov/govuk_publishing_components/pull/3509))
 * Ensure extra spaces are removed from search forms ([PR #3512](https://github.com/alphagov/govuk_publishing_components/pull/3512))
+* Add link option to tabs component ([PR #3486](https://github.com/alphagov/govuk_publishing_components/pull/3486))
 
 ## 35.11.0
 

--- a/app/views/govuk_publishing_components/components/_tabs.html.erb
+++ b/app/views/govuk_publishing_components/components/_tabs.html.erb
@@ -7,22 +7,30 @@
   panel_css_classes << "gem-c-tabs__panel--no-border" if panel_border == false
   panel_css_classes = panel_css_classes.join(" ")
 
+  as_links ||= false
   ga4_tracking ||= false
-  data_module = "govuk-tabs"
-  data_module << " ga4-event-tracker" if ga4_tracking
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("govuk-tabs gem-c-tabs")
+  component_helper.add_data_attribute({ module: "govuk-tabs" }) unless as_links
+
+  if ga4_tracking
+    component_helper.add_data_attribute({ module: "ga4-event-tracker" }) unless as_links
+    component_helper.add_data_attribute({ module: "ga4-link-tracker" }) if as_links
+  end
 %>
 <% if tabs.count > 1 %>
-  <div class="govuk-tabs gem-c-tabs" data-module="<%= data_module %>">
+  <%= tag.div(**component_helper.all_attributes) do %>
     <h2 class="govuk-tabs__title">
       <%= t("components.tabs.contents") %>
     </h2>
     <ul class="govuk-tabs__list">
       <% tabs.each_with_index do |tab, index| %>
-      <li class="govuk-tabs__list-item">
+      <li class="govuk-tabs__list-item <%= "govuk-tabs__list-item--selected" if tab[:active] %>">
         <%
           tab[:tab_data_attributes] ||= {}
           if ga4_tracking
-            tab[:tab_data_attributes][:ga4_event] = {
+            ga4_attributes = {
               event_name: "select_content",
               type: "tabs",
               text: tab[:label],
@@ -31,24 +39,32 @@
                 index_section_count: tabs.length,
               },
             }
+            ga4_attributes[:event_name] = "navigation" if as_links
+            tab[:tab_data_attributes][:ga4_link] = ga4_attributes if as_links
+            tab[:tab_data_attributes][:ga4_event] = ga4_attributes unless as_links
           end
+
+          tab_link = "##{tab[:id]}"
+          tab_link = tab[:href] if as_links
         %>
         <%= link_to(tab[:label],
-                    "##{tab[:id]}",
+                    tab_link,
                     class: "govuk-tabs__tab",
                     data: tab[:tab_data_attributes]) %>
       </li>
       <% end %>
     </ul>
-    <% tabs.each do |tab| %>
-      <section class="<%= panel_css_classes %>" id="<%= tab[:id] %>">
-        <% if tab[:title] %>
-          <h2 class="govuk-heading-l"><%= tab[:title] %></h2>
-        <% end %>
-        <%= tab[:content] %>
-      </section>
+    <% unless as_links %>
+      <% tabs.each do |tab| %>
+        <section class="<%= panel_css_classes %>" id="<%= tab[:id] %>">
+          <% if tab[:title] %>
+            <h2 class="govuk-heading-l"><%= tab[:title] %></h2>
+          <% end %>
+          <%= tab[:content] %>
+        </section>
+      <% end %>
     <% end %>
-  </div>
+  <% end %>
 <% end %>
 <% if tabs.count == 1 %>
     <section id="<%= tabs[0][:id] %>">

--- a/app/views/govuk_publishing_components/components/docs/tabs.yml
+++ b/app/views/govuk_publishing_components/components/docs/tabs.yml
@@ -30,6 +30,17 @@ examples:
           label: "Second section"
           content: |
             <p class="govuk-body-m">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam congue elementum commodo. Vestibulum elit turpis, efficitur quis posuere vitae, commodo vitae augue. Donec ut pharetra ligula. Phasellus ac mauris eu felis bibendum dapibus rutrum sed quam. Pellentesque posuere ante id consequat pretium.</p>
+  as_links:
+    description: With this option the tabs operate as links, rather than switching between elements within a single page.
+    data:
+      as_links: true
+      tabs:
+        - href: "link1"
+          label: "Page one"
+          active: true
+        - href: "link2"
+          label: "Page two"
+          active: false
   without_panel_border:
     data:
       panel_border: false
@@ -84,8 +95,8 @@ examples:
             tracking: GTM-123AB
           content: |
             <p class="govuk-body-m">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam congue elementum commodo. Vestibulum elit turpis, efficitur quis posuere vitae, commodo vitae augue. Donec ut pharetra ligula. Phasellus ac mauris eu felis bibendum dapibus rutrum sed quam. Pellentesque posuere ante id consequat pretium.</p>
-  with_ga4_tracking:
-    description: Enables GA4 tracking. This will add the required data module and data attributes to the tabs. See the [ga4-event-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) for more information.
+  with_ga4_tracking_on_tabs:
+    description: Enables GA4 tracking by adding the event tracker and required data attributes to the tabs. See the [ga4-event-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md) for more information.
     data:
       ga4_tracking: true
       tabs:
@@ -99,3 +110,15 @@ examples:
           title: "Second section"
           content: |
             <p class="govuk-body-m">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam congue elementum commodo. Vestibulum elit turpis, efficitur quis posuere vitae, commodo vitae augue. Donec ut pharetra ligula. Phasellus ac mauris eu felis bibendum dapibus rutrum sed quam. Pellentesque posuere ante id consequat pretium.</p>
+  with_ga4_tracking_on_tabs_as_links:
+    description: Enables GA4 tracking by adding the link tracker and required data attributes to the tabs. See the [ga4-link-tracker documentation](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md) for more information.
+    data:
+      as_links: true
+      ga4_tracking: true
+      tabs:
+        - href: "/page1"
+          label: "Link 1"
+          active: true
+        - href: "/page2"
+          label: "Link 2"
+          active: false

--- a/spec/components/tabs_spec.rb
+++ b/spec/components/tabs_spec.rb
@@ -31,7 +31,29 @@ describe "Tabs", type: :view do
     assert_select "#tab1"
   end
 
-  it "renders with GA4 tracking" do
+  it "renders tabs as links" do
+    render_component(
+      as_links: true,
+      tabs: [
+        {
+          label: "First section",
+          href: "/page1",
+        },
+        {
+          label: "Second section",
+          href: "/page2",
+        },
+      ],
+    )
+
+    assert_select ".govuk-tabs"
+    assert_select ".govuk-tabs__tab", 2
+    assert_select ".govuk-tabs__list-item", 2
+    assert_select "a.govuk-tabs__tab[href='/page1']"
+    assert_select "a.govuk-tabs__tab[href='/page2']"
+  end
+
+  it "renders with GA4 tracking on tabs" do
     render_component(
       ga4_tracking: true,
       tabs: [
@@ -57,5 +79,32 @@ describe "Tabs", type: :view do
     assert_select ".govuk-tabs__tab[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"tabs\",\"text\":\"First section\",\"index\":{\"index_section\":1,\"index_section_count\":3}}']"
     assert_select ".govuk-tabs__tab[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"tabs\",\"text\":\"Second section\",\"index\":{\"index_section\":2,\"index_section_count\":3}}']"
     assert_select ".govuk-tabs__tab[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"tabs\",\"text\":\"Third section\",\"index\":{\"index_section\":3,\"index_section_count\":3}}']"
+  end
+
+  it "renders with GA4 tracking on tabs as links" do
+    render_component(
+      ga4_tracking: true,
+      as_links: true,
+      tabs: [
+        {
+          href: "tab1",
+          label: "First section",
+          active: true,
+        },
+        {
+          href: "tab2",
+          label: "Second section",
+        },
+        {
+          href: "tab3",
+          label: "Third section",
+        },
+      ],
+    )
+
+    assert_select ".govuk-tabs[data-module='ga4-link-tracker']"
+    assert_select ".govuk-tabs__tab[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"tabs\",\"text\":\"First section\",\"index\":{\"index_section\":1,\"index_section_count\":3}}']"
+    assert_select ".govuk-tabs__tab[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"tabs\",\"text\":\"Second section\",\"index\":{\"index_section\":2,\"index_section_count\":3}}']"
+    assert_select ".govuk-tabs__tab[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"tabs\",\"text\":\"Third section\",\"index\":{\"index_section\":3,\"index_section_count\":3}}']"
   end
 end


### PR DESCRIPTION
## What
Adds an option to the tabs component to make the tabs act as links, instead of switching between hidden elements on the same page.

Note that for the purposes of tracking there has to be a bit of logic involved to switch from the GA4 event tracker to the link tracker. We're not actually tracking tabs as links anywhere on GOV.UK so this tracking is a bit unnecessary but it feels like more of a complete change if this is included now.

## Why
We have a tabs component in `collections-publisher` that looks exactly the same as this tabs component, but acts as links. If we add this option to the gem component we can reuse it in that application and remove a redundant component.

Related to issue https://github.com/alphagov/govuk_publishing_components/issues/3487

## Visual Changes
![Screenshot 2023-07-06 at 14 36 11](https://github.com/alphagov/govuk_publishing_components/assets/861310/5f50b403-597d-404a-abce-afcb350c079e)

