### PR TITLE
Version 35.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+## 35.14.0
+
 * Add GA4 pageview meta tag: ab_test ([PR #3523](https://github.com/alphagov/govuk_publishing_components/pull/3523))
 * Wrap the text of `start` buttons in a `span` ([PR #3478](https://github.com/alphagov/govuk_publishing_components/pull/3478))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.13.0)
+    govuk_publishing_components (35.14.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.13.0".freeze
+  VERSION = "35.14.0".freeze
 end


### PR DESCRIPTION
## 35.14.0

* Add GA4 pageview meta tag: ab_test ([PR #3523](https://github.com/alphagov/govuk_publishing_components/pull/3523))
* Wrap the text of `start` buttons in a `span` ([PR #3478](https://github.com/alphagov/govuk_publishing_components/pull/3478))
