### PR TITLE
Add version to component guide

### DIFF
--- a/app/views/layouts/govuk_publishing_components/application.html.erb
+++ b/app/views/layouts/govuk_publishing_components/application.html.erb
@@ -6,7 +6,7 @@
   <% else %>
     <%= render "govuk_publishing_components/components/layout_header", {
       environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
-      product_name: GovukPublishingComponents::Config.component_guide_title,
+      product_name: "#{GovukPublishingComponents::Config.component_guide_title} #{GovukPublishingComponents::VERSION}",
       href: component_guide_path
     } %>
     <div class="govuk-width-container app-width-container--wide">


### PR DESCRIPTION
## What
Adds the version number of the gem into the header of the component guide.

## Why
This is occasionally useful. For example when checking the [online version of the component guide](https://components.publishing.service.gov.uk/component-guide) to see if changes have been updated, or checking the version of the gem in a locally running application to see if it really is running what you think it's running.

## Visual Changes
Before | After
------ | -------
![Screenshot 2023-08-15 at 09 47 09](https://github.com/alphagov/govuk_publishing_components/assets/861310/734490d9-a406-423c-bd34-0c97323ad3ec) | ![Screenshot 2023-08-15 at 09 46 46](https://github.com/alphagov/govuk_publishing_components/assets/861310/11f360bd-f958-479a-895e-c86e8dccb645)
