### PR TITLE
Add section attribute to scroll tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add section attribute to scroll tracking ([PR #3537](https://github.com/alphagov/govuk_publishing_components/pull/3537))
 * Add navigation-page-type GA4 pageview attribute ([PR #3529](https://github.com/alphagov/govuk_publishing_components/pull/3529))
 
 ## 35.13.1

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
@@ -115,6 +115,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         data.type = node.eventData.type
         // following will be undefined if tracking percentages
         data.text = node.eventData.text
+        data.section = node.eventData.text
         data.index = node.eventData.index
         // following will be undefined if tracking headings
         data.percent_scrolled = node.eventData.percent_scrolled

--- a/docs/analytics-ga4/ga4-scroll-tracker.md
+++ b/docs/analytics-ga4/ga4-scroll-tracker.md
@@ -55,6 +55,7 @@ When tracking headings, the following data will be pushed to the dataLayer.
       index_section_count: 5 // total number of headings being tracked
     },
     text: "Text of heading",
+    section: "Text of heading",
     type: "heading"
   }
 }
@@ -96,6 +97,7 @@ When tracking markers, the following data will be pushed to the dataLayer.
       index_section_count: 2 // total number of markers being tracked
     },
     text: "Some content",
+    section: "Some content",
     type: "marker"
   }
 }

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
@@ -101,6 +101,7 @@ describe('GA4 scroll tracker', function () {
 
     it('should send a tracking event on initialisation for headings that are already visible', function () {
       expected.event_data.text = 'Heading 1'
+      expected.event_data.section = 'Heading 1'
       expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
     })
@@ -114,6 +115,7 @@ describe('GA4 scroll tracker', function () {
     it('should track headings on scroll and ignore already tracked headings', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
+      expected.event_data.section = 'Heading 1'
       expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
 
@@ -124,6 +126,7 @@ describe('GA4 scroll tracker', function () {
 
       expect(window.dataLayer.length).toEqual(2)
       expected.event_data.text = 'Heading 3'
+      expected.event_data.section = 'Heading 3'
       expected.event_data.index.index_section = 3
       expect(window.dataLayer[1]).toEqual(expected)
     })
@@ -131,6 +134,7 @@ describe('GA4 scroll tracker', function () {
     it('should track newly visible headings on scroll and ignore already tracked headings', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
+      expected.event_data.section = 'Heading 1'
       expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
 
@@ -140,6 +144,7 @@ describe('GA4 scroll tracker', function () {
       jasmine.clock().tick(200)
 
       expected.event_data.text = 'Heading 2'
+      expected.event_data.section = 'Heading 2'
       expected.event_data.index.index_section = 2
       expect(window.dataLayer[1]).toEqual(expected)
       expect(window.dataLayer.length).toEqual(2)
@@ -148,6 +153,7 @@ describe('GA4 scroll tracker', function () {
     it('should track when the body height changes', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
+      expected.event_data.section = 'Heading 1'
       expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
 
@@ -158,6 +164,7 @@ describe('GA4 scroll tracker', function () {
 
       expect(window.dataLayer.length).toEqual(2)
       expected.event_data.text = 'Heading 3'
+      expected.event_data.section = 'Heading 3'
       expected.event_data.index.index_section = 3
       expect(window.dataLayer[1]).toEqual(expected)
 
@@ -167,6 +174,7 @@ describe('GA4 scroll tracker', function () {
     it('should not track headings wrapped in ignored elements', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
+      expected.event_data.section = 'Heading 1'
       expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
 
@@ -284,6 +292,7 @@ describe('GA4 scroll tracker', function () {
 
     it('should send a tracking event on initialisation for headings that are already visible', function () {
       expected.event_data.text = 'Heading 1'
+      expected.event_data.section = 'Heading 1'
       expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
     })
@@ -297,6 +306,7 @@ describe('GA4 scroll tracker', function () {
     it('should track headings on scroll and ignore already tracked headings', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
+      expected.event_data.section = 'Heading 1'
       expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
 
@@ -307,6 +317,7 @@ describe('GA4 scroll tracker', function () {
 
       expect(window.dataLayer.length).toEqual(2)
       expected.event_data.text = 'Heading 3'
+      expected.event_data.section = 'Heading 3'
       expected.event_data.index.index_section = 3
       expect(window.dataLayer[1]).toEqual(expected)
     })
@@ -314,6 +325,7 @@ describe('GA4 scroll tracker', function () {
     it('should track newly visible headings on scroll and ignore already tracked headings', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
+      expected.event_data.section = 'Heading 1'
       expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
 
@@ -323,6 +335,7 @@ describe('GA4 scroll tracker', function () {
       jasmine.clock().tick(200)
 
       expected.event_data.text = 'Heading 2'
+      expected.event_data.section = 'Heading 2'
       expected.event_data.index.index_section = 2
       expect(window.dataLayer[1]).toEqual(expected)
       expect(window.dataLayer.length).toEqual(2)
@@ -331,6 +344,7 @@ describe('GA4 scroll tracker', function () {
     it('should track when the body height changes', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
+      expected.event_data.section = 'Heading 1'
       expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
 
@@ -341,6 +355,7 @@ describe('GA4 scroll tracker', function () {
 
       expect(window.dataLayer.length).toEqual(2)
       expected.event_data.text = 'Heading 3'
+      expected.event_data.section = 'Heading 3'
       expected.event_data.index.index_section = 3
       expect(window.dataLayer[1]).toEqual(expected)
 
@@ -350,6 +365,7 @@ describe('GA4 scroll tracker', function () {
     it('should not track headings wrapped in ignored elements', function () {
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
+      expected.event_data.section = 'Heading 1'
       expected.event_data.index.index_section = 1
       expect(window.dataLayer[0]).toEqual(expected)
 
@@ -397,6 +413,7 @@ describe('GA4 scroll tracker', function () {
 
       expect(window.dataLayer.length).toEqual(1)
       expected.event_data.text = 'Heading 1'
+      expected.event_data.section = 'Heading 1'
       expected.event_data.type = 'heading'
       expected.event_data.index.index_section = 1
       expected.event_data.index.index_section_count = 2


### PR DESCRIPTION
## What
Section attribute when tracking headings and markers should contain the same value as text, was missed during original implementation.

## Why
Part of the GA4 migration.

## Visual Changes
None.

Trello card: https://trello.com/c/BEPuXcrG/607-scroll-tracking-heading-type-home-page

