### PR TITLE
Add GA4 tracking to devolved nations banners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add GA4 tracking to devolved nations banners ([PR #3556](https://github.com/alphagov/govuk_publishing_components/pull/3556))
+
 ## 35.14.0
 
 * Add GA4 tracking to the emergency banner ([PR #3549](https://github.com/alphagov/govuk_publishing_components/pull/3549))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -55,7 +55,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             between fresh page loads and dynamic page updates. */
             dynamic: referrer ? 'true' : 'false',
             emergency_banner: document.querySelector('[data-ga4-emergency-banner]') ? 'true' : undefined,
-            phase_banner: this.getElementAttribute('data-ga4-phase-banner') || undefined
+            phase_banner: this.getElementAttribute('data-ga4-phase-banner') || undefined,
+            devolved_nations_banner: this.getElementAttribute('data-ga4-devolved-nations-banner') || undefined
           }
         }
         window.GOVUK.analyticsGa4.core.sendData(data)

--- a/app/views/govuk_publishing_components/components/_devolved_nations.html.erb
+++ b/app/views/govuk_publishing_components/components/_devolved_nations.html.erb
@@ -6,10 +6,24 @@
 
   applies_to ||= t("components.devolved_nations.applies_to")
   heading_level ||= 2
+  ga4_tracking ||= false
+  data_attributes = {}
+
+  if ga4_tracking
+    data_attributes[:ga4_devolved_nations_banner] = devolved_nations_helper.ga4_applicable_nations_title_text(true)
+    data_attributes[:module] = "ga4-link-tracker"
+    data_attributes[:ga4_track_links_only] = ""
+    data_attributes[:ga4_set_indexes] = ""
+    data_attributes[:ga4_link] = {
+      event_name: "navigation",
+      type: "devolved nations banner",
+      section: t("components.devolved_nations.applies_to", locale: :en) + " " + devolved_nations_helper.ga4_applicable_nations_title_text,
+    }.to_json
+  end
 %>
 
 <% if national_applicability.any? { |k,v| v[:applicable] == true } %>
-  <%= tag.section class: "gem-c-devolved-nations" do %>
+  <%= tag.section class: "gem-c-devolved-nations", data: data_attributes do %>
     <%= content_tag(shared_helper.get_heading_level, class: "govuk-heading-s govuk-!-margin-bottom-0") do %>
       <%= applies_to %> <%= devolved_nations_helper.applicable_nations_title_text %>
     <% end %>

--- a/app/views/govuk_publishing_components/components/docs/devolved_nations.yml
+++ b/app/views/govuk_publishing_components/components/docs/devolved_nations.yml
@@ -89,3 +89,19 @@ examples:
       national_applicability:
         england:
           applicable: true
+  with_ga4_tracking:
+    description: |
+      Enables GA4 tracking on the banner. This includes link tracking on the component itself, and allows pageviews to record the presence of the banner on page load.
+    data:
+      national_applicability:
+        england:
+          applicable: true
+        scotland:
+          applicable: true
+        wales:
+          applicable: true
+        northern_ireland:
+          applicable: false
+          alternative_url: /
+      type: detailed_guide
+      ga4_tracking: true

--- a/lib/govuk_publishing_components/presenters/devolved_nations_helper.rb
+++ b/lib/govuk_publishing_components/presenters/devolved_nations_helper.rb
@@ -8,15 +8,27 @@ module GovukPublishingComponents
         @type = local_assigns[:type] || "publication"
       end
 
-      def applicable_nations_title_text
+      def applicable_nations_title_text(use_english_translation = nil)
         @national_applicability
           .select { |_, v| v[:applicable] == true }
-          .map { |k, _| I18n.t("components.devolved_nations.#{k}") }
+          .map { |k, _| get_translation("components.devolved_nations.#{k}", use_english_translation) }
           .sort
           .to_sentence(
-            two_words_connector: I18n.t("components.devolved_nations.connectors.two_words"),
-            last_word_connector: I18n.t("components.devolved_nations.connectors.last_word"),
+            two_words_connector: get_translation("components.devolved_nations.connectors.two_words", use_english_translation),
+            last_word_connector: get_translation("components.devolved_nations.connectors.last_word", use_english_translation),
           )
+      end
+
+      def get_translation(key, use_english_translation = nil)
+        return I18n.t(key, locale: :en) if use_english_translation
+
+        I18n.t(key)
+      end
+
+      def ga4_applicable_nations_title_text(remove_connector_word = nil)
+        return applicable_nations_title_text(true).gsub(" and", ",") if remove_connector_word
+
+        applicable_nations_title_text(true)
       end
 
       def nations_with_urls

--- a/spec/components/devolved_nations_spec.rb
+++ b/spec/components/devolved_nations_spec.rb
@@ -157,4 +157,49 @@ describe "Devolved Nations", type: :view do
     )
     assert_select ".gem-c-devolved-nations > h3", text: "Applies to England"
   end
+
+  it "renders a devolved nations component, with ga4 tracking, correctly" do
+    render_component(
+      national_applicability: {
+        england: {
+          applicable: true,
+        },
+        northern_ireland: {
+          applicable: false,
+          alternative_url: "/publication-northern-ireland",
+        },
+        scotland: {
+          applicable: true,
+          alternative_url: "/publication-scotland",
+        },
+        wales: {
+          applicable: true,
+          alternative_url: "/publication-wales",
+        },
+      },
+      ga4_tracking: true,
+    )
+    assert_select ".gem-c-devolved-nations[data-ga4-devolved-nations-banner='England, Scotland, Wales']"
+    assert_select ".gem-c-devolved-nations[data-module=ga4-link-tracker]"
+    assert_select ".gem-c-devolved-nations[data-ga4-track-links-only]"
+    assert_select ".gem-c-devolved-nations[data-ga4-set-indexes]"
+    assert_select ".gem-c-devolved-nations[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"devolved nations banner\",\"section\":\"Applies to England, Scotland and Wales\"}']"
+  end
+
+  it "renders a devolved nations component, without ga4 tracking, correctly" do
+    render_component(
+      national_applicability: {
+        england: {
+          applicable: true,
+        },
+      },
+      ga4_tracking: false,
+    )
+
+    assert_no_selector ".gem-c-devolved-nations[data-ga4-devolved-nations-banner]"
+    assert_no_selector ".gem-c-devolved-nations[data-module=ga4-link-tracker]"
+    assert_no_selector ".gem-c-devolved-nations[data-ga4-track-links-only]"
+    assert_no_selector ".gem-c-devolved-nations[data-ga4-set-indexes]"
+    assert_no_selector ".gem-c-devolved-nations[data-ga4-link]"
+  end
 end

--- a/spec/components/emergency_banner_spec.rb
+++ b/spec/components/emergency_banner_spec.rb
@@ -87,4 +87,13 @@ describe "Emergency Banner", type: :view do
     assert_select ".gem-c-emergency-banner[data-ga4-set-indexes]"
     assert_select ".gem-c-emergency-banner[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"emergency banner\",\"section\":\"His Royal Highness Henry VIII\"}']"
   end
+
+  it "renders banner without ga4 attributes" do
+    render_component(emergency_banner_attributes({ campaign_class: "notable-death", ga4_tracking: false }))
+    assert_no_selector ".gem-c-emergency-banner[data-ga4-emergency-banner]"
+    assert_no_selector ".gem-c-emergency-banner[data-module=ga4-link-tracker]"
+    assert_no_selector ".gem-c-emergency-banner[data-ga4-track-links-only]"
+    assert_no_selector ".gem-c-emergency-banner[data-ga4-set-indexes]"
+    assert_no_selector ".gem-c-emergency-banner[data-ga4-link]"
+  end
 end

--- a/spec/components/phase_banner_spec.rb
+++ b/spec/components/phase_banner_spec.rb
@@ -49,4 +49,13 @@ describe "Phase banner", type: :view do
     assert_select ".gem-c-phase-banner[data-ga4-set-indexes]"
     assert_select ".gem-c-phase-banner[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"phase banner\",\"section\":\"This part of GOV.UK is being rebuilt – find out what beta means\"}']"
   end
+
+  it "renders banner without ga4 attributes" do
+    render_component(phase: "beta", ga4_tracking: false)
+    assert_no_selector ".gem-c-phase-banner[data-ga4-phase-banner]"
+    assert_no_selector ".gem-c-phase-banner[data-module=ga4-link-tracker]"
+    assert_no_selector ".gem-c-phase-banner[data-ga4-track-links-only]"
+    assert_no_selector ".gem-c-phase-banner[data-ga4-set-indexes]"
+    assert_no_selector ".gem-c-phase-banner[data-ga4-link]"
+  end
 end

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -52,7 +52,8 @@ describe('Google Tag Manager page view tracking', function () {
 
         dynamic: 'false',
         emergency_banner: undefined,
-        phase_banner: undefined
+        phase_banner: undefined,
+        devolved_nations_banner: undefined
       }
     }
     window.dataLayer = []
@@ -430,6 +431,16 @@ describe('Google Tag Manager page view tracking', function () {
     div.setAttribute('data-ga4-phase-banner', 'beta')
     document.body.appendChild(div)
     expected.page_view.phase_banner = 'beta'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
+    document.body.removeChild(div)
+  })
+
+  it('correctly sets the devolved_nations_banner parameter', function () {
+    var div = document.createElement('div')
+    div.setAttribute('data-ga4-devolved-nations-banner', 'England, Scotland, Wales')
+    document.body.appendChild(div)
+    expected.page_view.devolved_nations_banner = 'England, Scotland, Wales'
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
     expect(window.dataLayer[0]).toEqual(expected)
     document.body.removeChild(div)


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds GA4 tracking to the devolved nations banner component.
- More specifically, it adds `devolved_nations_banner: 'England'/'England, Scotland, Wales'/'Scotland, Wales'/etc/undefined` to the `pageview` if the banner is rendered. It grabs this value based on the value of the `data-ga4-devolved-nations-banner` attribute, for example: `data-ga4-devolved-nations-banner=England, Scotland, Wales`. This PR also adds the `ga4-link-tracker` to the banner. 
- Both of these rely on `ga4_tracking: true` so we can toggle the tracking on and off on the banner.
- I had to write a Ruby function to grab the nations for `data-ga4-devolved-nations-banner`, and for the link tracker's `section`. This is because I needed to ensure the English text for the countries was always used. I also used `gsub` to replace ` and` with `,` so that the `pageview` value is `England, Scotland, Wales` instead of `England, Scotland and Wales`.
- I've checked it in a local version of `static`.

- I also added a commit to ensure the other banners don't render any GA4 attributes when `ga4_tracking` is `false`, as it felt wrong not to check for this.


## Why
<!-- What are the reasons behind this change being made? -->
- https://trello.com/c/XtFFZH3C/664-banners-devolved-nations-banner-element-visibility-and-navigation

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

- Added a `with_ga4_tracking_example` to the docs for the component.