### PR TITLE
Render an outline for search button and input in Windows high contrast mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Extend component wrapper helper and use on heading component ([PR #3519](https://github.com/alphagov/govuk_publishing_components/pull/3519))
 * Remove licence-finder from list of audited applications ([PR #3518](https://github.com/alphagov/govuk_publishing_components/pull/3518))
 * Fix inconsistent focus state on document list component ([PR #3468](https://github.com/alphagov/govuk_publishing_components/pull/3468))
+* Render an outline for search button and input in Windows high contrast mode ([PR #3502](https://github.com/alphagov/govuk_publishing_components/pull/3502))
 
 ## 35.12.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -110,6 +110,10 @@ $large-input-size: 50px;
   border: 0;
   cursor: pointer;
   border-radius: 0;
+  // render a border in high contrast mode
+  outline: $govuk-border-width-form-element solid transparent;
+  // Ensure outline appears outside of the element
+  outline-offset: 0;
   position: relative;
   padding: 0;
   width: $input-size;
@@ -124,8 +128,6 @@ $large-input-size: 50px;
   &:focus {
     z-index: 2;
     outline: $govuk-focus-width solid $govuk-focus-colour;
-    // Ensure outline appears outside of the element
-    outline-offset: 0;
     // Double the border by adding its width again. Use `box-shadow` for this // instead of changing `border-width` - this is for consistency with
     // Also, `outline` cannot be utilised
     // here as it is already used for the yellow focus state.
@@ -161,6 +163,10 @@ $large-input-size: 50px;
 
   .gem-c-search__input {
     border-width: 0;
+    // Render a border in high contrast mode
+    outline: $govuk-border-width-form-element solid transparent;
+    // Ensure outline appears outside of the element
+    outline-offset: 0;
 
     // no need for black outline as there is enough contrast
     // with the blue background


### PR DESCRIPTION
## What
Add a transparent outline to the search button in all modes, and to form inputs in the blue background mode. This way Windows high contrast mode renders an outline for the elements, which helps to distinguish them from their background and makes them easier to identify. 

This does not result in any visual changes in the standard contrast mode.

## Why
We remove the default border from the search button in all modes, and the default border from from form input elements in the blue background mode, in order to comply with the GOV.UK design. 

However, this meant that these elements didn't have a visible outline in Windows high contrast mode which could make them difficult to distinguish from their background, or to identify. (This wasn't an issue in Firefox when users changes the default browser colours there because Firefox renders a distinct colour background inside buttons and form inputs.)

## Visual Changes

In Edge with Windows high contrast mode enabled.

### Default

[Example](https://components.publishing.service.gov.uk/component-guide/search/default)

#### Before

<img width="1001" alt="Screenshot 2023-07-24 at 15 55 23" src="https://github.com/alphagov/govuk_publishing_components/assets/5007934/81dcd4fa-2fb2-41ec-8832-6669637a6126">

#### After

<img width="998" alt="Screenshot 2023-07-24 at 15 55 16" src="https://github.com/alphagov/govuk_publishing_components/assets/5007934/d801b709-9495-40cc-b46e-6f8470c92ad4">

### Blue background

[Example](https://components.publishing.service.gov.uk/component-guide/search/for_use_on_govuk_blue_background)

### Before

<img width="987" alt="Screenshot 2023-07-24 at 15 55 39" src="https://github.com/alphagov/govuk_publishing_components/assets/5007934/a70e0ef1-808f-4e3e-96cd-fdfc7242d29e">

### After

<img width="1009" alt="Screenshot 2023-07-24 at 15 55 02" src="https://github.com/alphagov/govuk_publishing_components/assets/5007934/8c775650-c25b-4f46-b27d-b42a12ea4b30">


# Tested with

## High Contrast mode
✅ Windows High Contrast mode
✅  Firefox when uses changes the default colours in the browser

## Windows	
✅  Edge 114
✅  Google Chrome, latest
✅  Mozilla Firefox, latest
✅  Internet Explorer 11	

## macOS	
✅  Safari 16
✅  Google Chrome, latest
✅  Mozilla Firefox, latest

## iOS	
✅  Safari, iOS 16

## Android	
✅  Samsung Galaxy, Android 13

Fixes https://trello.com/c/bqURvY4r/1900-form-controls-may-not-be-identified-when-in-high-contrast-mode-45-m