### PR TITLE
Add 'search_term' to GA4 pageview object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Image card Two Thirds variant ([PR #3597](https://github.com/alphagov/govuk_publishing_components/pull/3597))
+* Add 'search_term' to GA4 pageview object ([PR #3615](https://github.com/alphagov/govuk_publishing_components/pull/3615))
 
 ## 35.15.5
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -59,7 +59,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             devolved_nations_banner: this.getElementAttribute('data-ga4-devolved-nations-banner') || undefined,
             cookie_banner: document.querySelector('[data-ga4-cookie-banner]') ? 'true' : undefined,
             intervention: this.getInterventionPresence(),
-            query_string: this.getQueryString()
+            query_string: this.getQueryString(),
+            search_term: this.getSearchTerm()
           }
         }
         window.GOVUK.analyticsGa4.core.sendData(data)
@@ -72,6 +73,23 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
 
     getSearch: function () {
       return window.location.search
+    },
+
+    getSearchTerm: function () {
+      var queryString = this.getSearch()
+
+      if (!queryString) {
+        return undefined
+      }
+
+      var searchTerm = queryString.match(/keywords=([^&]*)/)
+      if (!searchTerm) {
+        return undefined
+      }
+
+      searchTerm = searchTerm[0].replace('keywords=', '')
+      searchTerm = this.PIIRemover.stripPIIWithOverride(searchTerm, true, true)
+      return searchTerm
     },
 
     getQueryString: function () {

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.js
@@ -2,7 +2,7 @@
   'use strict'
 
   var GOVUK = global.GOVUK || {}
-  var EMAIL_PATTERN = /[^\s=/?&#]+(?:@|%40)[^\s=/?&]+/g
+  var EMAIL_PATTERN = /[^\s=/?&#+]+(?:@|%40)[^\s=/?&+]+/g
   var POSTCODE_PATTERN = /\b[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9](?!refund)[ABD-HJLNPQ-Z]{2,3}\b/gi
   var DATE_PATTERN_NUMERIC = /\d{4}(-?)\d{2}(-?)\d{2}/g
   var DATE_PATTERN_STRING = /\d{1,2}\s(January|February|March|April|May|June|July|August|September|October|November|December)\s\d{4}/g

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -56,7 +56,8 @@ describe('Google Tag Manager page view tracking', function () {
         devolved_nations_banner: undefined,
         cookie_banner: undefined,
         intervention: undefined,
-        query_string: undefined
+        query_string: undefined,
+        search_term: undefined
       }
     }
     window.dataLayer = []
@@ -534,5 +535,38 @@ describe('Google Tag Manager page view tracking', function () {
     expected.page_view.query_string = 'query1=hello&query2=world&email=[email]&postcode=[postcode]&birthday=[date]&_ga=[id]&_gl=[id]'
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
     expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  describe('search_term parameter', function () {
+    it('correctly sets the parameter using ?keywords= with PII values redacted', function () {
+      spyOn(GOVUK.analyticsGa4.analyticsModules.PageViewTracker, 'getSearch').and.returnValue('?keywords=hello+world+email@example.com+SW12AA+1990-01-01&another=one')
+      expected.page_view.query_string = 'keywords=hello+world+[email]+[postcode]+[date]&another=one'
+      expected.page_view.search_term = 'hello+world+[email]+[postcode]+[date]'
+      GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('correctly sets the  parameter using &keywords= with PII values redacted', function () {
+      spyOn(GOVUK.analyticsGa4.analyticsModules.PageViewTracker, 'getSearch').and.returnValue('?test=true&keywords=hello+world+email@example.com+SW12AA+1990-01-01&another=one')
+      expected.page_view.query_string = 'test=true&keywords=hello+world+[email]+[postcode]+[date]&another=one'
+      expected.page_view.search_term = 'hello+world+[email]+[postcode]+[date]'
+      GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('correctly ignores other query string values', function () {
+      spyOn(GOVUK.analyticsGa4.analyticsModules.PageViewTracker, 'getSearch').and.returnValue('?keywordss=not+search&keyywords=not+search+either&hello=world')
+      expected.page_view.query_string = 'keywordss=not+search&keyywords=not+search+either&hello=world'
+      expected.page_view.search_term = undefined
+      GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('functions correctly when there is no query string', function () {
+      spyOn(GOVUK.analyticsGa4.analyticsModules.PageViewTracker, 'getSearch').and.returnValue('')
+      expected.page_view.search_term = undefined
+      GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
   })
 })

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/pii-remover.spec.js
@@ -213,6 +213,11 @@ describe('GOVUK.analyticsGa4.PIIRemover', function () {
     })
   })
 
+  it('ensures the email address regex does not include the + character', function () {
+    var string = pii.stripPIIWithOverride('hello+world+email@example.com+SW12AA+1990-01-01', false, false)
+    expect(string).toEqual('hello+world+[email]+SW12AA+1990-01-01')
+  })
+
   function resetHead () {
     $('head').find('meta[name="govuk:static-analytics:strip-postcodes"]').remove()
     $('head').find('meta[name="govuk:static-analytics:strip-dates"]').remove()


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds the `search_term` query string to the pageview.
- Fixes an issue with the email PII redaction but it is not perfect, so it would need your opinion.
    - Currently, when this string is put through the PIIRemover: `hello+world+email@example.com+SW12AA+1990-01-01`, the PII remover will just return it as `[email]`. It should be `hello+world+[email]+[postcode]+[date]`.
    -  This happens because the PIIRemover treats `+` as part of the email address, so the whole string ends up being included as the email address to be redacted. 
    - I fixed this by making `+` a character to be excluded for pattern matching an email. 
    - This works, however I know that in gmail technically users can put a `+` in their email address. [See here](https://eit.ces.ncsu.edu/2023/02/gmail-plus-addressing-the-hidden-feature-that-can-help-you-get-more-out-of-your-inbox/#:~:text=Here's%20how%20it%20works%3A,%2Banythingyouwant%40gmail.com.)
    - Is there a way to stop the `+` issue, but still have email addresses with `+` work? 
    - We could solve it by replacing `+` with a space before it gets put through the PII remover for this `search_query` change. We would probably need to do something similar on the `referrer` `location`, `query_string` pageview values though.
- CI is failing but I believe it's an unrelated issue
## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/ZYon1wog/688-search-enhancement-new-attribute-search-term
## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.