### PR TITLE
Fix error in LUX script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Fix error in LUX script ([PR #3592](https://github.com/alphagov/govuk_publishing_components/pull/3592))
 * Prepend page path when tracking anchor links in GA4 ([PR #3590](https://github.com/alphagov/govuk_publishing_components/pull/3590))
 
 ## 35.15.1

--- a/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-reporter.js
+++ b/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-reporter.js
@@ -538,6 +538,10 @@
     // -------------------------------------------------------------------------
     // Settings
     // -------------------------------------------------------------------------
+    // This ID usually appended to the end of the lux.js as a query string when
+    // using the SpeedCurve hosted version - but we have to include it here as
+    // this is self hosted.
+    LUX.customerid = 47044334;
     // Set the sample rate to 1% to avoid all events being sent.
     LUX.samplerate = 1;
     // -------------------------------------------------------------------------
@@ -1494,10 +1498,9 @@
       }
       return getHighPercentileINP();
     }
+    // function simplified for our use, original would get the customerid from the script src URL
+    // but we set it inside the code in this file, so this function just returns that
     function getCustomerId() {
-      if (!LUX.customerid) {
-        LUX.customerid = thisScript.src.match(/id=(\d+)/).pop();
-      }
       return LUX.customerid || "";
     }
     function avgDomDepth() {
@@ -2200,11 +2203,6 @@
   // More settings
   // ---------------------------------------------------------------------------
   //
-  // This ID usually appended to the end of the lux.js as a query string when
-  // using the SpeedCurve hosted version - but we have to include it here as
-  // this is self hosted.
-  LUX.customerid = 47044334;
-
   // Setting debug to `true` shows what happening as it happens. Running
   // `LUX.getDebug()` in the browser's console will show the history of what's
   // happened.

--- a/docs/real-user-metrics.md
+++ b/docs/real-user-metrics.md
@@ -28,9 +28,9 @@ The customer ID is an identifier for the site using LUX, not for the user visiti
 
 When loading `lux.js` from SpeedCurve's CDN, the customer ID is appended to the end of the URI as a query string. The script looks for a script in the DOM with a source of `lux.js`, and from that extracts the customer ID.
 
-Rails adds a fingerprint to the URI which means that `lux.js` becomes (for example) `lux.self-7137780d5344a93190a2c698cd660619d4197420b9b1ef963b639a825a6aa5ff.js` and the script can't find itself.
+Rails adds a fingerprint to the URI which means that `lux.js` becomes (for example) `lux.self-7137780d5344a93190a2c698cd660619d4197420b9b1ef963b639a825a6aa5ff.js` and the script can't find itself. Because of this that part of the script would fail. Instead, we modify the `getCustomerId()` function to simply return `LUX.customerid`.
 
-Because of this the customer ID needs to be set at the end of the `lux.js` file:
+Because of this the customer ID needs to be set in the `lux.js` file:
 
 ```javascript
 LUX.customerid = 47044334


### PR DESCRIPTION
## What
Fix an error in the live real user monitoring script relating to the unusual way in which we use this script.

- to reproduce, clear cookies, reload page then accept cookies, error of `Uncaught TypeError: Cannot read properties of null (reading 'pop')` will occur
- this refers to the `getCustomerId()` function, which if `LUX.customerid` is not defined will attempt to determine it from the source URL of the LUX script, something like `lux.js?id=1234`
- we don't get our customerid this way, instead we hard code it into this file, because we host our own copy of the LUX script (see the documentation for more detail and background on this), so the script failed, because there was nothing to find
- instead we remove this part of the `getCustomerId()` function and simply return `LUX.customerid`. We also now need to set this inside the LUX object itself, because otherwise it isn't set properly in the steps described above
- documentation updated to reflect this for future updates

## Why
Was causing an error on the live site. This is bad.

## Visual Changes
None.
