### PR TITLE
Image card Two Thirds variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Image card Two Thirds variant ([PR #3597](https://github.com/alphagov/govuk_publishing_components/pull/3597))
+
 ## 35.15.5
 
 * Use an absolute URL for og:image Open Graph property ([PR #3619](https://github.com/alphagov/govuk_publishing_components/pull/3619))
@@ -15,7 +19,6 @@
 
 * Add query string to GA4 pageview tracking ([PR #3609](https://github.com/alphagov/govuk_publishing_components/pull/3609))
 * Add large dark icon for action link ([PR #3594](https://github.com/alphagov/govuk_publishing_components/pull/3596))
-* Image card Two Thirds variant ([PR #3597](https://github.com/alphagov/govuk_publishing_components/pull/3597))
 
 ## 35.15.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * Add query string to GA4 pageview tracking ([PR #3609](https://github.com/alphagov/govuk_publishing_components/pull/3609))
 * Add large dark icon for action link ([PR #3594](https://github.com/alphagov/govuk_publishing_components/pull/3596))
+* Image card Two Thirds variant ([PR #3597](https://github.com/alphagov/govuk_publishing_components/pull/3597))
 
 ## 35.15.3
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -41,6 +41,13 @@
   }
 }
 
+@include govuk-media-query($from: tablet) {
+  .gem-c-image-card.gem-c-image-card--two-thirds {
+    margin: 0 (- govuk-spacing(3)) govuk-spacing(6) (- govuk-spacing(3));
+    display: block;
+  }
+}
+
 @include govuk-media-query($from: mobile, $until: tablet) {
   .gem-c-image-card {
     margin: 0 (- govuk-spacing(3)) govuk-spacing(6) (- govuk-spacing(3));
@@ -52,6 +59,25 @@
 
   .gem-c-image-card__text-wrapper {
     @include govuk-grid-column($width: one-half, $at: mobile);
+  }
+
+  .gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--two-thirds {
+    @include govuk-grid-column($width: one-third, $float: right, $at: mobile);
+  }
+
+  .gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds {
+    @include govuk-grid-column($width: two-thirds, $float: right, $at: mobile);
+  }
+}
+
+@include govuk-media-query($from: tablet) {
+  .gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--two-thirds {
+    @include govuk-grid-column($width: one-third, $float: right, $at: tablet);
+  }
+
+  .gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds {
+    @include govuk-grid-column($width: two-thirds, $float: right, $at: tablet);
+    padding-left: 0;
   }
 }
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_image-card.scss
@@ -61,7 +61,7 @@
     @include govuk-grid-column($width: one-half, $at: mobile);
   }
 
-  .gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--two-thirds {
+  .gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--one-third {
     @include govuk-grid-column($width: one-third, $float: right, $at: mobile);
   }
 
@@ -71,7 +71,7 @@
 }
 
 @include govuk-media-query($from: tablet) {
-  .gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--two-thirds {
+  .gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--one-third {
     @include govuk-grid-column($width: one-third, $float: right, $at: tablet);
   }
 

--- a/app/views/govuk_publishing_components/components/_image_card.html.erb
+++ b/app/views/govuk_publishing_components/components/_image_card.html.erb
@@ -7,10 +7,16 @@
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
   card_helper = GovukPublishingComponents::Presenters::ImageCardHelper.new(local_assigns, brand_helper)
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+
   classes = %w[gem-c-image-card]
+  classes << "govuk-grid-row" if card_helper.two_thirds
   classes << "gem-c-image-card--large" if card_helper.large
+  classes << "gem-c-image-card--two-thirds" if card_helper.two_thirds
   classes << "gem-c-image-card--no-image" unless (card_helper.image_src || card_helper.youtube_video_id)
   classes << brand_helper.brand_class if brand_helper.brand_class
+
+  text_wrapper_classes = %w[gem-c-image-card__text-wrapper]
+  text_wrapper_classes << "gem-c-image-card__text-wrapper--two-thirds" if card_helper.two_thirds
 
   font_size ||= card_helper.large ? 'm' : 's'
   heading_class = %w[gem-c-image-card__title]
@@ -33,7 +39,7 @@
 %>
 <% if card_helper.href || card_helper.extra_details.any? %>
   <%= content_tag(:div, class: classes, "data-module": data_modules, lang: card_helper.lang) do %>
-    <div class="gem-c-image-card__text-wrapper">
+    <%= content_tag(:div, class: text_wrapper_classes) do %>
       <div class="gem-c-image-card__header-and-context-wrapper">
         <% if card_helper.heading_text %>
           <%= content_tag(shared_helper.get_heading_level, class: heading_class) do %>
@@ -69,7 +75,7 @@
       <% if card_helper.metadata %>
         <p class="gem-c-image-card__metadata"><%= card_helper.metadata %></p>
       <% end %>
-    </div>
+    <% end %>
     <%= card_helper.media %>
   <% end %>
 <% end %>

--- a/app/views/govuk_publishing_components/components/docs/image_card.yml
+++ b/app/views/govuk_publishing_components/components/docs/image_card.yml
@@ -205,6 +205,19 @@ examples:
       <div class="govuk-!-width-full">
         <%= component %>
       </div>
+  two_thirds_column:
+    description: This variant is used for the featured section on the homepage.
+    data:
+      two_thirds: true
+      href: "/still-not-a-page"
+      image_src: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/91397/s712_SG_Swear_in_1_.jpg"
+      image_alt: "some meaningful alt text please"
+      heading_text: "Something has happened nearby possibly"
+      description: "Following a news report that something has happened, further details are emerging of the thing that has happened and what that means for you."
+    embed: |
+      <div class="govuk-!-width-full">
+        <%= component %>
+      </div>
   youtube_video:
     description: |
       Given a Youtube video id, the image card will render a Youtube embed instead of an image. If Javascript fails to execute for any reason, then a fallback link to the Youtube video will be rendered instead.

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -4,7 +4,7 @@ module GovukPublishingComponents
       include ActionView::Helpers
       include ActionView::Context
 
-      attr_reader :href_data_attributes, :extra_details, :extra_details_no_indent, :heading_text, :metadata, :lang, :image_loading, :youtube_video_id, :image_src
+      attr_reader :href_data_attributes, :extra_details, :extra_details_no_indent, :heading_text, :metadata, :lang, :image_loading, :youtube_video_id, :image_src, :two_thirds
 
       def initialize(local_assigns, brand_helper)
         @href = local_assigns[:href]
@@ -20,6 +20,7 @@ module GovukPublishingComponents
         @context = local_assigns[:context]
         @description = local_assigns[:description]
         @large = local_assigns[:large]
+        @two_thirds = local_assigns[:two_thirds] || false
         @heading_text = local_assigns[:heading_text]
         @extra_details_no_indent = local_assigns[:extra_details_no_indent]
         @metadata = local_assigns[:metadata]
@@ -60,8 +61,11 @@ module GovukPublishingComponents
       end
 
       def image
+        classes = %w[gem-c-image-card__image-wrapper]
+        classes << "gem-c-image-card__image-wrapper--two-thirds" if @two_thirds
+
         if @image_src
-          content_tag(:figure, class: "gem-c-image-card__image-wrapper") do
+          content_tag(:figure, class: classes) do
             image_tag(
               @image_src,
               class: "gem-c-image-card__image",

--- a/lib/govuk_publishing_components/presenters/image_card_helper.rb
+++ b/lib/govuk_publishing_components/presenters/image_card_helper.rb
@@ -62,7 +62,7 @@ module GovukPublishingComponents
 
       def image
         classes = %w[gem-c-image-card__image-wrapper]
-        classes << "gem-c-image-card__image-wrapper--two-thirds" if @two_thirds
+        classes << "gem-c-image-card__image-wrapper--one-third" if @two_thirds
 
         if @image_src
           content_tag(:figure, class: classes) do

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -108,6 +108,13 @@ describe "ImageCard", type: :view do
     assert_select ".gem-c-image-card.gem-c-image-card--large"
   end
 
+  it "renders two thirds variant" do
+    render_component(href: "#", image_src: "/moo.jpg", image_alt: "some meaningful alt text", heading_text: "test", two_thirds: true)
+    assert_select ".gem-c-image-card.gem-c-image-card--two-thirds"
+    assert_select ".gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds"
+    assert_select ".gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--two-thirds"
+  end
+
   it "applies tracking attributes" do
     render_component(href: "#", href_data_attributes: { track_category: "cat" }, heading_text: "test")
     assert_select ".gem-c-image-card[data-module='gem-track-click ga4-link-tracker']"

--- a/spec/components/image_card_spec.rb
+++ b/spec/components/image_card_spec.rb
@@ -112,7 +112,7 @@ describe "ImageCard", type: :view do
     render_component(href: "#", image_src: "/moo.jpg", image_alt: "some meaningful alt text", heading_text: "test", two_thirds: true)
     assert_select ".gem-c-image-card.gem-c-image-card--two-thirds"
     assert_select ".gem-c-image-card__text-wrapper.gem-c-image-card__text-wrapper--two-thirds"
-    assert_select ".gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--two-thirds"
+    assert_select ".gem-c-image-card__image-wrapper.gem-c-image-card__image-wrapper--one-third"
   end
 
   it "applies tracking attributes" do


### PR DESCRIPTION
## What

Add a new variation of the image card. 'Two thirds' maintains the row layout of the image and text containers at all screen sizes. It uses the govuk grid layout with the image being 1/3 of the width of the row and the text being 2/3 of the width of the row.

## Why
<!-- What are the reasons behind this change being made? -->

This variation is part of changes being made to the homepage.

<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com -->

## Screenshot

![Screenshot 2023-09-18 at 11 19 51](https://github.com/alphagov/govuk_publishing_components/assets/3727504/d6c71a71-2181-476a-a721-4cd4ad17e595)


[Relevant Trello Card](https://trello.com/c/yMdhnPPD/2063-look-and-feel-homepage-action-link-new-variation-for-popular-section-m) 