### PR TITLE
Adjust core functions setIndexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Adjust core functions setIndexes ([PR #3541](https://github.com/alphagov/govuk_publishing_components/pull/3541))
 * Fix select width overlap bug ([PR #3538](https://github.com/alphagov/govuk_publishing_components/pull/3538))
 * Add section attribute to scroll tracking ([PR #3537](https://github.com/alphagov/govuk_publishing_components/pull/3537))
 * Add navigation-page-type GA4 pageview attribute ([PR #3529](https://github.com/alphagov/govuk_publishing_components/pull/3529))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -241,7 +241,8 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
 
         try {
           var ga4LinkData = JSON.parse(module.getAttribute('data-ga4-link'))
-          ga4LinkData.index_total = totalLinks
+          // use index_total if it already exists, otherwise calculate it and set it
+          ga4LinkData.index_total = ga4LinkData.index_total || totalLinks
           module.setAttribute('data-ga4-link', JSON.stringify(ga4LinkData))
         } catch (e) {
           // if there's a problem with the config, don't start the tracker

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -312,6 +312,17 @@ describe('GA4 core', function () {
           expect(linkIndex).toEqual('{"index_link": ' + (i + 1) + '}')
         }
       })
+
+      it('allows the index_total to be set manually in rare circumstances', function () {
+        var data = JSON.parse(module.getAttribute('data-ga4-link'))
+        expect(data.index_total).toEqual(5)
+
+        module.setAttribute('data-ga4-link', '{"someData": "blah", "index_total": 9000}')
+        GOVUK.analyticsGa4.core.trackFunctions.setIndexes(module)
+
+        data = JSON.parse(module.getAttribute('data-ga4-link'))
+        expect(data.index_total).toEqual(9000)
+      })
     })
 
     describe('when the data-ga4-set-indexes attribute exists on a module that contains search results or links with a data-ga4-do-not-index attribute', function () {


### PR DESCRIPTION
## What
- allow an index_total to be set and collected, to override a calculated index_total, normally determined by the number of links found in the element
- used in a rare situation on taxon pages where we want to use the setIndexes functionality but also need to adjust the index_total to account for an extra link

## Why
See related PR.

## Visual Changes
None.

Trello card: https://trello.com/c/DqMNdDNz/652-change-type-of-explore-sub-topics-links-to-subtopic-list