### PR TITLE
Fix 100% scroll problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix 100% scroll problem ([PR #3521](https://github.com/alphagov/govuk_publishing_components/pull/3521))
 * Extend component wrapper helper and use on heading component ([PR #3519](https://github.com/alphagov/govuk_publishing_components/pull/3519))
 * Remove licence-finder from list of audited applications ([PR #3518](https://github.com/alphagov/govuk_publishing_components/pull/3518))
 * Fix inconsistent focus state on document list component ([PR #3468](https://github.com/alphagov/govuk_publishing_components/pull/3468))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
@@ -199,14 +199,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   Ga4ScrollTracker.Percentage.prototype.getTrackingNodes = function (trackedNodes) {
     var body = document.body
     var html = document.documentElement
-    var pageHeight = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight)
+    // remove 20px from the calculated page height to allow for a possible horizontal scrollbar
+    var pageHeight = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight) - 20
 
     var percentDetails = []
 
     for (var i = 0; i < this.config.percentages.length; i++) {
       var percent = this.config.percentages[i]
-      // subtract 1 pixel to solve a bug where 100% can't be reached in some cases
-      var pos = ((pageHeight / 100) * percent) - 1
+      var pos = ((pageHeight / 100) * percent)
       var alreadySeen = false
       if (trackedNodes.length) {
         alreadySeen = trackedNodes[i].alreadySeen

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
@@ -198,7 +198,7 @@ describe('GA4 scroll tracker', function () {
     })
 
     it('should send a tracking event on page load for positions that are already visible', function () {
-      setPageHeight(10)
+      setPageHeight(window.innerHeight)
 
       expect(window.dataLayer.length).toEqual(5)
 


### PR DESCRIPTION
## What
Fix a problem with the scroll tracker, specifically:

- in some cases the percentage scroll mode doesn't work for the 100% scroll position
- I think this is being caused by the potential for a horizontal scrollbar, so the cleanest solution is to subtract 20px from the overall calculated page height prior to percentage position calculation, making all of the percentage positions very slightly further up the page, but allowing the 100% position to be reachable in all tested scenarios

Thanks to @AshGDS for his invaluable help in figuring out this problem 👏 

## Why
Sometimes the 100% scroll track event doesn't fire, because even if you're at the bottom of the page the calculated 100% position is slightly further away, and unreachable.

## Visual Changes
None.

