### PR TITLE
Change GA4 type for show/hide update links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add new light action link variant ([PR #3602](https://github.com/alphagov/govuk_publishing_components/pull/3602))
 * Add new homepage variant to search component ([PR #3599](https://github.com/alphagov/govuk_publishing_components/pull/3599))
+* Change GA4 type for show/hide update links ([PR #3643](https://github.com/alphagov/govuk_publishing_components/pull/3643))
 
 
 ## 35.16.1

--- a/app/views/govuk_publishing_components/components/_metadata.html.erb
+++ b/app/views/govuk_publishing_components/components/_metadata.html.erb
@@ -22,7 +22,7 @@
   ga4_tracking ||= false
   ga4_object = {
     event_name: "navigation",
-    type: "content",
+    type: "content history",
     section: "Top",
     action: "opened"
   }.to_json

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -211,7 +211,7 @@ describe "Metadata", type: :view do
 
     expected_ga4_json = {
       "event_name": "navigation",
-      "type": "content",
+      "type": "content history",
       "section": "Top",
       "action": "opened",
     }.to_json


### PR DESCRIPTION
## What
<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->
Changes the GA4 type for `See all updates` navigation events from `content` to `content history`. I believe the type of page that uses this event is https://www.gov.uk/hmrc-internal-manuals/self-assessment-claims-manual/sacm1005

## Why
<!-- What are the reasons behind this change being made? -->
https://trello.com/c/KdNfD2FM/682-change-see-updates-show-hide-all-updates-selectcontent-event-types-to-content-history

## Visual Changes
<!-- If change results in visual changes, include detailed screenshots that show the various states. -->

<!-- Please ensure that the changes are reviewed by a Designer if required. -->
<!-- To help Designers, please include a link to specific elements to review, -->
<!-- for example to https://components-gem-pr-[PULL REQUEST NUMBER].herokuapp.com/public -->

None.