### PR TITLE
Use an absolute URL for `og:image` Open Graph property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 35.15.5
+
+* Use an absolute URL for og:image Open Graph property ([PR #3619](https://github.com/alphagov/govuk_publishing_components/pull/3619))
+
 ## 35.15.4
 
 * Add query string to GA4 pageview tracking ([PR #3609](https://github.com/alphagov/govuk_publishing_components/pull/3609))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.15.4)
+    govuk_publishing_components (35.15.5)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -139,7 +139,7 @@ GEM
       sentry-rails (~> 5.3)
       sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
-    govuk_personalisation (0.14.0)
+    govuk_personalisation (0.15.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
     govuk_schemas (4.6.0)

--- a/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
+++ b/app/views/govuk_publishing_components/components/_layout_for_public.html.erb
@@ -87,7 +87,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <% # The default og:image is added below :head so that scrapers see any custom metatags first, and this is just a fallback %>
-    <meta property="og:image" content="<%= asset_path "govuk-opengraph-image.png" %>">
+    <meta property="og:image" content="<%= asset_url("govuk-opengraph-image.png", host: Plek.website_root) %>">
 
     <%= yield :head %>
   </head>

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.15.4".freeze
+  VERSION = "35.15.5".freeze
 end

--- a/spec/components/layout_for_public_spec.rb
+++ b/spec/components/layout_for_public_spec.rb
@@ -281,4 +281,12 @@ describe "Layout for public", type: :view do
 
     assert_select ".gem-c-layout-for-public.govuk-template__body.draft"
   end
+
+  it "has an Open Graph image with an absolute URL" do
+    render_component({})
+
+    assert_select "meta[property='og:image']" do |meta|
+      expect(meta.first["content"]).to match(%r{^https?://})
+    end
+  end
 end


### PR DESCRIPTION
> **Note:** for the sake of expediency, I've bumped the gem version within this PR.

## Context

Historically on GOV.UK, `og:image` asset URLs were always absolute URLs. This happened because the Rails app [static](https://github.com/alphagov/static), which renders the `layout_for_public` component for use on the frontend of GOV.UK, was configured with [`config.action_controller.asset_host`](https://guides.rubyonrails.org/configuring.html#config-action-controller-asset-host). This told Rails to use a different hostname for assets, meaning `asset_path` helper method would always produce absolute URLs – for example, `asset_path("example.png")` would output something like `http://assets.example.com/assets/example.png`.

That behaviour changed in alphagov/static@484fea37d3e957df9c7ea7395375933b386c93f6 when the `asset_host` config was removed. This resulted in the `asset_path` helper producing relative URLs for assets – for example, `/assets/example.png`.

In turn, this resulted in the `og:image` asset URLs becoming relative.

## The problem

[Open Graph](https://ogp.me/#metadata) URLs must always be absolute. Relative URLs are not valid for the `og:image` property. They will not work on social media sites _(or, at least, they won't work reliably or consistently)_.

For example, embedding a GOV.UK URL into a Tweet resulted in broken preview images:

<img width="515" alt="Screenshot of an embedded link on Twitter with a broken pewview image" src="https://github.com/alphagov/govuk_publishing_components/assets/7735945/5f6f1d87-2a6c-4ac6-9327-db9658120549">

## What

I've updated the `layout_for_public` component to use absolute URLs for the `og:image` [Open Graph property](https://ogp.me/#metadata).

It now uses the `asset_url` helper method, and we've specified the hostname as `Plek.website_root` to make sure it always points to the correct environment-dependent GOV.UK website URL.

## Why

This was reported to us in Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5489418