### PR TITLE
Add GA4 tracking to the emergency banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add GA4 tracking to the emergency banner ([PR #3549](https://github.com/alphagov/govuk_publishing_components/pull/3549))
+
 ## 35.13.2
 
 * Add a reset option into the GA4 scrolltracker ([PR #3544](https://github.com/alphagov/govuk_publishing_components/pull/3544))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -53,7 +53,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             /* The existence of a referrer parameter indicates that the page has been dynamically updated via an AJAX request
             and therefore we can use it to set the dynamic property appropriately. This value is used by PA's to differentiate
             between fresh page loads and dynamic page updates. */
-            dynamic: referrer ? 'true' : 'false'
+            dynamic: referrer ? 'true' : 'false',
+            emergency_banner: document.querySelector('[data-ga4-emergency-banner]') ? 'true' : undefined
           }
         }
         window.GOVUK.analyticsGa4.core.sendData(data)

--- a/app/views/govuk_publishing_components/components/_emergency_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_emergency_banner.html.erb
@@ -7,6 +7,7 @@
   link_text ||= "More information"
   campaign_class ||= nil
   homepage ||= false
+  ga4_tracking ||= false
 
   emergency_banner_helper = GovukPublishingComponents::Presenters::EmergencyBannerHelper.new()
 
@@ -28,9 +29,25 @@
   description_classes = %w[gem-c-emergency-banner__description]
   description_classes << "gem-c-emergency-banner__description--homepage" if homepage
 
+
+  data_attributes = {
+    "nosnippet": true,
+  }
+
+  if ga4_tracking
+    data_attributes[:ga4_emergency_banner] = ""
+    data_attributes[:module] = "ga4-link-tracker"
+    data_attributes[:ga4_track_links_only] = ""
+    data_attributes[:ga4_set_indexes] = ""
+    data_attributes[:ga4_link] = {
+      event_name: "navigation",
+      type: "emergency banner",
+      section: heading,
+    }.to_json
+  end
 %>
 
-<%= content_tag('section', class: banner_classes, "aria-labelledby": "emergency-banner-heading", "data-nosnippet": true ) do %>
+<%= content_tag('section', class: banner_classes, "aria-labelledby": "emergency-banner-heading", data: data_attributes) do %>
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/govuk_publishing_components/components/docs/emergency_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/emergency_banner.yml
@@ -45,3 +45,13 @@ examples:
       short_description: "1491 to 1547"
       link: "https://www.gov.uk/"
       homepage: true
+  with_ga4_tracking:
+    description: |
+      Enables GA4 tracking on the banner. This includes link tracking on the component itself, and allows pageviews to record the presence of the banner on page load.
+    data:
+      campaign_class: "notable-death"
+      heading: "His Royal Highness Henry VIII"
+      short_description: "1491 to 1547"
+      link: "https://www.gov.uk/"
+      homepage: true
+      ga4_tracking: true

--- a/spec/components/emergency_banner_spec.rb
+++ b/spec/components/emergency_banner_spec.rb
@@ -13,6 +13,7 @@ describe "Emergency Banner", type: :view do
       link: options[:link],
       link_text: options[:link_text],
       homepage: options[:homepage],
+      ga4_tracking: options[:ga4_tracking],
     }
   end
 
@@ -76,5 +77,14 @@ describe "Emergency Banner", type: :view do
     id = css_select(".gem-c-emergency-banner h2")[0][:id]
     # check that the aria-labelledby points to that header using the header id
     assert_select(".gem-c-emergency-banner[aria-labelledby='#{id}']")
+  end
+
+  it "renders banner with ga4 attributes" do
+    render_component(emergency_banner_attributes({ campaign_class: "notable-death", ga4_tracking: true }))
+    assert_select ".gem-c-emergency-banner[data-ga4-emergency-banner]"
+    assert_select ".gem-c-emergency-banner[data-module=ga4-link-tracker]"
+    assert_select ".gem-c-emergency-banner[data-ga4-track-links-only]"
+    assert_select ".gem-c-emergency-banner[data-ga4-set-indexes]"
+    assert_select ".gem-c-emergency-banner[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"emergency banner\",\"section\":\"His Royal Highness Henry VIII\"}']"
   end
 end

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -50,7 +50,8 @@ describe('Google Tag Manager page view tracking', function () {
         organisations: undefined,
         world_locations: undefined,
 
-        dynamic: 'false'
+        dynamic: 'false',
+        emergency_banner: undefined
       }
     }
     window.dataLayer = []
@@ -411,5 +412,15 @@ describe('Google Tag Manager page view tracking', function () {
     expected.page_view.step_navs = 'e01e924b-9c7c-4c71-8241-66a575c2f61f'
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
     expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('correctly sets the emergency_banner parameter', function () {
+    var div = document.createElement('div')
+    div.setAttribute('data-ga4-emergency-banner', '')
+    document.body.appendChild(div)
+    expected.page_view.emergency_banner = 'true'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
+    document.body.removeChild(div)
   })
 })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds GA4 tracking to the emergency banner component.
- More specifically, it adds `emergency_banner: true` to the `pageview` if the emergency banner is rendered. It also adds the `ga4-link-tracker`. Both of these rely on `ga4_tracking: true` so we can toggle the tracking on and off on the banner.
- I've checked it in a local version of `static`, the `pageview` attribute is added correctly.

## Why
<!-- What are the reasons behind this change being made? -->
- https://trello.com/c/yH88Twnv/661-banners-emergency-banner-element-visibility-and-navigation

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

- It adds a "With GA4 tracking" to the component examples