### PR TITLE
Updates placeholder schema references

### DIFF
--- a/spec/components/machine_readable_metadata_spec.rb
+++ b/spec/components/machine_readable_metadata_spec.rb
@@ -6,7 +6,7 @@ describe "Machine readable metadata", type: :view do
   end
 
   it "generates machine readable JSON-LD for articles" do
-    example = GovukSchemas::RandomExample.for_schema(frontend_schema: "generic")
+    example = GovukSchemas::RandomExample.for_schema(frontend_schema: "guide")
     render_component(content_item: example, schema: :article)
 
     json_linked_data = Nokogiri::HTML(rendered).css("script").text
@@ -60,7 +60,7 @@ describe "Machine readable metadata", type: :view do
   end
 
   it "escapes harmful HTML in the JSON" do
-    example = GovukSchemas::RandomExample.for_schema(frontend_schema: "generic")
+    example = GovukSchemas::RandomExample.for_schema(frontend_schema: "guide")
     example["description"] = bad_html
 
     render_component(content_item: example, schema: :article)
@@ -76,7 +76,7 @@ describe "Machine readable metadata", type: :view do
           "bar" => bad_html,
         },
       }))
-    example = GovukSchemas::RandomExample.for_schema(frontend_schema: "generic")
+    example = GovukSchemas::RandomExample.for_schema(frontend_schema: "guide")
 
     render_component(content_item: example, schema: :article)
     json_linked_data = Nokogiri::HTML(rendered).css("script").text

--- a/spec/features/contextual_navigation_spec.rb
+++ b/spec/features/contextual_navigation_spec.rb
@@ -325,7 +325,7 @@ describe "Contextual navigation" do
   end
 
   def not_step_by_step_content
-    not_step_by_step_content = random_item("placeholder")
+    not_step_by_step_content = random_item("guide")
     not_step_by_step_content["links"].delete("part_of_step_navs")
     not_step_by_step_content["links"].delete("secondary_to_step_navs")
     not_step_by_step_content
@@ -341,7 +341,7 @@ describe "Contextual navigation" do
   def given_there_is_a_parent_page_with_a_step_by_step
     step_by_step = random_step_nav_item("step_by_step_nav").merge("title" => "A step by step page")
 
-    @parent = random_item("placeholder")
+    @parent = random_item("guide")
     @parent["links"]["part_of_step_navs"] = [step_by_step]
     @parent["links"].delete("finder")
   end

--- a/spec/features/step_nav_helper_spec.rb
+++ b/spec/features/step_nav_helper_spec.rb
@@ -114,7 +114,7 @@ describe "Specimen usage of step by step navigation helpers" do
     end
   end
 
-  def content_store_has_random_item(base_path:, schema: "placeholder", part_of_step_navs: [])
+  def content_store_has_random_item(base_path:, schema: "guide", part_of_step_navs: [])
     links = if part_of_step_navs
               { "part_of_step_navs" => part_of_step_navs }
             else

--- a/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_ancestors_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_ancestors_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnAncestors do
   describe "#breadcrumbs" do
     it "can handle any valid content item" do
-      payload = GovukSchemas::RandomExample.for_schema(frontend_schema: "placeholder")
+      payload = GovukSchemas::RandomExample.for_schema(frontend_schema: "guide")
 
       expect { described_class.new(payload).breadcrumbs }.to_not raise_error
     end
@@ -87,7 +87,7 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentBreadcrumbsBasedOnA
   end
 
   def breadcrumbs_for(content_item)
-    fully_valid_content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "placeholder") do |random_item|
+    fully_valid_content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "guide") do |random_item|
       random_item.merge(content_item)
     end
 

--- a/spec/lib/govuk_publishing_components/presenters/related_navigation_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/presenters/related_navigation_helper_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
 
   describe "#related_navigation" do
     it "can handle randomly generated content" do
-      expect { payload_for("placeholder", {}) }.to_not raise_error
+      expect { payload_for("guide", {}) }.to_not raise_error
     end
 
     it "returns empty arrays if there are no related navigation sidebar links" do
       nothing = payload_for(
-        "placeholder",
+        "guide",
         "details" => {
           "external_related_links" => [],
         },
@@ -219,7 +219,7 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
 
     it "returns an Elsewhere on the web section for external related links" do
       payload = payload_for(
-        "placeholder",
+        "guide",
         "details" => {
           "external_related_links" => [
             {
@@ -262,7 +262,7 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
 
     it "returns live taxons" do
       payload = payload_for(
-        "placeholder",
+        "guide",
         "details" => {
           "external_related_links" => [],
         },
@@ -308,7 +308,7 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
     end
 
     context "for a sidebar" do
-      subject(:payload) { payload_for("placeholder", {}, :sidebar) }
+      subject(:payload) { payload_for("guide", {}, :sidebar) }
 
       it "only includes collections, guides and related items" do
         expect(payload).to include(
@@ -329,7 +329,7 @@ RSpec.describe GovukPublishingComponents::Presenters::RelatedNavigationHelper do
     end
 
     context "for a footer" do
-      subject(:payload) { payload_for("placeholder", {}, :footer) }
+      subject(:payload) { payload_for("guide", {}, :footer) }
 
       it "only includes contacts external links, statistical datasets, topical events, topics and world locations" do
         expect(payload).to include(


### PR DESCRIPTION
The placeholder schema was removed in [1], causing CI to fail. Swaps over to using `guide`.

[1]: https://github.com/alphagov/publishing-api/pull/2493