### PR TITLE
Add spelling_suggestion meta tag to the GA4 pageview object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix various bugs with the GA4 pageview tracker ([PR #3626](https://github.com/alphagov/govuk_publishing_components/pull/3626))
 * Add 'ga4-browse-topic' meta tag to track the mainstream browse topic ([PR #3628](https://github.com/alphagov/govuk_publishing_components/pull/3628))
 * Ensure cookie banner isn't tracked as visible when it is hidden via JS ([PR #3612](https://github.com/alphagov/govuk_publishing_components/pull/3612))
+* Add spelling_suggestion meta tag to the GA4 pageview object ([PR #3633](https://github.com/alphagov/govuk_publishing_components/pull/3633))
 
 ## 35.16.0
 

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
@@ -60,7 +60,8 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
             cookie_banner: this.getBannerPresence('[data-ga4-cookie-banner]'),
             intervention: this.getBannerPresence('[data-ga4-intervention-banner]'),
             query_string: this.getQueryString(),
-            search_term: this.getSearchTerm()
+            search_term: this.getSearchTerm(),
+            spelling_suggestion: this.getMetaContent('spelling-suggestion')
           }
         }
         window.GOVUK.analyticsGa4.core.sendData(data)

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.spec.js
@@ -57,7 +57,8 @@ describe('Google Tag Manager page view tracking', function () {
         cookie_banner: undefined,
         intervention: undefined,
         query_string: undefined,
-        search_term: undefined
+        search_term: undefined,
+        spelling_suggestion: undefined
       }
     }
     window.dataLayer = []
@@ -579,5 +580,12 @@ describe('Google Tag Manager page view tracking', function () {
       GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
       expect(window.dataLayer[0]).toEqual(expected)
     })
+  })
+
+  it('correctly sets the spelling_suggestion parameter', function () {
+    createMetaTags('spelling-suggestion', 'tax')
+    expected.page_view.spelling_suggestion = 'tax'
+    GOVUK.analyticsGa4.analyticsModules.PageViewTracker.init()
+    expect(window.dataLayer[0]).toEqual(expected)
   })
 })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- Adds `spelling_suggestion` to the GA4 Pageview object - it pulls this value from an existing meta tag `govuk:spelling-suggestion`.

## Why
<!-- What are the reasons behind this change being made? -->
- https://trello.com/c/RMPwoe93/689-search-enhancement-new-attribute-search-spelling-suggestion

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.
