### PR TITLE
[DO NOT MERGE] Add prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+app/assets/javascripts
+bin
+config
+docs
+lib
+spec/javascripts/helpers
+spec/javascripts/vendor
+spec/support
+CHANGELOG.md
+
+**/*.erb
+**/*.rb
+**/*.yml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "singleAttributePerLine": false,
+  "printWidth": 160
+}

--- a/package.json
+++ b/package.json
@@ -36,12 +36,13 @@
     "jasmine-browser-runner": "^2.3.0",
     "jasmine-core": "^5.1.1",
     "postcss": "^8.4.30",
+    "prettier": "3.0.3",
     "standardx": "^7.0.0",
     "stylelint": "^15.10.3",
     "stylelint-config-gds": "^1.0.0"
   },
   "resolutions": {
     "stylelint/strip-ansi": "6.0.1",
-    "stylelint/string-width": "4.2.3"    
+    "stylelint/string-width": "4.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2328,6 +2328,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
+  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"


### PR DESCRIPTION
## What
Adds Prettier. Maybe.

## Why
Stylelint was [recently upgraded](https://github.com/alphagov/govuk_publishing_components/pull/3522) to v1, which [removes all stylistic rules](https://github.com/alphagov/stylelint-config-gds/blob/main/CHANGELOG.md#100) meaning that we're no longer linting for loads of things such as rogue tabs vs spaces, empty space inside parentheses, single quotes, braces on new lines, etc.

Recommended solution is to adopt Prettier. However Prettier is very opinionated and allows little configuration, which means we'd have to change a lot of our code to match the expectations of the linter. Problems so far:

- it insists on removing spaces after function names e.g. `function example ()` becomes `function example()`
- it insists on adding zeroes to the start of numbers less than 1, e.g. `.2em` becomes `0.2em`
- you can choose between single or double quotes but apparently we're massively inconsistent so either approach will involve loads of changes
- it insists on flat indenting markup snippets in JS files e.g.

```
var html = 
  '<div>' +
    '<p>child</p>' +
  '</div>'
```

becomes

```
var html = 
  '<div>' +
  '<p>child</p>' +
  '</div>'
```


## Visual Changes
 None.
