### PR TITLE
Fix option select arrow when CSS missing

### DIFF
--- a/app/views/govuk_publishing_components/components/_option_select.html.erb
+++ b/app/views/govuk_publishing_components/components/_option_select.html.erb
@@ -43,8 +43,8 @@
 >
   <h3 class="gem-c-option-select__heading js-container-heading">
     <span class="gem-c-option-select__title js-container-button" id="<%= title_id %>"><%= title %></span>
-    <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="gem-c-option-select__icon gem-c-option-select__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
-    <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="gem-c-option-select__icon gem-c-option-select__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
+    <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="0" height="0" class="gem-c-option-select__icon gem-c-option-select__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
+    <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="0" height="0" class="gem-c-option-select__icon gem-c-option-select__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
   </h3>
 
   <%= content_tag(:div, role: "group", aria: { labelledby: title_id }, class: classes, id: options_container_id, tabindex: "-1") do %>


### PR DESCRIPTION
## What
- if CSS is disabled or fails to load, this component's SVG arrows (for expand/collapse) appear at a huge size
- this not only looks terrible but advertises that something is broken and gets in the way of the user using the component
- since the CSS sets the width and height of the SVG already, solution is to set width and height inline attributes on the SVG to zero, so if CSS fails to load the SVG doesn't appear

## Why
The component should be mostly usable without styles or JS enabled. Recently there was a problem with this component's styles and the massive SVG arrow was briefly visible on the live site. This has also happened a few times before.

## Visual Changes

Before | After
------ | -------
![Screenshot 2023-09-26 at 11 01 18](https://github.com/alphagov/govuk_publishing_components/assets/861310/3f9fea28-1c7c-470e-9961-5aa48bce8640) | ![Screenshot 2023-09-26 at 11 03 47](https://github.com/alphagov/govuk_publishing_components/assets/861310/4e10a20a-9e55-4344-ba89-0d4e361bfbae)
