### PR TITLE
Add GA4 pageview meta tag: ab_test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add GA4 pageview meta tag: ab_test ([PR #3523](https://github.com/alphagov/govuk_publishing_components/pull/3523))
+
 ## 35.13.0
 
 * Fix 100% scroll problem ([PR #3521](https://github.com/alphagov/govuk_publishing_components/pull/3521))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -21,6 +21,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             title: this.getTitle(),
             status_code: this.getStatusCode(),
 
+            ab_test: this.getMetaContent('ab-test'),
             document_type: this.getMetaContent('format'),
             publishing_app: this.getMetaContent('publishing-app'),
             rendering_app: this.getMetaContent('rendering-app'),

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -21,6 +21,7 @@ describe('Google Tag Manager page view tracking', function () {
         title: 'This here page',
         status_code: '200',
 
+        ab_test: undefined,
         document_type: undefined,
         publishing_app: undefined,
         rendering_app: undefined,
@@ -379,5 +380,12 @@ describe('Google Tag Manager page view tracking', function () {
 
       expect(window.dataLayer[0]).toEqual(expected)
     })
+  })
+
+  it('correctly sets the ab-test parameter', function () {
+    createMetaTags('ab-test', 'BankHolidaysTest:A')
+    expected.page_view.ab_test = 'BankHolidaysTest:A'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
   })
 })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds `ab_test` value to the GA4 Pageview
- Not sure if I've put it in the right 'place' in the object (as I can see attributes are being grouped via line breaks)
- Not sure if the test is overkill

## Why
<!-- What are the reasons behind this change being made? -->
- Requested by PAs
- https://trello.com/c/3LnlkGK0/630-page-view-enhancement-new-abtest-attribute

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
