### PR TITLE
Add GA4 tracking to the intervention banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Improve GA URL parameter stripping ([PR #3603](https://github.com/alphagov/govuk_publishing_components/pull/3603))
 * Fix bug with GA4 search results count ([PR #3594](https://github.com/alphagov/govuk_publishing_components/pull/3594))
 * Check HTML attribute when populating GA4 language ([PR #3598](https://github.com/alphagov/govuk_publishing_components/pull/3598))
+* Add GA4 tracking to the intervention banner ([PR #3567](https://github.com/alphagov/govuk_publishing_components/pull/3567))
 
 ## 35.15.2
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -57,7 +57,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             emergency_banner: document.querySelector('[data-ga4-emergency-banner]') ? 'true' : undefined,
             phase_banner: this.getElementAttribute('data-ga4-phase-banner') || undefined,
             devolved_nations_banner: this.getElementAttribute('data-ga4-devolved-nations-banner') || undefined,
-            cookie_banner: document.querySelector('[data-ga4-cookie-banner]') ? 'true' : undefined
+            cookie_banner: document.querySelector('[data-ga4-cookie-banner]') ? 'true' : undefined,
+            intervention: document.querySelector('[data-ga4-intervention-banner]') ? 'true' : undefined
           }
         }
         window.GOVUK.analyticsGa4.core.sendData(data)

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -58,7 +58,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             phase_banner: this.getElementAttribute('data-ga4-phase-banner') || undefined,
             devolved_nations_banner: this.getElementAttribute('data-ga4-devolved-nations-banner') || undefined,
             cookie_banner: document.querySelector('[data-ga4-cookie-banner]') ? 'true' : undefined,
-            intervention: document.querySelector('[data-ga4-intervention-banner]') ? 'true' : undefined
+            intervention: this.getInterventionPresence()
           }
         }
         window.GOVUK.analyticsGa4.core.sendData(data)
@@ -129,6 +129,25 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     getWithDrawn: function () {
       var withdrawn = this.getMetaContent('withdrawn')
       return (withdrawn === 'withdrawn') ? 'true' : 'false'
+    },
+
+    getInterventionPresence: function () {
+      /* If the user hides the banner using JS, a cookie is set to hide it on future page loads.
+       * Therefore we need to start the intervention banner early so that it hides if this cookie exists.
+       * Without this, our pageview object will track the banner as visible before it gets hidden. */
+
+      var intervention = document.querySelector('[data-ga4-intervention-banner]')
+
+      if (intervention) {
+        window.GOVUK.modules.start(intervention)
+        var interventionHidden = intervention.getAttribute('hidden') === '' || intervention.getAttribute('hidden')
+
+        if (interventionHidden) {
+          return undefined
+        }
+        return 'true'
+      }
+      return undefined
     },
 
     splitLongMetaContent: function (metatag) {

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -33,8 +33,9 @@
   dismiss_href = intervention_helper.dismiss_link
 
   ga4_tracking ||= false
-  suggestion_data_attributes[:module] = suggestion_data_attributes[:module] ? suggestion_data_attributes[:module] + " ga4-link-tracker" : "ga4-link-tracker" if ga4_tracking
+  suggestion_data_attributes[:module] = "#{suggestion_data_attributes[:module]} ga4-link-tracker".strip if ga4_tracking
   suggestion_data_attributes[:ga4_link] = { event_name: "navigation", type: "intervention", section: suggestion_text, index: 1, index_total: 1 }.to_json if ga4_tracking
+  data_attributes[:ga4_intervention_banner] = "" if ga4_tracking # Added to the parent element for the GA4 pageview object to use
 
   suggestion_tag_options = {
     class: "govuk-link",
@@ -51,8 +52,6 @@
     suggestion_link_text = intervention_helper.accessible_text
   end
 
-  data_attributes[:ga4_intervention_banner] = "" if ga4_tracking
-
   section_options = {
     class: "gem-c-intervention",
     role: "region", aria: aria_attributes,
@@ -60,7 +59,7 @@
   }
   section_options.merge!({ hidden: true }) if hide
 
-  dismiss_link_data_attributes[:module] = dismiss_link_data_attributes[:module] ? dismiss_link_data_attributes[:module] + " ga4-event-tracker" : "ga4-event-tracker" if ga4_tracking
+  dismiss_link_data_attributes[:module] = "#{dismiss_link_data_attributes[:module]} ga4-event-tracker".strip if ga4_tracking
   dismiss_link_data_attributes[:ga4_event] = { event_name: "select_content", type: "intervention", section: suggestion_text, action: 'closed' }.to_json if ga4_tracking
 %>
 <% if intervention_helper.show? %>

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -12,6 +12,7 @@
   data_attributes ||= {}
   suggestion_data_attributes ||= {}
   dismiss_data_attributes ||= {}
+  dismiss_link_data_attributes ||= {}
   data_attributes[:module] = "intervention"
   data_attributes["intervention-name"] = name
 
@@ -58,6 +59,9 @@
     data: data_attributes,
   }
   section_options.merge!({ hidden: true }) if hide
+
+  dismiss_link_data_attributes[:module] = dismiss_link_data_attributes[:module] ? dismiss_link_data_attributes[:module] + " ga4-event-tracker" : "ga4-event-tracker" if ga4_tracking
+  dismiss_link_data_attributes[:ga4_event] = { event_name: "select_content", type: "intervention", section: suggestion_text, action: 'closed' }.to_json if ga4_tracking
 %>
 <% if intervention_helper.show? %>
   <%= tag.section **section_options do %>
@@ -70,7 +74,7 @@
 
     <% if dismiss_text %>
       <%= tag.p class: "govuk-body", data: dismiss_data_attributes do %>
-        <%= tag.a class: "govuk-link js-dismiss-link", href: dismiss_href do %>
+        <%= tag.a class: "govuk-link js-dismiss-link", href: dismiss_href, data: dismiss_link_data_attributes do %>
           <svg class="gem-c-intervention__dismiss-icon"
             width="19" height="19" viewBox="0 0 19 19"
             aria-hidden="true"

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -11,6 +11,7 @@
 
   data_attributes ||= {}
   suggestion_data_attributes ||= {}
+  dismiss_data_attributes ||= {}
   data_attributes[:module] = "intervention"
   data_attributes["intervention-name"] = name
 
@@ -68,7 +69,7 @@
     </p>
 
     <% if dismiss_text %>
-      <p class="govuk-body">
+      <%= tag.p class: "govuk-body", data: dismiss_data_attributes do %>
         <%= tag.a class: "govuk-link js-dismiss-link", href: dismiss_href do %>
           <svg class="gem-c-intervention__dismiss-icon"
             width="19" height="19" viewBox="0 0 19 19"
@@ -80,7 +81,7 @@
           </svg>
           <%= dismiss_text %>
         <% end %>
-      </p>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/_intervention.html.erb
+++ b/app/views/govuk_publishing_components/components/_intervention.html.erb
@@ -30,6 +30,10 @@
   intervention_helper = GovukPublishingComponents::Presenters::InterventionHelper.new(options)
   dismiss_href = intervention_helper.dismiss_link
 
+  ga4_tracking ||= false
+  suggestion_data_attributes[:module] = suggestion_data_attributes[:module] ? suggestion_data_attributes[:module] + " ga4-link-tracker" : "ga4-link-tracker" if ga4_tracking
+  suggestion_data_attributes[:ga4_link] = { event_name: "navigation", type: "intervention", section: suggestion_text, index: 1, index_total: 1 }.to_json if ga4_tracking
+
   suggestion_tag_options = {
     class: "govuk-link",
     href: suggestion_link_url,
@@ -44,6 +48,8 @@
 
     suggestion_link_text = intervention_helper.accessible_text
   end
+
+  data_attributes[:ga4_intervention_banner] = "" if ga4_tracking
 
   section_options = {
     class: "gem-c-intervention",

--- a/app/views/govuk_publishing_components/components/docs/intervention.yml
+++ b/app/views/govuk_publishing_components/components/docs/intervention.yml
@@ -65,8 +65,8 @@ examples:
 
   with_data_attributes:
     description: |
-      This example shows the use of `suggestion_data_attributes` and
-      `dismiss_data_attributes` for click tracking.
+      This example shows the use of `suggestion_data_attributes`,
+      `dismiss_data_attributes` for click tracking on the dismiss section <p> tag, and `dismiss_link_data_attributes` for adding attributes to the dismiss link <a> tag.
 
       Other data attributes can also be applied as required. Note that the component does not include built in tracking. If this is required consider using the [track click script](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics/track-click.md).
     data:
@@ -87,6 +87,8 @@ examples:
         track-dimension: Hide this suggestion
         track-dimension-index: 29
         track-label: hide the intervention
+      dismiss_link_data_attributes:
+        track-category: example
   with_ga4_tracking:
     description: |
       Enables GA4 tracking on the banner. This includes link tracking on the component itself, event tracking on the 'Hide' link, and allows pageviews to record the presence of the banner on page load.

--- a/app/views/govuk_publishing_components/components/docs/intervention.yml
+++ b/app/views/govuk_publishing_components/components/docs/intervention.yml
@@ -87,3 +87,13 @@ examples:
         track-dimension: Hide this suggestion
         track-dimension-index: 29
         track-label: hide the intervention
+  with_ga4_tracking:
+    description: |
+      Enables GA4 tracking on the banner. This includes link tracking on the component itself, event tracking on the 'Hide' link, and allows pageviews to record the presence of the banner on page load.
+    data:
+      ga4_tracking: true
+      suggestion_text: Based on your browsing you might be interested in
+      suggestion_link_text: "Travel abroad: step by step"
+      suggestion_link_url: /travel-abroad
+      dismiss_text: Hide this suggestion
+      name: another-campaign-name

--- a/spec/components/cookie_banner_spec.rb
+++ b/spec/components/cookie_banner_spec.rb
@@ -125,14 +125,14 @@ describe "Cookie banner", type: :view do
 
   it "renders without GA4 attributes when ga4_tracking is false" do
     render_component({ ga4_tracking: false })
-    assert_no_selector ".gem-c-cookie-banner__confirmation-message--accepted[data-ga4-cookie-banner]"
-    assert_no_selector ".gem-c-cookie-banner__confirmation-message--accepted[data-module]"
-    assert_no_selector ".gem-c-cookie-banner__confirmation-message--accepted[data-ga4-track-links-only]"
-    assert_no_selector ".gem-c-cookie-banner__confirmation-message--accepted[data-ga4-set-indexes]"
-    assert_no_selector ".gem-c-cookie-banner__confirmation-message--accepted[data-ga4-link]"
+    assert_select ".gem-c-cookie-banner__confirmation-message--accepted[data-ga4-cookie-banner]", false
+    assert_select ".gem-c-cookie-banner__confirmation-message--accepted[data-module]", false
+    assert_select ".gem-c-cookie-banner__confirmation-message--accepted[data-ga4-track-links-only]", false
+    assert_select ".gem-c-cookie-banner__confirmation-message--accepted[data-ga4-set-indexes]", false
+    assert_select ".gem-c-cookie-banner__confirmation-message--accepted[data-ga4-link]", false
 
     assert_select ".gem-c-cookie-banner__hide-button[data-module='gem-track-click']"
-    assert_no_selector ".gem-c-cookie-banner__hide-button[data-module='gem-track-click ga4-event-tracker']"
-    assert_no_selector ".gem-c-cookie-banner__hide-button[data-ga4-event]"
+    assert_select ".gem-c-cookie-banner__hide-button[data-module='gem-track-click ga4-event-tracker']", false
+    assert_select ".gem-c-cookie-banner__hide-button[data-ga4-event]", false
   end
 end

--- a/spec/components/devolved_nations_spec.rb
+++ b/spec/components/devolved_nations_spec.rb
@@ -196,10 +196,10 @@ describe "Devolved Nations", type: :view do
       ga4_tracking: false,
     )
 
-    assert_no_selector ".gem-c-devolved-nations[data-ga4-devolved-nations-banner]"
-    assert_no_selector ".gem-c-devolved-nations[data-module=ga4-link-tracker]"
-    assert_no_selector ".gem-c-devolved-nations[data-ga4-track-links-only]"
-    assert_no_selector ".gem-c-devolved-nations[data-ga4-set-indexes]"
-    assert_no_selector ".gem-c-devolved-nations[data-ga4-link]"
+    assert_select ".gem-c-devolved-nations[data-ga4-devolved-nations-banner]", false
+    assert_select ".gem-c-devolved-nations[data-module=ga4-link-tracker]", false
+    assert_select ".gem-c-devolved-nations[data-ga4-track-links-only]", false
+    assert_select ".gem-c-devolved-nations[data-ga4-set-indexes]", false
+    assert_select ".gem-c-devolved-nations[data-ga4-link]", false
   end
 end

--- a/spec/components/emergency_banner_spec.rb
+++ b/spec/components/emergency_banner_spec.rb
@@ -90,10 +90,10 @@ describe "Emergency Banner", type: :view do
 
   it "renders banner without ga4 attributes" do
     render_component(emergency_banner_attributes({ campaign_class: "notable-death", ga4_tracking: false }))
-    assert_no_selector ".gem-c-emergency-banner[data-ga4-emergency-banner]"
-    assert_no_selector ".gem-c-emergency-banner[data-module=ga4-link-tracker]"
-    assert_no_selector ".gem-c-emergency-banner[data-ga4-track-links-only]"
-    assert_no_selector ".gem-c-emergency-banner[data-ga4-set-indexes]"
-    assert_no_selector ".gem-c-emergency-banner[data-ga4-link]"
+    assert_select ".gem-c-emergency-banner[data-ga4-emergency-banner]", false
+    assert_select ".gem-c-emergency-banner[data-module=ga4-link-tracker]", false
+    assert_select ".gem-c-emergency-banner[data-ga4-track-links-only]", false
+    assert_select ".gem-c-emergency-banner[data-ga4-set-indexes]", false
+    assert_select ".gem-c-emergency-banner[data-ga4-link]", false
   end
 end

--- a/spec/components/intervention_spec.rb
+++ b/spec/components/intervention_spec.rb
@@ -19,6 +19,44 @@ describe "Intervention", type: :view do
     assert_select ".gem-c-intervention .govuk-link", text: /Hide this suggestion/
   end
 
+  it "adds data attributes correctly" do
+    render_component(
+      name: "test-campaign",
+      suggestion_text: "You might be interested in",
+      suggestion_link_text: "Travel abroad",
+      suggestion_link_url: "/travel-abroad",
+      data_attributes: {
+        "hello": "world0",
+        "this-is": "a test 0",
+      },
+      suggestion_data_attributes: {
+        "hello": "world1",
+        "this-is": "a test 1",
+      },
+      dismiss_data_attributes: {
+        "hello": "world2",
+        "this-is": "a test 2",
+      },
+      dismiss_link_data_attributes: {
+        "hello": "world3",
+        "this-is": "a test 3",
+      },
+      dismiss_text: "Hide this suggestion",
+    )
+
+    assert_select ".gem-c-intervention[data-hello=world0]"
+    assert_select ".gem-c-intervention[data-this-is='a test 0']"
+
+    assert_select ".gem-c-intervention a:first-of-type[data-hello=world1]"
+    assert_select ".gem-c-intervention a:first-of-type[data-this-is='a test 1']"
+
+    assert_select ".gem-c-intervention p:nth-of-type(2)[data-hello=world2]"
+    assert_select ".gem-c-intervention p:nth-of-type(2)[data-this-is='a test 2']"
+
+    assert_select ".js-dismiss-link[data-hello=world3]"
+    assert_select ".js-dismiss-link[data-this-is='a test 3']"
+  end
+
   it "renders the component with GA4 tracking when ga4_tracking is true" do
     render_component(
       name: "test-campaign",
@@ -37,7 +75,27 @@ describe "Intervention", type: :view do
     assert_select ".js-dismiss-link[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"intervention\",\"section\":\"You might be interested in\",\"action\":\"closed\"}']"
   end
 
-  it "renders the component with GA4 tracking when ga4_tracking is false" do
+  it "ensures data modules are combined correctly when GA4 tracking is true" do
+    render_component(
+      name: "test-campaign",
+      suggestion_text: "You might be interested in",
+      suggestion_link_text: "Travel abroad",
+      suggestion_link_url: "/travel-abroad",
+      dismiss_text: "Hide this suggestion",
+      suggestion_data_attributes: {
+        module: "hello-world",
+      },
+      dismiss_link_data_attributes: {
+        module: "hello-world",
+      },
+      ga4_tracking: true,
+    )
+
+    assert_select ".gem-c-intervention a:first-of-type[data-module='hello-world ga4-link-tracker']"
+    assert_select ".js-dismiss-link[data-module='hello-world ga4-event-tracker']"
+  end
+
+  it "renders the component without GA4 tracking when ga4_tracking is false" do
     render_component(
       name: "test-campaign",
       suggestion_text: "You might be interested in",

--- a/spec/components/intervention_spec.rb
+++ b/spec/components/intervention_spec.rb
@@ -19,6 +19,42 @@ describe "Intervention", type: :view do
     assert_select ".gem-c-intervention .govuk-link", text: /Hide this suggestion/
   end
 
+  it "renders the component with GA4 tracking when ga4_tracking is true" do
+    render_component(
+      name: "test-campaign",
+      suggestion_text: "You might be interested in",
+      suggestion_link_text: "Travel abroad",
+      suggestion_link_url: "/travel-abroad",
+      dismiss_text: "Hide this suggestion",
+      ga4_tracking: true,
+    )
+
+    assert_select ".gem-c-intervention[data-ga4-intervention-banner]"
+    assert_select ".gem-c-intervention a:first-of-type[data-module='ga4-link-tracker']"
+    assert_select ".gem-c-intervention a:first-of-type[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"intervention\",\"section\":\"You might be interested in\",\"index\":1,\"index_total\":1}']"
+
+    assert_select ".js-dismiss-link[data-module=ga4-event-tracker]"
+    assert_select ".js-dismiss-link[data-ga4-event='{\"event_name\":\"select_content\",\"type\":\"intervention\",\"section\":\"You might be interested in\",\"action\":\"closed\"}']"
+  end
+
+  it "renders the component with GA4 tracking when ga4_tracking is false" do
+    render_component(
+      name: "test-campaign",
+      suggestion_text: "You might be interested in",
+      suggestion_link_text: "Travel abroad",
+      suggestion_link_url: "/travel-abroad",
+      dismiss_text: "Hide this suggestion",
+      ga4_tracking: false,
+    )
+
+    assert_select ".gem-c-intervention[data-ga4-intervention-banner]", false
+    assert_select ".gem-c-intervention a:first-of-type[data-module=ga4-link-tracker]", false
+    assert_select ".gem-c-intervention a:first-of-type[data-ga4-link]", false
+
+    assert_select ".js-dismiss-link[data-module=ga4-event-tracker]", false
+    assert_select ".js-dismiss-link[data-ga4-event]", false
+  end
+
   it "renders the component without dismiss button" do
     render_component(
       suggestion_text: "You might be interested in",

--- a/spec/components/phase_banner_spec.rb
+++ b/spec/components/phase_banner_spec.rb
@@ -52,10 +52,10 @@ describe "Phase banner", type: :view do
 
   it "renders banner without ga4 attributes" do
     render_component(phase: "beta", ga4_tracking: false)
-    assert_no_selector ".gem-c-phase-banner[data-ga4-phase-banner]"
-    assert_no_selector ".gem-c-phase-banner[data-module=ga4-link-tracker]"
-    assert_no_selector ".gem-c-phase-banner[data-ga4-track-links-only]"
-    assert_no_selector ".gem-c-phase-banner[data-ga4-set-indexes]"
-    assert_no_selector ".gem-c-phase-banner[data-ga4-link]"
+    assert_select ".gem-c-phase-banner[data-ga4-phase-banner]", false
+    assert_select ".gem-c-phase-banner[data-module=ga4-link-tracker]", false
+    assert_select ".gem-c-phase-banner[data-ga4-track-links-only]", false
+    assert_select ".gem-c-phase-banner[data-ga4-set-indexes]", false
+    assert_select ".gem-c-phase-banner[data-ga4-link]", false
   end
 end

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -54,7 +54,8 @@ describe('Google Tag Manager page view tracking', function () {
         emergency_banner: undefined,
         phase_banner: undefined,
         devolved_nations_banner: undefined,
-        cookie_banner: undefined
+        cookie_banner: undefined,
+        intervention: undefined
       }
     }
     window.dataLayer = []
@@ -490,6 +491,16 @@ describe('Google Tag Manager page view tracking', function () {
     div.setAttribute('data-ga4-cookie-banner', '')
     document.body.appendChild(div)
     expected.page_view.cookie_banner = 'true'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
+    document.body.removeChild(div)
+  })
+
+  it('correctly sets the intervention parameter', function () {
+    var div = document.createElement('div')
+    div.setAttribute('data-ga4-intervention-banner', '')
+    document.body.appendChild(div)
+    expected.page_view.intervention = 'true'
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
     expect(window.dataLayer[0]).toEqual(expected)
     document.body.removeChild(div)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -496,13 +496,35 @@ describe('Google Tag Manager page view tracking', function () {
     document.body.removeChild(div)
   })
 
-  it('correctly sets the intervention parameter', function () {
-    var div = document.createElement('div')
-    div.setAttribute('data-ga4-intervention-banner', '')
-    document.body.appendChild(div)
-    expected.page_view.intervention = 'true'
-    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
-    expect(window.dataLayer[0]).toEqual(expected)
-    document.body.removeChild(div)
+  describe('intervention banner', function () {
+    var div
+    beforeEach(function () {
+      div = document.createElement('div')
+      div.setAttribute('data-ga4-intervention-banner', '')
+      document.body.appendChild(div)
+    })
+
+    afterEach(function () {
+      document.body.removeChild(div)
+    })
+
+    it('correctly sets the parameter when the banner exists and no cookie exists', function () {
+      div.setAttribute('data-intervention-name', 'hello-world')
+      div.setAttribute('data-module', 'intervention')
+      expected.page_view.intervention = 'true'
+      GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('doesn\'t set the intervention parameter when the banner is hidden via the cookie', function () {
+      div.setAttribute('data-ga4-intervention-banner', '')
+      div.setAttribute('data-module', 'intervention')
+      div.setAttribute('data-intervention-name', 'hello-world')
+      window.GOVUK.setCookie('intervention_campaign', 'hello-world')
+      expected.page_view.intervention = undefined
+      GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+      expect(window.dataLayer[0]).toEqual(expected)
+      window.GOVUK.setCookie('intervention_campaign', '')
+    })
   })
 })


### PR DESCRIPTION
Hi @andysellick - would you be able to review this? I recommend looking commit by commit for this one. Thanks.

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds GA4 tracking to the intervention banner component.
- More specifically, it adds `intervention: 'true'/undefined` to the `pageview` if the banner is present. It sets this value based on the presence of `data-ga4-intervention-banner` in the DOM.
- The `ga4-link-tracker` is added to the element's "suggested" link.
- The `ga4-event-tracker` is added to the "Hide this message" link as we want to track it as `select_content` instead of a link.
- All of these rely on `ga4_tracking: true` so we can toggle tracking on and off on the banner.
- I also fixed a bug with the examples in the component guide. The `with_data_attributes` example implied that you can add `dismiss_data_attributes`, but I noticed that this value was missing from the Ruby template so I fixed it.
-  I needed to add `dismiss_link_data_attributes` to the template, to add the event tracker for "Hide this message". The event tracker needs to be on the link itself, and not on the parent `<p>` tag (and the `<p>` tag is what `dismiss_data_attributes` is for).
- I noticed that `assert_no_selector` always passes in tests. I was using this to check that `ga4_tracking: false` was working. Therefore I have changed all the banner tests to use `assert_select [element], false`.
- This issue with `assert_no_selector` seems to be across other components (did a test with the contextual_breadcrumbs), so I may fix that as a separate PR.
- I've checked this banner on a local version of `static` and the pageview is sending correctly.
- I've kept the commits separate so that it is hopefully easier to review. Will squash once approved.

Thanks :+1:

## Why
<!-- What are the reasons behind this change being made? -->
- https://trello.com/c/dqBVyVTJ/666-banners-interventions-element-visibility-navigation-and-hide-user-interaction

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

- Added a `with_ga4_tracking` example to the docs for the component and added `dismiss_link_data_attributes` to the `with_data_attributes` example.