### PR TITLE
Use replace() instead of replaceAll() in removeCrossDomainParams() 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add GA4 tracking to the emergency banner ([PR #3549](https://github.com/alphagov/govuk_publishing_components/pull/3549))
 * Ensure file attachments have the GA4 event_name 'file_download' ([PR #3553](https://github.com/alphagov/govuk_publishing_components/pull/3553))
 * Add GA4 tracking to the phase banner ([PR #3552](https://github.com/alphagov/govuk_publishing_components/pull/3552))
+* Use replace() instead of replaceAll() in removeCrossDomainParams() ([PR #3555](https://github.com/alphagov/govuk_publishing_components/pull/3555))
 
 ## 35.13.2
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -169,10 +169,10 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
       removeCrossDomainParams: function (href) {
         if (href.indexOf('_ga') !== -1 || href.indexOf('_gl') !== -1) {
           // _ga & _gl are values needed for cross domain tracking, but we don't want them included in our click tracking.
-          href = href.replaceAll(/_g[al]=([^&]*)/g, '')
+          href = href.replace(/_g[al]=([^&]*)/g, '')
 
           // The following code cleans up inconsistencies such as gov.uk/&&, gov.uk/?&hello=world, gov.uk/?, and gov.uk/&.
-          href = href.replaceAll(/(&&)+/g, '&')
+          href = href.replace(/(&&)+/g, '&')
           href = href.replace('?&', '?')
           if (this.stringEndsWith(href, '?') || this.stringEndsWith(href, '&')) {
             href = href.substring(0, href.length - 1)


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Change `replaceAll()` to `replace()` in GA4 link tracker's `removeCrossDomainParams` function.

## Why
<!-- What are the reasons behind this change being made? -->
- `replaceAll()` is not supported in IE11. Instead you can use `replace()` as long as you use a global regex pattern, which we already are using in this case. See here: https://stackoverflow.com/a/13340151

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
