### PR TITLE
Fix select width overlap bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix select width overlap bug ([PR #3538](https://github.com/alphagov/govuk_publishing_components/pull/3538))
 * Add section attribute to scroll tracking ([PR #3537](https://github.com/alphagov/govuk_publishing_components/pull/3537))
 * Add navigation-page-type GA4 pageview attribute ([PR #3529](https://github.com/alphagov/govuk_publishing_components/pull/3529))
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_select.scss
@@ -2,5 +2,6 @@
 @import "govuk/components/select/select";
 
 .gem-c-select__select--full-width {
-  width: 100%;
+  min-width: 100%;
+  max-width: 100%;
 }


### PR DESCRIPTION
## What / why
Adjust the select component 'full width' styling to fix a problem.

- where the full width option is used in a confined space, the select element can extend outside of the width of the containing element
- noticed on [topic filters on search pages](https://www.gov.uk/search/all?keywords=minister&level_one_taxon=d6c2de5d-ef90-45d1-82d4-5f2438369eea&order=relevance)

Tested in Edge, IE11, Chrome, Firefox, Opera, Safari.

## Visual Changes

Before | After
------ | -------
![Screenshot 2023-08-03 at 15 50 34](https://github.com/alphagov/govuk_publishing_components/assets/861310/7faa030a-3078-4235-89ef-cbdff028c014) | ![Screenshot 2023-08-03 at 15 50 41](https://github.com/alphagov/govuk_publishing_components/assets/861310/e99b0575-6728-4e1f-87e7-cf16d0e68e0e)


Fixes https://github.com/alphagov/govuk_publishing_components/issues/3525
