### PR TITLE
Update the documentation for loading component stylesheets individually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix select width overlap bug ([PR #3538](https://github.com/alphagov/govuk_publishing_components/pull/3538))
 * Add section attribute to scroll tracking ([PR #3537](https://github.com/alphagov/govuk_publishing_components/pull/3537))
 * Add navigation-page-type GA4 pageview attribute ([PR #3529](https://github.com/alphagov/govuk_publishing_components/pull/3529))
+* Update the documentation for loading component stylesheets individually ([PR #3543](https://github.com/alphagov/govuk_publishing_components/pull/3543))
 
 ## 35.13.1
 


### PR DESCRIPTION
## What

Update the documentation for loading component stylesheets individually:

- Update heading levels
- Change example PR from `frontend` to `government-frontend`, this change was done later and is a better example
- Remove reference to stylesheets loading in alphabetical order, this is no longer the case
- Update section on "Increased header size" and add links to relevant docs

## Why

Ensure documentation is accurate