### PR TITLE
Add bundleIndexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add GA4 pageview meta tag: ab_test ([PR #3523](https://github.com/alphagov/govuk_publishing_components/pull/3523))
+* Add bundleIndexes ([PR #3528](https://github.com/alphagov/govuk_publishing_components/pull/3528))
 
 ## 35.13.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -249,6 +249,24 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
         }
       },
 
+      bundleIndexes: function (groupNumber, module) {
+        var indexGroups = window.GOVUK.analyticsGa4.vars.indexGroups
+
+        if (typeof parseInt(groupNumber) === 'number' && !isNaN(groupNumber)) {
+          var indexGroupLinks = document.querySelectorAll('[data-ga4-index-group-number="' + groupNumber + '"] a')
+          var ga4LinkData = JSON.parse(module.getAttribute('data-ga4-link'))
+          ga4LinkData.index_total = indexGroupLinks.length
+          module.setAttribute('data-ga4-link', JSON.stringify(ga4LinkData))
+
+          if (!Object.prototype.hasOwnProperty.call(indexGroups, 'groupNumber' + groupNumber)) {
+            indexGroups['groupNumber' + groupNumber] = indexGroupLinks
+            for (var i = 0; i < indexGroupLinks.length; i++) {
+              indexGroups['groupNumber' + groupNumber][i].setAttribute('data-ga4-index', '{"index_link": ' + (i + 1) + '}')
+            }
+          }
+        }
+      },
+
       applyRedactionIfRequired: function (PIIRemover, element, data) {
         return element.closest('[data-ga4-do-not-redact]') ? data : PIIRemover.stripPIIWithOverride(data, true, true)
       }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -37,6 +37,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       if (this.module.hasAttribute('data-ga4-set-indexes')) {
         window.GOVUK.analyticsGa4.core.trackFunctions.setIndexes(this.module)
       }
+      if (this.module.hasAttribute('data-ga4-index-group-number')) {
+        window.GOVUK.analyticsGa4.core.trackFunctions.bundleIndexes(this.module.getAttribute('data-ga4-index-group-number'), this.module)
+      }
     }
   }
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/init-ga4.js
@@ -8,6 +8,9 @@ var initFunction = function () {
     window.GOVUK.analyticsGa4.vars.internalDomains = []
     window.GOVUK.analyticsGa4.vars.internalDomains.push(window.GOVUK.analyticsGa4.core.trackFunctions.getHostname())
     window.GOVUK.analyticsGa4.core.trackFunctions.appendDomainsWithoutWWW(window.GOVUK.analyticsGa4.vars.internalDomains)
+    if (document.querySelectorAll('[data-ga4-index-group-number]').length > 0) {
+      window.GOVUK.analyticsGa4.vars.indexGroups = {}
+    }
     window.GOVUK.analyticsGa4.core.load()
 
     var analyticsModules = window.GOVUK.analyticsGa4.analyticsModules


### PR DESCRIPTION
## What
This PR adds the `bundleIndexes` function - the purpose of this function is to combine index properties of links that appear in different modules. For example, on [finder pages](https://www.gov.uk/search/all), there are `Subscribe to feed` links at the top and bottom of the page. From an PA perspective, these links are related but because they appear in different modules, the index properties are not combined (e.g. the index properties are `{index: index_link: 1, index_total: 1}` on both links rather than `{index: index_link: 1/2, index_total: 2}`).

`bundleIndexes` addresses this by combining the index properties of all links that appear inside a module with a `data-ga4-index-group-number` attribute.

## How it works
Firstly, when our GA4 code is initialised in `init-ga4.js`, we look for any elements that have a `data-ga4-index-group-number` attribute. If it finds any, it creates an empty object called `indexGroups` on the `window.GOVUK.analyticsGa4.vars` object.

Secondly, when a link tracker module is initialised, it checks if it has a `data-ga4-index-group-number` attribute. If it does, it calls `window.GOVUK.analyticsGa4.core.trackFunctions.bundleIndexes` and passes the value of `data-ga4-index-group-number` (for the purposes of this example, this will be 1) and the module itself.

Thirdly, `bundleIndexes` combines the index properties of links that occur in modules that share the same `data-ga4-index-group-number` (in this case 1):

- the first thing `bundleIndexes` does is to check that `data-ga4-index-group-number` is a number
- if so, it finds all the links that occur within modules that have `data-ga4-index-group-number=1` 
- it sets the `index_total` on the module's `data-ga4-link` attribute to include all links that have `data-ga4-index-group-number=1` on their parent module, not just links in the module itself
- then it sets `data-ga4-index` on individual links in the index group:
    - firstly, it checks that `window.GOVUK.analyticsGa4.vars.indexGroups` does not already have a property for that group (this is to prevent the code from running multiple times as we only want to run it once per index group)
    - if not, it adds the group to the object and loops through the links to apply the appropriate index

Each module with a `data-ga4-index-group-number` attribute should now have an `index_total` that amounts to all the links that occur within modules that share the same `data-ga4-index-group-number` and each individual link should have a `link_index` which is equal to the `link_index` they'd have if they all were in the same module.

## Why
GA4 migration bug fix - [trello card](https://trello.com/c/kBakyMMc/613-fix-index-on-subscribe-to-feed-interaction)

## Visual Changes
N/A
