### PR TITLE
Version 35.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.15.1
 
 * Add new rule to fix accordion print style ([PR #3582](https://github.com/alphagov/govuk_publishing_components/pull/3582))
 * Fix GA4 bug - all attachments links tracked with the same JSON ([PR #3577](https://github.com/alphagov/govuk_publishing_components/pull/3577))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.15.0)
+    govuk_publishing_components (35.15.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.15.0".freeze
+  VERSION = "35.15.1".freeze
 end


### PR DESCRIPTION
## 35.15.1

* Add new rule to fix accordion print style ([PR #3582](https://github.com/alphagov/govuk_publishing_components/pull/3582))
* Fix GA4 bug - all attachments links tracked with the same JSON ([PR #3577](https://github.com/alphagov/govuk_publishing_components/pull/3577))
* LUX version 311 ([PR #3572](https://github.com/alphagov/govuk_publishing_components/pull/3572))
* Enable GA4 tracking on the phase banner ([PR #3588](https://github.com/alphagov/govuk_publishing_components/pull/3588))
* Add expansion to print style for govspeak links ([PR #3584](https://github.com/alphagov/govuk_publishing_components/pull/3584))
