### PR TITLE
Add GA4 tracking to the phase banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add GA4 tracking to the emergency banner ([PR #3549](https://github.com/alphagov/govuk_publishing_components/pull/3549))
 * Ensure file attachments have the GA4 event_name 'file_download' ([PR #3553](https://github.com/alphagov/govuk_publishing_components/pull/3553))
+* Add GA4 tracking to the phase banner ([PR #3552](https://github.com/alphagov/govuk_publishing_components/pull/3552))
 
 ## 35.13.2
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -54,7 +54,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             and therefore we can use it to set the dynamic property appropriately. This value is used by PA's to differentiate
             between fresh page loads and dynamic page updates. */
             dynamic: referrer ? 'true' : 'false',
-            emergency_banner: document.querySelector('[data-ga4-emergency-banner]') ? 'true' : undefined
+            emergency_banner: document.querySelector('[data-ga4-emergency-banner]') ? 'true' : undefined,
+            phase_banner: this.getElementAttribute('data-ga4-phase-banner') || undefined
           }
         }
         window.GOVUK.analyticsGa4.core.sendData(data)
@@ -89,6 +90,13 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
         return tag.getAttribute('content')
       } else {
         return this.nullValue
+      }
+    },
+
+    getElementAttribute: function (attributeName) {
+      var el = document.querySelector('[' + attributeName + ']')
+      if (el) {
+        return el.getAttribute(attributeName)
       }
     },
 

--- a/app/views/govuk_publishing_components/components/_phase_banner.html.erb
+++ b/app/views/govuk_publishing_components/components/_phase_banner.html.erb
@@ -5,6 +5,7 @@ app_name ||= nil
 phase ||= nil
 message ||= nil
 inverse ||= false
+ga4_tracking ||= false
 
 unless message.present?
   if phase == "beta"
@@ -16,9 +17,24 @@ end
 
 container_css_classes = %w(gem-c-phase-banner govuk-phase-banner)
 container_css_classes << "gem-c-phase-banner--inverse" if inverse
+
+data_attributes = {}
+
+if ga4_tracking
+  data_attributes[:ga4_phase_banner] = phase
+  data_attributes[:module] = "ga4-link-tracker"
+  data_attributes[:ga4_track_links_only] = ""
+  data_attributes[:ga4_set_indexes] = ""
+  data_attributes[:ga4_link] = {
+    event_name: "navigation",
+    type: "phase banner",
+    section: Nokogiri::HTML(message).text,
+  }.to_json
+end
+
 %>
 
-<%= tag.div class: container_css_classes do %>
+<%= tag.div class: container_css_classes, data: data_attributes do %>
   <%= tag.p class: "govuk-phase-banner__content" do %>
     <%= tag.strong app_name, class: "govuk-phase-banner__content__app-name" if app_name %>
     <%= tag.strong phase, class: "govuk-tag govuk-phase-banner__content__tag" if phase %>

--- a/app/views/govuk_publishing_components/components/docs/phase_banner.yml
+++ b/app/views/govuk_publishing_components/components/docs/phase_banner.yml
@@ -32,3 +32,11 @@ examples:
       app_name: Skittles Maker
       phase: beta
       inverse: true
+  with_ga4_tracking:
+    description: |
+      Enables GA4 tracking on the banner. This includes link tracking on the component itself, and allows pageviews to record the presence of the banner on page load.
+    data:
+      app_name: Skittles Maker
+      phase: beta
+      inverse: true
+      ga4_tracking: true

--- a/spec/components/phase_banner_spec.rb
+++ b/spec/components/phase_banner_spec.rb
@@ -40,4 +40,13 @@ describe "Phase banner", type: :view do
     render_component(phase: "beta", inverse: true)
     assert_select ".gem-c-phase-banner--inverse"
   end
+
+  it "renders banner with ga4 attributes" do
+    render_component(phase: "beta", ga4_tracking: true)
+    assert_select ".gem-c-phase-banner[data-ga4-phase-banner=beta]"
+    assert_select ".gem-c-phase-banner[data-module=ga4-link-tracker]"
+    assert_select ".gem-c-phase-banner[data-ga4-track-links-only]"
+    assert_select ".gem-c-phase-banner[data-ga4-set-indexes]"
+    assert_select ".gem-c-phase-banner[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"phase banner\",\"section\":\"This part of GOV.UK is being rebuilt – find out what beta means\"}']"
+  end
 end

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -51,7 +51,8 @@ describe('Google Tag Manager page view tracking', function () {
         world_locations: undefined,
 
         dynamic: 'false',
-        emergency_banner: undefined
+        emergency_banner: undefined,
+        phase_banner: undefined
       }
     }
     window.dataLayer = []
@@ -419,6 +420,16 @@ describe('Google Tag Manager page view tracking', function () {
     div.setAttribute('data-ga4-emergency-banner', '')
     document.body.appendChild(div)
     expected.page_view.emergency_banner = 'true'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
+    document.body.removeChild(div)
+  })
+
+  it('correctly sets the phase_banner parameter', function () {
+    var div = document.createElement('div')
+    div.setAttribute('data-ga4-phase-banner', 'beta')
+    document.body.appendChild(div)
+    expected.page_view.phase_banner = 'beta'
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
     expect(window.dataLayer[0]).toEqual(expected)
     document.body.removeChild(div)


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds GA4 tracking to the phase banner component.
- More specifically, it adds `phase_banner: alpha/beta/undefined` to the `pageview` if the phase banner is rendered. It grabs `alpha` `beta`  based on the value of the `data-ga4-phase-banner` attribute, for example: `data-ga4-phase-banner=beta`. This PR also adds the `ga4-link-tracker` to the banner. 
- Both of these rely on `ga4_tracking: true` so we can toggle the tracking on and off on the banner.
- I've checked it in a local version of `static`. The `pageview` attribute is added correctly fortunately (there was speculation in the implementation guide that this wouldn't be possible.) I believe this is working because our pageview fires after DOMContentLoaded so it doesn't matter where a banner is in the DOM.

## Why
<!-- What are the reasons behind this change being made? -->
- https://trello.com/c/d6CHHgco/663-banners-phase-banner-element-visibility-and-navigation

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

- It adds a "With GA4 tracking" to the component examples