### PR TITLE
Add query string to GA4 pageview tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add query string to GA4 pageview tracking ([PR #3609](https://github.com/alphagov/govuk_publishing_components/pull/3609))
+
 ## 35.15.3
 
 * Improve GA URL parameter stripping ([PR #3603](https://github.com/alphagov/govuk_publishing_components/pull/3603))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -58,7 +58,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             phase_banner: this.getElementAttribute('data-ga4-phase-banner') || undefined,
             devolved_nations_banner: this.getElementAttribute('data-ga4-devolved-nations-banner') || undefined,
             cookie_banner: document.querySelector('[data-ga4-cookie-banner]') ? 'true' : undefined,
-            intervention: this.getInterventionPresence()
+            intervention: this.getInterventionPresence(),
+            query_string: this.getQueryString()
           }
         }
         window.GOVUK.analyticsGa4.core.sendData(data)
@@ -67,6 +68,20 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
 
     getLocation: function () {
       return this.PIIRemover.stripPII(this.stripGaParam(document.location.href))
+    },
+
+    getSearch: function () {
+      return window.location.search
+    },
+
+    getQueryString: function () {
+      var queryString = this.getSearch()
+      if (queryString) {
+        queryString = this.PIIRemover.stripPIIWithOverride(queryString, true, true)
+        queryString = this.stripGaParam(queryString)
+        queryString = queryString.substring(1) // removes the '?' character from the start.
+        return queryString
+      }
     },
 
     getReferrer: function (referrer) {

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -55,7 +55,8 @@ describe('Google Tag Manager page view tracking', function () {
         phase_banner: undefined,
         devolved_nations_banner: undefined,
         cookie_banner: undefined,
-        intervention: undefined
+        intervention: undefined,
+        query_string: undefined
       }
     }
     window.dataLayer = []
@@ -526,5 +527,12 @@ describe('Google Tag Manager page view tracking', function () {
       expect(window.dataLayer[0]).toEqual(expected)
       window.GOVUK.setCookie('intervention_campaign', '')
     })
+  })
+
+  it('correctly sets the query_string parameter with PII and _ga/_gl values redacted', function () {
+    spyOn(GOVUK.analyticsGa4.analyticsModules.PageViewTracker, 'getSearch').and.returnValue('?query1=hello&query2=world&email=email@example.com&postcode=SW12AA&birthday=1990-01-01&_ga=1234.567&_gl=1234.567')
+    expected.page_view.query_string = 'query1=hello&query2=world&email=[email]&postcode=[postcode]&birthday=[date]&_ga=[id]&_gl=[id]'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
   })
 })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds the `query_string` parameter to our GA4 pageview object

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/Rb45fH1B/633-search-enhancement-new-attribute-query-string

## Visual Changes
None.
