### PR TITLE
Remove timestamps from GA4 video urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Change prev and next GA4 type ([PR #3631](https://github.com/alphagov/govuk_publishing_components/pull/3631))
+* Remove timestamps from GA4 video urls ([PR #3632](https://github.com/alphagov/govuk_publishing_components/pull/3632))
 * Remove option select GA4 attributes ([PR #3625](https://github.com/alphagov/govuk_publishing_components/pull/3625))
 * Fix various bugs with the GA4 pageview tracker ([PR #3626](https://github.com/alphagov/govuk_publishing_components/pull/3626))
 * Add 'ga4-browse-topic' meta tag to track the mainstream browse topic ([PR #3628](https://github.com/alphagov/govuk_publishing_components/pull/3628))

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.js
@@ -70,7 +70,7 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       var data = {}
       data.event_name = 'video_' + event
       data.type = 'video'
-      data.url = player.getVideoUrl()
+      data.url = this.cleanVideoUrl(player.getVideoUrl())
       data.text = player.videoTitle
       data.action = event
       data.video_current_time = Math.round(player.getCurrentTime())
@@ -81,6 +81,12 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       var schema = schemas.mergeProperties(data, 'event_data')
 
       window.GOVUK.analyticsGa4.core.sendData(schema)
+    },
+
+    cleanVideoUrl: function (url) {
+      url = url.replace(/[?]{1}t=[0-9]+[&]{1}/, '?') // replace ?t=123& with ?
+      url = url.replace(/[&]{1}t=[0-9]+/, '') // replace &t=123 with ''
+      return url
     }
   }
 

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.spec.js
@@ -16,7 +16,7 @@ describe('Google Analytics video tracker', function () {
           return 0
         },
         getVideoUrl: function () {
-          return 'youtube/something'
+          return 'https://www.youtube.com/watch?t=26&v=abcdef'
         },
         getDuration: function () {
           return 500
@@ -44,7 +44,7 @@ describe('Google Analytics video tracker', function () {
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.type = 'video'
-      expected.event_data.url = 'youtube/something'
+      expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
       expected.event_data.video_duration = 500
       expected.govuk_gem_version = 'aVersion'
     })
@@ -69,6 +69,46 @@ describe('Google Analytics video tracker', function () {
       expected.event_data.video_percent = 100
 
       expect(window.dataLayer[0]).toEqual(expected)
+    })
+  })
+
+  describe('cleans urls', function () {
+    beforeEach(function () {
+      videoTracker.configureVideo(event)
+      expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      expected.event = 'event_data'
+      expected.event_data.type = 'video'
+      expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
+      expected.event_data.video_duration = 500
+      expected.govuk_gem_version = 'aVersion'
+      expected.event_data.event_name = 'video_start'
+      expected.event_data.action = 'start'
+      expected.event_data.video_current_time = 0
+      expected.event_data.video_percent = 0
+    })
+
+    it('with a time as the first parameter', function () {
+      event.target.getVideoUrl = function () {
+        return 'https://www.youtube.com/watch?t=26&v=abcdef'
+      }
+      videoTracker.trackVideo(event, 'VideoUnstarted')
+      expect(window.dataLayer[0]).toEqual(expected)
+    })
+
+    it('with a time not as the first parameter', function () {
+      event.target.getVideoUrl = function () {
+        return 'https://www.youtube.com/watch?v=abcdef&t=03434'
+      }
+      expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
+      videoTracker.trackVideo(event, 'VideoUnstarted')
+      expect(window.dataLayer[0]).toEqual(expected)
+
+      event.target.getVideoUrl = function () {
+        return 'https://www.youtube.com/watch?v=abcdef&t=03434&test=test'
+      }
+      expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef&test=test'
+      videoTracker.trackVideo(event, 'VideoUnstarted')
+      expect(window.dataLayer[1]).toEqual(expected)
     })
   })
 
@@ -109,7 +149,7 @@ describe('Google Analytics video tracker', function () {
       expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
       expected.event = 'event_data'
       expected.event_data.type = 'video'
-      expected.event_data.url = 'youtube/something'
+      expected.event_data.url = 'https://www.youtube.com/watch?v=abcdef'
       expected.event_data.video_duration = 500
       expected.event_data.event_name = 'video_progress'
       expected.event_data.action = 'progress'
@@ -183,7 +223,7 @@ describe('Google Analytics video tracker', function () {
           return 0
         },
         getVideoUrl: function () {
-          return 'youtube/somethingElse'
+          return 'https://www.youtube.com/watch?t=26&v=abcdef'
         },
         getDuration: function () {
           return 1000


### PR DESCRIPTION
## What
- tracking videos includes the URL of the video, retrieved from the YouTube API
- the URL changes during playback to include the time position of the video, as a URL parameter of the form `t=[0-9]`
- use regexes to remove these parameters and preserve the original URL

## Why
It's quite hard to track videos being watched in GA4 when the URL is inconsistent - removing the timestamp should make the video URL always the same for a single video.

## Visual Changes
None.

Trello card: https://trello.com/c/4r5QApUs/695-placeholder-video-url-remove-extra-query-strings
