### PR TITLE
Add functionality for preventing the redaction of publicly available information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Ensure search forms have their text sent to GA4 in lowercase ([PR #3504](https://github.com/alphagov/govuk_publishing_components/pull/3504))
 * Add GA4 HTML attachment tracking to attachment component ([PR #3500](https://github.com/alphagov/govuk_publishing_components/pull/3500))
+* Add functionality for preventing the redaction of publicly available information ([PR #3509](https://github.com/alphagov/govuk_publishing_components/pull/3509))
 
 ## 35.11.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -272,6 +272,10 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
           // if there's a problem with the config, don't start the tracker
           console.error('Unable to JSON.parse or JSON.stringify index: ' + e.message, window.location)
         }
+      },
+
+      applyRedactionIfRequired: function (PIIRemover, element, data) {
+        return element.closest('[data-ga4-do-not-redact]') ? data : PIIRemover.stripPIIWithOverride(data, true, true)
       }
     },
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -81,12 +81,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       var text = data.text || event.target.textContent
       data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)
-      data.text = this.PIIRemover.stripPIIWithOverride(data.text, true, true)
+      data.text = window.GOVUK.analyticsGa4.core.trackFunctions.applyRedactionIfRequired(this.PIIRemover, element, data.text)
       if (!data.text && (element.querySelector('img') || element.querySelector('svg') || element.tagName === 'IMG' || element.closest('svg'))) {
         data.text = 'image'
       }
       var url = data.url || this.findLink(event.target).getAttribute('href')
-      data.url = window.GOVUK.analyticsGa4.core.trackFunctions.removeCrossDomainParams(this.PIIRemover.stripPIIWithOverride(url, true, true))
+      data.url = window.GOVUK.analyticsGa4.core.trackFunctions.applyRedactionIfRequired(this.PIIRemover, element, window.GOVUK.analyticsGa4.core.trackFunctions.removeCrossDomainParams(url))
       data.link_domain = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkDomain(data.url)
       data.link_path_parts = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkPathParts(data.url)
       data.method = window.GOVUK.analyticsGa4.core.trackFunctions.getClickType(event)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -433,6 +433,40 @@ describe('GA4 link tracker', function () {
       expect(window.dataLayer[0].event_data.link_path_parts[1]).toEqual('#/[date]/[postcode]/[email]')
       expect(window.dataLayer[0].event_data.text).toEqual('[date] [postcode] [email]')
     })
+
+    it('does not redact information when the \'data-ga4-do-not-redact\' attribute exists on a link', function () {
+      element = document.createElement('div')
+      element.setAttribute('data-ga4-track-links-only', '')
+      element.setAttribute('data-ga4-link', '{"someData": "blah"}')
+      element.innerHTML = '<a class="link" href="#/2022-02-02/SW10AA/email@example.com">2022-02-02 SW1 0AA email@example.com</a>'
+
+      var link = element.querySelector('.link')
+      link.setAttribute('data-ga4-do-not-redact', '')
+
+      initModule(element, false)
+      link.click()
+
+      expect(window.dataLayer[0].event_data.url).toEqual('#/2022-02-02/SW10AA/email@example.com')
+      expect(window.dataLayer[0].event_data.link_path_parts[1]).toEqual('#/2022-02-02/SW10AA/email@example.com')
+      expect(window.dataLayer[0].event_data.text).toEqual('2022-02-02 SW1 0AA email@example.com')
+    })
+
+    it('does not redact information when the \'data-ga4-do-not-redact\' attribute exists on a parent element', function () {
+      element = document.createElement('div')
+      element.setAttribute('data-ga4-track-links-only', '')
+      element.setAttribute('data-ga4-link', '{"someData": "blah"}')
+      element.setAttribute('data-ga4-do-not-redact', '')
+      element.innerHTML = '<a class="link" href="#/2022-02-02/SW10AA/email@example.com">2022-02-02 SW1 0AA email@example.com</a>'
+
+      var link = element.querySelector('.link')
+
+      initModule(element, false)
+      link.click()
+
+      expect(window.dataLayer[0].event_data.url).toEqual('#/2022-02-02/SW10AA/email@example.com')
+      expect(window.dataLayer[0].event_data.link_path_parts[1]).toEqual('#/2022-02-02/SW10AA/email@example.com')
+      expect(window.dataLayer[0].event_data.text).toEqual('2022-02-02 SW1 0AA email@example.com')
+    })
   })
 
   describe('if the link is an on an image with no inner text', function () {


### PR DESCRIPTION
## What
This PR adds functionality for preventing redaction by detecting a `data-ga4-do-not-redact` attribute on elements that contain information that we don't want redacted. For example, all email addresses are currently redacted however, in some cases, we don't want to redact this information e.g. when the email address is publicly available contact information and surfaced within a set of results [(example)](https://www.gov.uk/disabled-students-allowances-assessment-centre#results).

## Why
Requested by PA's.

[Trello card](https://trello.com/c/nDZmuHH1/622-public-email-address-redacted-on-place-forms)

## Visual Changes
N/A
