### PR TITLE
Add homepage variant of navbar for new design of homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Change GA4 type on contents lists ([PR #3647](https://github.com/alphagov/govuk_publishing_components/pull/3647))
 * Bump Ruby version and use floating patch version ([PR #3646](https://github.com/alphagov/govuk_publishing_components/pull/3646))
+* Add homepage variant of navbar for new design of homepage ([PR #3566](https://github.com/alphagov/govuk_publishing_components/pull/3566))
 
 ## 35.17.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -8,6 +8,10 @@ $search-width-or-height: $black-bar-height;
 $pseudo-underline-height: 3px;
 $button-pipe-colour: darken(govuk-colour("mid-grey"), 20%);
 
+$large-navbar-height: 86px;
+
+$pale-blue-colour: #d2e2f1;
+
 $after-link-padding: govuk-spacing(4);
 $after-button-padding-right: govuk-spacing(4);
 $after-button-padding-left: govuk-spacing(4);
@@ -89,6 +93,11 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+.gem-c-layout-super-navigation-header--blue-background {
+  background: $govuk-brand-colour;
+  border-top: 1px solid $govuk-brand-colour;
+}
+
 .gem-c-layout-super-navigation-header__container {
   position: relative;
 }
@@ -128,7 +137,6 @@ $after-button-padding-left: govuk-spacing(4);
 
 .gem-c-layout-super-navigation-header__navigation-item,
 .gem-c-layout-super-navigation-header__search-item {
-  background: govuk-colour("black");
   display: block;
   float: left;
   margin: 0;
@@ -205,6 +213,17 @@ $after-button-padding-left: govuk-spacing(4);
       }
     }
 
+    &.gem-c-layout-super-navigation-header__navigation-item-link--blue-background,
+    &.gem-c-layout-super-navigation-header__search-item-link--blue-background {
+      &:hover {
+        color: govuk-colour("white");
+
+        &::after {
+          background: govuk-colour("white");
+        }
+      }
+    }
+
     @include focus-and-focus-visible {
       .gem-c-layout-super-navigation-header__navigation-item-link-inner {
         border-color: $govuk-focus-colour;
@@ -267,6 +286,17 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+// to stop the black underline appearing underneath the menu
+// after it has been toggled closed if the blue background has
+// been enabled
+.gem-c-layout-super-navigation-header__navigation-top-toggle-button.gem-c-layout-super-navigation-header__navigation-top-toggle-button--blue-background {
+  &:focus:not(:focus-visible) {
+    &::after {
+      background: none;
+    }
+  }
+}
+
 .gem-c-layout-super-navigation-header__navigation-item-link {
   @include govuk-media-query($from: "desktop") {
     padding: govuk-spacing(3) 0;
@@ -279,9 +309,13 @@ $after-button-padding-left: govuk-spacing(4);
 }
 
 .gem-c-layout-super-navigation-header__navigation-item-link-inner {
-  background-color: govuk-colour("black");
   border-left: 1px solid $button-pipe-colour;
   padding: govuk-spacing(1) $after-link-padding;
+}
+
+.gem-c-layout-super-navigation-header__navigation-item-link-inner--blue-background {
+  border-left: 0;
+  border-right: 1px solid $pale-blue-colour;
 }
 
 // Search link and dropdown.
@@ -297,8 +331,6 @@ $after-button-padding-left: govuk-spacing(4);
     background: $govuk-brand-colour;
 
     &:hover {
-      background: govuk-colour("black");
-
       &::before {
         left: 0;
         right: 0;
@@ -321,10 +353,6 @@ $after-button-padding-left: govuk-spacing(4);
 
     @include focus-not-focus-visible {
       background: $govuk-link-colour;
-
-      &:hover {
-        background: govuk-colour("black");
-      }
     }
 
     @include focus-and-focus-visible {
@@ -345,6 +373,10 @@ $after-button-padding-left: govuk-spacing(4);
   height: 20px;
   pointer-events: none;
   width: 21px;
+}
+
+.gem-c-layout-super-navigation-header__open-button .gem-c-layout-super-navigation-header__search-toggle-button-link-icon {
+  display: none;
 }
 
 // Search and popular content dropdown.
@@ -472,15 +504,23 @@ $after-button-padding-left: govuk-spacing(4);
     .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
       border-color: $button-pipe-colour;
 
+      &.gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner--blue-background {
+        border-color: $pale-blue-colour;
+      }
+
       @include govuk-media-query($from: 360px) {
         &::before {
           @include chevron(govuk-colour("white"), true);
         }
       }
     }
+
     // stylelint-enable max-nesting-depth
   }
+}
 
+.gem-c-layout-super-navigation-header__navigation-top-toggle-button.gem-c-layout-super-navigation-header__navigation-top-toggle-button--blue-background,
+.gem-c-layout-super-navigation-header__navigation-top-toggle-button {
   // Open button modifier
   &.gem-c-layout-super-navigation-header__open-button {
     // stylelint-disable max-nesting-depth
@@ -528,6 +568,24 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
+.gem-c-layout-super-navigation-header__navigation-top-toggle-button--blue-background {
+  @include focus-not-focus-visible {
+    &:hover {
+      &::after {
+        background: govuk-colour("white");
+      }
+
+      .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
+        color: govuk-colour("white");
+
+        &::before {
+          border-color: govuk-colour("white");
+        }
+      }
+    }
+  }
+}
+
 .gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner {
   display: inline-block;
   border-left: 1px solid govuk-colour("white");
@@ -540,6 +598,10 @@ $after-button-padding-left: govuk-spacing(4);
       @include chevron(govuk-colour("white"));
     }
   }
+}
+
+.gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner--no-left-border {
+  border-left: 0;
 }
 
 // Styles for search toggle button.
@@ -580,9 +642,30 @@ $after-button-padding-left: govuk-spacing(4);
     }
 
     &:hover {
-      background: govuk-colour("black");
       border-bottom: $pseudo-underline-height solid govuk-colour("mid-grey");
       color: govuk-colour("mid-grey");
+    }
+
+    &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
+      &:hover {
+        border-bottom: $pseudo-underline-height solid govuk-colour("white");
+        color: govuk-colour("white");
+      }
+
+      // stylelint-disable max-nesting-depth
+      @include focus-not-focus-visible {
+        border-bottom: none;
+      }
+      // stylelint-enable max-nesting-depth
+    }
+
+    &:focus-visible {
+      &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
+        &:hover {
+          border-bottom: $pseudo-underline-height solid $govuk-focus-colour;
+          color: govuk-colour("black");
+        }
+      }
     }
 
     @include focus-and-focus-visible {
@@ -594,6 +677,13 @@ $after-button-padding-left: govuk-spacing(4);
 
   // Open button modifier
   &.gem-c-layout-super-navigation-header__open-button {
+    &.gem-c-layout-super-navigation-header__search-toggle-button--blue-background {
+      &:hover {
+        border-bottom: $pseudo-underline-height solid govuk-colour("white");
+        color: govuk-colour("white");
+      }
+    }
+
     @include focus-and-focus-visible {
       @include govuk-focused-text;
       border-color: $govuk-focus-colour;
@@ -625,9 +715,7 @@ $after-button-padding-left: govuk-spacing(4);
   font-weight: normal;
   left: 0;
   line-height: 22px;
-  padding: govuk-spacing(3) 0;
   pointer-events: none;
-  position: absolute;
   right: 0;
   text-align: center;
   top: 0;
@@ -786,5 +874,53 @@ $after-button-padding-left: govuk-spacing(4);
 @include govuk-media-query($media-type: print) {
   .gem-c-layout-super-navigation-header__content {
     display: none;
+  }
+}
+
+@include govuk-media-query($from: desktop) {
+  // can't use govuk-spacing here because the navbar height
+  // isn't a multiple of 5 :(
+  .gem-c-layout-super-navigation-header__navigation-item-link--large-navbar,
+  .gem-c-layout-super-navigation-header__search-item-link--large-navbar {
+    padding-top: 33px;
+    padding-bottom: 33px;
+  }
+
+  .gem-c-layout-super-navigation-header__logotype-crown--large-navbar {
+    height: 36px;
+    width: 49px;
+  }
+
+  .gem-c-header__link--large-navbar:focus {
+    box-shadow: 0 -4px 0 18px $govuk-focus-colour;
+    border-bottom: $govuk-focus-width solid govuk-colour("black");
+    padding-bottom: 10px;
+  }
+
+  .gem-c-header__link--large-navbar:hover {
+    padding-bottom: 10px;
+  }
+
+  .gem-c-layout-super-navigation-header__header-logo--large-navbar {
+    height: 35px;
+    padding-bottom: govuk-spacing(5);
+    padding-top: govuk-spacing(5);
+  }
+
+  .gem-c-layout-super-navigation-header__search-toggle-button--large-navbar {
+    height: $large-navbar-height;
+  }
+
+  // to stop the search icon moving on hover
+  .gem-c-layout-super-navigation-header__search-toggle-button--large-navbar:hover {
+    padding-bottom: 12px;
+  }
+
+  .gem-c-layout-super-navigation-header__button-container--large-navbar {
+    top: -$large-navbar-height;
+  }
+
+  .gem-c-layout-super-navigation-header__navigation-top-toggle-button--large-navbar {
+    height: $large-navbar-height;
   }
 }

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -6,6 +6,7 @@
   blue_bar ||= local_assigns.include?(:blue_bar) ? local_assigns[:blue_bar] : !full_width
   global_bar ||= nil
   html_lang ||= "en"
+  homepage ||= false
   layout_helper = GovukPublishingComponents::Presenters::PublicLayoutHelper.new(local_assigns)
   blue_bar_background_colour = layout_helper.blue_bar_background_colours.include?(blue_bar_background_colour) ? blue_bar_background_colour : nil
   logo_link ||= "/"
@@ -103,9 +104,15 @@
 
     <% unless omit_header %>
       <% if show_explore_header %>
-        <%= render "govuk_publishing_components/components/layout_super_navigation_header", {
-          logo_link: logo_link,
-        } %>
+        <% if homepage %>
+          <%= render "govuk_publishing_components/components/layout_for_public/layout_super_navigation_header_homepage", {
+            logo_link: logo_link,
+          } %>
+        <% else %>
+          <%= render "govuk_publishing_components/components/layout_super_navigation_header", {
+            logo_link: logo_link,
+          } %>
+        <% end %>
       <% else %>
         <%= render "govuk_publishing_components/components/layout_header", {
           search: show_search,
@@ -122,7 +129,7 @@
 
     <%= raw(emergency_banner) %>
 
-    <% if (blue_bar && !global_bar.present?) || (blue_bar_dedupe) %>
+    <% if (blue_bar && !global_bar.present? && !homepage) || (blue_bar_dedupe) %>
       <%= content_tag(:div, class: blue_bar_wrapper_classes) do %>
         <div class="gem-c-layout-for-public__blue-bar govuk-width-container"></div>
       <% end %>

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -5,6 +5,12 @@
   logo_link ||= "https://www.gov.uk/"
   logo_link_title ||= t("components.layout_super_navigation_header.logo_link_title")
   logo_text = t("components.layout_super_navigation_header.logo_text")
+
+  hide_logo_text ||= false
+  hide_button_left_border ||= false
+  blue_background ||= false
+  large_navbar ||= false
+
   navigation_links_columns = t("components.layout_super_navigation_header.navigation_links_columns")
   navigation_menu_heading = t("components.layout_super_navigation_header.navigation_menu_heading")
   navigation_search_heading = t("components.layout_super_navigation_header.navigation_search_heading")
@@ -17,63 +23,124 @@
   show_search_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.show", :label => "search")
   hide_navigation_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.hide", :label => "navigation")
   show_navigation_menu_text = t("components.layout_super_navigation_header.menu_toggle_label.show", :label => "navigation")
+
+  top_toggle_button_classes = %w(gem-c-layout-super-navigation-header__navigation-top-toggle-button
+  )
+  top_toggle_button_classes << "gem-c-layout-super-navigation-header__navigation-top-toggle-button--blue-background" if blue_background
+  top_toggle_button_classes << "gem-c-layout-super-navigation-header__navigation-top-toggle-button--large-navbar" if large_navbar
+
+  top_toggle_button_inner_classes = %w(gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner)
+  top_toggle_button_inner_classes << "gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner--no-left-border" if hide_button_left_border
+  top_toggle_button_inner_classes << "gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner--blue-background" if blue_background
+
+  search_toggle_button_classes = %w(gem-c-layout-super-navigation-header__search-toggle-button)
+  search_toggle_button_classes << "gem-c-layout-super-navigation-header__search-toggle-button--blue-background" if blue_background
+  search_toggle_button_classes << "gem-c-layout-super-navigation-header__search-toggle-button--large-navbar" if large_navbar
+
+  layout_super_navigation_header_classes = %w(gem-c-layout-super-navigation-header)
+  layout_super_navigation_header_classes << "gem-c-layout-super-navigation-header--blue-background" if blue_background
+
+  item_link_classes = %w(gem-c-layout-super-navigation-header__navigation-item-link)
+  item_link_classes << "gem-c-layout-super-navigation-header__navigation-item-link--blue-background" if blue_background
+  item_link_classes << "gem-c-layout-super-navigation-header__navigation-item-link--large-navbar" if large_navbar
+
+  item_link_inner_classes = %w(
+    gem-c-layout-super-navigation-header__navigation-item-link-inner
+  )
+  item_link_inner_classes << "gem-c-layout-super-navigation-header__navigation-item-link-inner--blue-background" if blue_background
+
+  search_item_link_classes = %w(gem-c-layout-super-navigation-header__search-item-link)
+  search_item_link_classes << "gem-c-layout-super-navigation-header__search-item-link--blue-background" if blue_background
+  search_item_link_classes << "gem-c-layout-super-navigation-header__search-item-link--large-navbar" if large_navbar
+
+  header_logo_classes = %w(gem-c-layout-super-navigation-header__header-logo)
+  header_logo_classes << "gem-c-layout-super-navigation-header__header-logo--large-navbar" if large_navbar
+
+  logotype_classes = %w(govuk-header__logotype-crown gem-c-layout-super-navigation-header__logotype-crown)
+  logotype_classes << "gem-c-layout-super-navigation-header__logotype-crown--large-navbar" if large_navbar
+
+  header_link_classes = %w(govuk-header__link govuk-header__link--homepage)
+  header_link_classes << "gem-c-header__link--large-navbar" if large_navbar
+
+  button_container_classes = %w(gem-c-layout-super-navigation-header__button-container)
+  button_container_classes << "gem-c-layout-super-navigation-header__button-container--large-navbar" if large_navbar
+
+
 %>
-<header role="banner" class="gem-c-layout-super-navigation-header" data-module="gem-track-click ga4-event-tracker ga4-link-tracker" data-track-links-only data-ga4-expandable>
+<%= content_tag("header",
+  {
+    role: "banner",
+    class: layout_super_navigation_header_classes,
+    data: {
+      module: "gem-track-click ga4-event-tracker ga4-link-tracker",
+      "track-links-only": '',
+      "ga4-expandable": '',
+    }
+}) do %>
   <div class="gem-c-layout-super-navigation-header__container govuk-clearfix">
     <div class="govuk-width-container">
-      <div class="gem-c-layout-super-navigation-header__header-logo">
-        <a
-          class="govuk-header__link govuk-header__link--homepage"
-          data-track-action="logoLink"
-          data-track-category="headerClicked"
-          data-track-label="<%= logo_link %>"
-          data-track-dimension="<%= logo_text %>"
-          data-track-dimension-index="29"
-          href="<%= logo_link %>"
-          id="logo"
-          title="<%= logo_link_title %>"
-          data-ga4-link="<%= {
-            "event_name": "navigation",
-            "type": "header menu bar",
-            "external": "false",
-            "text": "GOV.UK",
-            "section": "Logo",
-            "index": {
-              "index_link": 1,
-              "index_section": 0,
-              "index_section_count": 2,
-            },
-            "index_total": 1
-          }.to_json %>"
-        >
+      <%= content_tag(:div, {
+        class: header_logo_classes
+      }) do %>
+        <%= link_to logo_link, {
+          class: header_link_classes,
+          data: {
+            "track-action": "logoLink",
+            "track-category": "headerClicked",
+            "track-label": logo_link,
+            "track-dimension": logo_text,
+            "track-dimension-index": "29",
+            "ga4-link": {
+              "event_name": "navigation",
+              "type": "header menu bar",
+              "external": "false",
+              "text": "GOV.UK",
+              "section": "Logo",
+              "index": {
+                "index_link": 1,
+                "index_section": 0,
+                "index_section_count": 2,
+              },
+              "index_total": 1
+            }.to_json
+          },
+          id: "logo",
+          aria: {
+            label: logo_link_title,
+          }
+        } do %>
           <span class="govuk-header__logotype">
             <!--[if gt IE 8]><!-->
-            <svg
-              aria-hidden="true"
-              class="govuk-header__logotype-crown gem-c-layout-super-navigation-header__logotype-crown"
-              focusable="false"
-              height="30"
-              viewBox="0 0 132 97"
-              width="36"
-              xmlns="http://www.w3.org/2000/svg"
-            >
+            <%= content_tag(:svg, {
+              aria: {
+                hidden: true,
+              },
+              class: logotype_classes,
+              height: "30",
+              width: "36",    
+              focusable: "false",
+              viewBox: "0 0 132 97",
+              xmlns: "http://www.w3.org/2000/svg",
+            }) do %>
               <path
                 d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
                 fill="currentColor"
                 fill-rule="evenodd"
               >
               </path>
-            </svg>
+            <% end %>
             <!--<![endif]-->
             <!--[if IE 8]>
             <img src="<%= asset_path('govuk-logotype-crown.png') %>" alt="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32">
             <![endif]-->
-            <span class="govuk-header__logotype-text">
-              <%= logo_text %>
-            </span>
+            <% unless hide_logo_text %>
+              <span class="govuk-header__logotype-text">
+                <%= logo_text %>
+              </span>
+            <% end %>
           </span>
-        </a>
-      </div>
+        <% end %>
+      <% end %>
     </div>
     <nav
       aria-labelledby="super-navigation-menu-heading"
@@ -93,10 +160,12 @@
       %>
 
       <div class="govuk-width-container gem-c-layout-super-navigation-header__button-width-container">
-        <div class="gem-c-layout-super-navigation-header__button-container">
+        <%= content_tag(:div, {
+          class: button_container_classes
+        }) do %>
           <div class="gem-c-layout-super-navigation-header__navigation-item">
             <%= link_to link[:href], {
-              class: "gem-c-layout-super-navigation-header__navigation-item-link",
+              class: item_link_classes,
               data: {
                 track_action: "#{tracking_label}Link",
                 track_category: "headerClicked",
@@ -105,9 +174,11 @@
                 track_dimension_index: "29",
               }
             } do %>
-              <span class="gem-c-layout-super-navigation-header__navigation-item-link-inner">
+              <% content_tag(:span, {
+                class: item_link_inner_classes
+              }) do %>
                 <%= link[:label] %>
-              </span>
+              <% end %>
             <% end %>
 
             <%= content_tag(:button, {
@@ -116,7 +187,7 @@
                 expanded: false,
                 label: show_menu_text,
               },
-              class: "gem-c-layout-super-navigation-header__navigation-top-toggle-button",
+              class: top_toggle_button_classes,
               data: {
                 text_for_hide: hide_menu_text,
                 text_for_show: show_menu_text,
@@ -138,35 +209,40 @@
               id: "super-navigation-menu-#{unique_id}-toggle",
               type: "button",
             }) do %>
-              <%= tag.span link[:label], class: "gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner" %>
+              <%= tag.span link[:label], class: top_toggle_button_inner_classes %>
             <% end %>
           </div>
 
           <div class="gem-c-layout-super-navigation-header__search-item">
-            <button
-              aria-controls="super-search-menu"
-              aria-expanded="true"
-              aria-label="<%= hide_search_menu_text %>"
-              class="gem-c-layout-super-navigation-header__search-toggle-button"
-              data-text-for-hide="<%= hide_search_menu_text %>"
-              data-text-for-show="<%= show_search_menu_text %>"
-              data-toggle-mobile-group="top"
-              data-toggle-desktop-group="top"
-              data-tracking-key="search"
-              hidden
-              id="super-search-menu-toggle"
-              type="button"
-              data-ga4-event="<%= {
-                "event_name": "select_content",
-                "type": "header menu bar",
-                "text": "Search",
-                "index": {
-                  "index_section": 2,
-                  "index_section_count": 2,
-                },
-                "section": "Search"
-              }.to_json %>"
-            >
+            <%= content_tag(:button, {
+              id: "super-search-menu-toggle",
+              class: search_toggle_button_classes,
+              aria: {
+                controls: "super-search-menu",
+                expanded: "true",
+                label: hide_search_menu_text,
+              },
+              data: {
+                "text-for-hide": hide_search_menu_text,
+                "text-for-show": show_search_menu_text,
+                "toggle-mobile-group": "top",
+                "toggle-desktop-group": "top",
+                "tracking-key": "search",
+                "ga4-event": "#{{
+                  "event_name": "select_content",
+                  "type": "header menu bar",
+                  "text": "Search",
+                  "index": {
+                    "index_section": 2,
+                    "index_section_count": 2,
+                  },
+                  "section": "Search"
+                  }.to_json
+                }"
+              },
+              hidden: true,
+              type: "button",
+            }) do %>
               <span class="govuk-visually-hidden">
                 <%= search_text %>
               </span>
@@ -182,9 +258,11 @@
               >
                 &times;
               </span>
-            </button>
+            <% end %>
 
-            <a class="gem-c-layout-super-navigation-header__search-item-link" href="/search">
+            <%= link_to "/search", {
+              class: search_item_link_classes
+            } do %>
               <span class="govuk-visually-hidden">
                 <%= search_text %>
               </span>
@@ -193,9 +271,9 @@
                   classes: %w[gem-c-layout-super-navigation-header__search-item-link-icon],
                 }
               %>
-            </a>
+            <% end %>
           </div>
-        </div>
+        <% end %>
       </div>
 
       <div
@@ -336,4 +414,4 @@
       </div>
     </nav>
   </div>
-</header>
+<% end %>

--- a/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_for_public.yml
@@ -37,6 +37,11 @@ examples:
     description: This allows the feedback form to be omitted
     data:
       omit_feedback_form: true
+  homepage:
+    description: This allows for rendering the layout super navigation header in a different way for only the homepage.
+    data:
+      homepage: true
+      show_explore_header: true
   omit_footer_navigation:
     description: This allows the footer navigation to be omitted
     data:

--- a/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
+++ b/app/views/govuk_publishing_components/components/docs/layout_super_navigation_header.yml
@@ -34,3 +34,32 @@ examples:
     data:
       logo_link: "https://www.example.com"
       logo_link_title: "Go to example"
+  homepage:
+    description: |
+      This variant is used for the homepage. It toggles the following attributes: hide_button_left_border, hide_logo_text and blue_background
+    data:
+      hide_logo_text: true
+      hide_button_left_border: true
+      blue_background: true
+      large_navbar: true      
+  hide_logo_text:
+    description: |
+      Logo text is shown by default. This option allows us to hide the text for the homepage.
+    data:
+      hide_logo_text: true
+  remove_left_button_border:
+    description: |
+      The left border for the toggle button is shown by default. This option allows us to hide the text for the homepage.
+    data:
+      hide_button_left_border: true
+  blue_blackground_colour:
+    description: |
+      The black background is shown by default. This option allows us to change the background colour for the homepage.
+    data:
+      blue_background: true
+  large_navbar:
+    description: |
+      Make the links and buttons large on desktop only. Used for the homepage.
+    data:
+      large_navbar: true
+      hide_logo_text: true

--- a/app/views/govuk_publishing_components/components/layout_for_public/_layout_super_navigation_header_homepage.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_for_public/_layout_super_navigation_header_homepage.html.erb
@@ -1,0 +1,11 @@
+<% logo_link ||= "/" %>
+
+<%= render "govuk_publishing_components/components/layout_super_navigation_header",
+  {
+    hide_logo_text: true,
+    logo_link: logo_link,
+    blue_background: true,
+    hide_button_left_border: true,
+    large_navbar: true,
+  }
+%>

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -135,6 +135,12 @@ describe "Layout for public", type: :view do
     assert_select ".gem-c-layout-for-public__blue-bar"
   end
 
+  it "renders homepage variant of layout super navigation header if `homepage` is true" do
+    render_component(show_explore_header: true, homepage: true)
+
+    assert page.has_no_selector?(".govuk-header__logotype-text")
+  end
+
   it "renders the blue bar if `full_width` is true and `blue_bar` is true" do
     render_component(full_width: true, blue_bar: true)
 

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -103,6 +103,22 @@ describe "Super navigation header", type: :view do
     assert_select "a.govuk-header__link--homepage[href='https://www.example.com/']", count: 1
   end
 
+  it "hides logo text" do
+    render_component({
+      hide_logo_text: true,
+    })
+
+    assert_select "a.govuk-header__link--homepage[href='https://www.gov.uk/']", ""
+  end
+
+  it "hides left border of button" do
+    render_component({
+      hide_button_left_border: true,
+    })
+
+    assert_select ".gem-c-layout-super-navigation-header__navigation-top-toggle-button-inner--no-left-border"
+  end
+
   it "allows a custom crown logo link and custom title" do
     render_component({
       logo_link: "https://www.example.com/",
@@ -110,7 +126,33 @@ describe "Super navigation header", type: :view do
     })
 
     assert_select "a.govuk-header__link--homepage[href='https://www.example.com/']", count: 1
-    assert_select "a.govuk-header__link--homepage[title='Go to example']", count: 1
+    assert_select "a.govuk-header__link--homepage[aria-label='Go to example']", count: 1
+  end
+
+  it "renders blue background navbar variant" do
+    render_component({
+      blue_background: true,
+    })
+
+    assert_select ".gem-c-layout-super-navigation-header__navigation-top-toggle-button--blue-background"
+    assert_select ".gem-c-layout-super-navigation-header__search-toggle-button--blue-background"
+    assert_select ".gem-c-layout-super-navigation-header__search-item-link--blue-background"
+    assert_select ".gem-c-layout-super-navigation-header__navigation-item-link--blue-background"
+  end
+
+  it "renders large navbar variant" do
+    render_component({
+      large_navbar: true,
+    })
+
+    assert_select ".gem-c-layout-super-navigation-header__button-container--large-navbar"
+    assert_select ".gem-c-layout-super-navigation-header__header-logo--large-navbar"
+    assert_select ".gem-c-layout-super-navigation-header__navigation-top-toggle-button--large-navbar"
+    assert_select ".gem-c-layout-super-navigation-header__search-toggle-button--large-navbar"
+    assert_select ".gem-c-layout-super-navigation-header__search-item-link--large-navbar"
+    assert_select ".gem-c-layout-super-navigation-header__navigation-item-link--large-navbar"
+    assert_select ".gem-c-layout-super-navigation-header__logotype-crown--large-navbar"
+    assert_select ".gem-c-header__link--large-navbar"
   end
 
   it "doesn't have the initialised class before the JavaScript is run" do


### PR DESCRIPTION
## What

This commit contains several small changes that are part of the new design of the homepage. They are all optional parameters for layout_super_navigation_header and are the following:

* toggle the logo text off
* toggle the border left of the toggle button off
* change the background colour of the navbar to blue
* make the links/buttons larger for desktop only

Created a new partial `layout_super_navigation_header_home` which has all these changes toggled on. Also toggles some additional classes on elements when the navbar is blue to make sure the contrast between hover state styles is OK.

## Why

As part of several small changes that are going to be made to the homepage, we need to override some default styling of the layout super navigation header. As these variations will only be rendered on the homepage, a new partial `layout_super_navigation_header_home` has been created. This partial will render the specific homepage differences and it will mean that the `layout_for_public` will only need one variable to change between homepage styled layout super navigation header and the regular styled layout super navigation header.

## Screenshot

![Screenshot 2023-09-29 at 16 06 07](https://github.com/alphagov/govuk_publishing_components/assets/3727504/376e0f32-600a-492c-b889-4e00249f107f)


[Relevant Trello Link](https://trello.com/c/qTmNgPwV/2019-look-and-feel-homepage-top-menu-navigation-header-m)
