### PR TITLE
Add navigation-page-type GA4 pageview attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Add navigation-page-type GA4 pageview attribute ([PR #3529](https://github.com/alphagov/govuk_publishing_components/pull/3529))
+
 ## 35.13.1
 
 * Add GA4 pageview meta tag: ab_test ([PR #3523](https://github.com/alphagov/govuk_publishing_components/pull/3523))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -29,6 +29,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             content_id: this.getMetaContent('content-id'),
 
             browse_topic: this.getMetaContent('section'),
+            navigation_page_type: this.getMetaContent('navigation-page-type'),
             taxonomy_level1: this.getMetaContent('themes'),
             taxonomy_main: this.getMetaContent('taxon-slug'),
             taxonomy_main_id: this.getMetaContent('taxon-id'),

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -29,6 +29,7 @@ describe('Google Tag Manager page view tracking', function () {
         content_id: undefined,
 
         browse_topic: undefined,
+        navigation_page_type: undefined,
         taxonomy_main: undefined,
         taxonomy_main_id: undefined,
         taxonomy_level1: undefined,
@@ -385,6 +386,13 @@ describe('Google Tag Manager page view tracking', function () {
   it('correctly sets the ab-test parameter', function () {
     createMetaTags('ab-test', 'BankHolidaysTest:A')
     expected.page_view.ab_test = 'BankHolidaysTest:A'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('correctly sets the navigation-type parameter', function () {
+    createMetaTags('navigation-page-type', 'Browse level 2')
+    expected.page_view.navigation_page_type = 'Browse level 2'
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
     expect(window.dataLayer[0]).toEqual(expected)
   })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds `navigation_page_type` attribute to the GA4 Pageview object

## Why
<!-- What are the reasons behind this change being made? -->
- Requested by the PAs
- Trello card: https://trello.com/c/mqBb4kQ4/631-page-view-enhancement-new-navigationpagetype-attribute

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
