### PR TITLE
Fix row spacing on topics browse pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Redact GA params from pageview data ([PR #3568](https://github.com/alphagov/govuk_publishing_components/pull/3568))
 * Add GA4 tracking to devolved nations banners ([PR #3556](https://github.com/alphagov/govuk_publishing_components/pull/3556))
 * Add GA4 tracking to the cookie banner ([PR #3564](https://github.com/alphagov/govuk_publishing_components/pull/3564))
+* Fix row spacing on topics browse pages ([PR #3540](https://github.com/alphagov/govuk_publishing_components/pull/3540))
 
 ## 35.14.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_cards.scss
@@ -13,11 +13,8 @@
   margin: 0 govuk-spacing(-3);
 
   display: grid;
-  grid-auto-flow: row;
-  // Use CSS grid to calculate the number of rows
-  grid-template-rows: auto;
-  // Use the tallest cell in the grid to set the height for all rows
-  grid-auto-rows: fractions(1);
+  grid-auto-flow: row;   // Use CSS grid to calculate the number of rows
+  grid-auto-rows: fractions(1); // Set all rows to same fractional height of the complete grid
   grid-template-columns: fractions(1);
 
   @include govuk-media-query($from: "tablet") {


### PR DESCRIPTION
## What
The existing grid setup forced every row to be the same height as the tallest row. But this causes large gaps of whitespace if one content item is larger than all the others, and a peculiar behaviour for the first row where it would always collapse, leaving row heights inconsistent.

Removing `grid-template-rows: auto` prevents the first row collapsing and removes the whitespace anomalies for the other rows.

Note that this change also requires guidance to be provided for content authors to ensure that each content item is of similar length which helps keeps the row heights consistent.

[Trello Link](https://trello.com/c/z4SoPSlt/1883-spacing-bug-on-some-browse-pages)

## Why
After reviewing the usage of the grid, designers and content authors preferred to fix the presentation of rows to be consistently the same height., rather than the current behaviour.

## How

I've tested this using my local instance of the gem running in my local `collections` app and the changes look fine. 

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

![image](https://github.com/alphagov/govuk_publishing_components/assets/2166204/5401a091-2840-4c9b-b374-5de08a7b24fe)

### After

![image](https://github.com/alphagov/govuk_publishing_components/assets/2166204/81c746f1-86e6-4e77-a5fc-367a3881e512)

