### PR TITLE
Change GA4 type on contents lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Change GA4 type on contents lists ([PR #3647](https://github.com/alphagov/govuk_publishing_components/pull/3647))
+
 ## 35.17.0
 
 * Add new light action link variant ([PR #3602](https://github.com/alphagov/govuk_publishing_components/pull/3602))

--- a/app/views/govuk_publishing_components/components/_contents_list.html.erb
+++ b/app/views/govuk_publishing_components/components/_contents_list.html.erb
@@ -15,7 +15,6 @@
   ga4_tracking ||= false
   ga4_data = {
     event_name: "navigation",
-    type: "contents list",
     section: t("components.contents_list.contents", locale: :en) || "",
     index_total: cl_helper.get_index_total
   } if ga4_tracking
@@ -46,6 +45,7 @@
               ga4_data[:index] = {
                 "index_link": index_link,
               }
+              ga4_data[:type] = cl_helper.get_ga4_type(contents_item[:href]) if contents_item[:href]
             end
           %>
           <%= link_to_if !contents_item[:active], link_text, contents_item[:href],
@@ -70,6 +70,7 @@
                       ga4_data[:index] = {
                         "index_link": index_link,
                       }
+                      ga4_data[:type] = cl_helper.get_ga4_type(nested_contents_item[:href]) if nested_contents_item[:href]
                     end
                   %>
                   <%= link_to_if !nested_contents_item[:active], nested_contents_item[:text], nested_contents_item[:href],

--- a/app/views/govuk_publishing_components/components/docs/contents_list.yml
+++ b/app/views/govuk_publishing_components/components/docs/contents_list.yml
@@ -197,18 +197,17 @@ examples:
     data:
       ga4_tracking: true
       contents:
-        - href: "#first-thing"
+        - href: "https://www.gov.uk"
           text: 1. First thing
           items:
           - href: "#second-thing"
             text: 1. Nested Item
-          - href: "#third-thing"
-            text: 2. Nested Item
+          - text: 2. Nested Item
             active: true
         - href: "#first-thing"
           text: 2. Second thing
           items:
           - href: "#second-thing"
             text: 1. Nested Item
-          - href: "#third-thing"
+          - href: "https://www.gov.uk/browse"
             text: 2. Nested Item

--- a/lib/govuk_publishing_components/presenters/contents_list_helper.rb
+++ b/lib/govuk_publishing_components/presenters/contents_list_helper.rb
@@ -48,6 +48,12 @@ module GovukPublishingComponents
         total
       end
 
+      def get_ga4_type(link)
+        return "select content" if link.start_with?("#")
+
+        "contents list"
+      end
+
     private
 
       def parent_modifier

--- a/spec/components/contents_list_spec.rb
+++ b/spec/components/contents_list_spec.rb
@@ -8,7 +8,7 @@ describe "Contents list", type: :view do
   def contents_list
     [
       { href: "/one", text: "1. One" },
-      { href: "/two", text: "2. Two" },
+      { href: "#two", text: "2. Two" },
     ]
   end
 
@@ -28,7 +28,7 @@ describe "Contents list", type: :view do
         { href: "/nested-one", text: "Nested one" },
         { href: "/nested-two", text: "Nested two" },
         { text: "Active", active: true },
-        { href: "/nested-four", text: "4. Four" },
+        { href: "#nested-four", text: "4. Four" },
       ],
     }
   end
@@ -45,7 +45,7 @@ describe "Contents list", type: :view do
     render_component(contents: contents_list)
     assert_select ".gem-c-contents-list"
     assert_select ".gem-c-contents-list__link.govuk-link--no-underline[href='/one']", text: "1. One"
-    assert_select ".gem-c-contents-list__link.govuk-link--no-underline[href='/two']", text: "2. Two"
+    assert_select ".gem-c-contents-list__link.govuk-link--no-underline[href='#two']", text: "2. Two"
   end
 
   it "renders with the underline option" do
@@ -131,7 +131,6 @@ describe "Contents list", type: :view do
 
     expected_ga4_json = {
       event_name: "navigation",
-      type: "contents list",
       section: "Contents",
     }
 
@@ -150,7 +149,10 @@ describe "Contents list", type: :view do
     # should still be respected. Therefore the final link should still have an index of 7 even though there's only 6 <a> tags.
     index_links = [1, 2, 3, 4, 5, 7]
     texts = ["1. One", "2. Two", "3. Three", "Nested one", "Nested two", "4. Four"]
+    types = ["contents list", "select content", "contents list", "contents list", "contents list", "select content"]
+
     contents_list_links.each_with_index do |link, index|
+      expected_ga4_json[:type] = types[index]
       expected_ga4_json[:index] = { index_link: index_links[index] }
       expect(link.attr("data-ga4-link").to_s).to eq expected_ga4_json.to_json
       expect(link).to have_text(texts[index])

--- a/spec/lib/govuk_publishing_components/components/contents_list_helper_spec.rb
+++ b/spec/lib/govuk_publishing_components/components/contents_list_helper_spec.rb
@@ -96,6 +96,12 @@ RSpec.describe GovukPublishingComponents::Presenters::ContentsListHelper do
       cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({ contents: contents })
       expect(cl.get_index_total).to eql(4)
     end
+
+    it "returns the required GA4 type" do
+      cl = GovukPublishingComponents::Presenters::ContentsListHelper.new({})
+      expect(cl.get_ga4_type("#anchor")).to eql("select content")
+      expect(cl.get_ga4_type("https://www.gov.uk")).to eql("contents list")
+    end
   end
 
   def assert_split_number_and_text(number_and_text, number, text)


### PR DESCRIPTION
## What
- type should be 'contents list' for regular links (as it was previously)
- type should be 'select content' for anchor links (newly added)

## Why
Part of the GA4 migration.

## Visual Changes
None.

Trello card: https://trello.com/c/51i0EiqQ/673-contents-link-clicks-that-go-to-anchors-in-the-page-rather-than-other-pages-to-be-selectcontent-instead-of-navigation-events
