### PR TITLE
Change prev and next GA4 type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Change prev and next GA4 type ([PR #3631](https://github.com/alphagov/govuk_publishing_components/pull/3631))
 * Remove option select GA4 attributes ([PR #3625](https://github.com/alphagov/govuk_publishing_components/pull/3625))
 * Fix various bugs with the GA4 pageview tracker ([PR #3626](https://github.com/alphagov/govuk_publishing_components/pull/3626))
 * Add 'ga4-browse-topic' meta tag to track the mainstream browse topic ([PR #3628](https://github.com/alphagov/govuk_publishing_components/pull/3628))

--- a/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
+++ b/app/views/govuk_publishing_components/components/_previous_and_next_navigation.html.erb
@@ -19,8 +19,8 @@
         link_text_classes << "govuk-pagination__link-title--decorated" unless previous_page[:label].present?
       %>
       <div class="govuk-pagination__prev">
-        <a class="govuk-link govuk-pagination__link" 
-          href="<%= previous_page[:url] %>" 
+        <a class="govuk-link govuk-pagination__link"
+          href="<%= previous_page[:url] %>"
           rel="prev"
           data-track-category="contentsClicked"
           data-track-action="previous"
@@ -30,7 +30,7 @@
           <% if ga4_tracking %>
             data-ga4-link = "<%= {
               event_name: "navigation",
-              type: "content",
+              type: "previous and next",
               text: previous_page[:label] || title,
               section: "Previous",
             }.to_json %>"
@@ -55,8 +55,8 @@
         link_text_classes << "govuk-pagination__link-title--decorated" unless next_page[:label].present?
       %>
       <div class="govuk-pagination__next">
-        <a class="govuk-link govuk-pagination__link" 
-          href="<%= next_page[:url] %>" 
+        <a class="govuk-link govuk-pagination__link"
+          href="<%= next_page[:url] %>"
           rel="next"
           data-track-category="contentsClicked"
           data-track-action="next"
@@ -66,7 +66,7 @@
           <% if ga4_tracking %>
             data-ga4-link = "<%= {
               event_name: "navigation",
-              type: "content",
+              type: "previous and next",
               text: next_page[:label] || title,
               section: "Next",
             }.to_json %>"

--- a/spec/components/previous_and_next_navigation_spec.rb
+++ b/spec/components/previous_and_next_navigation_spec.rb
@@ -87,7 +87,7 @@ describe "Previous and next navigation", type: :view do
 
     expected_ga4_json = {
       "event_name": "navigation",
-      "type": "content",
+      "type": "previous and next",
       "text": "Previous page",
       "section": "Previous",
     }.to_json
@@ -98,7 +98,7 @@ describe "Previous and next navigation", type: :view do
 
     expected_ga4_json = {
       "event_name": "navigation",
-      "type": "content",
+      "type": "previous and next",
       "text": "Next page",
       "section": "Next",
     }.to_json


### PR DESCRIPTION
## What
Changes GA4 tracking 'type' for the previous/next navigation component from 'content' to 'previous and next'.

## Why
We want more specific types when tracking different kinds of interactions.

## Visual Changes
None.

Trello card: https://trello.com/c/6jQ96zS8/683-change-previous-and-next-page-navigation-event-types-to-previous-and-next