### PR TITLE
Change "Topics" to "Services and information"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Change "Topics" to "Services and information" ([PR #3570](https://github.com/alphagov/govuk_publishing_components/pull/3570))
 * Redact GA params from pageview data ([PR #3568](https://github.com/alphagov/govuk_publishing_components/pull/3568))
 * Add GA4 tracking to devolved nations banners ([PR #3556](https://github.com/alphagov/govuk_publishing_components/pull/3556))
 * Add GA4 tracking to the cookie banner ([PR #3564](https://github.com/alphagov/govuk_publishing_components/pull/3564))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_layout-super-navigation-header.scss
@@ -693,7 +693,7 @@ $after-button-padding-left: govuk-spacing(4);
   }
 }
 
-.gem-c-layout-super-navigation-header__navigation-second-items--topics {
+.gem-c-layout-super-navigation-header__navigation-second-items--services-and-information {
   @include govuk-media-query($until: "desktop") {
     border-bottom: 1px solid govuk-colour("mid-grey");
   }

--- a/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_super_navigation_header.html.erb
@@ -217,11 +217,11 @@
                 end
               %>
 
-              <div class="<%= width_class %> gem-c-layout-super-navigation-header__column--<%= column[:label].downcase.sub(" ", "-") %>">
+              <div class="<%= width_class %> gem-c-layout-super-navigation-header__column--<%= column[:label].downcase.gsub(" ", "-") %>">
                 <h3 class="govuk-heading-m gem-c-layout-super-navigation-header__column-header">
                   <%= column[:label] %>
                 </h3>
-                <ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--<%= column[:label].downcase.sub(" ", "-") %>">
+                <ul class="gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--<%= column[:label].downcase.gsub(" ", "-") %>">
                   <% index_total = column[:menu_contents].length %>
                   <% column[:menu_contents].each_with_index do | item, index | %>
                       <%

--- a/app/views/govuk_publishing_components/components/docs/cards.yml
+++ b/app/views/govuk_publishing_components/components/docs/cards.yml
@@ -20,7 +20,7 @@ uses_component_wrapper_helper: true
 examples:
   default:
     data:
-      heading: Topics
+      heading: Services and information
       items:
         - link:
             text: Benefits
@@ -109,7 +109,7 @@ examples:
 
       Override default subheading level by passing through `sub_heading_level` parameter (defaults to `<h3>`)
     data:
-      heading: Topics
+      heading: Services and information
       heading_level: 3
       sub_heading_level: 4
       items:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,7 +91,7 @@ en:
       copyright_html: <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
       licence_html: All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
       navigation_links:
-      - title: Topics
+      - title: Services and information
         menu_contents:
         - text: Benefits
           href: "/browse/benefits"
@@ -171,7 +171,7 @@ en:
         href: "/browse"
         label: Menu
       navigation_links_columns:
-      - label: Topics
+      - label: Services and information
         size: 2
         menu_contents:
         - label: Benefits

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -125,8 +125,8 @@ describe "Super navigation header", type: :view do
     assert_select "header[data-module='gem-track-click ga4-event-tracker ga4-link-tracker']"
     assert_select "a[data-ga4-link]", count: 28
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","external":"false","text":"GOV.UK","section":"Logo","index":{"index_link":1,"index_section":0,"index_section_count":2},"index_total":1}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":1,"index_link":1,"index_section_count":4},"index_total":16,"section":"Topics"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":1,"index_link":16,"index_section_count":4},"index_total":16,"section":"Topics"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":1,"index_link":1,"index_section_count":4},"index_total":16,"section":"Services and information"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":1,"index_link":16,"index_section_count":4},"index_total":16,"section":"Services and information"}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":2,"index_link":1,"index_section_count":4},"index_total":6,"section":"Government activity"}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":2,"index_link":6,"index_section_count":4},"index_total":6,"section":"Government activity"}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":4,"index_link":1,"index_section_count":4},"index_total":5,"section":"Popular on GOV.UK"}\']'


### PR DESCRIPTION
## What

In the footer and navbar, change all instances of `Topics` to `Services and information`.

## Why

Part of a series of changes being made to the homepage.

[Relevant Trello Card](https://trello.com/c/uUTQPB0r/1991-live-test-3-change-topics-to-services-and-information-on-homepage-header-footer-m)

## Visual Changes

### Before

![Screenshot 2023-08-23 at 15 31 09](https://github.com/alphagov/govuk_publishing_components/assets/3727504/76067cad-4f87-4115-aa31-987991e41680)

![Screenshot 2023-08-23 at 15 37 50](https://github.com/alphagov/govuk_publishing_components/assets/3727504/4719aae1-ce51-41d0-b339-a9870d690715)

### After

![Screenshot 2023-08-23 at 15 35 23](https://github.com/alphagov/govuk_publishing_components/assets/3727504/aa8af364-5149-419c-a2a2-668ecece8588)


![Screenshot 2023-08-23 at 15 35 29](https://github.com/alphagov/govuk_publishing_components/assets/3727504/cb7f2027-8238-4caf-92fa-e8c43d42046e)
