### PR TITLE
Extend component wrapper helper and use on heading component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Extend component wrapper helper and use on heading component ([PR #3519](https://github.com/alphagov/govuk_publishing_components/pull/3519))
 * Remove licence-finder from list of audited applications ([PR #3518](https://github.com/alphagov/govuk_publishing_components/pull/3518))
 
 ## 35.12.0

--- a/app/models/govuk_publishing_components/component_wrapper_helper_options.rb
+++ b/app/models/govuk_publishing_components/component_wrapper_helper_options.rb
@@ -9,6 +9,7 @@ This component uses the component wrapper helper. It accepts the following optio
 - `aria` - accepts a hash of aria attributes
 - `classes` - accepts a space separated string of classes, these should not be used for styling and must be prefixed with `js-`
 - `role` - accepts a space separated string of roles
+- `lang` - accepts a language attribute value
       "
     end
   end

--- a/app/views/govuk_publishing_components/components/_heading.html.erb
+++ b/app/views/govuk_publishing_components/components/_heading.html.erb
@@ -7,15 +7,18 @@
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
   heading_helper = GovukPublishingComponents::Presenters::HeadingHelper.new(local_assigns)
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
 
   classes = %w(gem-c-heading)
   classes << heading_helper.classes
   classes << brand_helper.brand_class
   classes << brand_helper.border_color_class
   classes << shared_helper.get_margin_bottom if [*0..9].include?(local_assigns[:margin_bottom])
+
+  component_helper.add_class(classes.join(" "))
+  component_helper.set_id(heading_helper.id)
+  element = shared_helper.get_heading_level
 %>
-<%= content_tag(shared_helper.get_heading_level, text,
-  class: classes,
-  id: heading_helper.id,
-  lang: lang
-) %>
+<%= content_tag(element, component_helper.all_attributes) do %>
+  <%= text %>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/heading.yml
+++ b/app/views/govuk_publishing_components/components/docs/heading.yml
@@ -15,6 +15,7 @@ accessibility_criteria: |
   - be part of a correct heading structure for a page
   - be semantically represented as a heading
   - convey the heading level
+uses_component_wrapper_helper: true  
 examples:
   default:
     data:
@@ -31,10 +32,6 @@ examples:
     data:
       text: 'One big heading'
       font_size: "xl"
-  with_id_attribute:
-    data:
-      text: 'Detail of outcome'
-      id: 'detail_of_outcome'
   right_to_left:
     data:
       text: 'مستندات'

--- a/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
+++ b/app/views/govuk_publishing_components/components/docs/single_page_notification_button.yml
@@ -9,6 +9,7 @@ body: |
   When the button is clicked, the `base_path` is submitted to an endpoint which proceeds to check the user's authentication status and whether they are already subscribed to the page or not. Depending on these factors, they will be routed accordingly.
 accessibility_criteria: |
   - The bell icon must be presentational and ignored by screen readers.
+uses_component_wrapper_helper: true  
 examples:
   default:
     description: By default this component prompts the user to subscribe to email notifications to this page.
@@ -19,12 +20,6 @@ examples:
     data:
       base_path: '/current-page-path'
       already_subscribed: true
-  with_data_attributes:
-    description: The component accepts data attributes (for example, for analytics)
-    data:
-      base_path: '/current-page-path'
-      data_attributes:
-        test_attribute: "testing"
   with_ga4_tracking:
     description: To add GA4 tracking, pass a `ga4_data_attributes` object with the necessary properties to the component. For example:-
     data:

--- a/app/views/govuk_publishing_components/components/docs/tabs.yml
+++ b/app/views/govuk_publishing_components/components/docs/tabs.yml
@@ -17,7 +17,7 @@ accessibility_criteria: |
     * be usable with touch
     * be usable with voice commands
     * have visible text
-
+uses_component_wrapper_helper: true
 examples:
   default:
     data:

--- a/docs/component-wrapper-helper.md
+++ b/docs/component-wrapper-helper.md
@@ -29,8 +29,9 @@ The component wrapper helper accepts the following options.
 - `aria` - accepts a hash of aria attributes
 - `classes` - accepts a space separated string of classes, these should not be used for styling and must be prefixed with `js-`
 - `role` - accepts a space separated string of roles
+- `lang` - accepts a language attribute value
 
-The helper checks that any passed `id` attribute is valid, specifically that it does not start with a number or contain whitespace or contain any characters other than letters, numbers, and `_` or `-`. It also checks that role attribute values are valid, along with some other checks detailed below.
+The helper checks that any passed `id` attribute is valid, specifically that it does not start with a number or contain whitespace or contain any characters other than letters, numbers, and `_` or `-`. It also checks that role and lang attribute values are valid, along with some other checks detailed below.
 
 ### Data and aria
 
@@ -73,6 +74,7 @@ The helper includes additional methods to make this possible.
 - `add_data_attribute({ module: "ga4-event-tracker" })` - combines the given data attributes with any that have been passed, merging duplicate keys, e.g. if `{ module: "gem-track-click", a: "1" }` had been passed, the result would be `{ module: "ga4-event-tracker gem-track-click", a: "1" }`
 - `add_aria_attribute()` - works the same as `add_data_attribute`
 - `add_role()` - works the same as `add_class`
+- `set_lang()` - works the same as `set_id`
 
 This is an example component template using some of these methods.
 

--- a/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
+++ b/lib/govuk_publishing_components/presenters/component_wrapper_helper.rb
@@ -9,6 +9,7 @@ module GovukPublishingComponents
         check_classes_are_valid(@options[:classes]) if @options.include?(:classes)
         check_aria_is_valid(@options[:aria]) if @options.include?(:aria)
         check_role_is_valid(@options[:role]) if @options.include?(:role)
+        check_lang_is_valid(@options[:lang]) if @options.include?(:lang)
       end
 
       def all_attributes
@@ -19,6 +20,7 @@ module GovukPublishingComponents
         attributes[:aria] = @options[:aria] unless @options[:aria].blank?
         attributes[:class] = @options[:classes] unless @options[:classes].blank?
         attributes[:role] = @options[:role] unless @options[:role].blank?
+        attributes[:lang] = @options[:lang] unless @options[:lang].blank?
 
         attributes
       end
@@ -48,6 +50,11 @@ module GovukPublishingComponents
         extend_string(:role, role)
       end
 
+      def set_lang(lang)
+        check_lang_is_valid(lang)
+        @options[:lang] = lang
+      end
+
     private
 
       def check_id_is_valid(id)
@@ -69,7 +76,7 @@ module GovukPublishingComponents
         return if classes.blank?
 
         class_array = classes.split(" ")
-        unless class_array.all? { |c| c.start_with?("js-", "gem-c-", "govuk-", "brand--") }
+        unless class_array.all? { |c| c.start_with?("js-", "gem-c-", "govuk-", "brand--", "brand__") }
           raise(ArgumentError, "Classes (#{classes}) must be prefixed with `js-`")
         end
       end
@@ -95,6 +102,15 @@ module GovukPublishingComponents
         role = role.split(" ") # can have more than one role
         unless role.all? { |r| roles.include? r }
           raise(ArgumentError, "Role attribute (#{(role - roles).join(', ')}) is not recognised")
+        end
+      end
+
+      def check_lang_is_valid(lang)
+        return if lang.blank?
+
+        langs = %w[ab aa af ak sq am ar an hy as av ae ay az bm ba eu be bn bh bi bs br bg my ca ch ce ny zh zh-Hans zh-Hant cv kw co cr hr cs da dv nl dz en eo et ee fo fj fi fr ff gl gd gv ka de el kl gn gu ht ha he hz hi ho hu is io ig id in ia ie iu ik ga it ja jv kl kn kr ks kk km ki rw rn ky kv kg ko ku kj lo la lv li ln lt lu lg lb gv mk mg ms ml mt mi mr mh mo mn na nv ng nd ne no nb nn ii oc oj cu or om os pi ps fa pl pt pa qu rm ro ru se sm sg sa sr sh st tn sn ii sd si ss sk sl so nr es su sw ss sv tl ty tg ta tt te th bo ti to ts tr tk tw ug uk ur uz ve vi vo wa cy wo fy xh yi ji yo za zu]
+        unless langs.include? lang
+          raise(ArgumentError, "lang attribute (#{lang}) is not recognised")
         end
       end
 

--- a/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/component_wrapper_helper_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
           labelledby: "element",
         },
         role: "navigation",
+        lang: "en",
       }
       component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(args)
       expected = {
@@ -21,14 +22,15 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
           labelledby: "element",
         },
         role: "navigation",
+        lang: "en",
       }
       expect(component_helper.all_attributes).to eql(expected)
     end
 
     it "accepts valid class names" do
-      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "gem-c-component govuk-component")
+      component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(classes: "gem-c-component govuk-component brand--thing brand__thing")
       expected = {
-        class: "gem-c-component govuk-component",
+        class: "gem-c-component govuk-component brand--thing brand__thing",
       }
       expect(component_helper.all_attributes).to eql(expected)
     end
@@ -86,6 +88,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         data_attributes: nil,
         aria: nil,
         role: nil,
+        lang: nil,
       )
       expect(component_helper.all_attributes).to eql({})
 
@@ -95,6 +98,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
         data_attributes: "",
         aria: "",
         role: "",
+        lang: "",
       )
       expect(component_helper.all_attributes).to eql({})
     end
@@ -158,6 +162,13 @@ RSpec.describe GovukPublishingComponents::Presenters::ComponentWrapperHelper do
       expect {
         helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(role: "navigation")
         helper.add_role("alert custarddoughnuts moose")
+      }.to raise_error(ArgumentError, error)
+    end
+
+    it "does not accept an invalid lang" do
+      error = "lang attribute (klingon) is not recognised"
+      expect {
+        GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(lang: "klingon")
       }.to raise_error(ArgumentError, error)
     end
   end


### PR DESCRIPTION
## What
Extend the component wrapper helper to support adding a `lang` attribute to components, e.g. `<div lang="cy">`.

Update the heading component to use the component wrapper helper.

Update other component documentation.

## Why
We want to pass data attributes to the heading component in another application (to do scroll tracking on the homepage), and switching it to using the component wrapper helper seemed like the simplest option. Except then it turned out that the heading component required a `lang` option, which wasn't supported, so this was added.

## Visual Changes
None, apart from small changes in the component guide to reflect this change.

Trello card: https://trello.com/c/BEPuXcrG/607-scroll-tracking-heading-type-home-page
