### PR TITLE
Change GA4 contents list type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Change GA4 contents list type ([PR #3635](https://github.com/alphagov/govuk_publishing_components/pull/3635))
 * Change prev and next GA4 type ([PR #3631](https://github.com/alphagov/govuk_publishing_components/pull/3631))
 * Remove timestamps from GA4 video urls ([PR #3632](https://github.com/alphagov/govuk_publishing_components/pull/3632))
 * Add stylistic plugin for stylelint ([PR #3629](https://github.com/alphagov/govuk_publishing_components/pull/3629))

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -15,7 +15,7 @@
   ga4_tracking ||= false
   ga4_data = {
       event_name: "navigation",
-      type: "content",
+      type: "contents list",
       section: t("components.contents_list.contents", locale: :en) || ""
   } if ga4_tracking
   local_assigns[:aria] ||= {}

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -130,7 +130,7 @@ describe "Contents list", type: :view do
 
     expected_ga4_json = {
       event_name: "navigation",
-      type: "content",
+      type: "contents list",
       section: "Contents",
     }
 


### PR DESCRIPTION
## What
Change GA4 attributes for the contents list component from type `content` to type `contents list`.

## Why
We want more specific types when tracking different kinds of interactions.

## Visual Changes
None.

Trello card: https://trello.com/c/kPQBqdSw/675-change-contents-navigation-selectcontent-event-types-to-contents-list
