### PR TITLE
Version 35.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.13.0
 
 * Fix 100% scroll problem ([PR #3521](https://github.com/alphagov/govuk_publishing_components/pull/3521))
 * Extend component wrapper helper and use on heading component ([PR #3519](https://github.com/alphagov/govuk_publishing_components/pull/3519))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.12.0)
+    govuk_publishing_components (35.13.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.12.0".freeze
+  VERSION = "35.13.0".freeze
 end


### PR DESCRIPTION
## 35.13.0

* Fix 100% scroll problem ([PR #3521](https://github.com/alphagov/govuk_publishing_components/pull/3521))
* Extend component wrapper helper and use on heading component ([PR #3519](https://github.com/alphagov/govuk_publishing_components/pull/3519))
* Remove licence-finder from list of audited applications ([PR #3518](https://github.com/alphagov/govuk_publishing_components/pull/3518))
* Fix inconsistent focus state on document list component ([PR #3468](https://github.com/alphagov/govuk_publishing_components/pull/3468))
* Render an outline for search button and input in Windows high contrast mode ([PR #3502](https://github.com/alphagov/govuk_publishing_components/pull/3502))
