### PR TITLE
Fix GA4 bug - all attachments links tracked with the same JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Redact GA params from pageview data ([PR #3568](https://github.com/alphagov/govuk_publishing_components/pull/3568))
 * Add GA4 tracking to devolved nations banners ([PR #3556](https://github.com/alphagov/govuk_publishing_components/pull/3556))
 * Add GA4 tracking to the cookie banner ([PR #3564](https://github.com/alphagov/govuk_publishing_components/pull/3564))
+* Fix GA4 bug - all attachments links tracked with the same JSON ([PR #3577](https://github.com/alphagov/govuk_publishing_components/pull/3577))
 
 ## 35.14.0
 

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -54,8 +54,9 @@
     )
   end
 
+  data_attributes[:ga4_link] = ga4_link
 %>
-<%= tag.section class: class_names(container_class_names), data: { module: "ga4-link-tracker", ga4_track_links_only: "", ga4_link: ga4_link } do %>
+<%= tag.section class: class_names(container_class_names), data: { module: "ga4-link-tracker" } do %>
   <%= tag.div class: "gem-c-attachment__thumbnail" do %>
     <%= link_to attachment.url,
                 class: "govuk-link",

--- a/spec/components/attachment_spec.rb
+++ b/spec/components/attachment_spec.rb
@@ -278,10 +278,9 @@ describe "Attachment", type: :view do
         type: "html",
       },
     )
-
     assert_select "section[data-module=ga4-link-tracker]"
-    assert_select "section[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"attachment\"}']"
-    assert_select "section[data-ga4-track-links-only]"
+    assert_select ".gem-c-attachment__thumbnail a[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"attachment\"}']"
+    assert_select ".gem-c-attachment__link[data-ga4-link='{\"event_name\":\"navigation\",\"type\":\"attachment\"}']"
   end
 
   it "includes GA4 tracking on file attachment links by default" do
@@ -295,7 +294,7 @@ describe "Attachment", type: :view do
     )
 
     assert_select "section[data-module=ga4-link-tracker]"
-    assert_select "section[data-ga4-link='{\"event_name\":\"file_download\",\"type\":\"attachment\"}']"
-    assert_select "section[data-ga4-track-links-only]"
+    assert_select ".gem-c-attachment__thumbnail a[data-ga4-link='{\"event_name\":\"file_download\",\"type\":\"attachment\"}']"
+    assert_select ".gem-c-attachment__link[data-ga4-link='{\"event_name\":\"file_download\",\"type\":\"attachment\"}']"
   end
 end


### PR DESCRIPTION

## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Previously, we had our GA4 JSON attribute on the parent element of the attachment links (the `<section>` tag.)
- This meant that every link within this element would be tracked with the same attributes listed in the JSON.
- We don't want to do this anymore, as we realised there are links that we don't want tracked in this way (e.g. email links can be nested in the attachments.)
- Therefore, we move the `ga4_link` JSON onto the `data_attributes` hash. This hash is used by the attachment thumbnail link, and the attachment title link. And this is good as we only want the tracking on those links.

http://0.0.0.0:3212/component-guide/attachment

## Why
<!-- What are the reasons behind this change being made? -->
- https://trello.com/c/MHFXw6H2/552-change-filedownloads-on-attachment-pages-to-have-attachment-instead-of-generic-download-type

## Visual Changes
None.