### PR TITLE
Prepend page path when tracking anchor links in GA4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Prepend page path when tracking anchor links in GA4 ([PR #3590](https://github.com/alphagov/govuk_publishing_components/pull/3590))
+
 ## 35.15.1
 
 * Add new rule to fix accordion print style ([PR #3582](https://github.com/alphagov/govuk_publishing_components/pull/3582))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -205,6 +205,10 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
         }
       },
 
+      getPathname: function () {
+        return window.location.pathname
+      },
+
       getProtocol: function () {
         return window.location.protocol
       },
@@ -252,6 +256,13 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
 
       applyRedactionIfRequired: function (PIIRemover, element, data) {
         return element.closest('[data-ga4-do-not-redact]') ? data : PIIRemover.stripPIIWithOverride(data, true, true)
+      },
+
+      appendPathToAnchorLinks: function (url) {
+        if (!this.stringStartsWith(url, '#') || this.getPathname() === '/') {
+          return url
+        }
+        return this.getPathname() + url
       }
     },
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
@@ -74,7 +74,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         if (aTag) {
           var href = aTag.getAttribute('href')
           if (href) {
-            schema.event_data.url = href
+            schema.event_data.url = window.GOVUK.analyticsGa4.core.trackFunctions.appendPathToAnchorLinks(href)
           }
         }
       }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
@@ -62,13 +62,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Ga4LinkTracker.prototype.trackClick = function (event) {
     var element = event.target
-
+    var trackFunctions = window.GOVUK.analyticsGa4.core.trackFunctions
     // don't track this link if it's already being tracked by the ecommerce tracker
     if (element.closest('[data-ga4-ecommerce-path]')) {
       return
     }
 
-    var target = window.GOVUK.analyticsGa4.core.trackFunctions.findTrackingAttributes(event.target, this.trackingTrigger)
+    var target = trackFunctions.findTrackingAttributes(event.target, this.trackingTrigger)
     if (target) {
       try {
         var data = target.getAttribute(this.trackingTrigger)
@@ -80,17 +80,19 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       var text = data.text || event.target.textContent
-      data.text = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(text)
-      data.text = window.GOVUK.analyticsGa4.core.trackFunctions.applyRedactionIfRequired(this.PIIRemover, element, data.text)
+      data.text = trackFunctions.removeLinesAndExtraSpaces(text)
+      data.text = trackFunctions.applyRedactionIfRequired(this.PIIRemover, element, data.text)
       if (!data.text && (element.querySelector('img') || element.querySelector('svg') || element.tagName === 'IMG' || element.closest('svg'))) {
         data.text = 'image'
       }
       var url = data.url || this.findLink(event.target).getAttribute('href')
-      data.url = window.GOVUK.analyticsGa4.core.trackFunctions.applyRedactionIfRequired(this.PIIRemover, element, window.GOVUK.analyticsGa4.core.trackFunctions.removeCrossDomainParams(url))
-      data.link_domain = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkDomain(data.url)
-      data.link_path_parts = window.GOVUK.analyticsGa4.core.trackFunctions.populateLinkPathParts(data.url)
-      data.method = window.GOVUK.analyticsGa4.core.trackFunctions.getClickType(event)
-      data.external = window.GOVUK.analyticsGa4.core.trackFunctions.isExternalLink(data.url) ? 'true' : 'false'
+      data.url = trackFunctions.removeCrossDomainParams(url)
+      data.url = trackFunctions.applyRedactionIfRequired(this.PIIRemover, element, data.url)
+      data.url = trackFunctions.appendPathToAnchorLinks(data.url)
+      data.link_domain = trackFunctions.populateLinkDomain(data.url)
+      data.link_path_parts = trackFunctions.populateLinkPathParts(data.url)
+      data.method = trackFunctions.getClickType(event)
+      data.external = trackFunctions.isExternalLink(data.url) ? 'true' : 'false'
       data.index = this.setIndex(data.index, event.target)
 
       if (data.type === 'smart answer' && data.action === 'change response') {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -269,6 +269,20 @@ describe('GA4 core', function () {
       })
     })
 
+    describe('when tracking anchor links', function () {
+      beforeEach(function () {
+        spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'getPathname').and.returnValue('/hello-world')
+      })
+
+      it('appends the page path to anchor links', function () {
+        var href = '#heading1'
+        expect(GOVUK.analyticsGa4.core.trackFunctions.appendPathToAnchorLinks(href)).toEqual('/hello-world#heading1')
+
+        href = '/not-an-anchor-link'
+        expect(GOVUK.analyticsGa4.core.trackFunctions.appendPathToAnchorLinks(href)).toEqual(href)
+      })
+    })
+
     it('accepts an array of domains and increases it to include variants without www at the start', function () {
       var domains = ['www.gov.uk']
       GOVUK.analyticsGa4.core.trackFunctions.appendDomainsWithoutWWW(domains)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.spec.js
@@ -431,17 +431,19 @@ describe('Google Analytics event tracker', function () {
         '</div>'
       document.body.appendChild(element)
       new GOVUK.Modules.Ga4EventTracker(element).init()
+
+      spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'getPathname').and.returnValue('/hello-world')
     })
 
-    it('should track tab click url locations', function () {
+    it('should track tab click url locations, with the page path appended if it\'s an anchor link', function () {
       var clickOn = element.querySelector('.tab-1')
       clickOn.click()
-      expect(window.dataLayer[0].event_data.url).toEqual('#tab-location-1')
+      expect(window.dataLayer[0].event_data.url).toEqual('/hello-world#tab-location-1')
 
       window.dataLayer = []
       clickOn = element.querySelector('.tab-2')
       clickOn.click()
-      expect(window.dataLayer[0].event_data.url).toEqual('#tab-location-2')
+      expect(window.dataLayer[0].event_data.url).toEqual('/hello-world#tab-location-2')
 
       window.dataLayer = []
       clickOn = element.querySelector('.random-list-item')

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.spec.js
@@ -510,4 +510,23 @@ describe('GA4 link tracker', function () {
       }
     })
   })
+
+  describe('if the link is an anchor', function () {
+    beforeEach(function () {
+      spyOn(GOVUK.analyticsGa4.core.trackFunctions, 'getPathname').and.returnValue('/hello-world')
+    })
+
+    it('adds the page path to the url value', function () {
+      element = document.createElement('div')
+      element.setAttribute('data-ga4-track-links-only', '')
+      element.setAttribute('data-ga4-link', '{"event_name": "navigation"}')
+      element.innerHTML = '<a class="link1" href="#link1"><img src=""/></a>'
+
+      initModule(element, true)
+      var link = element.querySelector('.link1')
+
+      link.click()
+      expect(window.dataLayer[0].event_data.url).toEqual('/hello-world#link1')
+    })
+  })
 })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Ensures the page path is added to anchor links tracked by the `ga4-link-tracker` and `ga4-event-tracker`
- For example, `#england-and-wales` will become `/bank-holidays#england-and-wales` in the GA4 dashboard.
- I also cleaned up the link tracker slightly as we kept repeating `window.GOVUK.analyticsGa4.core.trackFunctions`, let me know your thoughts.
- Will add CHANGELOG when the pending release PR is live

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/7thzJTbm/672-include-page-path-in-anchor-links

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.