### PR TITLE
Add large dark icon for action link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Add query string to GA4 pageview tracking ([PR #3609](https://github.com/alphagov/govuk_publishing_components/pull/3609))
+* Add large dark icon for action link ([PR #3594](https://github.com/alphagov/govuk_publishing_components/pull/3596))
 
 ## 35.15.3
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_action-link.scss
@@ -150,6 +150,22 @@
   }
 }
 
+.gem-c-action-link--dark-large-icon {
+  &:before {
+    background: image-url("govuk_publishing_components/action-link-arrow--dark.png");
+    background: image-url("govuk_publishing_components/action-link-arrow--dark.svg"), linear-gradient(transparent, transparent);
+    height: 34px;
+    width: 40px;
+    background-repeat: no-repeat;
+    background-size: 32px auto;
+    background-position: 0 2px;
+  }
+
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: govuk-spacing(2);
+  }
+}
+
 .gem-c-action-link--dark-icon,
 .gem-c-action-link--small-icon {
   max-width: none;

--- a/app/views/govuk_publishing_components/components/_action_link.html.erb
+++ b/app/views/govuk_publishing_components/components/_action_link.html.erb
@@ -16,6 +16,7 @@
   simple ||= false
   simple_light ||= false
   dark_icon ||= false
+  dark_large_icon ||= false
   small_icon ||= false
   nhs_icon ||= false
   brexit_icon ||= false
@@ -27,6 +28,7 @@
   css_classes = %w(gem-c-action-link)
   css_classes << "gem-c-action-link--light-text" if light_text
   css_classes << "gem-c-action-link--dark-icon" if dark_icon
+  css_classes << "gem-c-action-link--dark-large-icon" if dark_large_icon
   css_classes << "gem-c-action-link--small-icon" if small_icon
   css_classes << "gem-c-action-link--transparent-icon" if transparent_icon
   css_classes << "gem-c-action-link--nhs" if nhs_icon

--- a/app/views/govuk_publishing_components/components/docs/action_link.yml
+++ b/app/views/govuk_publishing_components/components/docs/action_link.yml
@@ -115,6 +115,11 @@ examples:
       text: Coronavirus (COVID-19)
       href: "/my-test-page"
       dark_icon: true
+  with_dark_large_icon:
+    data:
+      text: Coronavirus (COVID-19)
+      href: "/my-test-page"
+      dark_large_icon: true
   with_brexit_icon_and_custom_font_size:
     data:
       text: Guidance for businesses

--- a/spec/components/action_link_spec.rb
+++ b/spec/components/action_link_spec.rb
@@ -118,6 +118,15 @@ describe "Action link", type: :view do
     assert_select ".gem-c-action-link--dark-icon"
   end
 
+  it "renders dark large icon version" do
+    render_component(
+      text: "Get more info",
+      href: "/coronavirus",
+      dark_large_icon: true,
+    )
+    assert_select ".gem-c-action-link--dark-large-icon"
+  end
+
   it "renders small icon version" do
     render_component(
       text: "Get more info",


### PR DESCRIPTION
## What

Uses the existing dark icon but makes it slightly larger as per the
design recommendation for the new benefits calculator link being added
to the browse benefit page.

Related PR: https://github.com/alphagov/collections/pull/3373

## Why

Current dark icon is too small and doesn't fit the recommended design.

## Visual Changes

Large dark icon used for the new action link:

<img width="1343" alt="Screenshot 2023-09-13 at 10 39 04" src="https://github.com/alphagov/govuk_publishing_components/assets/24479188/dfb83dad-d122-499c-b186-fcd8ec8a7910">
<img width="462" alt="Screenshot 2023-09-13 at 10 39 39" src="https://github.com/alphagov/govuk_publishing_components/assets/24479188/f77359e5-f76b-4e3f-b12a-f8ce10532f98">

Trello:
https://trello.com/c/mwQET0e0/2153-add-link-to-the-benefits-smart-answer-to-the-browse-benefits-page