### PR TITLE
Add expansion to print style for govspeak links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Add new rule to fix accordion print style ([PR #3582](https://github.com/alphagov/govuk_publishing_components/pull/3582))
 * Fix GA4 bug - all attachments links tracked with the same JSON ([PR #3577](https://github.com/alphagov/govuk_publishing_components/pull/3577))
 * LUX version 311 ([PR #3572](https://github.com/alphagov/govuk_publishing_components/pull/3572))
+* Enable GA4 tracking on the phase banner ([PR #3588](https://github.com/alphagov/govuk_publishing_components/pull/3588))
+* Add expansion to print style for govspeak links ([PR #3584](https://github.com/alphagov/govuk_publishing_components/pull/3584))
 
 ## 35.15.0
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_govspeak.scss
@@ -34,6 +34,12 @@
   // stylelint-disable max-nesting-depth
 
   .gem-c-govspeak {
+    a[href^="/"]:after,a[href^="http://"]:after,a[href^="https://"]:after {
+      content: " (" attr(href) ")";
+      font-size: 90%;
+      word-wrap: break-word;
+    }
+
     .media-player {
       display: none;
     }

--- a/app/views/govuk_publishing_components/components/layout_for_public/_account-layout.html.erb
+++ b/app/views/govuk_publishing_components/components/layout_for_public/_account-layout.html.erb
@@ -1,6 +1,7 @@
 <div class="govuk-width-container">
   <%= render "govuk_publishing_components/components/phase_banner", {
     phase: "beta",
+    ga4_tracking: true,
     message: sanitize(t("components.layout_for_public.account_layout.feedback.banners.phase_banner_html"))
   } unless omit_account_phase_banner %>
 


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Add rule to add link expansion to a elements in govspeak.


## Why
<!-- What are the reasons behind this change being made? -->
Standard practice for print styles is that links should be expanded to show url. For all links with 'govuk-link' class this was working as expected but links rendered by govspeak don't have the 'govuk-link' class applied and so these styles were not being applied.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

### Before

![Screenshot 2023-09-01 at 15 12 29](https://github.com/alphagov/govuk_publishing_components/assets/3727504/b4f2a7b7-4eb7-4299-b1ff-57c7ad4fa1e4)

### After

![Screenshot 2023-09-01 at 15 12 47](https://github.com/alphagov/govuk_publishing_components/assets/3727504/4c755ef9-2a28-44a3-b12f-c961c7c283b7)
