### PR TITLE
Revert "Bump version 35.15.4"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## 35.15.4
+## Unreleased
 
 * Add query string to GA4 pageview tracking ([PR #3609](https://github.com/alphagov/govuk_publishing_components/pull/3609))
 * Add large dark icon for action link ([PR #3594](https://github.com/alphagov/govuk_publishing_components/pull/3596))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.15.4)
+    govuk_publishing_components (35.15.3)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -127,7 +127,7 @@ GEM
     google-protobuf (3.24.3)
     googleapis-common-protos-types (1.8.0)
       google-protobuf (~> 3.18)
-    govuk_app_config (9.2.0)
+    govuk_app_config (9.1.0)
       logstasher (~> 2.1)
       opentelemetry-exporter-otlp (>= 0.25, < 0.27)
       opentelemetry-instrumentation-all (>= 0.39.1, < 0.41.0)

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.15.4".freeze
+  VERSION = "35.15.3".freeze
 end


### PR DESCRIPTION
Reverts alphagov/govuk_publishing_components#3610