### PR TITLE
Redact GA params from pageview data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Redact GA params from pageview data ([PR #3568](https://github.com/alphagov/govuk_publishing_components/pull/3568))
 * Add GA4 tracking to devolved nations banners ([PR #3556](https://github.com/alphagov/govuk_publishing_components/pull/3556))
 * Add GA4 tracking to the cookie banner ([PR #3564](https://github.com/alphagov/govuk_publishing_components/pull/3564))
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -17,7 +17,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             location: this.getLocation(),
             /* If the init() function receives a referrer parameter, this indicates that it has been called as a part of an AJAX request and
             this.getReferrer() will not return the correct value. Therefore we need to rely on the referrer parameter. */
-            referrer: referrer ? this.PIIRemover.stripPIIWithOverride(referrer, true, true) : this.getReferrer(),
+            referrer: this.getReferrer(referrer),
             title: this.getTitle(),
             status_code: this.getStatusCode(),
 
@@ -65,11 +65,19 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     },
 
     getLocation: function () {
-      return this.PIIRemover.stripPII(document.location.href)
+      return this.PIIRemover.stripPII(this.stripGaParam(document.location.href))
     },
 
-    getReferrer: function () {
-      return this.PIIRemover.stripPIIWithOverride(document.referrer, true, true)
+    getReferrer: function (referrer) {
+      referrer = this.stripGaParam(referrer || document.referrer)
+      return this.PIIRemover.stripPIIWithOverride(referrer, true, true)
+    },
+
+    // remove GA parameters of the form _ga=2320.021-012302 or _gl=02.10320.01230-123
+    stripGaParam: function (str) {
+      str = str.replace(/(_ga=[0-9.-]+)/g, '_ga=[id]')
+      str = str.replace(/(_gl=[0-9.-]+)/g, '_gl=[id]')
+      return str
     },
 
     getTitle: function () {


### PR DESCRIPTION
## What
- replaces Google Analytics tracking parameters in URLs with `_ga=[id]` or `_gl=[id]` when creating GA pageviews
- has to happen prior to PII being stripped as they occasionally get mistaken for dates, which would break this redaction
- vaguely related: refactor the get referrer code to make it easier to read and insert the GA param redaction

## Why
To clean up the location data in GA4.

## Visual Changes
None.

Trello card: https://trello.com/c/2hJRUoDM/660-redact-strip-ga-and-gl-trackers-from-page-location-and-page-referrer-values
