### PR TITLE
Add GA4 to nested contents item links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add GA4 to nested contents item links ([PR #3638](https://github.com/alphagov/govuk_publishing_components/pull/3638))
 * Change GA4 contents list type ([PR #3635](https://github.com/alphagov/govuk_publishing_components/pull/3635))
 * Change prev and next GA4 type ([PR #3631](https://github.com/alphagov/govuk_publishing_components/pull/3631))
 * Remove timestamps from GA4 video urls ([PR #3632](https://github.com/alphagov/govuk_publishing_components/pull/3632))

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -14,9 +14,10 @@
 
   ga4_tracking ||= false
   ga4_data = {
-      event_name: "navigation",
-      type: "contents list",
-      section: t("components.contents_list.contents", locale: :en) || ""
+    event_name: "navigation",
+    type: "contents list",
+    section: t("components.contents_list.contents", locale: :en) || "",
+    index_total: cl_helper.get_index_total
   } if ga4_tracking
   local_assigns[:aria] ||= {}
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
@@ -37,15 +38,15 @@
     <% end %>
 
     <ol class="gem-c-contents-list__list">
+      <% index_link = 1 if ga4_tracking %>
       <% contents.each.with_index(1) do |contents_item, position| %>
         <li class="<%= cl_helper.list_item_classes(contents_item, false) %>" <%= "aria-current=true" if contents_item[:active] %>>
           <% link_text = format_numbers ? cl_helper.wrap_numbers_with_spans(contents_item[:text]) : contents_item[:text]
-             if ga4_tracking
+            if ga4_tracking
               ga4_data[:index] = {
-                  "index_link": position,
+                "index_link": index_link,
               }
-              ga4_data[:index_total] = contents.length
-             end
+            end
           %>
           <%= link_to_if !contents_item[:active], link_text, contents_item[:href],
             class:  link_classes,
@@ -59,11 +60,18 @@
               ga4_link: (ga4_tracking ? ga4_data.to_json : nil)
             }
           %>
-
+          <% index_link += 1 if ga4_tracking %>
           <% if contents_item[:items] && contents_item[:items].any? %>
             <ol class="gem-c-contents-list__nested-list">
               <% contents_item[:items].each.with_index(1) do |nested_contents_item, nested_position| %>
                 <li class="<%= cl_helper.list_item_classes(nested_contents_item, true) %>" <%= "aria-current=true" if nested_contents_item[:active] %>>
+                  <%
+                    if ga4_tracking
+                      ga4_data[:index] = {
+                        "index_link": index_link,
+                      }
+                    end
+                  %>
                   <%= link_to_if !nested_contents_item[:active], nested_contents_item[:text], nested_contents_item[:href],
                     class: link_classes,
                     data: {
@@ -72,13 +80,15 @@
                       track_label: nested_contents_item[:href],
                       track_options: {
                         dimension29: nested_contents_item[:text]
-                      }
+                      },
+                      ga4_link: (ga4_tracking ? ga4_data.to_json : nil)
                     }
                   %>
                 </li>
+                <% index_link += 1 if ga4_tracking %>
               <% end %>
             </ol>
-            <% end %>
+          <% end %>
         </li>
       <% end %>
     </ol>

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -204,6 +204,7 @@ examples:
             text: 1. Nested Item
           - href: "#third-thing"
             text: 2. Nested Item
+            active: true
         - href: "#first-thing"
           text: 2. Second thing
           items:

--- a/lib/govuk_publishing_components/presenters/contents_list_helper.rb
+++ b/lib/govuk_publishing_components/presenters/contents_list_helper.rb
@@ -40,6 +40,14 @@ module GovukPublishingComponents
         end
       end
 
+      def get_index_total
+        total = @contents.length
+        @contents.each do |parent|
+          total += parent[:items].length if parent[:items]
+        end
+        total
+      end
+
     private
 
       def parent_modifier

--- a/spec/lib/govuk_publishing_components/components/contents_list_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/contents_list_helper_spec.rb
@@ -74,6 +74,28 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentsListHelper do
       expected = '<a href="#run-an-effective-welfare-system">Run an effective welfare system part 1. Social Care</a>'
       expect(cl.wrap_numbers_with_spans(input)).to eql(expected)
     end
+
+    it "counts the number of links in the component" do
+      contents = [
+        {
+          text: "test1",
+          items: [
+            {
+              text: "test2",
+            },
+            {
+              text: "test3",
+              active: true,
+            },
+          ],
+        },
+        {
+          text: "test3",
+        },
+      ]
+      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({ contents: contents })
+      expect(cl.get_index_total).to eql(4)
+    end
   end
 
   def assert_split_number_and_text(number_and_text, number, text)


### PR DESCRIPTION
## What
- include GA4 attributes for tracking on nested contents item links
- includes new code to calculate the index_total (total number of links) and the index_link value for each link
- note that where a contents list item is 'active' (i.e. not a link) this should not alter the overall index_total or index_link values, it is assumed that this non-link item is included in those counts

Index values should be as follows:

```
Parent link // index_link 1
- nested link // index_link 2
- nested link // index_link 3
Parent link // index_link 4
- nested link // index_link 5
- active (not a link)
- nested link // index_link 7

index_total = 7
```

## Why
We weren't tracking clicks on nested contents items links, only on top level items.

## Visual Changes
One tiny change to the doc page for this component, under GA4 tracking include an `active` item to help with testing.

Trello card: https://trello.com/c/ZD50PFtM/693-add-tracking-to-dashed-child-content-items