### PR TITLE
Improve GA URL parameter stripping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Improve GA URL parameter stripping ([PR #3603](https://github.com/alphagov/govuk_publishing_components/pull/3603))
 * Fix bug with GA4 search results count ([PR #3594](https://github.com/alphagov/govuk_publishing_components/pull/3594))
 
 ## 35.15.2

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -76,7 +76,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     // remove GA parameters of the form _ga=2320.021-012302 or _gl=02.10320.01230-123
     stripGaParam: function (str) {
       str = str.replace(/(_ga=[0-9.-]+)/g, '_ga=[id]')
-      str = str.replace(/(_gl=[0-9.-]+)/g, '_gl=[id]')
+      str = str.replace(/(_gl=[a-zA-Z0-9._\-*]+)/g, '_gl=[id]')
       return str
     },
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -376,9 +376,12 @@ describe('Google Tag Manager page view tracking', function () {
     var url = 'https://www.gov.uk/welfare?'
     var param1 = '_ga=2.237932419.220854294.1692605006-1618308030.1687790776'
     var param2 = '_gl=32.23434234.243-32434220-230442300234.234324.42304-09320'
+    var param3 = '_gl=1*18346yi*_ga*OTkxOTU4OTU5LjE2OTQ0MzQyNTg.*_ga_HYBY4V8XVT*MTY5NDQzNDI1OC4xLjAuMTY5NDQzNDI1OC4wLjAuMA..'
 
     expect(GOVUK.analyticsGa4.analyticsModules.PageViewTracker.stripGaParam(url + param1)).toEqual(url + '_ga=[id]')
     expect(GOVUK.analyticsGa4.analyticsModules.PageViewTracker.stripGaParam(url + param2)).toEqual(url + '_gl=[id]')
+    expect(GOVUK.analyticsGa4.analyticsModules.PageViewTracker.stripGaParam(url + param1 + '&' + param2)).toEqual(url + '_ga=[id]&_gl=[id]')
+    expect(GOVUK.analyticsGa4.analyticsModules.PageViewTracker.stripGaParam(url + param3)).toEqual(url + '_gl=[id]')
   })
 
   it('redacts ga parameters from the location and referrer before they are mistaken for PII', function () {


### PR DESCRIPTION
## What
Improve the code that strips/redacts `_gl` URL parameters when recording the URL for pageviews in GA4.

## Why
The [previous code](https://github.com/alphagov/govuk_publishing_components/pull/3568) assumed that `_gl` parameters were the same as `_ga` parameters. Turns out they're not - they can also contain letters, uppercase letters, asterisks and dashes. And also the character combination `_ga`, which is frankly just confusing.

## Visual Changes
None.

Trello card: https://trello.com/c/2hJRUoDM/660-redact-strip-ga-and-gl-trackers-from-page-location-and-page-referrer-values
