### PR TITLE
Remove option select GA4 attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Remove option select GA4 attributes ([PR #3625](https://github.com/alphagov/govuk_publishing_components/pull/3625))
+
 ## 35.16.0
 
 * Add option select component ([PR #3623](https://github.com/alphagov/govuk_publishing_components/pull/3623))

--- a/app/assets/javascripts/govuk_publishing_components/components/option-select.js
+++ b/app/assets/javascripts/govuk_publishing_components/components/option-select.js
@@ -268,32 +268,32 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     return visibleCheckboxes
   }
 
-  OptionSelect.prototype.isFacetsContainerHidden = function isFacetsContainerHidden () {
-    var facetsContent = this.$optionSelect.parentElement
-    var isFacetsContentHidden = false
+  OptionSelect.prototype.isComponentParentHidden = function isComponentParentHidden () {
+    var parentContent = this.$optionSelect.parentElement
+    var isparentContentHidden = false
     // check whether this is hidden by progressive disclosure,
     // because height calculations won't work
     // would use offsetParent === null but for IE10+
-    if (facetsContent) {
-      isFacetsContentHidden = !(facetsContent.offsetWidth || facetsContent.offsetHeight || facetsContent.getClientRects().length)
+    if (parentContent) {
+      isparentContentHidden = !(parentContent.offsetWidth || parentContent.offsetHeight || parentContent.getClientRects().length)
     }
 
-    return isFacetsContentHidden
+    return isparentContentHidden
   }
 
   OptionSelect.prototype.setupHeight = function setupHeight () {
     var initialOptionContainerHeight = this.$optionsContainer.clientHeight
     var height = this.$optionList.offsetHeight
 
-    var isFacetsContainerHidden = this.isFacetsContainerHidden()
+    var isComponentParentHidden = this.isComponentParentHidden()
 
-    if (isFacetsContainerHidden) {
+    if (isComponentParentHidden) {
       initialOptionContainerHeight = 200
       height = 200
     }
 
     // Resize if the list is only slightly bigger than its container
-    // If isFacetsContainerHidden is true, then 200 < 250
+    // If isComponentParentHidden is true, then 200 < 250
     // And the container height is always set to 201px
     if (height < initialOptionContainerHeight + 50) {
       this.setContainerHeight(height + 1)

--- a/app/views/govuk_publishing_components/components/_option_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_option_select.html.erb
@@ -35,7 +35,7 @@
 <% end %>
 
 <div
-  class="gem-c-option-select" data-module="option-select" data-ga4-change-category="update-filter checkbox" data-ga4-section="<%= title %>"
+  class="gem-c-option-select" data-module="option-select"
   <% if local_assigns.include?(:closed_on_load) && closed_on_load %>data-closed-on-load="true"<% end %>
   <% if local_assigns.include?(:closed_on_load_mobile) && closed_on_load_mobile %>data-closed-on-load-mobile="true"<% end %>
   <% if local_assigns.include?(:aria_controls_id) %>data-input-aria-controls="<%= aria_controls_id %>"<% end %>


### PR DESCRIPTION
## What / why
Remove some GA4 attributes from the option select component.

- when this component was moved here from `finder-frontend` it included some Google Analytics 4 attributes that are specific to the use of the component in `finder-frontend`
- these attributes have now been [added to finder-frontend](https://github.com/alphagov/finder-frontend/pull/3165) in a wrapping element on the component, so they now need to be removed here

Also renames one of the functions in the option select JS to be more generic, now that the code is in the gem.

## Visual Changes
None.
