### PR TITLE
Add a reset option into the GA4 scrolltracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add a reset option into the GA4 scrolltracker ([PR #3544](https://github.com/alphagov/govuk_publishing_components/pull/3544))
 * Adjust core functions setIndexes ([PR #3541](https://github.com/alphagov/govuk_publishing_components/pull/3541))
 * GA4 pageview changes ([PR #3542](https://github.com/alphagov/govuk_publishing_components/pull/3542))
 * Fix select width overlap bug ([PR #3538](https://github.com/alphagov/govuk_publishing_components/pull/3538))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
@@ -60,6 +60,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       window.addEventListener('scroll', this.scrollEvent)
       this.resizeEvent = this.onResize.bind(this)
       window.addEventListener('resize', this.resizeEvent)
+      this.resetEvent = this.onReset.bind(this)
+      window.addEventListener('dynamic-page-update', this.resetEvent)
 
       // check if the page height changes e.g. accordion opened
       this.interval = window.setInterval(function () {
@@ -130,6 +132,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   Ga4ScrollTracker.prototype.isVisible = function (top, bottom) {
     var scroll = window.scrollY || document.documentElement.scrollTop // IE fallback
     return scroll <= top && (scroll + this.windowHeight) >= bottom
+  }
+
+  // if reset, we set all nodes 'alreadySeen' to false
+  // used when the page content is dynamically updated e.g. search
+  Ga4ScrollTracker.prototype.onReset = function () {
+    for (var i = 0; i < this.trackedNodes.length; i++) {
+      this.trackedNodes[i].alreadySeen = false
+    }
   }
 
   Ga4ScrollTracker.Heading = function (config) {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.spec.js
@@ -51,6 +51,7 @@ describe('GA4 scroll tracker', function () {
   function stopComponent (tracker) {
     window.removeEventListener('scroll', tracker.scrollEvent)
     window.removeEventListener('resize', tracker.resizeEvent)
+    window.removeEventListener('dynamic-page-update', tracker.resetEvent)
     clearInterval(tracker.interval)
   }
 
@@ -184,6 +185,14 @@ describe('GA4 scroll tracker', function () {
 
       expect(window.dataLayer.length).toEqual(1)
     })
+
+    it('should reset alreadyFound nodes when a dynamic page update event occurs', function () {
+      expect(scrollTracker.trackedNodes[0].alreadySeen).toEqual(true)
+      GOVUK.triggerEvent(document.body, 'dynamic-page-update')
+      for (var i = 0; i < scrollTracker.trackedNodes.length; i++) {
+        expect(scrollTracker.trackedNodes[i].alreadySeen).toEqual(false)
+      }
+    })
   })
 
   describe('when tracking by percentage scrolled', function () {
@@ -241,6 +250,18 @@ describe('GA4 scroll tracker', function () {
       expect(window.dataLayer[3]).toEqual(expected)
       expected.event_data.percent_scrolled = '100'
       expect(window.dataLayer[4]).toEqual(expected)
+    })
+
+    it('should reset alreadyFound nodes when a dynamic page update event occurs', function () {
+      // change the page height to begin with to set some nodes to alreadySeen true
+      setPageHeight(10)
+      var height = window.innerHeight
+      setPageHeight(height * 4)
+      expect(scrollTracker.trackedNodes[0].alreadySeen).toEqual(true)
+      GOVUK.triggerEvent(document.body, 'dynamic-page-update')
+      for (var i = 0; i < scrollTracker.trackedNodes.length; i++) {
+        expect(scrollTracker.trackedNodes[i].alreadySeen).toEqual(false)
+      }
     })
 
     function setPageHeight (height) {


### PR DESCRIPTION
## What
- code adds an event listener for 'dynamic-page-update' event, which resets all of the nodes to alreadySeen = false
- this event can then be triggered by code elsewhere, in order to 'reset' scroll tracking on any given page
- initial use is for search pages, where users change their search filters, page dynamically updates and so scroll tracking only works the first time, now if the search code triggers that event, the scroll tracker will reset

## Why
Scroll tracking works correctly on search pages until users change their filters. At that point the user is effectively on a new page (content and URL change) and we want the scroll tracking to 'reset' (i.e. if the user has scrolled to the bottom of the page previously, we want to also record that happened after the search filters are changed). Unfortunately because the page was updated dynamically using JS, the scroll tracker still thinks its on the same page, and therefore doesn't register GA4 events when users scroll. This PR fixes that - a related PR will be raised in `finder-frontend` to add to required event trigger.

## Visual Changes
None.

Trello card: https://trello.com/c/fhnLqnKw/669-scroll-tracker-to-refresh-on-dynamic-pages
