### PR TITLE
Fix bug with GA4 search results count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Fix bug with GA4 search results count ([PR #3594](https://github.com/alphagov/govuk_publishing_components/pull/3594))
+
 ## 35.15.2
 
 * Fix error in LUX script ([PR #3592](https://github.com/alphagov/govuk_publishing_components/pull/3592))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -290,7 +290,8 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
 
         // In order to extract the number of results from resultCount (which is a string at this point (e.g. '12,345 results')), we remove the comma and
         // split string at the space character so it can be parsed as an integer
-        resultCount = resultCount.textContent.replace(',', '')
+        resultCount = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(resultCount.textContent)
+        resultCount = resultCount.replace(',', '')
         resultCount = resultCount.split(' ')[0]
 
         return parseInt(resultCount)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -418,6 +418,12 @@ describe('GA4 core', function () {
         expect(GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getResultCount(resultCountContainer, 'results-count')).toEqual(54321)
         expect(typeof GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getResultCount(resultCountContainer, 'results-count')).toEqual('number')
       })
+
+      it('handles new lines and extra spaces', function () {
+        resultCountContainer.innerHTML = '<span id="results-count"> \n   54321 results    \n</span>'
+        expect(GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getResultCount(resultCountContainer, 'results-count')).toEqual(54321)
+        expect(typeof GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getResultCount(resultCountContainer, 'results-count')).toEqual('number')
+      })
     })
 
     describe('the correct index of the result is returned', function () {


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
The results count heading contained new line characters and extra spaces, so splitting via the space character to parse the integer broke. This was fixed by using our `removeLinesAndExtraSpaces` function. 

I checked it on a local version of finder-frontend and the search results count is coming through now.

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/MXhpmk9c/659-fix-search-results-count-on-viewitemlist-event

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
