### PR TITLE
Version 35.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.15.3
 
 * Improve GA URL parameter stripping ([PR #3603](https://github.com/alphagov/govuk_publishing_components/pull/3603))
 * Fix bug with GA4 search results count ([PR #3594](https://github.com/alphagov/govuk_publishing_components/pull/3594))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.15.2)
+    govuk_publishing_components (35.15.3)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.15.2".freeze
+  VERSION = "35.15.3".freeze
 end


### PR DESCRIPTION
## 35.15.3

* Improve GA URL parameter stripping ([PR #3603](https://github.com/alphagov/govuk_publishing_components/pull/3603))
* Fix bug with GA4 search results count ([PR #3594](https://github.com/alphagov/govuk_publishing_components/pull/3594))
* Check HTML attribute when populating GA4 language ([PR #3598](https://github.com/alphagov/govuk_publishing_components/pull/3598))
* Add GA4 tracking to the intervention banner ([PR #3567](https://github.com/alphagov/govuk_publishing_components/pull/3567))
* Add 6th link to popular links ([PR #3586](https://github.com/alphagov/govuk_publishing_components/pull/3586))

