### PR TITLE
Add new rule to fix accordion print style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add new rule to fix accordion print style ([PR #3582](https://github.com/alphagov/govuk_publishing_components/pull/3582))
+
 ## 35.15.0
 
 * Change "Topics" to "Services and information" ([PR #3570](https://github.com/alphagov/govuk_publishing_components/pull/3570))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_accordion.scss
@@ -17,6 +17,12 @@
     display: block !important; // stylelint-disable-line declaration-no-important
   }
 
+  .js-enabled .govuk-accordion__section-content[hidden] {
+    @supports (content-visibility: hidden) {
+      content-visibility: auto;
+    }
+  }
+
   // Change the colour from the blue link colour to black.
   .govuk-accordion__section-button {
     color: govuk-colour("black") !important; // stylelint-disable-line declaration-no-important


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Add new rule to override content-visibility in print styles.

## Why
<!-- What are the reasons behind this change being made? -->

The accordions should be expanded when printed. On browsers that support content visibility, the content was still hidden. The addition of this rule fixes this and ensures that printed pages will show all accordion sections.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

![Screenshot 2023-09-01 at 12 38 39](https://github.com/alphagov/govuk_publishing_components/assets/3727504/d393b634-d1ee-41af-b187-a59ecab15f4f)


### After

![Screenshot 2023-09-01 at 12 38 33](https://github.com/alphagov/govuk_publishing_components/assets/3727504/a726cc51-3656-45d8-bf60-6087e9ec02fd)

