### PR TITLE
Add stylistic plugin for stylelint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Change prev and next GA4 type ([PR #3631](https://github.com/alphagov/govuk_publishing_components/pull/3631))
 * Remove timestamps from GA4 video urls ([PR #3632](https://github.com/alphagov/govuk_publishing_components/pull/3632))
+* Add stylistic plugin for stylelint ([PR #3629](https://github.com/alphagov/govuk_publishing_components/pull/3629))
 * Remove option select GA4 attributes ([PR #3625](https://github.com/alphagov/govuk_publishing_components/pull/3625))
 * Fix various bugs with the GA4 pageview tracker ([PR #3626](https://github.com/alphagov/govuk_publishing_components/pull/3626))
 * Add 'ga4-browse-topic' meta tag to track the mainstream browse topic ([PR #3628](https://github.com/alphagov/govuk_publishing_components/pull/3628))

--- a/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_big-number.scss
@@ -16,7 +16,8 @@
   @include govuk-font($size: 19, $weight: bold);
 
   // This pseudo element is to bypass an issue with NVDA where block level elements are dictated separately.
-  // What's happening here is that the label and the number technically have an inline relationship but appear to have a block relationship thanks to this element
+  // What's happening here is that the label and the number technically have an inline relationship
+  // but appear to have a block relationship thanks to this element
   &::before {
     content: "";
     display: block;

--- a/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
@@ -365,7 +365,11 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
   $shadow-colour: govuk-colour("white");
 
   // to make numbers readable for users zooming text only in browsers such as Firefox
-  text-shadow: 0 -#{$shadow-offset} 0 $shadow-colour, $shadow-offset 0 0 $shadow-colour, 0 $shadow-offset 0 $shadow-colour, -#{$shadow-offset} 0 0 $shadow-colour;
+  text-shadow:
+    0 -#{$shadow-offset} 0 $shadow-colour,
+    $shadow-offset 0 0 $shadow-colour,
+    0 $shadow-offset 0 $shadow-colour,
+    -#{$shadow-offset} 0 0 $shadow-colour;
 }
 
 .gem-c-step-nav__circle-step-label,

--- a/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
+++ b/app/assets/stylesheets/govuk_publishing_components/components/_tabs.scss
@@ -10,7 +10,8 @@
 }
 
 // We have some styles within GOVUK (.content-block) which can leak into the list styles for this component.
-// These styles are defined in Static: https://github.com/alphagov/static/blob/a815620cada7ea1c65428c1c3b3ac4dbe28977bf/app/assets/stylesheets/helpers/_text.scss
+// These styles are defined in Static:
+// https://github.com/alphagov/static/blob/a815620cada7ea1c65428c1c3b3ac4dbe28977bf/app/assets/stylesheets/helpers/_text.scss
 // This sets more specific selectors so those unwanted styles are overidden
 ul.govuk-tabs__list { // stylelint-disable-line selector-no-qualifying-type
   margin: 0;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,12 @@
     }
   },
   "stylelint": {
-    "extends": "stylelint-config-gds/scss"
+    "extends": ["stylelint-config-gds/scss", "stylelint-stylistic/config"],
+    "rules": {
+      "stylistic/number-leading-zero": null,
+      "stylistic/max-line-length": 160,
+      "stylistic/block-closing-brace-newline-after": "never-single-line"
+    }
   },
   "dependencies": {
     "axe-core": "^4.8.1",
@@ -38,10 +43,11 @@
     "postcss": "^8.4.30",
     "standardx": "^7.0.0",
     "stylelint": "^15.10.3",
-    "stylelint-config-gds": "^1.0.0"
+    "stylelint-config-gds": "^1.0.0",
+    "stylelint-stylistic": "^0.4.3"
   },
   "resolutions": {
     "stylelint/strip-ansi": "6.0.1",
-    "stylelint/string-width": "4.2.3"    
+    "stylelint/string-width": "4.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2314,7 +2314,7 @@ postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.27, postcss@^8.4.30:
+postcss@^8.4.21, postcss@^8.4.27, postcss@^8.4.30:
   version "8.4.30"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.30.tgz#0e0648d551a606ef2192a26da4cabafcc09c1aa7"
   integrity sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==
@@ -2902,6 +2902,17 @@ stylelint-scss@^5.0.0:
     postcss-resolve-nested-selector "^0.1.1"
     postcss-selector-parser "^6.0.13"
     postcss-value-parser "^4.2.0"
+
+stylelint-stylistic@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/stylelint-stylistic/-/stylelint-stylistic-0.4.3.tgz#41f89dbade2028de0c30ad6cc1495bc5d7d1d5f0"
+  integrity sha512-WphmneK3MRrm5ixvRPWy7+c9+EQUh0FPvNMXW/N9VD85vyqtpxUejpD+mxubVVht0fRgidcqBxtW3s3tU2Ujhw==
+  dependencies:
+    is-plain-object "^5.0.0"
+    postcss "^8.4.21"
+    postcss-media-query-parser "^0.2.3"
+    postcss-value-parser "^4.2.0"
+    style-search "^0.1.0"
 
 stylelint@^15.10.3:
   version "15.10.3"


### PR DESCRIPTION
## What
Adds [stylelint-stylistic plugin](https://github.com/elirasza/stylelint-stylistic). This includes adding the plugin to package.json, along with a few configuration rules to match our coding style.

Some changes to the code are inevitable, but limited, and are included in a separate commit.

## Why

Stylelint was [recently upgraded](https://github.com/alphagov/govuk_publishing_components/pull/3522) to v1, which [removes all stylistic rules](https://github.com/alphagov/stylelint-config-gds/blob/main/CHANGELOG.md#100) meaning that we're no longer linting for loads of things such as rogue tabs vs spaces, empty space inside parentheses, single quotes, braces on new lines, etc.

Recommended solution is to adopt Prettier (attempted in https://github.com/alphagov/govuk_publishing_components/pull/3627). However Prettier is very opinionated and allows little configuration, so this alternative approach is to use a stylelint plugin.

## Visual Changes
None.
