### PR TITLE
Version 35.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.16.0
 
 * Add option select component ([PR #3623](https://github.com/alphagov/govuk_publishing_components/pull/3623))
 * Image card Two Thirds variant ([PR #3597](https://github.com/alphagov/govuk_publishing_components/pull/3597))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.15.5)
+    govuk_publishing_components (35.16.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.15.5".freeze
+  VERSION = "35.16.0".freeze
 end


### PR DESCRIPTION
## 35.16.0

* Add option select component ([PR #3623](https://github.com/alphagov/govuk_publishing_components/pull/3623))
* Image card Two Thirds variant ([PR #3597](https://github.com/alphagov/govuk_publishing_components/pull/3597))
* Add 'search_term' to GA4 pageview object ([PR #3615](https://github.com/alphagov/govuk_publishing_components/pull/3615))
