### PR TITLE
LUX version 311

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add new rule to fix accordion print style ([PR #3582](https://github.com/alphagov/govuk_publishing_components/pull/3582))
 * Fix GA4 bug - all attachments links tracked with the same JSON ([PR #3577](https://github.com/alphagov/govuk_publishing_components/pull/3577))
+* LUX version 311 ([PR #3572](https://github.com/alphagov/govuk_publishing_components/pull/3572))
 
 ## 35.15.0
 


### PR DESCRIPTION
## What / why
Updating to new version of LUX as per https://github.com/alphagov/govuk_publishing_components/blob/main/docs/real-user-metrics.md

Slightly odd upgrade this time around - some of the `__ENABLE_POLYFILLS` stuff has been stripped out, and in some cases replaced with apparently redundant wrapping `{}` braces, which I don't quite understand. There's also a few comments where the indentation has been the same for the last few updates and I've been doggedly preserving our indentation to reduce the diff, but it doesn't seem worth keeping that up.

## Visual Changes
None.
