### PR TITLE
Version 35.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.15.2
 
 * Fix error in LUX script ([PR #3592](https://github.com/alphagov/govuk_publishing_components/pull/3592))
 * Prepend page path when tracking anchor links in GA4 ([PR #3590](https://github.com/alphagov/govuk_publishing_components/pull/3590))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.15.1)
+    govuk_publishing_components (35.15.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.15.1".freeze
+  VERSION = "35.15.2".freeze
 end


### PR DESCRIPTION
## 35.15.2

* Fix error in LUX script ([PR #3592](https://github.com/alphagov/govuk_publishing_components/pull/3592))
* Prepend page path when tracking anchor links in GA4 ([PR #3590](https://github.com/alphagov/govuk_publishing_components/pull/3590))
