### PR TITLE
Fix attachment metadata styling issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * GA4 content navigation fixes ([PR #3495](https://github.com/alphagov/govuk_publishing_components/pull/3495))
 * Fix feedback component spacing ([PR #3470](https://github.com/alphagov/govuk_publishing_components/pull/3470))
+* Fix attachment metadata styling issue ([PR #3501](https://github.com/alphagov/govuk_publishing_components/pull/3501))
 
 ## 35.10.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_attachment.scss
@@ -67,6 +67,13 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey", $legacy: "grey-3");
   &:last-of-type {
     margin-bottom: 0;
   }
+
+  .gem-c-attachment__attribute {
+    // From the Design System
+    // Automatic wrapping for unbreakable text (e.g. URLs)
+    word-wrap: break-word; // Fallback for older browsers only
+    overflow-wrap: break-word;
+  }
 }
 
 .gem-c-attachment__metadata--compact {


### PR DESCRIPTION
## What
Fixes a styling issue where long strings of text for external links do not wrap onto a new line.

The approach used to fix the issue is the same as that used in the Design System - https://github.com/alphagov/govuk-frontend/blob/49a3eb389eec89e004873ddfeb8c1f9aa1d572e4/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss#L64-L68

## Why
The long string of text was not contained and overlapped with other elements on the page.

## Further info
Tested in the browsers below using BrowserStack:

- Chrome
- FireFox
- Safari
- Safari iOS
- IE11

The issue still exists in IE11, but it is worth noting that this issue existed before the recent change to use the attachment component from the gem.

I will create a separate issue for IE11, so this can be looked into separately.

## Visual Changes

### Before
<img width="1076" alt="before-text" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/e5b93e0d-1425-4296-8364-d143b24671d0">

#### Before - If the 1st link does not contain a hyphen
<img width="1141" alt="before-text-no-hyphen" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/d987c160-c98f-4f04-9534-8c191eda7bdf">

### After
<img width="1014" alt="after-text" src="https://github.com/alphagov/govuk_publishing_components/assets/28779939/67fa8a6e-8b60-4a8f-b37d-4eebb93b84d2">
