### PR TITLE
Account for licence finder results count in GA4 ecommerce tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add new light action link variant ([PR #3602](https://github.com/alphagov/govuk_publishing_components/pull/3602))
 * Add new homepage variant to search component ([PR #3599](https://github.com/alphagov/govuk_publishing_components/pull/3599))
 * Change GA4 type for show/hide update links ([PR #3643](https://github.com/alphagov/govuk_publishing_components/pull/3643))
+* Account for licence finder results count in GA4 ecommerce tracking ([PR #3641](https://github.com/alphagov/govuk_publishing_components/pull/3641))
 
 
 ## 35.16.1

--- a/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
+++ b/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js
@@ -288,11 +288,8 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
           return null
         }
 
-        // In order to extract the number of results from resultCount (which is a string at this point (e.g. '12,345 results')), we remove the comma and
-        // split string at the space character so it can be parsed as an integer
-        resultCount = window.GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(resultCount.textContent)
-        resultCount = resultCount.replace(',', '')
-        resultCount = resultCount.split(' ')[0]
+        // Remove anything that isn't a number from the result count heading. E.g. 'Results:' or the comma in '1,234'
+        resultCount = resultCount.textContent.replace(/[^0-9]+/g, '')
 
         return parseInt(resultCount)
       },

--- a/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
+++ b/spec/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.spec.js
@@ -404,7 +404,7 @@ describe('GA4 core', function () {
       var resultCountContainer
 
       resultCountContainer = document.createElement('span')
-      resultCountContainer.innerHTML = '<span id="results-count">54321 results</span>'
+      resultCountContainer.innerHTML = '<span id="results-count">54,321 results</span>'
 
       beforeEach(function () {
         document.body.appendChild(resultCountContainer)
@@ -420,7 +420,13 @@ describe('GA4 core', function () {
       })
 
       it('handles new lines and extra spaces', function () {
-        resultCountContainer.innerHTML = '<span id="results-count"> \n   54321 results    \n</span>'
+        resultCountContainer.innerHTML = '<span id="results-count"> \n   54,321 results    \n</span>'
+        expect(GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getResultCount(resultCountContainer, 'results-count')).toEqual(54321)
+        expect(typeof GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getResultCount(resultCountContainer, 'results-count')).toEqual('number')
+      })
+
+      it('handles "Results:" at the start of the string ', function () {
+        resultCountContainer.innerHTML = '<span id="results-count">Results: 54,321 licences</span>'
         expect(GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getResultCount(resultCountContainer, 'results-count')).toEqual(54321)
         expect(typeof GOVUK.analyticsGa4.core.ecommerceHelperFunctions.getResultCount(resultCountContainer, 'results-count')).toEqual('number')
       })


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
- On licence finders, the results count heading looks like `Results: 431 licences` https://www.gov.uk/find-licences
- The current method for grabbing results counts in our ecommerce tracking expects the heading to look like `1,234 results`
- Therefore the dataLayer was pushing `NaN` for licence finder results count
- This PR fixes this
- Note: we have a technical debt card to replace this with the meta tag `<meta name="govuk:search-result-count" content="431">` https://trello.com/c/uPzYr44q/640-use-search-results-count-meta-tag-to-grab-the-amount-of-search-results-for-finder-frontend-ecommerce-tracking

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/MXhpmk9c/659-fix-search-results-count-on-viewitemlist-event

## Testing
- To test this, point `finder-frontend` to your local `govuk_publishing_components` and checkout this branch in `govuk_publishing_components`
- Go to http://127.0.0.1:3062/find-licences
- You'll see `431` as the results number in the ecommerce object in the dataLayer.

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.