### PR TITLE
Add 'ga4-browse-topic' meta tag to track the mainstream browse topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## Unreleased
 
 * Remove option select GA4 attributes ([PR #3625](https://github.com/alphagov/govuk_publishing_components/pull/3625))
+* Fix various bugs with the GA4 pageview tracker ([PR #3626](https://github.com/alphagov/govuk_publishing_components/pull/3626))
+* Add 'ga4-browse-topic' meta tag to track the mainstream browse topic ([PR #3628](https://github.com/alphagov/govuk_publishing_components/pull/3628))
 
 ## 35.16.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -28,7 +28,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             schema_name: this.getMetaContent('schema-name'),
             content_id: this.getMetaContent('content-id'),
 
-            browse_topic: this.getMetaContent('section'),
+            browse_topic: this.getMetaContent('ga4-browse-topic'),
             navigation_page_type: this.getMetaContent('navigation-page-type'),
             navigation_list_type: this.getMetaContent('navigation-list-type'),
             step_navs: this.getMetaContent('stepnavs'),
@@ -68,7 +68,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     },
 
     getLocation: function () {
-      return this.PIIRemover.stripPII(this.stripGaParam(document.location.href))
+      return this.PIIRemover.stripPIIWithOverride(this.stripGaParam(document.location.href), true, true)
     },
 
     getSearch: function () {
@@ -95,8 +95,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     getQueryString: function () {
       var queryString = this.getSearch()
       if (queryString) {
-        queryString = this.PIIRemover.stripPIIWithOverride(queryString, true, true)
         queryString = this.stripGaParam(queryString)
+        queryString = this.PIIRemover.stripPIIWithOverride(queryString, true, true)
         queryString = queryString.substring(1) // removes the '?' character from the start.
         return queryString
       }
@@ -115,7 +115,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     },
 
     getTitle: function () {
-      return this.PIIRemover.stripPII(document.title)
+      return this.PIIRemover.stripPIIWithOverride(document.title, true, true)
     },
 
     // window.httpStatusCode is set in the source of the error page in static
@@ -148,7 +148,10 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       var content = document.getElementById('content')
       var html = document.querySelector('html')
       if (content) {
-        return content.getAttribute('lang') || this.nullValue
+        var contentLanguage = content.getAttribute('lang')
+        if (contentLanguage) {
+          return contentLanguage
+        }
       }
       // html.getAttribute('lang') is untested - Jasmine would not allow lang to be set on <html>.
       return html.getAttribute('lang') || this.nullValue

--- a/lib/govuk_publishing_components/presenters/meta_tags.rb
+++ b/lib/govuk_publishing_components/presenters/meta_tags.rb
@@ -48,6 +48,9 @@ module GovukPublishingComponents
         primary_publisher = content_item.dig(:links, :primary_publishing_organisation)
         primary_publisher = primary_publisher.first[:title] unless primary_publisher.blank?
         meta_tags["govuk:primary-publishing-organisation"] = primary_publisher unless primary_publisher.blank?
+        ga4_browse_topic = content_item.dig(:links, :ordered_related_items, 0, :links, :mainstream_browse_pages, 0, :links, :parent, 0, :title)
+        ga4_browse_topic = ga4_browse_topic.downcase if ga4_browse_topic
+        meta_tags["govuk:ga4-browse-topic"] = ga4_browse_topic if ga4_browse_topic
 
         meta_tags
       end

--- a/spec/components/meta_tags_spec.rb
+++ b/spec/components/meta_tags_spec.rb
@@ -434,6 +434,19 @@ describe "Meta tags", type: :view do
     end
   end
 
+  it "renders govuk:ga4-browse-topic by digging down mainstream_browse_pages" do
+    render_component(content_item: example_document_for("transaction", "transaction"))
+    assert_meta_tag("govuk:ga4-browse-topic", "housing and local services")
+  end
+
+  it "doesn't render govuk:ga4-browse-topic if the dig doesn't return anything" do
+    content_item = {
+      "links": nil,
+    }
+    render_component(content_item: example_document_for("transaction", "transaction").merge(content_item))
+    assert_no_meta_tag("govuk:ga4-browse-topic")
+  end
+
   def assert_political_status_for(political, current, expected_political_status)
     render_component(content_item: { details: { political: political, government: { current: current, slug: "government" } } })
     assert_meta_tag("govuk:political-status", expected_political_status)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -141,7 +141,7 @@ describe('Google Tag Manager page view tracking', function () {
     var tags = [
       {
         gtmName: 'browse_topic',
-        tagName: 'section',
+        tagName: 'ga4-browse-topic',
         value: 'this section'
       },
       {
@@ -345,12 +345,12 @@ describe('Google Tag Manager page view tracking', function () {
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
-  it('removes email pii from the title, location and referrer', function () {
-    document.title = 'example@gov.uk'
-    expected.page_view.title = '[email]'
+  it('removes email, postcode, and date pii from the title, location and referrer', function () {
+    document.title = 'example@gov.uk - SW12AA - 2020-01-01'
+    expected.page_view.title = '[email] - [postcode] - [date]'
 
-    spyOnProperty(document, 'referrer', 'get').and.returnValue('https://gov.uk/example@gov.uk')
-    expected.page_view.referrer = 'https://gov.uk/[email]'
+    spyOnProperty(document, 'referrer', 'get').and.returnValue('https://gov.uk/example@gov.uk/SW12AA/2020-01-01')
+    expected.page_view.referrer = 'https://gov.uk/[email]/[postcode]/[date]'
 
     // We can't spy on location, so instead we use an anchor link to change the URL temporarily
 
@@ -360,10 +360,10 @@ describe('Google Tag Manager page view tracking', function () {
     linkForURLMock.click()
     var location = document.location.href
 
-    expected.page_view.location = location + '[email]'
+    expected.page_view.location = location + '[email]/[postcode]/[date]'
 
-    // Add email address to the current page location
-    linkForURLMock.href = '#example@gov.uk'
+    // Add personally identifiable information to the current page location
+    linkForURLMock.href = '#example@gov.uk/SW12AA/2020-01-01'
     linkForURLMock.click()
 
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
@@ -531,7 +531,7 @@ describe('Google Tag Manager page view tracking', function () {
   })
 
   it('correctly sets the query_string parameter with PII and _ga/_gl values redacted', function () {
-    spyOn(GOVUK.analyticsGa4.analyticsModules.PageViewTracker, 'getSearch').and.returnValue('?query1=hello&query2=world&email=email@example.com&postcode=SW12AA&birthday=1990-01-01&_ga=1234.567&_gl=1234.567')
+    spyOn(GOVUK.analyticsGa4.analyticsModules.PageViewTracker, 'getSearch').and.returnValue('?query1=hello&query2=world&email=email@example.com&postcode=SW12AA&birthday=1990-01-01&_ga=19900101.567&_gl=19900101.567')
     expected.page_view.query_string = 'query1=hello&query2=world&email=[email]&postcode=[postcode]&birthday=[date]&_ga=[id]&_gl=[id]'
     GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
     expect(window.dataLayer[0]).toEqual(expected)


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
The PAs were previously using the `govuk:section` meta tag to populate `browse_topic` in our pageview tracking. If you look at `meta_tags.rb` in this repo, it looks like this value is populated by grabbing a `section` value from the `content_item`. However, in reality `govuk:section` was being added to the page by digging through the `content_item` in `frontend` and pulling a deeply nested value, rather than just using the `section` value in the `content_item`, which doesn't seem to exist where we'd want it. (For the code that's in `frontend`, [click here](https://github.com/alphagov/frontend/blob/542e53d60f12b21d3299424025cdb7905ede4303/app/controllers/content_items_controller.rb#L8)) This was why the meta tag looked like it was fine for our purpose on certain pages, as these were pages in `frontend`. 

So, `browse_topic` was only being populated in certain places like `frontend`, and not on other 'mainstream browse' pages in other rendering apps, as the `section` value doesn't seem to come through in the `content_item` where the PAs would want it to.

Instead of coding a `govuk:section` meta tag in each frontend app which digs through the content item, we can add one in our global meta tags section in this repo. I've called it `ga4-browse-topic`. This should populate our pageview `browse_topic` wherever it exists.

I guess the only downside of this is that if the user has rejected GA4, an extra meta tag is being sent which isn't used. But I guess that applies for other meta tags anyway that are only used for analytics/debugging purposes - (e.g. `govuk:rendering-app` isn't relevant to the public but is always sent in the page.)

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/DDaR9u6C/342-page-view-enhancement-fix-missing-govuksection-meta-tag-on-content-items-that-are-tagged-to-more-than-one-mainstream-browse-topi

## Testing

If you want to see the meta tag working, you can:
- Run `static` with this branch of `govuk_publishing_components`
- Run `government-frontend` with this branch of `govuk_publishing_components` and visit http://127.0.0.1:3090/universal-credit and you will see `<meta name="govuk:ga4-browse-topic" content="benefits">`
- Run `government-frontend` with this branch of `govuk_publishing_components` and visit http://127.0.0.1:3010/check-uk-visa and you will see `<meta name="govuk:ga4-browse-topic" content="visas and immigration">`
- Run `frontend` with this branch of `govuk_publishing_components` and visit http://127.0.0.1:3005/renew-driving-licence and you will see `<meta name="govuk:ga4-browse-topic" content="driving and transport">`

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
