### PR TITLE
Remove licence-finder from list of audited applications.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove licence-finder from list of audited applications ([PR #3518](https://github.com/alphagov/govuk_publishing_components/pull/3518))
+
 ## 35.12.0
 
 * Change how GA4 schema construction works ([PR #3436](https://github.com/alphagov/govuk_publishing_components/pull/3436))

--- a/app/controllers/govuk_publishing_components/audit_controller.rb
+++ b/app/controllers/govuk_publishing_components/audit_controller.rb
@@ -14,7 +14,6 @@ module GovukPublishingComponents
         government-frontend
         govspeak-preview
         info-frontend
-        licence-finder
         release
         search-admin
         signon

--- a/app/models/govuk_publishing_components/audit_comparer.rb
+++ b/app/models/govuk_publishing_components/audit_comparer.rb
@@ -12,7 +12,6 @@ module GovukPublishingComponents
           frontend
           government-frontend
           info-frontend
-          licence-finder
           service-manual-frontend
           smart-answers
           whitehall


### PR DESCRIPTION
## What

Remove licence finder from list of audited applications in controller and comparer.

## Why

Licence finder application is now retired, searches are handled by Finder Frontend.

https://trello.com/c/1VXQW5I1/2127-epic-retire-original-licence-finder-application