### PR TITLE
Fix various bugs with the GA4 pageview tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Remove option select GA4 attributes ([PR #3625](https://github.com/alphagov/govuk_publishing_components/pull/3625))
+* Fix various bugs with the GA4 pageview tracker ([PR #3626](https://github.com/alphagov/govuk_publishing_components/pull/3626))
 
 ## 35.16.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -95,8 +95,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     getQueryString: function () {
       var queryString = this.getSearch()
       if (queryString) {
-        queryString = this.PIIRemover.stripPIIWithOverride(queryString, true, true)
         queryString = this.stripGaParam(queryString)
+        queryString = this.PIIRemover.stripPIIWithOverride(queryString, true, true)
         queryString = queryString.substring(1) // removes the '?' character from the start.
         return queryString
       }

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -148,8 +148,9 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       var content = document.getElementById('content')
       var html = document.querySelector('html')
       if (content) {
-        if (content.getAttribute('lang')) {
-          return content.getAttribute('lang')
+        var contentLanguage = content.getAttribute('lang')
+        if (contentLanguage) {
+          return contentLanguage
         }
       }
       // html.getAttribute('lang') is untested - Jasmine would not allow lang to be set on <html>.

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -148,7 +148,9 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       var content = document.getElementById('content')
       var html = document.querySelector('html')
       if (content) {
-        return content.getAttribute('lang') || this.nullValue
+        if (content.getAttribute('lang')) {
+          return content.getAttribute('lang')
+        }
       }
       // html.getAttribute('lang') is untested - Jasmine would not allow lang to be set on <html>.
       return html.getAttribute('lang') || this.nullValue

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -68,7 +68,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     },
 
     getLocation: function () {
-      return this.PIIRemover.stripPII(this.stripGaParam(document.location.href))
+      return this.PIIRemover.stripPIIWithOverride(this.stripGaParam(document.location.href), true, true)
     },
 
     getSearch: function () {
@@ -115,7 +115,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     },
 
     getTitle: function () {
-      return this.PIIRemover.stripPII(document.title)
+      return this.PIIRemover.stripPIIWithOverride(document.title, true, true)
     },
 
     // window.httpStatusCode is set in the source of the error page in static

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -345,12 +345,12 @@ describe('Google Tag Manager page view tracking', function () {
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
-  it('removes email pii from the title, location and referrer', function () {
-    document.title = 'example@gov.uk'
-    expected.page_view.title = '[email]'
+  it('removes email, postcode, and date pii from the title, location and referrer', function () {
+    document.title = 'example@gov.uk - SW12AA - 2020-01-01'
+    expected.page_view.title = '[email] - [postcode] - [date]'
 
-    spyOnProperty(document, 'referrer', 'get').and.returnValue('https://gov.uk/example@gov.uk')
-    expected.page_view.referrer = 'https://gov.uk/[email]'
+    spyOnProperty(document, 'referrer', 'get').and.returnValue('https://gov.uk/example@gov.uk/SW12AA/2020-01-01')
+    expected.page_view.referrer = 'https://gov.uk/[email]/[postcode]/[date]'
 
     // We can't spy on location, so instead we use an anchor link to change the URL temporarily
 
@@ -360,10 +360,10 @@ describe('Google Tag Manager page view tracking', function () {
     linkForURLMock.click()
     var location = document.location.href
 
-    expected.page_view.location = location + '[email]'
+    expected.page_view.location = location + '[email]/[postcode]/[date]'
 
-    // Add email address to the current page location
-    linkForURLMock.href = '#example@gov.uk'
+    // Add personally identifiable information to the current page location
+    linkForURLMock.href = '#example@gov.uk/SW12AA/2020-01-01'
     linkForURLMock.click()
 
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -531,7 +531,7 @@ describe('Google Tag Manager page view tracking', function () {
   })
 
   it('correctly sets the query_string parameter with PII and _ga/_gl values redacted', function () {
-    spyOn(GOVUK.analyticsGa4.analyticsModules.PageViewTracker, 'getSearch').and.returnValue('?query1=hello&query2=world&email=email@example.com&postcode=SW12AA&birthday=1990-01-01&_ga=1234.567&_gl=1234.567')
+    spyOn(GOVUK.analyticsGa4.analyticsModules.PageViewTracker, 'getSearch').and.returnValue('?query1=hello&query2=world&email=email@example.com&postcode=SW12AA&birthday=1990-01-01&_ga=19900101.567&_gl=19900101.567')
     expected.page_view.query_string = 'query1=hello&query2=world&email=[email]&postcode=[postcode]&birthday=[date]&_ga=[id]&_gl=[id]'
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
     expect(window.dataLayer[0]).toEqual(expected)


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Fixes various bugs with the GA4 pageview tracker. These are:

1. In the `query_string` parameter, I was redacting PII before stripping `_ga` and `_gl`. This breaks the _ga/_gl stripping code, as the PIIRemover detects the random characters in these values as `[date]`. And therefore the regex for stripping the values would break, as correctly it doesn't count `[` and `]` as part of the _ga/_gl values.
2. Fixes `html lang='en'` never being grabbed in certain scenarios. Previously, if the `#content` element existed, it would either grab the language value from it, or return `this.nullValue` straight away. This isn't correct, as we want to check the HTML language value as well before returning `this.nullValue`. Ironically, we couldn't figure out how to test the `<html>` element, and if we could we would've spotted this sooner!
3. The highest level of PII redaction was removed by accident for `getLocation` in #3568 and `getTitle` in #2842. The default `stripPII` function only does extra redaction if certain meta tags exist. We usually use `stripPIIWithOverride` so that we can enable date and postcode redaction ourselves.
 This is a consequence of porting the PIIRemover directly from UA, and not really knowing what we wanted to redact at the time. Eventually we ended up needing to always use the highest level of redaction, so we created `stripPIIWithOverride` to allow this, whereas UA would use `stripPII` which would only redact emails, state, password tokens and unlock tokens. `stripPII` would only be stricter and redact dates/postcodes if certain meta tags existed on the page. Fortunately on `finder-frontend`, one of the meta tags existed `<meta name="govuk:static-analytics:strip-postcodes" content="true">` so postcodes weren't being tracked in searches. Dates however are coming through so this will fix that. This change will also ensure the data/postcode redaction is site-wide.

## Why
<!-- What are the reasons behind this change being made? -->
1. Will fix a bug with this card https://trello.com/c/Rb45fH1B/633-search-enhancement-new-attribute-query-string
2. Will fix a bug with this card https://trello.com/c/ljF64JLm/377-page-view-enhancement-content-language-not-consistently-tracked
3. Will prevent PII coming through/keep our PII consistent

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
