### PR TITLE
Add new homepage variant to search component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## Unreleased
 
 * Add new light action link variant ([PR #3602](https://github.com/alphagov/govuk_publishing_components/pull/3602))
+* Add new homepage variant to search component ([PR #3599](https://github.com/alphagov/govuk_publishing_components/pull/3599))
+
 
 ## 35.16.1
 

--- a/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_search.scss
@@ -55,7 +55,7 @@ $large-input-size: 50px;
   }
 }
 
-%gem-c-search-input-focus {
+@mixin gem-c-search-input-focus {
   outline: $govuk-focus-width solid $govuk-focus-colour;
   // Ensure outline appears outside of the element
   outline-offset: 0;
@@ -89,7 +89,7 @@ $large-input-size: 50px;
   }
 
   &:focus {
-    @extend %gem-c-search-input-focus;
+    @include gem-c-search-input-focus;
   }
 }
 
@@ -168,10 +168,9 @@ $large-input-size: 50px;
     // Ensure outline appears outside of the element
     outline-offset: 0;
 
-    // no need for black outline as there is enough contrast
-    // with the blue background
     &:focus {
-      box-shadow: none;
+      @include gem-c-search-input-focus;
+      box-shadow: inset 0 0 0 4px;
     }
   }
 
@@ -187,6 +186,17 @@ $large-input-size: 50px;
   .js-enabled & {
     .gem-c-search__label {
       color: $govuk-secondary-text-colour;
+    }
+  }
+}
+
+.gem-c-search--homepage {
+  .gem-c-search__submit {
+    background-color: #d2e2f1;
+    color: govuk-colour("blue");
+
+    &:hover {
+      background-color: lighten(#d2e2f1, 5%);
     }
   }
 }
@@ -211,6 +221,10 @@ $large-input-size: 50px;
   }
 }
 
+.gem-c-search__label--white {
+  color: govuk-colour("white");
+}
+
 .gem-c-search--no-border {
   .gem-c-search__label {
     color: govuk-colour("white");
@@ -218,6 +232,11 @@ $large-input-size: 50px;
 
   .gem-c-search__input[type="search"] {
     border: 0;
+
+    &:focus {
+      @include gem-c-search-input-focus;
+      box-shadow: inset 0 0 0 4px;
+    }
   }
 
   .js-enabled & {

--- a/app/views/govuk_publishing_components/components/_search.html.erb
+++ b/app/views/govuk_publishing_components/components/_search.html.erb
@@ -12,6 +12,7 @@
   label_size ||= nil
   label_text ||= t("components.search_box.label")
   name ||= "q"
+  homepage ||= false
   no_border ||= false
   size ||= ""
   value ||= ""
@@ -24,6 +25,7 @@
   classes << shared_helper.get_margin_bottom if local_assigns[:margin_bottom]
   classes << "gem-c-search--large" if size == "large"
   classes << "gem-c-search--large-on-mobile" if size == "large-mobile"
+  classes << "gem-c-search--homepage" if homepage
   classes << "gem-c-search--no-border" if no_border
   if local_assigns[:on_govuk_blue].eql?(true)
     classes << "gem-c-search--on-govuk-blue"
@@ -35,6 +37,7 @@
   label_classes = []
   if (shared_helper.valid_heading_size?(label_size))
     label_classes << "govuk-label govuk-label--#{label_size}"
+    label_classes << "gem-c-search__label--white" if no_border || homepage
   else
     label_classes << "gem-c-search__label"
   end

--- a/app/views/govuk_publishing_components/components/docs/search.yml
+++ b/app/views/govuk_publishing_components/components/docs/search.yml
@@ -35,6 +35,17 @@ examples:
       on_govuk_blue: true
     context:
       dark_background: true
+  homepage:
+    description: For use on the homepage.
+    data:
+      label_text: "Search"
+      inline_label: false
+      on_govuk_blue: true
+      label_size: "s"
+      homepage: true
+      size: "large"
+    context:
+      dark_background: true 
   change_label_text:
     data:
       label_text: "Search"

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -39,6 +39,11 @@ describe "Search", type: :view do
     end
   end
 
+  it "applies homepage class if homepage set to true" do
+    render_component(homepage: true)
+    assert_select ".gem-c-search--homepage"
+  end
+
   it "renders a search box with a custom id" do
     render_component(id: "my-unique-id")
     assert_select ".gem-c-search #my-unique-id.gem-c-search__input"


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

Add new 'homepage' parameter to search component. Apply class to search container if homepage is true.

## Why
<!-- What are the reasons behind this change being made? -->
As part of the new homepage designs, we need a new variant of the search component with a different styled submit button.

[Relevant Trello Card](https://trello.com/c/Sd5mI6Av/2062-look-and-feel-homepage-search-component-changes-m)

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

![Screenshot 2023-09-11 at 13 53 18](https://github.com/alphagov/govuk_publishing_components/assets/3727504/12282f68-dd86-4601-ae2c-fbf2a0718675)

