### PR TITLE
Add 6th link to popular links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix bug with GA4 search results count ([PR #3594](https://github.com/alphagov/govuk_publishing_components/pull/3594))
 * Check HTML attribute when populating GA4 language ([PR #3598](https://github.com/alphagov/govuk_publishing_components/pull/3598))
 * Add GA4 tracking to the intervention banner ([PR #3567](https://github.com/alphagov/govuk_publishing_components/pull/3567))
+* Add 6th link to popular links ([PR #3586](https://github.com/alphagov/govuk_publishing_components/pull/3586))
 
 ## 35.15.2
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -241,6 +241,8 @@ en:
         href: "/sign-in-universal-credit"
       - label: Check your National Insurance record
         href: "/check-national-insurance-record"
+      - label: 'Check MOT history of a vehicle'
+        href: /check-mot-history
       popular_links_heading: Popular on GOV.UK
       search_text: Search GOV.UK
     metadata:

--- a/spec/components/layout_super_navigation_header_spec.rb
+++ b/spec/components/layout_super_navigation_header_spec.rb
@@ -123,13 +123,13 @@ describe "Super navigation header", type: :view do
     render_component({ ga4_tracking: true })
 
     assert_select "header[data-module='gem-track-click ga4-event-tracker ga4-link-tracker']"
-    assert_select "a[data-ga4-link]", count: 28
+    assert_select "a[data-ga4-link]", count: 29
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","external":"false","text":"GOV.UK","section":"Logo","index":{"index_link":1,"index_section":0,"index_section_count":2},"index_total":1}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":1,"index_link":1,"index_section_count":4},"index_total":16,"section":"Services and information"}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":1,"index_link":16,"index_section_count":4},"index_total":16,"section":"Services and information"}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":2,"index_link":1,"index_section_count":4},"index_total":6,"section":"Government activity"}\']'
     assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":2,"index_link":6,"index_section_count":4},"index_total":6,"section":"Government activity"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":4,"index_link":1,"index_section_count":4},"index_total":5,"section":"Popular on GOV.UK"}\']'
-    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":4,"index_link":5,"index_section_count":4},"index_total":5,"section":"Popular on GOV.UK"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":4,"index_link":1,"index_section_count":4},"index_total":6,"section":"Popular on GOV.UK"}\']'
+    assert_select 'a[data-ga4-link=\'{"event_name":"navigation","type":"header menu bar","index":{"index_section":4,"index_link":5,"index_section_count":4},"index_total":6,"section":"Popular on GOV.UK"}\']'
   end
 end


### PR DESCRIPTION
## What

Add new link to list of popular links. Update tests that count links in the popular section.

## Why

Part of incremental changes being made to the homepage.

[Trello Card](https://trello.com/c/TAHoaSQ9/2025-live-test-4-add-6th-link-to-popular-on-14-sep-dev-work-m)

## Visual Changes

### Before

![Screenshot 2023-09-04 at 14 31 57](https://github.com/alphagov/govuk_publishing_components/assets/3727504/944541cc-9896-4156-9dfd-c80f5302c196)

### After

![Screenshot 2023-09-04 at 14 31 41](https://github.com/alphagov/govuk_publishing_components/assets/3727504/b6e1ac6d-7494-41b4-8134-29a0e573b8b4)

