### PR TITLE
Version 35.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.13.2
 
 * Add a reset option into the GA4 scrolltracker ([PR #3544](https://github.com/alphagov/govuk_publishing_components/pull/3544))
 * Expand GA4 form tracker ([PR #3546](https://github.com/alphagov/govuk_publishing_components/pull/3546))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.13.1)
+    govuk_publishing_components (35.13.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.13.1".freeze
+  VERSION = "35.13.2".freeze
 end


### PR DESCRIPTION
## 35.13.2

* Add a reset option into the GA4 scrolltracker ([PR #3544](https://github.com/alphagov/govuk_publishing_components/pull/3544))
* Expand GA4 form tracker ([PR #3546](https://github.com/alphagov/govuk_publishing_components/pull/3546))
* Adjust core functions setIndexes ([PR #3541](https://github.com/alphagov/govuk_publishing_components/pull/3541))
* GA4 pageview changes ([PR #3542](https://github.com/alphagov/govuk_publishing_components/pull/3542))
* Fix select width overlap bug ([PR #3538](https://github.com/alphagov/govuk_publishing_components/pull/3538))
* Add section attribute to scroll tracking ([PR #3537](https://github.com/alphagov/govuk_publishing_components/pull/3537))
* Add navigation-page-type GA4 pageview attribute ([PR #3529](https://github.com/alphagov/govuk_publishing_components/pull/3529))
* Update the documentation for loading component stylesheets individually ([PR #3543](https://github.com/alphagov/govuk_publishing_components/pull/3543))
* Add GA4 video tracking ([PR #3535](https://github.com/alphagov/govuk_publishing_components/pull/3535))
* Move GA4 attachment link tracking to all attachment links ([PR #3515](https://github.com/alphagov/govuk_publishing_components/pull/3515))

