### PR TITLE
Version 35.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.14.0
 
 * Add GA4 tracking to the emergency banner ([PR #3549](https://github.com/alphagov/govuk_publishing_components/pull/3549))
 * Ensure file attachments have the GA4 event_name 'file_download' ([PR #3553](https://github.com/alphagov/govuk_publishing_components/pull/3553))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.13.2)
+    govuk_publishing_components (35.14.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.13.2".freeze
+  VERSION = "35.14.0".freeze
 end


### PR DESCRIPTION
## 35.14.0

* Add GA4 tracking to the emergency banner ([PR #3549](https://github.com/alphagov/govuk_publishing_components/pull/3549))
* Ensure file attachments have the GA4 event_name 'file_download' ([PR #3553](https://github.com/alphagov/govuk_publishing_components/pull/3553))
* Add GA4 tracking to the phase banner ([PR #3552](https://github.com/alphagov/govuk_publishing_components/pull/3552))
* Use replace() instead of replaceAll() in removeCrossDomainParams() ([PR #3555](https://github.com/alphagov/govuk_publishing_components/pull/3555))