### PR TITLE
Add an `aria-label` to the attachment preview link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add 'ga4-browse-topic' meta tag to track the mainstream browse topic ([PR #3628](https://github.com/alphagov/govuk_publishing_components/pull/3628))
 * Ensure cookie banner isn't tracked as visible when it is hidden via JS ([PR #3612](https://github.com/alphagov/govuk_publishing_components/pull/3612))
 * Add spelling_suggestion meta tag to the GA4 pageview object ([PR #3633](https://github.com/alphagov/govuk_publishing_components/pull/3633))
+* Add an `aria-label` to the attachment preview link ([PR #3630](https://github.com/alphagov/govuk_publishing_components/pull/3630))
 
 ## 35.16.0
 

--- a/app/views/govuk_publishing_components/components/_attachment.html.erb
+++ b/app/views/govuk_publishing_components/components/_attachment.html.erb
@@ -99,7 +99,7 @@
     <% end %>
 
     <% if attachment.preview_url.present? %>
-      <%= tag.p link_to(t("components.attachment.preview_link"), attachment.preview_url, class: "govuk-link"), class: "gem-c-attachment__metadata" %>
+      <%= tag.p link_to(t("components.attachment.preview_link"), attachment.preview_url, class: "govuk-link", "aria-label": t("components.attachment.preview_aria_label", title: attachment.title)), class: "gem-c-attachment__metadata" %>
     <% end %>
 
     <% if attachment.is_official_document && !hide_order_copy_link %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -23,6 +23,7 @@ ar:
         other: "%{count} صفحات"
         two:
         zero:
+      preview_aria_label:
       preview_link:
       reference: 'مرجع: %{reference}'
       request_format_cta: طلب تنسيق يمكن الاطلاع عليه.

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -19,6 +19,7 @@ az:
       page:
         one:
         other: "%{count} səhifə"
+      preview_aria_label:
       preview_link:
       reference: 'İst: %{reference}'
       request_format_cta: İstifadə edilə bilən format tələb edin.

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -21,6 +21,7 @@ be:
         many:
         one: 1 старонка
         other: "%{count} старонкi"
+      preview_aria_label:
       preview_link:
       reference: 'Спасылка: %{reference}'
       request_format_cta: Запрасіць файл у іншым фармаце.

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -19,6 +19,7 @@ bg:
       page:
         one: 1-ва страница
         other: "%{count} страници"
+      preview_aria_label:
       preview_link:
       reference: 'Реф: %{reference}'
       request_format_cta: Поискайте достъпен формат.

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -19,6 +19,7 @@ bn:
       page:
         one: 1 পেজ
         other: "%{count} পেজ"
+      preview_aria_label:
       preview_link:
       reference: 'সুত্র: %{reference}'
       request_format_cta: একটি প্রবেশযোগ্য ফরম্যাটের অনুরোধ করুন।

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -20,6 +20,7 @@ cs:
         few:
         one: Strana 1
         other: "%{count} stránek"
+      preview_aria_label:
       preview_link:
       reference: 'Odkaz: %{reference}'
       request_format_cta: Vyžádejte si přístupný formát.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -23,6 +23,7 @@ cy:
         other: "%{count} o dudalennau"
         two:
         zero:
+      preview_aria_label:
       preview_link:
       reference: 'Cyfeirnod: %{reference}'
       request_format_cta: Gwneud cais am fformat hygyrch.

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -19,6 +19,7 @@ da:
       page:
         one: 1 side
         other: "%{count} sider"
+      preview_aria_label:
       preview_link:
       reference: 'Henvisning: %{reference}'
       request_format_cta: Anmod om et tilgængeligt format.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -19,6 +19,7 @@ de:
       page:
         one: 1 Seite
         other: "%{count} Seiten"
+      preview_aria_label:
       preview_link:
       reference: 'Ref: %{reference}'
       request_format_cta: Fordern Sie ein zugängliches Format an.

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -19,6 +19,7 @@ dr:
       page:
         one: صفحهء 1
         other: "%{count} صفحات"
+      preview_aria_label:
       preview_link:
       reference: "%{reference}:مرجع"
       request_format_cta: یک فارمت قابل دسترس را درخواست کنید.

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -19,6 +19,7 @@ el:
       page:
         one: 1 σελίδα
         other: "%{count} σελίδες"
+      preview_aria_label:
       preview_link:
       reference: 'Αναφ.: %{reference}'
       request_format_cta: Ζητήστε μια προσβάσιμη μορφή.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,10 +16,11 @@ en:
     attachment:
       opendocument_html: This file is in an <a href='https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation' target=%{target} class='govuk-link'>OpenDocument</a> format
       order_a_copy: Order a copy
-      preview_link: View online
       page:
         one: 1 page
         other: "%{count} pages"
+      preview_aria_label: View %{title} online
+      preview_link: View online
       reference: 'Ref: %{reference}'
       request_format_cta: Request an accessible format.
       request_format_details_html: If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email <a href='mailto:%{alternative_format_contact_email}' target='_blank' class='govuk-link'>%{alternative_format_contact_email}</a>. Please tell us what format you need. It will help us if you say what assistive technology you use.

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -19,6 +19,7 @@ es-419:
       page:
         one: 1 página
         other: "%{count} páginas"
+      preview_aria_label:
       preview_link:
       reference: 'Referencia: %{reference}'
       request_format_cta: Solicite un formato accesible.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -19,6 +19,7 @@ es:
       page:
         one: 1 página
         other: "%{count} páginas"
+      preview_aria_label:
       preview_link:
       reference: 'Ref.: %{reference}'
       request_format_cta: Solicitar un formato accesible.

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -19,6 +19,7 @@ et:
       page:
         one: 1 leht
         other: "%{count} lehte"
+      preview_aria_label:
       preview_link:
       reference: 'Viide: %{reference}'
       request_format_cta: Taotlege juurdepääsetavat vormingut.

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -19,6 +19,7 @@ fa:
       page:
         one:
         other: "%{count} صفحه"
+      preview_aria_label:
       preview_link:
       reference: 'مرجع: %{reference}'
       request_format_cta: درخواست یک قالب با قابلیت دسترسی بهتر.

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -19,6 +19,7 @@ fi:
       page:
         one: 1 sivu
         other: "%{count} pages"
+      preview_aria_label:
       preview_link:
       reference: 'Viite: %{reference}'
       request_format_cta: Pyydä helppokäyttöistä muotoa.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -19,6 +19,7 @@ fr:
       page:
         one: 1 page
         other: "%{count} pages"
+      preview_aria_label:
       preview_link:
       reference: 'Réf.: %{reference}'
       request_format_cta: Demandez un format accessible.

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -21,6 +21,7 @@ gd:
         one: 1 leathanach
         other: "%{count} leathanaigh"
         two:
+      preview_aria_label:
       preview_link:
       reference: 'Tagairt: %{reference}'
       request_format_cta: Is féidir leat formáid inrochtana a iarraidh.

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -19,6 +19,7 @@ gu:
       page:
         one: 1 પૃષ્ઠ
         other: "%{count} પૃષ્ઠો"
+      preview_aria_label:
       preview_link:
       reference: સંદર્ભ:%{reference}
       request_format_cta: કોઈ એક્સેસિબલ ફોરમેટ માટે વિનંતી કરો.

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -19,6 +19,7 @@ he:
       page:
         one: דף 1
         other: "%{count} דפים"
+      preview_aria_label:
       preview_link:
       reference: 'הפניה: %{reference}'
       request_format_cta: בקש פורמט נגיש.

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -19,6 +19,7 @@ hi:
       page:
         one: 1 पेज
         other: "%{count} पेज"
+      preview_aria_label:
       preview_link:
       reference: 'संदर्भ: %{reference}'
       request_format_cta: एक सुलभ प्रारूप का अनुरोध करें।

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -20,6 +20,7 @@ hr:
         few:
         one: 1 stranica
         other: "%{count} stranice"
+      preview_aria_label:
       preview_link:
       reference: 'Referenca: %{reference}'
       request_format_cta: Zatražite pristupačan format.

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -19,6 +19,7 @@ hu:
       page:
         one: 1 oldal
         other: "%{count} oldal"
+      preview_aria_label:
       preview_link:
       reference: 'Ref: %{reference}'
       request_format_cta: Kérjen hozzáférhető formátumot.

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -19,6 +19,7 @@ hy:
       page:
         one: 1 էջ
         other: "%{count} էջ"
+      preview_aria_label:
       preview_link:
       reference: Հղում՝ %{reference}
       request_format_cta: 'Նշեք համապատասխան ձևաչափ:'

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -18,6 +18,7 @@ id:
       order_a_copy: Pesan salinan
       page:
         other: "%{count} halaman"
+      preview_aria_label:
       preview_link:
       reference: 'Ref: %{reference}'
       request_format_cta: Minta format yang dapat diakses.

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -19,6 +19,7 @@ is:
       page:
         one: 1 síða
         other: "%{count} síður"
+      preview_aria_label:
       preview_link:
       reference: 'Tilv: %{reference}'
       request_format_cta: Óska eftir aðgengilegu sniði.

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -19,6 +19,7 @@ it:
       page:
         one: 1 pagina
         other: "%{count} pagine"
+      preview_aria_label:
       preview_link:
       reference: 'Rif: %{reference}'
       request_format_cta: Richiedi un formato accessibile.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,6 +18,7 @@ ja:
       order_a_copy: コピーを注文する
       page:
         other: "％{count}ページ"
+      preview_aria_label:
       preview_link:
       reference: 参照：%{reference}
       request_format_cta: アクセス可能なフォーマットをリクエストしてください。

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -19,6 +19,7 @@ ka:
       page:
         one: 1 გვერი
         other: "%{count} გვერდები"
+      preview_aria_label:
       preview_link:
       reference: 'მითითება: %{reference}'
       request_format_cta: ხელმისაწვდომი ფორმატის მოთხოვნა.

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -19,6 +19,7 @@ kk:
       page:
         one: 1 бет
         other: "%{count} бет"
+      preview_aria_label:
       preview_link:
       reference: 'Сілтеме: %{reference}'
       request_format_cta: Қолжетімді пішімді сұраңыз.

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -18,6 +18,7 @@ ko:
       order_a_copy:
       page:
         other:
+      preview_aria_label:
       preview_link:
       reference:
       request_format_cta:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -20,6 +20,7 @@ lt:
         few:
         one: 1 puslapis
         other: "%{count} puslapių"
+      preview_aria_label:
       preview_link:
       reference: 'Nuoroda: %{reference}'
       request_format_cta: Prašyti prieinamo formato.

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -19,6 +19,7 @@ lv:
       page:
         one: 1 lapa
         other: "%{count} lapas"
+      preview_aria_label:
       preview_link:
       reference: 'Ref.: %{reference}'
       request_format_cta: Pieprasīt pieejamu formātu.

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -18,6 +18,7 @@ ms:
       order_a_copy: Pesan satu salinan
       page:
         other: "%{count} halaman"
+      preview_aria_label:
       preview_link:
       reference: 'Ruj: %{reference}'
       request_format_cta: Minta format yang boleh diakses.

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -21,6 +21,7 @@ mt:
         many:
         one: 1 paġna
         other: "%{count} paġni"
+      preview_aria_label:
       preview_link:
       reference: 'Ref: %{reference}'
       request_format_cta: Itlob format aċċessibbli.

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -19,6 +19,7 @@ nl:
       page:
         one: 1 pagina
         other: "%{count} pagina's"
+      preview_aria_label:
       preview_link:
       reference: 'Ref: %{reference}'
       request_format_cta: Vraag een toegankelijk formaat aan.

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -19,6 +19,7 @@
       page:
         one: 1 side
         other: "%{count} sider"
+      preview_aria_label:
       preview_link:
       reference: 'Ref: %{reference}'
       request_format_cta: Be om et tilgjengelig format.

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -19,6 +19,7 @@ pa-pk:
       page:
         one: پہلا ورق
         other: ورقے {count}%
+      preview_aria_label:
       preview_link:
       reference: حوالہ:{reference}%
       request_format_cta: اک طریقے تک پوہنچن لئی اِک درخواست دیو۔

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -19,6 +19,7 @@ pa:
       page:
         one: 1 ਪੰਨਾ
         other: "%{count} ਪੰਨੇ"
+      preview_aria_label:
       preview_link:
       reference: 'ਹਵਾਲਾ: %{reference}'
       request_format_cta: ਇੱਕ ਪਹੁੰਚਯੋਗ ਫਾਰਮੈਟ ਦੀ ਬੇਨਤੀ ਕਰੋ।

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -21,6 +21,7 @@ pl:
         many:
         one: 1 strona
         other: "%{count} strony"
+      preview_aria_label:
       preview_link:
       reference: 'Odnośnik: %{reference}'
       request_format_cta: Poproś o inny format.

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -19,6 +19,7 @@ ps:
       page:
         one: 1 پاڼه
         other: "%{count} پاڼې"
+      preview_aria_label:
       preview_link:
       reference: حواله:%{reference}
       request_format_cta: د لاسرسي وړ پاڼه غوښتنه وکړئ.

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -19,6 +19,7 @@ pt:
       page:
         one: 1 página
         other: "%{count} páginas"
+      preview_aria_label:
       preview_link:
       reference: 'Ref: %{reference}'
       request_format_cta: Solicitar um formato acessível.

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -20,6 +20,7 @@ ro:
         few:
         one: 1 pagină
         other: "%{count} pagini"
+      preview_aria_label:
       preview_link:
       reference: 'Referință: %{reference}'
       request_format_cta: Solicitați un format accesibil.

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -21,6 +21,7 @@ ru:
         many:
         one: 1 страница
         other: "%{count} страниц"
+      preview_aria_label:
       preview_link:
       reference: 'Ссылка: %{reference}'
       request_format_cta: Запросить в доступном формате.

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -19,6 +19,7 @@ si:
       page:
         one: පිටු 1ක්
         other: පිටු %{count}ක්
+      preview_aria_label:
       preview_link:
       reference: 'යොමුව: %{reference}'
       request_format_cta: පිවිසිය හැකි ආකෘතියක් ඉල්ලන්න.

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -20,6 +20,7 @@ sk:
         few:
         one: 1 strana
         other: "%{count} strán"
+      preview_aria_label:
       preview_link:
       reference: 'Odkaz: %{reference}'
       request_format_cta: Vyžiadajte si prístupný formát.

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -21,6 +21,7 @@ sl:
         one: 1 stran
         other: "%{count} strani"
         two:
+      preview_aria_label:
       preview_link:
       reference: 'Referenca: % (reference}'
       request_format_cta: Zahtevajte dostopen format.

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -19,6 +19,7 @@ so:
       page:
         one: 1 boga
         other: "%{count} bogaga"
+      preview_aria_label:
       preview_link:
       reference: 'Tixraac: %{reference}'
       request_format_cta: Codso nidaam la gali karo.

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -19,6 +19,7 @@ sq:
       page:
         one: 1 faqe
         other: "%{count} faqet"
+      preview_aria_label:
       preview_link:
       reference: 'Ref: %{reference}'
       request_format_cta: Kërkoni një format të arritshëm.

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -20,6 +20,7 @@ sr:
         few:
         one: 1 stranica
         other: "%{count} str."
+      preview_aria_label:
       preview_link:
       reference: 'Ref: %{reference}'
       request_format_cta: Zatražite format kom možete da pristupite.

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -19,6 +19,7 @@ sv:
       page:
         one: 1 sida
         other: "%{count} sidor"
+      preview_aria_label:
       preview_link:
       reference: 'Ref: %{reference}'
       request_format_cta: Begär ett tillgängligt format.

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -19,6 +19,7 @@ sw:
       page:
         one: Ukurasa mmoja (1)
         other: Kurasa %{count}
+      preview_aria_label:
       preview_link:
       reference: 'Marejeleo: %{reference}'
       request_format_cta: Omba muundo unaoweza kutumika.

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -19,6 +19,7 @@ ta:
       page:
         one: 1 பக்கம்
         other: "%{count} பக்கங்கள்"
+      preview_aria_label:
       preview_link:
       reference: 'பார்வை: %{reference}'
       request_format_cta: அணுகக்கூடிய வடிவத்தைக் கோருக.

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -18,6 +18,7 @@ th:
       order_a_copy: สั่งซื้อสำเนา
       page:
         other: "%{count} หน้า"
+      preview_aria_label:
       preview_link:
       reference: 'อ้างอิง: %{reference}'
       request_format_cta: ขอรูปแบบไฟล์ที่สามารถเข้าถึงได้

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -19,6 +19,7 @@ tk:
       page:
         one: 1 sahypa
         other: "%{count} sahypalar"
+      preview_aria_label:
       preview_link:
       reference: 'Salgylanma: %{reference}'
       request_format_cta: Elýeterli formaty talap etmek.

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -19,6 +19,7 @@ tr:
       page:
         one: 1 sayfa
         other: "%{count} sayfa"
+      preview_aria_label:
       preview_link:
       reference: 'İlgi: %{reference}'
       request_format_cta: Erişilebilir bir format talep edin.

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -21,6 +21,7 @@ uk:
         many:
         one: 1 сторінка
         other: "%{count} сторінок"
+      preview_aria_label:
       preview_link:
       reference: 'Посилання: %{reference}'
       request_format_cta: Надішліть запит на доступний формат.

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -19,6 +19,7 @@ ur:
       page:
         one: 1 صفحہ
         other: "%{count} صفحات"
+      preview_aria_label:
       preview_link:
       reference: 'حوالہ: %{reference}'
       request_format_cta: قابل رسائی فارمیٹ کی درخواست دیں۔

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -19,6 +19,7 @@ uz:
       page:
         one: 1 саҳифа
         other: "%{count} саҳифа"
+      preview_aria_label:
       preview_link:
       reference: 'Ҳавола:  %{reference}'
       request_format_cta: Мақбул форматни олишга сўров.

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -18,6 +18,7 @@ vi:
       order_a_copy: Đặt hàng một bản sao
       page:
         other: "%{count} trang"
+      preview_aria_label:
       preview_link:
       reference: 'Tham khảo: %{reference}'
       request_format_cta: Yêu cầu một định dạng có thể truy cập.

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -18,6 +18,7 @@ zh-hk:
       order_a_copy: 索取副本
       page:
         other: "%{count} 頁"
+      preview_aria_label:
       preview_link:
       reference: 'Ref: %{reference}'
       request_format_cta: 索取可讀取之格式。

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -18,6 +18,7 @@ zh-tw:
       order_a_copy: 預定副本
       page:
         other: "%{count} 頁面"
+      preview_aria_label:
       preview_link:
       reference: 參考：%{reference}
       request_format_cta: 請求可參閱格式。

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -18,6 +18,7 @@ zh:
       order_a_copy: 订购副本
       page:
         other: "%{count} 页"
+      preview_aria_label:
       preview_link:
       reference: 参考号：%{reference}
       request_format_cta: 申请可访问格式。


### PR DESCRIPTION
# What

Add an `aria-label` of "View [attachment title] online" to attachment preview links

# Why

Fixes #3560 

When attaching a CSV file via the [Whitehall block attachment component](https://components.publishing.service.gov.uk/component-guide/govspeak#whitehall_block_attachments) it produces two links: "View online" and "Download CSV 21.7 KB" (for example). The "View online" link is not descriptive when out of context as it doesn't mention what you can view online.

This was found in the 2022 WCAG audit of GOV.UK and is a fail of 2.4.4 Link Purpose (In Context).

