### PR TITLE
Version 35.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 35.17.0
 
 * Add new light action link variant ([PR #3602](https://github.com/alphagov/govuk_publishing_components/pull/3602))
 * Add new homepage variant to search component ([PR #3599](https://github.com/alphagov/govuk_publishing_components/pull/3599))
 * Change GA4 type for show/hide update links ([PR #3643](https://github.com/alphagov/govuk_publishing_components/pull/3643))
 * Account for licence finder results count in GA4 ecommerce tracking ([PR #3641](https://github.com/alphagov/govuk_publishing_components/pull/3641))
-
 
 ## 35.16.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_publishing_components (35.16.1)
+    govuk_publishing_components (35.17.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/lib/govuk_publishing_components/version.rb
+++ b/lib/govuk_publishing_components/version.rb
@@ -1,3 +1,3 @@
 module GovukPublishingComponents
-  VERSION = "35.16.1".freeze
+  VERSION = "35.17.0".freeze
 end


### PR DESCRIPTION
## 35.17.0

* Add new light action link variant ([PR #3602](https://github.com/alphagov/govuk_publishing_components/pull/3602))
* Add new homepage variant to search component ([PR #3599](https://github.com/alphagov/govuk_publishing_components/pull/3599))
* Change GA4 type for show/hide update links ([PR #3643](https://github.com/alphagov/govuk_publishing_components/pull/3643))
* Account for licence finder results count in GA4 ecommerce tracking ([PR #3641](https://github.com/alphagov/govuk_publishing_components/pull/3641))