### PR TITLE
Ensure file attachments have the GA4 event_name 'file_download'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add GA4 tracking to the emergency banner ([PR #3549](https://github.com/alphagov/govuk_publishing_components/pull/3549))
+* Ensure file attachments have the GA4 event_name 'file_download' ([PR #3553](https://github.com/alphagov/govuk_publishing_components/pull/3553))
 
 ## 35.13.2
 

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -11,6 +11,7 @@
 
   container_class_names = %w[gem-c-attachment govuk-!-display-none-print]
   container_class_names << shared_helper.get_margin_bottom if local_assigns.key?(:margin_bottom)
+  ga4_link = { 'event_name': 'navigation', 'type': 'attachment' }
 
   case attachment.type
   when "file"
@@ -38,6 +39,9 @@
         class: "gem-c-attachment__attribute",
       )
     end
+
+    ga4_link[:event_name] = 'file_download'
+
   when "html"
     attributes << tag.span(
       "HTML",
@@ -51,7 +55,7 @@
   end
 
 %>
-<%= tag.section class: class_names(container_class_names), data: { module: "ga4-link-tracker", ga4_track_links_only: "", ga4_link: { 'event_name': 'navigation', 'type': 'attachment' } } do %>
+<%= tag.section class: class_names(container_class_names), data: { module: "ga4-link-tracker", ga4_track_links_only: "", ga4_link: ga4_link } do %>
   <%= tag.div class: "gem-c-attachment__thumbnail" do %>
     <%= link_to attachment.url,
                 class: "govuk-link",

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -269,7 +269,7 @@ describe "Attachment", type: :view do
     assert_select '.gem-c-attachment:not([class*="govuk-!-margin-bottom-"])'
   end
 
-  it "includes GA4 tracking on attachment links by default" do
+  it "includes GA4 tracking on HTML attachment links by default" do
     render_component(
       attachment: {
         title: "Test",
@@ -281,6 +281,21 @@ describe "Attachment", type: :view do
 
     assert_select "section[data-module=ga4-link-tracker]"
     assert_select "section[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"attachment\"}']"
+    assert_select "section[data-ga4-track-links-only]"
+  end
+
+  it "includes GA4 tracking on file attachment links by default" do
+    render_component(
+      attachment: {
+        title: "Test",
+        url: "https://example.com",
+        filename: "test",
+        content_type: "application/pdf",
+      },
+    )
+
+    assert_select "section[data-module=ga4-link-tracker]"
+    assert_select "section[data-ga4-link='{\"event_name\":\"file_download\",\"type\":\"attachment\"}']"
     assert_select "section[data-ga4-track-links-only]"
   end
 end


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
I mistakenly tracked file attachments with `event_name: navigation` when they need `event_name: file_download`. This PR fixes that.

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/MHFXw6H2/552-change-filedownloads-on-attachment-pages-to-have-attachment-instead-of-generic-download-type#comment-64db9a3327d6c9305d38c4e7

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.