### PR TITLE
Ensure extra spaces are removed from search forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Ensure search forms have their text sent to GA4 in lowercase ([PR #3504](https://github.com/alphagov/govuk_publishing_components/pull/3504))
 * Add GA4 HTML attachment tracking to attachment component ([PR #3500](https://github.com/alphagov/govuk_publishing_components/pull/3500))
 * Add functionality for preventing the redaction of publicly available information ([PR #3509](https://github.com/alphagov/govuk_publishing_components/pull/3509))
+* Ensure extra spaces are removed from search forms ([PR #3512](https://github.com/alphagov/govuk_publishing_components/pull/3512))
 
 ## 35.11.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
@@ -47,6 +47,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       if (data.action === 'search') {
         data.text = data.text.toLowerCase()
+        data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(data.text)
       }
 
       var schemas = new window.GOVUK.analyticsGa4.Schemas()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.spec.js
@@ -290,5 +290,15 @@ describe('Google Analytics form tracking', function () {
       window.GOVUK.triggerEvent(element, 'submit')
       expect(window.dataLayer[0]).toEqual(expected)
     })
+
+    it('removes extra spaces', function () {
+      element.innerHTML =
+        '<label for="text">Search</label>' +
+        '<input type="text" id="text" name="text" value="  there  should     be    no  extra  spaces     "/>'
+
+      expected.event_data.text = 'there should be no extra spaces'
+      window.GOVUK.triggerEvent(element, 'submit')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
   })
 })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Ensures extra spaces are removed from search terms on search forms.

## Why
<!-- What are the reasons behind this change being made? -->
I removed extra spaces on search terms in Finder Frontend, but this needs to be done for the header menu bar search forms, and  the homepage search forms etc.

[Trello card](https://trello.com/c/EE2V1XmQ/618-remove-invisible-spaces-from-search-terms)

## Visual Changes
None.
